### PR TITLE
Remove duplicate entries of target in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # GNUmakefile won't exist yet, so we catch that case as well.
 
 
-all check install installdirs installcheck installcheck-parallel installcheck-good uninstall clean distclean maintainer-clean dist distcheck world check-world install-world installcheck-world uninstall clean distclean maintainer-clean:
+all check install installdirs installcheck installcheck-parallel installcheck-good uninstall clean distclean maintainer-clean dist distcheck world check-world install-world installcheck-world:
 	@if [ ! -f GNUmakefile ] ; then \
 	   echo "You need to run the 'configure' program first. See the file"; \
 	   echo "'INSTALL' for installation instructions." ; \


### PR DESCRIPTION
Got the errors when running make clean, distclean ..., these duplicates need to be removed.

Makefile:14: target uninstall' given more than once in the same rule. 
Makefile:14: targetclean' given more than once in the same rule.
Makefile:14: target distclean' given more than once in the same rule. 
Makefile:14: targetmaintainer-clean' given more than once in the same rule.