### PR TITLE
Remove broken out/read support for PlannedStmts.

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -372,46 +372,6 @@ _outJoinPlanInfo(StringInfo str, Join *node)
 }
 
 static void
-_outPlannedStmt(StringInfo str, PlannedStmt *node)
-{
-	WRITE_NODE_TYPE("PLANNEDSTMT");
-	
-	WRITE_ENUM_FIELD(commandType, CmdType);
-	WRITE_ENUM_FIELD(planGen, PlanGenerator);
-	WRITE_BOOL_FIELD(canSetTag);
-	WRITE_BOOL_FIELD(transientPlan);
-	
-	WRITE_NODE_FIELD(planTree);
-	
-	WRITE_NODE_FIELD(rtable);
-	
-	WRITE_NODE_FIELD(resultRelations);
-	WRITE_NODE_FIELD(utilityStmt);
-	WRITE_NODE_FIELD(intoClause);
-	WRITE_NODE_FIELD(subplans);
-	WRITE_NODE_FIELD(rewindPlanIDs);
-	WRITE_NODE_FIELD(returningLists);
-	
-	WRITE_NODE_FIELD(result_partitions);
-	WRITE_NODE_FIELD(result_aosegnos);
-	WRITE_NODE_FIELD(queryPartOids);
-	WRITE_NODE_FIELD(queryPartsMetadata);
-	WRITE_NODE_FIELD(numSelectorsPerScanId);
-	WRITE_NODE_FIELD(rowMarks);
-	WRITE_NODE_FIELD(relationOids);
-	WRITE_NODE_FIELD(invalItems);
-	WRITE_INT_FIELD(nCrossLevelParams);
-	WRITE_INT_FIELD(nMotionNodes);
-	WRITE_INT_FIELD(nInitPlans);
-	
-	/* Don't serialize policy */
-	WRITE_NODE_FIELD(sliceTable);
-	
-	WRITE_UINT64_FIELD(query_mem);
-	WRITE_NODE_FIELD(transientTypeRecords);
-}
-
-static void
 _outPlan(StringInfo str, Plan *node)
 {
 	WRITE_NODE_TYPE("PLAN");
@@ -4046,28 +4006,6 @@ _outAlterTypeStmt(StringInfo str, AlterTypeStmt *node)
 	WRITE_NODE_FIELD(encoding);
 }
 
-static void
-_outTupleDescNode(StringInfo str, TupleDescNode *node)
-{
-	Assert(node->tuple->tdtypeid == RECORDOID);
-
-	WRITE_NODE_TYPE("TUPLEDESCNODE");
-	WRITE_INT_FIELD(natts);
-	WRITE_INT_FIELD(tuple->natts);
-
-	int i = 0;
-	for (; i < node->tuple->natts; i++)
-		appendBinaryStringInfo(str, node->tuple->attrs[i], ATTRIBUTE_FIXED_PART_SIZE);
-
-	Assert(node->tuple->constr == NULL);
-
-	WRITE_OID_FIELD(tuple->tdtypeid);
-	WRITE_INT_FIELD(tuple->tdtypmod);
-	WRITE_INT_FIELD(tuple->tdqdtypmod);
-	WRITE_BOOL_FIELD(tuple->tdhasoid);
-	WRITE_INT_FIELD(tuple->tdrefcount);
-}
-
 /*
  * _outNode -
  *	  converts a Node into ascii string and append it to 'str'
@@ -4092,9 +4030,6 @@ _outNode(StringInfo str, void *obj)
 		appendStringInfoChar(str, '{');
 		switch (nodeTag(obj))
 		{
-			case T_PlannedStmt:
-				_outPlannedStmt(str,obj);
-				break;
 			case T_Plan:
 				_outPlan(str, obj);
 				break;
@@ -4893,9 +4828,6 @@ _outNode(StringInfo str, void *obj)
 			case T_AlterTypeStmt:
 				_outAlterTypeStmt(str, obj);
 				break;
-            case T_TupleDescNode:
-                _outTupleDescNode(str, obj);
-                break;
 
 			default:
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2985,39 +2985,6 @@ _readAlterTypeStmt(void)
 	READ_DONE();
 }
 
-static TupleDescNode *
-_readTupleDescNode(const char **str)
-{
-	READ_LOCALS(TupleDescNode);
-	READ_INT_FIELD(natts);
-
-	local_node->tuple = CreateTemplateTupleDesc(local_node->natts, false);
-
-	READ_INT_FIELD(tuple->natts);
-	if (local_node->tuple->natts > 0)
-	{
-		int i = 0;
-		for (; i < local_node->tuple->natts; i++)
-		{
-			memcpy(local_node->tuple->attrs[i], *str, ATTRIBUTE_FIXED_PART_SIZE);
-			(*str)+=ATTRIBUTE_FIXED_PART_SIZE;
-		}
-	}
-
-	READ_OID_FIELD(tuple->tdtypeid);
-	READ_INT_FIELD(tuple->tdtypmod);
-	READ_INT_FIELD(tuple->tdqdtypmod);
-	READ_BOOL_FIELD(tuple->tdhasoid);
-	READ_INT_FIELD(tuple->tdrefcount);
-
-	// Transient type don't have constraint.
-	local_node->tuple->constr = NULL;
-
-	Assert(local_node->tuple->tdtypeid == RECORDOID);
-
-	READ_DONE();
-}
-
 /*
  * Greenplum Database developers added code to improve performance over the
  * linear searching that existed in the postgres version of
@@ -3185,7 +3152,6 @@ static ParseNodeInfo infoAr[] =
 	{"TABLEVALUEEXPR", (ReadFn)_readTableValueExpr},
 	{"TARGETENTRY", (ReadFn)_readTargetEntry},
 	{"TRUNCATESTMT", (ReadFn)_readTruncateStmt},
-	{"TUPLEDESCNODE", (ReadFn)_readTupleDescNode},
 	{"TYPECAST", (ReadFn)_readTypeCast},
 	{"TYPENAME", (ReadFn)_readTypeName},
 	{"VACUUMSTMT", (ReadFn)_readVacuumStmt},

--- a/src/include/access/tupdesc.h
+++ b/src/include/access/tupdesc.h
@@ -79,6 +79,15 @@ typedef struct tupleDesc
 	int			tdrefcount;		/* reference count, or -1 if not counting */
 }	*TupleDesc;
 
+/*
+ * When dispatching a planned statement from QD to QEs, we need to be able
+ * to transmit TupleDescs. TupleDesc doesn't have the Node header, so for
+ * convenience of the read and out functions, we wrap them in TupleDescNode
+ * structs, which do.
+ *
+ * These are never serialized on disk, only in the read/outfast protocol,
+ * as part of PlannedStmts.
+ */
 typedef struct tupleDescNode
 {
 	NodeTag		type;

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -166,6 +166,10 @@ typedef struct PlannedStmt
 	/* The overall memory consumption account (i.e., outside of an operator) */
 	MemoryAccount *memoryAccount;
 
+	/*
+	 * List of TupleDescNodes, one for each transient record type, when a
+	 * PlannedStmt is transferred from QD to QEs
+	 */
 	List	   *transientTypeRecords;
 } PlannedStmt;
 


### PR DESCRIPTION
_readTupleDescNode function in readfuncs.c had an 'str' argument, but it
was called with zero arguments. The reason that we haven't seen crashes
is that the out/readfuncs.c support for PlannedStmts and TupleDescNodes is
dead code. They are only serialized when sent from QD to QE, and we use
the out/readfast.c functions for that.

Remove the code, and add a few comments to TupleDescNode and PlannedStmt
to clarify this a bit.