### PR TITLE
Add feature to backup and restore catalog statistics.

### DIFF
--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -28,9 +28,9 @@ try:
     from gppylib.operations.restore import GetDbName, GetDumpTables, RecoverRemoteDumps, RestoreDatabase, ValidateTimestamp, \
                                            config_files_dumped, create_restore_plan, get_restore_dir, get_restore_tables_from_table_file, \
                                            global_file_dumped, is_begin_incremental_run, is_incremental_restore, restore_cdatabase_file_with_nbu, \
-                                           restore_config_files_with_nbu, restore_global_file_with_nbu, restore_increments_file_with_nbu, \
-                                           restore_partition_list_file_with_nbu, restore_report_file_with_nbu, restore_state_files_with_nbu, \
-                                           truncate_restore_tables, validate_tablenames
+                                           restore_config_files_with_nbu, restore_global_file_with_nbu, restore_statistics_file_with_nbu, \
+                                           restore_increments_file_with_nbu, restore_partition_list_file_with_nbu, restore_report_file_with_nbu, \
+                                           restore_state_files_with_nbu, truncate_restore_tables, validate_tablenames
     from gppylib.operations.utils import DEFAULT_NUM_WORKERS
     from gppylib.operations.unix import CheckFile, CheckRemoteFile, ListFilesByPattern, ListRemoteFilesByPattern
 except ImportError, e:
@@ -85,6 +85,11 @@ class GpdbRestore(Operation):
         self.report_status_dir = options.report_status_dir
         self.truncate = options.truncate
         self.change_schema = options.change_schema
+        self.restore_stats = options.restore_stats
+
+        if self.restore_stats:
+            self.no_analyze = True
+
         # NetBackup params
         self.netbackup_service_host = options.netbackup_service_host
         self.netbackup_block_size = options.netbackup_block_size
@@ -98,6 +103,9 @@ class GpdbRestore(Operation):
 
         if self.truncate and self.drop_db:
             raise Exception('Cannot specify --truncate and -e together')
+
+        if self.restore_stats == "only" and self.drop_db:
+            raise Exception('Cannot specify --restore-stats only and -e together')
 
         if self.table_file and self.restore_tables:
             raise Exception('Cannot specify -T and --table-file together')
@@ -183,12 +191,16 @@ class GpdbRestore(Operation):
                 restore_config_files_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.master_port, self.netbackup_service_host, self.netbackup_block_size)
             if global_file_dumped(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host):
                 restore_global_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host, self.netbackup_block_size)
+            if statistics_file_dumped(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host):
+                restore_statistics_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host, self.netbackup_block_size)
 
         if self.list_tables and self.db_timestamp is not None:
             return self._list_dump_tables()
 
         info = self._gather_info()
-        if is_incremental_restore(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, info['restore_timestamp']):
+        if self.restore_stats == "only":
+            restore_type = "Statistics-Only Restore"
+        elif is_incremental_restore(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, info['restore_timestamp']):
             if self.restore_tables is not None:
                 restore_type = "Incremental Table Restore"
             else:
@@ -261,11 +273,12 @@ class GpdbRestore(Operation):
                         no_ao_stats = self.no_ao_stats,
                         redirected_restore_db = self.redirected_restore_db,
                         report_status_dir = self.report_status_dir,
+                        restore_stats = self.restore_stats,
                         netbackup_service_host = self.netbackup_service_host,
                         netbackup_block_size = self.netbackup_block_size,
                         change_schema = self.change_schema).run()
 
-        if self.no_analyze:
+        if self.no_analyze and not self.restore_stats:
             logger.warn('--------------------------------------------------------------------------------------------------')
             logger.warn('Analyze bypassed on request; database performance may be adversely impacted until analyze is done.')
             logger.warn('--------------------------------------------------------------------------------------------------')
@@ -542,6 +555,21 @@ def restore_global_callback(option, opt_str, value, parser):
         raise OptionValueError('%s is not a valid argument for -G.  Valid arguments are "include" and "only".' % value)
     setattr(parser.values, option.dest, value)
 
+def restore_stats_callback(option, opt_str, value, parser):
+    assert value is None
+    if len(parser.rargs) > 0:
+        value = parser.rargs[0]
+        if value[:1] == "-":
+            value = "include"
+        else:
+            del parser.rargs[:1]
+
+    if value == None:
+        value = "include"
+    elif value not in ("include", "only"):
+        raise OptionValueError('%s is not a valid argument for --restore-stats.  Valid arguments are "include" and "only".' % value)
+    setattr(parser.values, option.dest, value)
+
 def create_parser():
     parser = OptParser(option_class=OptChecker,
                        version='%prog version $Revision$',
@@ -593,6 +621,8 @@ def create_parser():
                      help="Truncate's the restore tables specified using -T and --table-file option")
     addTo.add_option('--change-schema', dest='change_schema', metavar="<change schema>",
                      help="Different schema name to which tables will be restored")
+    addTo.add_option('--restore-stats', dest='restore_stats', action="callback", callback=restore_stats_callback,
+                     help="Restore database statistics. Analysis is skipped as if the --noanalyze flag were set.")
     parser.add_option_group(addTo)
 
     # For Incremental Restore

--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -379,6 +379,9 @@ def generate_dbdump_prefix(dump_prefix):
 def generate_createdb_prefix(dump_prefix):
     return '%sgp_cdatabase_1_1_' % (dump_prefix)
 
+def generate_stats_prefix(dump_prefix):
+    return '%sgp_statistics_1_1_' % (dump_prefix)
+
 def generate_createdb_filename(master_data_dir, backup_dir, dump_dir, dump_prefix, timestamp, ddboost=False):
     if ddboost:
         return '%s/%s/%s/%s%s' % (master_data_dir, dump_dir, timestamp[0:8], generate_createdb_prefix(dump_prefix), timestamp)
@@ -569,6 +572,14 @@ def generate_global_filename(master_data_dir, backup_dir, dump_dir, dump_prefix,
 def generate_cdatabase_filename(master_data_dir, backup_dir, dump_dir, dump_prefix, timestamp):
     use_dir = get_backup_directory(master_data_dir, backup_dir, dump_dir, timestamp)
     return "%s/%sgp_cdatabase_1_1_%s" % (use_dir, dump_prefix, timestamp)
+
+def generate_stats_filename(master_data_dir, backup_dir, dump_dir, dump_prefix, dump_date, timestamp):
+    if backup_dir is not None:
+        dir_path = backup_dir
+    else:
+        dir_path = master_data_dir
+
+    return os.path.join(dir_path, dump_dir, dump_date, "%s%s" % (generate_stats_prefix(dump_prefix), timestamp))
 
 def get_full_timestamp_for_incremental_with_nbu(dump_prefix, incremental_timestamp, netbackup_service_host, netbackup_block_size):
     if dump_prefix:

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -40,6 +40,7 @@ class restoreTestCase(unittest.TestCase):
                                        no_ao_stats = False,
                                        redirected_restore_db = None,
                                        report_status_dir = None,
+                                       restore_stats = None,
                                        ddboost = False,
                                        netbackup_service_host = None,
                                        netbackup_block_size = None,
@@ -106,12 +107,12 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.RestoreDatabase._process_createdb', side_effect=ExceptionNoStackTraceNeeded('Failed to create database'))
     @patch('time.sleep')
     def test_multitry_createdb_1(self, mock1, mock2):
-        r = RestoreDatabase('20121219', True, True, False, 'FOO', None, 1234, False, False, None, None, 'db_dumps', '', False, None, None, None, None, None)
+        r = RestoreDatabase('20121219', True, True, False, 'FOO', None, 1234, False, False, None, None, 'db_dumps', '', None, False, None, None, None, None, None)
         self.assertRaises(ExceptionNoStackTraceNeeded, r._multitry_createdb, '20121219', 'fullbkdb', None, 'FOO', None, 1234)
 
     @patch('gppylib.operations.restore.RestoreDatabase._process_createdb')
     def test_multitry_createdb_2(self, mock):
-        r = RestoreDatabase('20121219', True, True, False, 'FOO', None, 1234, False, False, None, None, 'db_dumps', '', False, None, None, None, None, None)
+        r = RestoreDatabase('20121219', True, True, False, 'FOO', None, 1234, False, False, None, None, 'db_dumps', '', None, False, None, None, None, None, None)
         r._multitry_createdb('20121219', 'fullbkdb', None, 'FOO', None, 1234)
 
     @patch('gppylib.operations.restore.get_partition_list', return_value=[('public', 't1'), ('public', 't2'), ('public', 't3')])
@@ -1527,7 +1528,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         db_name = 'FOO'
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, None, False, None, None, None, None, None)
         restoredb._analyze_restore_tables(db_name, restore_tables, None)
 
     @patch('gppylib.operations.restore.execSQL', side_effect=Exception('analyze failed'))
@@ -1537,7 +1538,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         db_name = 'FOO'
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, None, False, None, None, None, None, None)
         self.assertRaises(Exception, restoredb._analyze_restore_tables, db_name, restore_tables, None)
 
     @patch('gppylib.operations.backup_utils.execSQL')
@@ -1547,7 +1548,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         db_name = 'FOO'
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, None, False, None, None, None, None, None)
         self.assertRaises(Exception, restoredb._analyze_restore_tables, db_name, restore_tables, None)
 
     @patch('gppylib.operations.backup_utils.execSQL')
@@ -1557,7 +1558,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         db_name = 'FOO'
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, None, False, None, None, None, None, None)
         self.assertRaises(Exception, restoredb._analyze_restore_tables, db_name, restore_tables, None)
 
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
@@ -1568,7 +1569,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         port = 1234
         restore_tables = ['public.t%d' % i for i in range(3002)]
         expected_batch_count = 3
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, None, False, None, None, None, None, None)
         batch_count = restoredb._analyze_restore_tables(db_name, restore_tables, None)
         self.assertEqual(batch_count, expected_batch_count)
 
@@ -1580,7 +1581,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
         change_schema = 'newschema'
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, None, False, None, None, None, None, None)
         restoredb._analyze_restore_tables(db_name, restore_tables, change_schema)
 
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
@@ -1591,7 +1592,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         port = 1234
         restore_tables = ['public.t1', 'public.t2']
         change_schema = 'newschema'
-        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, False, None, None, None, None, None)
+        restoredb = RestoreDatabase('20121219', False, True, False, 'FOO', None, 1234, 'db_dumps', '', False, False, None, None, None, False, None, None, None, None, None)
         restoredb._analyze_restore_tables(db_name, restore_tables, change_schema)
 
 class ValidateTimestampTestCase(unittest.TestCase):

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -185,6 +185,7 @@ def impl(context, tabletype, table_name, compression_type, indexname, dbname):
     create_indexes(context, table_name, indexname, dbname)
 
 @given('there is a "{tabletype}" partition table "{table_name}" with compression "{compression_type}" in "{dbname}" with data')
+@then('there is a "{tabletype}" partition table "{table_name}" with compression "{compression_type}" in "{dbname}" with data')
 def impl(context, tabletype, table_name, compression_type, dbname):
     create_database_if_not_exists(context, dbname)
     drop_table_if_exists(context, table_name=table_name, dbname=dbname)
@@ -1070,6 +1071,8 @@ def verify_file_contents(context, file_type, file_dir, text_find, should_contain
         fn = '%sgp_dump_status_1_1_%s' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == 'filter':
         fn = '%sgp_dump_%s_filter' % (context.dump_prefix, context.backup_timestamp)
+    elif file_type == "statistics":
+        fn = '%sgp_statistics_1_1_%s' % (context.dump_prefix, context.backup_timestamp)
 
     subdirectory = context.backup_timestamp[0:8]
     
@@ -1302,6 +1305,8 @@ def impl(context, filetype, dir):
         filename = 'gp_restore_%s_plan' % context.backup_timestamp
     elif filetype == "global":
         filename = 'gp_global_1_1_%s' % context.backup_timestamp
+    elif filetype == "statistics":
+        filename = 'gp_statistics_1_1_%s' % context.backup_timestamp
     elif filetype == 'pipes':
         filename = 'gp_dump_%s_pipes' % context.backup_timestamp
     elif filetype == 'regular_files':
@@ -3725,4 +3730,11 @@ def impl(context, filepath):
 
     if found != len(split_message):
         raise Exception("expected to find %s tables in order and only found %s in order" % (len(split_message), found))
+
+@given('database "{dbname}" is dropped and recreated')
+@when('database "{dbname}" is dropped and recreated')
+@then('database "{dbname}" is dropped and recreated')
+def impl(context, dbname):
+    drop_database_if_exists(context, dbname)
+    create_database(context, dbname)
 

--- a/gpMgmt/bin/gppylib/test/behave_utils/utils.py
+++ b/gpMgmt/bin/gppylib/test/behave_utils/utils.py
@@ -5,6 +5,7 @@ from gppylib.commands.gp import GpStart, chk_local_db_running
 from gppylib.commands.base import Command, ExecutionError, REMOTE
 from gppylib.db import dbconn
 from gppylib.gparray import GpArray, MODE_SYNCHRONIZED
+from pygresql import pg
 
 PARTITION_START_DATE = '2010-01-01'
 PARTITION_END_DATE = '2013-01-01'
@@ -1324,6 +1325,10 @@ def verify_restored_table_is_analyzed(context, table_name, dbname):
     ROW_COUNT_SQL = """SELECT count(*) FROM %s""" % table_name
     if table_name.find('.') != -1:
         schema_name,table_name = table_name.split(".")
+    else:
+        schema_name = 'public'
+    schema_name = pg.escape_string(schema_name)
+    table_name = pg.escape_string(table_name)
     ROW_COUNT_PG_CLASS_SQL = """SELECT reltuples FROM pg_class WHERE relname = '%s'
                                 AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = '%s')""" % (table_name, schema_name)
     with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:

--- a/gpMgmt/bin/gppylib/test/behave_utils/utils.py
+++ b/gpMgmt/bin/gppylib/test/behave_utils/utils.py
@@ -1323,8 +1323,9 @@ def check_dump_dir_exists(context, dbname):
 def verify_restored_table_is_analyzed(context, table_name, dbname):
     ROW_COUNT_SQL = """SELECT count(*) FROM %s""" % table_name
     if table_name.find('.') != -1:
-        table_name = table_name.split(".")[1]
-    ROW_COUNT_PG_CLASS_SQL = """SELECT reltuples FROM pg_class WHERE relname = '%s'""" % (table_name)
+        schema_name,table_name = table_name.split(".")
+    ROW_COUNT_PG_CLASS_SQL = """SELECT reltuples FROM pg_class WHERE relname = '%s'
+                                AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = '%s')""" % (table_name, schema_name)
     with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
         curs = dbconn.execSQL(conn, ROW_COUNT_SQL)
         rows = curs.fetchall()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcrondump.py
@@ -56,6 +56,7 @@ class GpCronDumpTestCase(unittest.TestCase):
             self.include_schema_file = None
             self.exclude_schema_file = None
             self.exclude_dump_schema = None
+            self.dump_stats = None
 
             ## Enterprise init
             self.incremental = False

--- a/gpMgmt/doc/gpcrondump_help
+++ b/gpMgmt/doc/gpcrondump_help
@@ -319,6 +319,16 @@ OPTIONS
  block ICMP ping probes, specify this option. 
 
  
+--dump-stats
+
+ Dump optimizer statistics from pg_statistic. Statistics are dumped in the
+ master data directory to db_dumps/YYYYMMDD/gp_statistics_1_1_<timestamp>.
+
+ If --ddboost is specified, the backup is located on the default storage
+ unit in the directory specified by --ddboost-backupdir when the Data
+ Domain Boost credentials were set.
+
+
 -E <encoding> 
 
  Character set encoding of dumped data. Defaults to the encoding of the 

--- a/gpMgmt/doc/gpdbrestore_help
+++ b/gpMgmt/doc/gpdbrestore_help
@@ -303,6 +303,22 @@ OPTIONS
  directories. 
 
 
+--restore-stats [include|only]
+
+ Restores optimizer statistics if the statistics dump file
+ db_dumps/<date>/gp_statistics_1_1_<timestamp> is found in the master data
+ directory. Setting this option automatically skips the final analyze step,
+ so it is not necessary to also set the --noanalyze flag in conjunction with
+ this one.
+
+ Specify "--restore-stats only" to only restore the statistics dump file or
+ "--restore-stats include" to restore statistics along with a normal restore.
+ Defaults to "include" if neither argument is provided.
+ 
+ If "--restore-stats only" is specified along with the -e option, an error
+ is returned.
+
+
 -s <database_name>
 
  Looks for latest set of dump files for the given database name in the 


### PR DESCRIPTION
A --dump-stats flag has been added to gpcrondump.py to dump the
pg_class table tuple counts and pg_statistic catalog statistics
to a SQL file, to later be restored manually or with gpdbrestore.

A --restore-stats flag has been added to gpdbrestore to restore
the dumped statistics.  Passing it the argument "include", or
passing it no argument, will restore the statistics in addition
to performing a normal restore.  Passing it the argument "only"
will restore statistics but will not restore anything else; if
any tables do not exist, using this option will skip restoring
statistics to those tables, print a warning for each, and then
continue restoring statistics to other tables.

If --dump-stats or --restore-stats is used in conjunction with
other flags that include or exclude certain tables or schemas,
the statistics dump or restore will be filtered in the same way.

Authors: James McAtamney and Jimmy Yih