### PR TITLE
Fix orphaned share input scan QE process after OLAP grouping query

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -22,6 +22,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "cdb/cdbvars.h"
 #include "executor/executor.h"
 #include "executor/nodeShareInputScan.h"
@@ -945,6 +946,23 @@ shareinput_writer_waitdone(void *ctxt, int share_id, int nsharer_xslice)
 	while(ack_needed > 0)
 	{
 		CHECK_FOR_INTERRUPTS();
+
+		/*
+ 		 * Writer won't wait for data reading done notification from readers if transaction is
+ 		 * aborting. Readers may fail to send data reading done notification to writer in two
+		 * cases:
+		 *
+		 *     1. The transaction is aborted due to interrupts or exceptions, i.e., user cancels
+		 *        query, division by zero on some segment
+		 *
+		 *     2. Logic errors in reader which incur its unexpected exit, i.e., segmentation fault
+		 */
+		if (IsAbortInProgress())
+		{
+			elog(DEBUG1, "SISC WRITER (shareid=%d, slice=%d): do not wait for data-reading-done notification from readers, if the transaction is aborting",
+				 share_id, currentSliceId, ack_needed);
+			break;
+		}
 	
 		MPP_FD_ZERO(&rset);
 		MPP_FD_SET(pctxt->donefd, &rset);


### PR DESCRIPTION
This pull request is a manual merge of multiple commits as reviewed in https://github.com/greenplum-db/gpdb/pull/118. The purpose is to make it easier for commiters to merge the fix into main stream.