### PR TITLE
OSX commercial blds, generate i686 instructions

### DIFF
--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -145,6 +145,7 @@ export NO_M64=1
 
 # 32-bit/64-bit compiler/linker flag settings
 hpux_ia64_BLD_CFLAGS=-mlp64 -D_XOPEN_SOURCE_EXTENDED
+osx106_x86_BLD_CFLAGS=-m32 -march=i686
 rhel6_x86_64_BLD_CFLAGS=-m64
 rhel5_x86_64_BLD_CFLAGS=-m64
 rhel5_x86_32_BLD_CFLAGS=-m32


### PR DESCRIPTION
For OSX commercial builds, instruct the gcc compiler to produce
i686 (CPU) instructions.  This is needed to support an upstream
PostgreSQL merge which uses atomic instructions introduced in one of
those later CPUs.

Previously, there was no autoconf test for those instructions, and we
just compiled hand-crafted assembly to use those instructions anyway,
even though the rest of the compiler was targeting the older cpus.

reference: https://wiki.gentoo.org/wiki/GCC_optimization#-march

  Different CPUs have different capabilities, support different
  instruction sets, and have different ways of executing code. The
  -march flag will instruct the compiler to produce specific code for
  the system's CPU, with all its capabilities, features, instruction
  sets, quirks, and so on.