### PR TITLE
Fix call to fcntl2.open for newer glibc versions

### DIFF
--- a/src/tools/fsync/test_fsync.c
+++ b/src/tools/fsync/test_fsync.c
@@ -69,7 +69,7 @@ main(int argc, char *argv[])
 	for (i = 0; i < XLOG_SEG_SIZE; i++)
 		full_buf[i] = 'a';
 
-	if ((tmpfile = open(filename, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR, 0)) == -1)
+	if ((tmpfile = open(filename, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR)) == -1)
 		die("Cannot open output file.");
 	if (write(tmpfile, full_buf, XLOG_SEG_SIZE) != XLOG_SEG_SIZE)
 		die("write failed");


### PR DESCRIPTION
GP wouldn't compile with newer (definitely with 2.19) versions of glibc,
due to changes introduced by commit
3a50811c2fd1aff15552c0448fff66039488fee5 [1] and more precisely [2].
open calls were limited to 2-3 args, where master code was calling it
with four. This patch removes the last argument which should be
unnecesary.

[1]: http://sourceware.org/git/?p=glibc.git;a=commitdiff;h=3a50811c2fd1aff15552c0448fff66039488fee5
[2]: http://sourceware.org/git/?p=glibc.git;a=commitdiff;h=3a50811c2fd1aff15552c0448fff66039488fee5#patch6