### PR TITLE
gpdbrestore --truncate will not try to truncate a nonexistent table.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -412,7 +412,7 @@ def truncate_restore_tables(restore_tables, master_port, dbname):
                                                    SELECT 1
                                                    FROM pg_catalog.pg_class c
                                                    JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace
-                                                   WHERE n.nspname = '%s' and c.relname = '%s')""" % (schema, table)
+                                                   WHERE n.nspname = '%s' and c.relname = '%s')""" % (pg.escape_string(schema), pg.escape_string(table))
                 exists_result = execSQLForSingleton(conn, check_table_exists_qry)
                 if exists_result:
                     truncate_list.append(restore_table)

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -415,7 +415,10 @@ def truncate_restore_tables(restore_tables, master_port, dbname):
                 qry = 'Truncate %s' % t
                 execSQL(conn, qry)
             except Exception as e:
-                raise Exception("Could not truncate table %s.%s: %s" % (dbname, t, str(e).replace('\n', '')))
+                if 'relation "%s" does not exist' % t in str(e).replace('\n', ''):
+                    logger.warning("Skipping truncate of %s.%s because the relation does not exist." % (dbname, t))
+                else:
+                    raise Exception("Could not truncate table %s.%s: %s" % (dbname, t, str(e).replace('\n', '')))
 
         conn.commit()
     except Exception as e:

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -1784,6 +1784,21 @@ Feature: Validate command line arguments
         And gpdbrestore should return a return code of 0
         And verify that there is a "ao" table "public.ao_part_table" in "fullbkdb" with data
 
+    @truncate
+    Scenario: Full backup and restore with -T and --truncate with dropped table
+        Given the database is running
+        And the database "fullbkdb" does not exist
+        And database "fullbkdb" exists
+        And there is a "heap" table "heap_table" with compression "None" in "fullbkdb" with data
+        When the user runs "gpcrondump -a -x fullbkdb"
+        Then gpcrondump should return a return code of 0
+        And the timestamp from gpcrondump is stored
+        And table "public.heap_table" is dropped in "fullbkdb"
+        And the user runs "gpdbrestore -T public.heap_table -a --truncate" with the stored timestamp
+        And gpdbrestore should return a return code of 0
+        And gpdbrestore should print Skipping truncate of fullbkdb.public.heap_table because the relation does not exist to stdout
+        And verify that there is a "heap" table "public.heap_table" in "fullbkdb" with data
+
     @backupfire
     Scenario: Full backup -T test 3
         Given the database is running
@@ -5013,9 +5028,6 @@ Feature: Validate command line arguments
         And the user runs "gpdbrestore -T public.ao_index_table --redirect=testdb --truncate -a" with the stored timestamp
         And gpdbrestore should return a return code of 2
         And gpdbrestore should print Failure from truncating tables, FATAL:  database "testdb" does not exist to stdout
-        And the user runs "gpdbrestore -T public.ao_index_table_1 --truncate -a" with the stored timestamp
-        And gpdbrestore should return a return code of 2
-        And gpdbrestore should print Could not truncate table fullbkdb.public.ao_index_table_1 to stdout
         And there is a "ao" table "ao_index_table" with compression "None" in "testdb" with data
         And the user runs "gpdbrestore -T public.ao_index_table --redirect=testdb --truncate -a" with the stored timestamp
         And gpdbrestore should return a return code of 0


### PR DESCRIPTION
Previously, if the set of tables to be restored using gpdbrestore --truncate
included a table that did not exist in the target database, gpdbrestore would
raise an exception when attempting to truncate the nonexistent table.  Now,
gpdbrestore displays a warning regarding the nonexistent table, and the table is
restored normally.

Authors: Jimmy Yih and James McAtamney