### PR TITLE
Add gptransfer validation for missing filespaces on destination system

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gptransfer.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gptransfer.feature
@@ -112,6 +112,49 @@ Feature: gptransfer tests
         And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
         And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
 
+    Scenario: gptransfer full md5 validator in CSV format
+        Given the database is running
+        And the database "gptransfer_destdb" does not exist
+        And the database "gptransfer_testdb1" does not exist
+        And the database "gptransfer_testdb2" does not exist
+        And the database "gptransfer_testdb3" does not exist
+        And the database "gptransfer_testdb4" does not exist
+        And the database "gptransfer_testdb5" does not exist
+        And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 --format=csv"
+        Then gptransfer should return a return code of 0
+        And verify that table "t0" in "gptransfer_testdb1" has "100" rows
+        And verify that table "t1" in "gptransfer_testdb1" has "200" rows
+        And verify that table "t2" in "gptransfer_testdb1" has "300" rows
+        And verify that table "t3" in "gptransfer_testdb2" has "400" rows
+        And verify that table "t4" in "gptransfer_testdb2" has "500" rows
+        And verify that table "t5" in "gptransfer_testdb2" has "600" rows
+        And verify that table "t0" in "gptransfer_testdb3" has "700" rows
+        And verify that table "empty_table" in "gptransfer_testdb4" has "0" rows
+        And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
+        And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
+
+    Scenario: gptransfer full count validator in CSV format
+        Given the database is running
+        And the database "gptest" does not exist
+        And the database "gptransfer_destdb" does not exist
+        And the database "gptransfer_testdb1" does not exist
+        And the database "gptransfer_testdb2" does not exist
+        And the database "gptransfer_testdb3" does not exist
+        And the database "gptransfer_testdb4" does not exist
+        And the database "gptransfer_testdb5" does not exist
+        And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate count --format=csv"
+        Then gptransfer should return a return code of 0
+        And verify that table "t0" in "gptransfer_testdb1" has "100" rows
+        And verify that table "t1" in "gptransfer_testdb1" has "200" rows
+        And verify that table "t2" in "gptransfer_testdb1" has "300" rows
+        And verify that table "t3" in "gptransfer_testdb2" has "400" rows
+        And verify that table "t4" in "gptransfer_testdb2" has "500" rows
+        And verify that table "t5" in "gptransfer_testdb2" has "600" rows
+        And verify that table "t0" in "gptransfer_testdb3" has "700" rows
+        And verify that table "empty_table" in "gptransfer_testdb4" has "0" rows
+        And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
+        And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
+
     @T339915
     Scenario: gptransfer full with drop
         Given the database is running
@@ -1349,7 +1392,6 @@ Feature: gptransfer tests
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
 
-
    @T339824
     Scenario: gptransfer full with all ddl, dml and filespace
         Given the database is running
@@ -1436,6 +1478,30 @@ Feature: gptransfer tests
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
 
+   Scenario: gptransfer filespace exists test with --full -t and -d options
+        Given the database is running
+        And the database "gptransfer_destdb" does not exist
+        And the database "gptransfer_testdb1" does not exist
+        And the database "gptransfer_testdb2" does not exist
+        And the database "gptransfer_testdb3" does not exist
+        And the database "gptransfer_testdb4" does not exist
+        And the database "gptransfer_testdb5" does not exist
+        And the database "gptest" does not exist
+        And the user "GPTRANSFER_SOURCE_USER" creates filespace_config file for "fs" on host "GPTRANSFER_SOURCE_HOST" with gpdb port "GPTRANSFER_SOURCE_PORT" and config "gpfilespace_config_src" in "HOME" directory
+        And the user "GPTRANSFER_SOURCE_USER" creates filespace on host "GPTRANSFER_SOURCE_HOST" with gpdb port "GPTRANSFER_SOURCE_PORT" and config "gpfilespace_config_src" in "HOME" directory
+        And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/filespace_exists_test.sql -d template1"
+        And psql should return a return code of 0 
+        And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE > /tmp/gptransfer_stdout.txt"
+        Then gptransfer should return a return code of 2
+        And verify that the file "/tmp/gptransfer_stdout.txt" contains "Filespace 'fs' does not exist on destination. Please create the filespace to run gptransfer"
+        And the user runs "gptransfer -d gptransfer_filespace_test --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE > /tmp/gptransfer_stdout.txt"
+        Then gptransfer should return a return code of 2
+        And verify that the file "/tmp/gptransfer_stdout.txt" contains "Filespace 'fs' does not exist on destination. Please create the filespace to run gptransfer"
+        And the user runs "gptransfer -t gptransfer_filespace_test.public.t2 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE > /tmp/gptransfer_stdout.txt"
+        Then gptransfer should return a return code of 2
+        And verify that the file "/tmp/gptransfer_stdout.txt" contains "Filespace 'fs' does not exist on destination. Please create the filespace to run gptransfer"
+        And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/filespace_exists_test_teardown.sql -d template1"
+        And psql should return a return code of 0 
 
     @T339870
     Scenario: gptransfer with max-line-length of 16KB
@@ -1502,48 +1568,6 @@ Feature: gptransfer tests
         And gptransfer should print Value must be between 32768 and 268435456 to stdout
         And the temporary table file "wide_row_269484032.sql" is removed
         And drop the table "wide_row_269484032" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
-
-    Scenario: gptransfer full md5 validator in CSV format
-        Given the database is running
-        And the database "gptransfer_destdb" does not exist
-        And the database "gptransfer_testdb1" does not exist
-        And the database "gptransfer_testdb2" does not exist
-        And the database "gptransfer_testdb3" does not exist
-        And the database "gptransfer_testdb4" does not exist
-        And the database "gptransfer_testdb5" does not exist
-        And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate md5 --format=csv"
-        Then gptransfer should return a return code of 0
-        And verify that table "t0" in "gptransfer_testdb1" has "100" rows
-        And verify that table "t1" in "gptransfer_testdb1" has "200" rows
-        And verify that table "t2" in "gptransfer_testdb1" has "300" rows
-        And verify that table "t3" in "gptransfer_testdb2" has "400" rows
-        And verify that table "t4" in "gptransfer_testdb2" has "500" rows
-        And verify that table "t5" in "gptransfer_testdb2" has "600" rows
-        And verify that table "t0" in "gptransfer_testdb3" has "700" rows
-        And verify that table "empty_table" in "gptransfer_testdb4" has "0" rows
-        And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
-        And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
-
-    Scenario: gptransfer full count validator in CSV format
-        Given the database is running
-        And the database "gptransfer_destdb" does not exist
-        And the database "gptransfer_testdb1" does not exist
-        And the database "gptransfer_testdb2" does not exist
-        And the database "gptransfer_testdb3" does not exist
-        And the database "gptransfer_testdb4" does not exist
-        And the database "gptransfer_testdb5" does not exist
-        And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --validate count --format=csv"
-        Then gptransfer should return a return code of 0
-        And verify that table "t0" in "gptransfer_testdb1" has "100" rows
-        And verify that table "t1" in "gptransfer_testdb1" has "200" rows
-        And verify that table "t2" in "gptransfer_testdb1" has "300" rows
-        And verify that table "t3" in "gptransfer_testdb2" has "400" rows
-        And verify that table "t4" in "gptransfer_testdb2" has "500" rows
-        And verify that table "t5" in "gptransfer_testdb2" has "600" rows
-        And verify that table "t0" in "gptransfer_testdb3" has "700" rows
-        And verify that table "empty_table" in "gptransfer_testdb4" has "0" rows
-        And verify that table "one_row_table" in "gptransfer_testdb4" has "1" rows
-        And verify that table "wide_rows" in "gptransfer_testdb5" has "10" rows
 
     Scenario: Negative test for gptransfer full with invalid delimiter and format option
         Given the database is running

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -41,12 +41,14 @@ try:
     from gppylib.commands.unix import MakeDirectory, RemoveDirectory, \
         RemoveFiles, FileDirExists, Scp, LINUX, curr_platform
     from gppylib.commands.gp import get_gphome
+    from gppylib.db import dbconn
     from gppylib.db.dbconn import connect, DbURL, execSQL, \
         execSQLForSingletonRow
     from gppylib.db.catalog import getUserDatabaseList, doesSchemaExist, dropSchemaIfExist
     from gppylib.gparray import GpArray
     from gppylib.userinput import ask_yesno
     from pygresql.pg import DB
+    from pygresql import pg
 except ImportError, import_exception:
     sys.exit('Cannot import modules.  Please check that you have sourced'
              ' greenplum_path.sh.  Detail: %s' % str(import_exception))
@@ -2382,6 +2384,10 @@ class GpTransfer(object):
 
         self._validate_table_transfer_set()
 
+        self._validate_filespace(self._options.source_host, self._options.source_port, self._options.source_user,
+                                 self._options.dest_host, self._options.dest_port, self._options.dest_user,
+                                 self._options.full)
+
         # At most we'll execute primary segment count of commands in the subbatches
         # so we can reduce it if the value exceeds the number of primary segs.
         if self._src_config.get_primary_count() < self._options.sub_batch_size \
@@ -2924,6 +2930,48 @@ class GpTransfer(object):
         if self._options.delimiter == ',' and self._options.format.lower() == 'text':
             raise ProgramArgumentValidationException(
                 'Invalid --delimiter. Default delimiter "," is not allowed in TEXT format. Specify --delimiter option for TEXT')
+
+    # Validate if destination system is missing required filespaces
+    def _validate_filespace(self, source_host, source_port, source_user, dest_host, dest_port, dest_user, full):
+        # Get all the filespaces of destination system
+        list_dest_fs = self._get_destination_filespaces(dest_host, dest_port, 'template1', dest_user)
+
+        # Check if source filespace exists in destination system
+        if full:
+            # For transferring in full mode
+            source_fs_sql = """SELECT fsname FROM pg_catalog.pg_filespace"""
+            self._check_filespace(source_host, source_port, 'template1', source_user, list_dest_fs, source_fs_sql)
+        else:
+            # For transferring in table mode
+            template_source_fs_sql = """SELECT fsname FROM pg_catalog.pg_filespace WHERE oid IN
+                                        (SELECT spcfsoid FROM pg_catalog.pg_tablespace
+                                        WHERE oid IN (SELECT dattablespace FROM pg_catalog.pg_database WHERE datname = '%s')
+                                        OR oid IN (SELECT reltablespace FROM pg_catalog.pg_class where relname = '%s'));"""
+            for table_pair in self._table_transfer_set:
+                dbname = pg.escape_string(table_pair.source.database)
+                tablename = pg.escape_string(table_pair.source.table)
+                source_fs_sql = template_source_fs_sql % (dbname, tablename)
+                self._check_filespace(source_host, source_port, table_pair.source.database, source_user, list_dest_fs, source_fs_sql)
+
+    def _get_destination_filespaces(self, dest_host, dest_port, database, dest_user):
+        list_dest_fs = []
+        dest_fs_sql = """SELECT fsname FROM pg_catalog.pg_filespace"""
+        with dbconn.connect(dbconn.DbURL(dest_host, dest_port, database, dest_user)) as dest_conn:
+            dest_cur = execSQL(dest_conn, dest_fs_sql)
+            for row in dest_cur:
+                list_dest_fs.append(row[0])
+            dest_cur.close()
+        return list_dest_fs
+
+    def _check_filespace(self, source_host, source_port, database, source_user, list_dest_fs, source_fs_sql):
+        with dbconn.connect(dbconn.DbURL(source_host, source_port, database, source_user)) as source_conn:
+            source_cur = execSQL(source_conn, source_fs_sql)
+            for row in source_cur:
+                fs = row[0]
+                if fs not in list_dest_fs:
+                    source_cur.close()
+                    raise Exception("Filespace '%s' does not exist on destination. Please create the filespace to run gptransfer" % fs)
+            source_cur.close()
 
     def _get_configurations(self):
         """


### PR DESCRIPTION
gptransfer currently does not validate whether required filespaces are missing on the destination system. If filespace does not exist, it fails and returns stack trace. It should return proper error message.

Prior to doing a gptransfer, gptransfer will now validate filespaces on destination system and exit accordingly with the proper error message.