### PR TITLE
Refactor binary read out funcs

### DIFF
--- a/src/Makefile.mock
+++ b/src/Makefile.mock
@@ -17,6 +17,8 @@ MOCK_LIBS := -ldl $(filter-out -lpgport -ledit, $(LIBS))
 EXCL_OBJS=src/backend/bootstrap/bootparse.o \
 			src/backend/catalog/caql/gram.o \
 			src/backend/parser/gram.o \
+			src/backend/nodes/readfast.o \
+			src/backend/nodes/outfast.o \
 			src/backend/regex/regcomp.o \
 			src/backend/regex/regexec.o \
 			src/backend/utils/adt/like.o \

--- a/src/backend/nodes/Makefile
+++ b/src/backend/nodes/Makefile
@@ -17,4 +17,8 @@ OBJS = nodeFuncs.o nodes.o list.o bitmapset.o tidbitmap.o \
        outfuncs.o readfuncs.o print.o read.o params.o value.o \
 	   outfast.o readfast.o
 
+# readfast.c #includes readfuncs.c. Same with outfast.c and outfast.c
+readfast.o: readfuncs.c
+outfast.o: outfuncs.c
+
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -18,8 +18,8 @@
  *     By design, the only user of these routines is the function
  *     serializeNode in cdbsrlz.c.  Other callers beware.
  *
- *    This file is based on outfuncs.c, however, it is optimized for speed
- *    at the expense legibility.
+ *    Like readfast.c, this file borrows the definitions of most functions
+ *    from outfuncs.c.
  *
  * 	  Rather than serialize to a (somewhat human-readable) string, these
  *    routines create a binary serialization via a simple depth-first walk
@@ -106,12 +106,6 @@
 /* Write a Node field */
 #define WRITE_NODE_FIELD(fldname) \
 	(_outNode(str, node->fldname))
-
-/* Write a List field: this is a shortcut (you can call
- * WRITE_NODE_FIELD for list fields) to avoid an extra call to
- * _outNode() */
-#define WRITE_LIST_FIELD(fldname) \
-	(_outList(str, node->fldname))
 
 /* Write a bitmapset field */
 #define WRITE_BITMAPSET_FIELD(fldname) \
@@ -259,6 +253,8 @@ _outDatum(StringInfo str, Datum value, int typlen, bool typbyval)
 	}
 }
 
+#define COMPILING_BINARY_FUNCS
+#include "outfuncs.c"
 
 /*
  *	Stuff from plannodes.h
@@ -270,7 +266,6 @@ _outDatum(StringInfo str, Datum value, int typlen, bool typbyval)
 static void
 _outPlanInfo(StringInfo str, Plan *node)
 {
-
 	if (print_variable_fields)
 	{
 		WRITE_INT_FIELD(plan_node_id);
@@ -289,7 +284,7 @@ _outPlanInfo(StringInfo str, Plan *node)
 	WRITE_BITMAPSET_FIELD(allParam);
 
 	WRITE_INT_FIELD(nParamExec);
-	
+
 	if (print_variable_fields)
 	{
 		WRITE_NODE_FIELD(flow);
@@ -313,78 +308,27 @@ _outPlanInfo(StringInfo str, Plan *node)
 	}
 }
 
-/*
- * print the basic stuff of all nodes that inherit from Scan
- */
-static void
-_outScanInfo(StringInfo str, Scan *node)
-{
-	_outPlanInfo(str, (Plan *) node);
-
-	if (print_variable_fields)
-	{
-		WRITE_UINT_FIELD(scanrelid);
-	}
-	else
-	{
-		/*
-		 * Serializing for workfile caching.
-		 * Instead of outputing rtable indices, serialize the actual rtable entry
-		 */
-		Assert(range_table != NULL);
-
-		RangeTblEntry *rte = rt_fetch(node->scanrelid, range_table);
-		/*
-		 * Serialize all rtable entries except for subquery type.
-		 * For subquery scan, the rtable entry contains the entire plan of the
-		 * subquery, but this is serialized elsewhere in outSubqueryScan, no
-		 * need to duplicate it here
-		 */
-		if (rte->type != RTE_SUBQUERY)
-		{
-			_outNode(str,rte);
-		}
-	}
-
-	WRITE_INT_FIELD(partIndex);
-	WRITE_INT_FIELD(partIndexPrintable);
-}
-
-/*
- * print the basic stuff of all nodes that inherit from Join
- */
-static void
-_outJoinPlanInfo(StringInfo str, Join *node)
-{
-	_outPlanInfo(str, (Plan *) node);
-
-	WRITE_BOOL_FIELD(prefetch_inner);
-
-	WRITE_ENUM_FIELD(jointype, JoinType);
-	WRITE_NODE_FIELD(joinqual);
-}
-
 static void
 _outPlannedStmt(StringInfo str, PlannedStmt *node)
 {
 	WRITE_NODE_TYPE("PLANNEDSTMT");
-	
+
 	WRITE_ENUM_FIELD(commandType, CmdType);
 	WRITE_ENUM_FIELD(planGen, PlanGenerator);
 	WRITE_BOOL_FIELD(canSetTag);
 	WRITE_BOOL_FIELD(transientPlan);
-	
+
 	WRITE_NODE_FIELD(planTree);
-	
+
 	WRITE_NODE_FIELD(rtable);
-	
+
 	WRITE_NODE_FIELD(resultRelations);
 	WRITE_NODE_FIELD(utilityStmt);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(subplans);
 	WRITE_NODE_FIELD(rewindPlanIDs);
 	WRITE_NODE_FIELD(returningLists);
-	
+
 	WRITE_NODE_FIELD(result_partitions);
 	WRITE_NODE_FIELD(result_aosegnos);
 	WRITE_NODE_FIELD(queryPartOids);
@@ -396,149 +340,12 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_INT_FIELD(nCrossLevelParams);
 	WRITE_INT_FIELD(nMotionNodes);
 	WRITE_INT_FIELD(nInitPlans);
-	
+
 	/* Don't serialize policy */
 	WRITE_NODE_FIELD(sliceTable);
-	
+
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(transientTypeRecords);
-}
-
-static void
-_outPlan(StringInfo str, Plan *node)
-{
-	WRITE_NODE_TYPE("PLAN");
-
-	_outPlanInfo(str, (Plan *) node);
-}
-
-static void
-_outResult(StringInfo str, Result *node)
-{
-	WRITE_NODE_TYPE("RESULT");
-
-	_outPlanInfo(str, (Plan *) node);
-
-	WRITE_NODE_FIELD(resconstantqual);
-
-	WRITE_BOOL_FIELD(hashFilter);
-	WRITE_NODE_FIELD(hashList);
-}
-
-static void
-_outRepeat(StringInfo str, Repeat *node)
-{
-	WRITE_NODE_TYPE("REPEAT");
-
-	_outPlanInfo(str, (Plan *) node);
-
-	WRITE_NODE_FIELD(repeatCountExpr);
-	WRITE_UINT64_FIELD(grouping);
-}
-
-static void
-_outAppend(StringInfo str, Append *node)
-{
-	WRITE_NODE_TYPE("APPEND");
-
-	_outPlanInfo(str, (Plan *) node);
-
-	WRITE_NODE_FIELD(appendplans);
-	WRITE_BOOL_FIELD(isTarget);
-	WRITE_BOOL_FIELD(isZapped);
-	WRITE_BOOL_FIELD(hasXslice);
-}
-
-static void
-_outSequence(StringInfo str, Sequence *node)
-{
-	WRITE_NODE_TYPE("SEQUENCE");
-	_outPlanInfo(str, (Plan *)node);
-	WRITE_NODE_FIELD(subplans);
-}
-
-static void
-_outBitmapAnd(StringInfo str, BitmapAnd *node)
-{
-	WRITE_NODE_TYPE("BITMAPAND");
-
-	_outPlanInfo(str, (Plan *) node);
-
-	WRITE_LIST_FIELD(bitmapplans);
-}
-
-static void
-_outBitmapOr(StringInfo str, BitmapOr *node)
-{
-	WRITE_NODE_TYPE("BITMAPOR");
-
-	_outPlanInfo(str, (Plan *) node);
-
-	WRITE_LIST_FIELD(bitmapplans);
-}
-
-static void
-_outScan(StringInfo str, Scan *node)
-{
-	WRITE_NODE_TYPE("SCAN");
-
-	_outScanInfo(str, (Scan *) node);
-}
-
-static void
-_outSeqScan(StringInfo str, SeqScan *node)
-{
-	WRITE_NODE_TYPE("SEQSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-}
-
-static void
-_outAppendOnlyScan(StringInfo str, AppendOnlyScan *node)
-{
-	WRITE_NODE_TYPE("APPENDONLYSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-}
-
-static void
-_outAOCSScan(StringInfo str, AOCSScan *node)
-{
-	WRITE_NODE_TYPE("AOCSSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-}
-
-static void
-_outTableScan(StringInfo str, TableScan *node)
-{
-	WRITE_NODE_TYPE("TABLESCAN");
-	_outScanInfo(str, (Scan *)node);
-}
-static void
-_outDynamicTableScan(StringInfo str, DynamicTableScan *node)
-{
-	WRITE_NODE_TYPE("DYNAMICTABLESCAN");
-	_outScanInfo(str, (Scan *)node);
-	WRITE_INT_FIELD(partIndex);
-	WRITE_INT_FIELD(partIndexPrintable);
-}
-static void
-_outExternalScan(StringInfo str, ExternalScan *node)
-{
-	WRITE_NODE_TYPE("EXTERNALSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-
-	WRITE_NODE_FIELD(uriList);
-	WRITE_NODE_FIELD(fmtOpts);
-	WRITE_CHAR_FIELD(fmtType);
-	WRITE_BOOL_FIELD(isMasterOnly);
-	WRITE_INT_FIELD(rejLimit);
-	WRITE_BOOL_FIELD(rejLimitInRows);
-	WRITE_OID_FIELD(fmterrtbl);
-	WRITE_INT_FIELD(encoding);
-	WRITE_INT_FIELD(scancounter);
 }
 
 static void
@@ -547,100 +354,12 @@ outLogicalIndexInfo(StringInfo str, LogicalIndexInfo *node)
 	WRITE_OID_FIELD(logicalIndexOid);
 	WRITE_INT_FIELD(nColumns);
 	WRITE_INT_ARRAY(indexKeys, nColumns, AttrNumber);
-	WRITE_LIST_FIELD(indPred);
-	WRITE_LIST_FIELD(indExprs);
+	WRITE_NODE_FIELD(indPred);
+	WRITE_NODE_FIELD(indExprs);
 	WRITE_BOOL_FIELD(indIsUnique);
 	WRITE_ENUM_FIELD(indType, LogicalIndexType);
 	WRITE_NODE_FIELD(partCons);
-	WRITE_LIST_FIELD(defaultLevels);
-}
-
-static void
-outIndexScanFields(StringInfo str, IndexScan *node)
-{
-	_outScanInfo(str, (Scan *) node);
-
-	WRITE_OID_FIELD(indexid);
-	WRITE_LIST_FIELD(indexqual);
-	WRITE_LIST_FIELD(indexqualorig);
-	WRITE_LIST_FIELD(indexstrategy);
-	WRITE_LIST_FIELD(indexsubtype);
-	WRITE_ENUM_FIELD(indexorderdir, ScanDirection);
-
-	if (isDynamicScan(&node->scan))
-	{
-		Assert(node->logicalIndexInfo);
-		outLogicalIndexInfo(str, node->logicalIndexInfo);
-	}
-	else
-	{
-		Assert(node->logicalIndexInfo == NULL);
-	}
-}
-
-static void
-_outIndexScan(StringInfo str, IndexScan *node)
-{
-	WRITE_NODE_TYPE("INDEXSCAN");
-
-	outIndexScanFields(str, node);
-}
-
-static void
-_outDynamicIndexScan(StringInfo str, DynamicIndexScan *node)
-{
-	WRITE_NODE_TYPE("DYNAMICINDEXSCAN");
-	/* DynamicIndexScan has the same content as IndexScan. */
-	outIndexScanFields(str, (IndexScan *) node);
-}
-
-static void
-_outBitmapIndexScan(StringInfo str, BitmapIndexScan *node)
-{
-	WRITE_NODE_TYPE("BITMAPINDEXSCAN");
-	/* BitmapIndexScan has the same content as IndexScan. */
-	outIndexScanFields(str, (IndexScan *) node);
-}
-
-static void
-_outBitmapHeapScan(StringInfo str, BitmapHeapScan *node)
-{
-	WRITE_NODE_TYPE("BITMAPHEAPSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-
-	WRITE_LIST_FIELD(bitmapqualorig);
-}
-
-static void
-_outBitmapAppendOnlyScan(StringInfo str, BitmapAppendOnlyScan *node)
-{
-	WRITE_NODE_TYPE("BITMAPAPPENDONLYSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-
-	WRITE_LIST_FIELD(bitmapqualorig);
-	WRITE_BOOL_FIELD(isAORow);
-}
-
-static void
-_outBitmapTableScan(StringInfo str, BitmapTableScan *node)
-{
-	WRITE_NODE_TYPE("BITMAPTABLESCAN");
-
-	_outScanInfo(str, (Scan *) node);
-
-	WRITE_LIST_FIELD(bitmapqualorig);
-}
-
-static void
-_outTidScan(StringInfo str, TidScan *node)
-{
-	WRITE_NODE_TYPE("TIDSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-
-	WRITE_NODE_FIELD(tidquals);
+	WRITE_NODE_FIELD(defaultLevels);
 }
 
 static void
@@ -652,65 +371,6 @@ _outSubqueryScan(StringInfo str, SubqueryScan *node)
 
 	WRITE_NODE_FIELD(subplan);
 	/* Planner-only: subrtable -- don't serialize. */
-}
-
-static void
-_outFunctionScan(StringInfo str, FunctionScan *node)
-{
-	WRITE_NODE_TYPE("FUNCTIONSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-}
-
-static void
-_outValuesScan(StringInfo str, ValuesScan *node)
-{
-	WRITE_NODE_TYPE("VALUESSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-}
-
-static void
-_outJoin(StringInfo str, Join *node)
-{
-	WRITE_NODE_TYPE("JOIN");
-
-	_outJoinPlanInfo(str, (Join *) node);
-}
-
-static void
-_outNestLoop(StringInfo str, NestLoop *node)
-{
-	WRITE_NODE_TYPE("NESTLOOP");
-
-	_outJoinPlanInfo(str, (Join *) node);
-
-    WRITE_BOOL_FIELD(outernotreferencedbyinner);    /*CDB*/
-	WRITE_BOOL_FIELD(shared_outer);
-	WRITE_BOOL_FIELD(singleton_outer); /*CDB-OLAP*/
-}
-
-
-static void
-_outMergeJoin(StringInfo str, MergeJoin *node)
-{
-	WRITE_NODE_TYPE("MERGEJOIN");
-
-	_outJoinPlanInfo(str, (Join *) node);
-
-	WRITE_LIST_FIELD(mergeclauses);
-	WRITE_BOOL_FIELD(unique_outer);
-}
-
-static void
-_outHashJoin(StringInfo str, HashJoin *node)
-{
-	WRITE_NODE_TYPE("HASHJOIN");
-
-	_outJoinPlanInfo(str, (Join *) node);
-
-	WRITE_LIST_FIELD(hashclauses);
-	WRITE_LIST_FIELD(hashqualclauses);
 }
 
 static void
@@ -764,42 +424,6 @@ _outWindow(StringInfo str, Window *node)
 	WRITE_INT_ARRAY(partColIdx, numPartCols, AttrNumber);
 
 	WRITE_NODE_FIELD(windowKeys);
-}
-
-static void
-_outTableFunctionScan(StringInfo str, TableFunctionScan *node)
-{
-	WRITE_NODE_TYPE("TABLEFUNCTIONSCAN");
-
-	_outScanInfo(str, (Scan *) node);
-}
-
-static void
-_outMaterial(StringInfo str, Material *node)
-{
-	WRITE_NODE_TYPE("MATERIAL");
-
-    WRITE_BOOL_FIELD(cdb_strict);
-
-	WRITE_ENUM_FIELD(share_type, ShareType);
-	WRITE_INT_FIELD(share_id);
-	WRITE_INT_FIELD(driver_slice);
-	WRITE_INT_FIELD(nsharer);
-	WRITE_INT_FIELD(nsharer_xslice);
-
-	_outPlanInfo(str, (Plan *) node);
-}
-
-static void
-_outShareInputScan(StringInfo str, ShareInputScan *node)
-{
-	WRITE_NODE_TYPE("SHAREINPUTSCAN");
-
-	WRITE_ENUM_FIELD(share_type, ShareType);
-	WRITE_INT_FIELD(share_id);
-	WRITE_INT_FIELD(driver_slice);
-
-	_outPlanInfo(str, (Plan *) node);
 }
 
 static void
@@ -859,26 +483,6 @@ _outSetOp(StringInfo str, SetOp *node)
 }
 
 static void
-_outLimit(StringInfo str, Limit *node)
-{
-	WRITE_NODE_TYPE("LIMIT");
-
-	_outPlanInfo(str, (Plan *) node);
-
-	WRITE_NODE_FIELD(limitOffset);
-	WRITE_NODE_FIELD(limitCount);
-}
-
-static void
-_outHash(StringInfo str, Hash *node)
-{
-	WRITE_NODE_TYPE("HASH");
-
-	_outPlanInfo(str, (Plan *) node);
-    WRITE_BOOL_FIELD(rescannable);          /*CDB*/
-}
-
-static void
 _outMotion(StringInfo str, Motion *node)
 {
 
@@ -888,8 +492,8 @@ _outMotion(StringInfo str, Motion *node)
 	WRITE_ENUM_FIELD(motionType, MotionType);
 	WRITE_BOOL_FIELD(sendSorted);
 
-	WRITE_LIST_FIELD(hashExpr);
-	WRITE_LIST_FIELD(hashDataTypes);
+	WRITE_NODE_FIELD(hashExpr);
+	WRITE_NODE_FIELD(hashDataTypes);
 
 	WRITE_INT_FIELD(numOutputSegs);
 	WRITE_INT_ARRAY(outputSegIdx, numOutputSegs, int);
@@ -903,173 +507,12 @@ _outMotion(StringInfo str, Motion *node)
 	_outPlanInfo(str, (Plan *) node);
 }
 
-/*
- * _outDML
- */
-static void
-_outDML(StringInfo str, DML *node)
-{
-	WRITE_NODE_TYPE("DML");
-
-	WRITE_UINT_FIELD(scanrelid);
-	WRITE_INT_FIELD(oidColIdx);
-	WRITE_INT_FIELD(actionColIdx);
-	WRITE_INT_FIELD(ctidColIdx);
-	WRITE_INT_FIELD(tupleoidColIdx);
-
-	_outPlanInfo(str, (Plan *) node);
-}
-
-
-/*
- * _outSplitUpdate
- */
-static void
-_outSplitUpdate(StringInfo str, SplitUpdate *node)
-{
-	WRITE_NODE_TYPE("SPLITUPDATE");
-
-	WRITE_INT_FIELD(actionColIdx);
-	WRITE_INT_FIELD(ctidColIdx);
-	WRITE_INT_FIELD(tupleoidColIdx);
-	WRITE_NODE_FIELD(insertColIdx);
-	WRITE_NODE_FIELD(deleteColIdx);
-
-	_outPlanInfo(str, (Plan *) node);
-}
-
-/*
- * _outRowTrigger
- */
-static void
-_outRowTrigger(StringInfo str, RowTrigger *node)
-{
-	WRITE_NODE_TYPE("ROWTRIGGER");
-
-	WRITE_INT_FIELD(relid);
-	WRITE_INT_FIELD(eventFlags);
-	WRITE_NODE_FIELD(oldValuesColIdx);
-	WRITE_NODE_FIELD(newValuesColIdx);
-
-	_outPlanInfo(str, (Plan *) node);
-}
-
-/*
- * _outAssertOp
- */
-static void
-_outAssertOp(StringInfo str, AssertOp *node)
-{
-	WRITE_NODE_TYPE("ASSERTOP");
-
-	WRITE_NODE_FIELD(errmessage);
-	WRITE_INT_FIELD(errcode);
-	
-	_outPlanInfo(str, (Plan *) node);
-}
-
-/*
- * _outPartitionSelector
- */
-static void
-_outPartitionSelector(StringInfo str, PartitionSelector *node)
-{
-	WRITE_NODE_TYPE("PARTITIONSELECTOR");
-
-	WRITE_INT_FIELD(relid);
-	WRITE_INT_FIELD(nLevels);
-	WRITE_INT_FIELD(scanId);
-	WRITE_INT_FIELD(selectorId);
-	WRITE_NODE_FIELD(levelEqExpressions);
-	WRITE_NODE_FIELD(levelExpressions);
-	WRITE_NODE_FIELD(residualPredicate);
-	WRITE_NODE_FIELD(propagationExpression);
-	WRITE_NODE_FIELD(printablePredicate);
-	WRITE_BOOL_FIELD(staticSelection);
-	WRITE_NODE_FIELD(staticPartOids);
-	WRITE_NODE_FIELD(staticScanIds);
-
-	_outPlanInfo(str, (Plan *) node);
-}
 
 /*****************************************************************************
  *
  *	Stuff from primnodes.h.
  *
  *****************************************************************************/
-
-static void
-_outAlias(StringInfo str, Alias *node)
-{
-	WRITE_NODE_TYPE("ALIAS");
-
-	WRITE_STRING_FIELD(aliasname);
-	WRITE_NODE_FIELD(colnames);
-}
-
-static void
-_outRangeVar(StringInfo str, RangeVar *node)
-{
-	WRITE_NODE_TYPE("RANGEVAR");
-
-	/*
-	 * we deliberately ignore catalogname here, since it is presently not
-	 * semantically meaningful
-	 */
-	WRITE_STRING_FIELD(schemaname);
-	WRITE_STRING_FIELD(relname);
-	WRITE_ENUM_FIELD(inhOpt, InhOption);
-	WRITE_BOOL_FIELD(istemp);
-	WRITE_NODE_FIELD(alias);
-    WRITE_INT_FIELD(location);  /*CDB*/
-}
-
-static void
-_outIntoClause(StringInfo str, IntoClause *node)
-{
-	WRITE_NODE_TYPE("INTOCLAUSE");
-	
-	WRITE_NODE_FIELD(rel);
-	WRITE_NODE_FIELD(colNames);
-	WRITE_NODE_FIELD(options);
-	WRITE_ENUM_FIELD(onCommit, OnCommitAction);
-	WRITE_STRING_FIELD(tableSpaceName);
-	WRITE_OID_FIELD(oidInfo.relOid);
-	WRITE_OID_FIELD(oidInfo.comptypeOid);
-	WRITE_OID_FIELD(oidInfo.toastOid);
-	WRITE_OID_FIELD(oidInfo.toastIndexOid);
-	WRITE_OID_FIELD(oidInfo.toastComptypeOid);
-	WRITE_OID_FIELD(oidInfo.aosegOid);
-	WRITE_OID_FIELD(oidInfo.aosegIndexOid);
-	WRITE_OID_FIELD(oidInfo.aosegComptypeOid);
-	WRITE_OID_FIELD(oidInfo.aovisimapOid);
-	WRITE_OID_FIELD(oidInfo.aovisimapIndexOid);
-	WRITE_OID_FIELD(oidInfo.aovisimapComptypeOid);
-	WRITE_OID_FIELD(oidInfo.aoblkdirOid);
-	WRITE_OID_FIELD(oidInfo.aoblkdirIndexOid);
-	WRITE_OID_FIELD(oidInfo.aoblkdirComptypeOid);	
-
-}
-
-static void
-_outVar(StringInfo str, Var *node)
-{
-	WRITE_NODE_TYPE("VAR");
-
-	if (print_variable_fields)
-	{
-		WRITE_UINT_FIELD(varno);
-	}
-	WRITE_INT_FIELD(varattno);
-	WRITE_OID_FIELD(vartype);
-	WRITE_INT_FIELD(vartypmod);
-	WRITE_UINT_FIELD(varlevelsup);
-	if (print_variable_fields)
-	{
-		WRITE_UINT_FIELD(varnoold);
-	}
-	WRITE_INT_FIELD(varoattno);
-}
 
 static void
 _outConst(StringInfo str, Const *node)
@@ -1083,16 +526,6 @@ _outConst(StringInfo str, Const *node)
 
 	if (!node->constisnull)
 		_outDatum(str, node->constvalue, node->constlen, node->constbyval);
-}
-
-static void
-_outParam(StringInfo str, Param *node)
-{
-	WRITE_NODE_TYPE("PARAM");
-
-	WRITE_ENUM_FIELD(paramkind, ParamKind);
-	WRITE_INT_FIELD(paramid);
-	WRITE_OID_FIELD(paramtype);
 }
 
 static void
@@ -1113,46 +546,6 @@ _outAggref(StringInfo str, Aggref *node)
 }
 
 static void
-_outAggOrder(StringInfo str, AggOrder *node)
-{
-	WRITE_NODE_TYPE("AGGORDER");
-
-    WRITE_BOOL_FIELD(sortImplicit);
-    WRITE_NODE_FIELD(sortTargets);
-    WRITE_NODE_FIELD(sortClause);
-}
-
-static void
-_outWindowRef(StringInfo str, WindowRef *node)
-{
-	WRITE_NODE_TYPE("WINDOWREF");
-
-	WRITE_OID_FIELD(winfnoid);
-	WRITE_OID_FIELD(restype);
-	WRITE_NODE_FIELD(args);
-	WRITE_UINT_FIELD(winlevelsup);
-	WRITE_BOOL_FIELD(windistinct);
-	WRITE_UINT_FIELD(winspec);
-	WRITE_UINT_FIELD(winindex);
-	WRITE_ENUM_FIELD(winstage, WinStage);
-	WRITE_UINT_FIELD(winlevel);
-}
-
-	static void
-_outArrayRef(StringInfo str, ArrayRef *node)
-{
-	WRITE_NODE_TYPE("ARRAYREF");
-
-	WRITE_OID_FIELD(refrestype);
-	WRITE_OID_FIELD(refarraytype);
-	WRITE_OID_FIELD(refelemtype);
-	WRITE_NODE_FIELD(refupperindexpr);
-	WRITE_NODE_FIELD(reflowerindexpr);
-	WRITE_NODE_FIELD(refexpr);
-	WRITE_NODE_FIELD(refassgnexpr);
-}
-
-static void
 _outFuncExpr(StringInfo str, FuncExpr *node)
 {
 	WRITE_NODE_TYPE("FUNCEXPR");
@@ -1166,45 +559,8 @@ _outFuncExpr(StringInfo str, FuncExpr *node)
 }
 
 static void
-_outOpExpr(StringInfo str, OpExpr *node)
-{
-	WRITE_NODE_TYPE("OPEXPR");
-
-	WRITE_OID_FIELD(opno);
-	WRITE_OID_FIELD(opfuncid);
-	WRITE_OID_FIELD(opresulttype);
-	WRITE_BOOL_FIELD(opretset);
-	WRITE_NODE_FIELD(args);
-}
-
-static void
-_outDistinctExpr(StringInfo str, DistinctExpr *node)
-{
-	WRITE_NODE_TYPE("DISTINCTEXPR");
-
-	WRITE_OID_FIELD(opno);
-	WRITE_OID_FIELD(opfuncid);
-	WRITE_OID_FIELD(opresulttype);
-	WRITE_BOOL_FIELD(opretset);
-	WRITE_NODE_FIELD(args);
-}
-
-static void
-_outScalarArrayOpExpr(StringInfo str, ScalarArrayOpExpr *node)
-{
-	WRITE_NODE_TYPE("SCALARARRAYOPEXPR");
-
-	WRITE_OID_FIELD(opno);
-	WRITE_OID_FIELD(opfuncid);
-	WRITE_BOOL_FIELD(useOr);
-	WRITE_NODE_FIELD(args);
-}
-
-static void
 _outBoolExpr(StringInfo str, BoolExpr *node)
 {
-
-
 	WRITE_NODE_TYPE("BOOLEXPR");
 	WRITE_ENUM_FIELD(boolop, BoolExprType);
 
@@ -1224,211 +580,6 @@ _outSubLink(StringInfo str, SubLink *node)
 }
 
 static void
-_outSubPlan(StringInfo str, SubPlan *node)
-{
-	WRITE_NODE_TYPE("SUBPLAN");
-
-    WRITE_INT_FIELD(qDispSliceId);  /*CDB*/
-	WRITE_ENUM_FIELD(subLinkType, SubLinkType);
-	WRITE_NODE_FIELD(testexpr);
-	WRITE_NODE_FIELD(paramIds);
-	WRITE_INT_FIELD(plan_id);
-	WRITE_OID_FIELD(firstColType);
-	WRITE_INT_FIELD(firstColTypmod);
-	WRITE_BOOL_FIELD(useHashTable);
-	WRITE_BOOL_FIELD(unknownEqFalse);
-	WRITE_BOOL_FIELD(is_initplan); /*CDB*/
-	WRITE_BOOL_FIELD(is_multirow); /*CDB*/
-	WRITE_NODE_FIELD(setParam);
-	WRITE_NODE_FIELD(parParam);
-	WRITE_NODE_FIELD(args);
-	WRITE_NODE_FIELD(extParam);
-}
-
-static void
-_outFieldSelect(StringInfo str, FieldSelect *node)
-{
-	WRITE_NODE_TYPE("FIELDSELECT");
-
-	WRITE_NODE_FIELD(arg);
-	WRITE_INT_FIELD(fieldnum);
-	WRITE_OID_FIELD(resulttype);
-	WRITE_INT_FIELD(resulttypmod);
-}
-
-static void
-_outFieldStore(StringInfo str, FieldStore *node)
-{
-	WRITE_NODE_TYPE("FIELDSTORE");
-
-	WRITE_NODE_FIELD(arg);
-	WRITE_NODE_FIELD(newvals);
-	WRITE_NODE_FIELD(fieldnums);
-	WRITE_OID_FIELD(resulttype);
-}
-
-static void
-_outRelabelType(StringInfo str, RelabelType *node)
-{
-	WRITE_NODE_TYPE("RELABELTYPE");
-
-	WRITE_NODE_FIELD(arg);
-	WRITE_OID_FIELD(resulttype);
-	WRITE_INT_FIELD(resulttypmod);
-	WRITE_ENUM_FIELD(relabelformat, CoercionForm);
-}
-
-static void
-_outConvertRowtypeExpr(StringInfo str, ConvertRowtypeExpr *node)
-{
-	WRITE_NODE_TYPE("CONVERTROWTYPEEXPR");
-
-	WRITE_NODE_FIELD(arg);
-	WRITE_OID_FIELD(resulttype);
-	WRITE_ENUM_FIELD(convertformat, CoercionForm);
-}
-
-static void
-_outCaseExpr(StringInfo str, CaseExpr *node)
-{
-	WRITE_NODE_TYPE("CASE");
-
-	WRITE_OID_FIELD(casetype);
-	WRITE_NODE_FIELD(arg);
-	WRITE_NODE_FIELD(args);
-	WRITE_NODE_FIELD(defresult);
-}
-
-static void
-_outCaseWhen(StringInfo str, CaseWhen *node)
-{
-	WRITE_NODE_TYPE("WHEN");
-
-	WRITE_NODE_FIELD(expr);
-	WRITE_NODE_FIELD(result);
-}
-
-static void
-_outCaseTestExpr(StringInfo str, CaseTestExpr *node)
-{
-	WRITE_NODE_TYPE("CASETESTEXPR");
-
-	WRITE_OID_FIELD(typeId);
-	WRITE_INT_FIELD(typeMod);
-}
-
-static void
-_outArrayExpr(StringInfo str, ArrayExpr *node)
-{
-	WRITE_NODE_TYPE("ARRAY");
-
-	WRITE_OID_FIELD(array_typeid);
-	WRITE_OID_FIELD(element_typeid);
-	WRITE_NODE_FIELD(elements);
-	WRITE_BOOL_FIELD(multidims);
-}
-
-static void
-_outRowExpr(StringInfo str, RowExpr *node)
-{
-	WRITE_NODE_TYPE("ROW");
-
-	WRITE_NODE_FIELD(args);
-	WRITE_OID_FIELD(row_typeid);
-	WRITE_ENUM_FIELD(row_format, CoercionForm);
-}
-
-static void
-_outRowCompareExpr(StringInfo str, RowCompareExpr *node)
-{
-	WRITE_NODE_TYPE("ROWCOMPARE");
-
-	WRITE_ENUM_FIELD(rctype, RowCompareType);
-	WRITE_NODE_FIELD(opnos);
-	WRITE_NODE_FIELD(opclasses);
-	WRITE_NODE_FIELD(largs);
-	WRITE_NODE_FIELD(rargs);
-}
-
-static void
-_outCoalesceExpr(StringInfo str, CoalesceExpr *node)
-{
-	WRITE_NODE_TYPE("COALESCE");
-
-	WRITE_OID_FIELD(coalescetype);
-	WRITE_NODE_FIELD(args);
-}
-
-static void
-_outMinMaxExpr(StringInfo str, MinMaxExpr *node)
-{
-	WRITE_NODE_TYPE("MINMAX");
-
-	WRITE_OID_FIELD(minmaxtype);
-	WRITE_ENUM_FIELD(op, MinMaxOp);
-	WRITE_NODE_FIELD(args);
-}
-
-static void
-_outNullIfExpr(StringInfo str, NullIfExpr *node)
-{
-	WRITE_NODE_TYPE("NULLIFEXPR");
-
-	WRITE_OID_FIELD(opno);
-	WRITE_OID_FIELD(opfuncid);
-	WRITE_OID_FIELD(opresulttype);
-	WRITE_BOOL_FIELD(opretset);
-	WRITE_NODE_FIELD(args);
-}
-
-static void
-_outNullTest(StringInfo str, NullTest *node)
-{
-	WRITE_NODE_TYPE("NULLTEST");
-
-	WRITE_NODE_FIELD(arg);
-	WRITE_ENUM_FIELD(nulltesttype, NullTestType);
-}
-
-static void
-_outBooleanTest(StringInfo str, BooleanTest *node)
-{
-	WRITE_NODE_TYPE("BOOLEANTEST");
-
-	WRITE_NODE_FIELD(arg);
-	WRITE_ENUM_FIELD(booltesttype, BoolTestType);
-}
-
-static void
-_outCoerceToDomain(StringInfo str, CoerceToDomain *node)
-{
-	WRITE_NODE_TYPE("COERCETODOMAIN");
-
-	WRITE_NODE_FIELD(arg);
-	WRITE_OID_FIELD(resulttype);
-	WRITE_INT_FIELD(resulttypmod);
-	WRITE_ENUM_FIELD(coercionformat, CoercionForm);
-}
-
-static void
-_outCoerceToDomainValue(StringInfo str, CoerceToDomainValue *node)
-{
-	WRITE_NODE_TYPE("COERCETODOMAINVALUE");
-
-	WRITE_OID_FIELD(typeId);
-	WRITE_INT_FIELD(typeMod);
-}
-
-static void
-_outSetToDefault(StringInfo str, SetToDefault *node)
-{
-	WRITE_NODE_TYPE("SETTODEFAULT");
-
-	WRITE_OID_FIELD(typeId);
-	WRITE_INT_FIELD(typeMod);
-}
-
-static void
 _outCurrentOfExpr(StringInfo str, CurrentOfExpr *node)
 {
 	WRITE_NODE_TYPE("CURRENTOFEXPR");
@@ -1437,30 +588,8 @@ _outCurrentOfExpr(StringInfo str, CurrentOfExpr *node)
 	WRITE_UINT_FIELD(cvarno);
 	WRITE_OID_FIELD(target_relid);
 	WRITE_INT_FIELD(gp_segment_id);
-	WRITE_BINARY_FIELD(ctid, sizeof(ItemPointerData));	
+	WRITE_BINARY_FIELD(ctid, sizeof(ItemPointerData));
 	WRITE_OID_FIELD(tableoid);
-}
-
-static void
-_outTargetEntry(StringInfo str, TargetEntry *node)
-{
-	WRITE_NODE_TYPE("TARGETENTRY");
-
-	WRITE_NODE_FIELD(expr);
-	WRITE_INT_FIELD(resno);
-	WRITE_STRING_FIELD(resname);
-	WRITE_UINT_FIELD(ressortgroupref);
-	WRITE_OID_FIELD(resorigtbl);
-	WRITE_INT_FIELD(resorigcol);
-	WRITE_BOOL_FIELD(resjunk);
-}
-
-static void
-_outRangeTblRef(StringInfo str, RangeTblRef *node)
-{
-	WRITE_NODE_TYPE("RANGETBLREF");
-
-	WRITE_INT_FIELD(rtindex);
 }
 
 static void
@@ -1476,15 +605,6 @@ _outJoinExpr(StringInfo str, JoinExpr *node)
 	WRITE_NODE_FIELD(quals);
 	WRITE_NODE_FIELD(alias);
 	WRITE_INT_FIELD(rtindex);
-}
-
-static void
-_outFromExpr(StringInfo str, FromExpr *node)
-{
-	WRITE_NODE_TYPE("FROMEXPR");
-
-	WRITE_NODE_FIELD(fromlist);
-	WRITE_NODE_FIELD(quals);
 }
 
 static void
@@ -1512,313 +632,13 @@ _outFlow(StringInfo str, Flow *node)
 
 /*****************************************************************************
  *
- *	Stuff from cdbpathlocus.h.
- *
- *****************************************************************************/
-
-/*
- * _outCdbPathLocus
- */
-static void
-_outCdbPathLocus(StringInfo str, CdbPathLocus *node)
-{
-    WRITE_ENUM_FIELD(locustype, CdbLocusType);
-    WRITE_NODE_FIELD(partkey);
-}                               /* _outCdbPathLocus */
-
-
-/*****************************************************************************
- *
  *	Stuff from relation.h.
  *
  *****************************************************************************/
 
-/*
- * print the basic stuff of all nodes that inherit from Path
- *
- * Note we do NOT print the parent, else we'd be in infinite recursion
- */
-static void
-_outPathInfo(StringInfo str, Path *node)
-{
-	WRITE_ENUM_FIELD(pathtype, NodeTag);
-	WRITE_FLOAT_FIELD(startup_cost, "%.2f");
-	WRITE_FLOAT_FIELD(total_cost, "%.2f");
-    WRITE_NODE_FIELD(parent);
-    _outCdbPathLocus(str, &node->locus);
-	WRITE_NODE_FIELD(pathkeys);
-}
-
-/*
- * print the basic stuff of all nodes that inherit from JoinPath
- */
-static void
-_outJoinPathInfo(StringInfo str, JoinPath *node)
-{
-	_outPathInfo(str, (Path *) node);
-
-	WRITE_ENUM_FIELD(jointype, JoinType);
-	WRITE_NODE_FIELD(outerjoinpath);
-	WRITE_NODE_FIELD(innerjoinpath);
-	WRITE_NODE_FIELD(joinrestrictinfo);
-}
-
-static void
-_outPath(StringInfo str, Path *node)
-{
-	WRITE_NODE_TYPE("PATH");
-
-	_outPathInfo(str, (Path *) node);
-}
-
-static void
-_outIndexPath(StringInfo str, IndexPath *node)
-{
-	WRITE_NODE_TYPE("INDEXPATH");
-
-	_outPathInfo(str, (Path *) node);
-
-	WRITE_NODE_FIELD(indexinfo);
-	WRITE_NODE_FIELD(indexclauses);
-	WRITE_NODE_FIELD(indexquals);
-	WRITE_BOOL_FIELD(isjoininner);
-	WRITE_ENUM_FIELD(indexscandir, ScanDirection);
-	WRITE_FLOAT_FIELD(indextotalcost, "%.2f");
-	WRITE_FLOAT_FIELD(indexselectivity, "%.4f");
-	WRITE_FLOAT_FIELD(rows, "%.0f");
-    WRITE_INT_FIELD(num_leading_eq);
-}
-
-static void
-_outBitmapHeapPath(StringInfo str, BitmapHeapPath *node)
-{
-	WRITE_NODE_TYPE("BITMAPHEAPPATH");
-
-	_outPathInfo(str, (Path *) node);
-
-	WRITE_NODE_FIELD(bitmapqual);
-	WRITE_BOOL_FIELD(isjoininner);
-	WRITE_FLOAT_FIELD(rows, "%.0f");
-}
-
-static void
-_outBitmapAppendOnlyPath(StringInfo str, BitmapAppendOnlyPath *node)
-{
-	WRITE_NODE_TYPE("BITMAPAPPENDONLYPATH");
-
-	_outPathInfo(str, (Path *) node);
-
-	WRITE_NODE_FIELD(bitmapqual);
-	WRITE_BOOL_FIELD(isjoininner);
-	WRITE_FLOAT_FIELD(rows, "%.0f");
-	WRITE_BOOL_FIELD(isAORow);
-}
-
-static void
-_outBitmapAndPath(StringInfo str, BitmapAndPath *node)
-{
-	WRITE_NODE_TYPE("BITMAPANDPATH");
-
-	_outPathInfo(str, (Path *) node);
-
-	WRITE_NODE_FIELD(bitmapquals);
-	WRITE_FLOAT_FIELD(bitmapselectivity, "%.4f");
-}
-
-static void
-_outBitmapOrPath(StringInfo str, BitmapOrPath *node)
-{
-	WRITE_NODE_TYPE("BITMAPORPATH");
-
-	_outPathInfo(str, (Path *) node);
-
-	WRITE_NODE_FIELD(bitmapquals);
-	WRITE_FLOAT_FIELD(bitmapselectivity, "%.4f");
-}
-
-static void
-_outTidPath(StringInfo str, TidPath *node)
-{
-	WRITE_NODE_TYPE("TIDPATH");
-
-	_outPathInfo(str, (Path *) node);
-
-	WRITE_NODE_FIELD(tidquals);
-}
-
-static void
-_outAppendPath(StringInfo str, AppendPath *node)
-{
-	WRITE_NODE_TYPE("APPENDPATH");
-
-	_outPathInfo(str, (Path *) node);
-
-	WRITE_NODE_FIELD(subpaths);
-}
-
-static void
-_outAppendOnlyPath(StringInfo str, AppendOnlyPath *node)
-{
-	WRITE_NODE_TYPE("APPENDONLYPATH");
-
-	_outPathInfo(str, (Path *) node);
-}
-
-static void
-_outAOCSPath(StringInfo str, AOCSPath *node)
-{
-	WRITE_NODE_TYPE("AOCSPATH");
-
-	_outPathInfo(str, (Path *) node);
-}
-static void
-_outResultPath(StringInfo str, ResultPath *node)
-{
-	WRITE_NODE_TYPE("RESULTPATH");
-
-	_outPathInfo(str, (Path *) node);
-
-	WRITE_NODE_FIELD(quals);
-}
-
-static void
-_outMaterialPath(StringInfo str, MaterialPath *node)
-{
-	WRITE_NODE_TYPE("MATERIALPATH");
-
-	_outPathInfo(str, (Path *) node);
-    WRITE_BOOL_FIELD(cdb_strict);
-
-	WRITE_NODE_FIELD(subpath);
-}
-
-static void
-_outUniquePath(StringInfo str, UniquePath *node)
-{
-	WRITE_NODE_TYPE("UNIQUEPATH");
-
-	_outPathInfo(str, (Path *) node);
-	WRITE_ENUM_FIELD(umethod, UniquePathMethod);
-	WRITE_FLOAT_FIELD(rows, "%.0f");
-    WRITE_BOOL_FIELD(must_repartition);                 /*CDB*/
-    WRITE_BITMAPSET_FIELD(distinct_on_rowid_relids);    /*CDB*/
-	WRITE_NODE_FIELD(distinct_on_exprs);                /*CDB*/
-
-	WRITE_NODE_FIELD(subpath);
-}
-
-static void
-_outNestPath(StringInfo str, NestPath *node)
-{
-	WRITE_NODE_TYPE("NESTPATH");
-
-	_outJoinPathInfo(str, (JoinPath *) node);
-}
-
-static void
-_outMergePath(StringInfo str, MergePath *node)
-{
-	WRITE_NODE_TYPE("MERGEPATH");
-
-	_outJoinPathInfo(str, (JoinPath *) node);
-
-	WRITE_NODE_FIELD(path_mergeclauses);
-	WRITE_NODE_FIELD(outersortkeys);
-	WRITE_NODE_FIELD(innersortkeys);
-}
-
-static void
-_outHashPath(StringInfo str, HashPath *node)
-{
-	WRITE_NODE_TYPE("HASHPATH");
-
-	_outJoinPathInfo(str, (JoinPath *) node);
-
-	WRITE_NODE_FIELD(path_hashclauses);
-}
-
-static void
-_outCdbMotionPath(StringInfo str, CdbMotionPath *node)
-{
-    WRITE_NODE_TYPE("MOTIONPATH");
-
-    _outPathInfo(str, &node->path);
-
-    WRITE_NODE_FIELD(subpath);
-}
-
-static void
-_outPlannerInfo(StringInfo str, PlannerInfo *node)
-{
-	WRITE_NODE_TYPE("PLANNERINFO");
-
-	/* NB: this isn't a complete set of fields */
-	WRITE_NODE_FIELD(parse);
-	WRITE_NODE_FIELD(join_rel_list);
-	WRITE_NODE_FIELD(equi_key_list);
-	WRITE_NODE_FIELD(left_join_clauses);
-	WRITE_NODE_FIELD(right_join_clauses);
-	WRITE_NODE_FIELD(full_join_clauses);
-	WRITE_NODE_FIELD(oj_info_list);
-	WRITE_NODE_FIELD(in_info_list);
-	WRITE_NODE_FIELD(append_rel_list);
-	WRITE_NODE_FIELD(query_pathkeys);
-	WRITE_NODE_FIELD(group_pathkeys);
-	WRITE_NODE_FIELD(sort_pathkeys);
-	WRITE_FLOAT_FIELD(total_table_pages, "%.0f");
-	WRITE_FLOAT_FIELD(tuple_fraction, "%.4f");
-	WRITE_BOOL_FIELD(hasJoinRTEs);
-	WRITE_BOOL_FIELD(hasOuterJoins);
-	WRITE_BOOL_FIELD(hasHavingQual);
-	WRITE_BOOL_FIELD(hasPseudoConstantQuals);
-}
-
-static void
-_outRelOptInfo(StringInfo str, RelOptInfo *node)
-{
-	WRITE_NODE_TYPE("RELOPTINFO");
-
-	/* NB: this isn't a complete set of fields */
-	WRITE_ENUM_FIELD(reloptkind, RelOptKind);
-	WRITE_BITMAPSET_FIELD(relids);
-	WRITE_FLOAT_FIELD(rows, "%.0f");
-	WRITE_INT_FIELD(width);
-	WRITE_NODE_FIELD(reltargetlist);
-	/* Skip writing Path ptrs to avoid endless recursion */
-	/* WRITE_NODE_FIELD(pathlist); */
-	/* WRITE_NODE_FIELD(cheapest_startup_path); */
-	/* WRITE_NODE_FIELD(cheapest_total_path); */
-
-	WRITE_NODE_FIELD(dedup_info);
-	WRITE_UINT_FIELD(relid);
-	WRITE_ENUM_FIELD(rtekind, RTEKind);
-	WRITE_INT_FIELD(min_attr);
-	WRITE_INT_FIELD(max_attr);
-	WRITE_NODE_FIELD(indexlist);
-	WRITE_UINT_FIELD(pages);
-	WRITE_FLOAT_FIELD(tuples, "%.0f");
-	WRITE_NODE_FIELD(subplan);
-	WRITE_NODE_FIELD(locationlist);
-	WRITE_STRING_FIELD(execcommand);
-	WRITE_CHAR_FIELD(fmttype);
-	WRITE_STRING_FIELD(fmtopts);
-	WRITE_INT_FIELD(rejectlimit);
-	WRITE_CHAR_FIELD(rejectlimittype);
-	WRITE_OID_FIELD(fmterrtbl);
-	WRITE_INT_FIELD(ext_encoding);
-	WRITE_BOOL_FIELD(isrescannable);
-	WRITE_BOOL_FIELD(writable);
-	WRITE_NODE_FIELD(baserestrictinfo);
-	WRITE_NODE_FIELD(joininfo);
-	WRITE_BITMAPSET_FIELD(index_outer_relids);
-	/* Skip writing Path ptrs to avoid endless recursion */
-	/* WRITE_NODE_FIELD(index_inner_paths); */
-}
-
 static void
 _outIndexOptInfo(StringInfo str, IndexOptInfo *node)
 {
-
 	WRITE_NODE_TYPE("INDEXOPTINFO");
 
 	/* NB: this isn't a complete set of fields */
@@ -1844,65 +664,6 @@ _outIndexOptInfo(StringInfo str, IndexOptInfo *node)
 }
 
 static void
-_outCdbRelDedupInfo(StringInfo str, CdbRelDedupInfo *node)
-{
-	WRITE_NODE_TYPE("CdbRelDedupInfo");
-
-	WRITE_BITMAPSET_FIELD(prejoin_dedup_subqrelids);
-	WRITE_BITMAPSET_FIELD(spent_subqrelids);
-	WRITE_BOOL_FIELD(try_postjoin_dedup);
-	WRITE_BOOL_FIELD(no_more_subqueries);
-	WRITE_NODE_FIELD(join_unique_ininfo);
-	/* Skip writing Path ptrs to avoid endless recursion */
-	/* WRITE_NODE_FIELD(later_dedup_pathlist);  */
-	/* WRITE_NODE_FIELD(cheapest_startup_path); */
-	/* WRITE_NODE_FIELD(cheapest_total_path);   */
-}
-
-static void
-_outPathKeyItem(StringInfo str, PathKeyItem *node)
-{
-	WRITE_NODE_TYPE("PATHKEYITEM");
-
-	WRITE_NODE_FIELD(key);
-	WRITE_OID_FIELD(sortop);
-}
-
-static void
-_outRestrictInfo(StringInfo str, RestrictInfo *node)
-{
-	WRITE_NODE_TYPE("RESTRICTINFO");
-
-	/* NB: this isn't a complete set of fields */
-	WRITE_NODE_FIELD(clause);
-	WRITE_BOOL_FIELD(is_pushed_down);
-	WRITE_BOOL_FIELD(outerjoin_delayed);
-	WRITE_BOOL_FIELD(can_join);
-	WRITE_BOOL_FIELD(pseudoconstant);
-	WRITE_BITMAPSET_FIELD(clause_relids);
-	WRITE_BITMAPSET_FIELD(required_relids);
-	WRITE_BITMAPSET_FIELD(left_relids);
-	WRITE_BITMAPSET_FIELD(right_relids);
-	WRITE_NODE_FIELD(orclause);
-	WRITE_OID_FIELD(mergejoinoperator);
-	WRITE_OID_FIELD(left_sortop);
-	WRITE_OID_FIELD(right_sortop);
-	WRITE_NODE_FIELD(left_pathkey);
-	WRITE_NODE_FIELD(right_pathkey);
-	WRITE_OID_FIELD(hashjoinoperator);
-}
-
-static void
-_outInnerIndexscanInfo(StringInfo str, InnerIndexscanInfo *node)
-{
-	WRITE_NODE_TYPE("INNERINDEXSCANINFO");
-	WRITE_BITMAPSET_FIELD(other_relids);
-	WRITE_BOOL_FIELD(isouterjoin);
-	WRITE_NODE_FIELD(cheapest_startup_innerpath);
-	WRITE_NODE_FIELD(cheapest_total_innerpath);
-}
-
-static void
 _outOuterJoinInfo(StringInfo str, OuterJoinInfo *node)
 {
 	WRITE_NODE_TYPE("OUTERJOININFO");
@@ -1911,30 +672,6 @@ _outOuterJoinInfo(StringInfo str, OuterJoinInfo *node)
 	WRITE_BITMAPSET_FIELD(min_righthand);
 	WRITE_ENUM_FIELD(join_type, JoinType);
 	WRITE_BOOL_FIELD(lhs_strict);
-}
-
-static void
-_outInClauseInfo(StringInfo str, InClauseInfo *node)
-{
-	WRITE_NODE_TYPE("INCLAUSEINFO");
-
-	WRITE_BITMAPSET_FIELD(righthand);
-    WRITE_BOOL_FIELD(try_join_unique);                  /*CDB*/
-	WRITE_NODE_FIELD(sub_targetlist);
-}
-
-static void
-_outAppendRelInfo(StringInfo str, AppendRelInfo *node)
-{
-	WRITE_NODE_TYPE("APPENDRELINFO");
-
-	WRITE_UINT_FIELD(parent_relid);
-	WRITE_UINT_FIELD(child_relid);
-	WRITE_OID_FIELD(parent_reltype);
-	WRITE_OID_FIELD(child_reltype);
-	WRITE_NODE_FIELD(col_mappings);
-	WRITE_NODE_FIELD(translated_vars);
-	WRITE_OID_FIELD(parent_reloid);
 }
 
 /*****************************************************************************
@@ -1987,31 +724,6 @@ _outCreateStmt(StringInfo str, CreateStmt *node)
 }
 
 static void
-_outColumnReferenceStorageDirective(StringInfo str, ColumnReferenceStorageDirective *node)
-{
-	WRITE_NODE_TYPE("COLUMNREFERENCESTORAGEDIRECTIVE");
-	
-	WRITE_NODE_FIELD(column);
-	WRITE_BOOL_FIELD(deflt);
-	WRITE_NODE_FIELD(encoding);
-}
-
-static void
-_outPartitionBy(StringInfo str, PartitionBy *node)
-{
-	WRITE_NODE_TYPE("PARTITIONBY");
-	WRITE_ENUM_FIELD(partType, PartitionByType);
-	WRITE_NODE_FIELD(keys);
-	WRITE_NODE_FIELD(keyopclass);
-	WRITE_NODE_FIELD(partNum);
-	WRITE_NODE_FIELD(subPart);
-	WRITE_NODE_FIELD(partSpec);
-	WRITE_INT_FIELD(partDepth);
-	WRITE_INT_FIELD(partQuiet);
-	WRITE_INT_FIELD(location);
-}
-
-static void
 _outPartitionSpec(StringInfo str, PartitionSpec *node)
 {
 	WRITE_NODE_TYPE("PARTITIONSPEC");
@@ -2023,44 +735,12 @@ _outPartitionSpec(StringInfo str, PartitionSpec *node)
 }
 
 static void
-_outPartitionElem(StringInfo str, PartitionElem *node)
-{
-	WRITE_NODE_TYPE("PARTITIONELEM");
-	WRITE_NODE_FIELD(partName);
-	WRITE_NODE_FIELD(boundSpec);
-	WRITE_NODE_FIELD(subSpec);
-	WRITE_BOOL_FIELD(isDefault);
-	WRITE_NODE_FIELD(storeAttr);
-	WRITE_INT_FIELD(partno);
-	WRITE_LONG_FIELD(rrand);
-	WRITE_NODE_FIELD(colencs);
-	WRITE_INT_FIELD(location);
-}
-
-static void
-_outPartitionRangeItem(StringInfo str, PartitionRangeItem *node)
-{
-	WRITE_NODE_TYPE("PARTITIONRANGEITEM");
-	WRITE_NODE_FIELD(partRangeVal);
-	WRITE_ENUM_FIELD(partedge, PartitionEdgeBounding);
-	WRITE_INT_FIELD(location);
-}
-
-static void
 _outPartitionBoundSpec(StringInfo str, PartitionBoundSpec *node)
 {
 	WRITE_NODE_TYPE("PARTITIONBOUNDSPEC");
 	WRITE_NODE_FIELD(partStart);
 	WRITE_NODE_FIELD(partEnd);
 	WRITE_NODE_FIELD(partEvery);
-	WRITE_INT_FIELD(location);
-}
-
-static void
-_outPartitionValuesSpec(StringInfo str, PartitionValuesSpec *node)
-{
-	WRITE_NODE_TYPE("PARTITIONVALUESSPEC");
-	WRITE_NODE_FIELD(partValues);
 	WRITE_INT_FIELD(location);
 }
 
@@ -2103,262 +783,6 @@ _outPartitionRule(StringInfo str, PartitionRule *node)
 }
 
 static void
-_outPartitionNode(StringInfo str, PartitionNode *node)
-{
-	WRITE_NODE_TYPE("PARTITIONNODE");
-
-	WRITE_NODE_FIELD(part);
-	WRITE_NODE_FIELD(default_part);
-	WRITE_NODE_FIELD(rules);
-}
-
-static void
-_outPgPartRule(StringInfo str, PgPartRule *node)
-{
-	WRITE_NODE_TYPE("PGPARTRULE");
-
-	WRITE_NODE_FIELD(pNode);
-	WRITE_NODE_FIELD(topRule);
-	WRITE_STRING_FIELD(partIdStr);
-	WRITE_BOOL_FIELD(isName);
-	WRITE_INT_FIELD(topRuleRank);
-	WRITE_STRING_FIELD(relname);
-}
-
-static void
-_outSegfileMapNode(StringInfo str, SegfileMapNode *node)
-{
-	WRITE_NODE_TYPE("SEGFILEMAPNODE");
-
-	WRITE_OID_FIELD(relid);
-	WRITE_INT_FIELD(segno);
-}
-
-static void
-_outExtTableTypeDesc(StringInfo str, ExtTableTypeDesc *node)
-{
-	WRITE_NODE_TYPE("EXTTABLETYPEDESC");
-
-	WRITE_ENUM_FIELD(exttabletype, ExtTableType);
-	WRITE_NODE_FIELD(location_list);
-	WRITE_NODE_FIELD(on_clause);
-	WRITE_STRING_FIELD(command_string);
-}
-
-static void
-_outCreateExternalStmt(StringInfo str, CreateExternalStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEEXTERNALSTMT");
-
-	WRITE_NODE_FIELD(relation);
-	WRITE_NODE_FIELD(tableElts);
-	WRITE_NODE_FIELD(exttypedesc);
-	WRITE_STRING_FIELD(format);
-	WRITE_NODE_FIELD(formatOpts);
-	WRITE_BOOL_FIELD(isweb);
-	WRITE_BOOL_FIELD(iswritable);
-	WRITE_NODE_FIELD(sreh);
-	WRITE_NODE_FIELD(encoding);
-	WRITE_NODE_FIELD(distributedBy);
-
-}
-
-static void
-_outCreateForeignStmt(StringInfo str, CreateForeignStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEFOREIGNSTMT");
-
-	WRITE_NODE_FIELD(relation);
-	WRITE_NODE_FIELD(tableElts);
-	WRITE_STRING_FIELD(srvname);
-	WRITE_NODE_FIELD(options);
-}
-
-static void
-_outIndexStmt(StringInfo str, IndexStmt *node)
-{
-	WRITE_NODE_TYPE("INDEXSTMT");
-
-	WRITE_STRING_FIELD(idxname);
-	WRITE_NODE_FIELD(relation);
-	WRITE_STRING_FIELD(accessMethod);
-	WRITE_STRING_FIELD(tableSpace);
-	WRITE_NODE_FIELD(indexParams);
-	WRITE_NODE_FIELD(options);
-
-	WRITE_NODE_FIELD(whereClause);
-	WRITE_NODE_FIELD(rangetable);
-	WRITE_BOOL_FIELD(is_part_child);
-	WRITE_BOOL_FIELD(unique);
-	WRITE_BOOL_FIELD(primary);
-	WRITE_BOOL_FIELD(isconstraint);
-	WRITE_STRING_FIELD(altconname);
-	WRITE_OID_FIELD(constrOid);
-	WRITE_BOOL_FIELD(concurrent);
-	WRITE_NODE_FIELD(idxOids);
-}
-
-static void
-_outReindexStmt(StringInfo str, ReindexStmt *node)
-{
-	WRITE_NODE_TYPE("REINDEXSTMT");
-
-	WRITE_ENUM_FIELD(kind,ObjectType);
-	WRITE_NODE_FIELD(relation);
-	WRITE_STRING_FIELD(name);
-	WRITE_BOOL_FIELD(do_system);
-	WRITE_BOOL_FIELD(do_user);
-	WRITE_NODE_FIELD(new_ind_oids);
-	WRITE_OID_FIELD(relid);
-}
-
-
-static void
-_outViewStmt(StringInfo str, ViewStmt *node)
-{
-	WRITE_NODE_TYPE("VIEWSTMT");
-
-	WRITE_NODE_FIELD(view);
-	WRITE_NODE_FIELD(aliases);
-	WRITE_NODE_FIELD(query);
-	WRITE_BOOL_FIELD(replace);
-	WRITE_OID_FIELD(relOid);
-	WRITE_OID_FIELD(comptypeOid);
-	WRITE_OID_FIELD(rewriteOid);
-}
-
-static void
-_outRuleStmt(StringInfo str, RuleStmt *node)
-{
-	WRITE_NODE_TYPE("RULESTMT");
-
-	WRITE_NODE_FIELD(relation);
-	WRITE_STRING_FIELD(rulename);
-	WRITE_NODE_FIELD(whereClause);
-	WRITE_ENUM_FIELD(event,CmdType);
-	WRITE_BOOL_FIELD(instead);
-	WRITE_NODE_FIELD(actions);
-	WRITE_BOOL_FIELD(replace);
-	WRITE_OID_FIELD(ruleOid);
-}
-
-static void
-_outDropStmt(StringInfo str, DropStmt *node)
-{
-	WRITE_NODE_TYPE("DROPSTMT");
-
-	WRITE_NODE_FIELD(objects);
-	WRITE_ENUM_FIELD(removeType, ObjectType);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-	WRITE_BOOL_FIELD(missing_ok);
-	WRITE_BOOL_FIELD(bAllowPartn);
-
-
-}
-
-static void
-_outDropPropertyStmt(StringInfo str, DropPropertyStmt *node)
-{
-	WRITE_NODE_TYPE("DROPPROPSTMT");
-
-	WRITE_NODE_FIELD(relation);
-	WRITE_STRING_FIELD(property);
-	WRITE_ENUM_FIELD(removeType, ObjectType);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-	WRITE_BOOL_FIELD(missing_ok);
-
-}
-
-static void
-_outDropOwnedStmt(StringInfo str, DropOwnedStmt *node)
-{
-	WRITE_NODE_TYPE("DROPOWNEDSTMT");
-
-	WRITE_NODE_FIELD(roles);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-}
-
-static void
-_outReassignOwnedStmt(StringInfo str, ReassignOwnedStmt *node)
-{
-	WRITE_NODE_TYPE("REASSIGNOWNEDSTMT");
-
-	WRITE_NODE_FIELD(roles);
-	WRITE_STRING_FIELD(newrole)
-
-}
-
-static void
-_outTruncateStmt(StringInfo str, TruncateStmt *node)
-{
-	WRITE_NODE_TYPE("TRUNCATESTMT");
-
-	WRITE_NODE_FIELD(relations);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-	WRITE_NODE_FIELD(relids);
-	WRITE_NODE_FIELD(new_heap_oids);
-	WRITE_NODE_FIELD(new_toast_oids);
-	WRITE_NODE_FIELD(new_aoseg_oids);
-	WRITE_NODE_FIELD(new_aoblkdir_oids);
-	WRITE_NODE_FIELD(new_aovisimap_oids);
-	WRITE_NODE_FIELD(new_ind_oids);
-}
-
-static void
-_outAlterTableStmt(StringInfo str, AlterTableStmt *node)
-{
-	int m;
-	WRITE_NODE_TYPE("ALTERTABLESTMT");
-
-	WRITE_NODE_FIELD(relation);
-	WRITE_NODE_FIELD(cmds);
-	WRITE_ENUM_FIELD(relkind, ObjectType);
-	WRITE_NODE_FIELD(oidmap);
-	WRITE_INT_FIELD(oidInfoCount);
-
-	for (m = 0; m < node->oidInfoCount; m++)
-	{
-		WRITE_OID_FIELD(oidInfo[m].relOid);
-		WRITE_OID_FIELD(oidInfo[m].comptypeOid);
-		WRITE_OID_FIELD(oidInfo[m].toastOid);
-		WRITE_OID_FIELD(oidInfo[m].toastIndexOid);
-		WRITE_OID_FIELD(oidInfo[m].toastComptypeOid);
-		WRITE_OID_FIELD(oidInfo[m].aosegOid);
-		WRITE_OID_FIELD(oidInfo[m].aosegIndexOid);
-		WRITE_OID_FIELD(oidInfo[m].aosegComptypeOid);
-		WRITE_OID_FIELD(oidInfo[m].aovisimapOid);
-		WRITE_OID_FIELD(oidInfo[m].aovisimapIndexOid);
-		WRITE_OID_FIELD(oidInfo[m].aovisimapComptypeOid);
-		WRITE_OID_FIELD(oidInfo[m].aoblkdirOid);
-		WRITE_OID_FIELD(oidInfo[m].aoblkdirIndexOid);
-		WRITE_OID_FIELD(oidInfo[m].aoblkdirComptypeOid);
-	}
-}
-
-static void
-_outAlterTableCmd(StringInfo str, AlterTableCmd *node)
-{
-	WRITE_NODE_TYPE("ALTERTABLECMD");
-
-	WRITE_ENUM_FIELD(subtype, AlterTableType);
-	WRITE_STRING_FIELD(name);
-	WRITE_NODE_FIELD(def);
-	WRITE_NODE_FIELD(transform);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-	WRITE_BOOL_FIELD(part_expanded);
-	WRITE_NODE_FIELD(partoids);
-}
-
-static void
-_outInheritPartitionCmd(StringInfo str, InheritPartitionCmd *node)
-{
-	WRITE_NODE_TYPE("INHERITPARTITION");
-
-	WRITE_NODE_FIELD(parent);
-}
-
-static void
-
 _outAlterPartitionCmd(StringInfo str, AlterPartitionCmd *node)
 {
 	WRITE_NODE_TYPE("ALTERPARTITIONCMD");
@@ -2366,178 +790,7 @@ _outAlterPartitionCmd(StringInfo str, AlterPartitionCmd *node)
 	WRITE_NODE_FIELD(partid);
 	WRITE_NODE_FIELD(arg1);
 	WRITE_NODE_FIELD(arg2);
-	WRITE_LIST_FIELD(newOids);
-}
-
-static void
-_outAlterPartitionId(StringInfo str, AlterPartitionId *node)
-{
-	WRITE_NODE_TYPE("ALTERPARTITIONID");
-
-	WRITE_ENUM_FIELD(idtype, AlterPartitionIdType);
-	WRITE_NODE_FIELD(partiddef);
-}
-
-static void
-_outCreateRoleStmt(StringInfo str, CreateRoleStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEROLESTMT");
-
-	WRITE_ENUM_FIELD(stmt_type, RoleStmtType);
-	WRITE_STRING_FIELD(role);
-	WRITE_NODE_FIELD(options);
-	WRITE_OID_FIELD(roleOid);
-}
-
-static void
-_outDenyLoginInterval(StringInfo str, DenyLoginInterval *node)
-{
-	WRITE_NODE_TYPE("DENYLOGININTERVAL");
-
-	WRITE_NODE_FIELD(start);
-	WRITE_NODE_FIELD(end);
-}
-
-static void
-_outDenyLoginPoint(StringInfo str, DenyLoginPoint *node)
-{
-	WRITE_NODE_TYPE("DENYLOGINPOINT");
-
-	WRITE_NODE_FIELD(day);
-	WRITE_NODE_FIELD(time);
-}
-
-static  void
-_outDropRoleStmt(StringInfo str, DropRoleStmt *node)
-{
-	WRITE_NODE_TYPE("DROPROLESTMT");
-
-	WRITE_NODE_FIELD(roles);
-	WRITE_BOOL_FIELD(missing_ok);
-}
-
-static  void
-_outAlterRoleStmt(StringInfo str, AlterRoleStmt *node)
-{
-	WRITE_NODE_TYPE("ALTERROLESTMT");
-
-	WRITE_STRING_FIELD(role);
-	WRITE_NODE_FIELD(options);
-	WRITE_INT_FIELD(action);
-}
-
-static  void
-_outAlterRoleSetStmt(StringInfo str, AlterRoleSetStmt *node)
-{
-	WRITE_NODE_TYPE("ALTERROLESETSTMT");
-
-	WRITE_STRING_FIELD(role);
-	WRITE_STRING_FIELD(variable);
-	WRITE_NODE_FIELD(value);
-}
-
-
-static  void
-_outAlterOwnerStmt(StringInfo str, AlterOwnerStmt *node)
-{
-	WRITE_NODE_TYPE("ALTEROWNERSTMT");
-
-	WRITE_ENUM_FIELD(objectType,ObjectType);
-	WRITE_NODE_FIELD(relation);
-	WRITE_NODE_FIELD(object);
-	WRITE_NODE_FIELD(objarg);
-	WRITE_STRING_FIELD(addname);
-	WRITE_STRING_FIELD(newowner);
-
-}
-
-
-static void
-_outRenameStmt(StringInfo str, RenameStmt *node)
-{
-	WRITE_NODE_TYPE("RENAMESTMT");
-
-	WRITE_NODE_FIELD(relation);
-	WRITE_OID_FIELD(objid);
-	WRITE_NODE_FIELD(object);
-	WRITE_NODE_FIELD(objarg);
-	WRITE_STRING_FIELD(subname);
-	WRITE_STRING_FIELD(newname);
-	WRITE_ENUM_FIELD(renameType,ObjectType);
-	WRITE_BOOL_FIELD(bAllowPartn);
-
-}
-
-static void
-_outAlterObjectSchemaStmt(StringInfo str, AlterObjectSchemaStmt *node)
-{
-	WRITE_NODE_TYPE("ALTEROBJECTSCHEMASTMT");
-
-	WRITE_NODE_FIELD(relation);
-	WRITE_NODE_FIELD(object);
-	WRITE_NODE_FIELD(objarg);
-	WRITE_STRING_FIELD(addname);
-	WRITE_STRING_FIELD(newschema);
-	WRITE_ENUM_FIELD(objectType,ObjectType);
-}
-
-static void
-_outCreateSeqStmt(StringInfo str, CreateSeqStmt *node)
-{
-	WRITE_NODE_TYPE("CREATESEQSTMT");
-	WRITE_NODE_FIELD(sequence);
-	WRITE_NODE_FIELD(options);
-	WRITE_OID_FIELD(relOid);
-	WRITE_OID_FIELD(comptypeOid);
-}
-
-static void
-_outAlterSeqStmt(StringInfo str, AlterSeqStmt *node)
-{
-	WRITE_NODE_TYPE("ALTERSEQSTMT");
-	WRITE_NODE_FIELD(sequence);
-	WRITE_NODE_FIELD(options);
-}
-
-static void
-_outClusterStmt(StringInfo str, ClusterStmt *node)
-{
-	WRITE_NODE_TYPE("CLUSTERSTMT");
-
-	WRITE_NODE_FIELD(relation);
-	WRITE_STRING_FIELD(indexname);
-	WRITE_OID_FIELD(oidInfo.relOid);
-	WRITE_OID_FIELD(oidInfo.comptypeOid);
-	WRITE_OID_FIELD(oidInfo.toastOid);
-	WRITE_OID_FIELD(oidInfo.toastIndexOid);
-	WRITE_OID_FIELD(oidInfo.toastComptypeOid);
-	WRITE_OID_FIELD(oidInfo.aosegOid);
-	WRITE_OID_FIELD(oidInfo.aosegIndexOid);
-	WRITE_OID_FIELD(oidInfo.aosegComptypeOid);
-	WRITE_OID_FIELD(oidInfo.aovisimapOid);
-	WRITE_OID_FIELD(oidInfo.aovisimapIndexOid);
-	WRITE_OID_FIELD(oidInfo.aovisimapComptypeOid);
-	WRITE_OID_FIELD(oidInfo.aoblkdirOid);
-	WRITE_OID_FIELD(oidInfo.aoblkdirIndexOid);
-	WRITE_OID_FIELD(oidInfo.aoblkdirComptypeOid);
-	WRITE_NODE_FIELD(new_ind_oids);
-}
-
-static void
-_outCreatedbStmt(StringInfo str, CreatedbStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEDBSTMT");
-	WRITE_STRING_FIELD(dbname);
-	WRITE_NODE_FIELD(options);
-	WRITE_OID_FIELD(dbOid);
-}
-
-static void
-_outDropdbStmt(StringInfo str, DropdbStmt *node)
-{
-	WRITE_NODE_TYPE("DROPDBSTMT");
-	WRITE_STRING_FIELD(dbname);
-	WRITE_BOOL_FIELD(missing_ok);
+	WRITE_NODE_FIELD(newOids);
 }
 
 static void
@@ -2559,432 +812,6 @@ _outAlterDomainStmt(StringInfo str, AlterDomainStmt *node)
 	WRITE_STRING_FIELD(name);
 	WRITE_NODE_FIELD(def);
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
-}
-
-static void
-_outCreateFdwStmt(StringInfo str, CreateFdwStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEFDWSTMT");
-	WRITE_STRING_FIELD(fdwname);
-	WRITE_NODE_FIELD(validator);
-	WRITE_NODE_FIELD(options);
-}
-
-static void
-_outAlterFdwStmt(StringInfo str, AlterFdwStmt *node)
-{
-	WRITE_NODE_TYPE("ALTERFDWSTMT");
-	WRITE_STRING_FIELD(fdwname);
-	WRITE_NODE_FIELD(validator);
-	WRITE_BOOL_FIELD(change_validator);
-	WRITE_NODE_FIELD(options);
-}
-
-static void
-_outDropFdwStmt(StringInfo str, DropFdwStmt *node)
-{
-	WRITE_NODE_TYPE("DROPFDWSTMT");
-	WRITE_STRING_FIELD(fdwname);
-	WRITE_BOOL_FIELD(missing_ok);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-}
-
-static void
-_outCreateForeignServerStmt(StringInfo str, CreateForeignServerStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEFOREIGNSERVERSTMT");
-	WRITE_STRING_FIELD(servername);
-	WRITE_STRING_FIELD(servertype);
-	WRITE_STRING_FIELD(version);
-	WRITE_STRING_FIELD(fdwname);
-	WRITE_NODE_FIELD(options);
-}
-
-static void
-_outAlterForeignServerStmt(StringInfo str, AlterForeignServerStmt *node)
-{
-	WRITE_NODE_TYPE("ALTERFOREIGNSERVERSTMT");
-	WRITE_STRING_FIELD(servername);
-	WRITE_STRING_FIELD(version);
-	WRITE_NODE_FIELD(options);
-	WRITE_BOOL_FIELD(has_version);
-}
-
-static void
-_outDropForeignServerStmt(StringInfo str, DropForeignServerStmt *node)
-{
-	WRITE_NODE_TYPE("DROPFOREIGNSERVERSTMT");
-	WRITE_STRING_FIELD(servername);
-	WRITE_BOOL_FIELD(missing_ok);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-}
-
-static void
-_outCreateUserMappingStmt(StringInfo str, CreateUserMappingStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEUSERMAPPINGSTMT");
-	WRITE_STRING_FIELD(username);
-	WRITE_STRING_FIELD(servername);
-	WRITE_NODE_FIELD(options);
-}
-
-static void
-_outAlterUserMappingStmt(StringInfo str, AlterUserMappingStmt *node)
-{
-	WRITE_NODE_TYPE("ALTERUSERMAPPINGSTMT");
-	WRITE_STRING_FIELD(username);
-	WRITE_STRING_FIELD(servername);
-	WRITE_NODE_FIELD(options);
-}
-
-static void
-_outDropUserMappingStmt(StringInfo str, DropUserMappingStmt *node)
-{
-	WRITE_NODE_TYPE("DROPUSERMAPPINGSTMT");
-	WRITE_STRING_FIELD(username);
-	WRITE_STRING_FIELD(servername);
-	WRITE_BOOL_FIELD(missing_ok);
-}
-
-static void
-_outCreateFunctionStmt(StringInfo str, CreateFunctionStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEFUNCSTMT");
-	WRITE_BOOL_FIELD(replace);
-	WRITE_NODE_FIELD(funcname);
-	WRITE_NODE_FIELD(parameters);
-	WRITE_NODE_FIELD(returnType);
-	WRITE_NODE_FIELD(options);
-	WRITE_NODE_FIELD(withClause);
-	WRITE_OID_FIELD(funcOid);
-	WRITE_OID_FIELD(shelltypeOid);
-}
-
-static void
-_outFunctionParameter(StringInfo str, FunctionParameter *node)
-{
-	WRITE_NODE_TYPE("FUNCTIONPARAMETER");
-	WRITE_STRING_FIELD(name);
-	WRITE_NODE_FIELD(argType);
-	WRITE_ENUM_FIELD(mode, FunctionParameterMode);
-
-}
-
-static void
-_outRemoveFuncStmt(StringInfo str, RemoveFuncStmt *node)
-{
-	WRITE_NODE_TYPE("REMOVEFUNCSTMT");
-	WRITE_ENUM_FIELD(kind,ObjectType);
-	WRITE_NODE_FIELD(name);
-	WRITE_NODE_FIELD(args);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-	WRITE_BOOL_FIELD(missing_ok);
-}
-
-static void
-_outAlterFunctionStmt(StringInfo str, AlterFunctionStmt *node)
-{
-	WRITE_NODE_TYPE("ALTERFUNCTIONSTMT");
-	WRITE_NODE_FIELD(func);
-	WRITE_NODE_FIELD(actions);
-}
-
-
-
-
-
-static void
-_outDefineStmt(StringInfo str, DefineStmt *node)
-{
-	WRITE_NODE_TYPE("DEFINESTMT");
-	WRITE_ENUM_FIELD(kind, ObjectType);
-	WRITE_BOOL_FIELD(oldstyle);
-	WRITE_NODE_FIELD(defnames);
-	WRITE_NODE_FIELD(args);
-	WRITE_NODE_FIELD(definition);
-	WRITE_OID_FIELD(newOid);
-	WRITE_OID_FIELD(shadowOid);
-	WRITE_BOOL_FIELD(ordered);  /* CDB */
-	WRITE_BOOL_FIELD(trusted);  /* CDB */
-}
-
-static void
-_outCompositeTypeStmt(StringInfo str, CompositeTypeStmt *node)
-{
-	WRITE_NODE_TYPE("COMPTYPESTMT");
-
-	WRITE_NODE_FIELD(typevar);
-	WRITE_NODE_FIELD(coldeflist);
-	WRITE_OID_FIELD(relOid);
-	WRITE_OID_FIELD(comptypeOid);
-
-}
-
-static void
-_outCreateCastStmt(StringInfo str, CreateCastStmt *node)
-{
-	WRITE_NODE_TYPE("CREATECAST");
-	WRITE_NODE_FIELD(sourcetype);
-	WRITE_NODE_FIELD(targettype);
-	WRITE_NODE_FIELD(func);
-	WRITE_ENUM_FIELD(context, CoercionContext);
-	WRITE_OID_FIELD(castOid);
-}
-
-static void
-_outDropCastStmt(StringInfo str, DropCastStmt *node)
-{
-	WRITE_NODE_TYPE("DROPCAST");
-	WRITE_NODE_FIELD(sourcetype);
-	WRITE_NODE_FIELD(targettype);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-	WRITE_BOOL_FIELD(missing_ok);
-}
-
-static void
-_outCreateOpClassStmt(StringInfo str, CreateOpClassStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEOPCLASS");
-	WRITE_NODE_FIELD(opclassname);
-	WRITE_STRING_FIELD(amname);
-	WRITE_NODE_FIELD(datatype);
-	WRITE_NODE_FIELD(items);
-	WRITE_BOOL_FIELD(isDefault);
-	WRITE_OID_FIELD(opclassOid);
-}
-
-static void
-_outCreateOpClassItem(StringInfo str, CreateOpClassItem *node)
-{
-	WRITE_NODE_TYPE("CREATEOPCLASSITEM");
-	WRITE_INT_FIELD(itemtype);
-	WRITE_NODE_FIELD(name);
-	WRITE_NODE_FIELD(args);
-	WRITE_INT_FIELD(number);
-	WRITE_BOOL_FIELD(recheck);
-	WRITE_NODE_FIELD(storedtype);
-}
-
-static void
-_outRemoveOpClassStmt(StringInfo str, RemoveOpClassStmt *node)
-{
-	WRITE_NODE_TYPE("REMOVEOPCLASS");
-	WRITE_NODE_FIELD(opclassname);
-	WRITE_STRING_FIELD(amname);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-	WRITE_BOOL_FIELD(missing_ok);
-}
-
-static void
-_outCreateConversionStmt(StringInfo str, CreateConversionStmt *node)
-{
-	WRITE_NODE_TYPE("CREATECONVERSION");
-	WRITE_NODE_FIELD(conversion_name);
-	WRITE_STRING_FIELD(for_encoding_name);
-	WRITE_STRING_FIELD(to_encoding_name);
-	WRITE_NODE_FIELD(func_name);
-	WRITE_BOOL_FIELD(def);
-	WRITE_OID_FIELD(convOid);
-}
-
-static void
-_outTransactionStmt(StringInfo str, TransactionStmt *node)
-{
-	WRITE_NODE_TYPE("TRANSACTIONSTMT");
-
-	WRITE_ENUM_FIELD(kind, TransactionStmtKind);
-	WRITE_NODE_FIELD(options);
-
-}
-
-static void
-_outNotifyStmt(StringInfo str, NotifyStmt *node)
-{
-	WRITE_NODE_TYPE("NOTIFY");
-
-	WRITE_NODE_FIELD(relation);
-}
-
-static void
-_outDeclareCursorStmt(StringInfo str, DeclareCursorStmt *node)
-{
-	WRITE_NODE_TYPE("DECLARECURSOR");
-
-	WRITE_STRING_FIELD(portalname);
-	WRITE_INT_FIELD(options);
-	WRITE_NODE_FIELD(query);
-	WRITE_BOOL_FIELD(is_simply_updatable);
-}
-
-static void
-_outSingleRowErrorDesc(StringInfo str, SingleRowErrorDesc *node)
-{
-	WRITE_NODE_TYPE("SINGLEROWERRORDESC");
-	WRITE_NODE_FIELD(errtable);
-	WRITE_INT_FIELD(rejectlimit);
-	WRITE_BOOL_FIELD(is_keep);
-	WRITE_BOOL_FIELD(is_limit_in_rows);
-	WRITE_BOOL_FIELD(reusing_existing_errtable);
-	WRITE_BOOL_FIELD(into_file);
-}
-
-static void
-_outCopyStmt(StringInfo str, CopyStmt *node)
-{
-	WRITE_NODE_TYPE("COPYSTMT");
-	WRITE_NODE_FIELD(relation);
-	WRITE_NODE_FIELD(attlist);
-	WRITE_BOOL_FIELD(is_from);
-	WRITE_BOOL_FIELD(skip_ext_partition);
-	WRITE_STRING_FIELD(filename);
-	WRITE_NODE_FIELD(options);
-	WRITE_NODE_FIELD(sreh);
-	WRITE_NODE_FIELD(partitions);
-	WRITE_NODE_FIELD(ao_segnos);
-}
-
-
-static void
-_outGrantStmt(StringInfo str, GrantStmt *node)
-{
-	WRITE_NODE_TYPE("GRANTSTMT");
-	WRITE_BOOL_FIELD(is_grant);
-	WRITE_ENUM_FIELD(objtype,GrantObjectType);
-	WRITE_NODE_FIELD(objects);
-	WRITE_NODE_FIELD(privileges);
-	WRITE_NODE_FIELD(grantees);
-	WRITE_BOOL_FIELD(grant_option);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-	WRITE_NODE_FIELD(cooked_privs);
-}
-
-static void
-_outPrivGrantee(StringInfo str, PrivGrantee *node)
-{
-	WRITE_NODE_TYPE("PRIVGRANTEE");
-	WRITE_STRING_FIELD(rolname);
-}
-
-static void
-_outFuncWithArgs(StringInfo str, FuncWithArgs *node)
-{
-	WRITE_NODE_TYPE("FUNCWITHARGS");
-	WRITE_NODE_FIELD(funcname);
-	WRITE_NODE_FIELD(funcargs);
-}
-
-static void
-_outGrantRoleStmt(StringInfo str, GrantRoleStmt *node)
-{
-	WRITE_NODE_TYPE("GRANTROLESTMT");
-	WRITE_NODE_FIELD(granted_roles);
-	WRITE_NODE_FIELD(grantee_roles);
-	WRITE_BOOL_FIELD(is_grant);
-	WRITE_BOOL_FIELD(admin_opt);
-	WRITE_STRING_FIELD(grantor);
-	WRITE_ENUM_FIELD(behavior, DropBehavior);
-}
-
-static void
-_outLockStmt(StringInfo str, LockStmt *node)
-{
-	WRITE_NODE_TYPE("LOCKSTMT");
-	WRITE_NODE_FIELD(relations);
-	WRITE_INT_FIELD(mode);
-	WRITE_BOOL_FIELD(nowait);
-}
-
-static void
-_outConstraintsSetStmt(StringInfo str, ConstraintsSetStmt *node)
-{
-	WRITE_NODE_TYPE("CONSTRAINTSSETSTMT");
-	WRITE_NODE_FIELD(constraints);
-	WRITE_BOOL_FIELD(deferred);
-}
-
-static void
-_outFuncCall(StringInfo str, FuncCall *node)
-{
-	WRITE_NODE_TYPE("FUNCCALL");
-
-	WRITE_NODE_FIELD(funcname);
-	WRITE_NODE_FIELD(args);
-    WRITE_NODE_FIELD(agg_order);
-	WRITE_BOOL_FIELD(agg_star);
-	WRITE_BOOL_FIELD(agg_distinct);
-	WRITE_NODE_FIELD(over);
-	WRITE_INT_FIELD(location);
-	WRITE_NODE_FIELD(agg_filter);
-}
-
-static void
-_outDefElem(StringInfo str, DefElem *node)
-{
-	WRITE_NODE_TYPE("DEFELEM");
-
-	WRITE_STRING_FIELD(defname);
-	WRITE_NODE_FIELD(arg);
-	WRITE_ENUM_FIELD(defaction, DefElemAction);
-}
-
-static void
-_outLockingClause(StringInfo str, LockingClause *node)
-{
-	WRITE_NODE_TYPE("LOCKINGCLAUSE");
-
-	WRITE_NODE_FIELD(lockedRels);
-	WRITE_BOOL_FIELD(forUpdate);
-	WRITE_BOOL_FIELD(noWait);
-}
-
-static void
-_outDMLActionExpr(StringInfo str, DMLActionExpr *node)
-{
-	WRITE_NODE_TYPE("DMLACTIONEXPR");
-}
-
-static void
-_outPartOidExpr(StringInfo str, PartOidExpr *node)
-{
-	WRITE_NODE_TYPE("PARTOIDEXPR");
-
-	WRITE_INT_FIELD(level);
-}
-
-static void
-_outPartDefaultExpr(StringInfo str, PartDefaultExpr *node)
-{
-	WRITE_NODE_TYPE("PARTDEFAULTEXPR");
-
-	WRITE_INT_FIELD(level);
-}
-
-static void
-_outPartBoundExpr(StringInfo str, PartBoundExpr *node)
-{
-	WRITE_NODE_TYPE("PARTBOUNDEXPR");
-
-	WRITE_INT_FIELD(level);
-	WRITE_OID_FIELD(boundType);
-	WRITE_BOOL_FIELD(isLowerBound);
-}
-
-static void
-_outPartBoundInclusionExpr(StringInfo str, PartBoundInclusionExpr *node)
-{
-	WRITE_NODE_TYPE("PARTBOUNDOPENEXPR");
-
-	WRITE_INT_FIELD(level);
-	WRITE_BOOL_FIELD(isLowerBound);
-}
-
-static void
-_outPartBoundOpenExpr(StringInfo str, PartBoundOpenExpr *node)
-{
-	WRITE_NODE_TYPE("PARTBOUNDINCLUSIONEXPR");
-
-	WRITE_INT_FIELD(level);
-	WRITE_BOOL_FIELD(isLowerBound);
 }
 
 static void
@@ -3031,23 +858,6 @@ _outTypeCast(StringInfo str, TypeCast *node)
 }
 
 static void
-_outIndexElem(StringInfo str, IndexElem *node)
-{
-	WRITE_NODE_TYPE("INDEXELEM");
-
-	WRITE_STRING_FIELD(name);
-	WRITE_NODE_FIELD(expr);
-	WRITE_NODE_FIELD(opclass);
-}
-
-static void
-_outVariableResetStmt(StringInfo str, VariableResetStmt *node)
-{
-	WRITE_NODE_TYPE("VARIABLERESETSTMT");
-	WRITE_STRING_FIELD(name);
-}
-
-static void
 _outQuery(StringInfo str, Query *node)
 {
 	WRITE_NODE_TYPE("QUERY");
@@ -3084,161 +894,6 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(result_aosegnos);
 	WRITE_NODE_FIELD(returningLists);
 	/* Don't serialize policy */
-}
-
-static void
-_outSortClause(StringInfo str, SortClause *node)
-{
-	WRITE_NODE_TYPE("SORTCLAUSE");
-
-	WRITE_UINT_FIELD(tleSortGroupRef);
-	WRITE_OID_FIELD(sortop);
-}
-
-static void
-_outGroupClause(StringInfo str, GroupClause *node)
-{
-	WRITE_NODE_TYPE("GROUPCLAUSE");
-
-	WRITE_UINT_FIELD(tleSortGroupRef);
-	WRITE_OID_FIELD(sortop);
-}
-
-static void
-_outGroupingClause(StringInfo str, GroupingClause *node)
-{
-	WRITE_NODE_TYPE("GROUPINGCLAUSE");
-
-	WRITE_ENUM_FIELD(groupType, GroupingType);
-	WRITE_NODE_FIELD(groupsets);
-}
-
-static void
-_outGroupingFunc(StringInfo str, GroupingFunc *node)
-{
-	WRITE_NODE_TYPE("GROUPINGFUNC");
-
-	WRITE_NODE_FIELD(args);
-	WRITE_INT_FIELD(ngrpcols);
-}
-
-static void
-_outGrouping(StringInfo str, Grouping *node)
-{
-	WRITE_NODE_TYPE("GROUPING");
-}
-
-static void
-_outGroupId(StringInfo str, GroupId *node)
-{
-	WRITE_NODE_TYPE("GROUPID");
-}
-
-static void
-_outWindowSpecParse(StringInfo str, WindowSpecParse *node)
-{
-	WRITE_NODE_TYPE("WINDOWSPECPARSE");
-
-	WRITE_STRING_FIELD(name);
-	WRITE_NODE_FIELD(elems);
-}
-
-static void
-_outWindowSpec(StringInfo str, WindowSpec *node)
-{
-	WRITE_NODE_TYPE("WINDOWSPEC");
-
-	WRITE_STRING_FIELD(name);
-	WRITE_STRING_FIELD(parent);
-	WRITE_NODE_FIELD(partition);
-	WRITE_NODE_FIELD(order);
-	WRITE_NODE_FIELD(frame);
-    WRITE_INT_FIELD(location);
-}
-
-static void
-_outWindowFrame(StringInfo str, WindowFrame *node)
-{
-	WRITE_NODE_TYPE("WINDOWFRAME");
-
-	WRITE_BOOL_FIELD(is_rows);
-	WRITE_BOOL_FIELD(is_between);
-	WRITE_NODE_FIELD(trail);
-	WRITE_NODE_FIELD(lead);
-	WRITE_ENUM_FIELD(exclude, WindowExclusion);
-}
-
-static void
-_outWindowFrameEdge(StringInfo str, WindowFrameEdge *node)
-{
-	WRITE_NODE_TYPE("WINDOWFRAMEEDGE");
-
-	WRITE_ENUM_FIELD(kind, WindowBoundingKind);
-	WRITE_NODE_FIELD(val);
-}
-
-static void
-_outPercentileExpr(StringInfo str, PercentileExpr *node)
-{
-	WRITE_NODE_TYPE("PERCENTILEEXPR");
-
-	WRITE_OID_FIELD(perctype);
-	WRITE_NODE_FIELD(args);
-	WRITE_ENUM_FIELD(perckind, PercKind);
-	WRITE_NODE_FIELD(sortClause);
-	WRITE_NODE_FIELD(sortTargets);
-	WRITE_NODE_FIELD(pcExpr);
-	WRITE_NODE_FIELD(tcExpr);
-	WRITE_INT_FIELD(location);
-}
-
-static void
-_outRowMarkClause(StringInfo str, RowMarkClause *node)
-{
-	WRITE_NODE_TYPE("ROWMARKCLAUSE");
-
-	WRITE_UINT_FIELD(rti);
-	WRITE_BOOL_FIELD(forUpdate);
-	WRITE_BOOL_FIELD(noWait);
-}
-
-static void
-_outWithClause(StringInfo str, WithClause *node)
-{
-	WRITE_NODE_TYPE("WITHCLAUSE");
-	
-	WRITE_NODE_FIELD(ctes);
-	WRITE_BOOL_FIELD(recursive);
-	WRITE_INT_FIELD(location);
-}
-
-static void
-_outCommonTableExpr(StringInfo str, CommonTableExpr *node)
-{
-	WRITE_NODE_TYPE("COMMONTABLEEXPR");
-	
-    WRITE_STRING_FIELD(ctename);
-	WRITE_NODE_FIELD(aliascolnames);
-	WRITE_NODE_FIELD(ctequery);
-	WRITE_INT_FIELD(location);
-	WRITE_BOOL_FIELD(cterecursive);
-	WRITE_INT_FIELD(cterefcount);
-	WRITE_NODE_FIELD(ctecolnames);
-	WRITE_NODE_FIELD(ctecoltypes);
-	WRITE_NODE_FIELD(ctecoltypmods);
-}
-
-static void
-_outSetOperationStmt(StringInfo str, SetOperationStmt *node)
-{
-	WRITE_NODE_TYPE("SETOPERATIONSTMT");
-
-	WRITE_ENUM_FIELD(op, SetOperation);
-	WRITE_BOOL_FIELD(all);
-	WRITE_NODE_FIELD(larg);
-	WRITE_NODE_FIELD(rarg);
-	WRITE_NODE_FIELD(colTypes);
-	WRITE_NODE_FIELD(colTypmods);
 }
 
 static void
@@ -3389,24 +1044,6 @@ _outValue(StringInfo str, Value *value)
 }
 
 static void
-_outColumnRef(StringInfo str, ColumnRef *node)
-{
-	WRITE_NODE_TYPE("COLUMNREF");
-
-	WRITE_NODE_FIELD(fields);
-	WRITE_INT_FIELD(location);
-}
-
-static void
-_outParamRef(StringInfo str, ParamRef *node)
-{
-	WRITE_NODE_TYPE("PARAMREF");
-
-	WRITE_INT_FIELD(number);
-	WRITE_INT_FIELD(location);  /*CDB*/
-}
-
-static void
 _outAConst(StringInfo str, A_Const *node)
 {
 	WRITE_NODE_TYPE("A_CONST");
@@ -3415,35 +1052,6 @@ _outAConst(StringInfo str, A_Const *node)
 	WRITE_NODE_FIELD(typname);
 	WRITE_INT_FIELD(location);  /*CDB*/
 
-}
-
-static void
-_outA_Indices(StringInfo str, A_Indices *node)
-{
-	WRITE_NODE_TYPE("A_INDICES");
-
-	WRITE_NODE_FIELD(lidx);
-	WRITE_NODE_FIELD(uidx);
-}
-
-static void
-_outA_Indirection(StringInfo str, A_Indirection *node)
-{
-	WRITE_NODE_TYPE("A_INDIRECTION");
-
-	WRITE_NODE_FIELD(arg);
-	WRITE_NODE_FIELD(indirection);
-}
-
-static void
-_outResTarget(StringInfo str, ResTarget *node)
-{
-	WRITE_NODE_TYPE("RESTARGET");
-
-	WRITE_STRING_FIELD(name);
-	WRITE_NODE_FIELD(indirection);
-	WRITE_NODE_FIELD(val);
-	WRITE_INT_FIELD(location);
 }
 
 static void
@@ -3486,190 +1094,13 @@ _outConstraint(StringInfo str, Constraint *node)
 }
 
 static void
-_outFkConstraint(StringInfo str, FkConstraint *node)
-{
-	WRITE_NODE_TYPE("FKCONSTRAINT");
-
-	WRITE_STRING_FIELD(constr_name);
-	WRITE_OID_FIELD(constrOid);
-	WRITE_NODE_FIELD(pktable);
-	WRITE_NODE_FIELD(fk_attrs);
-	WRITE_NODE_FIELD(pk_attrs);
-	WRITE_CHAR_FIELD(fk_matchtype);
-	WRITE_CHAR_FIELD(fk_upd_action);
-	WRITE_CHAR_FIELD(fk_del_action);
-	WRITE_BOOL_FIELD(deferrable);
-	WRITE_BOOL_FIELD(initdeferred);
-	WRITE_BOOL_FIELD(skip_validation);
-	WRITE_OID_FIELD(trig1Oid);
-	WRITE_OID_FIELD(trig2Oid);
-	WRITE_OID_FIELD(trig3Oid);
-	WRITE_OID_FIELD(trig4Oid);
-}
-
-static void
-_outCreateSchemaStmt(StringInfo str, CreateSchemaStmt *node)
-{
-	WRITE_NODE_TYPE("CREATESCHEMASTMT");
-
-	WRITE_STRING_FIELD(schemaname);
-	WRITE_STRING_FIELD(authid);
-	WRITE_BOOL_FIELD(istemp);
-	WRITE_OID_FIELD(schemaOid);
-
-}
-
-static void
-_outCreatePLangStmt(StringInfo str, CreatePLangStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEPLANGSTMT");
-
-	WRITE_STRING_FIELD(plname);
-	WRITE_NODE_FIELD(plhandler);
-	WRITE_NODE_FIELD(plvalidator);
-	WRITE_BOOL_FIELD(pltrusted);
-	WRITE_OID_FIELD(plangOid);
-	WRITE_OID_FIELD(plhandlerOid);
-	WRITE_OID_FIELD(plvalidatorOid);
-
-}
-
-static void
-_outDropPLangStmt(StringInfo str, DropPLangStmt *node)
-{
-	WRITE_NODE_TYPE("DROPPLANGSTMT");
-
-	WRITE_STRING_FIELD(plname);
-	WRITE_ENUM_FIELD(behavior,DropBehavior);
-	WRITE_BOOL_FIELD(missing_ok);
-
-}
-
-static void
-_outVacuumStmt(StringInfo str, VacuumStmt *node)
-{
-	WRITE_NODE_TYPE("VACUUMSTMT");
-
-	WRITE_BOOL_FIELD(vacuum);
-	WRITE_BOOL_FIELD(full);
-	WRITE_BOOL_FIELD(analyze);
-	WRITE_BOOL_FIELD(verbose);
-	WRITE_BOOL_FIELD(rootonly);
-	WRITE_INT_FIELD(freeze_min_age);
-	WRITE_NODE_FIELD(relation);
-	WRITE_NODE_FIELD(va_cols);
-	WRITE_NODE_FIELD(expanded_relids);
-	WRITE_NODE_FIELD(extra_oids);
-	WRITE_NODE_FIELD(appendonly_compaction_segno);
-	WRITE_NODE_FIELD(appendonly_compaction_insert_segno);
-	WRITE_BOOL_FIELD(appendonly_compaction_vacuum_cleanup);
-	WRITE_BOOL_FIELD(appendonly_compaction_vacuum_prepare);
-	WRITE_BOOL_FIELD(heap_truncate);
-}
-
-
-static void
-_outCdbProcess(StringInfo str, CdbProcess *node)
-{
-	WRITE_NODE_TYPE("CDBPROCESS");
-	WRITE_STRING_FIELD(listenerAddr);
-	WRITE_INT_FIELD(listenerPort);
-	WRITE_INT_FIELD(pid);
-	WRITE_INT_FIELD(contentid);
-}
-
-static void
-_outSlice(StringInfo str, Slice *node)
-{
-	WRITE_NODE_TYPE("SLICE");
-	WRITE_INT_FIELD(sliceIndex);
-	WRITE_INT_FIELD(rootIndex);
-	WRITE_ENUM_FIELD(gangType,GangType);
-	WRITE_INT_FIELD(gangSize);
-	WRITE_INT_FIELD(numGangMembersToBeActive);
-	WRITE_BOOL_FIELD(directDispatch.isDirectDispatch);
-	WRITE_NODE_FIELD(directDispatch.contentIds); /* List of int */
-	WRITE_DUMMY_FIELD(primaryGang);
-	WRITE_INT_FIELD(primary_gang_id);
-	WRITE_INT_FIELD(parentIndex); /* List of int index */
-	WRITE_NODE_FIELD(children); /* List of int index */
-	WRITE_NODE_FIELD(primaryProcesses); /* List of (CDBProcess *) */
-}
-
-static void
-_outSliceTable(StringInfo str, SliceTable *node)
-{
-	WRITE_NODE_TYPE("SLICETABLE");
-	WRITE_INT_FIELD(nMotions);
-	WRITE_INT_FIELD(nInitPlans);
-	WRITE_INT_FIELD(localSlice);
-	WRITE_NODE_FIELD(slices); /* List of int */
-    WRITE_BOOL_FIELD(doInstrument);
-	WRITE_INT_FIELD(ic_instance_id);
-}
-
-
-static void
-_outCreateTrigStmt(StringInfo str, CreateTrigStmt *node)
-{
-	WRITE_NODE_TYPE("CREATETRIGSTMT");
-
-	WRITE_STRING_FIELD(trigname);
-	WRITE_NODE_FIELD(relation);
-	WRITE_NODE_FIELD(funcname);
-	WRITE_NODE_FIELD(args);
-	WRITE_BOOL_FIELD(before);
-	WRITE_BOOL_FIELD(row);
-	WRITE_STRING_FIELD(actions);
-	WRITE_BOOL_FIELD(isconstraint);
-	WRITE_BOOL_FIELD(deferrable);
-	WRITE_BOOL_FIELD(initdeferred);
-	WRITE_NODE_FIELD(constrrel);
-	WRITE_OID_FIELD(trigOid);
-
-}
-
-static void
-_outCreateFileSpaceStmt(StringInfo str, CreateFileSpaceStmt *node)
-{
-	WRITE_NODE_TYPE("CREATEFILESPACESTMT");
-
-	WRITE_STRING_FIELD(filespacename);
-	WRITE_STRING_FIELD(owner);
-	WRITE_NODE_FIELD(locations);
-	WRITE_OID_FIELD(fsoid);
-}
-
-static void
-_outFileSpaceEntry(StringInfo str, FileSpaceEntry *node)
-{
-	WRITE_NODE_TYPE("FILESPACEENTRY");
-
-	WRITE_INT_FIELD(dbid);
-	WRITE_INT_FIELD(contentid);
-	WRITE_STRING_FIELD(location);
-	WRITE_STRING_FIELD(hostname);
-}
-
-static void
-_outCreateTableSpaceStmt(StringInfo str, CreateTableSpaceStmt *node)
-{
-	WRITE_NODE_TYPE("CREATETABLESPACESTMT");
-
-	WRITE_STRING_FIELD(tablespacename);
-	WRITE_STRING_FIELD(owner);
-	WRITE_STRING_FIELD(filespacename);
-	WRITE_OID_FIELD(tsoid);
-}
-
-static void
 _outCreateQueueStmt(StringInfo str, CreateQueueStmt *node)
 {
 	WRITE_NODE_TYPE("CREATEQUEUESTMT");
 
 	WRITE_STRING_FIELD(queue);
 	WRITE_NODE_FIELD(options); /* List of DefElem nodes */
-	WRITE_OID_FIELD(queueOid); 
+	WRITE_OID_FIELD(queueOid);
 	WRITE_NODE_FIELD(optids); /* List of oids for nodes */
 }
 
@@ -3684,53 +1115,17 @@ _outAlterQueueStmt(StringInfo str, AlterQueueStmt *node)
 }
 
 static void
-_outDropQueueStmt(StringInfo str, DropQueueStmt *node)
-{
-	WRITE_NODE_TYPE("DROPQUEUESTMT");
-
-	WRITE_STRING_FIELD(queue);
-}
-
-static void
-_outCommentStmt(StringInfo str, CommentStmt *node)
-{
-        WRITE_NODE_TYPE("COMMENTSTMT");
-
-        WRITE_ENUM_FIELD(objtype, ObjectType);
-        WRITE_NODE_FIELD(objname);
-        WRITE_NODE_FIELD(objargs);
-        WRITE_STRING_FIELD(comment);
-}
-
-
-static void
-_outTableValueExpr(StringInfo str, TableValueExpr *node)
-{
-	WRITE_NODE_TYPE("TABLEVALUEEXPR");
-
-	WRITE_NODE_FIELD(subquery);
-}
-
-static void
-_outAlterTypeStmt(StringInfo str, AlterTypeStmt *node)
-{
-	WRITE_NODE_TYPE("ALTERTYPESTMT");
-
-	WRITE_NODE_FIELD(typname);
-	WRITE_NODE_FIELD(encoding);
-}
-
-static void
 _outTupleDescNode(StringInfo str, TupleDescNode *node)
 {
+	int			i;
+
 	Assert(node->tuple->tdtypeid == RECORDOID);
 
 	WRITE_NODE_TYPE("TUPLEDESCNODE");
 	WRITE_INT_FIELD(natts);
 	WRITE_INT_FIELD(tuple->natts);
 
-	int i = 0;
-	for (; i < node->tuple->natts; i++)
+	for (i = 0; i < node->tuple->natts; i++)
 		appendBinaryStringInfo(str, node->tuple->attrs[i], ATTRIBUTE_FIXED_PART_SIZE);
 
 	Assert(node->tuple->constr == NULL);
@@ -4346,7 +1741,7 @@ _outNode(StringInfo str, void *obj)
 			case T_DropUserMappingStmt:
 				_outDropUserMappingStmt(str, obj);
 				break;
-				
+
 			case T_TransactionStmt:
 				_outTransactionStmt(str, obj);
 				break;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -38,6 +38,15 @@
 #include "utils/workfile_mgr.h"
 #include "parser/parsetree.h"
 
+
+/*
+ * outfuncs.c is compiled normally into outfuncs.o, but it's also
+ * #included from outfast.c. When #included, outfast.c defines
+ * COMPILING_BINARY_FUNCS, and provides replacements WRITE_* macros. See
+ * comments at top of readfast.c.
+ */
+#ifndef COMPILING_BINARY_FUNCS
+
 /*
  * Macros to simplify output of different kinds of fields.	Use these
  * wherever possible to reduce the chance for silly typos.	Note that these
@@ -129,6 +138,7 @@
 #define booltostr(x)  ((x) ? "true" : "false")
 
 static void _outNode(StringInfo str, void *obj);
+
 
 /* When serializing a plan for workfile caching, we want to leave out
  * all variable fields by setting this to false */
@@ -270,11 +280,16 @@ _outDatum(StringInfo str, Datum value, int typlen, bool typbyval)
 	}
 }
 
+#endif /* COMPILING_BINARY_FUNCS */
+
+static void _outPlanInfo(StringInfo str, Plan *node);
+static void outLogicalIndexInfo(StringInfo str, LogicalIndexInfo *node);
 
 /*
  *	Stuff from plannodes.h
  */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPlannedStmt(StringInfo str, PlannedStmt *node)
 {
@@ -311,14 +326,15 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(transientTypeRecords);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * print the basic stuff of all nodes that inherit from Plan
  */
 static void
 _outPlanInfo(StringInfo str, Plan *node)
 {
-
 	if (print_variable_fields)
 	{
 		WRITE_INT_FIELD(plan_node_id);
@@ -350,12 +366,13 @@ _outPlanInfo(StringInfo str, Plan *node)
 	WRITE_NODE_FIELD(lefttree);
 	WRITE_NODE_FIELD(righttree);
 	WRITE_NODE_FIELD(initPlan);
-	
+
 	if (print_variable_fields)
 	{
 		WRITE_UINT64_FIELD(operatorMemKB);
 	}
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * print the basic stuff of all nodes that inherit from Scan
@@ -547,6 +564,7 @@ _outExternalScan(StringInfo str, ExternalScan *node)
 	WRITE_INT_FIELD(scancounter);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 outLogicalIndexInfo(StringInfo str, LogicalIndexInfo *node)
 {
@@ -564,6 +582,7 @@ outLogicalIndexInfo(StringInfo str, LogicalIndexInfo *node)
 	WRITE_NODE_FIELD(partCons);
 	WRITE_NODE_FIELD(defaultLevels);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 outIndexScanFields(StringInfo str, IndexScan *node)
@@ -653,6 +672,7 @@ _outTidScan(StringInfo str, TidScan *node)
 	WRITE_NODE_FIELD(tidquals);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outSubqueryScan(StringInfo str, SubqueryScan *node)
 {
@@ -663,6 +683,7 @@ _outSubqueryScan(StringInfo str, SubqueryScan *node)
 	WRITE_NODE_FIELD(subplan);
 	WRITE_NODE_FIELD(subrtable); /* debugging convenience */
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outFunctionScan(StringInfo str, FunctionScan *node)
@@ -722,6 +743,7 @@ _outHashJoin(StringInfo str, HashJoin *node)
 	WRITE_NODE_FIELD(hashqualclauses);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outAgg(StringInfo str, Agg *node)
 {
@@ -751,7 +773,9 @@ _outAgg(StringInfo str, Agg *node)
 	WRITE_BOOL_FIELD(lastAgg);
 	WRITE_BOOL_FIELD(streaming);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outWindowKey(StringInfo str, WindowKey *node)
 {
@@ -770,8 +794,9 @@ _outWindowKey(StringInfo str, WindowKey *node)
 
 	WRITE_NODE_FIELD(frame);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
-
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outWindow(StringInfo str, Window *node)
 {
@@ -789,6 +814,7 @@ _outWindow(StringInfo str, Window *node)
 
 	WRITE_NODE_FIELD(windowKeys);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outTableFunctionScan(StringInfo str, TableFunctionScan *node)
@@ -826,6 +852,7 @@ _outShareInputScan(StringInfo str, ShareInputScan *node)
 	_outPlanInfo(str, (Plan *) node);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outSort(StringInfo str, Sort *node)
 {
@@ -856,7 +883,9 @@ _outSort(StringInfo str, Sort *node)
 	WRITE_INT_FIELD(nsharer);
 	WRITE_INT_FIELD(nsharer_xslice);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outUnique(StringInfo str, Unique *node)
 {
@@ -872,7 +901,9 @@ _outUnique(StringInfo str, Unique *node)
 	for (i = 0; i < node->numCols; i++)
 		appendStringInfo(str, " %d", node->uniqColIdx[i]);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outSetOp(StringInfo str, SetOp *node)
 {
@@ -891,6 +922,7 @@ _outSetOp(StringInfo str, SetOp *node)
 
 	WRITE_INT_FIELD(flagColIdx);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outLimit(StringInfo str, Limit *node)
@@ -912,6 +944,7 @@ _outHash(StringInfo str, Hash *node)
     WRITE_BOOL_FIELD(rescannable);          /*CDB*/
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outMotion(StringInfo str, Motion *node)
 {
@@ -945,6 +978,7 @@ _outMotion(StringInfo str, Motion *node)
 
 	_outPlanInfo(str, (Plan *) node);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _outDML
@@ -1112,6 +1146,7 @@ _outVar(StringInfo str, Var *node)
 	WRITE_INT_FIELD(varoattno);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outConst(StringInfo str, Const *node)
 {
@@ -1128,6 +1163,7 @@ _outConst(StringInfo str, Const *node)
 	else
 		_outDatum(str, node->constvalue, node->constlen, node->constbyval);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outParam(StringInfo str, Param *node)
@@ -1139,6 +1175,7 @@ _outParam(StringInfo str, Param *node)
 	WRITE_OID_FIELD(paramtype);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outAggref(StringInfo str, Aggref *node)
 {
@@ -1167,6 +1204,7 @@ _outAggref(StringInfo str, Aggref *node)
     if (node->aggorder != NULL)
         WRITE_NODE_FIELD(aggorder);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outAggOrder(StringInfo str, AggOrder *node)
@@ -1208,6 +1246,7 @@ _outArrayRef(StringInfo str, ArrayRef *node)
 	WRITE_NODE_FIELD(refassgnexpr);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outFuncExpr(StringInfo str, FuncExpr *node)
 {
@@ -1224,6 +1263,7 @@ _outFuncExpr(StringInfo str, FuncExpr *node)
 		WRITE_BOOL_FIELD(is_tablefunc);  /* GPDB */
 	}
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outOpExpr(StringInfo str, OpExpr *node)
@@ -1260,6 +1300,7 @@ _outScalarArrayOpExpr(StringInfo str, ScalarArrayOpExpr *node)
 	WRITE_NODE_FIELD(args);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outBoolExpr(StringInfo str, BoolExpr *node)
 {
@@ -1285,7 +1326,9 @@ _outBoolExpr(StringInfo str, BoolExpr *node)
 
 	WRITE_NODE_FIELD(args);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outSubLink(StringInfo str, SubLink *node)
 {
@@ -1302,6 +1345,7 @@ _outSubLink(StringInfo str, SubLink *node)
      */
 	WRITE_NODE_FIELD(subselect);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outSubPlan(StringInfo str, SubPlan *node)
@@ -1508,6 +1552,7 @@ _outSetToDefault(StringInfo str, SetToDefault *node)
 	WRITE_INT_FIELD(typeMod);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outCurrentOfExpr(StringInfo str, CurrentOfExpr *node)
 {
@@ -1519,6 +1564,7 @@ _outCurrentOfExpr(StringInfo str, CurrentOfExpr *node)
 
 	/* some attributes omitted as they're bound only just before executor dispatch */
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outTargetEntry(StringInfo str, TargetEntry *node)
@@ -1542,6 +1588,7 @@ _outRangeTblRef(StringInfo str, RangeTblRef *node)
 	WRITE_INT_FIELD(rtindex);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outJoinExpr(StringInfo str, JoinExpr *node)
 {
@@ -1558,6 +1605,7 @@ _outJoinExpr(StringInfo str, JoinExpr *node)
 	WRITE_NODE_FIELD(alias);
 	WRITE_INT_FIELD(rtindex);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outFromExpr(StringInfo str, FromExpr *node)
@@ -1568,6 +1616,7 @@ _outFromExpr(StringInfo str, FromExpr *node)
 	WRITE_NODE_FIELD(quals);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outFlow(StringInfo str, Flow *node)
 {
@@ -1605,6 +1654,7 @@ _outFlow(StringInfo str, Flow *node)
 
 	WRITE_NODE_FIELD(flow_before_req_move);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*****************************************************************************
  *
@@ -1768,7 +1818,6 @@ _outAOCSPath(StringInfo str, AOCSPath *node)
 	_outPathInfo(str, (Path *) node);
 }
 
-
 static void
 _outResultPath(StringInfo str, ResultPath *node)
 {
@@ -1845,6 +1894,7 @@ _outCdbMotionPath(StringInfo str, CdbMotionPath *node)
     WRITE_NODE_FIELD(subpath);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPlannerGlobal(StringInfo str, PlannerGlobal *node)
 {
@@ -1867,6 +1917,7 @@ _outPlannerGlobal(StringInfo str, PlannerGlobal *node)
 	WRITE_NODE_FIELD(share.planNodes);
 	WRITE_INT_FIELD(share.nextPlanId);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outPlannerInfo(StringInfo str, PlannerInfo *node)
@@ -1935,6 +1986,7 @@ _outRelOptInfo(StringInfo str, RelOptInfo *node)
 	/* WRITE_NODE_FIELD(index_inner_paths);     */
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outIndexOptInfo(StringInfo str, IndexOptInfo *node)
 {
@@ -1970,7 +2022,9 @@ _outIndexOptInfo(StringInfo str, IndexOptInfo *node)
 	WRITE_BOOL_FIELD(amoptionalkey);
 	WRITE_BOOL_FIELD(cdb_default_stats_used);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outCdbRelColumnInfo(StringInfo str, CdbRelColumnInfo *node)
 {
@@ -1983,6 +2037,7 @@ _outCdbRelColumnInfo(StringInfo str, CdbRelColumnInfo *node)
     WRITE_STRING_FIELD(colname);
 	WRITE_NODE_FIELD(defexpr);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outCdbRelDedupInfo(StringInfo str, CdbRelDedupInfo *node)
@@ -2043,6 +2098,7 @@ _outInnerIndexscanInfo(StringInfo str, InnerIndexscanInfo *node)
 	WRITE_NODE_FIELD(cheapest_total_innerpath);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outOuterJoinInfo(StringInfo str, OuterJoinInfo *node)
 {
@@ -2058,6 +2114,7 @@ _outOuterJoinInfo(StringInfo str, OuterJoinInfo *node)
     WRITE_NODE_FIELD(left_equi_key_list);
     WRITE_NODE_FIELD(right_equi_key_list);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outInClauseInfo(StringInfo str, InClauseInfo *node)
@@ -2089,6 +2146,7 @@ _outAppendRelInfo(StringInfo str, AppendRelInfo *node)
  *
  *****************************************************************************/
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outCreateStmt(StringInfo str, CreateStmt *node)
 {
@@ -2131,6 +2189,7 @@ _outCreateStmt(StringInfo str, CreateStmt *node)
 	WRITE_BOOL_FIELD(buildAoBlkdir);
 	WRITE_NODE_FIELD(attr_encodings);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outColumnReferenceStorageDirective(StringInfo str, ColumnReferenceStorageDirective *node)
@@ -2259,8 +2318,6 @@ _outDropStmt(StringInfo str, DropStmt *node)
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
 	WRITE_BOOL_FIELD(missing_ok);
 	WRITE_BOOL_FIELD(bAllowPartn);
-
-
 }
 
 static void
@@ -2273,7 +2330,6 @@ _outDropPropertyStmt(StringInfo str, DropPropertyStmt *node)
 	WRITE_ENUM_FIELD(removeType, ObjectType);
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
 	WRITE_BOOL_FIELD(missing_ok);
-
 }
 
 static void
@@ -2362,6 +2418,7 @@ _outInheritPartitionCmd(StringInfo str, InheritPartitionCmd *node)
 	WRITE_NODE_FIELD(parent);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outAlterPartitionCmd(StringInfo str, AlterPartitionCmd *node)
 {
@@ -2371,6 +2428,7 @@ _outAlterPartitionCmd(StringInfo str, AlterPartitionCmd *node)
 	WRITE_NODE_FIELD(arg1);
 	WRITE_NODE_FIELD(arg2);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outAlterPartitionId(StringInfo str, AlterPartitionId *node)
@@ -2390,7 +2448,6 @@ _outCreateRoleStmt(StringInfo str, CreateRoleStmt *node)
 	WRITE_STRING_FIELD(role);
 	WRITE_NODE_FIELD(options);
 	WRITE_OID_FIELD(roleOid);
-
 }
 
 static void
@@ -2452,7 +2509,6 @@ _outAlterOwnerStmt(StringInfo str, AlterOwnerStmt *node)
 	WRITE_NODE_FIELD(objarg);
 	WRITE_STRING_FIELD(addname);
 	WRITE_STRING_FIELD(newowner);
-
 }
 
 
@@ -2469,7 +2525,6 @@ _outRenameStmt(StringInfo str, RenameStmt *node)
 	WRITE_STRING_FIELD(newname);
 	WRITE_ENUM_FIELD(renameType,ObjectType);
 	WRITE_BOOL_FIELD(bAllowPartn);
-
 }
 
 static void
@@ -2544,6 +2599,7 @@ _outDropdbStmt(StringInfo str, DropdbStmt *node)
 	WRITE_BOOL_FIELD(missing_ok);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outCreateDomainStmt(StringInfo str, CreateDomainStmt *node)
 {
@@ -2553,7 +2609,9 @@ _outCreateDomainStmt(StringInfo str, CreateDomainStmt *node)
 	WRITE_NODE_FIELD(constraints);
 	WRITE_OID_FIELD(domainOid);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outAlterDomainStmt(StringInfo str, AlterDomainStmt *node)
 {
@@ -2564,6 +2622,7 @@ _outAlterDomainStmt(StringInfo str, AlterDomainStmt *node)
 	WRITE_NODE_FIELD(def);
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outCreateFdwStmt(StringInfo str, CreateFdwStmt *node)
@@ -2671,7 +2730,6 @@ _outFunctionParameter(StringInfo str, FunctionParameter *node)
 	WRITE_STRING_FIELD(name);
 	WRITE_NODE_FIELD(argType);
 	WRITE_ENUM_FIELD(mode, FunctionParameterMode);
-
 }
 
 static void
@@ -2708,6 +2766,7 @@ _outPartitionBy(StringInfo str, PartitionBy *node)
 	WRITE_INT_FIELD(location);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPartitionSpec(StringInfo str, PartitionSpec *node)
 {
@@ -2717,6 +2776,7 @@ _outPartitionSpec(StringInfo str, PartitionSpec *node)
 	WRITE_BOOL_FIELD(istemplate);
 	WRITE_INT_FIELD(location);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outPartitionElem(StringInfo str, PartitionElem *node)
@@ -2742,6 +2802,7 @@ _outPartitionRangeItem(StringInfo str, PartitionRangeItem *node)
 	WRITE_INT_FIELD(location);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPartitionBoundSpec(StringInfo str, PartitionBoundSpec *node)
 {
@@ -2753,6 +2814,7 @@ _outPartitionBoundSpec(StringInfo str, PartitionBoundSpec *node)
 	WRITE_STRING_FIELD(pWithTnameStr);
 	WRITE_INT_FIELD(location);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outPartitionValuesSpec(StringInfo str, PartitionValuesSpec *node)
@@ -2762,6 +2824,7 @@ _outPartitionValuesSpec(StringInfo str, PartitionValuesSpec *node)
 	WRITE_INT_FIELD(location);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outInhRelation(StringInfo str, InhRelation *node)
 {
@@ -2769,7 +2832,9 @@ _outInhRelation(StringInfo str, InhRelation *node)
 	WRITE_NODE_FIELD(relation);
 	WRITE_NODE_FIELD(options);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPartition(StringInfo str, Partition *node)
 {
@@ -2791,7 +2856,9 @@ _outPartition(StringInfo str, Partition *node)
 	for (i = 0; i < node->parnatts; i++)
 		appendStringInfo(str, " %d", node->parclass[i]);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPartitionRule(StringInfo str, PartitionRule *node)
 {
@@ -2813,6 +2880,7 @@ _outPartitionRule(StringInfo str, PartitionRule *node)
 	WRITE_OID_FIELD(partemplatespaceId);
 	WRITE_NODE_FIELD(children);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outPartitionNode(StringInfo str, PartitionNode *node)
@@ -2860,7 +2928,6 @@ _outDefineStmt(StringInfo str, DefineStmt *node)
 	WRITE_OID_FIELD(shadowOid);
 	WRITE_BOOL_FIELD(ordered);  /* CDB */
 	WRITE_BOOL_FIELD(trusted);  /* CDB */
-
 }
 
 static void
@@ -2872,7 +2939,6 @@ _outCompositeTypeStmt(StringInfo str, CompositeTypeStmt *node)
 	WRITE_NODE_FIELD(coldeflist);
 	WRITE_OID_FIELD(relOid);
 	WRITE_OID_FIELD(comptypeOid);
-
 }
 
 static void
@@ -2949,7 +3015,6 @@ _outTransactionStmt(StringInfo str, TransactionStmt *node)
 
 	WRITE_ENUM_FIELD(kind, TransactionStmtKind);
 	WRITE_NODE_FIELD(options);
-
 }
 
 static void
@@ -3057,6 +3122,7 @@ _outConstraintsSetStmt(StringInfo str, ConstraintsSetStmt *node)
 	WRITE_BOOL_FIELD(deferred);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outInsertStmt(StringInfo str, InsertStmt *node)
 {
@@ -3067,8 +3133,9 @@ _outInsertStmt(StringInfo str, InsertStmt *node)
 	WRITE_NODE_FIELD(selectStmt);
 	WRITE_NODE_FIELD(returningList);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
-
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * SelectStmt's are never written to the catalog, they only exist
  * between parse and parseTransform.  The only use of this function
@@ -3103,6 +3170,7 @@ _outSelectStmt(StringInfo str, SelectStmt *node)
 	WRITE_NODE_FIELD(rarg);
 	WRITE_NODE_FIELD(distributedBy);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outFuncCall(StringInfo str, FuncCall *node)
@@ -3189,6 +3257,7 @@ _outPartBoundOpenExpr(StringInfo str, PartBoundOpenExpr *node)
 	WRITE_BOOL_FIELD(isLowerBound);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outColumnDef(StringInfo str, ColumnDef *node)
 {
@@ -3207,7 +3276,9 @@ _outColumnDef(StringInfo str, ColumnDef *node)
 	WRITE_NODE_FIELD(constraints);
 	WRITE_NODE_FIELD(encoding);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outTypeName(StringInfo str, TypeName *node)
 {
@@ -3222,7 +3293,9 @@ _outTypeName(StringInfo str, TypeName *node)
 	WRITE_NODE_FIELD(arrayBounds);
 	WRITE_INT_FIELD(location);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outTypeCast(StringInfo str, TypeCast *node)
 {
@@ -3231,6 +3304,7 @@ _outTypeCast(StringInfo str, TypeCast *node)
 	WRITE_NODE_FIELD(arg);
 	WRITE_NODE_FIELD_AS(typname, typename);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outIndexElem(StringInfo str, IndexElem *node)
@@ -3246,9 +3320,11 @@ static void
 _outVariableResetStmt(StringInfo str, VariableResetStmt *node)
 {
 	WRITE_NODE_TYPE("VARIABLERESETSTMT");
+
 	WRITE_STRING_FIELD(name);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outQuery(StringInfo str, Query *node)
 {
@@ -3379,6 +3455,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(returningLists); /* TODO Merge issue */
 	/* Don't serialize policy */
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outSortClause(StringInfo str, SortClause *node)
@@ -3535,6 +3612,7 @@ _outSetOperationStmt(StringInfo str, SetOperationStmt *node)
 	WRITE_NODE_FIELD(colTypmods);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outRangeTblEntry(StringInfo str, RangeTblEntry *node)
 {
@@ -3599,7 +3677,9 @@ _outRangeTblEntry(StringInfo str, RangeTblEntry *node)
 	WRITE_BOOL_FIELD(forceDistRandom);
     WRITE_NODE_FIELD(pseudocols);                                       /*CDB*/
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outAExpr(StringInfo str, A_Expr *node)
 {
@@ -3655,7 +3735,9 @@ _outAExpr(StringInfo str, A_Expr *node)
 	WRITE_NODE_FIELD(rexpr);
 	WRITE_INT_FIELD(location);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outValue(StringInfo str, Value *value)
 {
@@ -3690,12 +3772,15 @@ _outValue(StringInfo str, Value *value)
 			break;
 	}
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outNull(StringInfo str, Node *n __attribute__((unused)))
 {
 	WRITE_NODE_TYPE("NULL");
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outColumnRef(StringInfo str, ColumnRef *node)
@@ -3715,6 +3800,7 @@ _outParamRef(StringInfo str, ParamRef *node)
 	WRITE_INT_FIELD(location);  /*CDB*/
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outAConst(StringInfo str, A_Const *node)
 {
@@ -3731,6 +3817,7 @@ _outAConst(StringInfo str, A_Const *node)
      * view or rule definition is stored in the catalog.
      */
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outA_Indices(StringInfo str, A_Indices *node)
@@ -3761,6 +3848,7 @@ _outResTarget(StringInfo str, ResTarget *node)
 	WRITE_INT_FIELD(location);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outConstraint(StringInfo str, Constraint *node)
 {
@@ -3807,6 +3895,7 @@ _outConstraint(StringInfo str, Constraint *node)
 			break;
 	}
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outFkConstraint(StringInfo str, FkConstraint *node)
@@ -3839,7 +3928,6 @@ _outCreateSchemaStmt(StringInfo str, CreateSchemaStmt *node)
 	WRITE_STRING_FIELD(authid);
 	WRITE_BOOL_FIELD(istemp);
 	WRITE_OID_FIELD(schemaOid);
-
 }
 
 static void
@@ -3854,7 +3942,6 @@ _outCreatePLangStmt(StringInfo str, CreatePLangStmt *node)
 	WRITE_OID_FIELD(plangOid);
 	WRITE_OID_FIELD(plhandlerOid);
 	WRITE_OID_FIELD(plvalidatorOid);
-
 }
 
 static void
@@ -3889,7 +3976,6 @@ _outVacuumStmt(StringInfo str, VacuumStmt *node)
 	WRITE_BOOL_FIELD(appendonly_compaction_vacuum_prepare);
 	WRITE_BOOL_FIELD(heap_truncate);
 }
-
 
 static void
 _outCdbProcess(StringInfo str, CdbProcess *node)
@@ -3931,8 +4017,6 @@ _outSliceTable(StringInfo str, SliceTable *node)
 	WRITE_INT_FIELD(ic_instance_id);
 }
 
-
-
 static void
 _outCreateTrigStmt(StringInfo str, CreateTrigStmt *node)
 {
@@ -3950,7 +4034,6 @@ _outCreateTrigStmt(StringInfo str, CreateTrigStmt *node)
 	WRITE_BOOL_FIELD(initdeferred);
 	WRITE_NODE_FIELD(constrrel);
 	WRITE_OID_FIELD(trigOid);
-
 }
 
 static void
@@ -3986,7 +4069,7 @@ _outCreateTableSpaceStmt(StringInfo str, CreateTableSpaceStmt *node)
 	WRITE_OID_FIELD(tsoid);
 }
 
-
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outCreateQueueStmt(StringInfo str, CreateQueueStmt *node)
 {
@@ -3996,7 +4079,9 @@ _outCreateQueueStmt(StringInfo str, CreateQueueStmt *node)
 	WRITE_NODE_FIELD(options); /* List of DefElem nodes */
 	WRITE_OID_FIELD(queueOid); 
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outAlterQueueStmt(StringInfo str, AlterQueueStmt *node)
 {
@@ -4005,6 +4090,7 @@ _outAlterQueueStmt(StringInfo str, AlterQueueStmt *node)
 	WRITE_STRING_FIELD(queue);
 	WRITE_NODE_FIELD(options); /* List of DefElem nodes */
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outDropQueueStmt(StringInfo str, DropQueueStmt *node)
@@ -4043,6 +4129,7 @@ _outAlterTypeStmt(StringInfo str, AlterTypeStmt *node)
 	WRITE_NODE_FIELD(encoding);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outTupleDescNode(StringInfo str, TupleDescNode *node)
 {
@@ -4065,7 +4152,9 @@ _outTupleDescNode(StringInfo str, TupleDescNode *node)
 	WRITE_BOOL_FIELD(tuple->tdhasoid);
 	WRITE_INT_FIELD(tuple->tdrefcount);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _outNode -
  *	  converts a Node into ascii string and append it to 'str'
@@ -4952,3 +5041,5 @@ nodeToString(void *obj)
 	_outNode(&str, obj);
 	return str.data;
 }
+
+#endif /* COMPILING_BINARY_FUNCS */

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -34,6 +34,13 @@
 #include "utils/lsyscache.h"  /* For get_typlenbyval */
 #include "cdb/cdbgang.h"
 
+/*
+ * readfuncs.c is compiled normally into readfuncs.o, but it's also
+ * #included from readfast.c. When #included, readfuncs.c defines
+ * COMPILING_BINARY_FUNCS, and provides replacements READ_* macros. See
+ * comments at top of readfast.c.
+ */
+#ifndef COMPILING_BINARY_FUNCS
 
 /*
  * Macros to simplify reading of different kinds of fields.  Use these
@@ -290,10 +297,12 @@ inline static char extended_char(char* token, size_t length)
 		nodeRead(NULL, 0) \
 	)
 
+#endif /* COMPILING_BINARY_FUNCS */
 
 static Datum readDatum(bool typbyval);
 
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readQuery
  */
@@ -435,6 +444,7 @@ _readQuery(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _readNotifyStmt
@@ -465,6 +475,7 @@ _readDeclareCursorStmt(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readCurrentOfExpr
  */
@@ -481,6 +492,7 @@ _readCurrentOfExpr(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _readSingleRowErrorDesc
@@ -580,6 +592,7 @@ _readWindowSpecParse(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static WindowSpec *
 _readWindowSpec(void)
 {
@@ -599,6 +612,7 @@ _readWindowSpec(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static WindowFrame *
 _readWindowFrame(void)
@@ -720,6 +734,7 @@ _readAlias(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static RangeVar *
 _readRangeVar(void)
 {
@@ -742,7 +757,9 @@ _readRangeVar(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static IntoClause *
 _readIntoClause(void)
 {
@@ -800,6 +817,7 @@ _readIntoClause(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _readVar
@@ -820,6 +838,7 @@ _readVar(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readConst
  */
@@ -841,7 +860,9 @@ _readConst(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readConstraint
  */
@@ -893,6 +914,7 @@ _readConstraint(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static IndexStmt *
 _readIndexStmt(void)
@@ -931,6 +953,7 @@ _readIndexElem(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static ReindexStmt *
 _readReindexStmt(void)
 {
@@ -945,8 +968,8 @@ _readReindexStmt(void)
 	READ_OID_FIELD(relid);
 
 	READ_DONE();
-
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static ViewStmt *
 _readViewStmt(void)
@@ -981,6 +1004,7 @@ _readRuleStmt(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static DropStmt *
 _readDropStmt(void)
 {
@@ -995,7 +1019,9 @@ _readDropStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static DropPropertyStmt *
 _readDropPropertyStmt(void)
 {
@@ -1009,7 +1035,9 @@ _readDropPropertyStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static TruncateStmt *
 _readTruncateStmt(void)
 {
@@ -1020,7 +1048,9 @@ _readTruncateStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static AlterTableStmt *
 _readAlterTableStmt(void)
 {
@@ -1057,7 +1087,9 @@ _readAlterTableStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static AlterTableCmd *
 _readAlterTableCmd(void)
 {
@@ -1073,6 +1105,7 @@ _readAlterTableCmd(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static InheritPartitionCmd *
 _readInheritPartitionCmd(void)
@@ -1084,6 +1117,7 @@ _readInheritPartitionCmd(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static AlterPartitionCmd *
 _readAlterPartitionCmd(void)
 {
@@ -1095,6 +1129,7 @@ _readAlterPartitionCmd(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static AlterPartitionId *
 _readAlterPartitionId(void)
@@ -1177,6 +1212,7 @@ _readAlterRoleSetStmt(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static AlterObjectSchemaStmt *
 _readAlterObjectSchemaStmt(void)
 {
@@ -1191,9 +1227,9 @@ _readAlterObjectSchemaStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
-
-
+#ifndef COMPILING_BINARY_FUNCS
 static AlterOwnerStmt *
 _readAlterOwnerStmt(void)
 {
@@ -1208,7 +1244,7 @@ _readAlterOwnerStmt(void)
 
 	READ_DONE();
 }
-
+#endif /* COMPILING_BINARY_FUNCS */
 
 static RenameStmt *
 _readRenameStmt(void)
@@ -1228,6 +1264,7 @@ _readRenameStmt(void)
 }
 
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readFuncCall
  *
@@ -1251,6 +1288,7 @@ _readFuncCall(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static DefElem *
 _readDefElem(void)
@@ -1260,9 +1298,11 @@ _readDefElem(void)
 	READ_STRING_FIELD(defname);
 	READ_NODE_FIELD(arg);
 	READ_ENUM_FIELD(defaction, DefElemAction);
+
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static A_Const *
 _readAConst(void)
 {
@@ -1328,8 +1368,9 @@ _readAConst(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
-
+#ifndef COMPILING_BINARY_FUNCS
 static A_Expr *
 _readAExpr(void)
 {
@@ -1395,6 +1436,7 @@ _readAExpr(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _readParam
@@ -1411,6 +1453,7 @@ _readParam(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readAggref
  */
@@ -1448,6 +1491,7 @@ _readAggref(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _outAggOrder
@@ -1505,6 +1549,7 @@ _readArrayRef(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readFuncExpr
  */
@@ -1526,7 +1571,9 @@ _readFuncExpr(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readOpExpr
  */
@@ -1554,7 +1601,9 @@ _readOpExpr(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readDistinctExpr
  */
@@ -1582,7 +1631,9 @@ _readDistinctExpr(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readScalarArrayOpExpr
  */
@@ -1609,7 +1660,9 @@ _readScalarArrayOpExpr(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readBoolExpr
  */
@@ -1634,7 +1687,9 @@ _readBoolExpr(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readSubLink
  */
@@ -1654,6 +1709,7 @@ _readSubLink(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _readFieldSelect
@@ -1839,6 +1895,7 @@ _readMinMaxExpr(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readNullIfExpr
  */
@@ -1866,6 +1923,7 @@ _readNullIfExpr(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _readNullTest
@@ -1971,6 +2029,7 @@ _readRangeTblRef(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readJoinExpr
  */
@@ -1991,6 +2050,7 @@ _readJoinExpr(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _readFromExpr
@@ -2072,6 +2132,7 @@ _readTypeCast(void)
 }
 
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readRangeTblEntry
  */
@@ -2140,6 +2201,7 @@ _readRangeTblEntry(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * Greenplum Database additions for serialization support
@@ -2147,6 +2209,7 @@ _readRangeTblEntry(void)
  */
 #include "nodes/plannodes.h"
 
+#ifndef COMPILING_BINARY_FUNCS
 static CreateStmt *
 _readCreateStmt(void)
 {
@@ -2195,7 +2258,9 @@ _readCreateStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static Partition *
 _readPartition(void)
 {
@@ -2212,7 +2277,9 @@ _readPartition(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static PartitionRule *
 _readPartitionRule(void)
 {
@@ -2236,7 +2303,9 @@ _readPartitionRule(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
 static PartitionNode *
 _readPartitionNode(void)
 {
@@ -2247,6 +2316,7 @@ _readPartitionNode(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static PgPartRule *
 _readPgPartRule(void)
@@ -2287,6 +2357,7 @@ _readExtTableTypeDesc(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static CreateExternalStmt *
 _readCreateExternalStmt(void)
 {
@@ -2306,6 +2377,7 @@ _readCreateExternalStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static CreateForeignStmt *
 _readCreateForeignStmt(void)
@@ -2373,9 +2445,9 @@ _readCreatePLangStmt(void)
 	READ_OID_FIELD(plvalidatorOid);
 
 	READ_DONE();
-
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static DropPLangStmt *
 _readDropPLangStmt(void)
 {
@@ -2386,8 +2458,8 @@ _readDropPLangStmt(void)
 	READ_BOOL_FIELD(missing_ok);
 
 	READ_DONE();
-
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static CreateSeqStmt *
 _readCreateSeqStmt(void)
@@ -2406,6 +2478,7 @@ static AlterSeqStmt *
 _readAlterSeqStmt(void)
 {
 	READ_LOCALS(AlterSeqStmt);
+
 	READ_NODE_FIELD(sequence);
 	READ_NODE_FIELD(options);
 
@@ -2442,9 +2515,9 @@ static CreatedbStmt *
 _readCreatedbStmt(void)
 {
 	READ_LOCALS(CreatedbStmt);
+
 	READ_STRING_FIELD(dbname);
 	READ_NODE_FIELD(options);
-
 	READ_OID_FIELD(dbOid);
 
 	READ_DONE();
@@ -2474,6 +2547,7 @@ _readCreateDomainStmt(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static AlterDomainStmt *
 _readAlterDomainStmt(void)
 {
@@ -2487,6 +2561,7 @@ _readAlterDomainStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static CreateFdwStmt *
 _readCreateFdwStmt(void)
@@ -2604,6 +2679,7 @@ static CreateFunctionStmt *
 _readCreateFunctionStmt(void)
 {
 	READ_LOCALS(CreateFunctionStmt);
+
 	READ_BOOL_FIELD(replace);
 	READ_NODE_FIELD(funcname);
 	READ_NODE_FIELD(parameters);
@@ -2620,6 +2696,7 @@ static FunctionParameter *
 _readFunctionParameter(void)
 {
 	READ_LOCALS(FunctionParameter);
+
 	READ_STRING_FIELD(name);
 	READ_NODE_FIELD(argType);
 	READ_ENUM_FIELD(mode, FunctionParameterMode);
@@ -2627,10 +2704,12 @@ _readFunctionParameter(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static RemoveFuncStmt *
 _readRemoveFuncStmt(void)
 {
 	READ_LOCALS(RemoveFuncStmt);
+
 	READ_ENUM_FIELD(kind,ObjectType);
 	READ_NODE_FIELD(name);
 	READ_NODE_FIELD(args);
@@ -2639,6 +2718,7 @@ _readRemoveFuncStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static AlterFunctionStmt *
 _readAlterFunctionStmt(void)
@@ -2651,6 +2731,7 @@ _readAlterFunctionStmt(void)
 }
 
 
+#ifndef COMPILING_BINARY_FUNCS
 static DefineStmt *
 _readDefineStmt(void)
 {
@@ -2666,8 +2747,8 @@ _readDefineStmt(void)
 	READ_BOOL_FIELD(trusted);   /* CDB */
 
 	READ_DONE();
-
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static CompositeTypeStmt *
 _readCompositeTypeStmt(void)
@@ -2679,13 +2760,13 @@ _readCompositeTypeStmt(void)
 	READ_OID_FIELD(comptypeOid);
 
 	READ_DONE();
-
 }
 
 static CreateCastStmt *
 _readCreateCastStmt(void)
 {
 	READ_LOCALS(CreateCastStmt);
+
 	READ_NODE_FIELD(sourcetype);
 	READ_NODE_FIELD(targettype);
 	READ_NODE_FIELD(func);
@@ -2695,10 +2776,12 @@ _readCreateCastStmt(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static DropCastStmt *
 _readDropCastStmt(void)
 {
 	READ_LOCALS(DropCastStmt);
+
 	READ_NODE_FIELD(sourcetype);
 	READ_NODE_FIELD(targettype);
 	READ_ENUM_FIELD(behavior, DropBehavior);
@@ -2706,11 +2789,13 @@ _readDropCastStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static CreateOpClassStmt *
 _readCreateOpClassStmt(void)
 {
 	READ_LOCALS(CreateOpClassStmt);
+
 	READ_NODE_FIELD(opclassname);
 	READ_STRING_FIELD(amname);
 	READ_NODE_FIELD(datatype);
@@ -2735,6 +2820,7 @@ _readCreateOpClassItem(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static RemoveOpClassStmt *
 _readRemoveOpClassStmt(void)
 {
@@ -2746,11 +2832,13 @@ _readRemoveOpClassStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static CreateConversionStmt *
 _readCreateConversionStmt(void)
 {
 	READ_LOCALS(CreateConversionStmt);
+
 	READ_NODE_FIELD(conversion_name);
 	READ_STRING_FIELD(for_encoding_name);
 	READ_STRING_FIELD(to_encoding_name);
@@ -2761,6 +2849,7 @@ _readCreateConversionStmt(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static GrantStmt *
 _readGrantStmt(void)
 {
@@ -2777,6 +2866,7 @@ _readGrantStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static PrivGrantee *
 _readPrivGrantee(void)
@@ -2799,6 +2889,7 @@ _readFuncWithArgs(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static GrantRoleStmt *
 _readGrantRoleStmt(void)
 {
@@ -2813,6 +2904,7 @@ _readGrantRoleStmt(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static LockStmt *
 _readLockStmt(void)
@@ -2837,6 +2929,7 @@ _readConstraintsSetStmt(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * _readWindowKey
  */
@@ -2852,6 +2945,7 @@ _readWindowKey(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 /*
  * _readVacuumStmt
@@ -2871,6 +2965,7 @@ _readVacuumStmt(void)
 	READ_NODE_FIELD(va_cols);
 	READ_NODE_FIELD(expanded_relids);
 	READ_NODE_FIELD(extra_oids);
+
 	READ_NODE_FIELD(appendonly_compaction_segno);
 	READ_NODE_FIELD(appendonly_compaction_insert_segno);
 	READ_BOOL_FIELD(appendonly_compaction_vacuum_cleanup);
@@ -2894,6 +2989,7 @@ _readCdbProcess(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static Slice *
 _readSlice(void)
 {
@@ -2914,6 +3010,7 @@ _readSlice(void)
 
 	READ_DONE();
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static SliceTable *
 _readSliceTable(void)
@@ -2941,6 +3038,7 @@ _readVariableResetStmt(void)
 }
 
 
+#ifndef COMPILING_BINARY_FUNCS
 static CreateTrigStmt *
 _readCreateTrigStmt(void)
 {
@@ -2962,8 +3060,8 @@ _readCreateTrigStmt(void)
 	READ_OID_FIELD(trigOid);
 
 	READ_DONE();
-
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 
 static TableValueExpr *
@@ -2987,6 +3085,7 @@ _readAlterTypeStmt(void)
 	READ_DONE();
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 /*
  * Greenplum Database developers added code to improve performance over the
  * linear searching that existed in the postgres version of
@@ -3309,3 +3408,4 @@ readDatum(bool typbyval)
 
 	return res;
 }
+#endif /* COMPILING_BINARY_FUNCS */

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -99,10 +99,10 @@
 inline static char extended_char(char* token, size_t length)
 {
 	char c, *s;
-	
+
 	if ( length == 1 )
 		return *token;
-	
+
 	s = debackslash(token, length);
 	if ( strlen(s) == 1 )
 		c = s[0];
@@ -262,10 +262,10 @@ inline static char extended_char(char* token, size_t length)
 	((length) == 0 ? NULL : debackslash(token, length))
 
 /* The following READ_..._VALUE macros mimic the corresponding READ_..._FIELD
- * macros above, but produce the value read (with appropriate type) instead of 
- * assigning it to a field of local_node.  They are expressions, not statements.  
+ * macros above, but produce the value read (with appropriate type) instead of
+ * assigning it to a field of local_node.  They are expressions, not statements.
  *
- * Note that the fldname parameter is not used, but retained is for symmetry. 
+ * Note that the fldname parameter is not used, but retained is for symmetry.
  * These macros exist only to simplify supporting old node formats.
  */
 
@@ -307,7 +307,7 @@ _readQuery(void)
 	READ_BOOL_FIELD(canSetTag);
 	READ_NODE_FIELD(utilityStmt);
 	READ_INT_FIELD(resultRelation);
-	
+
 	if ( ! pg_strtok_peek_fldname("intoClause"))
 	{
 		/* If the Query node was written with 3.3 or earlier, there is no intoClause,
@@ -320,7 +320,7 @@ _readQuery(void)
 		List *op = READ_NODE_VALUE(intoOptions);
 		OnCommitAction oc = READ_ENUM_VALUE(intoOnCommit, OnCommitAction);
 		char * ts = READ_STRING_VALUE(intoTableSpaceName);
-		
+
 		if ( rv == NULL && op == NIL && oc == ONCOMMIT_NOOP && ts == NULL )
 		{
 			/* Nothing to say. */
@@ -354,7 +354,7 @@ _readQuery(void)
 		/* Post 3.3, it's easier. */
 		READ_NODE_FIELD(intoClause);
 	}
-	
+
 	READ_BOOL_FIELD(hasAggs);
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
@@ -392,7 +392,7 @@ _readQuery(void)
 		READ_BOOL_FIELD(hasRecursive);
 		READ_BOOL_FIELD(hasModifyingCTE);
 	}
-	
+
 	READ_NODE_FIELD(limitOffset);
 	READ_NODE_FIELD(limitCount);
 	READ_NODE_FIELD(rowMarks);
@@ -402,12 +402,12 @@ _readQuery(void)
 	READ_NODE_FIELD(result_aosegnos);
 	READ_NODE_FIELD(returningLists);
 
-    /* In some earlier releases (including 3.3) a TableOidInfo was held in the 
-     * Query node.  Maybe some values got stored in the catalog as part of a 
-     * rule (possible?)  Maybe the Query was a CTAS. In any case, we don't want 
+    /* In some earlier releases (including 3.3) a TableOidInfo was held in the
+     * Query node.  Maybe some values got stored in the catalog as part of a
+     * rule (possible?)  Maybe the Query was a CTAS. In any case, we don't want
      * to remember the OIDs assigned in the past.
      *
-     * Now TableOidInfo is in the node's intoClause. As noted, we don't actually 
+     * Now TableOidInfo is in the node's intoClause. As noted, we don't actually
      * need the values but, if they exist, we need scan over them.
      */
     if (pg_strtok_peek_fldname("intoOidInfo.relOid"))
@@ -528,6 +528,9 @@ _readGroupClause(void)
 	READ_DONE();
 }
 
+/*
+ * _readGroupingClause
+ */
 static GroupingClause *
 _readGroupingClause(void)
 {
@@ -567,7 +570,7 @@ _readGroupId(void)
 }
 
 static WindowSpecParse *
-_readWindowSpecParse(const char ** str)
+_readWindowSpecParse(void)
 {
 	READ_LOCALS(WindowSpecParse);
 
@@ -578,7 +581,7 @@ _readWindowSpecParse(const char ** str)
 }
 
 static WindowSpec *
-_readWindowSpec(const char ** str)
+_readWindowSpec(void)
 {
 	READ_LOCALS(WindowSpec);
 
@@ -598,7 +601,7 @@ _readWindowSpec(const char ** str)
 }
 
 static WindowFrame *
-_readWindowFrame(const char ** str)
+_readWindowFrame(void)
 {
 	READ_LOCALS(WindowFrame);
 
@@ -612,7 +615,7 @@ _readWindowFrame(const char ** str)
 }
 
 static WindowFrameEdge *
-_readWindowFrameEdge(const char ** str)
+_readWindowFrameEdge(void)
 {
 	READ_LOCALS(WindowFrameEdge);
 
@@ -623,7 +626,7 @@ _readWindowFrameEdge(const char ** str)
 }
 
 static PercentileExpr *
-_readPercentileExpr(const char ** str)
+_readPercentileExpr(void)
 {
 	READ_LOCALS(PercentileExpr);
 
@@ -657,11 +660,11 @@ static WithClause *
 _readWithClause(void)
 {
 	READ_LOCALS(WithClause);
-	
+
 	READ_NODE_FIELD(ctes);
 	READ_BOOL_FIELD(recursive);
 	READ_INT_FIELD(location);
-	
+
 	READ_DONE();
 }
 
@@ -669,7 +672,7 @@ static CommonTableExpr *
 _readCommonTableExpr(void)
 {
 	READ_LOCALS(CommonTableExpr);
-	
+
 	READ_STRING_FIELD(ctename);
 	READ_NODE_FIELD(aliascolnames);
 	READ_NODE_FIELD(ctequery);
@@ -744,14 +747,14 @@ static IntoClause *
 _readIntoClause(void)
 {
 	READ_LOCALS(IntoClause);
-	
+
 	READ_NODE_FIELD(rel);
 	READ_NODE_FIELD(colNames);
 	READ_NODE_FIELD(options);
 	READ_ENUM_FIELD(onCommit, OnCommitAction);
 	READ_STRING_FIELD(tableSpaceName);
 	READ_OID_FIELD(oidInfo.relOid);
-    READ_OID_FIELD(oidInfo.comptypeOid); 
+    READ_OID_FIELD(oidInfo.comptypeOid);
     READ_OID_FIELD(oidInfo.toastOid);
     READ_OID_FIELD(oidInfo.toastIndexOid);
     READ_OID_FIELD(oidInfo.toastComptypeOid);
@@ -769,15 +772,15 @@ _readIntoClause(void)
         READ_OID_FIELD(oidInfo.aoblkdirComptypeOid);
     }
 	/* policy not serialized */
-	
+
 	/* Is this code, carried over from 3.3, actually needed?
 	 *
-	 * If the Query was a CTAS, and the CTAS was stored in the catalog 
-	 * as part of a rule, we don't want to remember the OIDs assigned 
+	 * If the Query was a CTAS, and the CTAS was stored in the catalog
+	 * as part of a rule, we don't want to remember the OIDs assigned
 	 * in the past.  Not sure we can ever have that happen.
 	 */
 	Assert(local_node->oidInfo.relOid == InvalidOid);
-	
+
 	local_node->oidInfo.relOid = InvalidOid;
 	local_node->oidInfo.comptypeOid = InvalidOid;
 	local_node->oidInfo.toastOid = InvalidOid;
@@ -794,7 +797,7 @@ _readIntoClause(void)
 	local_node->oidInfo.aovisimapComptypeOid = InvalidOid;
 
 	/* policy not serialized */
-	
+
 	READ_DONE();
 }
 
@@ -845,7 +848,6 @@ _readConst(void)
 static Constraint *
 _readConstraint(void)
 {
-
 	READ_LOCALS(Constraint);
 
 	READ_OID_FIELD(conoid);
@@ -889,7 +891,6 @@ _readConstraint(void)
 		local_node->contype = CONSTR_NOTNULL;
 	}
 
-
 	READ_DONE();
 }
 
@@ -926,7 +927,6 @@ _readIndexElem(void)
 	READ_STRING_FIELD(name);
 	READ_NODE_FIELD(expr);
 	READ_NODE_FIELD(opclass);
-
 
 	READ_DONE();
 }
@@ -1052,7 +1052,6 @@ _readAlterTableStmt(void)
 			READ_OID_FIELD(oidInfo[m].aoblkdirOid);
 			READ_OID_FIELD(oidInfo[m].aoblkdirIndexOid);
 			READ_OID_FIELD(oidInfo[m].aoblkdirComptypeOid);
-
 		}
 	}
 
@@ -1122,10 +1121,10 @@ _readCreateRoleStmt(void)
 }
 
 static DenyLoginInterval *
-_readDenyLoginInterval(const char ** str)
+_readDenyLoginInterval(void)
 {
 	READ_LOCALS(DenyLoginInterval);
-	
+
 	READ_NODE_FIELD(start);
 	READ_NODE_FIELD(end);
 
@@ -1133,13 +1132,13 @@ _readDenyLoginInterval(const char ** str)
 }
 
 static DenyLoginPoint *
-_readDenyLoginPoint(const char ** str)
+_readDenyLoginPoint(void)
 {
 	READ_LOCALS(DenyLoginPoint);
-	
+
 	READ_NODE_FIELD(day);
 	READ_NODE_FIELD(time);
-	
+
 	READ_DONE();
 }
 
@@ -1152,10 +1151,9 @@ _readDropRoleStmt(void)
 	READ_BOOL_FIELD(missing_ok);
 
 	READ_DONE();
-
 }
 
-static  AlterRoleStmt *
+static AlterRoleStmt *
 _readAlterRoleStmt(void)
 {
 	READ_LOCALS(AlterRoleStmt);
@@ -1163,11 +1161,11 @@ _readAlterRoleStmt(void)
 	READ_STRING_FIELD(role);
 	READ_NODE_FIELD(options);
 	READ_INT_FIELD(action);
-	READ_DONE();
 
+	READ_DONE();
 }
 
-static  AlterRoleSetStmt *
+static AlterRoleSetStmt *
 _readAlterRoleSetStmt(void)
 {
 	READ_LOCALS(AlterRoleSetStmt);
@@ -1177,7 +1175,6 @@ _readAlterRoleSetStmt(void)
 	READ_NODE_FIELD(value);
 
 	READ_DONE();
-
 }
 
 static AlterObjectSchemaStmt *
@@ -1249,8 +1246,8 @@ _readFuncCall(void)
 	READ_BOOL_FIELD(agg_distinct);
     READ_INT_FIELD(location);
 
-    READ_NODE_FIELD(over);          /*CDB*/
-    READ_NODE_FIELD(agg_filter);    /*CDB*/
+	READ_NODE_FIELD(over);          /*CDB*/
+	READ_NODE_FIELD(agg_filter);    /*CDB*/
 
 	READ_DONE();
 }
@@ -1392,7 +1389,6 @@ _readAExpr(void)
 		elog(ERROR,"Unable to understand A_Expr node %.30s",token);
 	}
 
-
 	READ_NODE_FIELD(lexpr);
 	READ_NODE_FIELD(rexpr);
 	READ_INT_FIELD(location);
@@ -1484,7 +1480,7 @@ _readWindowRef(void)
 	READ_BOOL_FIELD(windistinct);
 	READ_UINT_FIELD(winspec);
 	READ_UINT_FIELD(winindex);
-    READ_ENUM_FIELD(winstage, WinStage);
+	READ_ENUM_FIELD(winstage, WinStage);
 	READ_UINT_FIELD(winlevel);
 
 	READ_DONE();
@@ -1988,7 +1984,7 @@ _readJoinExpr(void)
 	READ_NODE_FIELD(larg);
 	READ_NODE_FIELD(rarg);
     /* CDB: subqfromlist is used only within planner; don't need to read it */
-    READ_NODE_FIELD(usingClause);   /*CDB*/
+	READ_NODE_FIELD(usingClause);   /*CDB*/
 	READ_NODE_FIELD(quals);
 	READ_NODE_FIELD(alias);
 	READ_INT_FIELD(rtindex);
@@ -2201,7 +2197,7 @@ _readCreateStmt(void)
 }
 
 static Partition *
-_readPartition(const char **str)
+_readPartition(void)
 {
 	READ_LOCALS(Partition);
 
@@ -2218,7 +2214,7 @@ _readPartition(const char **str)
 }
 
 static PartitionRule *
-_readPartitionRule(const char **str)
+_readPartitionRule(void)
 {
 	READ_LOCALS(PartitionRule);
 
@@ -2242,7 +2238,7 @@ _readPartitionRule(const char **str)
 }
 
 static PartitionNode *
-_readPartitionNode(const char **str)
+_readPartitionNode(void)
 {
 	READ_LOCALS(PartitionNode);
 
@@ -2253,7 +2249,7 @@ _readPartitionNode(const char **str)
 }
 
 static PgPartRule *
-_readPgPartRule(const char **str)
+_readPgPartRule(void)
 {
 	READ_LOCALS(PgPartRule);
 
@@ -2268,7 +2264,7 @@ _readPgPartRule(const char **str)
 }
 
 static SegfileMapNode *
-_readSegfileMapNode(const char **str)
+_readSegfileMapNode(void)
 {
 	READ_LOCALS(SegfileMapNode);
 
@@ -2307,7 +2303,7 @@ _readCreateExternalStmt(void)
 	READ_NODE_FIELD(encoding);
 	READ_NODE_FIELD(distributedBy);
 	local_node->policy = NULL;
-	
+
 	READ_DONE();
 }
 
@@ -2320,12 +2316,12 @@ _readCreateForeignStmt(void)
 	READ_NODE_FIELD(tableElts);
 	READ_STRING_FIELD(srvname);
 	READ_NODE_FIELD(options);
-	
+
 	READ_DONE();
 }
 
 static FkConstraint *
-_outFkConstraint(void)
+_readFkConstraint(void)
 {
 	READ_LOCALS(FkConstraint);
 
@@ -2496,11 +2492,11 @@ static CreateFdwStmt *
 _readCreateFdwStmt(void)
 {
 	READ_LOCALS(CreateFdwStmt);
-	
+
 	READ_STRING_FIELD(fdwname);
 	READ_NODE_FIELD(validator);
 	READ_NODE_FIELD(options);
-	
+
 	READ_DONE();
 }
 
@@ -2508,7 +2504,7 @@ static AlterFdwStmt *
 _readAlterFdwStmt(void)
 {
 	READ_LOCALS(AlterFdwStmt);
-	
+
 	READ_STRING_FIELD(fdwname);
 	READ_NODE_FIELD(validator);
 	READ_BOOL_FIELD(change_validator);
@@ -2521,7 +2517,7 @@ static DropFdwStmt *
 _readDropFdwStmt(void)
 {
 	READ_LOCALS(DropFdwStmt);
-	
+
 	READ_STRING_FIELD(fdwname);
 	READ_BOOL_FIELD(missing_ok);
 	READ_ENUM_FIELD(behavior, DropBehavior);
@@ -2533,7 +2529,7 @@ static CreateForeignServerStmt *
 _readCreateForeignServerStmt(void)
 {
 	READ_LOCALS(CreateForeignServerStmt);
-	
+
 	READ_STRING_FIELD(servername);
 	READ_STRING_FIELD(servertype);
 	READ_STRING_FIELD(version);
@@ -2547,7 +2543,7 @@ static AlterForeignServerStmt *
 _readAlterForeignServerStmt(void)
 {
 	READ_LOCALS(AlterForeignServerStmt);
-	
+
 	READ_STRING_FIELD(servername);
 	READ_STRING_FIELD(version);
 	READ_NODE_FIELD(options);
@@ -2560,7 +2556,7 @@ static DropForeignServerStmt *
 _readDropForeignServerStmt(void)
 {
 	READ_LOCALS(DropForeignServerStmt);
-	
+
 	READ_STRING_FIELD(servername);
 	READ_BOOL_FIELD(missing_ok);
 	READ_ENUM_FIELD(behavior, DropBehavior);
@@ -2572,7 +2568,7 @@ static CreateUserMappingStmt *
 _readCreateUserMappingStmt(void)
 {
 	READ_LOCALS(CreateUserMappingStmt);
-	
+
 	READ_STRING_FIELD(username);
 	READ_STRING_FIELD(servername);
 	READ_NODE_FIELD(options);
@@ -2584,7 +2580,7 @@ static AlterUserMappingStmt *
 _readAlterUserMappingStmt(void)
 {
 	READ_LOCALS(AlterUserMappingStmt);
-	
+
 	READ_STRING_FIELD(username);
 	READ_STRING_FIELD(servername);
 	READ_NODE_FIELD(options);
@@ -2596,7 +2592,7 @@ static DropUserMappingStmt *
 _readDropUserMappingStmt(void)
 {
 	READ_LOCALS(DropUserMappingStmt);
-	
+
 	READ_STRING_FIELD(username);
 	READ_STRING_FIELD(servername);
 	READ_BOOL_FIELD(missing_ok);
@@ -2786,6 +2782,7 @@ static PrivGrantee *
 _readPrivGrantee(void)
 {
 	READ_LOCALS(PrivGrantee);
+
 	READ_STRING_FIELD(rolname);
 
 	READ_DONE();
@@ -2795,6 +2792,7 @@ static FuncWithArgs *
 _readFuncWithArgs(void)
 {
 	READ_LOCALS(FuncWithArgs);
+
 	READ_NODE_FIELD(funcname);
 	READ_NODE_FIELD(funcargs);
 
@@ -2805,6 +2803,7 @@ static GrantRoleStmt *
 _readGrantRoleStmt(void)
 {
 	READ_LOCALS(GrantRoleStmt);
+
 	READ_NODE_FIELD(granted_roles);
 	READ_NODE_FIELD(grantee_roles);
 	READ_BOOL_FIELD(is_grant);
@@ -2819,6 +2818,7 @@ static LockStmt *
 _readLockStmt(void)
 {
 	READ_LOCALS(LockStmt);
+
 	READ_NODE_FIELD(relations);
 	READ_INT_FIELD(mode);
 	READ_BOOL_FIELD(nowait);
@@ -2830,6 +2830,7 @@ static ConstraintsSetStmt *
 _readConstraintsSetStmt(void)
 {
 	READ_LOCALS(ConstraintsSetStmt);
+
 	READ_NODE_FIELD(constraints);
 	READ_BOOL_FIELD(deferred);
 
@@ -2933,6 +2934,7 @@ static VariableResetStmt *
 _readVariableResetStmt(void)
 {
 	READ_LOCALS(VariableResetStmt);
+
 	READ_STRING_FIELD(name);
 
 	READ_DONE();
@@ -3066,7 +3068,7 @@ static ParseNodeInfo infoAr[] =
 	{"CREATEEXTERNALSTMT", (ReadFn)_readCreateExternalStmt},
 	{"CREATEFDWSTMT", (ReadFn)_readCreateFdwStmt},
 	{"CREATEFOREIGNSERVERSTMT", (ReadFn)_readCreateForeignServerStmt},
-	{"CREATEFOREIGNSTMT", (ReadFn)_readCreateForeignStmt},	
+	{"CREATEFOREIGNSTMT", (ReadFn)_readCreateForeignStmt},
 	{"CREATEUSERMAPPINGSTMT", (ReadFn)_readCreateUserMappingStmt},
 	{"CREATEFUNCSTMT", (ReadFn)_readCreateFunctionStmt},
 	{"CREATEOPCLASS", (ReadFn)_readCreateOpClassStmt},
@@ -3096,7 +3098,7 @@ static ParseNodeInfo infoAr[] =
 	{"EXTTABLETYPEDESC", (ReadFn)_readExtTableTypeDesc},
 	{"FIELDSELECT", (ReadFn)_readFieldSelect},
 	{"FIELDSTORE", (ReadFn)_readFieldStore},
-	{"FKCONSTRAINT", (ReadFn)_outFkConstraint},
+	{"FKCONSTRAINT", (ReadFn)_readFkConstraint},
 	{"FROMEXPR", (ReadFn)_readFromExpr},
 	{"FUNCCALL", (ReadFn)_readFuncCall},
 	{"FUNCEXPR", (ReadFn)_readFuncExpr},


### PR DESCRIPTION
Per my email to gpdb-dev earlier today:

> Every time a new field is added/removed in one of the parse or plan tree structs, its read/out/equal functions need to be adjusted accordingly. This is laborious, and often produces bugs of omission in PostgreSQL too. For Greenplum, we just need to remember to update these functions whenever we modify Greenplum-specific structs, like upstream does.
>
> There's one extra twist that presents a merge hazard however: In addition to the out and read functions for each struct, Greenplum has a copy of each out and read functions, in outfast.c and readfast.c. They need to be manually kept in sync.
>
> Let's try to refactor outfast.c and readfast.c so that we don't need to update these files whenever a new field is added in upstream. Perhaps we can put some ifdefs in outfuncs.c and readfuncs.c so that we can compile those files twice, with different READ_* and WRITE_* macros, to produce the same code that we have in outfast.c and readfast.c.`

So, that's what this pull request does. I took a super conservative approach, and when there was any difference whatsoever between the text and binary functions, I didn't merge them. That includes some functions that were identical except that one had an assertion, as well as some that I looked obviously broken to me. I'll leave cleaning those up to follow up patches. 