### PR TITLE
Fix bug: alter partitioned table set distributed by will crash.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -3925,10 +3925,9 @@ ATController(Relation rel, List *cmds, bool recurse,
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		List *umap = NIL; /* the full OID map for all relations */
-		ListCell *lc;
-		AlterTableCmd *mastercmd = NULL; /* the command which was expanded */
-
+		AlterTableCmd *masterCmd = NULL; /* the command which was expanded */
+		SetDistributionCmd *masterSetCmd = NULL; 
+		ListCell *lc = NULL;
 		/* 
 		 * Iterate over the work queue looking for SET WITH DISTRIBUTED
 		 * statements.
@@ -3947,49 +3946,38 @@ ATController(Relation rel, List *cmds, bool recurse,
 
 				if (cmd->subtype == AT_SetDistributedBy)
 				{
-					if (!mastercmd)
+					if (!masterCmd)
 					{
 						Assert(tab->relid == relid);
-						mastercmd = cmd;
+						masterCmd = cmd;
+						masterSetCmd = lsecond((List *)cmd->def);
+						continue;
 					}
 
 					/*
 					 * cmd->def stores the data we're sending to the QEs.
 					 * The second element is where we stash QE data to drive
-					 * the command. The second element of qe_data is our
-					 * OID map. See ATExecSetDistributedBy().
-					 *
-					 * Yes, this is begging to be improved.
+					 * the command.
 					 */
 					List *data = (List *)cmd->def;
-					List *qe_data = lsecond(data);
+					SetDistributionCmd *qeData = lsecond(data);
 
-					if (qe_data && list_length(qe_data) >= 2)
+					int qeBackendId = qeData->backendId;
+					if (qeBackendId != 0)
 					{
-						List *oidmap = lsecond(qe_data);
+						if(masterSetCmd->backendId == 0)
+						{
+							masterSetCmd->backendId = qeBackendId;
+						}
 
-						umap = list_concat(umap, oidmap);
+						List *qeRelids = qeData->relids;
+						masterSetCmd->relids = list_concat(masterSetCmd->relids, qeRelids);
+						List *qeIdxOidMap = qeData->indexOidMap;
+						masterSetCmd->indexOidMap = list_concat(masterSetCmd->indexOidMap, qeIdxOidMap);
+						List *qeHiddenTypes = qeData->hiddenTypes;
+						masterSetCmd->hiddenTypes = list_concat(masterSetCmd->hiddenTypes, qeHiddenTypes);
 					}
 				}
-			}
-		}
-
-		/* Finally, push it all back into the master command */
-		if (mastercmd && umap)
-		{
-			List *qe_data = lsecond((List *)mastercmd->def);
-
-			if (list_length(qe_data) >= 2)
-				lsecond(qe_data) = umap;
-			else if (list_length(qe_data) == 1)
-			{
-				qe_data = lappend(qe_data, umap);
-
-				/* 
-				 * We've changed the pointer, save it back to the master
-				 * definition.
-				 */
-				lsecond((List *)mastercmd->def) = qe_data;
 			}
 		}
 	}
@@ -13258,7 +13246,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 	Oid			tmprelid;
 	Oid			tarrelid = RelationGetRelid(rel);
 	List	   *oid_map = NIL;
-	List	   *qe_data = NIL; /* data to pass to QEs */
 	bool        rand_pol = false;
 	bool        force_reorg = false;
 	Datum		newOptions = PointerGetDatum(NULL);
@@ -13269,6 +13256,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 	List	   *hidden_types = NIL; /* types we need to build for dropped columns */
 	int         nattr; /* number of attributes */
 	bool useExistingColumnAttributes = true;
+	SetDistributionCmd *qe_data = NULL; 
 
 	/* Permissions checks */
 	if (!pg_class_ownercheck(RelationGetRelid(rel), GetUserId()))
@@ -13469,6 +13457,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 				 * (see the non-random distribution case below for why.
 				 */
 				heap_close(rel, NoLock);
+				lsecond(lprime) = makeNode(SetDistributionCmd); 
 				goto l_distro_fini;
 			}
 		}
@@ -13597,7 +13586,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 						heap_close(rel, NoLock);
 						/* Tell QEs to do nothing */
 						linitial(lprime) = NULL;
-						lsecond(lprime) = list_make1(NULL);
+						lsecond(lprime) = makeNode(SetDistributionCmd); 
 
 						return;
 						/* don't goto l_distro_fini -- didn't do anything! */
@@ -13651,7 +13640,9 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		 * Step (d) - tell the seg nodes about the temporary relation. This
 		 * involves stomping on the node we've been given
 		 */
-		qe_data = lappend(qe_data, makeInteger(MyBackendId));
+		qe_data = makeNode(SetDistributionCmd);
+		qe_data->backendId = MyBackendId;
+		qe_data->relids = list_make1_oid(tarrelid); 
 	}
 	else
 	{
@@ -13677,18 +13668,23 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			reorg = false;
 
 		/* Set to random distribution on master with no reorganisation */
-		if (!reorg && list_length(qe_data) == 1 && linitial(qe_data) == NULL)
+		if (!reorg && qe_data->backendId == 0)
 		{
 			/* caller expects rel to be closed for this AT type */
 			heap_close(rel, NoLock);
 			goto l_distro_fini;			
 		}
 
-		backend_id = intVal(linitial(qe_data));
+		if (list_find_oid(qe_data->relids, tarrelid) < 0)
+		{
+			heap_close(rel, NoLock);
+			goto l_distro_fini;			
+		}
+
+		backend_id = qe_data->backendId;
 		tmprv = make_temp_table_name(rel, backend_id);
-		oid_map = lsecond(qe_data);
-		if (list_length(qe_data) == 3)
-			hidden_types = lthird(qe_data);
+		oid_map = qe_data->indexOidMap;
+		hidden_types = qe_data->hiddenTypes;
 
 		if (list_length(lprime) == 3)
 		{
@@ -13809,10 +13805,10 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		if (change_policy)
 			GpPolicyReplace(tarrelid, policy);
 
-		qe_data = lappend(qe_data, oid_map);
+		qe_data->indexOidMap = oid_map;
 
 		if (hidden_types)
-			qe_data = lappend(qe_data, hidden_types);
+			qe_data->hiddenTypes = hidden_types;
 		linitial(lprime) = lwith;
 		lsecond(lprime) = qe_data;
 		lprime = lappend(lprime, makeInteger(is_ao ? (is_aocs ? 2 : 1) : 0));

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2768,6 +2768,19 @@ _copyAlterTableCmd(AlterTableCmd *from)
 	return newnode;
 }
 
+static SetDistributionCmd*
+_copySetDistributionCmd(SetDistributionCmd *from)
+{
+	SetDistributionCmd *newnode = makeNode(SetDistributionCmd);
+
+	COPY_SCALAR_FIELD(backendId);
+	COPY_NODE_FIELD(relids);
+	COPY_NODE_FIELD(indexOidMap);
+	COPY_NODE_FIELD(hiddenTypes);
+
+	return newnode;
+}
+
 static InheritPartitionCmd *
 _copyInheritPartitionCmd(InheritPartitionCmd *from)
 {
@@ -4585,6 +4598,9 @@ copyObject(void *from)
 			break;
 		case T_AlterTableCmd:
 			retval = _copyAlterTableCmd(from);
+			break;
+		case T_SetDistributionCmd:
+			retval = _copySetDistributionCmd(from);
 			break;
 		case T_InheritPartitionCmd:
 			retval = _copyInheritPartitionCmd(from);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -926,6 +926,16 @@ _equalAlterTableCmd(AlterTableCmd *a, AlterTableCmd *b)
 }
 
 static bool
+_equalSetDistributionCmd(SetDistributionCmd *a, SetDistributionCmd *b)
+{
+	COMPARE_SCALAR_FIELD(backendId);
+	COMPARE_NODE_FIELD(relids);
+	COMPARE_NODE_FIELD(indexOidMap);
+	COMPARE_NODE_FIELD(hiddenTypes);
+
+	return true;
+}
+static bool
 _equalInheritPartitionCmd(InheritPartitionCmd *a, InheritPartitionCmd *b)
 {
 	COMPARE_NODE_FIELD(parent);
@@ -2587,6 +2597,9 @@ equal(void *a, void *b)
 			break;
 		case T_AlterTableCmd:
 			retval = _equalAlterTableCmd(a, b);
+			break;
+		case T_SetDistributionCmd:
+			retval = _equalSetDistributionCmd(a, b);
 			break;
 		case T_InheritPartitionCmd:
 			retval = _equalInheritPartitionCmd(a, b);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1655,6 +1655,9 @@ _outNode(StringInfo str, void *obj)
 			case T_AlterTableCmd:
 				_outAlterTableCmd(str, obj);
 				break;
+			case T_SetDistributionCmd:
+				_outSetDistributionCmd(str, obj);
+				break;
 			case T_InheritPartitionCmd:
 				_outInheritPartitionCmd(str, obj);
 				break;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2415,6 +2415,17 @@ _outAlterTableCmd(StringInfo str, AlterTableCmd *node)
 }
 
 static void
+_outSetDistributionCmd(StringInfo str, SetDistributionCmd*node)
+{
+	WRITE_NODE_TYPE("SETDISTRIBUTIONCMD");
+
+	WRITE_INT_FIELD(backendId);
+	WRITE_NODE_FIELD(relids);
+	WRITE_NODE_FIELD(indexOidMap);
+	WRITE_NODE_FIELD(hiddenTypes);
+}
+
+static void
 _outInheritPartitionCmd(StringInfo str, InheritPartitionCmd *node)
 {
 	WRITE_NODE_TYPE("INHERITPARTITION");
@@ -3281,6 +3292,7 @@ _outQuery(StringInfo str, Query *node)
 			case T_TruncateStmt:
 			case T_AlterTableStmt:
 			case T_AlterTableCmd:
+			case T_SetDistributionCmd:
 			case T_ViewStmt:
 			case T_RuleStmt:
 
@@ -4603,6 +4615,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_AlterTableCmd:
 				_outAlterTableCmd(str, obj);
+				break;
+			case T_SetDistributionCmd:
+				_outSetDistributionCmd(str, obj);
 				break;
 			case T_InheritPartitionCmd:
 				_outInheritPartitionCmd(str, obj);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -590,6 +590,19 @@ _readAlterTableCmd(void)
 	READ_DONE();
 }
 
+static SetDistributionCmd *
+_readSetDistributionCmd(void)
+{
+	READ_LOCALS(SetDistributionCmd);
+
+	READ_INT_FIELD(backendId);
+	READ_NODE_FIELD(relids);
+	READ_NODE_FIELD(indexOidMap);
+	READ_NODE_FIELD(hiddenTypes);
+
+	READ_DONE();
+}
+
 static AlterPartitionCmd *
 _readAlterPartitionCmd(void)
 {
@@ -3009,6 +3022,9 @@ readNodeBinary(void)
 				break;
 			case T_AlterTableCmd:
 				return_value = _readAlterTableCmd();
+				break;
+			case T_SetDistributionCmd:
+				return_value = _readSetDistributionCmd();
 				break;
 			case T_InheritPartitionCmd:
 				return_value = _readInheritPartitionCmd();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1107,6 +1107,21 @@ _readAlterTableCmd(void)
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
+#ifndef COMPILING_BINARY_FUNCS
+static SetDistributionCmd *
+_readSetDistributionCmd(void)
+{
+	READ_LOCALS(SetDistributionCmd);
+
+	READ_INT_FIELD(backendId);
+	READ_NODE_FIELD(relids);
+	READ_NODE_FIELD(indexOidMap);
+	READ_NODE_FIELD(hiddenTypes);
+
+	READ_DONE();
+}
+#endif /* COMPILING_BINARY_FUNCS */
+
 static InheritPartitionCmd *
 _readInheritPartitionCmd(void)
 {
@@ -3129,6 +3144,7 @@ static ParseNodeInfo infoAr[] =
 	{"RULESTMT", (ReadFn)_readRuleStmt},
 	{"SCALARARRAYOPEXPR", (ReadFn)_readScalarArrayOpExpr},
 	{"SEGFILEMAPNODE", (ReadFn)_readSegfileMapNode},
+	{"SETDISTRIBUTIONCMD", (ReadFn)_readSetDistributionCmd},
 	{"SETOPERATIONSTMT", (ReadFn)_readSetOperationStmt},
 	{"SETTODEFAULT", (ReadFn)_readSetToDefault},
 	{"SINGLEROWERRORDESC",(ReadFn)_readSingleRowErrorDesc},

--- a/src/backend/optimizer/util/predtest.c
+++ b/src/backend/optimizer/util/predtest.c
@@ -475,6 +475,8 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate)
 	Node	   *not_arg;
 	bool		result;
 
+	CHECK_FOR_INTERRUPTS();
+
 	/* skip through RestrictInfo */
 	Assert(clause != NULL);
 	if (IsA(clause, RestrictInfo))

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -426,6 +426,7 @@ typedef enum NodeTag
 	T_DenyLoginInterval,
 	T_DenyLoginPoint,
 	T_AlterTypeStmt,
+	T_SetDistributionCmd,
 
 	/**/
 	

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1200,6 +1200,17 @@ typedef struct AlterTableCmd	/* one subcommand of an ALTER TABLE */
 	List	   *partoids;		/* If applicable, OIDs of partition part tables */
 } AlterTableCmd;
 
+
+typedef struct SetDistributionCmd 
+{
+	NodeTag		type;
+	int	        backendId;
+	List	   *relids;
+	List	   *indexOidMap;
+	List	   *hiddenTypes;
+} SetDistributionCmd;
+
+
 typedef enum AlterPartitionIdType
 {
 	AT_AP_IDNone,				/* no ID */

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -8199,3 +8199,28 @@ select count(*) from gp_distribution_policy
 reset enable_indexscan;
 reset enable_seqscan;
 drop table distrib_index_test;
+-- alter partitioned table crash
+-- Alter partitioned table set distributed by will crash when:
+--     1. reorganize = false.
+--     2. table have index.
+--     3. partition table have "with" option.
+drop index if exists distrib_part_test_idx;
+NOTICE:  index "distrib_part_test_idx" does not exist, skipping
+drop table if exists distrib_part_test;
+NOTICE:  table "distrib_part_test" does not exist, skipping
+CREATE TABLE distrib_part_test
+(
+  col1 int,
+  col2 decimal,
+  col3 text,
+  col4 bool
+)
+distributed by (col1)
+partition by list(col2)
+(
+    partition part1 values(1,2,3,4,5,6,7,8,9,10) WITH (appendonly=false )
+);
+NOTICE:  CREATE TABLE will create partition "distrib_part_test_1_prt_part1" for table "distrib_part_test"
+create index distrib_part_test_idx on distrib_part_test(col1);
+NOTICE:  building index for child partition "distrib_part_test_1_prt_part1"
+ALTER TABLE public.distrib_part_test SET with (reorganize=false) DISTRIBUTED RANDOMLY;

--- a/src/test/regress/expected/alter_distribution_policy_optimizer.out
+++ b/src/test/regress/expected/alter_distribution_policy_optimizer.out
@@ -8198,3 +8198,28 @@ select count(*) from gp_distribution_policy
 reset enable_indexscan;
 reset enable_seqscan;
 drop table distrib_index_test;
+-- alter partitioned table crash
+-- Alter partitioned table set distributed by will crash when:
+--     1. reorganize = false.
+--     2. table have index.
+--     3. partition table have "with" option.
+drop index if exists distrib_part_test_idx;
+NOTICE:  index "distrib_part_test_idx" does not exist, skipping
+drop table if exists distrib_part_test;
+NOTICE:  table "distrib_part_test" does not exist, skipping
+CREATE TABLE distrib_part_test
+(
+  col1 int,
+  col2 decimal,
+  col3 text,
+  col4 bool
+)
+distributed by (col1)
+partition by list(col2)
+(
+    partition part1 values(1,2,3,4,5,6,7,8,9,10) WITH (appendonly=false )
+);
+NOTICE:  CREATE TABLE will create partition "distrib_part_test_1_prt_part1" for table "distrib_part_test"
+create index distrib_part_test_idx on distrib_part_test(col1);
+NOTICE:  building index for child partition "distrib_part_test_1_prt_part1"
+ALTER TABLE public.distrib_part_test SET with (reorganize=false) DISTRIBUTED RANDOMLY;

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -2134,3 +2134,25 @@ select count(*) from gp_distribution_policy
 reset enable_indexscan;
 reset enable_seqscan;
 drop table distrib_index_test;
+
+-- alter partitioned table crash
+-- Alter partitioned table set distributed by will crash when:
+--     1. reorganize = false.
+--     2. table have index.
+--     3. partition table have "with" option.
+drop index if exists distrib_part_test_idx;
+drop table if exists distrib_part_test;
+CREATE TABLE distrib_part_test 
+(
+  col1 int,
+  col2 decimal,
+  col3 text,
+  col4 bool
+)
+distributed by (col1)
+partition by list(col2)
+(
+    partition part1 values(1,2,3,4,5,6,7,8,9,10) WITH (appendonly=false )
+);
+create index distrib_part_test_idx on distrib_part_test(col1);
+ALTER TABLE public.distrib_part_test SET with (reorganize=false) DISTRIBUTED RANDOMLY;


### PR DESCRIPTION
Alter partitioned table set distributed by will dispatch information
from QD to QEs, the information is not correctly coded and decoded on
both sides when:
1. reorganize = false.
2. table have index.
3. partition table have "with" option.