### PR TITLE
cleanup the dead code in backup restore

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_backup_archiver.c
+++ b/src/bin/pg_dump/cdb/cdb_backup_archiver.c
@@ -2105,43 +2105,6 @@ _tocEntryRequired(TocEntry *te, RestoreOptions *ropt, bool include_acls)
 			return 0;
 	}
 
-	if (ropt->selTypes)
-	{
-		if (strcmp(te->desc, "TABLE") == 0 ||
-			strcmp(te->desc, "EXTNRNAL TABLE") == 0 ||
-			strcmp(te->desc, "FOREIGN TABLE") == 0 ||
-			strcmp(te->desc, "TABLE DATA") == 0)
-		{
-			if (!ropt->selTable)
-				return 0;
-			if (ropt->tableNames && strcmp(ropt->tableNames, te->tag) != 0)
-				return 0;
-		}
-		else if (strcmp(te->desc, "INDEX") == 0)
-		{
-			if (!ropt->selIndex)
-				return 0;
-			if (ropt->indexNames && strcmp(ropt->indexNames, te->tag) != 0)
-				return 0;
-		}
-		else if (strcmp(te->desc, "FUNCTION") == 0)
-		{
-			if (!ropt->selFunction)
-				return 0;
-			if (ropt->functionNames && strcmp(ropt->functionNames, te->tag) != 0)
-				return 0;
-		}
-		else if (strcmp(te->desc, "TRIGGER") == 0)
-		{
-			if (!ropt->selTrigger)
-				return 0;
-			if (ropt->triggerNames && strcmp(ropt->triggerNames, te->tag) != 0)
-				return 0;
-		}
-		else
-			return 0;
-	}
-
 	/*
 	 * Check if we had a dataDumper. Indicates if the entry is schema or data
 	 */

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -2067,43 +2067,6 @@ _tocEntryRequired(TocEntry *te, RestoreOptions *ropt, bool include_acls)
 			return 0;
 	}
 
-	if (ropt->selTypes)
-	{
-		if (strcmp(te->desc, "TABLE") == 0 ||
-			strcmp(te->desc, "EXTNRNAL TABLE") == 0 ||
-			strcmp(te->desc, "FOREIGN TABLE") == 0 ||
-			strcmp(te->desc, "TABLE DATA") == 0)
-		{
-			if (!ropt->selTable)
-				return 0;
-			if (ropt->tableNames && strcmp(ropt->tableNames, te->tag) != 0)
-				return 0;
-		}
-		else if (strcmp(te->desc, "INDEX") == 0)
-		{
-			if (!ropt->selIndex)
-				return 0;
-			if (ropt->indexNames && strcmp(ropt->indexNames, te->tag) != 0)
-				return 0;
-		}
-		else if (strcmp(te->desc, "FUNCTION") == 0)
-		{
-			if (!ropt->selFunction)
-				return 0;
-			if (ropt->functionNames && strcmp(ropt->functionNames, te->tag) != 0)
-				return 0;
-		}
-		else if (strcmp(te->desc, "TRIGGER") == 0)
-		{
-			if (!ropt->selTrigger)
-				return 0;
-			if (ropt->triggerNames && strcmp(ropt->triggerNames, te->tag) != 0)
-				return 0;
-		}
-		else
-			return 0;
-	}
-
 	/*
 	 * Check if we had a dataDumper. Indicates if the entry is schema or data
 	 */


### PR DESCRIPTION
backup restore does not support operations based on object types like
index/function/trigger/data/table, which were originally from postgres;
the restore also keeps dead codelines; backup restore only supports
plain text file format with compression program, so removing other
unsupported file format options.