### PR TITLE
Initiate the entries of the result table of function pinv inside pinv.

### DIFF
--- a/src/backend/utils/stat/pinv.c
+++ b/src/backend/utils/stat/pinv.c
@@ -284,6 +284,7 @@ pinv(int rows, int columns, double *A, double *Aplus)
 	{
 		for (j = 0; j < rows; j++)
 		{
+			Aplus[i * rows + j] = 0.0;
 			for (k = 0; k < minmn; k++)
 				Aplus[i * rows + j] += Vx(i, k) * Splus[k] * Ux(j, k);
 		}

--- a/src/backend/utils/stat/regress.c
+++ b/src/backend/utils/stat/regress.c
@@ -476,7 +476,7 @@ float8_mregr_compute(MRegrState	*inState,
 	 * Precondition: inState->len * inState->len * sizeof(float8) < STATE_LEN(inState->len)
 	 *           and IS_FEASIBLE_STATE_LEN(STATE_LEN(inState->len))
 	 */
-	XtX_inv = palloc0((uint64) inState->len * inState->len * sizeof(float8));
+	XtX_inv = palloc((uint64) inState->len * inState->len * sizeof(float8));
 	pinv(inState->len, inState->len, inState->XtX, XtX_inv);
 	
 	/*


### PR DESCRIPTION
Function pinv, and not its caller, should be responsible for initiating the entries of the result table.
Actually, we move the fix of commit 5d87015609abd330c68a5402c1267fc86cbc9e1f inside pinv.