### PR TITLE
Fixed coverity issue about not freeing a variable

### DIFF
--- a/src/backend/utils/misc/fstream/fstream.c
+++ b/src/backend/utils/misc/fstream/fstream.c
@@ -313,6 +313,7 @@ static int glob_path(fstream_t *fs, const char *path)
 	if (!path2)
 	{
 		gfile_printf_then_putc_newline("fstream out of memory");
+		gfile_free(path2);
 		return 1;
 	}
 
@@ -334,6 +335,7 @@ static int glob_path(fstream_t *fs, const char *path)
 			glob_and_copy(path, GLOB_MARK | GLOB_NOCHECK, 0, &fs->glob))
 		{
 			gfile_printf_then_putc_newline("fstream glob failed");
+			gfile_free(path2);
 			return 1;
 		}
 		path = p;

--- a/src/backend/utils/misc/fstream/fstream.c
+++ b/src/backend/utils/misc/fstream/fstream.c
@@ -313,7 +313,6 @@ static int glob_path(fstream_t *fs, const char *path)
 	if (!path2)
 	{
 		gfile_printf_then_putc_newline("fstream out of memory");
-		gfile_free(path2);
 		return 1;
 	}
 


### PR DESCRIPTION
Fixed coverity issue in fstream.c about freeing a path variable. 


Authors : Nikhil Kak & Marbin Victor Tan