### PR TITLE
Fixing NodeAgg's Memory issue

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -151,6 +151,7 @@ static void finalize_aggregate(AggState *aggstate,
 				   Datum *resultVal, bool *resultIsNull);
 static Bitmapset *find_unaggregated_cols(AggState *aggstate);
 static bool find_unaggregated_cols_walker(Node *node, Bitmapset **colnos);
+static void clear_agg_object(AggState *aggstate);
 static TupleTableSlot *agg_retrieve_direct(AggState *aggstate);
 static TupleTableSlot *agg_retrieve_hash_table(AggState *aggstate);
 static void ExecAggExplainEnd(PlanState *planstate, struct StringInfoData *buf);
@@ -1108,6 +1109,28 @@ ExecAgg(AggState *node)
 }
 
 /*
+ * clear_agg_object
+ * 		Clear necessary memory (pergroup & perpassthrough) when agg context memory get reset & deleted.
+ * 		aggstate - pointer to aggstate
+ */
+static void
+clear_agg_object(AggState *aggstate)
+{
+	int aggno = 0;
+	for(aggno = 0; aggno < aggstate->numaggs; aggno++)
+	{
+		AggStatePerGroup pergroupstate = &aggstate->pergroup[aggno];
+		pergroupstate->transValue = 0;
+		pergroupstate->transValueIsNull = true;
+		if (NULL != aggstate->perpassthru) {
+			pergroupstate = &aggstate->perpassthru[aggno];
+			pergroupstate->transValue = 0;
+			pergroupstate->transValueIsNull = true;
+		}
+	}
+}
+
+/*
  * ExecAgg for non-hashed case
  */
 static TupleTableSlot *
@@ -1230,13 +1253,8 @@ agg_retrieve_direct(AggState *aggstate)
 
 			MemoryContextResetAndDeleteChildren(aggstate->aggcontext);
 
-			int aggno = 0;
-			for(aggno = 0; aggno < aggstate->numaggs; aggno++)
-			{
-				AggStatePerGroup pergroupstate = &pergroup[aggno];
-				pergroupstate->transValue = 0;
-				pergroupstate->transValueIsNull = true;
-			}
+			/* Clear necessary memory (pergroup & perpassthrough) when aggcontext get reset & deleted */
+			clear_agg_object(aggstate);
 
 			/*
 			 * Initialize working state for a new input tuple group

--- a/src/test/regress/expected/aggregate_with_groupingsets.out
+++ b/src/test/regress/expected/aggregate_with_groupingsets.out
@@ -1,0 +1,37 @@
+---
+--- Drop existing table
+---
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+---
+--- Create new table foo
+---
+CREATE TABLE foo(type INTEGER, prod VARCHAR, quantity NUMERIC);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'type' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+---
+--- Insert some value
+---
+INSERT INTO foo VALUES(1, 'Table', 100);
+INSERT INTO foo VALUES(2, 'Chair', 250);
+INSERT INTO foo VALUES(3, 'Bed', 300);
+---
+--- Select query with grouping sets
+---
+SELECT type, prod, sum(quantity) s_quant
+FROM
+(
+  SELECT type, prod, quantity
+  FROM foo F1
+  LIMIT 3
+) F2 GROUP BY GROUPING SETS((type, prod), (prod)) ORDER BY type, s_quant;
+ type | prod  | s_quant 
+------+-------+---------
+    1 | Table |     100
+    2 | Chair |     250
+    3 | Bed   |     300
+      | Table |     100
+      | Chair |     250
+      | Bed   |     300
+(6 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -60,6 +60,9 @@ test: resource_queue
 
 test: filespace trig auth_constraint role rle portals_updatable plpgsql_cache timeseries resource_queue_function pg_stat_last_operation gp_numeric_agg gp_toolkit plan_size partindex_test direct_dispatch partition_pruning_with_fn dsp
 
+#Aggregate function
+test: aggregate_with_groupingsets
+
 ignore: tpch500GB_orca
 
 # XXX: This test depends on libgpoptudfs library, which includes ORCA helper

--- a/src/test/regress/sql/aggregate_with_groupingsets.sql
+++ b/src/test/regress/sql/aggregate_with_groupingsets.sql
@@ -1,0 +1,27 @@
+---
+--- Drop existing table
+---
+DROP TABLE IF EXISTS foo;
+
+---
+--- Create new table foo
+---
+CREATE TABLE foo(type INTEGER, prod VARCHAR, quantity NUMERIC);
+
+---
+--- Insert some value
+---
+INSERT INTO foo VALUES(1, 'Table', 100);
+INSERT INTO foo VALUES(2, 'Chair', 250);
+INSERT INTO foo VALUES(3, 'Bed', 300);
+
+---
+--- Select query with grouping sets
+---
+SELECT type, prod, sum(quantity) s_quant
+FROM
+(
+  SELECT type, prod, quantity
+  FROM foo F1
+  LIMIT 3
+) F2 GROUP BY GROUPING SETS((type, prod), (prod)) ORDER BY type, s_quant;


### PR DESCRIPTION
With grouping sets, we found it is causing segmentation fault. This is because we try to delete the memory which is already deleted memory context get deleted. This change has a function that reset all the memory to NULL when associate memory context get deleted.

@gcaragea @armenatzoglou @foyzur @entong @xinzweb 
Please take a look when you get chance