### PR TITLE
Enable immediate response to SIGTERM when hanging at recv.

### DIFF
--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -304,7 +304,17 @@ rloop:
 	{
 		prepare_for_client_read();
 
+		bool saved_ImmediateInterruptOK = ImmediateInterruptOK;
+		ImmediateInterruptOK = true;
+
+		if (ProcDiePending)
+		{
+			CHECK_FOR_INTERRUPTS();
+		}
+
 		n = recv(port->sock, ptr, len, 0);
+
+		ImmediateInterruptOK = saved_ImmediateInterruptOK;
 
 		client_read_ended();
 	}


### PR DESCRIPTION
This addresses the problem that we cannot terminate QD by pg_terminate_backend()
if someone issues 'COPY tbl FROM stdin' and then leaves forever.