### PR TITLE
gpinitsystem -p does not produce correct postgresql.conf file

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -463,19 +463,29 @@ SED_PG_CONF () {
 					LOG_MSG "[INFO]:-Appended line $SUB_TXT to $FILENAME" 
 				fi
 			else
-                if [ $KEEP_PREV -eq 0 ];then
-                    $SED -i'.bak' -e "s/${SEARCH_TXT}/${SUB_TXT} #/g" $FILENAME
-                else
-                    $SED -i'.bak' -e "s/^${SEARCH_TXT}.*/${SUB_TXT}/g" $FILENAME
-                fi
+				if [ $KEEP_PREV -eq 0 ];then
+					$SED -i'.bak1' -e "s/${SEARCH_TXT}/${SUB_TXT} #${SEARCH_TXT}/g" $FILENAME
+				else
+					$SED -i'.bak1' -e "s/${SEARCH_TXT}.*/${SUB_TXT}/g" $FILENAME
+				fi
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
 					LOG_MSG "[WARN]:-Failed to replace $SEARCH_TXT in $FILENAME"
 					ERROR_EXIT=1
 				else
 					LOG_MSG "[INFO]:-Replaced line in $FILENAME"
+					$RM -f ${FILENAME}.bak1
 				fi
-		    fi
+				$SED -i'.bak2' -e "s/^#${SEARCH_TXT}/${SEARCH_TXT}/g" $FILENAME
+				RETVAL=$?
+				if [ $RETVAL -ne 0 ]; then
+					LOG_MSG "[WARN]:-Failed to replace #$SEARCH_TXT in $FILENAME"
+					ERROR_EXIT=1
+				else
+					LOG_MSG "[INFO]:-Replaced line in $FILENAME"
+					$RM -f ${FILENAME}.bak2
+				fi
+			fi
 	else
 		if [ `$TRUSTED_SHELL $SED_HOST "$GREP -c \"${SEARCH_TXT}\" $FILENAME"` -gt 1 ]; then
 			LOG_MSG "[INFO]:-Found more than 1 instance of $SEARCH_TXT in $FILENAME on $SED_HOST, will append" 1
@@ -492,21 +502,33 @@ SED_PG_CONF () {
 			fi
 		else
 			if [ $KEEP_PREV -eq 0 ];then
-            $ECHO "s/${SEARCH_TXT}/${SUB_TXT} #/g" > $SED_TMP_FILE
+				$ECHO "s/${SEARCH_TXT}/${SUB_TXT} #${SEARCH_TXT}/g" > $SED_TMP_FILE
 			else
-            $ECHO "s/^${SEARCH_TXT}.*/${SUB_TXT}/g" > $SED_TMP_FILE
+				$ECHO "s/${SEARCH_TXT}.*/${SUB_TXT}/g" > $SED_TMP_FILE
 			fi
-			#$SCP $SED_TMP_FILE ${SED_HOST}:/tmp > /dev/null 2>&1
 			$CAT $SED_TMP_FILE | $TRUSTED_SHELL ${SED_HOST} $DD of=$SED_TMP_FILE > /dev/null 2>&1
-			$TRUSTED_SHELL $SED_HOST "sed -i'.bak' -f $SED_TMP_FILE $FILENAME" > /dev/null 2>&1
+			$TRUSTED_SHELL $SED_HOST "sed -i'.bak1' -f $SED_TMP_FILE $FILENAME" > /dev/null 2>&1
 			RETVAL=$?
 			if [ $RETVAL -ne 0 ]; then
 				LOG_MSG "[WARN]:-Failed to insert $SUB_TXT in $FILENAME on $SED_HOST"
 				ERROR_EXIT=1
 			else
 				LOG_MSG "[INFO]:-Replaced line in $FILENAME on $SED_HOST"
+				$TRUSTED_SHELL $SED_HOST "$RM -f ${FILENAME}.bak1" > /dev/null 2>&1
+			fi
+			$ECHO "s/^#${SEARCH_TXT}/${SEARCH_TXT}/g" > $SED_TMP_FILE
+			$CAT $SED_TMP_FILE | $TRUSTED_SHELL ${SED_HOST} $DD of=$SED_TMP_FILE > /dev/null 2>&1
+			$TRUSTED_SHELL $SED_HOST "sed -i'.bak2' -f $SED_TMP_FILE $FILENAME" > /dev/null 2>&1
+			RETVAL=$?
+			if [ $RETVAL -ne 0 ]; then
+				LOG_MSG "[WARN]:-Failed to substitute #${SEARCH_TXT} in $FILENAME on $SED_HOST"
+				ERROR_EXIT=1
+			else
+				LOG_MSG "[INFO]:-Replaced line in $FILENAME on $SED_HOST"
+				$TRUSTED_SHELL $SED_HOST "$RM -f ${FILENAME}.bak2" > /dev/null 2>&1
 			fi
 			$TRUSTED_SHELL $SED_HOST "$RM -f $SED_TMP_FILE"
+
 			$RM -f $SED_TMP_FILE
 		fi
 	fi


### PR DESCRIPTION
when the add-on config file contains GUCs which exist in postgresql.conf.sample,
and are commented out(e.g, #max_resource_queues), these GUC settings would not
take effect because incorrect posgresql.conf would be generated by gpinitsystem.