### PR TITLE
Fix the typo for external table dump

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_backup_archiver.c
+++ b/src/bin/pg_dump/cdb/cdb_backup_archiver.c
@@ -2108,7 +2108,7 @@ _tocEntryRequired(TocEntry *te, RestoreOptions *ropt, bool include_acls)
 	if (ropt->selTypes)
 	{
 		if (strcmp(te->desc, "TABLE") == 0 ||
-			strcmp(te->desc, "EXTNRNAL TABLE") == 0 ||
+			strcmp(te->desc, "EXTERNAL TABLE") == 0 ||
 			strcmp(te->desc, "FOREIGN TABLE") == 0 ||
 			strcmp(te->desc, "TABLE DATA") == 0)
 		{

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -2070,7 +2070,7 @@ _tocEntryRequired(TocEntry *te, RestoreOptions *ropt, bool include_acls)
 	if (ropt->selTypes)
 	{
 		if (strcmp(te->desc, "TABLE") == 0 ||
-			strcmp(te->desc, "EXTNRNAL TABLE") == 0 ||
+			strcmp(te->desc, "EXTERNAL TABLE") == 0 ||
 			strcmp(te->desc, "FOREIGN TABLE") == 0 ||
 			strcmp(te->desc, "TABLE DATA") == 0)
 		{


### PR DESCRIPTION
The typo is from the dumping based on object types(i.e,
index/function/trigger/table/data), but currently gpdb
does not support this feature ported from postgres.

Initially planned to remove the related dead code, but
as we do the merge of the upstream postgres, I decide to
save the code to minimize the diff and effort in case
we want to support such in future.