### PR TITLE
Fix brackets missing issue while describe views having ordered-set aggregates

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -4391,10 +4391,11 @@ get_rule_expr(Node *node, deparse_context *context,
 					else
 						Assert(false);
 					get_rule_expr((Node *) p->args, context, true);
-					appendStringInfoString(buf, ") WITHIN GROUP ");
+					appendStringInfoString(buf, ") WITHIN GROUP (");
 					get_sortlist_expr(p->sortClause,
 									  p->sortTargets,
 									  false, context, "ORDER BY ");
+					appendStringInfoString(buf, ") ");
 				}
 			}
 			break;

--- a/src/test/regress/expected/percentile.out
+++ b/src/test/regress/expected/percentile.out
@@ -973,8 +973,8 @@ select * from percv;
 reset gp_idf_deduplicate;
 select pg_get_viewdef('percv');
                                                                                                                                                        pg_get_viewdef                                                                                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT percentile_cont(float8(0.4)) WITHIN GROUP ORDER BY float8((perct.a / 10)) AS "percentile_cont", median(float8(perct.a)) AS "median", percentile_disc(float8(0.51)) WITHIN GROUP ORDER BY float8(perct.a) DESC AS "percentile_disc" FROM perct GROUP BY perct.b ORDER BY perct.b;
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT percentile_cont(float8(0.4)) WITHIN GROUP (ORDER BY float8((perct.a / 10))) AS "percentile_cont", median(float8(perct.a)) AS "median", percentile_disc(float8(0.51)) WITHIN GROUP (ORDER BY float8(perct.a) DESC) AS "percentile_disc" FROM perct GROUP BY perct.b ORDER BY perct.b;
 (1 row)
 
 select pg_get_viewdef('percv2');


### PR DESCRIPTION
After creating view that contain ordered-set (WITHIN GROUP) aggregates, \d+ or pg_dump can not get the correct definition of the view back, the brackets around the ORDER BY clause disappear.

View definition is stored in pg_rewrite in the form of parsetree, get_rule_expr() parses the T_Percentile node back to query string format, it should append the brackets around ORDER BY clause.