### PR TITLE
stream is needed for gpcheckperf memory testing

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -33,7 +33,7 @@ core: pygresql subprocess32
 ifneq "$(wildcard $(CURDIR)/pythonSrc/ext/*.tar.gz)" ""
 all: core lockfile paramiko pycrypto stream pychecker psi unittest2
 else
-all: core
+all: core stream
 endif
 
 #

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -41,7 +41,7 @@ endif
 #
 
 #
-#  STREAM
+#  STREAM which is used by gpcheckperf for memory bandwidth testing.
 #
 STREAM_DIR=$(SRC)/src/stream
 stream:


### PR DESCRIPTION
without stream, gpcheckperf will report following error when performing memory bandwidth testing:

/home/gpadmin/build/gpdb/bin/gpcheckperf -r s -d /home/gpadmin/tmp -h g0

--------------------
--  STREAM TEST
--------------------
binary file not found: /home/gpadmin/build/gpdb/bin/lib/stream

