### PR TITLE
Added column to allow retrieval of 'proper' sql data type

### DIFF
--- a/src/backend/catalog/information_schema.sql
+++ b/src/backend/catalog/information_schema.sql
@@ -638,6 +638,10 @@ CREATE VIEW columns AS
            CAST(current_database() AS sql_identifier) AS udt_catalog,
            CAST(coalesce(nbt.nspname, nt.nspname) AS sql_identifier) AS udt_schema,
            CAST(coalesce(bt.typname, t.typname) AS sql_identifier) AS udt_name,
+           CAST(
+             format_type(a.atttypid,t.typtypmod)
+             AS character_data)
+             AS sql_data_type,
 
            CAST(null AS sql_identifier) AS scope_catalog,
            CAST(null AS sql_identifier) AS scope_schema,


### PR DESCRIPTION
This pull request adds a column to a view that simplifies the sql needed to get the actual sql datatype used in a create table statement. This doesn't include the limits on variables like varchar or char, but it does eliminate the guesswork on arrays and user-defined types.  The original columns are unmodified so existing sql will not break, this just adds info that is hidden by the view and would require redundant joins or a rewrite of the sql to avoid referencing tables that are already used.