### PR TITLE
Fix gp_dump drop schema prior to create.

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -4002,6 +4002,22 @@ Feature: Validate command line arguments
         And verify that there is a "heap" table "heap_table" in "fullbkdb"
         And verify that there is a "ao" table "ao_table" in "fullbkdb"
         And verify that there is a "ao" table "ao_part_table" in "fullbkdb"
+
+    Scenario: Backup and Restore of schema table with -C option redirected to empty database
+        Given the database is running
+        And the database "fullbkdb" does not exist
+        And the database "fullbkdb2" does not exist
+        And database "fullbkdb" exists
+        And database "fullbkdb2" exists
+        And there are no backup files
+        And there is schema "testschema" exists in "fullbkdb"
+        And there is a "heap" table "testschema.schema_heap_table" with compression "None" in "fullbkdb" with data
+        When the user runs "gpcrondump -a -x fullbkdb -C"
+        Then gpcrondump should return a return code of 0
+        And the timestamp from gpcrondump is stored
+        When the user runs "gpdbrestore -a --redirect fullbkdb2" with the stored timestamp
+        Then gpdbrestore should return a return code of 0
+        And verify that there is a "heap" table "testschema.schema_heap_table" in "fullbkdb2"
     
     Scenario: Incremental Backup with -C option
         Given the database is running

--- a/src/bin/pg_dump/cdb/cdb_backup_archiver.c
+++ b/src/bin/pg_dump/cdb/cdb_backup_archiver.c
@@ -275,6 +275,22 @@ RestoreArchive(Archive *AHX, RestoreOptions *ropt)
 				ahprintf(AH, "%s", te->dropStmt);
 			}
 		}
+
+		/*
+		 * _selectOutputSchema may have set currSchema to reflect the effect
+		 * of a "SET search_path" command it emitted.  However, by now we may
+		 * have dropped that schema; or it might not have existed in the first
+		 * place.  In either case the effective value of search_path will not
+		 * be what we think.  Forcibly reset currSchema so that we will
+		 * re-establish the search_path setting when needed (after creating
+		 * the schema).
+		 *
+		 * If we treated users as pg_dump'able objects then we'd need to reset
+		 * currUser here too.
+		 */
+		if (AH->currSchema)
+			free(AH->currSchema);
+		AH->currSchema = NULL;
 	}
 
 	/*


### PR DESCRIPTION
During a restore on a database without the related schemas (ex. --redirect
to empty database) in which these schemas are set to be dropped, the SET
search_path can be missing before the CREATE TABLE statements in the dump
file. This results in tables being restored in the default schema instead
of their expected schema.

The main issue was that the ArchiveHandle->currSchema was not being reset
when drop schema prior to create was requested in gp_dump. The
ArchiveHandle->currSchema is now properly reset. This was originally fixed
in upstream Postgres, and this commit just ports over that fix to gp_dump.