### PR TITLE
Copy perl modules (atmsort.pm & explain.pm) to bin

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -1109,6 +1109,7 @@ endif
 	cp -rp $(GPMGMT)/sbin/* $(INSTLOC)/sbin/.
 	cp -p extensions/gpfdist/gpfdist$(EXE_EXT) $(INSTLOC)/bin/
 	cp $(GPPGDIR)/src/test/regress/*.pl $(INSTLOC)/bin
+	cp $(GPPGDIR)/src/test/regress/*.pm $(INSTLOC)/bin
 	if [ ! -d ${INSTLOC}/docs ] ; then mkdir ${INSTLOC}/docs ; fi
 	if [ -d $(GPMGMT)/doc ]; then cp -rp $(GPMGMT)/doc $(INSTLOC)/docs/cli_help; fi
 	if [ -d $(GPMGMT)/demo/gpmapreduce ]; then \


### PR DESCRIPTION
Supporting the commercial build, the new perl modules (atmsort.pm &
explain.pm) supporting gpdiff.pl need to be copied to the bin directory.

This was noticed by the current test runs which cannot run gpdiff.pl due to the inability to locate the modules.  Placing the perl modules in the bin directory allows gpdiff.pl to run.