### PR TITLE
Replace pgsql-bugs@postgresql.org with bugs@greenplum.org

### DIFF
--- a/configure
+++ b/configure
@@ -2858,7 +2858,7 @@ PostgreSQL has apparently not been ported to your platform yet.
 To try a manual configuration, look into the src/template directory
 for a similar platform and use the '--with-template=' option.
 
-Please also contact <pgsql-bugs@postgresql.org> to see about
+Please also contact <bugs@greenplum.org> to see about
 rectifying this.  Include the above 'checking host system type...'
 line.
 *******************************************************************

--- a/configure.in
+++ b/configure.in
@@ -90,7 +90,7 @@ PostgreSQL has apparently not been ported to your platform yet.
 To try a manual configuration, look into the src/template directory
 for a similar platform and use the '--with-template=' option.
 
-Please also contact <pgsql-bugs@postgresql.org> to see about
+Please also contact <bugs@greenplum.org> to see about
 rectifying this.  Include the above 'checking host system type...'
 line.
 *******************************************************************

--- a/contrib/pgbench/pgbench.c
+++ b/contrib/pgbench/pgbench.c
@@ -315,7 +315,7 @@ usage(const char *progname)
 		   "  --help       show this help, then exit\n"
 		   "  --version    output version information, then exit\n"
 		   "\n"
-		   "Report bugs to <pgsql-bugs@postgresql.org>.\n",
+		   "Report bugs to <bugs@greenplum.org>.\n",
 		   progname, progname);
 }
 

--- a/src/backend/catalog/genbki.sh
+++ b/src/backend/catalog/genbki.sh
@@ -66,7 +66,7 @@ do
             echo "The environment variable AWK determines which Awk program"
             echo "to use. The default is \`awk'."
             echo
-            echo "Report bugs to <pgsql-bugs@postgresql.org>."
+            echo "Report bugs to <bugs@greenplum.org>."
             exit 0
             ;;
         -*)

--- a/src/backend/main/main.c
+++ b/src/backend/main/main.c
@@ -350,7 +350,7 @@ help(const char *progname)
 	printf(_("\nPlease read the documentation for the complete list of run-time\n"
 	 "configuration settings and how to set them on the command line or in\n"
 			 "the configuration file.\n\n"
-			 "Report bugs to <pgsql-bugs@postgresql.org>.\n"));
+			 "Report bugs to <bugs@greenplum.org>.\n"));
 }
 
 

--- a/src/backend/utils/Gen_fmgrtab.sh
+++ b/src/backend/utils/Gen_fmgrtab.sh
@@ -45,7 +45,7 @@ do
             echo "The environment variable AWK determines which Awk program"
             echo "to use. The default is \`awk'."
             echo
-            echo "Report bugs to <pgsql-bugs@postgresql.org>."
+            echo "Report bugs to <bugs@greenplum.org>."
             exit 0
             ;;
         -*)

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -2867,7 +2867,7 @@ usage(const char *progname)
 	printf(_("  -m, --formirror           only create data needed to start the backend in mirror mode\n"));
 	printf(_("\nIf the data directory is not specified, the environment variable PGDATA\n"
 			 "is used.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }
 
 int

--- a/src/bin/ipcclean/ipcclean.sh
+++ b/src/bin/ipcclean/ipcclean.sh
@@ -14,7 +14,7 @@ if [ "$1" = '-?' -o "$1" = "--help" ]; then
     echo
     echo "Note: Since the utilities underlying this script are very different"
     echo "from platform to platform, chances are that it might not work on"
-    echo "yours. If that is the case, please write to <pgsql-bugs@postgresql.org>"
+    echo "yours. If that is the case, please write to <bugs@greenplum.org>"
     echo "so that your platform can be supported in the future."
     exit 0
 fi

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -143,7 +143,7 @@ usage(void)
 	printf(_("  -w, --no-password      never prompt for password\n"));
 	printf(_("  -W, --password         force password prompt (should happen automatically)\n"));
 	printf(_("  -E, --exclude          exclude path names\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }
 
 

--- a/src/bin/pg_basebackup/pg_receivexlog.c
+++ b/src/bin/pg_basebackup/pg_receivexlog.c
@@ -72,7 +72,7 @@ usage(void)
 	printf(_("  -U, --username=NAME    connect as specified database user\n"));
 	printf(_("  -w, --no-password      never prompt for password\n"));
 	printf(_("  -W, --password         force password prompt (should happen automatically)\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }
 
 static bool

--- a/src/bin/pg_config/pg_config.c
+++ b/src/bin/pg_config/pg_config.c
@@ -469,7 +469,7 @@ help(void)
 	printf(_("  --version             show the PostgreSQL version\n"));
 	printf(_("  --help                show this help, then exit\n"));
 	printf(_("\nWith no arguments, all known items are shown.\n\n"));
-	printf(_("Report bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
 }
 
 static void

--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -36,7 +36,7 @@ usage(const char *progname)
 		);
 	printf(_("\nIf no data directory (DATADIR) is specified, "
 			 "the environment variable PGDATA\nis used.\n\n"));
-	printf(_("Report bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
 }
 
 

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -1712,7 +1712,7 @@ do_help(void)
 	printf(_("  -U USERNAME     user name of account to register PostgreSQL server\n"));
 #endif
 
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }
 
 

--- a/src/bin/pg_dump/cdb/cdb_dump.c
+++ b/src/bin/pg_dump/cdb/cdb_dump.c
@@ -1492,7 +1492,7 @@ help(const char *progname)
 
 	printf(("\nIf no database name is supplied, then the PGDATABASE environment\n"
 			"variable value is used.\n\n"));
-	/* printf(("Report bugs to <pgsql-bugs@postgresql.org>.\n")); */
+	/* printf(("Report bugs to <bugs@greenplum.org>.\n")); */
 }
 
 

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -1346,7 +1346,7 @@ help(const char *progname)
 
 	printf(_("\nIf no database name is supplied, then the PGDATABASE environment\n"
 			 "variable value is used.\n\n"));
-	/* printf(_("Report bugs to <pgsql-bugs@postgresql.org>.\n")); */
+	/* printf(_("Report bugs to <bugs@greenplum.org>.\n")); */
 }
 
 /*

--- a/src/bin/pg_dump/cdb/cdb_restore_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_restore_agent.c
@@ -1078,7 +1078,7 @@ usage(const char *progname)
 	printf(("   --post-data-schema-only restore schema only from special post-data file\n"));
 
 	printf(_("\nIf no input file name is supplied, then standard input is used.\n\n"));
-	printf(_("Report bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
 }
 
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -929,7 +929,7 @@ help(const char *progname)
 
 	printf(_("\nIf no database name is supplied, then the PGDATABASE environment\n"
 			 "variable value is used.\n\n"));
-	printf(_("Report bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
 }
 
 void

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -536,7 +536,7 @@ help(void)
 
 	printf(_("\nIf -f/--file is not used, then the SQL script will be written to the standard\n"
 			 "output.\n\n"));
-	printf(_("Report bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
 }
 
 

--- a/src/bin/pg_dump/pg_restore.c
+++ b/src/bin/pg_dump/pg_restore.c
@@ -425,5 +425,5 @@ usage(const char *progname)
 	printf(_("  -e, --exit-on-error      exit on error, default is to continue\n"));
 
 	printf(_("\nIf no input file name is supplied, then standard input is used.\n\n"));
-	printf(_("Report bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/pg_resetxlog/pg_resetxlog.c
+++ b/src/bin/pg_resetxlog/pg_resetxlog.c
@@ -986,5 +986,5 @@ usage(void)
 	printf(_("  --help          show this help, then exit\n"));
 	printf(_("  --version       output version information, then exit\n"));
 	printf(_("  --gp-version    output Greenplum version information, then exit\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/psql/help.c
+++ b/src/bin/psql/help.c
@@ -158,7 +158,7 @@ usage(void)
 	printf(_("\nFor more information, type \"\\?\" (for internal commands) or \"\\help\" (for SQL\n"
 			 "commands) from within psql, or consult the psql section in the PostgreSQL\n"
 			 "documentation.\n\n"));
-	printf(_("Report bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
 }
 
 

--- a/src/bin/scripts/clusterdb.c
+++ b/src/bin/scripts/clusterdb.c
@@ -255,5 +255,5 @@ help(const char *progname)
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("\nRead the description of the SQL command CLUSTER for details.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/scripts/createdb.c
+++ b/src/bin/scripts/createdb.c
@@ -222,5 +222,5 @@ help(const char *progname)
 	printf(_("  -w, --no-password            never prompt for password\n"));
 	printf(_("  -W, --password               force password prompt\n"));
 	printf(_("\nBy default, a database with the same name as the current user is created.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/scripts/createlang.c
+++ b/src/bin/scripts/createlang.c
@@ -226,5 +226,5 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/scripts/createuser.c
+++ b/src/bin/scripts/createuser.c
@@ -326,5 +326,5 @@ help(const char *progname)
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("\nIf one of -d, -D, -r, -R, -s, -S, and ROLENAME is not specified, you will\n"
 			 "be prompted interactively.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/scripts/dropdb.c
+++ b/src/bin/scripts/dropdb.c
@@ -150,5 +150,5 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/scripts/droplang.c
+++ b/src/bin/scripts/droplang.c
@@ -343,5 +343,5 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/scripts/dropuser.c
+++ b/src/bin/scripts/dropuser.c
@@ -149,5 +149,5 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as (not the one to drop)\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/scripts/reindexdb.c
+++ b/src/bin/scripts/reindexdb.c
@@ -329,5 +329,5 @@ help(const char *progname)
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("\nRead the description of the SQL command REINDEX for details.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/bin/scripts/vacuumdb.c
+++ b/src/bin/scripts/vacuumdb.c
@@ -280,5 +280,5 @@ help(const char *progname)
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("\nRead the description of the SQL command VACUUM for details.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }

--- a/src/include/storage/s_lock.h
+++ b/src/include/storage/s_lock.h
@@ -862,7 +862,7 @@ spin_delay(void)
 
 /* Blow up if we didn't have any way to do spinlocks */
 #ifndef HAS_TEST_AND_SET
-#error PostgreSQL does not have native spinlock support on this platform.  To continue the compilation, rerun configure using --disable-spinlocks.  However, performance will be poor.  Please report this to pgsql-bugs@postgresql.org.
+#error Greenplum does not have native spinlock support on this platform.  To continue the compilation, rerun configure using --disable-spinlocks.  However, performance will be poor.  Please report this to bugs@greenplum.org.
 #endif
 
 

--- a/src/interfaces/ecpg/preproc/ecpg.c
+++ b/src/interfaces/ecpg/preproc/ecpg.c
@@ -59,7 +59,7 @@ help(const char *progname)
 	printf(_("  --version      output version information, then exit\n"));
 	printf(_("\nIf no output file is specified, the name is formed by adding .c to the\n"
 			 "input file name, after stripping off .pgc if present.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }
 
 static void

--- a/src/interfaces/ecpg/preproc/pgc.l
+++ b/src/interfaces/ecpg/preproc/pgc.l
@@ -1172,7 +1172,7 @@ cppline			{space}*#(.*\\{space})*.*{newline}
 						
 			  		}
 				}
-<INITIAL>{other}|\n     	{ mmerror(PARSE_ERROR, ET_FATAL, "internal error: unreachable state; please report this to <pgsql-bugs@postgresql.org>"); }
+<INITIAL>{other}|\n     	{ mmerror(PARSE_ERROR, ET_FATAL, "internal error: unreachable state; please report this to <bugs@greenplum.org>"); }
 %%
 void
 lex_init(void)

--- a/src/interfaces/ecpg/preproc/type.c
+++ b/src/interfaces/ecpg/preproc/type.c
@@ -255,7 +255,7 @@ ECPGdump_a_type(FILE *o, const char *name, struct ECPGtype * type,
 					break;
 				default:
 					if (!IS_SIMPLE_TYPE(type->u.element->type))
-						base_yyerror("internal error: unknown datatype, please report this to <pgsql-bugs@postgresql.org>");
+						base_yyerror("internal error: unknown datatype, please report this to <bugs@greenplum.org>");
 
 					ECPGdump_a_simple(o, name,
 									  type->u.element->type,
@@ -543,7 +543,7 @@ ECPGfree_type(struct ECPGtype * type)
 						break;
 					default:
 						if (!IS_SIMPLE_TYPE(type->u.element->type))
-							base_yyerror("internal error: unknown datatype, please report this to <pgsql-bugs@postgresql.org>");
+							base_yyerror("internal error: unknown datatype, please report this to <bugs@greenplum.org>");
 
 						free(type->u.element);
 				}

--- a/src/nls-global.mk
+++ b/src/nls-global.mk
@@ -36,7 +36,7 @@ PO_FILES = $(addprefix po/, $(addsuffix .po, $(LANGUAGES)))
 MO_FILES = $(addprefix po/, $(addsuffix .mo, $(LANGUAGES)))
 
 ifdef XGETTEXT
-XGETTEXT += -ctranslator --copyright-holder='PostgreSQL Global Development Group' --msgid-bugs-address=pgsql-bugs@postgresql.org
+XGETTEXT += -ctranslator --copyright-holder='Greenplum Project' --msgid-bugs-address=bugs@greenplum.org
 endif
 
 

--- a/src/port/chklocale.c
+++ b/src/port/chklocale.c
@@ -327,7 +327,7 @@ pg_get_encoding_from_locale(const char *ctype)
 	ereport(WARNING,
 			(errmsg("could not determine encoding for locale \"%s\": codeset is \"%s\"",
 					ctype, sys),
-		   errdetail("Please report this to <pgsql-bugs@postgresql.org>.")));
+		   errdetail("Please report this to <bugs@greenplum.org>.")));
 #endif
 
 	free(sys);

--- a/src/test/regress/bugbuster/expected/bkup_pg.out
+++ b/src/test/regress/bugbuster/expected/bkup_pg.out
@@ -136,7 +136,7 @@ Connection options:
 
 If no input file name is supplied, then standard input is used.
 
-Report bugs to <pgsql-bugs@postgresql.org>.
+Report bugs to <bugs@greenplum.org>.
 \! pg_dump --help
 pg_dump dumps a database as a text file or to other formats.
 
@@ -189,6 +189,6 @@ Connection options:
 If no database name is supplied, then the PGDATABASE environment
 variable value is used.
 
-Report bugs to <pgsql-bugs@postgresql.org>.
+Report bugs to <bugs@greenplum.org>.
 \echo -- end_ignore
 -- end_ignore

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2103,7 +2103,7 @@ help(void)
 	printf(_("The exit status is 0 if all tests passed, 1 if some tests failed, and 2\n"));
 	printf(_("if the tests could not be run for some reason.\n"));
 	printf(_("\n"));
-	printf(_("Report bugs to <pgsql-bugs@postgresql.org>.\n"));
+	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
 }
 
 int


### PR DESCRIPTION
This patch replaces all occurrences of pgsql-bugs@postgresql.org with
bugs@greenplum.org. Pointers to the pgsql-bugs mailinglist in the code
remain as they re. Regression and BugBuster tests are also patched.