### PR TITLE
Fix: Immutable function mregr_coef returns different results

### DIFF
--- a/src/backend/utils/stat/regress.c
+++ b/src/backend/utils/stat/regress.c
@@ -476,7 +476,7 @@ float8_mregr_compute(MRegrState	*inState,
 	 * Precondition: inState->len * inState->len * sizeof(float8) < STATE_LEN(inState->len)
 	 *           and IS_FEASIBLE_STATE_LEN(STATE_LEN(inState->len))
 	 */
-	XtX_inv = palloc((uint64) inState->len * inState->len * sizeof(float8));
+	XtX_inv = palloc0((uint64) inState->len * inState->len * sizeof(float8));
 	pinv(inState->len, inState->len, inState->XtX, XtX_inv);
 	
 	/*


### PR DESCRIPTION
The immutable function was returning different values, because it was allocating memory and using a table whose entries may have a garbage initial value.
The fix initiates the entries of the table to zero.