### PR TITLE
Include several utility statements into resource management.

### DIFF
--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1507,7 +1507,10 @@ PortalRunUtility(Portal portal, Node *utilityStmt, bool isTopLevel,
 
 	/* check if this utility statement need to be involved into resoure queue
 	 * mgmt */
-	ResHandleUtilityStmt(portal, utilityStmt);
+	if (ResourceSchedulerUtility && Gp_role == GP_ROLE_DISPATCH && !superuser())
+	{
+		ResHandleUtilityStmt(portal, utilityStmt);
+	}
 
 	if ( isTopLevel )
 	{

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -443,6 +443,7 @@ log_autostats=off	# print additional autostats information
 #max_resource_queues = 9		# no. of resource queues to create.
 #max_resource_portals_per_transaction = 64	# no. of portals per backend.
 #resource_select_only = on		# resource lock SELECT queries only.
+#resource_scheduler_utility = on	# resource lock utility statements.
 #resource_cleanup_gangs_on_wait = on	# Cleanup idle reader gangs before
 										# resource lockwait.
 gp_resqueue_memory_policy = 'eager_free'	# memory request based queueing. 

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -24,6 +24,7 @@
  * GUC variables.
  */
 extern bool	ResourceScheduler;
+extern bool	ResourceSchedulerUtility;
 extern int	MaxResourceQueues;
 extern int	MaxResourcePortalsPerXact;
 extern bool	ResourceSelectOnly;


### PR DESCRIPTION
Get COPY, ANALYZE, VACUUM, CLUSTER and REINDEX involved in resource queue,
and add a guc resource_scheduler_utility to control the switch. Note that,
resource_scheduler_utility and resource_select_only depends on the turning
on of resource_scheduler, while they two cannot be turned on at the same
time.