### PR TITLE
Add parentheses for AO table block size macros

### DIFF
--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -40,12 +40,12 @@
 #include "cdb/cdbappendonlystoragewrite.h"
 #include "cdb/cdbappendonlyblockdirectory.h"
 
-#define DEFAULT_COMPRESS_LEVEL				 0
-#define MIN_APPENDONLY_BLOCK_SIZE			 8 * 1024
-#define DEFAULT_APPENDONLY_BLOCK_SIZE		32 * 1024
-#define MAX_APPENDONLY_BLOCK_SIZE			 2 * 1024 * 1024
-#define DEFAULT_VARBLOCK_TEMPSPACE_LEN   	 4 * 1024 
-#define DEFAULT_FS_SAFE_WRITE_SIZE			 0
+#define DEFAULT_COMPRESS_LEVEL				 (0)
+#define MIN_APPENDONLY_BLOCK_SIZE			 (8 * 1024)
+#define DEFAULT_APPENDONLY_BLOCK_SIZE		(32 * 1024)
+#define MAX_APPENDONLY_BLOCK_SIZE			 (2 * 1024 * 1024)
+#define DEFAULT_VARBLOCK_TEMPSPACE_LEN   	 (4 * 1024)
+#define DEFAULT_FS_SAFE_WRITE_SIZE			 (0)
 
 /*
  * AppendOnlyInsertDescData is used for inserting data into append-only


### PR DESCRIPTION
There are some AO table var-block size related macros which are defined without parentheses. The lack of parentheses would cause wrong answers in the following case:

postgres=# CREATE TABLE foo1 (
a INT)
WITH (appendonly=true, orientation=row, blocksize=8193);
ERROR:  block size must be between 8KB and 2MB and be an 8KB multiple. Got 8193
postgres=# CREATE TABLE foo2 (
a INT)
WITH (appendonly=true, orientation=row, blocksize=8200);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE

The foo2 table is created successfully, which is not the expected behaviour.

The expected answer should be:

postgres=# CREATE TABLE foo1 (
a INT)
WITH (appendonly=true, orientation=row, blocksize=8193);
ERROR:  block size must be between 8KB and 2MB and be an 8KB multiple. Got 8193
postgres=# CREATE TABLE foo2 (
a INT)
WITH (appendonly=true, orientation=row, blocksize=8200);
ERROR:  block size must be between 8KB and 2MB and be an 8KB multiple. Got 8200

