### PR TITLE
OSX commercial blds, generate i686 instructions

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -146,8 +146,8 @@ GPPKG_PLATFORMS=rhel5_x86_64 rhel6_x86_64 suse10_x86_64 suse11_x86_64
 
 INLINE_FLAGS=-finline-limit=1800
 
-OPTFLAGS="$(strip -O3 -funroll-loops -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(INLINE_FLAGS) $(TRACE_GCC_FLAG))"
-PROFFLAGS="$(strip -O3 -funroll-loops -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(INLINE_FLAGS) $(TRACE_GCC_FLAG))"
+OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -funroll-loops -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(INLINE_FLAGS) $(TRACE_GCC_FLAG))"
+PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -funroll-loops -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(INLINE_FLAGS) $(TRACE_GCC_FLAG))"
 
 ifeq (on, ${GPDBGINLINE})
 CFLAGS_INLINE=$(INLINE_FLAGS)
@@ -167,7 +167,7 @@ else
 DEBUG_CFLAGS_OPT=-g3
 endif
 
-DEBUGFLAGS="$(strip $(CFLAGS_INLINE) $(CFLAGS_OPT) $(DEBUG_CFLAGS_OPT) $(TRACE_GCC_FLAG))"
+DEBUGFLAGS="$(strip $(BLD_CFLAGS) $(CFLAGS_INLINE) $(CFLAGS_OPT) $(DEBUG_CFLAGS_OPT) $(TRACE_GCC_FLAG))"
 
 #---------------------------------------------------------------------
 # configure

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -145,6 +145,7 @@ export NO_M64=1
 
 # 32-bit/64-bit compiler/linker flag settings
 hpux_ia64_BLD_CFLAGS=-mlp64 -D_XOPEN_SOURCE_EXTENDED
+osx106_x86_BLD_CFLAGS=-m32 -march=i686
 rhel6_x86_64_BLD_CFLAGS=-m64
 rhel5_x86_64_BLD_CFLAGS=-m64
 rhel5_x86_32_BLD_CFLAGS=-m32


### PR DESCRIPTION
For OSX commercial builds, instruct the gcc compiler to produce
i686 (CPU) instructions.  This is needed to support an upstream
PostgreSQL merge which uses atomic instructions introduced in one of
those later CPUs.

Previously, there was no autoconf test for those instructions, and we
just compiled hand-crafted assembly to use those instructions anyway,
even though the rest of the compiler was targeting the older cpus.

reference: https://wiki.gentoo.org/wiki/GCC_optimization#-march

  Different CPUs have different capabilities, support different
  instruction sets, and have different ways of executing code. The
  -march flag will instruct the compiler to produce specific code for
  the system's CPU, with all its capabilities, features, instruction
  sets, quirks, and so on.

@hlinnaka - NOTE: I have tested this by pulling your dev fork's master branch and applying the change.  L1 and L2 builds passed.