### PR TITLE
Change gpdbrestore -G flag to allow globals-only restore.

### DIFF
--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -514,6 +514,21 @@ class GpdbRestore(Operation):
         date, time = dates_and_times[choice]
         return "%s%s" % (date, time)
 
+def restore_global_callback(option, opt_str, value, parser):
+    assert value is None
+    if len(parser.rargs) > 0:
+        value = parser.rargs[0]
+        if value[:1] == "-":
+            value = "include"
+        else:
+            del parser.rargs[:1]
+
+    if value == None:
+        value = "include"
+    elif value not in ("include", "only"):
+        raise OptionValueError('%s is not a valid argument for -G.  Valid arguments are "include" and "only".' % value)
+    setattr(parser.values, option.dest, value)
+
 def create_parser():
     parser = OptParser(option_class=OptChecker,
                        version='%prog version $Revision$',
@@ -541,8 +556,8 @@ def create_parser():
                      help="Drop (erase) target database before recovery commences")
     addTo.add_option('-B', dest='batch_default', type='int', default=DEFAULT_NUM_WORKERS, metavar="<number>",
                      help="Dispatches work to segment hosts in batches of specified size [default: %s]" % DEFAULT_NUM_WORKERS)
-    addTo.add_option('-G', action='store_true', dest='restore_global', default=False,
-                     help="Restore global objects dump file if found in target dumpset. The global objects file is secured via the gpcrondump -G options, and has a filename of the form gp_global_1_1_<timestamp>")
+    addTo.add_option('-G', dest='restore_global', action="callback", callback=restore_global_callback,
+                     help="Restore global objects dump file if found in target dumpset. The global objects file is secured via the gpcrondump -G options, and has a filename of the form gp_global_1_1_<timestamp>. Specify \"-G only\" to only restore the global objects dump file or \"-G include\" to restore globals objects along with a normal restore. Defaults to \"include\" if neither argument is provided.")
     addTo.add_option('-T', dest='restore_tables', metavar='<schema.tablename>',
                      help="Restore a single table from a backup set. For multiple tables, supply a comma separated list of schema.tablenames. Note, table schema must exist in target database.")
     addTo.add_option('-K', action='store_true', dest='keep_dump_files', default=False,

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -476,6 +476,8 @@ class RestoreDatabase(Operation):
 
         if self.restore_global:
             self._restore_global(restore_timestamp, self.master_datadir, self.backup_dir)
+            if self.restore_global == "only":
+                return
 
         """
         For full restore with table filter or for the first recurssion of the incremental restore

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -656,6 +656,24 @@ Feature: Validate command line arguments
         Then gpcrondump should return a return code of 0
         And "global" file should be created under " "
 
+    @Gonly
+    Scenario: Backup and restore with -G only
+        Given the database is running
+        And there are no backup files
+        And there is a "heap" table "heap_table" with compression "None" in "fullbkdb" with data
+        And the user runs "psql -c 'CREATE ROLE foo_user' fullbkdb"
+        And verify that a role "foo_user" exists in database "fullbkdb"
+        When the user runs "gpcrondump -a -x fullbkdb -G"
+        And the timestamp from gpcrondump is stored
+        Then gpcrondump should return a return code of 0
+        And "global" file should be created under " "
+        And the user runs "psql -c 'DROP ROLE foo_user' fullbkdb"
+        And the user runs gpdbrestore with the stored timestamp and options "-G only" 
+        And gpdbrestore should return a return code of 0
+        And verify that a role "foo_user" exists in database "fullbkdb"
+        And verify that there is no table "heap_table" in "fullbkdb"
+        And the user runs "psql -c 'DROP ROLE foo_user' fullbkdb"
+
     @valgrind
     Scenario: Valgrind test of gp_dump incremental
         Given the database is running

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/backup_mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/backup_mgmt_utils.py
@@ -377,3 +377,15 @@ def impl(context, dumpfile):
 );"""
     if not buf in open(dumpfile).read():
         raise Exception("pg_dump did not backup aggregate functions correctly.")
+
+@given('verify that a role "{role_name}" exists in database "{dbname}"')
+@then('verify that a role "{role_name}" exists in database "{dbname}"')
+def impl(context, role_name, dbname):
+    query = "select rolname from pg_roles where rolname = '%s'" % role_name
+    conn = dbconn.connect(dbconn.DbURL(dbname=dbname))
+    try:
+        result = getRows(dbname, query)[0][0]
+        if result != role_name:
+            raise Exception("Role %s does not exist in database %s." % (role_name, dbname))
+    except:
+        raise Exception("Role %s does not exist in database %s." % (role_name, dbname))

--- a/gpMgmt/doc/gpdbrestore_help
+++ b/gpMgmt/doc/gpdbrestore_help
@@ -170,11 +170,15 @@ OPTIONS
  it. 
 
 
--G (restore global objects) 
+-G [include|only]
 
  Restores global objects such as roles and tablespaces if the global 
  object dump file db_dumps/<date>/gp_global_1_1_<timestamp> is found in 
- the master data directory. 
+ the master data directory.
+
+ Specify either "-G only" to only restore the global objects dump file
+ or "-G include" to restore global objects along with a normal restore.
+ Defaults to "include" if neither argument is provided.
 
 
 -l <logfile_directory>


### PR DESCRIPTION
The gpdbrestore -G flag has been modified from a boolean flag
to one that accepts an optional argument.  Passing it the
argument "include" will carry out the old -G functionality,
restoring global objects in addition to performing a normal
restore; passing it no argument will do the same, to retain
backwards compatibility.  Passing it the argument "only" will
restore global objects but will not restore anything else.

Authors: James McAtamney and Jimmy Yih