### PR TITLE
Error out when sequence with NO CYCLE specified reaches maxvalue

### DIFF
--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -873,7 +873,20 @@ nextval_internal(Oid relid)
                              &is_overflow);
 	last_used_seq = elm;
 
-    relation_close(seqrel, NoLock);
+        if(is_overflow)
+        {
+                StringInfo str = makeStringInfo();
+                appendStringInfo(str, "%s", RelationGetRelationName(seqrel));
+                relation_close(seqrel, NoLock);
+
+                ereport(ERROR,
+                        (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+                        errmsg("nextval: reached %s value of sequence \"%s\" (" INT64_FORMAT ")",
+                        elm->increment>0 ? "maximum":"minimum",
+                        str->data, elm->last)));
+        }
+
+	relation_close(seqrel, NoLock);
 	return elm->last;
 }
 

--- a/src/test/regress/expected/sequence.out
+++ b/src/test/regress/expected/sequence.out
@@ -212,3 +212,60 @@ REVOKE ALL ON seq3 FROM seq_user;
 ROLLBACK;
 DROP USER seq_user;
 DROP SEQUENCE seq;
+---
+--- Test Overflow with NO CIRCLE
+---
+CREATE TABLE tmp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tmp_table VALUES (0),(1),(2),(3);
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2 START 1 CACHE 1 NO CYCLE;
+SELECT nextval('tmp_seq');
+ nextval
+---------
+       1
+(1 row)
+
+SELECT nextval('tmp_seq');
+ nextval
+---------
+       2
+(1 row)
+
+-- Fails because it reaches MAXVALUE
+SELECT nextval('tmp_seq');
+ERROR:  nextval: reached maximum value of sequence "tmp_seq" (2)
+DROP SEQUENCE tmp_seq;
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 4 START 1 CACHE 1 NO CYCLE;
+SELECT val from (SELECT nextval('tmp_seq'), a as val FROM tmp_table ORDER BY a) as val ORDER BY val;
+ val
+-----
+   0
+   1
+   2
+   3
+(4 rows)
+
+DROP SEQUENCE tmp_seq;
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2 START 1 CACHE 20 NO CYCLE;
+SELECT nextval('tmp_seq');
+ nextval
+---------
+       1
+(1 row)
+
+SELECT nextval('tmp_seq');
+ nextval
+---------
+       2
+(1 row)
+
+-- Fails because it reaches MAXVALUE
+SELECT nextval('tmp_seq');
+ERROR:  nextval: reached maximum value of sequence "tmp_seq" (2)
+DROP SEQUENCE tmp_seq;
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 4 START 1 CACHE 20 NO CYCLE;
+SELECT nextval('tmp_seq'), a FROM tmp_table ORDER BY a;
+ERROR:  nextval: reached maximum value of sequence "tmp_seq" (4)  (seg0 slice1 nikos-mac:40001 pid=78074)
+DROP SEQUENCE tmp_seq;
+DROP TABLE tmp_table;

--- a/src/test/regress/expected/sequence_optimizer.out
+++ b/src/test/regress/expected/sequence_optimizer.out
@@ -218,3 +218,67 @@ REVOKE ALL ON seq3 FROM seq_user;
 ROLLBACK;
 DROP USER seq_user;
 DROP SEQUENCE seq;
+---
+--- Test Overflow with NO CIRCLE
+---
+CREATE TABLE tmp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tmp_table VALUES (0),(1),(2),(3);
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2 START 1 CACHE 1 NO CYCLE;
+SELECT nextval('tmp_seq');
+ nextval
+---------
+       1
+(1 row)
+
+SELECT nextval('tmp_seq');
+ nextval
+---------
+       2
+(1 row)
+
+-- Fails because it reaches MAXVALUE
+SELECT nextval('tmp_seq');
+ERROR:  nextval: reached maximum value of sequence "tmp_seq" (2)
+DROP SEQUENCE tmp_seq;
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 4 START 1 CACHE 1 NO CYCLE;
+SELECT val from (SELECT nextval('tmp_seq'), a as val FROM tmp_table ORDER BY a) as val ORDER BY val;
+ val
+-----
+   0
+   1
+   2
+   3
+(4 rows)
+
+DROP SEQUENCE tmp_seq;
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2 START 1 CACHE 20 NO CYCLE;
+SELECT nextval('tmp_seq');
+ nextval
+---------
+       1
+(1 row)
+
+SELECT nextval('tmp_seq');
+ nextval
+---------
+       2
+(1 row)
+
+-- Fails because it reaches MAXVALUE
+SELECT nextval('tmp_seq');
+ERROR:  nextval: reached maximum value of sequence "tmp_seq" (2)
+DROP SEQUENCE tmp_seq;
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 4 START 1 CACHE 20 NO CYCLE;
+SELECT nextval('tmp_seq'), a FROM tmp_table ORDER BY a;
+ nextval | a
+---------+---
+       1 | 0
+       2 | 1
+       3 | 2
+       4 | 3
+(4 rows)
+
+DROP SEQUENCE tmp_seq;
+DROP TABLE tmp_table;

--- a/src/test/regress/sql/sequence.sql
+++ b/src/test/regress/sql/sequence.sql
@@ -106,3 +106,34 @@ ROLLBACK;
 
 DROP USER seq_user;
 DROP SEQUENCE seq;
+
+---
+--- Test Overflow with NO CIRCLE
+---
+CREATE TABLE tmp_table (a int);
+INSERT INTO tmp_table VALUES (0),(1),(2),(3);
+
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2 START 1 CACHE 1 NO CYCLE;
+SELECT nextval('tmp_seq');
+SELECT nextval('tmp_seq');
+-- Fails because it reaches MAXVALUE
+SELECT nextval('tmp_seq');
+DROP SEQUENCE tmp_seq;
+
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 4 START 1 CACHE 1 NO CYCLE;
+SELECT val from (SELECT nextval('tmp_seq'), a as val FROM tmp_table ORDER BY a) as val ORDER BY val;
+DROP SEQUENCE tmp_seq;
+
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2 START 1 CACHE 20 NO CYCLE;
+SELECT nextval('tmp_seq');
+SELECT nextval('tmp_seq');
+-- Fails because it reaches MAXVALUE
+SELECT nextval('tmp_seq');
+DROP SEQUENCE tmp_seq;
+
+CREATE SEQUENCE tmp_seq INCREMENT 1 MINVALUE 1 MAXVALUE 4 START 1 CACHE 20 NO CYCLE;
+SELECT nextval('tmp_seq'), a FROM tmp_table ORDER BY a;
+DROP SEQUENCE tmp_seq;
+
+DROP TABLE tmp_table;
+


### PR DESCRIPTION
In a sequence, if NO CYCLE is specified, any calls to nextval after the sequence has reached its maximum value will return an error.