### PR TITLE
Fix Errors caused by SET command if cursor is declared

### DIFF
--- a/src/backend/cdb/cdbdisp.c
+++ b/src/backend/cdb/cdbdisp.c
@@ -143,7 +143,7 @@ addSegDBToDispatchThreadPool(DispatchCommandParms  *ParmsAr,
 							 CdbDispatchResult     *dispatchResult);
 
 static void
-cdbdisp_dispatchCommandToAllGangs(const char	*strCommand,
+cdbdisp_dispatchSetCommandToAllGangs(const char	*strCommand,
 						char					*serializedQuerytree,
 						int						serializedQuerytreelen,
 						char					*serializedPlantree,
@@ -1450,8 +1450,14 @@ cdbdisp_check_estate_for_cancel(struct EState *estate)
 	return false;
 }
 
+/*
+ * Dispatch SET command to all gangs.
+ * 
+ * Can not dispatch SET commands to busy reader gangs (allocated by cursors) directly, errors raise.
+ * Cursors only allocate reader gangs, so primary writer and idle reader gangs can be dispatched to.
+ */
 static void
-cdbdisp_dispatchCommandToAllGangs(const char	*strCommand,
+cdbdisp_dispatchSetCommandToAllGangs(const char	*strCommand,
 								  char			*serializedQuerytree,
 								  int			serializedQuerytreelen,
 								  char			*serializedPlantree,
@@ -1463,13 +1469,14 @@ cdbdisp_dispatchCommandToAllGangs(const char	*strCommand,
 	DispatchCommandQueryParms queryParms;
 	
 	Gang		*primaryGang;
-    List		*readerGangs;
-    ListCell	*le;
+	List		*idleReaderGangs;
+	List		*busyReaderGangs;
+	ListCell	*le;
 
-    int			nsegdb = getgpsegmentCount();
+	int			nsegdb = getgpsegmentCount();
 	int			gangCount;
 	
-    ds->primaryResults = NULL;	
+	ds->primaryResults = NULL;	
 	ds->dispatchThreads = NULL;
 
 	MemSet(&queryParms, 0, sizeof(queryParms));
@@ -1491,14 +1498,15 @@ cdbdisp_dispatchCommandToAllGangs(const char	*strCommand,
 	/* serialized a version of our snapshot */
 	queryParms.serializedDtxContextInfo = 
 		qdSerializeDtxContextInfo(&queryParms.serializedDtxContextInfolen, true /* withSnapshot */, false /* cursor*/,
-								  generateTxnOptions(needTwoPhase), "cdbdisp_dispatchCommandToAllGangs");
+								  generateTxnOptions(needTwoPhase), "cdbdisp_dispatchSetCommandToAllGangs");
 	
-	readerGangs = getAllReaderGangs();
+	idleReaderGangs = getAllIdleReaderGangs();
+	busyReaderGangs = getAllBusyReaderGangs();
 	
 	/*
 	 * Dispatch the command.
 	 */
-	gangCount = 1 + list_length(readerGangs);
+	gangCount = 1 + list_length(idleReaderGangs);
 	ds->primaryResults = cdbdisp_makeDispatchResults(nsegdb * gangCount, 0, cancelOnError);
 
 	ds->primaryResults->writer_gang = primaryGang;
@@ -1507,7 +1515,7 @@ cdbdisp_dispatchCommandToAllGangs(const char	*strCommand,
 						   &queryParms,
 						   primaryGang, -1, gangCount, DEFAULT_DISP_DIRECT);
 
-	foreach(le, readerGangs)
+	foreach(le, idleReaderGangs)
 	{
 		Gang  *rg = lfirst(le);
 		cdbdisp_dispatchToGang(ds,
@@ -1515,7 +1523,17 @@ cdbdisp_dispatchCommandToAllGangs(const char	*strCommand,
 							   &queryParms,
 							   rg, -1, gangCount, DEFAULT_DISP_DIRECT);
 	}
-}	/* cdbdisp_dispatchCommandToAllGangs */
+
+	/* 
+	* Can not send set command to busy gangs, so those gangs
+	* can not be reused because their GUC is not set.
+	*/
+	foreach(le, busyReaderGangs)
+	{
+		Gang  *rg = lfirst(le);
+		rg->noReuse = true;
+	}
+}	/* cdbdisp_dispatchSetCommandToAllGangs */
 
 /*--------------------------------------------------------------------*/
 
@@ -2826,21 +2844,21 @@ CdbDoCommand(const char *strCommand,
 
 
 void
-CdbDoCommandOnAllGangs(const char *strCommand,
+CdbSetGucOnAllGangs(const char *strCommand,
 					   bool cancelOnError,
 					   bool needTwoPhase)
 {
 	volatile CdbDispatcherState ds = {NULL, NULL};
 	const bool withSnapshot = true;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5), "CdbDoCommandOnAllGangs for command = '%s', needTwoPhase = %s",
+	elog((Debug_print_full_dtm ? LOG : DEBUG5), "CdbSetGucOnAllGangs for command = '%s', needTwoPhase = %s",
 		 strCommand, (needTwoPhase ? "true" : "false"));
 
-	dtmPreCommand("CdbDoCommandOnAllGangs", strCommand, NULL, needTwoPhase, withSnapshot, false /* inCursor */ );
+	dtmPreCommand("CdbSetGucOnAllGangs", strCommand, NULL, needTwoPhase, withSnapshot, false /* inCursor */ );
 
 	PG_TRY();
 	{
-		cdbdisp_dispatchCommandToAllGangs(strCommand, NULL, 0, NULL, 0, cancelOnError, needTwoPhase, (struct CdbDispatcherState *)&ds);
+		cdbdisp_dispatchSetCommandToAllGangs(strCommand, NULL, 0, NULL, 0, cancelOnError, needTwoPhase, (struct CdbDispatcherState *)&ds);
 
 		/*
 		 * Wait for all QEs to finish. If not all of our QEs were successful,

--- a/src/backend/cdb/cdbgang.c
+++ b/src/backend/cdb/cdbgang.c
@@ -639,6 +639,7 @@ buildGangDefinition(GangType type, int gang_id, int size, int content, char *por
 	newGangDefinition->gang_id = gang_id;
 	newGangDefinition->allocated = false;
 	newGangDefinition->active = false;
+	newGangDefinition->noReuse = false;
 	newGangDefinition->portal_name = (portal_name ? pstrdup(portal_name) : (char *) NULL);
 
 	if (gp_log_gang >= GPVARS_VERBOSITY_VERBOSE)
@@ -1306,6 +1307,12 @@ static Gang *primaryWriterGang = NULL;
 List *
 getAllReaderGangs()
 {
+	return list_concat(getAllIdleReaderGangs(), getAllBusyReaderGangs());
+}
+
+List *
+getAllIdleReaderGangs()
+{
 	List	   *res = NIL;
 	ListCell   *le;
 
@@ -1324,6 +1331,23 @@ getAllReaderGangs()
 	{
 		res = lappend(res, lfirst(le));
 	}
+
+	return res;
+}
+
+List *
+getAllBusyReaderGangs()
+{
+	List	   *res = NIL;
+	ListCell   *le;
+
+	/*
+	 * using list_concat() here will destructively modify the lists!
+	 *
+	 * res = list_concat(availableReaderGangsN,
+	 * list_concat(availableReaderGangs1, list_concat(allocatedReaderGangsN,
+	 * allocatedReaderGangs1)));
+	 */
 	foreach(le, allocatedReaderGangsN)
 	{
 		res = lappend(res, lfirst(le));
@@ -2051,6 +2075,14 @@ cleanupGang(Gang *gp)
 
 	if (gp_log_gang >= GPVARS_VERBOSITY_DEBUG)
 		elog(LOG, "cleanupGang done");
+
+	if (gp->noReuse)
+	{
+		disconnectAndDestroyGang(gp);
+		gp = NULL;
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5251,7 +5251,7 @@ SetPGVariable(const char *name, List *args, bool is_local, bool gp_dispatch)
 
 		if (gp_dispatch)
 		{
-	        CdbDoCommandOnAllGangs( buffer.data, false, /*no txn*/ false );
+			CdbSetGucOnAllGangs( buffer.data, false, /*no txn*/ false );
 		}
 	}
 }
@@ -5308,7 +5308,7 @@ set_config_by_name(PG_FUNCTION_ARGS)
 			if (is_local)
 					appendStringInfo(&buffer, "LOCAL ");
 			appendStringInfo(&buffer, "%s TO '%s'", name, value);
-			CdbDoCommandOnAllGangs(buffer.data,
+			CdbSetGucOnAllGangs(buffer.data,
 								   false /* cancelOnError */,
 								   false /* no two phase commit */);
     }

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -390,7 +390,7 @@ CdbDoCommand(const char *strCommand, bool cancelOnError, bool needTwoPhase);
  * gangs, both reader and writer
  */
 void
-CdbDoCommandOnAllGangs(const char *strCommand, bool cancelOnError, bool needTwoPhase);
+CdbSetGucOnAllGangs(const char *strCommand, bool cancelOnError, bool needTwoPhase);
 
 /*--------------------------------------------------------------------*/
 struct SliceTable;

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -55,6 +55,9 @@ typedef struct Gang
 	bool		all_valid_segdbs_connected;
 	bool		allocated;
 
+	/* should be destoryed in cleanupGang() if set*/
+	bool		noReuse;
+
 	/* MPP-24003: pointer to array of segment database info for each reader and writer gang. */
 	struct		CdbComponentDatabaseInfo *segment_database_info;
 } Gang;
@@ -76,6 +79,10 @@ extern void disconnectAndDestroyAllGangs(void);
 extern void CheckForResetSession(void);
 
 extern List * getAllReaderGangs(void);
+
+extern List * getAllIdleReaderGangs(void);
+
+extern List * getAllBusyReaderGangs(void);
 
 extern void detectFailedConnections(void);
 

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -491,3 +491,51 @@ DROP TABLE guc_test1;
 DROP TABLE guc_test2;
 ERROR:  table "guc_test2" does not exist
 -- end_ignore
+--
+-- Test GUC if cursor is opened
+--
+-- start_ignore
+drop table if exists test_cursor_set_table;
+NOTICE:  table "test_cursor_set_table" does not exist, skipping
+drop function if exists test_set_in_loop();
+NOTICE:  function test_set_in_loop() does not exist, skipping
+drop function if exists test_call_set_command();
+NOTICE:  function test_call_set_command() does not exist, skipping
+-- end_ignore
+create table test_cursor_set_table as select * from generate_series(1, 100);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE FUNCTION test_set_in_loop () RETURNS numeric
+    AS $$
+DECLARE
+    rec record;
+    result numeric;
+    tmp numeric;
+BEGIN
+	result = 0;
+FOR rec IN select * from test_cursor_set_table
+LOOP
+        select test_call_set_command() into tmp;
+        result = result + 1;
+END LOOP;
+return result;
+END;
+$$
+    LANGUAGE plpgsql NO SQL;
+CREATE FUNCTION test_call_set_command() returns numeric
+AS $$
+BEGIN
+       execute 'SET gp_workfile_limit_per_query=524;';
+       return 0;
+END;
+$$
+    LANGUAGE plpgsql NO SQL;
+select * from test_set_in_loop();
+ test_set_in_loop
+------------------
+              100
+(1 row)
+
+drop table if exists test_cursor_set_table;
+drop function if exists test_set_in_loop();
+drop function if exists test_call_set_command();

--- a/src/test/regress/sql/guc.sql
+++ b/src/test/regress/sql/guc.sql
@@ -151,3 +151,49 @@ SHOW gp_disable_catalog_access_on_segment;
 DROP TABLE guc_test1;
 DROP TABLE guc_test2;
 -- end_ignore
+
+--
+-- Test GUC if cursor is opened
+--
+-- start_ignore
+drop table if exists test_cursor_set_table;
+drop function if exists test_set_in_loop();
+drop function if exists test_call_set_command();
+-- end_ignore
+
+create table test_cursor_set_table as select * from generate_series(1, 100);
+
+CREATE FUNCTION test_set_in_loop () RETURNS numeric
+    AS $$
+DECLARE
+    rec record;
+    result numeric;
+    tmp numeric;
+BEGIN
+	result = 0;
+FOR rec IN select * from test_cursor_set_table
+LOOP
+        select test_call_set_command() into tmp;
+        result = result + 1;
+END LOOP;
+return result;
+END;
+$$
+    LANGUAGE plpgsql NO SQL;
+
+
+CREATE FUNCTION test_call_set_command() returns numeric
+AS $$
+BEGIN
+       execute 'SET gp_workfile_limit_per_query=524;';
+       return 0;
+END;
+$$
+    LANGUAGE plpgsql NO SQL;
+
+
+select * from test_set_in_loop();
+
+drop table if exists test_cursor_set_table;
+drop function if exists test_set_in_loop();
+drop function if exists test_call_set_command();


### PR DESCRIPTION
SET command is session effective, all existed idle gangs should be set for later reuse,
but for busy gangs declared by cursors, errors occur if they receive a set command. Way
to fix it is marking busy gangs to no reuse so they can be destroyed after cursors been
closed.