### PR TITLE
fix: gphdfs unicode support

### DIFF
--- a/gpAux/extensions/gphdfs/src/java/1.2/com/emc/greenplum/gpdb/hadoop/io/GPDBWritable.java
+++ b/gpAux/extensions/gphdfs/src/java/1.2/com/emc/greenplum/gpdb/hadoop/io/GPDBWritable.java
@@ -418,8 +418,8 @@ public class GPDBWritable implements Writable {
 					 * at the beginning and add a "\0" at the end */
 					default: {
 						String outStr = (String)colValue[i]+"\0";
-						out.writeInt(outStr.length());
 						byte[] data = (outStr).getBytes(CHARSET);
+						out.writeInt(data.length);
 						out.write(data);
 						break;
 					}


### PR DESCRIPTION
SIGSEGV on segment when reading data form avro file that contains unicode
character.  In this case the character was this
http://www.fileformat.info/info/unicode/char/85/index.htm