### PR TITLE
Add Notes Section to README.md and a Clarification for Building with Existing Postgres Builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,3 @@ make installcheck-good
 
 For Greenplum Database documentation, please check online docs:
 http://gpdb.docs.pivotal.io
-
-## NOTES
-
-* If you aready have a Postgres build environment/installation in the default location (/usr/local/pgsql/), make sure to provide different installation location to the GPDB build (./configure --prefix <...>) to avoid build failures.

--- a/README.md
+++ b/README.md
@@ -172,3 +172,7 @@ make installcheck-good
 
 For Greenplum Database documentation, please check online docs:
 http://gpdb.docs.pivotal.io
+
+## Notes
+
+* If you aready have a Postgres build environment/installation in the default location (/usr/local/pgsql/), make sure to provide different installation location to the GPDB build (./configure --prefix <...>) to avoid build failures.

--- a/README.md
+++ b/README.md
@@ -172,3 +172,7 @@ make installcheck-good
 
 For Greenplum Database documentation, please check online docs:
 http://gpdb.docs.pivotal.io
+
+## NOTES
+
+* If you aready have a Postgres build environment/installation in the default location (/usr/local/pgsql/), make sure to provide different installation location to the GPDB build (./configure --prefix <...>) to avoid build failures.


### PR DESCRIPTION
1) Add Notes section to the README.md
2) If building on a machine with existing Postgres build/install, GPDB build may fail. Add note to clarify and give recommendation for workaround.