### PR TITLE
Avoid SEGV during backend initialization due to elog(ERROR).

### DIFF
--- a/src/backend/executor/test/Makefile
+++ b/src/backend/executor/test/Makefile
@@ -33,7 +33,9 @@ nodeSubplan_REAL_OBJS=\
         $(top_srcdir)/src/port/qsort.o \
         $(top_srcdir)/src/port/thread.o \
         $(top_srcdir)/src/timezone/localtime.o \
-        $(top_srcdir)/src/timezone/pgtz.o
+        $(top_srcdir)/src/timezone/pgtz.o \
+        $(top_srcdir)/src/backend/utils/error/elog.o \
+        $(top_srcdir)/src/timezone/strftime.o
 
 nodeShareInputScan_REAL_OBJS=\
         $(top_srcdir)/src/backend/access/hash/hashfunc.o \
@@ -139,6 +141,7 @@ execHHashagg_REAL_OBJS=\
         $(top_srcdir)/src/backend/storage/page/itemptr.o \
 	$(top_srcdir)/src/backend/utils/adt/datum.o \
         $(top_srcdir)/src/backend/utils/adt/like.o \
+        $(top_srcdir)/src/backend/utils/error/elog.o \
         $(top_srcdir)/src/backend/utils/hash/hashfn.o \
         $(top_srcdir)/src/backend/utils/misc/guc.o \
         $(top_srcdir)/src/backend/utils/misc/guc_gp.o \
@@ -150,6 +153,7 @@ execHHashagg_REAL_OBJS=\
         $(top_srcdir)/src/port/qsort.o \
         $(top_srcdir)/src/port/thread.o \
         $(top_srcdir)/src/timezone/localtime.o \
-        $(top_srcdir)/src/timezone/pgtz.o
+        $(top_srcdir)/src/timezone/pgtz.o \
+        $(top_srcdir)/src/timezone/strftime.o
 
 include $(top_builddir)/src/Makefile.mock

--- a/src/backend/postmaster/test/Makefile
+++ b/src/backend/postmaster/test/Makefile
@@ -21,6 +21,7 @@ backoff_REAL_OBJS=\
 		$(top_srcdir)/src/backend/storage/page/itemptr.o \
 		$(top_srcdir)/src/backend/utils/adt/datum.o \
 		$(top_srcdir)/src/backend/utils/adt/like.o \
+		$(top_srcdir)/src/backend/utils/error/elog.o \
 		$(top_srcdir)/src/backend/utils/hash/hashfn.o \
 		$(top_srcdir)/src/backend/utils/mb/mbutils.o \
 		$(top_srcdir)/src/backend/utils/mb/wchar.o \

--- a/src/backend/utils/adt/test/Makefile
+++ b/src/backend/utils/adt/test/Makefile
@@ -21,6 +21,7 @@ common_REAL_OBJS=\
     $(top_srcdir)/src/backend/storage/page/itemptr.o \
     $(top_srcdir)/src/backend/utils/adt/datum.o \
     $(top_srcdir)/src/backend/utils/adt/like.o \
+    $(top_srcdir)/src/backend/utils/error/elog.o \
     $(top_srcdir)/src/backend/utils/hash/hashfn.o \
     $(top_srcdir)/src/backend/utils/misc/guc.o \
     $(top_srcdir)/src/backend/utils/misc/guc_gp.o \
@@ -33,7 +34,7 @@ common_REAL_OBJS=\
     $(top_srcdir)/src/port/thread.o \
     $(top_srcdir)/src/timezone/localtime.o \
 	$(top_srcdir)/src/timezone/strftime.o \
-    $(top_srcdir)/src/timezone/pgtz.o    
+    $(top_srcdir)/src/timezone/pgtz.o
 
 varlena_REAL_OBJS=$(common_REAL_OBJS) \
 	$(top_srcdir)/src/backend/utils/mmgr/mcxt.o \
@@ -43,7 +44,6 @@ varlena_REAL_OBJS=$(common_REAL_OBJS) \
 date_REAL_OBJS=$(common_REAL_OBJS) \
 	$(top_srcdir)/src/backend/utils/adt/datetime.o \
 	$(top_srcdir)/src/backend/utils/adt/varlena.o \
-	$(top_srcdir)/src/backend/utils/error/elog.o \
 	$(top_srcdir)/src/backend/utils/fmgr/fmgr.o \
 	$(top_srcdir)/src/backend/utils/mb/mbutils.o \
 	$(top_srcdir)/src/backend/utils/mb/wchar.o

--- a/src/backend/utils/fmgr/test/dfmgr_test.c
+++ b/src/backend/utils/fmgr/test/dfmgr_test.c
@@ -21,6 +21,11 @@
  * expectation. Note, an error is the success case
  */
 #define errfinish errfinish_impl
+/*
+ * Mock PG_RE_THROW as well, because we are not using real elog.o.
+ * The closest mockery is to call siglongjmp().
+ */
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
 
 /* Buffer to store the last error mesage from errdetail */
 static char lastErrorMsg[ERROR_MESSAGE_MAX_LEN];

--- a/src/backend/utils/mmgr/test/aset_test.c
+++ b/src/backend/utils/mmgr/test/aset_test.c
@@ -11,6 +11,8 @@ extern MemoryAccount *MemoryAccountTreeLogicalRoot;
 extern MemoryAccount *TopMemoryAccount;
 extern MemoryAccount *MemoryAccountMemoryAccount;
 
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
+
 /*
  * This method will emulate the real ExceptionalCondition
  * function by re-throwing the exception, essentially falling

--- a/src/backend/utils/mmgr/test/idle_tracker_test.c
+++ b/src/backend/utils/mmgr/test/idle_tracker_test.c
@@ -35,6 +35,8 @@ InitFakeSessionState(int activeProcessCount, int cleanupCountdown, RunawayStatus
 	MySessionState->spinLock = 0;
 }
 
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
+
 /*
  * This method will emulate the real ExceptionalCondition
  * function by re-throwing the exception, essentially falling

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -76,6 +76,7 @@ fwrite_mock(const char *data, Size size, Size count, FILE *file)
 	return count;
 }
 
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
 /*
  * This method will emulate the real ExceptionalCondition
  * function by re-throwing the exception, essentially falling

--- a/src/backend/utils/mmgr/test/redzone_handler_test.c
+++ b/src/backend/utils/mmgr/test/redzone_handler_test.c
@@ -24,6 +24,8 @@
 static uint32 fakeIsRunawayDetector = 0;
 extern bool sessionStateInited;
 
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
+
 /*
  * This method will emulate the real ExceptionalCondition
  * function by re-throwing the exception, essentially falling

--- a/src/backend/utils/mmgr/test/runaway_cleaner_test.c
+++ b/src/backend/utils/mmgr/test/runaway_cleaner_test.c
@@ -55,7 +55,7 @@ InitFakeSessionState(int activeProcessCount, int cleanupCountdown, RunawayStatus
 	MySessionState->spinLock = 0;
 }
 
-
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
 
 /*
  * This method will emulate the real ExceptionalCondition

--- a/src/backend/utils/mmgr/test/vmem_tracker_test.c
+++ b/src/backend/utils/mmgr/test/vmem_tracker_test.c
@@ -14,6 +14,8 @@
 
 #define SEGMENT_VMEM_CHUNKS_TEST_VALUE 100
 
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
+
 /*
  * This method will emulate the real ExceptionalCondition
  * function by re-throwing the exception, essentially falling

--- a/src/backend/utils/test/session_state_test.c
+++ b/src/backend/utils/test/session_state_test.c
@@ -47,6 +47,8 @@ static Size mul_size(Size s1, Size s2);
     	will_return_with_sideeffect(errstart, false, &_ExceptionalCondition, NULL);\
     } \
 
+#define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
+
 /*
  * This method will emulate the real ExceptionalCondition
  * function by re-throwing the exception, essentially falling

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -359,8 +359,17 @@ extern PGDLLIMPORT ErrorContextCallback *error_context_stack;
 		error_context_stack = save_context_stack; \
 	} while (0)
 
+/*
+ * gcc understands __attribute__((noreturn)); for other compilers, insert
+ * pg_unreachable() so that the compiler gets the point.
+ */
+#ifdef __GNUC__
 #define PG_RE_THROW()  \
-	siglongjmp(*PG_exception_stack, 1)
+	pg_re_throw()
+#else
+#define PG_RE_THROW()  \
+	(pg_re_throw(), pg_unreachable())
+#endif
 
 extern PGDLLIMPORT sigjmp_buf *PG_exception_stack;
 


### PR DESCRIPTION
This is fixed in PostgreSQL and I found parts of those fixes pulled in already.
This commit pulls in the remnants.  The SEGV was found at a customer site
where default_tablespace was configured for a role.  While new connections were
made by the role, GRANT/REVOKE on the same tablespace was running concurrently.
The assign hook for default_tablespace invoked elog(ERROR) but target for
siglongjmp was not initialized, causing a segv and PANIC.

Some cmockery unit tests had to be changed to accommodate the fix.

Original commits from PostgreSQL:
88f1fd29897df477f0af3c5ffcefe53c697a6ff3
79ca7ffeb6a43c1f2af80ead6a2dffd120594cf9