### PR TITLE
Add --change-schema flag to allow restoring tables to a different schema

### DIFF
--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -24,7 +24,7 @@ try:
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.operations import Operation
     from gppylib.operations.backup_utils import check_dir_writable, generate_createdb_prefix, generate_master_dbdump_prefix, \
-                                                generate_report_filename, get_lines_from_file
+                                                generate_report_filename, get_lines_from_file, check_schema_exists
     from gppylib.operations.restore import GetDbName, GetDumpTables, RecoverRemoteDumps, RestoreDatabase, ValidateTimestamp, \
                                            config_files_dumped, create_restore_plan, get_restore_dir, get_restore_tables_from_table_file, \
                                            global_file_dumped, is_begin_incremental_run, is_incremental_restore, restore_cdatabase_file_with_nbu, \
@@ -84,6 +84,7 @@ class GpdbRestore(Operation):
         self.redirected_restore_db = options.redirected_restore_db
         self.report_status_dir = options.report_status_dir
         self.truncate = options.truncate
+        self.change_schema = options.change_schema
         # NetBackup params
         self.netbackup_service_host = options.netbackup_service_host
         self.netbackup_block_size = options.netbackup_block_size
@@ -103,6 +104,9 @@ class GpdbRestore(Operation):
 
         if self.list_backup and self.restore_tables:
             raise Exception('Cannot specify -T and --list-backup together')
+
+        if self.change_schema and not (self.restore_tables or self.table_file):
+            raise Exception('-T or --table-file option must be specified with the --change-schema option')
 
         if self.restore_tables is not None:
             self.restore_tables = self.restore_tables.split(',')
@@ -196,6 +200,14 @@ class GpdbRestore(Operation):
 
         self._output_info(info, restore_type)
 
+        if self.change_schema and not check_schema_exists(self.change_schema, info['restore_db']) and not self.redirected_restore_db:
+            raise Exception('Cannot restore tables to schema %s: schema does not exist' % self.change_schema)
+
+        if self.change_schema and self.redirected_restore_db:
+            if self.redirected_restore_db is not None:
+                if not check_schema_exists(self.change_schema, self.redirected_restore_db):
+                    raise Exception('Cannot restore tables to the database %s: schema %s does not exist' % (self.redirected_restore_db, self.change_schema))
+
         if self.interactive:
             if not userinput.ask_yesno(None, "\nContinue with Greenplum restore", 'N'):
                 raise UserAbortedException()
@@ -250,7 +262,8 @@ class GpdbRestore(Operation):
                         redirected_restore_db = self.redirected_restore_db,
                         report_status_dir = self.report_status_dir,
                         netbackup_service_host = self.netbackup_service_host,
-                        netbackup_block_size = self.netbackup_block_size).run()
+                        netbackup_block_size = self.netbackup_block_size,
+                        change_schema = self.change_schema).run()
 
         if self.no_analyze:
             logger.warn('--------------------------------------------------------------------------------------------------')
@@ -563,6 +576,8 @@ def create_parser():
                      help="Writable directory for report and status file creation")
     addTo.add_option('--truncate', action='store_true', dest='truncate', default=False,
                      help="Truncate's the restore tables specified using -T and --table-file option")
+    addTo.add_option('--change-schema', dest='change_schema', metavar="<change schema>",
+                     help="Different schema name to which tables will be restored")
     parser.add_option_group(addTo)
 
     # For Incremental Restore

--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -8,6 +8,7 @@ from gppylib.commands.unix import Scp
 from gppylib.db import dbconn
 from gppylib.db.dbconn import execSQL
 from gppylib.gparray import GpArray
+from pygresql import pg
 
 logger = gplog.get_default_logger()
 
@@ -614,3 +615,16 @@ def get_latest_full_ts_with_nbu(dbname, backup_dir, dump_prefix, netbackup_servi
             return timestamp
 
     raise Exception('No full backup found for given incremental on the specified NetBackup server')
+
+def getRows(dbname, exec_sql):
+    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+        curs = dbconn.execSQL(conn, exec_sql)
+        results = curs.fetchall()
+    return results
+
+def check_schema_exists(schema_name, dbname):
+    schemaname = pg.escape_string(schema_name)
+    schema_check_sql = "select * from pg_catalog.pg_namespace where nspname='%s';" % schemaname
+    if len(getRows(dbname, schema_check_sql)) < 1:
+        return False
+    return True

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -42,7 +42,8 @@ class restoreTestCase(unittest.TestCase):
                                        report_status_dir = None,
                                        ddboost = False,
                                        netbackup_service_host = None,
-                                       netbackup_block_size = None)
+                                       netbackup_block_size = None,
+                                       change_schema = None)
 
     def create_backup_dirs(self, top_dir=os.getcwd(), dump_dirs=[]):
         if dump_dirs is None:
@@ -105,12 +106,12 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.RestoreDatabase._process_createdb', side_effect=ExceptionNoStackTraceNeeded('Failed to create database'))
     @patch('time.sleep')
     def test_multitry_createdb_1(self, mock1, mock2):
-        r = RestoreDatabase('20121219', True, True, False, 'FOO', None, 1234, False, False, None, None, 'db_dumps', '', False, None, None, None, None)
+        r = RestoreDatabase('20121219', True, True, False, 'FOO', None, 1234, False, False, None, None, 'db_dumps', '', False, None, None, None, None, None)
         self.assertRaises(ExceptionNoStackTraceNeeded, r._multitry_createdb, '20121219', 'fullbkdb', None, 'FOO', None, 1234)
 
     @patch('gppylib.operations.restore.RestoreDatabase._process_createdb')
     def test_multitry_createdb_2(self, mock):
-        r = RestoreDatabase('20121219', True, True, False, 'FOO', None, 1234, False, False, None, None, 'db_dumps', '', False, None, None, None, None)
+        r = RestoreDatabase('20121219', True, True, False, 'FOO', None, 1234, False, False, None, None, 'db_dumps', '', False, None, None, None, None, None)
         r._multitry_createdb('20121219', 'fullbkdb', None, 'FOO', None, 1234)
 
     @patch('gppylib.operations.restore.get_partition_list', return_value=[('public', 't1'), ('public', 't2'), ('public', 't3')])
@@ -908,7 +909,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         full_restore_with_filter = False
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d bkdb -a'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -924,7 +926,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         full_restore_with_filter = False
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-f=/tmp/foo --gp-c -d bkdb'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -941,7 +944,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         self.restore.ddboost = True
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d bkdb -a --ddboost'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -958,7 +962,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         full_restore_with_filter = False
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-r=/tmp --status=/tmp --gp-c -d bkdb -a --gp-nostats'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -974,7 +979,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         full_restore_with_filter = False
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d bkdb -a --gp-nostats'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -990,7 +996,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         full_restore_with_filter = False
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-f=/tmp/foo --gp-c -d bkdb --gp-nostats'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -1007,7 +1014,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         self.restore.ddboost = True
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d bkdb -a --gp-nostats --ddboost'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -1025,7 +1033,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         self.restore.ddboost = True
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --prefix=bar_ --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d bkdb -a --gp-nostats --ddboost'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -1043,7 +1052,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         full_restore_with_filter = False
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/tmp/db_dumps/20121212 --gp-r=/tmp/db_dumps/20121212 --status=/tmp/db_dumps/20121212 --gp-c -d bkdb -a --gp-nostats'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -1061,7 +1071,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         full_restore_with_filter = False
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/tmp/db_dumps/20121212 --gp-c -d bkdb -a --gp-nostats'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -1094,7 +1105,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         full_restore_with_filter = False
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/foo/db_dumps/20121212 --gp-r=/tmp --status=/tmp --gp-c -d bkdb -a --gp-nostats'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -1112,7 +1124,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         full_restore_with_filter = True
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/foo/db_dumps/20121212 --gp-r=/tmp --status=/tmp --gp-c -d bkdb -a --gp-nostats'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -1132,7 +1145,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         self.restore.ddboost = False
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/foo/db_dumps/20121212 --gp-r=/tmp --status=/tmp --gp-c -d bkdb -a --gp-nostats --netbackup-service-host=mdw'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -1152,7 +1166,27 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         self.restore.dump_dir = 'backup/DCA-35'
         expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=backup/DCA-35/20121212 --gp-r=/tmp --status=/tmp --gp-c -d bkdb -a --gp-nostats --ddboost --netbackup-service-host=mdw'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats, full_restore_with_filter)
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
+        self.assertEqual(restore_line, expected_output)
+
+    # Test to verify the command line for gp_restore
+    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
+    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
+    def test_build_restore_line_15(self, mock1, mock2):
+        restore_timestamp = '20121212121212'
+        restore_db = 'bkdb'
+        compress = True
+        master_port = '5432'
+        ddboost = False
+        no_plan = True
+        no_ao_stats = False
+        table_filter_file = None
+        full_restore_with_filter = False
+        change_schema = 'newschema'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d bkdb -a --change-schema=newschema'
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, change_schema)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.generate_plan_filename', return_value='foo')
@@ -1518,8 +1552,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         db_name = 'FOO'
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None)
-        restoredb._analyze_restore_tables(db_name, restore_tables)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb._analyze_restore_tables(db_name, restore_tables, None)
 
     @patch('gppylib.operations.restore.execSQL', side_effect=Exception('analyze failed'))
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
@@ -1528,8 +1562,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         db_name = 'FOO'
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None)
-        self.assertRaises(Exception, restoredb._analyze_restore_tables, db_name, restore_tables)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        self.assertRaises(Exception, restoredb._analyze_restore_tables, db_name, restore_tables, None)
 
     @patch('gppylib.operations.backup_utils.execSQL')
     @patch('gppylib.operations.backup_utils.dbconn.DbURL', side_effect=Exception('Failed'))
@@ -1538,8 +1572,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         db_name = 'FOO'
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None)
-        self.assertRaises(Exception, restoredb._analyze_restore_tables, db_name, restore_tables)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        self.assertRaises(Exception, restoredb._analyze_restore_tables, db_name, restore_tables, None)
 
     @patch('gppylib.operations.backup_utils.execSQL')
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
@@ -1548,8 +1582,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         db_name = 'FOO'
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None)
-        self.assertRaises(Exception, restoredb._analyze_restore_tables, db_name, restore_tables)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        self.assertRaises(Exception, restoredb._analyze_restore_tables, db_name, restore_tables, None)
 
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')
@@ -1559,9 +1593,31 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         port = 1234
         restore_tables = ['public.t%d' % i for i in range(3002)]
         expected_batch_count = 3
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None)
-        batch_count = restoredb._analyze_restore_tables(db_name, restore_tables)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        batch_count = restoredb._analyze_restore_tables(db_name, restore_tables, None)
         self.assertEqual(batch_count, expected_batch_count)
+
+    @patch('gppylib.operations.backup_utils.dbconn.DbURL')
+    @patch('gppylib.operations.backup_utils.dbconn.connect')
+    @patch('gppylib.operations.backup_utils.dbconn.execSQL')
+    def test_analyze_restore_tables_05(self, mock1, mock2, mock3):
+        db_name = 'FOO'
+        port = 1234
+        restore_tables = ['public.t1', 'public.t2']
+        change_schema = 'newschema'
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb._analyze_restore_tables(db_name, restore_tables, change_schema)
+
+    @patch('gppylib.operations.backup_utils.dbconn.DbURL')
+    @patch('gppylib.operations.backup_utils.dbconn.connect')
+    @patch('gppylib.operations.backup_utils.dbconn.execSQL')
+    def test_analyze_restore_tables_06(self, mock1, mock2, mock3):
+        db_name = 'FOO'
+        port = 1234
+        restore_tables = ['public.t1', 'public.t2']
+        change_schema = 'newschema'
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb._analyze_restore_tables(db_name, restore_tables, change_schema)
 
 class ValidateTimestampTestCase(unittest.TestCase):
 

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1005,6 +1005,13 @@ def impl(context, table_list, dbname):
     for t in tables:
         backup_data(context, t.strip(), dbname) 
 
+@when('verify that there is a table "{tablename}" of "{tabletype}" type in "{dbname}" with same data as table "{backedup_table}"')
+@then('verify that there is a table "{tablename}" of "{tabletype}" type in "{dbname}" with same data as table "{backedup_table}"')
+def impl(context, tablename, tabletype, dbname, backedup_table):
+    if not check_table_exists(context, dbname=dbname, table_name=tablename, table_type=tabletype):
+        raise Exception("Table '%s' does not exist when it should" % tablename)
+    validate_restore_data(context, tablename, dbname, backedup_table)
+
 @when('verify that there is a "{table_type}" table "{tablename}" in "{dbname}" with data')
 @then('verify that there is a "{table_type}" table "{tablename}" in "{dbname}" with data')
 def impl(context, table_type, tablename, dbname):

--- a/gpMgmt/bin/gppylib/test/behave_utils/utils.py
+++ b/gpMgmt/bin/gppylib/test/behave_utils/utils.py
@@ -257,11 +257,14 @@ def diff_backup_restore_data(context, backup_file, restore_file):
     if not filecmp.cmp(backup_file, restore_file):
         raise Exception('%s and %s do not match' % (backup_file, restore_file))
     
-def validate_restore_data(context, tablename, dbname):
+def validate_restore_data(context, tablename, dbname, backedup_table=None):
     filename = tablename.strip() + "_restore"
     get_table_data_to_file(filename, tablename, dbname)
     current_dir = os.getcwd()
-    backup_file = os.path.join(current_dir, './gppylib/test/data', tablename.strip() + "_backup")
+    if backedup_table != None:
+        backup_file = os.path.join(current_dir, './gppylib/test/data', backedup_table.strip() + "_backup")
+    else:
+        backup_file = os.path.join(current_dir, './gppylib/test/data', tablename.strip() + "_backup")
     restore_file = os.path.join(current_dir, './gppylib/test/data', tablename.strip() + "_restore")
     diff_backup_restore_data(context, backup_file, restore_file)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
@@ -125,7 +125,7 @@ COPY ao_table (column1, column2, column3) FROM stdin;
         dump_tables = set([('pepper', 'ao_table')])
         with open(out_name, 'w') as fdout:
             with open(in_name, 'r') as fdin:
-                process_data(dump_schemas, dump_tables, fdin, fdout)
+                process_data(dump_schemas, dump_tables, fdin, fdout, None)
 
         with open(out_name, 'r') as fd:
             results = fd.read()
@@ -294,7 +294,7 @@ COPY ao_part_table_comp_1_prt_p1_2_prt_1 (column1, column2, column3) FROM stdin;
         dump_tables = set([('public', 'ao_part_table_comp_1_prt_p1_2_prt_1'), ('public', 'ao_part_table_1_prt_p1_2_prt_1')])
         with open(out_name, 'w') as fdout:
             with open(in_name, 'r') as fdin:
-                process_data(dump_schemas, dump_tables, fdin, fdout)
+                process_data(dump_schemas, dump_tables, fdin, fdout, None)
 
         with open(out_name, 'r') as fd:
             results = fd.read()
@@ -327,7 +327,7 @@ COPY ao_table (column1, column2, column3) FROM stdin;
         dump_tables = set([('public', 'ao_table')])
         with open(out_name, 'w') as fdout:
             with open(in_name, 'r') as fdin:
-                process_data(dump_schemas, dump_tables, fdin, fdout)
+                process_data(dump_schemas, dump_tables, fdin, fdout, None)
 
         with open(out_name, 'r') as fd:
             results = fd.read()
@@ -426,7 +426,7 @@ SET search_path = pepper, pg_catalog;
         dump_tables = set([('pepper', 'ao_table')])
         with open(out_name, 'w') as fdout:
             with open(in_name, 'r') as fdin:
-                process_data(dump_schemas, dump_tables, fdin, fdout)
+                process_data(dump_schemas, dump_tables, fdin, fdout, None)
 
         with open(out_name, 'r') as fd:
             results = fd.read()
@@ -471,7 +471,7 @@ COPY "测试" (column1, column2, column3) FROM stdin;
         dump_tables = set([('public', '测试')])
         with open(out_name, 'w') as fdout:
             with open(in_name, 'r') as fdin:
-                process_data(dump_schemas, dump_tables, fdin, fdout)
+                process_data(dump_schemas, dump_tables, fdin, fdout, None)
 
         with open(out_name, 'r') as fd:
             results = fd.read()
@@ -542,7 +542,7 @@ CREATE TABLE heap_table1 (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -621,7 +621,7 @@ CREATE TABLE heap_table (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -702,7 +702,7 @@ CREATE TABLE heap_table1 (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -775,7 +775,7 @@ CREATE TABLE heap_table1 (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -856,7 +856,7 @@ CREATE TABLE heap_table1 (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -940,7 +940,7 @@ CREATE TABLE heap_table1 (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1029,7 +1029,7 @@ CREATE TABLE heap_table1 (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1117,7 +1117,7 @@ COPY ao_part_table from stdin;
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1214,7 +1214,7 @@ COPY ao_part_table from stdin;
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1307,7 +1307,7 @@ CREATE TABLE ao_part_table (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1408,7 +1408,7 @@ CREATE TABLE ao_part_table (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1509,7 +1509,7 @@ CREATE TABLE ao_part_table (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1584,7 +1584,7 @@ CREATE TABLE ao_part_table (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1662,7 +1662,7 @@ CREATE TABLE ao_part_table (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1799,7 +1799,7 @@ CREATE TABLE ao_part_table (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1905,7 +1905,7 @@ $$ LANGUAGE plpgsql;"""
 
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -1993,7 +1993,7 @@ CREATE TABLE ao_part_table (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -2271,7 +2271,7 @@ GRANT ALL ON TABLE user_table TO user_role_b;
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -2421,7 +2421,7 @@ CREATE FOREIGN TABLE ao_part_table (
             
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET search_path = public, pg_catalog;
 
@@ -2585,7 +2585,7 @@ GRANT ALL ON TABLE user_table TO user_role_b;
      
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -2750,7 +2750,7 @@ GRANT ALL ON TABLE "测试" TO user_role_b;
      
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -2913,7 +2913,7 @@ GRANT ALL ON TABLE "Áá" TO user_role_b;
      
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -3076,7 +3076,7 @@ GRANT ALL ON TABLE "Ж" TO user_role_b;
      
         with open(infile, 'r') as fdin:
             with open(outfile, 'w') as fdout:
-                process_schema(dump_schemas, dump_tables, fdin, fdout)
+                process_schema(dump_schemas, dump_tables, fdin, fdout, None)
 
         expected_out = """SET statement_timeout = 0;
 SET client_encoding = 'UTF8';

--- a/gpMgmt/doc/gpdbrestore_help
+++ b/gpMgmt/doc/gpdbrestore_help
@@ -138,6 +138,20 @@ OPTIONS
  validation. If not specified, the utility will start up to 60 parallel 
  processes depending on how many segment instances it needs to restore. 
 
+
+--change-schema=schema-name
+
+ Optional. Restores tables from a backup created with gpcrondump to a
+ different schema. The specified schema must exist in the database.
+ If the schema does not exist, the utility returns an error. System
+ catalog schemas are not supported.
+
+ You must specify tables to restore with the -T and --table-file options.
+ If a table that is being restored exists in schema-name, the utility
+ returns a warning and attempts to append the data to the table from the
+ backup. You can specify the --trunctate option to truncate table data
+ before restoring data to the table from the backup.
+
  
 -d <master_data_directory>
 

--- a/src/bin/pg_dump/cdb/cdb_dump_util.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.c
@@ -1039,11 +1039,13 @@ formPostDataSchemaOnlyPsqlCommandLine(char** retVal, const char* inputFileSpec, 
 }
 
 
+/* Build command line for gp_restore_agent */
 void 
 formSegmentPsqlCommandLine(char** retVal, const char* inputFileSpec, bool compUsed, const char* compProg,
 							const char* filter_script, const char* table_filter_file, 
 							int role, const char* psqlPg, const char* catPg,
-							const char* gpNBURestorePg, const char* netbackupServiceHost, const char* netbackupBlockSize)
+							const char* gpNBURestorePg, const char* netbackupServiceHost, const char* netbackupBlockSize,
+							const char* change_schema)
 {
 	char* pszCmdLine = *retVal;
 	if (compUsed)
@@ -1109,6 +1111,11 @@ formSegmentPsqlCommandLine(char** retVal, const char* inputFileSpec, bool compUs
 		/* Add filter option with table file to filter data only for specified tables. */
 		strcat(pszCmdLine, " -t ");
 		strcat(pszCmdLine, table_filter_file);
+		if (change_schema)
+		{
+			strcat(pszCmdLine, " -c ");
+			strcat(pszCmdLine, change_schema);
+		}
 	}
 
     strcat(pszCmdLine, " | ");

--- a/src/bin/pg_dump/cdb/cdb_dump_util.h
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.h
@@ -165,7 +165,8 @@ extern void formDDBoostPsqlCommandLine(char** retVal, bool compUsed, const char*
 extern void formSegmentPsqlCommandLine(char** retVal, const char* inputFileSpec, 
 						bool compUsed, const char* compProg, const char* filter_script, 
 						const char* table_filter_file, int role, const char* psqlPg, const char* catPg,
-                        const char* gpNBURestorePg, const char* netbackupServiceHost, const char* netbackupBlockSize);
+                        const char* gpNBURestorePg, const char* netbackupServiceHost, const char* netbackupBlockSize,
+						const char* change_schema);
 extern void formPostDataSchemaOnlyPsqlCommandLine(char** retVal, const char* inputFileSpec, 
 						bool compUsed, const char* compProg, const char* post_data_filter_script,
                         const char* table_filter_file, const char* psqlPg, const char* catPg,

--- a/src/bin/pg_dump/cdb/cdb_restore.c
+++ b/src/bin/pg_dump/cdb/cdb_restore.c
@@ -76,6 +76,8 @@ static char *status_file = NULL;
 static char *netbackup_service_host = NULL;
 static char *netbackup_block_size = NULL;
 
+static char *change_schema = NULL;
+
 #ifdef USE_DDBOOST
 static int dd_boost_enabled = 0;
 #endif
@@ -293,6 +295,7 @@ usage(void)
 	printf(("                          where backups are located. For example: --gp-l=i[10,12,15]\n"));
 	printf(("  --gp-f=FILE             FILE, present on all machines, with tables to include in restore\n"));
 	printf(("  --prefix=PREFIX         PREFIX of the dump files to be restored\n"));
+	printf(("  --change-schema=SCHEMA  Name of the schema to which files are to be restored\n"));
 }
 
 bool
@@ -369,6 +372,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 		{"status", required_argument, NULL, 14},
 		{"netbackup-service-host", required_argument, NULL, 15},
 		{"netbackup-block-size", required_argument, NULL, 16},
+		{"change-schema", required_argument, NULL, 17},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -744,6 +748,12 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 			case 16:
 				netbackup_block_size = Safe_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-block-size", netbackup_block_size, pInputOpts->pszPassThroughParms);
+				break;
+			case 17:
+				change_schema = Safe_strdup(optarg);
+				pInputOpts->pszPassThroughParms = addPassThroughLongParm("change-schema", change_schema, pInputOpts->pszPassThroughParms);
+				if (change_schema!= NULL)
+					free(change_schema);
 				break;
 
 			default:

--- a/src/bin/pg_dump/cdb/cdb_restore_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_restore_agent.c
@@ -150,6 +150,8 @@ static char * dump_prefix = NULL;
 static char *netbackup_service_host = NULL;
 static char *netbackup_block_size = NULL;
 
+static char *change_schema = NULL;
+
 int
 main(int argc, char **argv)
 {
@@ -237,6 +239,7 @@ main(int argc, char **argv)
 		{"status", required_argument, NULL, 14},
 		{"netbackup-service-host", required_argument, NULL, 15},
 		{"netbackup-block-size", required_argument, NULL, 16},
+		{"change-schema", required_argument, NULL, 17},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -445,6 +448,9 @@ main(int argc, char **argv)
 				break;
 			case 16:
 				netbackup_block_size = strdup(optarg);
+				break;
+			case 17:
+				change_schema = strdup(fmtId(optarg));
 				break;
 
 
@@ -812,7 +818,7 @@ main(int argc, char **argv)
 					formSegmentPsqlCommandLine(&pszCmdLine, inputFileSpec, bCompUsed, g_compPg,
 							filterScript, table_filter_file,
 							g_role, psqlPg, catPg,
-							gpNBURestorePg, netbackup_service_host, netbackup_block_size);
+							gpNBURestorePg, netbackup_service_host, netbackup_block_size, change_schema);
 				}
 #ifdef USE_DDBOOST
 			}
@@ -999,6 +1005,8 @@ main(int argc, char **argv)
 
 	DestroyStatusOpList(g_pStatusOpList);
 
+    if (change_schema)
+        free(change_schema);
 	if (SegDB.pszHost)
 		free(SegDB.pszHost);
 	if (SegDB.pszDBName)

--- a/src/bin/pg_dump/cdb/test/cdb_dump_util_test.c
+++ b/src/bin/pg_dump/cdb/test/cdb_dump_util_test.c
@@ -247,7 +247,7 @@ void test__formSegmentPsqlCommandLine1(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg, 
 							   filter_script, table_filter_file, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "cat fileSpec | gzip -c | filter.py -t filter.conf | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -270,7 +270,7 @@ void test__formSegmentPsqlCommandLine2(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg, 
 							   NULL, NULL, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "cat fileSpec | gzip -c | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -295,7 +295,7 @@ void test__formSegmentPsqlCommandLine3(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg, 
 							   filter_script, table_filter_file, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "cat fileSpec | filter.py -t filter.conf | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -318,7 +318,7 @@ void test__formSegmentPsqlCommandLine4(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg, 
 							   NULL, NULL, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "cat fileSpec | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -343,7 +343,7 @@ void test__formSegmentPsqlCommandLine5(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg, 
 							   filter_script, table_filter_file, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "cat fileSpec | gzip -c | filter.py -m -t filter.conf | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -366,7 +366,7 @@ void test__formSegmentPsqlCommandLine6(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg, 
 							   NULL, NULL, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "cat fileSpec | gzip -c | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -391,7 +391,7 @@ void test__formSegmentPsqlCommandLine7(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg, 
 							   filter_script, table_filter_file, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "cat fileSpec | filter.py -m -t filter.conf | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -414,7 +414,7 @@ void test__formSegmentPsqlCommandLine8(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg, 
 							   NULL, NULL, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "cat fileSpec | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -439,7 +439,7 @@ void test__formSegmentPsqlCommandLine9(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg,
 							   filter_script, table_filter_file, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-filename fileSpec --netbackup-block-size 1024 | filter.py -t filter.conf | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -462,7 +462,7 @@ void test__formSegmentPsqlCommandLine10(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg,
 							   NULL, NULL, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-filename fileSpec --netbackup-block-size 1024 | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -487,7 +487,7 @@ void test__formSegmentPsqlCommandLine11(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg,
 							   filter_script, table_filter_file, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-filename fileSpec | filter.py -m -t filter.conf | psql";
 	assert_string_equal(cmdLine, expected_output);
@@ -510,9 +510,61 @@ void test__formSegmentPsqlCommandLine12(void **state)
 	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg,
 							   NULL, NULL, role,
 							   psqlPg, catPg, gpNBURestorePg,
-							   netbackupServiceHost, netbackupBlockSize);
+							   netbackupServiceHost, netbackupBlockSize, NULL);
 
 	char *expected_output = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-filename fileSpec --netbackup-block-size 1024 | psql";
+	assert_string_equal(cmdLine, expected_output);
+	free(cmdLine);
+}
+
+/* Test to verify command line for gp_restore_agent */
+void test__formSegmentPsqlCommandLine13(void **state)
+{
+	char *cmdLine = calloc(1000000, 1);
+	char *inputFileSpec = "fileSpec";
+	bool compUsed = false;
+	const char* compProg = "gzip -c ";
+	int role = ROLE_MASTER;
+	const char* filter_script = "filter.py"; 
+	const char* table_filter_file = "filter.conf";
+	const char* psqlPg = "psql";
+	const char* catPg = "cat";
+	const char* gpNBURestorePg = "gp_bsa_restore_agent";
+	const char* netbackupServiceHost = "mdw";
+	const char* netbackupBlockSize = "1024";
+	const char* change_schema = "newschema";
+
+	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg,
+							   filter_script, table_filter_file, role,
+							   psqlPg, catPg, gpNBURestorePg,
+							   netbackupServiceHost, netbackupBlockSize, change_schema);
+
+	char *expected_output = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-filename fileSpec --netbackup-block-size 1024 | filter.py -m -t filter.conf -c newschema | psql";
+	assert_string_equal(cmdLine, expected_output);
+	free(cmdLine);
+}
+
+/* Test to verify command line for restore filter */
+void test__formSegmentPsqlCommandLine14(void **state)
+{
+	char *cmdLine = calloc(1000000, 1);
+	char *inputFileSpec = "fileSpec";
+	bool compUsed = false;
+	const char* compProg = "gzip -c ";
+	int role = ROLE_MASTER;
+	const char* filter_script = "filter.py"; 
+	const char* table_filter_file = "filter.conf";
+	const char* psqlPg = "psql";
+	const char* catPg = "cat";
+	const char* gpNBURestorePg = "gp_bsa_restore_agent";
+	const char* change_schema = "newschema";
+
+	formSegmentPsqlCommandLine(&cmdLine, inputFileSpec, compUsed, compProg,
+							   filter_script, table_filter_file, role,
+							   psqlPg, catPg, gpNBURestorePg,
+							   NULL, NULL, change_schema);
+
+	char *expected_output = "cat fileSpec | filter.py -m -t filter.conf -c newschema | psql";
 	assert_string_equal(cmdLine, expected_output);
 	free(cmdLine);
 }
@@ -1078,6 +1130,8 @@ main(int argc, char* argv[])
 			unit_test(test__formSegmentPsqlCommandLine10),
 			unit_test(test__formSegmentPsqlCommandLine11),
 			unit_test(test__formSegmentPsqlCommandLine12),
+			unit_test(test__formSegmentPsqlCommandLine13),
+			unit_test(test__formSegmentPsqlCommandLine14),
             #ifdef USE_DDBOOST
 			unit_test(test__formDDBoostPsqlCommandLine1),
 			unit_test(test__formDDBoostPsqlCommandLine2),


### PR DESCRIPTION
Currently gpdbrestore does not allow tables to be restored from one schema to another. Added a new option, --change-schema, for enhancement.
Eg:
testschema.testtable => anotherschema.testtable

 