### PR TITLE
Concurrent drop should not report error for drop IF EXISTS.

### DIFF
--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -299,7 +299,7 @@ void DropErrorTable(CdbSreh *cdbsreh)
 							 RelationGetRelationName(cdbsreh->errtbl), -1);
 
 	/* DROP the relation on the QD */
-	RemoveRelation(errtbl_rv,DROP_RESTRICT, NULL);
+	RemoveRelation(errtbl_rv,DROP_RESTRICT, NULL, RELKIND_RELATION);
 				   
 	/* dispatch the DROP to the QEs */
 	CdbDoCommand(dropstmt.data, false, /*no txn */ false);

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -62,8 +62,8 @@ extern void	DefinePartitionedRelation(CreateStmt *stmt, Oid reloid);
 
 extern void EvaluateDeferredStatements(List *deferredStmts);
 
-extern void RemoveRelation(const RangeVar *relation, DropBehavior behavior,
-						   DropStmt *stmt /* MPP */);
+extern bool RemoveRelation(const RangeVar *relation, DropBehavior behavior,
+						   DropStmt *stmt /* MPP */, char relkind);
 
 extern bool RelationToRemoveIsTemp(const RangeVar *relation, DropBehavior behavior);
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -40,5 +40,6 @@ extern bool QueryIsReadOnly(Query *parsetree);  /* Obsolete */
 extern bool CommandIsReadOnly(Node *parsetree);
 
 extern void CheckRelationOwnership(RangeVar *rel, bool noCatalogs);
+extern void DropErrorMsgNonExistent(const RangeVar *rel, char rightkind, bool missing_ok);
 
 #endif   /* UTILITY_H */


### PR DESCRIPTION
Relation can potential be dropped while waiting to acquire lock.
If cannot find the relation for "if_exists" case should just emit
NOTICE and act as noop.

Test case (change patch) for the same was aded to currently separate isolation test framework (we will mostly likely soon start using isolationtester from postgres for this kind of scenarios).

```
Change 227963 by agrawa2@ashwin_tinc_mac_new on 2015/10/26 17:24:02

	Test case for concurrent drop.

	[JIRA: ]
	[CR: ]

Affected files ...

... //tincrepo/main/mpp/gpdb/tests/catalog/drop_rename/drop_rename.ans#3 edit
... //tincrepo/main/mpp/gpdb/tests/catalog/drop_rename/drop_rename.sql#3 edit
... //tincrepo/main/mpp/gpdb/tests/catalog/drop_rename/test_drop_rename.py#3 edit

Differences ...

==== //tincrepo/main/mpp/gpdb/tests/catalog/drop_rename/drop_rename.ans#3 (text) ====

55a56,79
>
> 1:drop table if exists t3;
> DROP
> 1:create table t3 (a int, b text) distributed by (a);
> CREATE
> 1:insert into t3 select i, '123 '||i from generate_series(1,10)i;
> INSERT 10
> 1:begin;
> BEGIN
> 1:drop table t3;
> DROP
> 2&:drop table if exists t3;  <waiting ...>
> 3&:drop table t3;  <waiting ...>
> 1:commit;
> COMMIT
> 3<:  <... completed>
> ERROR:  relation "t3" does not exist
> 2<:  <... completed>
> DROP
> 2:select count(*) from t3;
> ERROR:  relation "t3" does not exist
> LINE 1: select count(*) from t3;
>                              ^
>

==== //tincrepo/main/mpp/gpdb/tests/catalog/drop_rename/drop_rename.sql#3 (text) ====

30a31,43
>
> 1:drop table if exists t3;
> 1:create table t3 (a int, b text) distributed by (a);
> 1:insert into t3 select i, '123 '||i from generate_series(1,10)i;
> 1:begin;
> 1:drop table t3;
> 2&:drop table if exists t3;
> 3&:drop table t3;
> 1:commit;
> 3<:
> 2<:
> 2:select count(*) from t3;
>
```



@asimrp please review as well.
