### PR TITLE
Refactor gpmgmt1 test in bugbuster.

### DIFF
--- a/src/test/regress/bugbuster/expected/gpmgmt1.out
+++ b/src/test/regress/bugbuster/expected/gpmgmt1.out
@@ -9,5 +9,4 @@
 \! gpcheckperf -h localhost -d /tmp/  -r s  &>  /dev/null
 \! gpstate -v &> /dev/null
 \! gpstate -b &> /dev/null
-\! gpstate -f &> /dev/null
 \! gpstate -e &> /dev/null

--- a/src/test/regress/bugbuster/sql/gpmgmt1.sql
+++ b/src/test/regress/bugbuster/sql/gpmgmt1.sql
@@ -9,8 +9,4 @@
 \! gpcheckperf -h localhost -d /tmp/  -r s  &>  /dev/null
 \! gpstate -v &> /dev/null
 \! gpstate -b &> /dev/null
-\! gpstate -f &> /dev/null
 \! gpstate -e &> /dev/null
-
-
-


### PR DESCRIPTION
In the gpmgmt1 bugbuster test, the gpstate -f line makes a
connection to the template1 database which can cause the
other tests in gpmgmt1's parallel test group to fail.  An
example of this is when metadata_track tries to create
databases and fails as template1 is being accessed.

gpstate -f in gpmgmt1 bugbuster test has been removed.