### PR TITLE
Show hostname when name lookup fails in gpssh-exkeys

### DIFF
--- a/gpMgmt/bin/gpssh-exkeys
+++ b/gpMgmt/bin/gpssh-exkeys
@@ -522,7 +522,11 @@ try:
     localhosts = []
     for hostname in (socket.gethostname(), socket.getfqdn()):
         if addHost(hostname, localhosts, True):
-            (primary, aliases, ipaddrs) = socket.gethostbyaddr(hostname)
+            try:
+                (primary, aliases, ipaddrs) = socket.gethostbyaddr(hostname)
+            except Exception, e:
+                print u'Problem getting hostname for {0}: {1}'.format(hostname, e)
+                raise
             addHost(primary, localhosts, True)
             for alias in aliases:
                 addHost(alias, localhosts, True)


### PR DESCRIPTION
When running gpssh-exkeys, if a hostname failed the gethostbyname lookup, the error message would give no indication what host failed name lookup, just printing "socket.gaierror: [Errno -2] Name or service not known"

This change prints the name of the failed host lookup for easier troubleshooting, like so:

Problem getting hostname for ip-10-10-2-193: [Errno -2] Name or service not known
