### PR TITLE
fix: allow classpath to be absolute

### DIFF
--- a/gpAux/extensions/pljava/src/java/pljava/org/postgresql/pljava/sqlj/Loader.java
+++ b/gpAux/extensions/pljava/src/java/pljava/org/postgresql/pljava/sqlj/Loader.java
@@ -95,7 +95,20 @@ public class Loader extends ClassLoader
 		{
 			try 
 			{
-				URL url = new URL("file:///" + jarpath + "/" + m_classpath[i]);
+				String path="file:///";
+
+				// Previous behaviour required that paths be relative to $GPHOME/lib/postgresql/java/
+				// if the user specifies a relative path we will respect that behaviour
+				if (!m_classpath[i].startsWith("/"))
+				{
+					path += jarpath + '/';
+				}
+
+				// add the classpath, note from above that if the path starts with /
+				// then the classpath will be absolute.
+				path += m_classpath[i];
+
+				URL url = new URL(path);
 				JarLoader loader = new JarLoader(this, url);
 				m_jarloaders.add(loader);
 			}

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7773,10 +7773,10 @@ static struct config_string ConfigureNamesString[] =
 		"", NULL, NULL
 	},
 	{
-		{"pljava_classpath", PGC_USERSET, CUSTOM_OPTIONS,
+		{"pljava_classpath", PGC_SUSET, CUSTOM_OPTIONS,
 			gettext_noop("classpath used by the the JVM"),
 			NULL,
-		 GUC_GPDB_ADDOPT
+		 GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
 		},
 		&pljava_classpath,
 		"", NULL, NULL


### PR DESCRIPTION
Previously the  classpath was relative
to $GPHOME/lib/postgresql/java/

The implication of this is that in order to reference jars outside
of this directory the classpath will look like ../../../ etc.

This patch retains that behaviour but adds the ability to use absolute
paths.

For security purposes changing the classpath can only be done by a
super user or set in postgresql.conf