### PR TITLE
fix compiler error on OS X. Subtracting two unsigned ints will never …

### DIFF
--- a/gpAux/extensions/gpfdist/gpfdist.c
+++ b/gpAux/extensions/gpfdist/gpfdist.c
@@ -2929,7 +2929,7 @@ static void handle_post_request(request_t *r, int header_end)
 		ssize_t n;
 		size_t buf_space_left = r->in.dbufmax - r->in.dbuftop;
 
-		if (r->in.davailable - buf_space_left >= 0)
+		if (r->in.davailable > buf_space_left)
 			want = buf_space_left;
 		else
 			want = r->in.davailable;


### PR DESCRIPTION
…be less than 0