### PR TITLE
Use ssize_t for return value from send()

### DIFF
--- a/gpAux/platform/gpnetbench/gpnetbenchClient.c
+++ b/gpAux/platform/gpnetbench/gpnetbenchClient.c
@@ -171,7 +171,7 @@ int main(int argc, char** argv)
 
 void send_buffer(int fd, char* buffer, int bytes)
 {
-	size_t retval;
+	ssize_t retval;
 
 	while(bytes > 0)
 	{


### PR DESCRIPTION
`send()` returns -1 in case of errors and thus we must use `ssize_t` rather than `size_t` in order for the error check to be useful.