### PR TITLE
Fix gpcrondump and gpdbrestore to report errors in the status file.

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_dump.c
+++ b/src/bin/pg_dump/cdb/cdb_dump.c
@@ -741,7 +741,7 @@ void addFileNameParam(const char* flag, char* file_name, InputOptions* pInputOpt
 	tmp_name = MakeString("%s%s", directory_name, short_file_name);
 	pInputOpts->pszPassThroughParms =
 			addPassThroughLongParm(flag, tmp_name, pInputOpts->pszPassThroughParms);
-	tableFileName = Safe_strdup(file_name);
+	tableFileName = pg_strdup(file_name);
 	free(tmp_name);
 }
 
@@ -966,7 +966,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 'E':			/* Dump encoding */
-				dumpencoding = Safe_strdup(optarg);
+				dumpencoding = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughParm(c, optarg, pInputOpts->pszPassThroughParms);
 				break;
 
@@ -981,7 +981,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 */
 			case 'h':			/* server host */
-				pInputOpts->pszPGHost = Safe_strdup(optarg);
+				pInputOpts->pszPGHost = pg_strdup(optarg);
 				break;
 
 			case 'i':			/* ignore database version mismatch */
@@ -990,7 +990,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 'n':			/* Dump data for this schema only */
-				selectSchemaName = Safe_strdup(optarg);
+				selectSchemaName = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughParm(c, optarg, pInputOpts->pszPassThroughParms);
 				simple_string_list_append(&schema_include_patterns, optarg);
 				include_everything = false;
@@ -1013,7 +1013,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 'p':			/* server port */
-				pInputOpts->pszPGPort = Safe_strdup(optarg);
+				pInputOpts->pszPGPort = pg_strdup(optarg);
 				break;
 
 			case 'R':
@@ -1031,7 +1031,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 't':			/* Dump data for this table only */
-				selectTableName = Safe_strdup(optarg);
+				selectTableName = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughParm(c, optarg, pInputOpts->pszPassThroughParms);
 				simple_string_list_append(&table_include_patterns, optarg);
 				include_everything = false;
@@ -1048,7 +1048,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 'U':
-				pInputOpts->pszUserName = Safe_strdup(optarg);
+				pInputOpts->pszUserName = pg_strdup(optarg);
 				break;
 
 			case 'v':			/* verbose */
@@ -1101,7 +1101,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 
 			case 1:
 				/* gp-c remote compression program */
-				pInputOpts->pszCompressionProgram = "gzip";		/* Safe_strdup(optarg); */
+				pInputOpts->pszCompressionProgram = "gzip";		/* pg_strdup(optarg); */
 				break;
 
 			case 2:
@@ -1128,12 +1128,12 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 
 			case 3:
 				/* gp-d backup remote directory */
-				pInputOpts->pszBackupDirectory = Safe_strdup(optarg);
+				pInputOpts->pszBackupDirectory = pg_strdup(optarg);
 				break;
 
 			case 4:
 				/* gp-r report directory */
-				pInputOpts->pszReportDirectory = Safe_strdup(optarg);
+				pInputOpts->pszReportDirectory = pg_strdup(optarg);
 				break;
 
 			case 5:
@@ -1146,7 +1146,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				else if (strncasecmp(optarg, "i", 1) == 0)
 				{
 					pInputOpts->actors = SET_INDIVIDUAL;
-					pInputOpts->pszRawDumpSet = Safe_strdup(optarg);
+					pInputOpts->pszRawDumpSet = pg_strdup(optarg);
 				}
 				else
 				{
@@ -1205,7 +1205,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 10:
-				pInputOpts->pszTimestampKey = Safe_strdup(optarg);
+				pInputOpts->pszTimestampKey = pg_strdup(optarg);
 				if (!ValidateTimestampKey(pInputOpts->pszTimestampKey)) {
 					mpp_err_msg_cache(logError, progname, "Invalid timestamp key provided\n");
 					goto cleanup;
@@ -1216,34 +1216,34 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
                 no_expand_children = true;
                 break;
             case 12:
-                dump_prefix = Safe_strdup(optarg);
+                dump_prefix = pg_strdup(optarg);
                 pInputOpts->pszPassThroughParms = addPassThroughLongParm("prefix", DUMP_PREFIX, pInputOpts->pszPassThroughParms);
                 break; 
 			case 13:
-				incremental_filter = Safe_strdup(optarg);
+				incremental_filter = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("incremental-filter", incremental_filter, pInputOpts->pszPassThroughParms);
 				break;
 			case 14:
 				no_lock = true;
 				break;
 			case 15:
-				netbackup_service_host = Safe_strdup(optarg);
+				netbackup_service_host = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-service-host", netbackup_service_host, pInputOpts->pszPassThroughParms);
 				break;
 			case 16:
-				netbackup_policy = Safe_strdup(optarg);
+				netbackup_policy = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-policy", netbackup_policy, pInputOpts->pszPassThroughParms);
 				break;
 			case 17:
-				netbackup_schedule = Safe_strdup(optarg);
+				netbackup_schedule = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-schedule", netbackup_schedule, pInputOpts->pszPassThroughParms);
 				break;
 			case 18:
-				netbackup_block_size = Safe_strdup(optarg);
+				netbackup_block_size = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-block-size", netbackup_block_size, pInputOpts->pszPassThroughParms);
 				break;
 			case 19:
-				netbackup_keyword = Safe_strdup(optarg);
+				netbackup_keyword = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-keyword", netbackup_keyword, pInputOpts->pszPassThroughParms);
 				break;
 			case 20:
@@ -1297,9 +1297,9 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 
 		/* If no directory is specified, for example when we gp_dump, then dump to default directory db_dumps */		
 		if (pInputOpts->pszBackupDirectory)
-			ddboost_directory = Safe_strdup(pInputOpts->pszBackupDirectory);
+			ddboost_directory = pg_strdup(pInputOpts->pszBackupDirectory);
 		else
-			ddboost_directory = Safe_strdup("db_dumps/");
+			ddboost_directory = pg_strdup("db_dumps/");
 	
 		pInputOpts->pszPassThroughParms = addPassThroughLongParm("dd_boost_dir", ddboost_directory, pInputOpts->pszPassThroughParms);
 	}
@@ -1307,7 +1307,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 
 	 /* Get database name from command line */
 	if (optind < argc)
-		pInputOpts->pszDBName = Safe_strdup(argv[optind]);
+		pInputOpts->pszDBName = pg_strdup(argv[optind]);
 
 	 /*
 	  * get PG env variables, override only of no cmd-line value specified
@@ -1315,19 +1315,19 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 	if (pInputOpts->pszDBName == NULL)
 	{
 		if (getenv("PGDATABASE") != NULL)
-			pInputOpts->pszDBName = Safe_strdup(getenv("PGDATABASE"));
+			pInputOpts->pszDBName = pg_strdup(getenv("PGDATABASE"));
 	}
 
 	if (pInputOpts->pszPGPort == NULL)
 	{
 		if (getenv("PGPORT") != NULL)
-			pInputOpts->pszPGPort = Safe_strdup(getenv("PGPORT"));
+			pInputOpts->pszPGPort = pg_strdup(getenv("PGPORT"));
 	}
 
 	if (pInputOpts->pszPGHost == NULL)
 	{
 		if (getenv("PGHOST") != NULL)
-			pInputOpts->pszPGHost = Safe_strdup(getenv("PGHOST"));
+			pInputOpts->pszPGHost = pg_strdup(getenv("PGHOST"));
 	}
 
 	 /*
@@ -1680,7 +1680,7 @@ reportBackupResults(InputOptions inputopts, ThreadParmArray *pParmAr)
 			 * report directory not set by user - default to
 			 * $MASTER_DATA_DIRECTORY
 			 */
-			pszReportDirectory = Safe_strdup(getenv("MASTER_DATA_DIRECTORY"));
+			pszReportDirectory = pg_strdup(getenv("MASTER_DATA_DIRECTORY"));
 		}
 		else
 		{
@@ -1864,7 +1864,7 @@ spinOffThreads(PGconn *pConn,
 
 		pParm->pTargetSegDBData = &psegDBAr->pData[i];
 		pParm->pOptionsData = pInputOpts;
-		pParm->bSuccess = false;
+		pParm->bSuccess = true;
 
 		mpp_msg(logInfo, progname, "Creating thread to backup dbid %d: host %s port %d database %s\n",
 				pParm->pTargetSegDBData->dbid,
@@ -1935,10 +1935,10 @@ spinOffThreads(PGconn *pConn,
 	if (pParm->pTargetSegDBData->role == ROLE_MASTER && no_lock)
 	{	
 		char *dumpkey = pParmAr->pData[0].pOptionsData->pszKey;
-		char *filedir = Safe_strdup(pInputOpts->pszReportDirectory);
+		char *filedir = pg_strdup(pInputOpts->pszReportDirectory);
 		if (filedir == NULL)
 		{
-			filedir = Safe_strdup(getenv("MASTER_DATA_DIRECTORY"));
+			filedir = pg_strdup(getenv("MASTER_DATA_DIRECTORY"));
 		}
 		char *signalFileName = MakeString("%s/gp_lockfile_%s", filedir, &dumpkey[8]);
 		mpp_msg(logInfo, progname, "Signal filename is %s.\n", signalFileName);
@@ -2006,6 +2006,7 @@ threadProc(void *arg)
 
 	char	   *pszPassThroughCredentials;
 	PQExpBuffer Qry;
+	PQExpBuffer pqBuffer;
 	PGresult   *pRes;
 	int			sock;
 	bool		bSentCancelMessage;
@@ -2095,7 +2096,7 @@ threadProc(void *arg)
 
 	mpp_msg(logInfo, progname, "Successfully launched Greenplum Database backup on dbid %d server\n", pSegDB->dbid);
 
-	pParm->pszRemoteBackupPath = strdup(PQgetvalue(pRes, 0, 0));
+	pParm->pszRemoteBackupPath = pg_strdup(PQgetvalue(pRes, 0, 0));
 
 	PQclear(pRes);
 	destroyPQExpBuffer(Qry);
@@ -2259,15 +2260,27 @@ threadProc(void *arg)
 
 	/*
 	 * We don't get here unless the BackupStateMachine reached a final state.
-	 * If the status indicates an error, we process this error in the switch
+	 * Do a force scan of the dump status file for ERRORS, such as broken pipe, even if
+	 * segment may report success.
+	 */
+	pqBuffer = createPQExpBuffer();
+	int status = ReadBackendBackupFileError(pConn, pInputOpts->pszBackupDirectory, pszKey,
+			BFT_BACKUP_STATUS, progname, pqBuffer);
+	if(status != 0)
+	{
+		pParm->pszErrorMsg = pqBuffer->data;
+		pParm->bSuccess = false;
+		g_b_SendCancelMessage = true;
+	}
+
+	/*
+	 * If the status already indicated a specific error, we process this error in the switch
 	 * statement below.
 	 */
 	if (!pState->bStatus)
 	{
 		g_b_SendCancelMessage = true;
 		pParm->bSuccess = false;
-		mpp_err_msg(logError, progname, "backup failed for dbid %d on host %s\n",
-				  pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"));
 
 		switch (pState->currentState)
 		{
@@ -2283,14 +2296,7 @@ threadProc(void *arg)
 												"there are various reasons that may cause this to happen. Please "
 							"inspect the server log of dbid %d on host %s\n "
 									  "Detail from remote status file: %s\n",
-				   pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"),
-				 ReadBackendBackupFile(pConn, pInputOpts->pszBackupDirectory,
-									pszKey, BFT_BACKUP_STATUS, progname));
-
-				break;
-			case STATE_BACKUP_ERROR:
-				/* Make call to get error message from file on server */
-				pParm->pszErrorMsg = ReadBackendBackupFile(pConn, pInputOpts->pszBackupDirectory, pszKey, BFT_BACKUP_STATUS, progname);
+				   pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"), StringNotNull(pParm->pszErrorMsg, ""));
 
 				break;
 
@@ -2302,18 +2308,24 @@ threadProc(void *arg)
 				  pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"));
 				break;
 
+			case STATE_BACKUP_ERROR:
 			default:
 				break;
 		}
 
-		mpp_err_msg(logError, progname, pParm->pszErrorMsg);
 	}
-	else
+
+	if (pParm->bSuccess)
 	{
-		pParm->bSuccess = true;
 		mpp_msg(logInfo, progname, "backup succeeded for dbid %d on host %s\n",
 				pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"));
 	}
+	else
+	{
+		mpp_err_msg(logError, progname, "backup failed for dbid %d on host %s\n%s\n",
+				pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"), StringNotNull(pParm->pszErrorMsg, ""));
+	}
+
 
 cleanup:
 	/*

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -589,7 +589,7 @@ main(int argc, char **argv)
 				break;
 
 			case 'S':			/* Username for superuser in plain text output */
-				outputSuperuser = strdup(optarg);
+				outputSuperuser = pg_strdup(optarg);
 				break;
 
 			case 't':			/* include table(s) */
@@ -654,13 +654,13 @@ main(int argc, char **argv)
 
 
 			case 1:				/* MPP Dump Info Format is Key_role_dbid */
-				g_CDBDumpInfo = strdup(optarg);
+				g_CDBDumpInfo = pg_strdup(optarg);
 				if (!ParseCDBDumpInfo((char *) progname, g_CDBDumpInfo, &g_CDBDumpKey, &g_role, &g_dbID, &g_CDBPassThroughCredentials))
 					exit(1);
 				break;
 
 			case 2:				/* --gp-d CDB Output Directory */
-				g_pszCDBOutputDirectory = strdup(optarg);
+				g_pszCDBOutputDirectory = pg_strdup(optarg);
 				break;
 
 			case 3: 			/*	--table-file */
@@ -684,25 +684,25 @@ main(int argc, char **argv)
 				}
 				break;
 			case 5:
-				dump_prefix = strdup(optarg);
+				dump_prefix = pg_strdup(optarg);
 				break;
 
 #ifdef USE_DDBOOST
 			case 6:
-				g_pszDDBoostFile = strdup(optarg);
+				g_pszDDBoostFile = pg_strdup(optarg);
 				break;
 			case 7:
 				dd_boost_enabled = 1;
 				break;
 			case 8:
-				g_pszDDBoostDir = strdup(optarg);
+				g_pszDDBoostDir = pg_strdup(optarg);
 				break;
 			case 9:
 				sscanf(optarg, "%d", &dd_boost_buf_size);
 				break;
 #endif
 			case 10:
-				incrementalFilter = strdup(optarg);
+				incrementalFilter = pg_strdup(optarg);
 				break;
 			/* Hack to pass NetBackup params to gp_dump_agent */
 			case 11:
@@ -861,9 +861,9 @@ main(int argc, char **argv)
 	g_SegDB.dbid = g_dbID;
 	g_SegDB.role = g_role;
 	g_SegDB.port = pgport ? atoi(pgport) : 5432;
-	g_SegDB.pszHost = pghost ? strdup(pghost) : NULL;
-	g_SegDB.pszDBName = dbname ? strdup(dbname) : NULL;
-	g_SegDB.pszDBUser = username ? strdup(username) : NULL;
+	g_SegDB.pszHost = pghost ? pg_strdup(pghost) : NULL;
+	g_SegDB.pszDBName = dbname ? pg_strdup(dbname) : NULL;
+	g_SegDB.pszDBUser = username ? pg_strdup(username) : NULL;
 	g_SegDB.pszDBPswd = NULL;
 
 	/*
@@ -1195,13 +1195,13 @@ dumpMain(bool oids, const char *dumpencoding, int outputBlobs, int plainText, Re
 		blobobj->objType = DO_BLOBS;
 		blobobj->catId = nilCatalogId;
 		AssignDumpId(blobobj);
-		blobobj->name = strdup("BLOBS");
+		blobobj->name = pg_strdup("BLOBS");
 
 		blobobj = (DumpableObject *) malloc(sizeof(DumpableObject));
 		blobobj->objType = DO_BLOB_COMMENTS;
 		blobobj->catId = nilCatalogId;
 		AssignDumpId(blobobj);
-		blobobj->name = strdup("BLOB COMMENTS");
+		blobobj->name = pg_strdup("BLOB COMMENTS");
 	}
 
 	/*
@@ -2583,7 +2583,7 @@ dumpNamespace(Archive *fout, NamespaceInfo *nspinfo)
 	q = createPQExpBuffer();
 	delq = createPQExpBuffer();
 
-	qnspname = strdup(fmtId(nspinfo->dobj.name));
+	qnspname = pg_strdup(fmtId(nspinfo->dobj.name));
 
 	appendPQExpBuffer(delq, "DROP SCHEMA %s;\n", qnspname);
 
@@ -3190,7 +3190,7 @@ dumpProcLang(Archive *fout, ProcLangInfo *plang)
 	defqry = createPQExpBuffer();
 	delqry = createPQExpBuffer();
 
-	qlanname = strdup(fmtId(plang->dobj.name));
+	qlanname = pg_strdup(fmtId(plang->dobj.name));
 
 	/*
 	 * If dumping a HANDLER clause, treat the language as being in the handler
@@ -3343,7 +3343,7 @@ getFuncOwner(Oid funcOid, const char *templateField)
 	if (ntups != 0)
 	{
 		i_funcowner = PQfnumber(res, "funcowner");
-		functionOwner = strdup(PQgetvalue(res, 0, i_funcowner));
+		functionOwner = pg_strdup(PQgetvalue(res, 0, i_funcowner));
 	}
 
 	PQclear(res);
@@ -3391,8 +3391,8 @@ dumpPlTemplateFunc(Oid funcOid, const char *templateField, PQExpBuffer buffer)
 	{
 		i_signature = PQfnumber(res, "signature");
 		i_owner = PQfnumber(res, "owner");
-		functionSignature = strdup(PQgetvalue(res, 0, i_signature));
-		ownerName = strdup(PQgetvalue(res, 0, i_owner));
+		functionSignature = pg_strdup(PQgetvalue(res, 0, i_signature));
+		ownerName = pg_strdup(PQgetvalue(res, 0, i_owner));
 
 		if (functionSignature != NULL && ownerName != NULL)
 		{
@@ -4235,7 +4235,7 @@ convertRegProcReference(const char *proc)
 	if (strcmp(proc, "-") == 0)
 		return NULL;
 
-	name = strdup(proc);
+	name = pg_strdup(proc);
 	/* find non-double-quoted left paren */
 	inquote = false;
 	for (paren = name; *paren; paren++)
@@ -4274,7 +4274,7 @@ convertOperatorReference(const char *opr)
 	if (strcmp(opr, "0") == 0)
 		return NULL;
 
-	name = strdup(opr);
+	name = pg_strdup(opr);
 	/* find non-double-quoted left paren, and check for non-quoted dot */
 	inquote = false;
 	sawdot = false;
@@ -4386,7 +4386,7 @@ dumpOpclass(Archive *fout, OpclassInfo *opcinfo)
 	opckeytype = PQgetvalue(res, 0, i_opckeytype);
 	opcdefault = PQgetvalue(res, 0, i_opcdefault);
 	/* amname will still be needed after we PQclear res */
-	amname = strdup(PQgetvalue(res, 0, i_amname));
+	amname = pg_strdup(PQgetvalue(res, 0, i_amname));
 
 	/*
 	 * DROP must be fully qualified in case same name appears in pg_catalog
@@ -4919,7 +4919,7 @@ getFunctionName(Oid oid)
 	}
 
 	/* already quoted */
-	result = strdup(PQgetvalue(res, 0, 0));
+	result = pg_strdup(PQgetvalue(res, 0, 0));
 
 	PQclear(res);
 	destroyPQExpBuffer(query);
@@ -4978,7 +4978,7 @@ dumpExtProtocol(Archive *fout, ExtProtInfo *ptcinfo)
 			if(protoFuncs[i].pfuncinfo != NULL)
 			{
 				protoFuncs[i].dumpable = true;
-				protoFuncs[i].name = strdup(protoFuncs[i].pfuncinfo->dobj.name);
+				protoFuncs[i].name = pg_strdup(protoFuncs[i].pfuncinfo->dobj.name);
 				protoFuncs[i].internal = false;
 			}
 			else
@@ -5043,7 +5043,7 @@ dumpExtProtocol(Archive *fout, ExtProtInfo *ptcinfo)
 				 NULL, NULL);
 
 	/* Handle the ACL */
-	namecopy = strdup(fmtId(ptcinfo->dobj.name));
+	namecopy = pg_strdup(fmtId(ptcinfo->dobj.name));
 	dumpACL(fout, ptcinfo->dobj.catId, ptcinfo->dobj.dumpId,
 			"PROTOCOL",
 			namecopy, ptcinfo->dobj.name,
@@ -5123,7 +5123,7 @@ dumpTable(Archive *fout, TableInfo *tbinfo)
 			dumpTableSchema(fout, tbinfo);
 
 		/* Handle the ACL here */
-		namecopy = strdup(fmtId(tbinfo->dobj.name));
+		namecopy = pg_strdup(fmtId(tbinfo->dobj.name));
 		dumpACL(fout, tbinfo->dobj.catId, tbinfo->dobj.dumpId,
 				(tbinfo->relkind == RELKIND_SEQUENCE) ? "SEQUENCE" : "TABLE",
 				namecopy, tbinfo->dobj.name,
@@ -5383,8 +5383,8 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 				{
 					appendPQExpBuffer(q, "LOG ERRORS ");
 
-					char *errtablename = Safe_strdup(fmtId(errtblname));
-					char *tablename = Safe_strdup(fmtId(tbinfo->dobj.name));
+					char *errtablename = pg_strdup(fmtId(errtblname));
+					char *tablename = pg_strdup(fmtId(tbinfo->dobj.name));
 
 					/* Check error table was not generated by LOG ERRORS statement.
 					 * To do: deprecate the use of LOG ERRORS INTO
@@ -5805,8 +5805,8 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 			for (i = 0; i < ntups; i++)
 			{
 				char tmpExtTable[500] = {0};
-				relname = strdup(PQgetvalue(res, i, i_relname));
-				parname = strdup(PQgetvalue(res, i, i_parname));
+				relname = pg_strdup(PQgetvalue(res, i, i_relname));
+				parname = pg_strdup(PQgetvalue(res, i, i_parname));
 				snprintf(tmpExtTable, sizeof(tmpExtTable), "%s%s", relname, EXT_PARTITION_NAME_POSTFIX);
 				appendPQExpBuffer(q, "ALTER TABLE %s ", fmtId(tbinfo->dobj.name));
 				appendPQExpBuffer(q, "EXCHANGE PARTITION %s ", fmtId(parname));
@@ -5853,8 +5853,8 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 
 			for (i = 0; i < ntups; i++)
 			{
-				schemaname = strdup(PQgetvalue(res, i, i_schemaname));
-				relname = strdup(PQgetvalue(res, i, i_relname));
+				schemaname = pg_strdup(PQgetvalue(res, i, i_schemaname));
+				relname = pg_strdup(PQgetvalue(res, i, i_relname));
 				appendPQExpBuffer(q, "ALTER TABLE %s ", fmtId(relname));
 				appendPQExpBuffer(q, "SET SCHEMA %s;", fmtId(schemaname));
 
@@ -6957,13 +6957,13 @@ getFormattedTypeName(Oid oid, OidOptions opts)
 	if (oid == 0)
 	{
 		if ((opts & zeroAsOpaque) != 0)
-			return strdup(g_opaque_type);
+			return pg_strdup(g_opaque_type);
 		else if ((opts & zeroAsAny) != 0)
-			return strdup("'any'");
+			return pg_strdup("'any'");
 		else if ((opts & zeroAsStar) != 0)
-			return strdup("*");
+			return pg_strdup("*");
 		else if ((opts & zeroAsNone) != 0)
-			return strdup("NONE");
+			return pg_strdup("NONE");
 	}
 
 	query = createPQExpBuffer();
@@ -6983,7 +6983,7 @@ getFormattedTypeName(Oid oid, OidOptions opts)
 	}
 
 	/* already quoted */
-	result = strdup(PQgetvalue(res, 0, 0));
+	result = pg_strdup(PQgetvalue(res, 0, 0));
 
 	PQclear(res);
 	destroyPQExpBuffer(query);
@@ -7668,7 +7668,7 @@ _check_database_version(ArchiveHandle *AH)
 
 	remoteversion = _parse_version(AH, remoteversion_str);
 
-	AH->public.remoteVersionStr = strdup(remoteversion_str);
+	AH->public.remoteVersionStr = pg_strdup(remoteversion_str);
 	AH->public.remoteVersion = remoteversion;
 
 	if (myversion != remoteversion
@@ -7779,7 +7779,7 @@ updateArchiveWithDDFile(ArchiveHandle *AH, char *g_pszDDBoostFile, const char *g
 	path1.su_name = DDP_SU_NAME;
 
 	if (g_pszDDBoostDir)
-		path1.path_name  = strdup(g_pszDDBoostDir);
+		path1.path_name  = pg_strdup(g_pszDDBoostDir);
 	else
 		path1.path_name = dir_name;
 

--- a/src/bin/pg_dump/cdb/cdb_dump_util.h
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.h
@@ -121,8 +121,9 @@ extern char *MakeString(const char *fmt,...);
 /* breaks the input parameter associated with --cdb-k into its components for cdb_dump and cdb_restore*/
 extern bool ParseCDBDumpInfo(const char *progName, char *pszCDBDumpInfo, char **ppCDBDumpKey, int *pCDBInstID, int *pCDBSegID, char **ppCDBPassThroughCredentials);
 
-/* reads the contents out of the appropriate file on the database server */
-extern char *ReadBackendBackupFile(PGconn *pConn, const char *pszBackupDirectory, const char *pszKey, BackupFileType fileType, const char *progName);
+/* reads the contents for "ERROR:" and "[ERROR]" out of the appropriate file on the database server */
+extern int ReadBackendBackupFileError(PGconn *pConn, const char *pszBackupDirectory, const char *pszKey,
+		                                        BackupFileType fileType, const char *progName, PQExpBuffer buf);
 
 /* returns strdup if not NULL, NULL otherwise */
 extern char *Safe_strdup(const char *s);

--- a/src/bin/pg_dump/cdb/cdb_restore.c
+++ b/src/bin/pg_dump/cdb/cdb_restore.c
@@ -70,7 +70,7 @@ static const char *logFatal = "FATAL";
 const char *progname;
 static char * addPassThroughLongParm(const char *Parm, const char *pszValue, char *pszPassThroughParmString);
 static char *dump_prefix = NULL;
-static char *status_file = NULL;
+static char *status_file_dir = NULL;
 
 /* NetBackup related variable */
 static char *netbackup_service_host = NULL;
@@ -738,8 +738,8 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("prefix", DUMP_PREFIX, pInputOpts->pszPassThroughParms);
 				break;
 			case 14:
-				status_file = Safe_strdup(optarg);
-				pInputOpts->pszPassThroughParms = addPassThroughLongParm("status", status_file, pInputOpts->pszPassThroughParms);
+				status_file_dir = Safe_strdup(optarg);
+				pInputOpts->pszPassThroughParms = addPassThroughLongParm("status", status_file_dir, pInputOpts->pszPassThroughParms);
 				break;
 			case 15:
 				netbackup_service_host = Safe_strdup(optarg);
@@ -984,6 +984,7 @@ threadProc(void *arg)
 	char	   *pszPassThroughCredentials;
 	char	   *pszPassThroughTargetInfo;
 	PQExpBuffer Qry;
+	PQExpBuffer pqBuffer;
 	PGresult   *pRes;
 	int			sock;
 	bool		bSentCancelMessage;
@@ -1020,7 +1021,7 @@ threadProc(void *arg)
 		sSegDB->pszDBName = Safe_strdup(pInputOpts->pszDBName);
 	}
 
-	/* connect to the source segDB to start gp_dump_agent there */
+	/* connect to the source segDB to start gp_restore_agent there */
 	pConn = MakeDBConnection(sSegDB, false);
 	if (PQstatus(pConn) == CONNECTION_BAD)
 	{
@@ -1178,8 +1179,10 @@ threadProc(void *arg)
 					g_b_SendCancelMessage = true;
 					bIsFinished = true;
 					pParm->bSuccess = false;
+					pqBuffer = createPQExpBuffer();
 					/* Make call to get error message from file on server */
-					pParm->pszErrorMsg = ReadBackendBackupFile(pConn, pInputOpts->pszBackupDirectory, pszKey, BFT_RESTORE_STATUS, progname);
+					ReadBackendBackupFileError(pConn, status_file_dir, pszKey, BFT_RESTORE_STATUS, progname, pqBuffer);
+					pParm->pszErrorMsg = pqBuffer->data;
 
 					mpp_err_msg(logError, progname, "restore failed for source dbid %d, target dbid %d on host %s\n",
 								sSegDB->dbid, tSegDB->dbid, StringNotNull(sSegDB->pszHost, "localhost"));
@@ -1205,6 +1208,23 @@ threadProc(void *arg)
 					bSentCancelMessage = true;
 				}
 			}
+		}
+	}
+
+
+	/* We want a force scan of the restore status file for ERRORS, even if
+	 * segment returns success, because psql client does not report the correct
+	 * error code upon SQL failure.
+	 */
+	if (pParm->bSuccess)
+	{
+		pqBuffer = createPQExpBuffer();
+		int status = ReadBackendBackupFileError(pConn, status_file_dir, pszKey, BFT_RESTORE_STATUS, progname, pqBuffer);
+		if (status != 0)
+		{
+			pParm->pszErrorMsg = pqBuffer->data;
+			pParm->bSuccess = false;
+			g_b_SendCancelMessage = true;
 		}
 	}
 
@@ -1299,7 +1319,7 @@ restoreMaster(InputOptions * pInputOpts,
 	pParm->pTargetSegDBData = tSegDB;
 	pParm->pSourceSegDBData = sSegDB;
 	pParm->pOptionsData = pInputOpts;
-	pParm->bSuccess = false;
+	pParm->bSuccess = true;
 	pParm->pszErrorMsg = NULL;
 	pParm->pszRemoteBackupPath = NULL;
 
@@ -1477,7 +1497,7 @@ spinOffThreads(PGconn *pConn, InputOptions * pInputOpts, const RestorePairArray 
 		pParm->pSourceSegDBData = &restorePairAr->pData[i].segdb_source;
 		pParm->pTargetSegDBData = &restorePairAr->pData[i].segdb_target;
 		pParm->pOptionsData = pInputOpts;
-		pParm->bSuccess = false;
+		pParm->bSuccess = true;
 
 		/* exclude master node */
 		if (pParm->pTargetSegDBData->role == ROLE_MASTER)


### PR DESCRIPTION
gpcrondump and gpdbrestore log the errors into status file and report
success in the end without inspecting them.

Authors: Pengcheng Tang, Nikhil Kak