### PR TITLE
gpcrondump -c and -o now accepts a given number or a timestamp

### DIFF
--- a/gpMgmt/bin/gpcrondump.py
+++ b/gpMgmt/bin/gpcrondump.py
@@ -1497,10 +1497,10 @@ def create_parser():
     addTo.add_option('-K', dest='timestamp_key', metavar="<YYYYMMDDHHMMSS>",
                      help="Timestamp key for the dump.")
 
-    addTo.add_option('--cleanup-date', dest='cleanup_date', default=None, metavar='<YYYYMMDD date>',
-                     help="Specific dump date to clear.")
-    addTo.add_option('--cleanup-total', dest='cleanup_total', default=None, metavar='<N int>',
-                     help="Specific number of old dumps to clear.")
+    addTo.add_option('--cleanup-date', dest='cleanup_date', default=None, metavar='<yyyymmdd date>',
+                     help="Remove backup sets for a yyyymmdd date.")
+    addTo.add_option('--cleanup-total', dest='cleanup_total', default=None, metavar='<n int>',
+                     help="Remove the n oldest backup sets based on the backup timestamp.")
     addTo.add_option('--list-backup-files', dest='list_backup_files', default=False, action='store_true',
                      help="Files created during the dump operation for a particular input timestamp")
     addTo.add_option('--prefix', dest='local_dump_prefix', default='', metavar='<filename prefix>',

--- a/gpMgmt/bin/gppylib/operations/dump.py
+++ b/gpMgmt/bin/gppylib/operations/dump.py
@@ -1659,7 +1659,7 @@ class DeleteCurrentSegDump(Operation):
             RemoveFile(os.path.join(path, filename)).run()
 
 class DeleteOldestDumps(Operation):
-    def __init__(self, master_datadir, master_port, dump_dir, cleanup_date=None, cleanup_total=None, ddboost):
+    def __init__(self, master_datadir, master_port, dump_dir, cleanup_date=None, cleanup_total=None, ddboost=False):
         self.master_datadir = master_datadir
         self.master_port = master_port
         self.dump_dir = dump_dir

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -1479,7 +1479,8 @@ Feature: Validate command line arguments
         Then the get_partition_state result should contain "pepper, t1, 999999999999999"
 
     @backupfire
-    Scenario: Test gpcrondump dump deletion (-o option)
+    @dumpdelete
+    Scenario: Test gpcrondump dump deletion only (-o option)
         Given the database is running
         And the database "deletedumpdb" does not exist
         And database "deletedumpdb" exists
@@ -1506,7 +1507,8 @@ Feature: Validate command line arguments
         And the database "deletedumpdb" does not exist
 
     @backupfire
-    Scenario: Negative test gpcrondump dump deletion (-o option)
+    @dumpdelete
+    Scenario: Negative test gpcrondump dump deletion only (-o option)
         Given the database is running
         And the database "deletedumpdb" does not exist
         And database "deletedumpdb" exists
@@ -1530,22 +1532,34 @@ Feature: Validate command line arguments
         And gpcrondump should print -o argument is not an integer: abc to stdout
 
     @backupfire
-    Scenario: Verify the gpcrondump -c  option is not broken
+    @dumpdelete
+    Scenario: Test gpcrondump dump deletion (-c option)
         Given the database is running
-        And the database "schematestdb" does not exist
-        And database "schematestdb" exists
-        And there is schema "pepper" exists in "schematestdb"
-        And there is a "ao" table "pepper.ao_table" with compression "None" in "schematestdb" with data
-        And there is a "co" table "pepper.co_table" with compression "None" in "schematestdb" with data
+        And the database "dumpdeletedb" does not exist
+        And database "dumpdeletedb" exists
+        And there is a "heap" table "public.heap_table" with compression "None" in "deletedumpdb" with data 
         And there are no backup files
-        And the user runs "gpcrondump -a -x schematestdb"
+        And the user runs "gpcrondump -a -x deletedumpdb"
         And the full backup timestamp from gpcrondump is stored
         And gpcrondump should return a return code of 0
         And older backup directories "20130101" exists
-        When the user runs "gpcrondump -c -x schematestdb -a" 
+        When the user runs "gpcrondump -a -x deletedumpdb -c"
         Then gpcrondump should return a return code of 0
         And the dump directories "20130101" should not exist
-        And the dump directory for the stored timestamp should exist 
+        And the dump directory for the stored timestamp should exist
+        And older backup directories "20130101" exists
+        And older backup directories "20130102" exists
+        When the user runs "gpcrondump -a -x deletedumpdb -c 2"
+        Then gpcrondump should return a return code of 0
+        And the dump directories "20130101" should not exist
+        And the dump directories "20130102" should not exist
+        And the dump directory for the stored timestamp should exist
+        And older backup directories "20130101" exists
+        When the user runs "gpcrondump -a -x deletedumpdb -c 20130101"
+        Then gpcrondump should return a return code of 0
+        And the dump directories "20130101" should not exist
+        And the dump directory for the stored timestamp should exist
+        And the database "deletedumpdb" does not exist 
 
     Scenario: Verify the gpcrondump -g option is not broken
         Given the database is running

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -1478,8 +1478,6 @@ Feature: Validate command line arguments
         When the method get_partition_state is executed on table "public.tuple_count_table" in "tempdb" for ao table "pepper.t1"
         Then the get_partition_state result should contain "pepper, t1, 999999999999999"
 
-    @backupfire
-    @dumpdelete
     Scenario: Test gpcrondump dump deletion only (-o option)
         Given the database is running
         And the database "deletedumpdb" does not exist
@@ -1494,20 +1492,18 @@ Feature: Validate command line arguments
         Then gpcrondump should return a return code of 0
         And the dump directories "20130101" should not exist
         And older backup directories "20130101" exists
-        When the user runs "gpcrondump -o 20130101"
+        When the user runs "gpcrondump -o --cleanup-date=20130101"
         Then gpcrondump should return a return code of 0
         And the dump directories "20130101" should not exist
         And older backup directories "20130101" exists
         And older backup directories "20130102" exists
-        When the user runs "gpcrondump -o 2"
+        When the user runs "gpcrondump -o --cleanup-total=2"
         Then gpcrondump should return a return code of 0
         And the dump directories "20130101" should not exist
         And the dump directories "20130102" should not exist
         And the dump directory for the stored timestamp should exist
         And the database "deletedumpdb" does not exist
 
-    @backupfire
-    @dumpdelete
     Scenario: Negative test gpcrondump dump deletion only (-o option)
         Given the database is running
         And the database "deletedumpdb" does not exist
@@ -1521,18 +1517,20 @@ Feature: Validate command line arguments
         Then gpcrondump should return a return code of 0
         And gpcrondump should print No old backup sets to remove to stdout
         And older backup directories "20130101" exists
-        When the user runs "gpcrondump -o 20130100"
+        When the user runs "gpcrondump -o --cleanup-date=20130100"
         Then gpcrondump should return a return code of 0
         And gpcrondump should print Timestamp dump 20130100 does not exist. to stdout
-        When the user runs "gpcrondump -o 2"
+        When the user runs "gpcrondump -o --cleanup-total=2"
         Then gpcrondump should return a return code of 0
         And gpcrondump should print Unable to delete 2 backups.  Only have 1 backups. to stdout
-        When the user runs "gpcrondump -o abc"
+        When the user runs "gpcrondump --cleanup-date=20130100"
         Then gpcrondump should return a return code of 2
-        And gpcrondump should print -o argument is not an integer: abc to stdout
+        And gpcrondump should print Must supply -c or -o with --cleanup-date option to stdout
+        When the user runs "gpcrondump --cleanup-total=2"
+        Then gpcrondump should return a return code of 2
+        And gpcrondump should print Must supply -c or -o with --cleanup-total option to stdout
 
     @backupfire
-    @dumpdelete
     Scenario: Test gpcrondump dump deletion (-c option)
         Given the database is running
         And the database "dumpdeletedb" does not exist
@@ -1549,13 +1547,13 @@ Feature: Validate command line arguments
         And the dump directory for the stored timestamp should exist
         And older backup directories "20130101" exists
         And older backup directories "20130102" exists
-        When the user runs "gpcrondump -a -x deletedumpdb -c 2"
+        When the user runs "gpcrondump -a -x deletedumpdb -c --cleanup-total=2"
         Then gpcrondump should return a return code of 0
         And the dump directories "20130101" should not exist
         And the dump directories "20130102" should not exist
         And the dump directory for the stored timestamp should exist
         And older backup directories "20130101" exists
-        When the user runs "gpcrondump -a -x deletedumpdb -c 20130101"
+        When the user runs "gpcrondump -a -x deletedumpdb -c --cleanup-date=20130101"
         Then gpcrondump should return a return code of 0
         And the dump directories "20130101" should not exist
         And the dump directory for the stored timestamp should exist

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcrondump.py
@@ -30,6 +30,8 @@ class GpCronDumpTestCase(unittest.TestCase):
             self.compress = True
             self.free_space_percent = None
             self.clear_dumps = False
+            self.cleanup_date = None
+            self.cleanup_total = None
             self.dump_schema = False
             self.dump_databases = 'testdb'
             self.bypass_disk_check = True

--- a/gpMgmt/doc/gpcrondump_help
+++ b/gpMgmt/doc/gpcrondump_help
@@ -15,7 +15,8 @@ gpcrondump -x database_name
      [-u backup_directory] [-R post_dump_script] [--incremental] 
      [ -K <timestamp> [--list-backup-files] ] 
      [--prefix <prefix_string> [--list-filter-tables] ]
-     [-c] [-z] [-r] [-f <free_space_percent>] [-b] [-h] [-j | -k] 
+     [ -c  [ --cleanup-date yyyymmdd  |  --cleanup-total n ] ]
+     [-z] [-r] [-f <free_space_percent>] [-b] [-h] [-j | -k]
      [-g] [-G] [-C] [-d <master_data_directory>] [-B <parallel_processes>] 
      [-a] [-q] [-y <reportfile>] [-l <logfile_directory>]
      [--email-file <path_to_file> ] [-v]
@@ -38,7 +39,7 @@ gpcrondump --ddboost-host <ddboost_hostname>
 
 gpcrondump --ddboost-config-remove
 
-gpcrondump -o
+gpcrondump -o  [ --cleanup-date yyyymmdd  |  --cleanup-total n ]
 
 gpcrondump -? 
 
@@ -174,11 +175,8 @@ OPTIONS
  required to perform the restore are not deleted. The gpdbrestore utility 
  option --list-backup lists the backup sets required to perform a backup. 
 
- If --cleanup-date=<YYYYMMDD date> is specified, the specified date will
- be deleted.
-
- If --cleanup-total=<N int> is specified, the oldest N dump dates will
- be deleted.
+ You can specify the option --cleanup-date or --cleanup-total to specify
+ backup sets to delete.
 
  If --ddboost is specified, only the old files on Data Domain Boost are 
  deleted. 
@@ -199,16 +197,33 @@ OPTIONS
  option is specified. 
 
 
---cleanup-date <YYYYMMDD date>
+--cleanup-date=yyyymmdd
 
- Addon for -c (clear dumps) and -o (clear dumps only) options. Delete a
- specified date.
+ Remove backup sets for the date yyyy-mm-dd. The date format is yyyymmdd.
+ If multiple backup sets were created on the date, all the backup sets
+ for that date are deleted. If no backup sets are found, gpcrondump
+ returns a warning message and no backup sets are deleted. If the -c
+ option is specified, the backup process continues.
+
+ Valid only with the -c or -o option.
+
+ WARNING: Before using this option, ensure that incremental backups
+ required to perform the restore are not deleted. The gpdbrestore utility
+ option --list-backup lists the backup sets required to perform a backup.
 
 
---cleanup-total <N int>
+--cleanup-total=n
 
- Addon for -c (clear dumps) and -o (clear dumps only) options. Delete
- the oldest N dump dates.
+ Remove the n oldest backup sets based on the backup timestamp. If there
+ are fewer than n backup sets, gpcrondump returns a warning message and
+ no backup sets are deleted. If the -c option is specified, the backup
+ process continues.
+
+ Valid only with the -c or -o option.
+
+ WARNING: Before using this option, ensure that incremental backups
+ required to perform the restore are not deleted. The gpdbrestore utility
+ option --list-backup lists the backup sets required to perform a backup.
 
 
 --column-inserts 
@@ -573,11 +588,8 @@ OPTIONS
  option --list-backup lists the backup sets required to perform a 
  restore. 
 
- If --cleanup-date=<YYYYMMDD date> is specified, the specified date will
- be deleted.
-
- If --cleanup-total=<N int> is specified, the oldest N dump dates will
- be deleted.
+ You can specify the option --cleanup-date or --cleanup-total to specify
+ backup sets to delete.
 
  If --ddboost is specified, only the old files on Data Domain Boost are 
  deleted. 

--- a/gpMgmt/doc/gpcrondump_help
+++ b/gpMgmt/doc/gpcrondump_help
@@ -161,7 +161,7 @@ OPTIONS
  processes depending on how many segment instances it needs to dump. 
 
 
--c (clear old dump files first) 
+-c [<N dumps>|<timestamp>]
 
  Specify this option to delete old backups before performing a back up. 
  In the db_dumps directory, the directory where the name is the oldest 
@@ -169,6 +169,10 @@ OPTIONS
  directory is not deleted. The default is to not delete old backup files. 
 
  The deleted directory might contain files from one or more backups. 
+
+ Specify an integer N to remove N number of oldest dump directories or a
+ YYYYMMDD timestamp to remove a specific dump directory.  Defaults to N=1,
+ the oldest dump directory, if no argument is provided.
 
  WARNING: Before using this option, ensure that incremental backups 
  required to perform the restore are not deleted. The gpdbrestore utility 
@@ -544,11 +548,15 @@ OPTIONS
  Do not output commands to set object privileges (GRANT/REVOKE commands). 
 
 
--o (clear old dump files only) 
+-o [<N dumps>|<timestamp>]
 
  Clear out old dump files only, but do not run a dump. This will remove 
  the oldest dump directory except the current date's dump directory. 
- All dump sets within that directory will be removed. 
+ All dump sets within that directory will be removed.
+
+ Specify an integer N to remove N number of oldest dump directories or a
+ YYYYMMDD timestamp to remove a specific dump directory.  Defaults to N=1,
+ the oldest dump directory, if no argument is provided.
 
  WARNING: Before using this option, ensure that incremental backups 
  required to perform the restore are not deleted. The gpdbrestore utility 

--- a/gpMgmt/doc/gpcrondump_help
+++ b/gpMgmt/doc/gpcrondump_help
@@ -161,7 +161,7 @@ OPTIONS
  processes depending on how many segment instances it needs to dump. 
 
 
--c [<N dumps>|<timestamp>]
+-c (clear old dump files first)
 
  Specify this option to delete old backups before performing a back up. 
  In the db_dumps directory, the directory where the name is the oldest 
@@ -170,13 +170,15 @@ OPTIONS
 
  The deleted directory might contain files from one or more backups. 
 
- Specify an integer N to remove N number of oldest dump directories or a
- YYYYMMDD timestamp to remove a specific dump directory.  Defaults to N=1,
- the oldest dump directory, if no argument is provided.
-
  WARNING: Before using this option, ensure that incremental backups 
  required to perform the restore are not deleted. The gpdbrestore utility 
  option --list-backup lists the backup sets required to perform a backup. 
+
+ If --cleanup-date=<YYYYMMDD date> is specified, the specified date will
+ be deleted.
+
+ If --cleanup-total=<N int> is specified, the oldest N dump dates will
+ be deleted.
 
  If --ddboost is specified, only the old files on Data Domain Boost are 
  deleted. 
@@ -195,6 +197,18 @@ OPTIONS
  If --incremental is specified and the files are on NFS storage, the -C 
  option is not supported. The database objects are not dropped if the -C 
  option is specified. 
+
+
+--cleanup-date <YYYYMMDD date>
+
+ Addon for -c (clear dumps) and -o (clear dumps only) options. Delete a
+ specified date.
+
+
+--cleanup-total <N int>
+
+ Addon for -c (clear dumps) and -o (clear dumps only) options. Delete
+ the oldest N dump dates.
 
 
 --column-inserts 
@@ -548,20 +562,22 @@ OPTIONS
  Do not output commands to set object privileges (GRANT/REVOKE commands). 
 
 
--o [<N dumps>|<timestamp>]
+-o (clear old dump files only)
 
  Clear out old dump files only, but do not run a dump. This will remove 
  the oldest dump directory except the current date's dump directory. 
  All dump sets within that directory will be removed.
 
- Specify an integer N to remove N number of oldest dump directories or a
- YYYYMMDD timestamp to remove a specific dump directory.  Defaults to N=1,
- the oldest dump directory, if no argument is provided.
-
  WARNING: Before using this option, ensure that incremental backups 
  required to perform the restore are not deleted. The gpdbrestore utility 
  option --list-backup lists the backup sets required to perform a 
  restore. 
+
+ If --cleanup-date=<YYYYMMDD date> is specified, the specified date will
+ be deleted.
+
+ If --cleanup-total=<N int> is specified, the oldest N dump dates will
+ be deleted.
 
  If --ddboost is specified, only the old files on Data Domain Boost are 
  deleted. 


### PR DESCRIPTION
The gpcrondump utility now accepts a given number or a timestamp
for the -c and -o option to delete N number of old dumps or a specific
timestamp dump.  Default is to delete the oldest dump when only
-c or -o is given without arguments to preserve backwards compatibility.

Authors: Karen Huddleston and Jimmy Yih