### PR TITLE
Fix block size calculation for CO in case of RLE.

### DIFF
--- a/src/backend/commands/conversioncmds.c
+++ b/src/backend/commands/conversioncmds.c
@@ -154,16 +154,6 @@ DropConversionCommand(List *name, DropBehavior behavior, bool missing_ok)
 	}
 
 	ConversionDrop(conversionOid, behavior);
-	
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		DropStmt * stmt = makeNode(DropStmt);
-		stmt->objects = list_make1(name);
-		stmt->removeType = OBJECT_CONVERSION;
-		stmt->behavior=behavior;
-		stmt->missing_ok = true;
-		CdbDispatchUtilityStatement((Node *) stmt, "DropConversionCommand");
-	}
 }
 
 /*

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -30,6 +30,7 @@
 #include "lib/stringinfo.h"
 #include "libpq/libpq.h"
 #include "libpq/pqformat.h"
+#include "miscadmin.h"
 #include "nodes/pg_list.h"
 #include "replication/basebackup.h"
 #include "replication/walsender.h"
@@ -41,7 +42,6 @@
 #include "utils/elog.h"
 #include "utils/faultinjector.h"
 #include "utils/guc.h"
-#include "utils/memutils.h"
 #include "utils/ps_status.h"
 
 typedef struct
@@ -390,16 +390,7 @@ void
 SendBaseBackup(BaseBackupCmd *cmd)
 {
 	DIR		   *dir;
-	MemoryContext backup_context;
-	MemoryContext old_context;
 	basebackup_options opt;
-
-	backup_context = AllocSetContextCreate(CurrentMemoryContext,
-										   "Streaming base backup context",
-										   ALLOCSET_DEFAULT_MINSIZE,
-										   ALLOCSET_DEFAULT_INITSIZE,
-										   ALLOCSET_DEFAULT_MAXSIZE);
-	old_context = MemoryContextSwitchTo(backup_context);
 
 	parse_basebackup_options(cmd->options, &opt);
 
@@ -450,8 +441,6 @@ SendBaseBackup(BaseBackupCmd *cmd)
 
 	CommitTransactionCommand();
 
-	MemoryContextSwitchTo(old_context);
-	MemoryContextDelete(backup_context);
 }
 
 static void
@@ -671,7 +660,7 @@ match_exclude_list(char *path, List *exclude)
 
 /*
  * Include all files from the given directory in the output tar stream. If
- * 'sizeonly' is true, we just calculate a total length and return ig, without
+ * 'sizeonly' is true, we just calculate a total length and return it, without
  * actually sending anything.
  */
 static int64
@@ -709,7 +698,7 @@ sendDir(char *path, int basepathlen, List *exclude, bool sizeonly)
 		 * error in that case. The error handler further up will call
 		 * do_pg_abort_backup() for us.
 		 */
-		if (walsender_shutdown_requested || walsender_ready_to_stop)
+		if (ProcDiePending || walsender_ready_to_stop)
 			ereport(ERROR,
 				(errmsg("shutdown requested, aborting active base backup")));
 

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1090,12 +1090,9 @@ ProcessUtility(Node *parsetree,
 					{
 						/*
 						 * If we are the QD, dispatch this DROP command to all the QEs
-						 * NOTE: on the segments we convert all drop-statements into
-						 * drop-if-exists.
 						 */
 						if (Gp_role == GP_ROLE_DISPATCH)
 						{
-							stmt->missing_ok = true;
 							CdbDispatchUtilityStatement((Node *) stmt, "ProcessUtility");
 						}
 					}

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -15,7 +15,7 @@
 #define NAMESPACE_H
 
 #include "nodes/primnodes.h"
-
+#include "storage/lock.h"
 
 /*
  *	This structure holds a list of possible functions or operators
@@ -32,8 +32,14 @@ typedef struct _FuncCandidateList
 	Oid			args[1];		/* arg types --- VARIABLE LENGTH ARRAY */
 }	*FuncCandidateList;	/* VARIABLE LENGTH STRUCT */
 
+typedef void (*RangeVarGetRelidCallback) (const RangeVar *relation, Oid relId,
+										   Oid oldRelId, void *callback_arg);
 
 extern Oid	RangeVarGetRelid(const RangeVar *relation, bool failOK);
+extern Oid  RangeVarGetRelidExtended(const RangeVar *relation,
+						 LOCKMODE lockmode, bool missing_ok, bool nowait,
+						 RangeVarGetRelidCallback callback,
+						 void *callback_arg);
 extern Oid	RangeVarGetCreationNamespace(const RangeVar *newRelation);
 extern Oid	RelnameGetRelid(const char *relname);
 extern bool RelationIsVisible(Oid relid);

--- a/src/include/replication/walsender.h
+++ b/src/include/replication/walsender.h
@@ -20,7 +20,6 @@
 /* global state */
 extern bool am_walsender;
 extern bool am_cascading_walsender;
-extern volatile sig_atomic_t walsender_shutdown_requested;
 extern volatile sig_atomic_t walsender_ready_to_stop;
 
 /* user-settable parameters */
@@ -28,7 +27,9 @@ extern int	max_wal_senders;
 extern int	replication_timeout;
 extern int	repl_catchup_within_range;
 
-extern int	WalSenderMain(void);
+extern void InitWalSender(void);
+extern void exec_replication_command(const char *query_string);
+extern void WalSndErrorCleanup(void);
 extern void WalSndSignals(void);
 extern Size WalSndShmemSize(void);
 extern void WalSndShmemInit(void);

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -8950,7 +8950,7 @@ set optimizer_disable_missing_stats_collection = on;
 -- Push components of disjunctive predicates
 create table cust(cid integer, firstname text, lastname text) distributed by (cid);
 create table datedim(date_sk integer, year integer, moy integer) distributed by (date_sk);
-create table sales(item_sk integer, ticket_number integer, cid integer, date_sk integer, type text)
+create table sales_optimizer(item_sk integer, ticket_number integer, cid integer, date_sk integer, type text)
   distributed by (item_sk, ticket_number);
 -- create a volatile function which should not be pushed
 CREATE FUNCTION plusone(integer) RETURNS integer AS $$
@@ -8965,24 +8965,24 @@ select c.cid cid,
        c.firstname firstname,
        c.lastname lastname,
        d.year dyear
-from cust c, sales s, datedim d
+from cust c, sales_optimizer s, datedim d
 where c.cid = s.cid and s.date_sk = d.date_sk and
       ((d.year = 2001 and lower(s.type) = 't1' and plusone(d.moy) = 5) or (d.moy = 4 and upper(s.type) = 'T2'));
                                                                                       QUERY PLAN                                                                                      
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..1293.00 rows=1 width=24)
    ->  Hash Join  (cost=0.00..1293.00 rows=1 width=24)
-         Hash Cond: cust.cid = sales.cid
+         Hash Cond: cust.cid = sales_optimizer.cid
          ->  Table Scan on cust  (cost=0.00..431.00 rows=1 width=20)
          ->  Hash  (cost=862.00..862.00 rows=1 width=8)
                ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..862.00 rows=1 width=8)
-                     Hash Key: sales.cid
+                     Hash Key: sales_optimizer.cid
                      ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
-                           Hash Cond: sales.date_sk = datedim.date_sk
-                           Join Filter: (datedim.year = 2001 AND lower(sales.type) = 't1'::text AND plusone(datedim.moy) = 5) OR (datedim.moy = 4 AND upper(sales.type) = 'T2'::text)
+                           Hash Cond: sales_optimizer.date_sk = datedim.date_sk
+                           Join Filter: (datedim.year = 2001 AND lower(sales_optimizer.type) = 't1'::text AND plusone(datedim.moy) = 5) OR (datedim.moy = 4 AND upper(sales_optimizer.type) = 'T2'::text)
                            ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=16)
-                                 Hash Key: sales.date_sk
-                                 ->  Table Scan on sales  (cost=0.00..431.00 rows=1 width=16)
+                                 Hash Key: sales_optimizer.date_sk
+                                 ->  Table Scan on sales_optimizer  (cost=0.00..431.00 rows=1 width=16)
                                        Filter: lower(type) = 't1'::text OR upper(type) = 'T2'::text
                            ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                                  ->  Table Scan on datedim  (cost=0.00..431.00 rows=1 width=12)

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -935,7 +935,7 @@ set optimizer_disable_missing_stats_collection = on;
 -- Push components of disjunctive predicates
 create table cust(cid integer, firstname text, lastname text) distributed by (cid);
 create table datedim(date_sk integer, year integer, moy integer) distributed by (date_sk);
-create table sales(item_sk integer, ticket_number integer, cid integer, date_sk integer, type text)
+create table sales_optimizer(item_sk integer, ticket_number integer, cid integer, date_sk integer, type text)
   distributed by (item_sk, ticket_number);
 -- create a volatile function which should not be pushed
 CREATE FUNCTION plusone(integer) RETURNS integer AS $$
@@ -951,7 +951,7 @@ select c.cid cid,
        c.firstname firstname,
        c.lastname lastname,
        d.year dyear
-from cust c, sales s, datedim d
+from cust c, sales_optimizer s, datedim d
 where c.cid = s.cid and s.date_sk = d.date_sk and
       ((d.year = 2001 and lower(s.type) = 't1' and plusone(d.moy) = 5) or (d.moy = 4 and upper(s.type) = 'T2'));
 reset optimizer_segments;


### PR DESCRIPTION
The patch adds size required to finalize the rle repeats array size
to the block space calculation for CO, to correctly detect if current
block is full and should start new block for current item.

If its non-repeated item (NULL / value), need to finalize the rle
repeats counts array and then store new value. Space calculation only
checked for space required for new item either in NULLs array or actual
item space, but missed that to store the item which is non-repeating,
would have to finalize the previous repeating array which would need 4 bytes
of space along with it. Hence said okay to store the item but later caused
failure to insert when pushing the block to disk as its over
blocksize specified for the table.