### PR TITLE
Fix row estimation of some catalog tables in planner.

### DIFF
--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -125,6 +125,9 @@ build_simple_rel(PlannerInfo *root, int relid, RelOptKind reloptkind)
 				rel->cdbpolicy->ptype = POLICYTYPE_PARTITIONED;
 				rel->cdbpolicy->nattrs = 0;
 				rel->cdbpolicy->attrs[0] = 1;
+
+				/* Scribble the tuple number of rel to reflect the real size */
+				rel->tuples = rel->tuples * planner_segment_count();
 			}
 			break;
 		case RTE_SUBQUERY:

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -54,8 +54,7 @@ cdbpath_rows(PlannerInfo *root, Path *path)
 		: IsA(p, BitmapAppendOnlyPath) ? ((BitmapAppendOnlyPath *)p)->rows
 		: IsA(p, IndexPath)        ? ((IndexPath *)p)->rows
 		: IsA(p, UniquePath)       ? ((UniquePath *)p)->rows
-		: (CdbPathLocus_IsBottleneck(path->locus) ||
-		   CdbPathLocus_IsReplicated(path->locus)) 
+		: CdbPathLocus_IsReplicated(path->locus)
 		? path->parent->rows * root->config->cdbpath_segments
 		: path->parent->rows;
 

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1079,25 +1079,26 @@ where relname like 'gp_%' and gp_segment_id=0
 except 
 select i, relname, relowner from pg_class, generate_series(-1, (select max(content) 
 from gp_configuration)) i order by 1;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- SetOp Except  (cost=402614.97..416095.04 rows=134801 width=72)
-   ->  Sort  (cost=402614.97..405984.99 rows=1348008 width=72)
+                                                  QUERY PLAN
+--------------------------------------------------------------------------------------------------------------
+ SetOp Except  (cost=3897843.61..4028154.54 rows=1303110 width=72)
+   ->  Sort  (cost=3897843.61..3930421.34 rows=13031093 width=72)
          Sort Key: gp_segment_id, relname, relowner
-         ->  Append  (cost=0.00..61946.70 rows=1348008 width=72)
-               ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..14.18 rows=8 width=72)
-                     ->  Subquery Scan "*SELECT* 1"  (cost=0.00..14.18 rows=4 width=72)
-                           ->  Seq Scan on pg_class  (cost=0.00..14.11 rows=4 width=72)
+         ->  Append  (cost=0.00..391697.68 rows=13031093 width=72)
+               ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..507.85 rows=93 width=72)
+                     ->  Subquery Scan "*SELECT* 1"  (cost=0.00..507.85 rows=47 width=72)
+                           ->  Seq Scan on pg_class  (cost=0.00..506.93 rows=47 width=72)
                                  Filter: relname ~~ 'gp_%'::text AND gp_segment_id = 0
-               ->  Subquery Scan "*SELECT* 2"  (cost=0.02..61932.52 rows=1348000 width=72)
-                     ->  Nested Loop  (cost=0.02..48452.52 rows=1348000 width=72)
+               ->  Subquery Scan "*SELECT* 2"  (cost=13.52..391189.83 rows=13031000 width=72)
+                     ->  Nested Loop  (cost=13.52..260879.83 rows=13031000 width=72)
                            InitPlan  (slice2)
-                             ->  Aggregate  (cost=0.01..0.02 rows=1 width=2)
-                                   ->  Seq Scan on gp_configuration  (cost=0.00..0.00 rows=2 width=2)
-                           ->  Function Scan on generate_series i  (cost=0.00..12.50 rows=2000 width=4)
-                           ->  Seq Scan on pg_class  (cost=0.00..10.74 rows=1348 width=68)
+                             ->  Aggregate  (cost=0.01..0.01 rows=1 width=2)
+                                   ->  Seq Scan on gp_configuration  (cost=0.00..0.00 rows=1 width=2)
+                           ->  Seq Scan on pg_class  (cost=0.00..246.31 rows=13031 width=68)
+                           ->  Materialize  (cost=13.50..23.50 rows=500 width=4)
+                                 ->  Function Scan on generate_series i  (cost=0.00..12.50 rows=1000 width=4)
  Settings:  optimizer_segments=3
-(16 rows)
+(17 rows)
 
 drop table if exists t1;
 drop table if exists t2;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1083,25 +1083,26 @@ where relname like 'gp_%' and gp_segment_id=0
 except 
 select i, relname, relowner from pg_class, generate_series(-1, (select max(content) 
 from gp_configuration)) i order by 1;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- SetOp Except  (cost=402614.97..416095.04 rows=134801 width=72)
-   ->  Sort  (cost=402614.97..405984.99 rows=1348008 width=72)
+                                                  QUERY PLAN
+--------------------------------------------------------------------------------------------------------------
+ SetOp Except  (cost=3897843.61..4028154.54 rows=1303110 width=72)
+   ->  Sort  (cost=3897843.61..3930421.34 rows=13031093 width=72)
          Sort Key: gp_segment_id, relname, relowner
-         ->  Append  (cost=0.00..61946.70 rows=1348008 width=72)
-               ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..14.18 rows=8 width=72)
-                     ->  Subquery Scan "*SELECT* 1"  (cost=0.00..14.18 rows=4 width=72)
-                           ->  Seq Scan on pg_class  (cost=0.00..14.11 rows=4 width=72)
+         ->  Append  (cost=0.00..391697.68 rows=13031093 width=72)
+               ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..507.85 rows=93 width=72)
+                     ->  Subquery Scan "*SELECT* 1"  (cost=0.00..507.85 rows=47 width=72)
+                           ->  Seq Scan on pg_class  (cost=0.00..506.93 rows=47 width=72)
                                  Filter: relname ~~ 'gp_%'::text AND gp_segment_id = 0
-               ->  Subquery Scan "*SELECT* 2"  (cost=0.02..61932.52 rows=1348000 width=72)
-                     ->  Nested Loop  (cost=0.02..48452.52 rows=1348000 width=72)
+               ->  Subquery Scan "*SELECT* 2"  (cost=13.52..391189.83 rows=13031000 width=72)
+                     ->  Nested Loop  (cost=13.52..260879.83 rows=13031000 width=72)
                            InitPlan  (slice2)
-                             ->  Aggregate  (cost=0.01..0.02 rows=1 width=2)
-                                   ->  Seq Scan on gp_configuration  (cost=0.00..0.00 rows=2 width=2)
-                           ->  Function Scan on generate_series i  (cost=0.00..12.50 rows=2000 width=4)
-                           ->  Seq Scan on pg_class  (cost=0.00..10.74 rows=1348 width=68)
- Settings:  optimizer=on; optimizer_segments=3
-(16 rows)
+                             ->  Aggregate  (cost=0.01..0.01 rows=1 width=2)
+                                   ->  Seq Scan on gp_configuration  (cost=0.00..0.00 rows=1 width=2)
+                           ->  Seq Scan on pg_class  (cost=0.00..246.31 rows=13031 width=68)
+                           ->  Materialize  (cost=13.50..23.50 rows=500 width=4)
+                                 ->  Function Scan on generate_series i  (cost=0.00..12.50 rows=1000 width=4)
+ Settings:  optimizer_segments=3
+(17 rows)
 
 drop table if exists t1;
 drop table if exists t2;


### PR DESCRIPTION
When the cluster has multiple segments, planner now mistakenly calculates the
row number of catalog tables. One example is: SELECT COUNT(*) FROM pg_class may
say the table has 200 rows of records, while EXPLAIN SELECT * FROM pg_class
would say there are 200 * N rows of records, even if you have already issued ANALYZE
upon pg_class and restarted the session(to reload the relation cache), where N
is the number of primary segments.

Another bug is for query like SELECT * FROM gp_dist_random('pg_class'), in this
case, planner should assume the size of pg_class to be 200 * N, instead of the
current 200.