### PR TITLE
Copy curl binary file into bin directory

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -1229,8 +1229,20 @@ copylibs : thirdparty-dist copy-rsa-libs copy-nbu-libs
 ifeq "$(findstring $(BLD_ARCH),aix5_ppc_32 aix5_ppc_64 win32 win64)" ""
 	# Copy curl header file
 	cp -rp $(BLD_THIRDPARTY_INCLUDE_DIR)/curl $(INSTLOC)/include/
-	# Copy in openssl files needed by gpperfmon
 endif
+
+# Copy curl binary file into bin directory (only for server builds).
+ifneq "$(BLD_GPDB_BUILDSET)" "partial"
+	@if [ -f $(BLD_THIRDPARTY_BIN_DIR)/curl ]; then \
+		echo "Copying $(BLD_THIRDPARTY_BIN_DIR)/curl into $(INSTLOC)/bin/"; \
+		cp -p $(BLD_THIRDPARTY_BIN_DIR)/curl $(INSTLOC)/bin/; \
+	else \
+	    echo "INFO: curl binary not found on this platform: $(BLD_ARCH)"; \
+	    exit 1; \
+	fi
+endif
+
+	# Copy in openssl files needed by gpperfmon
 ifeq "$(findstring $(BLD_ARCH),aix5_ppc_32 win32 win64)" ""
 ifneq "$(BLD_ARCH)" "osx104_x86"
 	cp -rp $(BLD_THIRDPARTY_BIN_DIR)/openssl $(INSTLOC)/bin/


### PR DESCRIPTION
This is a Greenplum release process change to include the **curl** binary into the **server** installation (bin directory).  This is needed to address a potential curl version mismatch on systems with **curl** binaries which are incompatible with the **libcurl** version included in Greenplum releases.