### PR TITLE
Update gpcheckcat summary report

### DIFF
--- a/gpMgmt/bin/lib/gpcheckcat
+++ b/gpMgmt/bin/lib/gpcheckcat
@@ -4695,8 +4695,8 @@ def checkcatReport():
     myprint('')
     myprint('SUMMARY REPORT')
     myprint('===================================================================')
-    elapsed = str(datetime.timedelta(seconds=GV.elapsedTime)).split('.')[0]
-    endTime = str(datetime.datetime.now().strftime('%Y-%m-%d %H:%I:%S'))
+    elapsed = datetime.timedelta(seconds=int(GV.elapsedTime))
+    endTime = datetime.datetime.now().strftime('%Y-%m-%d %H:%I:%S')
     myprint('Completed %d test(s) on database \'%s\' at %s with elapsed time %s' \
             % (GV.totalTestRun, GV.dbname, endTime, elapsed))
 

--- a/gpMgmt/bin/lib/gpcheckcat
+++ b/gpMgmt/bin/lib/gpcheckcat
@@ -4695,8 +4695,10 @@ def checkcatReport():
     myprint('')
     myprint('SUMMARY REPORT')
     myprint('===================================================================')
-    elapsed = str(datetime.timedelta(seconds=GV.elapsedTime))[:-4]
-    myprint('Total runtime for %d test(s): %s' % (GV.totalTestRun, elapsed))
+    elapsed = str(datetime.timedelta(seconds=GV.elapsedTime)).split('.')[0]
+    startTime = str(datetime.datetime.now().strftime('%Y-%m-%d %H:%I:%S'))
+    myprint('Completed %d test(s) on database \'%s\' at %s with elapsed time %s' \
+            % (GV.totalTestRun, GV.dbname, startTime, elapsed))
 
     if len(GPObjectGraph) == 0 and len(GV.failedTest) == 0:
         myprint('Found no catalog issue\n')

--- a/gpMgmt/bin/lib/gpcheckcat
+++ b/gpMgmt/bin/lib/gpcheckcat
@@ -4696,9 +4696,9 @@ def checkcatReport():
     myprint('SUMMARY REPORT')
     myprint('===================================================================')
     elapsed = str(datetime.timedelta(seconds=GV.elapsedTime)).split('.')[0]
-    startTime = str(datetime.datetime.now().strftime('%Y-%m-%d %H:%I:%S'))
+    endTime = str(datetime.datetime.now().strftime('%Y-%m-%d %H:%I:%S'))
     myprint('Completed %d test(s) on database \'%s\' at %s with elapsed time %s' \
-            % (GV.totalTestRun, GV.dbname, startTime, elapsed))
+            % (GV.totalTestRun, GV.dbname, endTime, elapsed))
 
     if len(GPObjectGraph) == 0 and len(GV.failedTest) == 0:
         myprint('Found no catalog issue\n')


### PR DESCRIPTION
Currently to check previous runtimes it takes multiple grep commands to summarize the log file. This change adds all the information to a single line making it far easier to check historical runtimes. The historical runtimes can be used to estimate the required maintenance window for future runs.