### PR TITLE
Silence compiler warnings in src/backend/gpopt code

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4965,7 +4965,7 @@ CTranslatorDXLToPlStmt::PrteFromTblDescr
 			// add those to the RTE as they are required by GPDB
 			for (INT iDroppedColAttno = iLastAttno + 1; iDroppedColAttno < iAttno; iDroppedColAttno++)
 			{
-				Value *pvalDroppedColName = gpdb::PvalMakeString("");
+				Value *pvalDroppedColName = gpdb::PvalMakeString(PStrDup(""));
 				palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalDroppedColName);
 			}
 			
@@ -4990,7 +4990,7 @@ CTranslatorDXLToPlStmt::PrteFromTblDescr
 	// if there are any dropped columns at the end, add those too to the RangeTblEntry
 	for (ULONG ul = iLastAttno + 1; ul <= ulRelColumns; ul++)
 	{
-		Value *pvalDroppedColName = gpdb::PvalMakeString("");
+		Value *pvalDroppedColName = gpdb::PvalMakeString(PStrDup(""));
 		palias->colnames = gpdb::PlAppendElement(palias->colnames, pvalDroppedColName);
 	}
 	

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3929,7 +3929,7 @@ CDXLNode *
 CTranslatorQueryToDXL::PdxlnPrEFromGPDBExpr
 	(
 	Expr *pexpr,
-	CHAR *szAliasName,
+	const CHAR *szAliasName,
 	BOOL fInsistNewColIds
 	)
 {

--- a/src/backend/gpopt/utils/nodeutils.cpp
+++ b/src/backend/gpopt/utils/nodeutils.cpp
@@ -43,7 +43,7 @@ char *textToString(text *pt)
 //		String to text type. Caller is responsible for freeing memory.
 //---------------------------------------------------------------------------
 
-text *stringToText(char *sz)
+text *stringToText(const char *sz)
 {
 	int len = (int) (strlen(sz) + VARHDRSZ);
 	text *ptResult = (text *) palloc(len + VARHDRSZ);

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -479,8 +479,8 @@ FaultInjectorType_e
 FaultInjector_InjectFaultIfSet(
 							   FaultInjectorIdentifier_e identifier,
 							   DDLStatement_e			 ddlStatement,
-							   char*					 databaseName,
-							   char*					 tableName)
+							   const char*					 databaseName,
+							   const char*					 tableName)
 {
 	
 	FaultInjectorEntry_s   *entryShared, localEntry,

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -332,7 +332,7 @@ namespace gpdxl
 				);
 
 			// translate a target list entry or a join alias entry into a project element
-			CDXLNode *PdxlnPrEFromGPDBExpr(Expr *pexpr, CHAR *szAliasName, BOOL fInsistNewColIds = false);
+			CDXLNode *PdxlnPrEFromGPDBExpr(Expr *pexpr, const CHAR *szAliasName, BOOL fInsistNewColIds = false);
 
 			// translate a CTE into a DXL logical CTE operator
 			CDXLNode *PdxlnFromCTE

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -98,12 +98,6 @@ TupleTableSlot *ExecutorRun(QueryDesc *pqueryDesc, ScanDirection direction, long
 extern
 void ExecutorEnd(QueryDesc *pqueryDesc);
 
-extern FaultInjectorType_e FaultInjector_InjectFaultIfSet(
-							   FaultInjectorIdentifier_e identifier,
-							   DDLStatement_e			 ddlStatement,
-							   char*					 databaseName,
-							   char*					 tableName);
-
 } // end extern C
 
 

--- a/src/include/gpopt/utils/nodeutils.h
+++ b/src/include/gpopt/utils/nodeutils.h
@@ -20,7 +20,7 @@ extern struct List *extract_nodes(struct Node *ps, int nodeTag);
 // String related functionality.
 
 extern char *textToString(text *pt);
-extern text *stringToText(char *sz);
+extern text *stringToText(const char *sz);
 extern struct Const *stringToConst(char *sz);
 extern char *constToString(Const *pconst);
 

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -351,8 +351,8 @@ extern void FaultInjector_ShmemInit(void);
 extern FaultInjectorType_e FaultInjector_InjectFaultIfSet(
 							   FaultInjectorIdentifier_e identifier,
 							   DDLStatement_e			 ddlStatement,
-							   char*					 databaseName,
-							   char*					 tableName);
+							   const char*				 databaseName,
+							   const char*				 tableName);
 
 extern int FaultInjector_SetFaultInjection(
 							FaultInjectorEntry_s	*entry);


### PR DESCRIPTION
This patch, together with pull request #137, eliminates all compiler warnings I'm seeing from src/backend/gpopt on my laptop.