### PR TITLE
Rectify OID allocation for int8_ops for btree access method.

### DIFF
--- a/src/include/catalog/pg_opclass.h
+++ b/src/include/catalog/pg_opclass.h
@@ -139,9 +139,9 @@ DATA(insert (	405		int2_ops			PGNSP PGUID 1977   21 t 0 ));
 DATA(insert OID = 1978 ( 403	int4_ops	PGNSP PGUID 1976   23 t 0 ));
 #define INT4_BTREE_OPS_OID 1978
 DATA(insert (	405		int4_ops			PGNSP PGUID 1977   23 t 0 ));
-DATA(insert (	403		int8_ops			PGNSP PGUID 1976   20 t 0 ));
 #define INT8_BTREE_OPS_OID 1980
-DATA(insert OID = 1980 ( 405	int8_ops	PGNSP PGUID 1977   20 t 0 ));
+DATA(insert OID = 1980 ( 403	int8_ops	PGNSP PGUID 1976   20 t 0 ));
+DATA(insert ( 405	int8_ops	PGNSP PGUID 1977   20 t 0 ));
 DATA(insert (	403		interval_ops		PGNSP PGUID 1982 1186 t 0 ));
 DATA(insert (	405		interval_ops		PGNSP PGUID 1983 1186 t 0 ));
 DATA(insert (	403		macaddr_ops			PGNSP PGUID 1984  829 t 0 ));


### PR DESCRIPTION
Thank you @volkovandr for pointing out the issue in #174.  Note that updatable appendonly regression tests (not open sourced yet) are also failing because of this issue.

I haven't added any new tests to installcheck because this already covered by multiple tests in the above mentioned regression suite.

Currently only appendonly code uses the constant `INT8_BTREE_OPS_OID` and hence the impact of the bug was limited.