### PR TITLE
Fix AO/CO stats restoration.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -38,25 +38,31 @@ POST_DATA_SUFFIX = '_post_data'
 
 # TODO: use CLI-agnostic custom exceptions instead of ExceptionNoStackTraceNeeded
 
-def update_ao_stat_func(conn, schema, table, counter, batch_size):
-    qry = "SELECT * FROM gp_update_ao_master_stats('%s.%s')" % (schema, table)
+def update_ao_stat_func(conn, ao_table, counter, batch_size):
+    qry = "SELECT * FROM gp_update_ao_master_stats('%s')" % ao_table
     rows = execSQLForSingleton(conn, qry)
     if counter % batch_size == 0:
         conn.commit()
 
-def update_ao_statistics(master_port, dbname):
+def update_ao_statistics(master_port, dbname, restored_tables):
     qry = """SELECT c.relname,n.nspname
-                      FROM pg_class c, pg_namespace n
-                      WHERE c.relnamespace=n.oid
-                      AND (c.relstorage='a' OR c.relstorage='c')"""
+             FROM pg_class c, pg_namespace n
+             WHERE c.relnamespace=n.oid
+                 AND (c.relstorage='a' OR c.relstorage='c')"""
 
     conn = None
     counter = 1
     try:
         results = execute_sql(qry, master_port, dbname)
+        ao_tables = ['%s.%s' % (sch, tbl) for (tbl, sch) in results]
+        restored_ao_tables = set(ao_tables).intersection(restored_tables)
+        if not restored_ao_tables:
+            logger.info("No AO/CO tables restored, skipping statistics update...")
+            return
+
         with dbconn.connect(dbconn.DbURL(port=master_port, dbname=dbname)) as conn:
-            for (tbl, sch) in results:
-                update_ao_stat_func(conn, sch, tbl, counter, batch_size=1000)
+            for ao_table in sorted(restored_ao_tables):
+                update_ao_stat_func(conn, ao_table, counter, batch_size=1000)
                 counter = counter + 1
             conn.commit()
     except Exception as e:
@@ -238,38 +244,6 @@ def validate_restore_tables_list(plan_file_contents, restore_tables):
 
     if invalid_tables != []:
         raise Exception('Invalid tables for -T option: The following tables were not found in plan file : "%s"' % (invalid_tables))
-
-def restore_incremental_data_only(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp,
-                                  restore_tables, redirected_restore_db, report_status_dir,
-                                  ddboost=False, netbackup_service_host=None, netbackup_block_size=None,
-                                  change_schema=None):
-    restore_data = False
-    plan_file_items = get_plan_file_contents(master_datadir, backup_dir, timestamp, dump_dir, dump_prefix)
-    table_file = None
-    table_files = []
-
-    validate_restore_tables_list(plan_file_items, restore_tables)
-
-    for (ts, table_list) in plan_file_items:
-        if table_list:
-            restore_data = True
-            table_file = get_restore_table_list(table_list.split(','), restore_tables)
-            if table_file is None:
-                continue
-            cmd = _build_gpdbrestore_cmd_line(ts, table_file, backup_dir, redirected_restore_db, report_status_dir, dump_prefix, ddboost, netbackup_service_host,
-                                              netbackup_block_size, change_schema)
-            logger.info('Invoking commandline: %s' % cmd)
-            Command('Invoking gpdbrestore', cmd).run(validateAfter=True)
-            table_files.append(table_file)
-
-    if not restore_data:
-        raise Exception('There were no tables to restore. Check the plan file contents for restore timestamp %s' % timestamp)
-
-    for table_file in table_files:
-        if table_file:
-            os.remove(table_file)
-
-    return True
 
 #NetBackup related functions
 def restore_state_files_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size):
@@ -517,21 +491,7 @@ class RestoreDatabase(Operation):
 
         if begin_incremental:
             logger.info("Running data restore")
-            restore_incremental_data_only(self.master_datadir,
-                                          self.backup_dir,
-                                          self.dump_dir,
-                                          self.dump_prefix,
-                                          self.restore_timestamp,
-                                          self.restore_tables,
-                                          self.redirected_restore_db,
-                                          self.report_status_dir,
-                                          self.ddboost,
-                                          self.netbackup_service_host,
-                                          self.netbackup_block_size,
-                                          self.change_schema)
-
-            logger.info("Updating AO/CO statistics on master")
-            update_ao_statistics(self.master_port, restore_db)
+            self.restore_incremental_data_only(restore_db)
         else:
             table_filter_file = self.create_filter_file() # returns None if nothing to filter
 
@@ -643,6 +603,48 @@ class RestoreDatabase(Operation):
             run_pool_command(addresses, cmd, self.batch_default, check_results=False)
         except Exception as e:
             logger.info("cleaning up filter table list file failed: %s" % e.__str__())
+
+    def restore_incremental_data_only(self, restore_db):
+        restore_data = False
+        plan_file_items = get_plan_file_contents(self.master_datadir, self.backup_dir,
+                                                 self.restore_timestamp, self.dump_dir,
+                                                 self.dump_prefix)
+        table_file = None
+        table_files = []
+        restored_tables = []
+
+        validate_restore_tables_list(plan_file_items, self.restore_tables)
+
+        for (ts, table_list) in plan_file_items:
+            if table_list:
+                restore_data = True
+                table_file = get_restore_table_list(table_list.split(','), self.restore_tables)
+                if table_file is None:
+                    continue
+                cmd = _build_gpdbrestore_cmd_line(ts, table_file, self.backup_dir,
+                                                  self.redirected_restore_db,
+                                                  self.report_status_dir, self.dump_prefix,
+                                                  self.ddboost, self.netbackup_service_host,
+                                                  self.netbackup_block_size, self.change_schema)
+                logger.info('Invoking commandline: %s' % cmd)
+                Command('Invoking gpdbrestore', cmd).run(validateAfter=True)
+                table_files.append(table_file)
+                restored_tables.extend(get_restore_tables_from_table_file(table_file))
+
+        if not restore_data:
+            raise Exception('There were no tables to restore. Check the plan file contents for restore timestamp %s' % self.restore_timestamp)
+
+        if not self.no_ao_stats:
+            logger.info("Updating AO/CO statistics on master")
+            update_ao_statistics(self.master_port, restore_db, restored_tables)
+        else:
+            logger.info("noaostats enabled. Skipping update of AO/CO statistics on master.")
+
+        for table_file in table_files:
+            if table_file:
+                os.remove(table_file)
+
+        return True
 
     def _restore_global(self, restore_timestamp, master_datadir, backup_dir):
         logger.info('Commencing restore of global objects')

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -39,7 +39,7 @@ POST_DATA_SUFFIX = '_post_data'
 # TODO: use CLI-agnostic custom exceptions instead of ExceptionNoStackTraceNeeded
 
 def update_ao_stat_func(conn, ao_table, counter, batch_size):
-    qry = "SELECT * FROM gp_update_ao_master_stats('%s')" % ao_table
+    qry = "SELECT * FROM gp_update_ao_master_stats('%s')" % pg.escape_string(ao_table)
     rows = execSQLForSingleton(conn, qry)
     if counter % batch_size == 0:
         conn.commit()

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -1456,7 +1456,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('pygresql.pgdb.pgdbCnx.commit')
     def test_update_ao_stat_func_00(self, m1, m2):
         conn = None
-        ao_table = None
+        ao_table = 'schema.table'
         counter = 1
         batch_size = 1000
         update_ao_stat_func(conn, ao_table, counter, batch_size)
@@ -1465,7 +1465,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.execSQLForSingleton')
     def test_update_ao_stat_func_01(self, m1, m2):
         conn = None
-        ao_table = None
+        ao_table = 'schema.table'
         counter = 999
         batch_size = 1000
         update_ao_stat_func(conn, ao_table, counter, batch_size)
@@ -1474,7 +1474,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('pygresql.pgdb.pgdbCnx.commit')
     def test_update_ao_stat_func_02(self, m1, m2):
         conn = None
-        ao_table = None
+        ao_table = 'schema.table'
         counter = 1000
         batch_size = 1000
         with self.assertRaisesRegexp(AttributeError, "'NoneType' object has no attribute 'commit'"):
@@ -1484,7 +1484,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('pygresql.pgdb.pgdbCnx.commit')
     def test_update_ao_stat_func_03(self, m1, m2):
         conn = None
-        ao_table = None
+        ao_table = 'schema.table'
         counter = 1001
         batch_size = 1000
         update_ao_stat_func(conn, ao_table, counter, batch_size)
@@ -1493,7 +1493,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('pygresql.pgdb.pgdbCnx.commit')
     def test_update_ao_stat_func_04(self, m1, m2):
         conn = None
-        ao_table = None
+        ao_table = 'schema.table'
         counter = 2000
         batch_size = 1000
         with self.assertRaisesRegexp(AttributeError, "'NoneType' object has no attribute 'commit'"):

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -37,7 +37,7 @@ from gppylib.test.behave_utils.utils import bring_nic_down, bring_nic_up, run_cm
                                             get_distribution_policy, validate_distribution_policy, cleanup_backup_files, create_schema, drop_schema_if_exists, \
                                             create_mixed_storage_partition, create_external_partition, validate_mixed_partition_storage_types, validate_storage_type, truncate_table, \
                                             get_table_oid, verify_truncate_in_pg_stat_last_operation, verify_truncate_not_in_pg_stat_last_operation, insert_numbers, \
-                                            populate_partition_diff_data_same_eof, populate_partition_same_data, execute_sql, verify_integer_tuple_counts,  validate_no_aoco_stats, \
+                                            populate_partition_diff_data_same_eof, populate_partition_same_data, execute_sql, verify_integer_tuple_counts, validate_aoco_stats, validate_no_aoco_stats, \
                                             check_string_not_present_stdout, clear_all_saved_data_verify_files, copy_file_to_all_db_hosts, validate_num_restored_tables, \
                                             get_partition_list, verify_stats, drop_external_table_if_exists, get_all_hostnames_as_list, get_pid_for_segment, kill_process, get_num_segments, \
                                             check_user_permissions, get_change_tracking_segment_info, add_partition, drop_partition, check_pl_exists, check_constraint_exists, \
@@ -1875,6 +1875,12 @@ def impl(context, dbname, tables):
     tables = tables.split(',')
     for t in tables:
         validate_no_aoco_stats(context, dbname, t.strip())
+
+@then('verify that there are "{tupcount}" tuples in "{dbname}" for table "{tables}"')
+def impl(context, tupcount, dbname, tables):
+    tables = tables.split(',')
+    for t in tables:
+        validate_aoco_stats(context, dbname, t.strip(), tupcount)
 
 @when('the performance timer is started')
 def impl(context):


### PR DESCRIPTION
Previously, when performing an incremental restore, tuple counts
on the master for all AO/CO tables would be updated, including
those AO/CO tables that already existed in the target database.
These counts would still be updated regardless of which tables
were restored, or whether any of the restored tables were AO/CO
tables.

AO/CO statistics are now updated only for those AO/CO tables that
are part of the incremental restore.

Authors: Jimmy Yih and James McAtamney