### PR TITLE
Fix bug in IN-to-join conversion.

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -1152,9 +1152,6 @@ convert_IN_to_join(PlannerInfo *root, List** rtrlist_inout, SubLink *sublink)
 							  rtindex,
 							  &ininfo->sub_targetlist);
 
-	/* Add the completed node to the query's list */
-	root->in_info_list = lappend(root->in_info_list, ininfo);
-
 	return result;
 }                               /* convert_IN_to_join */
 

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1204,3 +1204,17 @@ select id from tbl_25484 where 3 = (select 3 where 3 = (select num));
 drop table tbl_25484;
 reset optimizer_segments;
 reset optimizer_nestloop_factor;
+--
+-- Test case that once triggered a bug in the IN-clause pull-up code.
+--
+SELECT p.id
+    FROM (SELECT * FROM generate_series(1,10) id
+          WHERE id IN (
+              SELECT 1
+              UNION ALL
+              SELECT 0)) p;
+ id 
+----
+  1
+(1 row)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1213,3 +1213,17 @@ select id from tbl_25484 where 3 = (select 3 where 3 = (select num));
 drop table tbl_25484;
 reset optimizer_segments;
 reset optimizer_nestloop_factor;
+--
+-- Test case that once triggered a bug in the IN-clause pull-up code.
+--
+SELECT p.id
+    FROM (SELECT * FROM generate_series(1,10) id
+          WHERE id IN (
+              SELECT 1
+              UNION ALL
+              SELECT 0)) p;
+ id 
+----
+  1
+(1 row)
+

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -520,3 +520,13 @@ select id from tbl_25484 where 3 = (select 3 where 3 = (select num));
 drop table tbl_25484;
 reset optimizer_segments;
 reset optimizer_nestloop_factor;
+
+--
+-- Test case that once triggered a bug in the IN-clause pull-up code.
+--
+SELECT p.id
+    FROM (SELECT * FROM generate_series(1,10) id
+          WHERE id IN (
+              SELECT 1
+              UNION ALL
+              SELECT 0)) p;


### PR DESCRIPTION
This bug was introduced in merge commit 1f4ad703, by a mishap in merging
the upstream changes to convert_IN_to_join. The constructed InInfoClause
entry was accidentally added to the list of in-clauses twice. That was
usually harmless, but if the in-clause was later pulled up from a subquery,
the code adjusts the varnos while merging the range tables of the subquery
and its parent, ran twice. In doing so, it adjusted the varno twice,
pointing it to wrong or non-existing range table entry.


Thanks to @asubramanya for extracting the test case from an out-of-tree test suite.