### PR TITLE
Fix dead loop, and fix gpdiff.pl, atmsort.pm, explain.pm format issue by replace tab with space

### DIFF
--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -58,18 +58,18 @@ my $equiv_expected_rows;
 sub atmsort_init
 {
     my %args = (
-		# defaults
-		IGNORE_HEADERS	=> 0,
-		IGNORE_PLANS	=> 0,
-		INIT_FILES		=> [],
-		DO_EQUIV		=> 'ignore',	# can be 'ignore', 'compare', or 'make'
-		ORDER_WARN		=> 0,
-		VERBOSE			=> 0,
+        # defaults
+        IGNORE_HEADERS  => 0,
+        IGNORE_PLANS    => 0,
+        INIT_FILES      => [],
+        DO_EQUIV        => 'ignore',    # can be 'ignore', 'compare', or 'make'
+        ORDER_WARN      => 0,
+        VERBOSE         => 0,
 
-		# override the defaults from argument list
-		@_
+        # override the defaults from argument list
+        @_
     );
-    
+
     $glob_compare_equiv       = 0;
     $glob_make_equiv_expected = 0;
     $glob_ignore_headers      = 0;
@@ -77,9 +77,9 @@ sub atmsort_init
     $glob_ignore_whitespace   = 0;
     @glob_init                = ();
 
-	$glob_orderwarn           = 0;
-	$glob_verbose             = 0;
-	$glob_fqo                 = {count => 0};
+    $glob_orderwarn           = 0;
+    $glob_verbose             = 0;
+    $glob_fqo                 = {count => 0};
 
     my $compare_equiv = 0;
     my $make_equiv_expected = 0;
@@ -92,21 +92,21 @@ sub atmsort_init
 
     if ($args{DO_EQUIV} =~ m/^(ignore)/i)
     {
-		# ignore all - default
+        # ignore all - default
     }
     elsif ($args{DO_EQUIV} =~ m/^(compare)/i)
     {
-		# compare equiv region
-		$compare_equiv = 1;
+        # compare equiv region
+        $compare_equiv = 1;
     }
-    elsif ($args{DO_EQUIV} =~ m/^(make)/i)            
+    elsif ($args{DO_EQUIV} =~ m/^(make)/i)
     {
-		# make equiv expected output
-		$make_equiv_expected = 1;
+        # make equiv expected output
+        $make_equiv_expected = 1;
     }
     else
     {
-		die "unknown do_equiv option: $do_equiv\nvalid options are:\n\tdo_equiv=compare\n\tdo_equiv=make";
+        die "unknown do_equiv option: $do_equiv\nvalid options are:\n\tdo_equiv=compare\n\tdo_equiv=make";
     }
     $glob_compare_equiv       = $compare_equiv;
     $glob_make_equiv_expected = $make_equiv_expected;
@@ -118,8 +118,8 @@ sub atmsort_init
 
     @glob_init = @{$args{INIT_FILES}};
 
-	$glob_orderwarn           = $args{ORDER_WARN};
-    $glob_verbose      		  = $args{VERBOSE};
+    $glob_orderwarn           = $args{ORDER_WARN};
+    $glob_verbose             = $args{VERBOSE};
 
     init_match_subs();
     init_matchignores();
@@ -211,13 +211,13 @@ sub _build_match_subs
 
             # store the function pointer and the text of the function
             # definition
-            push @{$glob_match_then_sub_fnlist}, 
-			[$fn1, $bigdef, $cmt, $defi->[0], $defi->[1]];
+            push @{$glob_match_then_sub_fnlist},
+            [$fn1, $bigdef, $cmt, $defi->[0], $defi->[1]];
 
-			if ($glob_verbose)
-			{
-				print $atmsort_outfh "GP_IGNORE: Defined $cmt\t$defi->[0]\t$defi->[1]\n"
-			}
+            if ($glob_verbose)
+            {
+                print $atmsort_outfh "GP_IGNORE: Defined $cmt\t$defi->[0]\t$defi->[1]\n"
+            }
         }
         else
         {
@@ -230,7 +230,7 @@ sub _build_match_subs
     }
 
 #    print Data::Dumper->Dump($glob_match_then_sub_fnlist);
-   
+
     return $stat;
 
 } # end _build_match_subs
@@ -239,7 +239,7 @@ sub _build_match_subs
 sub init_match_subs
 {
     my $here_matchsubs;
-	
+
 
 # construct a "HERE" document of match expressions followed by
 # substitution expressions.  Embedded comments and blank lines are ok
@@ -281,7 +281,7 @@ s/connection.*failed.*(http|gpfdist).*/connection failed dummy_protocol\:\/\/DUM
 EOF_matchsubs
 
     $glob_match_then_sub_fnlist = [];
-	
+
     my $stat = _build_match_subs($here_matchsubs, "DEFAULT");
 
     if (scalar(@{$stat}) > 1)
@@ -300,22 +300,22 @@ sub match_then_subs
 
         # get the function and execute it
         my $fn1 = $ff->[0];
-		if (!$glob_verbose)
-		{
-			$ini = &$fn1($ini);
-		}
-		else
-		{
-			my $subs = &$fn1($ini);
+        if (!$glob_verbose)
+        {
+            $ini = &$fn1($ini);
+        }
+        else
+        {
+            my $subs = &$fn1($ini);
 
-			unless ($subs eq $ini)
-			{
-				print $atmsort_outfh "GP_IGNORE: was: $ini";				
-				print $atmsort_outfh "GP_IGNORE: matched $ff->[-3]\t$ff->[-2]\t$ff->[-1]\n"
-			}
+            unless ($subs eq $ini)
+            {
+                print $atmsort_outfh "GP_IGNORE: was: $ini";
+                print $atmsort_outfh "GP_IGNORE: matched $ff->[-3]\t$ff->[-2]\t$ff->[-1]\n"
+            }
 
-			$ini = &$fn1($ini);
-		}
+            $ini = &$fn1($ini);
+        }
 
     }
     return $ini;
@@ -345,7 +345,7 @@ sub _build_match_ignores
     {
         next
             if ($lin =~ m/^\s*$/); # skip blanks
-        
+
         push @{$matchignores_arr}, $lin;
     }
 
@@ -373,12 +373,12 @@ sub _build_match_ignores
 
             # store the function pointer and the text of the function
             # definition
-            push @{$glob_match_then_ignore_fnlist}, 
-			[$fn1, $bigdef, $cmt, $defi, "(ignore)"];
-			if ($glob_verbose)
-			{
-				print $atmsort_outfh "GP_IGNORE: Defined $cmt\t$defi\n"
-			}
+            push @{$glob_match_then_ignore_fnlist},
+            [$fn1, $bigdef, $cmt, $defi, "(ignore)"];
+            if ($glob_verbose)
+            {
+                print $atmsort_outfh "GP_IGNORE: Defined $cmt\t$defi\n"
+            }
 
         }
         else
@@ -392,7 +392,7 @@ sub _build_match_ignores
     }
 
 #    print Data::Dumper->Dump($glob_match_then_ignore_fnlist);
-   
+
     return $stat;
 
 } # end _build_match_ignores
@@ -456,14 +456,14 @@ sub match_then_ignore
         # get the function and execute it
         my $fn1 = $ff->[0];
 
-		if (&$fn1($ini))
-		{
-			if ($glob_verbose)
-			{
-				print $atmsort_outfh "GP_IGNORE: matched $ff->[-3]\t$ff->[-2]\t$ff->[-1]\n"
-			}
-			return 1; # matched
-		}
+        if (&$fn1($ini))
+        {
+            if ($glob_verbose)
+            {
+                print $atmsort_outfh "GP_IGNORE: matched $ff->[-3]\t$ff->[-2]\t$ff->[-1]\n"
+            }
+            return 1; # matched
+        }
     }
     return 0; # no match
 }
@@ -499,16 +499,16 @@ sub tablelizer
 
     return undef
         unless (scalar(@lines));
-    
+
     shift @lines # skip dashed separator (unless it was skipped already)
         unless (defined($got_line1));
-    
+
     my @rows;
 
     for my $lin (@lines)
     {
         my @cols = split(/\|/, $lin, scalar(@colheads));
-        last 
+        last
             unless (scalar(@cols) == scalar(@colheads));
 
         my $rowh = {};
@@ -533,81 +533,81 @@ sub format_explain
 {
     my ($outarr, $directive) = @_;
     my $prefix = "";
-	my $xopt = "perl"; # normal case
+    my $xopt = "perl"; # normal case
 
     $directive = {} unless (defined($directive));
-    
+
     # Ignore plan content if its between start_ignore and end_ignore blocks
     # or if -ignore_plans is specified.
     $prefix = "GP_IGNORE:"
          if (exists($directive->{ignore})) || ($glob_ignore_plans);
 
-	my @tmp_lines;
-	my $sort = 0;
+    my @tmp_lines;
+    my $sort = 0;
 
-	if (scalar(@{$outarr}))
-	{
-		@tmp_lines = (
-			"QUERY PLAN\n",
-			("-" x 71) . "\n",
-			@{$outarr},
-			"(111 rows)\n"
-			);
-	}
-		
-	if (exists($directive->{explain})
-		&& ($directive->{explain} =~ m/operator/i))
-	{
-		$xopt = "operator";
-		$sort = 1;
-	}
+    if (scalar(@{$outarr}))
+    {
+        @tmp_lines = (
+            "QUERY PLAN\n",
+            ("-" x 71) . "\n",
+            @{$outarr},
+            "(111 rows)\n"
+            );
+    }
 
-	my $xplan = '';
+    if (exists($directive->{explain})
+        && ($directive->{explain} =~ m/operator/i))
+    {
+        $xopt = "operator";
+        $sort = 1;
+    }
 
-	open(my $xplan_fh, ">", \$xplan)
-		or die "Can't open in-memory file handle to variable: $!";
+    my $xplan = '';
 
-	explain::explain_init(OPERATION => $xopt,
-				  PRUNE => 'heavily',
-				  INPUT_LINES => \@tmp_lines,
-				  OUTPUT_FH => $xplan_fh);
+    open(my $xplan_fh, ">", \$xplan)
+        or die "Can't open in-memory file handle to variable: $!";
 
-	explain::run();
+    explain::explain_init(OPERATION => $xopt,
+                  PRUNE => 'heavily',
+                  INPUT_LINES => \@tmp_lines,
+                  OUTPUT_FH => $xplan_fh);
 
-	close $xplan_fh;
+    explain::run();
 
-	my @lines = split /\n/, $xplan;
+    close $xplan_fh;
 
-	if ($sort && scalar(@lines) > 0)
-	{
-		@lines = sort @lines;
-	}
+    my @lines = split /\n/, $xplan;
 
-	# Apply prefix to each line, if requested.
-	if (defined($prefix) && length($prefix))
-	{
-		my @prefixedlines;
-	
-		foreach my $line (@lines)
-		{
-			$line = $prefix . $line;
-		}
-	}
+    if ($sort && scalar(@lines) > 0)
+    {
+        @lines = sort @lines;
+    }
 
-	# Put back newlines
-	foreach my $line (@lines)
-	{
-		$line .= "\n";
-	}
+    # Apply prefix to each line, if requested.
+    if (defined($prefix) && length($prefix))
+    {
+        my @prefixedlines;
 
-	# Print it
-	foreach my $line (@lines)
-	{
-		print $atmsort_outfh $line;
-	}
+        foreach my $line (@lines)
+        {
+            $line = $prefix . $line;
+        }
+    }
 
-	return  \@lines;
-}    
+    # Put back newlines
+    foreach my $line (@lines)
+    {
+        $line .= "\n";
+    }
+
+    # Print it
+    foreach my $line (@lines)
+    {
+        print $atmsort_outfh $line;
+    }
+
+    return  \@lines;
+}
 
 # reformat the query output according to the directive hash
 sub format_query_output
@@ -617,39 +617,39 @@ sub format_query_output
 
     $directive = {} unless (defined($directive));
 
-	$fqostate->{count} += 1;
+    $fqostate->{count} += 1;
 
-	if ($glob_verbose)
-	{
-		print $atmsort_outfh "GP_IGNORE: start fqo $fqostate->{count}\n";
-	}
+    if ($glob_verbose)
+    {
+        print $atmsort_outfh "GP_IGNORE: start fqo $fqostate->{count}\n";
+    }
 
     if (exists($directive->{make_equiv_expected}))
     {
-		# special case for EXPLAIN PLAN as first "query"
-		if (exists($directive->{explain}))
-		{
-			my $stat = format_explain($outarr, $directive);
+        # special case for EXPLAIN PLAN as first "query"
+        if (exists($directive->{explain}))
+        {
+            my $stat = format_explain($outarr, $directive);
 
-			# save the first query output from equiv as "expected rows"
+            # save the first query output from equiv as "expected rows"
 
-			if ($stat)
-			{
-				push @{$equiv_expected_rows}, @{$stat};
-			}
-			else
-			{
-				push @{$equiv_expected_rows}, @{$outarr};
-			}
+            if ($stat)
+            {
+                push @{$equiv_expected_rows}, @{$stat};
+            }
+            else
+            {
+                push @{$equiv_expected_rows}, @{$outarr};
+            }
 
-			if ($glob_verbose)
-			{
-				print $atmsort_outfh "GP_IGNORE: end fqo $fqostate->{count}\n";
-			}
+            if ($glob_verbose)
+            {
+                print $atmsort_outfh "GP_IGNORE: end fqo $fqostate->{count}\n";
+            }
 
-			return ;
+            return ;
 
-		}
+        }
 
         # save the first query output from equiv as "expected rows"
         push @{$equiv_expected_rows}, @{$outarr};
@@ -662,17 +662,17 @@ sub format_query_output
         push @{$outarr}, @{$equiv_expected_rows};
     }
 
-	# explain (if not in an equivalence region)
+    # explain (if not in an equivalence region)
     if (exists($directive->{explain}))
     {
        format_explain($outarr, $directive);
-	   if ($glob_verbose)
-	   {
-		   print $atmsort_outfh "GP_IGNORE: end fqo $fqostate->{count}\n";
-	   }
-	   return;
+       if ($glob_verbose)
+       {
+           print $atmsort_outfh "GP_IGNORE: end fqo $fqostate->{count}\n";
+       }
+       return;
     }
-	
+
     $prefix = "GP_IGNORE:"
         if (exists($directive->{ignore}));
 
@@ -692,10 +692,10 @@ sub format_query_output
 #            print "No tablelizer hash for $lines, $firstline\n";
 #            print STDERR "No tablelizer hash for $lines, $firstline\n";
 
-			if ($glob_verbose)
-			{
-				print $atmsort_outfh "GP_IGNORE: end fqo $fqostate->{count}\n";
-			}
+            if ($glob_verbose)
+            {
+                print $atmsort_outfh "GP_IGNORE: end fqo $fqostate->{count}\n";
+            }
 
             return;
         }
@@ -744,7 +744,7 @@ sub format_query_output
                 unless (scalar(@scols))
                 {
                     print $atmsort_outfh "invalid dependency specification: $colset[0]\n";
-                    print STDERR 
+                    print STDERR
                         "invalid dependency specification: $colset[0]\n";
                     next;
                 }
@@ -801,18 +801,18 @@ sub format_query_output
         }
 
         my %unsorth;
-        
+
         for my $col (@allcols)
         {
             $unsorth{$col} = 1;
         }
 
-		# clear sorted column list if just "order 0"
+        # clear sorted column list if just "order 0"
         if ((1 == scalar(@presortcols))
-			&& ($presortcols[0] eq "0"))
+            && ($presortcols[0] eq "0"))
         {
-			@presortcols = ();
-		}
+            @presortcols = ();
+        }
 
 
         for my $col (@presortcols)
@@ -845,7 +845,7 @@ sub format_query_output
 
                 @collist = ();
 
-#            print "hrow:",Data::Dumper->Dump([$h_row]), "\n";            
+#            print "hrow:",Data::Dumper->Dump([$h_row]), "\n";
 
                 for my $col (@presortcols)
                 {
@@ -857,7 +857,7 @@ sub format_query_output
                     else
                     {
                         my $maxcol = scalar(@allcols);
-                        my $errstr = 
+                        my $errstr =
                             "specified ORDER column out of range: $col vs $maxcol\n";
                         print $atmsort_outfh $errstr;
                         print STDERR $errstr;
@@ -887,7 +887,7 @@ sub format_query_output
 
                     @collist = ();
 
-#            print "hrow:",Data::Dumper->Dump([$h_row]), "\n";            
+#            print "hrow:",Data::Dumper->Dump([$h_row]), "\n";
 
                     for my $col (@{$mspec->{allcol}})
                     {
@@ -899,7 +899,7 @@ sub format_query_output
                         else
                         {
                             my $maxcol = scalar(@allcols);
-                            my $errstr = 
+                            my $errstr =
                             "specified MVD column out of range: $col vs $maxcol\n";
                             print $errstr;
                             print STDERR $errstr;
@@ -953,7 +953,7 @@ sub format_query_output
                 if (scalar(@presortcols))
                 {
                     $hd2 .= " ( " . join(", ", @presortcols) . ")";
-                    # have to compare all columns as unsorted 
+                    # have to compare all columns as unsorted
                     push @unsortcols, @presortcols;
                 }
             }
@@ -978,12 +978,12 @@ sub format_query_output
                 if (scalar(@mvd_nodeps))
                 {
                     $hd2 .= " (( " . join(", ", @mvd_nodeps) . "))";
-                    # have to compare all columns as unsorted 
+                    # have to compare all columns as unsorted
                     push @unsortcols, @mvd_nodeps;
                 }
 
             }
-            
+
         }
 
         print $hd2, "\n", "-"x(length($hd2)), "\n";
@@ -1007,7 +1007,7 @@ sub format_query_output
                     else
                     {
                         my $maxcol = scalar(@allcols);
-                        my $errstr = 
+                        my $errstr =
                             "specified UNSORT column out of range: $col vs $maxcol\n";
                         print $errstr;
                         print STDERR $errstr;
@@ -1025,10 +1025,10 @@ sub format_query_output
             }
         }
 
-		if ($glob_verbose)
-		{
-			print "GP_IGNORE: end fqo $fqostate->{count}\n";
-		}
+        if ($glob_verbose)
+        {
+            print "GP_IGNORE: end fqo $fqostate->{count}\n";
+        }
 
         return;
     } # end order
@@ -1055,7 +1055,7 @@ sub format_query_output
                 unless ($line =~ m/\n$/);
 
               push @ggg2, $line;
-           } 
+           }
            @ggg= @ggg2;
         }
 
@@ -1071,7 +1071,7 @@ sub format_query_output
                my $fl2 = $directive->{firstline};
                my $sql_statement = $directive->{sql_statement};
                $sql_statement =~ s/\n/ /gm;
-               my @ocols = 
+               my @ocols =
                    ($sql_statement =~ m/select.*order.*by\s+(.*)\;/is);
 
 #               print Data::Dumper->Dump(\@ocols);
@@ -1093,10 +1093,10 @@ sub format_query_output
                {
                   my $ocolstr = shift @ocols;
                   my @ocols2  = split (/\,/, $ocolstr);
-                  
+
                   if (scalar(@ocols2) < scalar(@allcols2))
                   {
-				     print "GP_IGNORE: ORDER_WARNING: OUTPUT ",
+                     print "GP_IGNORE: ORDER_WARNING: OUTPUT ",
                      scalar(@allcols2), " columns, but ORDER BY on ",
                      scalar(@ocols2), " \n";
                   }
@@ -1130,7 +1130,7 @@ sub format_query_output
                 unless ($line =~ m/\n$/);
 
               push @ggg2, $line;
-           } 
+           }
            @ggg= sort @ggg2;
         }
         for my $line (@ggg)
@@ -1139,10 +1139,10 @@ sub format_query_output
         }
     }
 
-	if ($glob_verbose)
-	{
-		print "GP_IGNORE: end fqo $fqostate->{count}\n";
-	}
+    if ($glob_verbose)
+    {
+        print "GP_IGNORE: end fqo $fqostate->{count}\n";
+    }
 }
 
 
@@ -1246,11 +1246,11 @@ EOF_formatfix
         if ($big_ignore > 0)
         {
             if (($ini =~ m/\-\-\s*end\_equiv\s*$/i) && !($do_equiv))
-            { 
+            {
                 $big_ignore -= 1;
             }
             if ($ini =~ m/\-\-\s*end\_ignore\s*$/i)
-            { 
+            {
                 $big_ignore -= 1;
             }
             print $atmsort_outfh "GP_IGNORE:", $ini;
@@ -1268,19 +1268,19 @@ EOF_formatfix
 
         if ($getrows) # getting rows from SELECT output
         {
-	    # The end of "result set" for a COPY TO STDOUT is a bit tricky
-	    # to find. There is no explicit marker for it. We look for a
-	    # line that looks like a SQL comment or a new query, or an ERROR.
-	    # This is not bullet-proof, but works for the current tests.
+        # The end of "result set" for a COPY TO STDOUT is a bit tricky
+        # to find. There is no explicit marker for it. We look for a
+        # line that looks like a SQL comment or a new query, or an ERROR.
+        # This is not bullet-proof, but works for the current tests.
             if ($copy_to_stdout_result &&
                 ($ini =~ m/\-\-/ ||
                  $ini =~ m/ERROR/ ||
-		 $ini =~ m/(copy)|(create)|(drop)|(select)|(insert)|(update)/i))
+         $ini =~ m/(copy)|(create)|(drop)|(select)|(insert)|(update)/i))
             {
                 my @ggg= sort @outarr;
                 for my $line (@ggg)
                 {
-		    print $atmsort_outfh $bpref, $line;
+            print $atmsort_outfh $bpref, $line;
                 }
 
                 @outarr = ();
@@ -1288,20 +1288,20 @@ EOF_formatfix
                 $has_order = 0;
                 $copy_to_stdout_result = 0;
 
-		# Process the row again, in case it begins another
-		# COPY TO STDOUT statement, or another query.
-		goto reprocess_row;
+        # Process the row again, in case it begins another
+        # COPY TO STDOUT statement, or another query.
+        goto reprocess_row;
             }
 
             # regex example: (5 rows)
             if ($ini =~ m/^\s*\(\d+\s+row(s)*\)\s*$/)
             {
                 format_query_output($glob_fqo,
-									$has_order, \@outarr, $directive);
-          
-      
-                # Always ignore the rowcount for explain plan out as the skeleton plans might be the 
-                # same even if the row counts differ because of session level GUCs. 
+                                    $has_order, \@outarr, $directive);
+
+
+                # Always ignore the rowcount for explain plan out as the skeleton plans might be the
+                # same even if the row counts differ because of session level GUCs.
                 if (exists($directive->{explain}))
                 {
                     $ini = "GP_IGNORE:" . $ini;
@@ -1314,7 +1314,7 @@ EOF_formatfix
             }
         }
         else # finding SQL statement or start of SELECT output
-        { 
+        {
             if (($ini =~ m/\-\-\s*start\_match(subs|ignore)\s*$/i))
             {
                 $define_match_expression = $ini;
@@ -1322,7 +1322,7 @@ EOF_formatfix
             }
             if (($ini =~ m/\-\-\s*start\_ignore\s*$/i) ||
                 (($ini =~ m/\-\-\s*start\_equiv\s*$/i) && !($do_equiv)))
-            { 
+            {
                 $big_ignore += 1;
 
                 for my $line (@outarr)
@@ -1334,7 +1334,7 @@ EOF_formatfix
                 print $atmsort_outfh "GP_IGNORE:", $ini;
                 next;
             }
-            elsif (($ini =~ m/\-\-\s*start\_equiv\s*$/i) && 
+            elsif (($ini =~ m/\-\-\s*start\_equiv\s*$/i) &&
                    $glob_make_equiv_expected)
             {
                 $equiv_expected_rows = [];
@@ -1348,13 +1348,13 @@ EOF_formatfix
 
             # Note: \d is for the psql "describe"
             if ($ini =~ m/(insert|update|delete|select|\\d|copy)/i)
-            {                
+            {
                 $copy_to_stdout_result = 0;
                 $has_order = 0;
                 $sql_statement = "";
 
                 if ($ini =~ m/explain.*(insert|update|delete|select)/i)
-                { 
+                {
                    $directive->{explain} = "normal";
                 }
 
@@ -1362,26 +1362,26 @@ EOF_formatfix
 
             if ($ini =~ m/\-\-\s*force\_explain\s+operator.*$/i)
             {
-                # ENGINF-137: force_explain 
+                # ENGINF-137: force_explain
                 $directive->{explain} = "operator";
             }
             if ($ini =~ m/\-\-\s*force\_explain\s*$/i)
             {
-                # ENGINF-137: force_explain 
+                # ENGINF-137: force_explain
                 $directive->{explain} = "normal";
             }
             if ($ini =~ m/\-\-\s*ignore\s*$/i)
-            { 
+            {
                 $directive->{ignore} = "ignore";
             }
             if ($ini =~ m/\-\-\s*order\s+\d+.*$/i)
-            { 
+            {
                 my $olist = $ini;
                 $olist =~ s/^.*\-\-\s*order//;
                 $directive->{order} = $olist;
             }
             if ($ini =~ m/\-\-\s*mvd\s+\d+.*$/i)
-            { 
+            {
                 my $olist = $ini;
                 $olist =~ s/^.*\-\-\s*mvd//;
                 $directive->{mvd} = $olist;
@@ -1406,8 +1406,8 @@ EOF_formatfix
             {
                 $ini =~ s/\s+(\W)?(\W)?\(seg.*pid.*\)//;
 
-				# also remove line numbers from errors
-				$ini =~ s/\s+(\W)?(\W)?\(\w+\.[ch]:\d+\)/ (SOMEFILE:SOMEFUNC)/;
+                # also remove line numbers from errors
+                $ini =~ s/\s+(\W)?(\W)?\(\w+\.[ch]:\d+\)/ (SOMEFILE:SOMEFUNC)/;
                 my $outsize = scalar(@outarr);
 
                 my $lastguy = -1;
@@ -1450,11 +1450,11 @@ EOF_formatfix
             # and special case these guys:
             #  copy test1 to stdout
             #  \copy test1 to stdout
-	    my $matches_copy_to_stdout = 0;
+        my $matches_copy_to_stdout = 0;
             if ($ini =~ m/^copy\s+((\(select.*\))|\w+)\s+to stdout.*;$/i ||
                 $ini =~ m/^\\copy\s+((\(select.*\))|\w+)\s+to stdout.*$/i)
             {
-	        $matches_copy_to_stdout = 1;
+            $matches_copy_to_stdout = 1;
             }
             # regex example: ---- or ---+---
             # need at least 3 dashes to avoid confusion with "--" comments
@@ -1514,12 +1514,12 @@ EOF_formatfix
                 {
                     $ini = "GP_IGNORE:" . $ini;
                 }
-                
+
                 print $atmsort_outfh $apref, $ini;
 
                 if (defined($sql_statement)
                     && length($sql_statement)
-                    # multiline match 
+                    # multiline match
                     && ($sql_statement =~ m/select.*order.*by/is))
                 {
                     $has_order = 1; # so do *not* sort output
@@ -1553,10 +1553,10 @@ EOF_formatfix
             $ini =~ s/External table .*line (\d)+.*/External table DUMMY_EX, line DUMMY_LINE of DUMMY_LOCATION/;
               $ini =~ s/\s+/ /;
              # MPP-1557,AUTO-3: horrific ERROR DETAIL External Table trifecta
-			if ($glob_verbose)
-			{
-				print $atmsort_outfh "GP_IGNORE: External Table ERROR DETAIL fixup\n";
-			}
+            if ($glob_verbose)
+            {
+                print $atmsort_outfh "GP_IGNORE: External Table ERROR DETAIL fixup\n";
+            }
              if ($ini !~ m/^DETAIL/)
              {
                 # find a "blank" DETAIL tag preceding current line
@@ -1569,7 +1569,7 @@ EOF_formatfix
                    $error_detail_exttab_trifecta_skip = 1;
                 }
              }
-             if (scalar(@outarr) && 
+             if (scalar(@outarr) &&
                  ($outarr[-1] =~ m/^ERROR:\s+missing\s+data\s+for\s+column/))
              {
                 $outarr[-1] = "ERROR:  missing data for column DUMMY_COL\n";
@@ -1600,52 +1600,52 @@ L_push_outarr:
 # The arguments are input and output file names
 sub run
 {
-	my $infname = shift;
-	my $outfname = shift;
+    my $infname = shift;
+    my $outfname = shift;
 
-	open my $infh,  '<', $infname  or die "could not open $infname: $!";
-	open my $outfh, '>', $outfname or die "could not open $outfname: $!";
+    open my $infh,  '<', $infname  or die "could not open $infname: $!";
+    open my $outfh, '>', $outfname or die "could not open $outfname: $!";
 
-	run_fhs($infh, $outfh);
+    run_fhs($infh, $outfh);
 
-	close $infh;
-	close $outfh;
+    close $infh;
+    close $outfh;
 }
 
 # The arguments are input and output file handles
 sub run_fhs
 {
-	my $infh = shift;
-	my $outfh = shift;
+    my $infh = shift;
+    my $outfh = shift;
 
-	# allow multiple init files
-	if (@glob_init)
-	{
-		my $devnullfh;
-		my $init_file_fh;
-	
-		open $devnullfh, "> /dev/null" or die "can't open /dev/null: $!";
+    # allow multiple init files
+    if (@glob_init)
+    {
+        my $devnullfh;
+        my $init_file_fh;
 
-		for my $init_file (@glob_init)
-		{
-			die "no such file: $init_file"
-			unless (-e $init_file);
+        open $devnullfh, "> /dev/null" or die "can't open /dev/null: $!";
 
-			# Perform initialization from this init_file by passing it
-			# to bigloop. Open the file, and pass that as the input file
-			# handle, and redirect output to /dev/null.
-			open $init_file_fh, "< $init_file" or die "could not open $init_file: $!";
+        for my $init_file (@glob_init)
+        {
+            die "no such file: $init_file"
+            unless (-e $init_file);
 
-			atmsort_bigloop($init_file_fh, $devnullfh);
+            # Perform initialization from this init_file by passing it
+            # to bigloop. Open the file, and pass that as the input file
+            # handle, and redirect output to /dev/null.
+            open $init_file_fh, "< $init_file" or die "could not open $init_file: $!";
 
-			close $init_file_fh;
-		}
+            atmsort_bigloop($init_file_fh, $devnullfh);
 
-		close $devnullfh;
-	}
+            close $init_file_fh;
+        }
 
-	# loop over input file.
-	atmsort_bigloop($infh, $outfh);
+        close $devnullfh;
+    }
+
+    # loop over input file.
+    atmsort_bigloop($infh, $outfh);
 }
 
 1;

--- a/src/test/regress/explain.pm
+++ b/src/test/regress/explain.pm
@@ -823,7 +823,7 @@ sub run
         }
         else
         {
-            last if ($lineno == $#glob_in_lines);
+            last if ($#glob_in_lines < 0 || $lineno == $#glob_in_lines);
             $ini = $glob_in_lines[$lineno];
         }
         $lineno++;

--- a/src/test/regress/explain.pm
+++ b/src/test/regress/explain.pm
@@ -9,25 +9,25 @@ use warnings;
 # IMPLEMENTATION NOTES:
 #
 # EXPLAIN ANALYZE final statistics in analyze_node:
-# 
+#
 # The final statistics look like this:
-# 
+#
 #  Slice statistics:
 #    (slice0)    Executor memory: 472K bytes.
 #    (slice1)    Executor memory: 464K bytes avg x 2 workers, 464K bytes max (seg0).
 #  Settings:
-# 
+#
 #  Total runtime: 52347.493 ms
-# 
+#
 # The "Settings" entry is optional (ie, it only exists if you change the
 # settings in your session).  If the "Settings" entry is missing explain.pl
 # adds a dummy entry to the statistics.  This technique is a bit easier
 # than changing the parser to handle both cases.
 #
 # Parse_node:
-#   InitPlan entries in greenplum are in separate slices, so explain.pl 
+#   InitPlan entries in greenplum are in separate slices, so explain.pl
 #   prefixes them with an arrow (and adds a fake cost) to make them
-#   look like a top-level execution node.  Again, this technique was 
+#   look like a top-level execution node.  Again, this technique was
 #   easier than modifying the parser to special case InitPlan.
 #
 #  Plan parsing in general:
@@ -56,7 +56,7 @@ use warnings;
 #  explain.pl only fixes them up for dot output, but not for yaml, perl, etc.
 #  The rationale is that dot handle digraphs nicely, but yaml and perl are
 #  more suitable for tree output.
-# 
+#
 
 my $outfh; # current output file handle
 my $outfh_need_close = 0;
@@ -245,12 +245,12 @@ sub dodumpcolor
 
         for my $cc (@{$coltab->{$ggg[$ii]}})
         {
-            print $fh '"' . $ii. '" -> "' . $ii. "." . $jj. '"' 
+            print $fh '"' . $ii. '" -> "' . $ii. "." . $jj. '"'
                 . " [len=1];\n";
             $jj++;
         }
     }
-    
+
     print $fh '"root" [label="color schemes"]' . ";\n";
 
     for my $ii (0..(scalar(@ggg)-1))
@@ -259,9 +259,9 @@ sub dodumpcolor
 
         my $jj = 0;
 
-        for my $cc (@{$coltab->{$ggg[$ii]}}) 
+        for my $cc (@{$coltab->{$ggg[$ii]}})
         {
-            print $fh '"' . $ii . "." . $jj . 
+            print $fh '"' . $ii . "." . $jj .
                 '" [label="", style=filled, ' .
                 'fillcolor="' . $cc . '"]' . ";\n";
             $jj++;
@@ -275,25 +275,25 @@ sub dodumpcolor
 sub explain_init
 {
     my %args = (
-		# defaults
-		QUERY_LIST => [],
-		OPERATION => 'YAML',
-		INPUT_FH => undef,
-		INPUT_LINES => undef,
-		OUTPUT => undef,
-		OUTPUT_FH => undef,
-		DIRECTION => 'BT',
-		COLOR_SCHEME => 'set28',
-		TIMELINE => '',
-		PRUNE => undef,
-		STATCOLOR => undef,
-		EDGE_SCHEME => undef,
+        # defaults
+        QUERY_LIST => [],
+        OPERATION => 'YAML',
+        INPUT_FH => undef,
+        INPUT_LINES => undef,
+        OUTPUT => undef,
+        OUTPUT_FH => undef,
+        DIRECTION => 'BT',
+        COLOR_SCHEME => 'set28',
+        TIMELINE => '',
+        PRUNE => undef,
+        STATCOLOR => undef,
+        EDGE_SCHEME => undef,
 
-		# override the defaults from argument list
-		@_
+        # override the defaults from argument list
+        @_
     );
 
-	my @qlst = @{$args{QUERY_LIST}};
+    my @qlst = @{$args{QUERY_LIST}};
 
     $glob_optn = $args{OPERATION};
     $glob_optn = "jpg" if ($glob_optn =~ m/^jpeg/i);
@@ -303,14 +303,14 @@ sub explain_init
 
     if (defined($args{INPUT_FH}))
     {
-	$glob_in_fh = $args{INPUT_FH};
+    $glob_in_fh = $args{INPUT_FH};
     } elsif(defined($args{INPUT_LINES}))
     {
-	@glob_in_lines = @{$args{INPUT_LINES}};
+    @glob_in_lines = @{$args{INPUT_LINES}};
     }
     else
     {
-	die "INPUT_FH or INPUT_LINES argument must be given";
+    die "INPUT_FH or INPUT_LINES argument must be given";
     }
 
     my $DEFAULT_COLOR = "set28";
@@ -358,7 +358,7 @@ sub explain_init
             dodumpcolor(\%glob_coltab, $tmpfh);
 
             close $tmpfh;
-            
+
             my $catcmd = "cat $tmpnam";
 
             # format with neato if jpg was specified
@@ -378,7 +378,7 @@ sub explain_init
             }
 
             system($catcmd);
-            
+
             unlink $tmpnam;
 
             exit(0);
@@ -388,7 +388,7 @@ sub explain_init
             my $colorschemelist = join("\n", sort(keys(%glob_coltab))) . "\n";
 
             # identify the default color
-            $colorschemelist =~ 
+            $colorschemelist =~
                 s/$DEFAULT_COLOR/$DEFAULT_COLOR  \(default\)/gm;
 
             print "\nvalid color schemes are:\n";
@@ -422,21 +422,21 @@ sub analyze_node
             my $t1 = $node->{txt};
 
             # NOTE: the final statistics look something like this:
-            
+
             # Slice statistics:
             #   (slice0)    Executor memory: 472K bytes.
             #   (slice1)    Executor memory: 464K bytes avg x 2 workers, 464K bytes max (seg0).
             # Settings:
             # Total runtime: 52347.493 ms
 
-            # (we've actually added some vertical bars so it might look 
+            # (we've actually added some vertical bars so it might look
             # like this):
             # || Slice statistics:
             # ||   (slice0)    Executor memory: 472K bytes.
 
             # NB: the "Settings" entry is optional, so
             # add Settings if they are missing
-            unless ($t1 =~ 
+            unless ($t1 =~
                     m/Slice\s+statistics.*Settings.*Total\s+runtime/s)
             {
                 $t1 =~
@@ -444,7 +444,7 @@ sub analyze_node
             }
 
             my @foo = ($t1 =~ m/Slice\s+statistics\:\s+(.*)\s+Settings\:\s+(.*)\s+Total\s+runtime:\s+(.*)\s+ms/s);
-            
+
             if (scalar(@foo) == 3)
             {
                 my $mem  = shift @foo;
@@ -520,7 +520,7 @@ sub analyze_node
             {
                 $node->{short} = "";
             }
-        
+
             # last try!!
             unless (defined($node->{short}) && length($node->{short}))
             {
@@ -565,14 +565,14 @@ sub analyze_node
             if ($node->{txt} =~ m/(\d+(\.\d*)?)(\s*ms\s*to\s*end)/i)
             {
 
-                my @ggg = 
+                my @ggg =
                     ($node->{txt} =~ m/(\d+(\.\d*)?)(\s*ms\s*to\s*end)/i);
-            
+
 #                print join('*', @ggg), "\n";
 
                 my $tt = $ggg[0];
 
-                $node->{to_end} = $tt; 
+                $node->{to_end} = $tt;
 
                 $parse_ctx->{alltimes}->{$tt} = 1;
 
@@ -585,15 +585,15 @@ sub analyze_node
                     $parse_ctx->{h_to_end}->{$tt} = ['"'. $node->{id} . '"'];
                 }
 
-                    
+
 
             }
             if ($node->{txt} =~ m/(\d+(\.\d*)?)(\s*ms\s*to\s*first\s*row)/i)
             {
 
-                my @ggg = 
+                my @ggg =
                     ($node->{txt} =~ m/(\d+(\.\d*)?)(\s*ms\s*to\s*first\s*row)/i);
-            
+
 #                print join('*', @ggg), "\n";
 
                 my $tt = $ggg[0];
@@ -616,14 +616,14 @@ sub analyze_node
             if ($node->{txt} =~ m/start offset by (\d+(\.\d*)?)(\s*ms)/i)
             {
 
-                my @ggg = 
+                my @ggg =
                     ($node->{txt} =~ m/start offset by (\d+(\.\d*)?)(\s*ms)/i);
-            
+
 #                print join('*', @ggg), "\n";
 
                 my $tt = $ggg[0];
 
-                $node->{to_startoff} = $tt; 
+                $node->{to_startoff} = $tt;
 
                 $parse_ctx->{allstarttimes}->{$tt} = 1;
 
@@ -639,7 +639,7 @@ sub analyze_node
 
             if (exists($node->{to_end}))
             {
-                $node->{total_time} = 
+                $node->{total_time} =
                     (exists($node->{to_first})) ?
                     ($node->{to_end} - $node->{to_first}) :
                     $node->{to_end};
@@ -653,7 +653,7 @@ sub analyze_node
             if (exists($node->{child}))
             {
                 delete $node->{child}
-                  unless (defined($node->{child}) 
+                  unless (defined($node->{child})
                           && scalar(@{$node->{child}}));
             }
         }
@@ -689,7 +689,7 @@ sub parse_node
             $node->{child} = [];
 
             $node->{txt} = "";
-    
+
             $node->{parent} = $parent
                 if (defined($parent));
 
@@ -699,7 +699,7 @@ sub parse_node
             $node->{id} = $id;
         }
 
-        # XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX 
+        # XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX XXX
         # make initplan into a fake node so the graphs look nicer (eg
         # tpch query 15).  Prefix it with an arrow and add a fake cost.
         if ($row =~ m/\|(\s)*InitPlan(.*)slice/)
@@ -755,7 +755,7 @@ sub parse_node
             {
                 # found a child
                 push @{$node->{child}}, parse_node($ref_id, $parse_ctx,
-                                                   $spclen, $plan_rows, 
+                                                   $spclen, $plan_rows,
                                                    $node->{id});
             }
 
@@ -770,7 +770,7 @@ sub parse_node
                 if (defined($node) && exists($node->{txt}))
                 {
                     analyze_node($node, $parse_ctx);
-                    
+
                     return $node;
                 }
             }
@@ -784,7 +784,7 @@ sub parse_node
         $no_more_text = 1;
 
     } # end while
-    
+
     if (defined($node))
     {
         analyze_node($node, $parse_ctx);
@@ -798,36 +798,36 @@ sub parse_node
 sub run
 {
     my @bigarr;
-    
+
     my $state = "INIT";
-    
+
     my $pair = undef;
-    
+
     my ($query, $plan);
-    
+
     my $tpch_format=0;
     my $bigdash = '-' x 40; # make big dash smaller
 
     my $magic;
 
-	my $lineno = 0;
-	
+    my $lineno = 0;
+
     while(1)
     {
-		my $ini;
+        my $ini;
 
-		if ($glob_in_fh)
-		{
-			$ini = <$glob_in_fh>;
-			last if (!defined($ini)); # EOF
-		}
-		else
-		{
-			last if ($lineno == $#glob_in_lines);
-			$ini = $glob_in_lines[$lineno];
-		}
-		$lineno++;
-		
+        if ($glob_in_fh)
+        {
+            $ini = <$glob_in_fh>;
+            last if (!defined($ini)); # EOF
+        }
+        else
+        {
+            last if ($lineno == $#glob_in_lines);
+            $ini = $glob_in_lines[$lineno];
+        }
+        $lineno++;
+
         if ($state =~ m/INIT/)
         {
             if ($ini !~ m/(^EXPLAIN ANALYZE)|(QUERY PLAN)/)
@@ -918,9 +918,9 @@ sub run
 
                 $query .= $ini;
             }
-            
+
         } # end not getplan
-        
+
         if ($state =~ m/GETPLAN/)
         {
 
@@ -940,10 +940,10 @@ sub run
                     next;
                 }
             }
-			# a bit weird here -- just ignore the separator.  But
-			# maybe we should invest some effort to determine that the
-			# separator is the next line after the header (and only
-			# ignore it once) ?
+            # a bit weird here -- just ignore the separator.  But
+            # maybe we should invest some effort to determine that the
+            # separator is the next line after the header (and only
+            # ignore it once) ?
             next
                 if ($ini =~ m/$bigdash/);
 
@@ -958,7 +958,7 @@ sub run
 
             $plan .= $ini;
         }
-        
+
     } # end big for
     if (defined($pair))
     {
@@ -966,17 +966,17 @@ sub run
         $pair->{query} = $query;
         push @bigarr, $pair;
     }
-    
+
 #print scalar(@bigarr), "\n";
-    
-    
+
+
 #print Data::Dumper->Dump(\@bigarr);
-    
+
 #print $bigarr[0]->{plan};
 
     unless(scalar(@{$glob_qlist}))
     {
-        # build a 1-based list of queries 
+        # build a 1-based list of queries
         for (my $ii =1; $ii <= scalar(@bigarr); $ii++)
         {
             push @{$glob_qlist}, $ii;
@@ -992,7 +992,7 @@ sub run
             warn("specified query $qqq is out-of-range -- skipping...\n");
             next;
         }
-        
+
         if ($glob_optn =~ m/query|text|txt/i)
         {
             doquery($bigarr[$qnum]->{query});
@@ -1003,14 +1003,14 @@ sub run
 
         unless (defined($plantxt) && length($plantxt))
         {
-            warn("invalid plan for query $qqq -- skipping...\n");   
+            warn("invalid plan for query $qqq -- skipping...\n");
             next;
         }
-        
+
 #print $plantxt, "\n";
-        
+
         my @plan_r = split(/\n/, $plantxt);
-        
+
         my $pr = \@plan_r;
 
         my $parse_ctx = {};
@@ -1026,10 +1026,10 @@ sub run
         $parse_ctx->{explain_analyze_stats} = {};
 
         my $plantree = parse_node(\$id, $parse_ctx, 0, $pr);
-        
+
 #        my @timelist = sort {$a <=> $b} keys (%{$parse_ctx->{alltimes}});
         my @timelist = sort {$a <=> $b} keys (%{$parse_ctx->{allstarttimes}});
-        
+
 
         if (defined($glob_prune))
         {
@@ -1062,7 +1062,7 @@ sub run
         if ($glob_optn =~ m/magic/i)
         {
             $glob_optn = "jpg";
-            
+
             use IO::File;
             use POSIX qw(tmpnam);
 
@@ -1086,17 +1086,17 @@ sub run
             # reset output file name to create files in the new
             # temporary directory
             $glob_outi = File::Spec->catfile($tmpdir, "query_");
-            
-            $magic = $glob_outi;    
+
+            $magic = $glob_outi;
         }
 
         if ($glob_outi)
         {
-			if ($outfh_need_close)
-			{
-				close $outfh;
-				$outfh_need_close = 0;
-			}
+            if ($outfh_need_close)
+            {
+                close $outfh;
+                $outfh_need_close = 0;
+            }
 
             my $outfilename = $glob_outi;
 
@@ -1143,17 +1143,17 @@ sub run
             }
 
             open ($outfh, ">$outfilename" ) or die "can't open file $outfilename: $!";
-			$outfh_need_close = 1;
+            $outfh_need_close = 1;
 #            print $outfilename, "\n";
         }
-		elsif ($glob_outfh)
-		{
-			$outfh = $glob_outfh;
-		}
-		else
-		{
-			$outfh = *STDOUT;
-		}
+        elsif ($glob_outfh)
+        {
+            $outfh = $glob_outfh;
+        }
+        else
+        {
+            $outfh = *STDOUT;
+        }
 
         if ($glob_optn =~ m/yaml/i)
         {
@@ -1169,7 +1169,7 @@ sub run
         }
         if ($glob_optn =~ m/dot|graph/i)
         {
-            dodotfile($plantree, \@timelist, $qqq, $parse_ctx, 
+            dodotfile($plantree, \@timelist, $qqq, $parse_ctx,
                       $glob_direction);
         }
         if ($glob_optn =~ m/operator/i)
@@ -1208,10 +1208,10 @@ sub run
 
             close STDOUT;
             open (STDOUT, ">$tmpnam" ) or die "can't open STDOUT: $!";
- 
+
             select STDOUT; $| = 1;      # make unbuffered
 
-            dodotfile($plantree, \@timelist, $qqq, $parse_ctx, 
+            dodotfile($plantree, \@timelist, $qqq, $parse_ctx,
                       $glob_direction);
 
             close STDOUT;
@@ -1221,15 +1221,15 @@ sub run
 
             unlink $tmpnam;
 
-            
+
         }
     } #end for querynum
 
-	if ($outfh_need_close)
-	{
-		close $outfh;
-		$outfh_need_close = 0;
-	}
+    if ($outfh_need_close)
+    {
+        close $outfh;
+        $outfh_need_close = 0;
+    }
 
     # magically display all files
     if (defined($magic))
@@ -1258,8 +1258,8 @@ sub run
             }
         }
     }
-    
-} 
+
+}
 #print "\nmax id: $id\n\n";
 
 #
@@ -1286,7 +1286,7 @@ sub doDataDump
 {
     my $plantree = shift;
 
-    
+
     local $Data::Dumper::Indent   = 1;
     local $Data::Dumper::Terse    = 1;
     local $Data::Dumper::Sortkeys = 1;
@@ -1294,23 +1294,23 @@ sub doDataDump
     my $map_expr = 'delete $node->{txt};';
 #    my $map_expr = 'print "foo\n"';
     treeMap($plantree, undef, $map_expr);
-    
+
     print $outfh Data::Dumper->Dump([$plantree]);
 }
 
 sub doOperatorDump
 {
     my $plantree = shift;
-    
-	print $outfh $plantree->{short}, "\n" if (exists($plantree->{short}));
 
-	return
-		unless (exists($plantree->{child}));
+    print $outfh $plantree->{short}, "\n" if (exists($plantree->{short}));
 
-	for my $kid (@{$plantree->{child}})
-	{
-		doOperatorDump($kid);
-	}
+    return
+        unless (exists($plantree->{child}));
+
+    for my $kid (@{$plantree->{child}})
+    {
+        doOperatorDump($kid);
+    }
 }
 
 # add slice info to node
@@ -1320,22 +1320,22 @@ sub addslice
     my ($node, $ctx) = @_;
 
     # AUTO-6: find nodes with "(slice1)" info where the slice numbers aren't
-    # part of the "Slice statistics" 
+    # part of the "Slice statistics"
 
     my $txt1 = $node->{txt};
     $txt1 =~ s/Slice statistics.*//gs;
 
-    if ($txt1 =~ /(slice(\d+))/) 
-    { 
-        my @ggg = ($txt1 =~ m/(slice(\d+))/) ; 
-        $node->{slice} = shift @ggg; 
+    if ($txt1 =~ /(slice(\d+))/)
+    {
+        my @ggg = ($txt1 =~ m/(slice(\d+))/) ;
+        $node->{slice} = shift @ggg;
 
         # check if we have explain analyze stats for the slice
         if (exists($ctx->{explain_analyze_stats})
             && exists($ctx->{explain_analyze_stats}->{memory})
             && exists($ctx->{explain_analyze_stats}->{memory}->{$node->{slice}}))
         {
-            $node->{memory} = 
+            $node->{memory} =
                 $ctx->{explain_analyze_stats}->{memory}->{$node->{slice}};
         }
 
@@ -1366,7 +1366,7 @@ sub doyaml
             my $map_expr = 'delete $node->{txt};';
 
             treeMap($plantree, undef, $map_expr);
-    
+
             # because JSON is REQUIREd, not USEd, the symbols are not
             # imported into the environment.
             print $outfh JSON::objToJson($plantree, {pretty => 1, indent => 2});
@@ -1387,7 +1387,7 @@ sub doyaml
             my $map_expr = 'delete $node->{txt};';
 
             treeMap($plantree, undef, $map_expr);
-    
+
             # because YAML is REQUIREd, not USEd, the symbols are not
             # imported into the environment.
             print $outfh YAML::Dump($plantree);
@@ -1397,7 +1397,7 @@ sub doyaml
             die("Fatal Error: The required package YAML is not installed -- please download it from www.cpan.org\n");
             exit(1);
         }
-        
+
     }
 
 }
@@ -1407,30 +1407,30 @@ sub prune_heavily
 {
     my $node = shift;
 
-    return 
+    return
         unless (exists($node->{short}));
 
-	if ($node->{short} =~ m/Delete\s*\(slice.*segment.*\)\s*\(row.*width.*\)/)
-	{
-		# QA-1309: fix strange DELETE operator formatting
-		$node->{short} = "Delete";
-	}
-	elsif ($node->{short} =~ m/Update\s*\(slice.*segment.*\)\s*\(row.*width.*\)/)
+    if ($node->{short} =~ m/Delete\s*\(slice.*segment.*\)\s*\(row.*width.*\)/)
+    {
+        # QA-1309: fix strange DELETE operator formatting
+        $node->{short} = "Delete";
+    }
+    elsif ($node->{short} =~ m/Update\s*\(slice.*segment.*\)\s*\(row.*width.*\)/)
         {
                 # QA-1309: fix strange UPDATE operator formatting
                 $node->{short} = "Update";
         }
-	elsif ($node->{short} =~ m/\d+\:\d+/)
-	{
+    elsif ($node->{short} =~ m/\d+\:\d+/)
+    {
 
-		# example: Gather Motion 8:1 (slice4);
+        # example: Gather Motion 8:1 (slice4);
 
-		# strip the number of nodes and slice information
-		$node->{short} =~ s/\s+\d+\:\d+.*//;
+        # strip the number of nodes and slice information
+        $node->{short} =~ s/\s+\d+\:\d+.*//;
 
-		# Note: don't worry about removing "(slice1)" info from the
-		# "short" because addslice processes node->{text}
-	}
+        # Note: don't worry about removing "(slice1)" info from the
+        # "short" because addslice processes node->{text}
+    }
 }
 
 # identify the slice for each node
@@ -1461,14 +1461,14 @@ sub pre_slice
             # if the Shared Scan has a child it is the "primary"
             if (exists($node->{child}))
             {
-				my $share_short_fixup = $node->{short};
+                my $share_short_fixup = $node->{short};
 
-				# remove the slice number from the "short"
-				$share_short_fixup =~ s/(\d+)\:/\:/g;
+                # remove the slice number from the "short"
+                $share_short_fixup =~ s/(\d+)\:/\:/g;
 
                 if (!exists($ctx->{share_input_h}->{$share_short_fixup}))
                 {
-                    $ctx->{share_input_h}->{$share_short_fixup} = $node; 
+                    $ctx->{share_input_h}->{$share_short_fixup} = $node;
                 }
             }
             else # not the primary, mark as a duplicate node
@@ -1481,7 +1481,7 @@ sub pre_slice
             # choose first Multi Slice Motion node as primary
             if (!exists($ctx->{multi_slice_h}->{$node->{short}}))
             {
-                $ctx->{multi_slice_h}->{$node->{short}} = $node; 
+                $ctx->{multi_slice_h}->{$node->{short}} = $node;
             }
             else # not the primary, mark as a duplicate node
             {
@@ -1528,14 +1528,14 @@ sub sharedscan_fixup
 
     if (exists($node->{SharedScanDuplicate}))
     {
-		my $share_short_fixup = $node->{short};
+        my $share_short_fixup = $node->{short};
 
-		# remove the slice number from the "short"
-		$share_short_fixup =~ s/(\d+)\:/\:/g;
+        # remove the slice number from the "short"
+        $share_short_fixup =~ s/(\d+)\:/\:/g;
 
         $node->{SharedScanDuplicate} =
             $ctx->{share_input_h}->{$share_short_fixup};
-#        $node->{id} = 
+#        $node->{id} =
 #            $node->{SharedScanDuplicate}->{id};
     }
 
@@ -1544,7 +1544,7 @@ sub sharedscan_fixup
         $node->{MultiSliceMotionDuplicate} =
             $ctx->{multi_slice_h}->{$node->{short}};
         # XXX XXX: for this case the node is really the same
-        $node->{id} = 
+        $node->{id} =
             $node->{MultiSliceMotionDuplicate}->{id};
     }
 
@@ -1596,7 +1596,7 @@ sub nestedloop_fixup
         }
     }
 
-    return 
+    return
         unless (2 == scalar(@kidlist));
 
     if ($kidlist[0]->{id} < $kidlist[1]->{id})
@@ -1617,7 +1617,7 @@ sub get_rows_out
 {
     my ($node, $ctx, $edge) = @_;
 
-    return 
+    return
         unless ($node->{txt} =~ m/(Rows out\:)|(\(cost\=.*\s+rows=.*\s+width\=.*\))/);
 
     my $long = ($edge =~ m/long|med/i);
@@ -1627,10 +1627,10 @@ sub get_rows_out
         if (!$long)
         {
             # short result
-            my @foo = 
-                ($node->{txt} =~ 
+            my @foo =
+                ($node->{txt} =~
                  m/Rows out\:\s+Avg\s+(.*)\s+rows\s+x\s+(.*)\s+workers/);
-        
+
             goto L_get_est unless (2 == scalar(@foo));
 
             # calculate row count as avg x num workers
@@ -1638,10 +1638,10 @@ sub get_rows_out
         }
         else
         {
-            my @foo = 
-                ($node->{txt} =~ 
+            my @foo =
+                ($node->{txt} =~
                  m/Rows out\:\s+(Avg.*workers)/);
-        
+
             goto L_get_est unless (1 == scalar(@foo));
 
             # just print the string
@@ -1658,10 +1658,10 @@ sub get_rows_out
     }
     elsif ($node->{txt} =~ m/Rows out\:\s+.*\s+rows/)
     {
-        my @foo = 
-            ($node->{txt} =~ 
+        my @foo =
+            ($node->{txt} =~
              m/Rows out\:\s+(.*)\s+rows/);
-        
+
         goto L_get_est unless (1 == scalar(@foo));
 
         $node->{rows_out} = $foo[0];
@@ -1679,7 +1679,7 @@ sub get_rows_out
             my @foo = ($node->{rows_out} =~ m/(x.*)$/);
 
             my $tail = $foo[0];
-        
+
             @foo = ($node->{rows_out} =~ m/(.*)\s+x.*/);
 
             my $head = $foo[0];
@@ -1701,7 +1701,7 @@ sub get_rows_out
 L_get_est:
 
     # add row estimates
-    if ($long && 
+    if ($long &&
         ($node->{txt} =~ m/\(cost\=.*\s+rows=.*\s+width\=.*\)/))
     {
         my @foo = ($node->{txt} =~ m/cost\=.*\s+rows=(\d+)\s+width\=.*/);
@@ -1735,12 +1735,12 @@ sub calc_color_rank
 
     if ($ctx->{time_stats_h}->{cnt} > 1)
     {
-        # population variance = 
+        # population variance =
         # (sum of the squares)/n - (square of the sums)/n*n
         my $sum   = $ctx->{time_stats_h}->{sum};
         my $sumsq = $ctx->{time_stats_h}->{sumsq};
         my $enn   = $ctx->{time_stats_h}->{cnt};
-        
+
         my $pop_var = ($sumsq/$enn) - (($sum*$sum)/($enn*$enn));
         my $std_dev = sqrt($pop_var);
         my $mean    = $sum/$enn;
@@ -1814,38 +1814,38 @@ sub dodotfile
 
     {
         my $map_expr = 'addslice($node, $ctx); ';
-        
+
         treeMap($plantree, $map_expr, undef, $parse_ctx);
     }
 
 
 #    $map_expr = 'propslice($node, $ctx);';
-    my $ctx = {level => 0, a1 => [], 
-               share_input_h => {}, multi_slice_h => {}, 
+    my $ctx = {level => 0, a1 => [],
+               share_input_h => {}, multi_slice_h => {},
                time_stats_h => { cnt=>0, sum=>0, sumsq=>0, tt_h => {} }  };
 
 #    my $map_expr = 'print "foo\n"';
-    treeMap($plantree, 
+    treeMap($plantree,
             'pre_slice($node, $ctx); ',
             'post_slice($node, $ctx); ',
             $ctx);
 
     calc_color_rank($ctx);
 
-    treeMap($plantree, 
+    treeMap($plantree,
             'sharedscan_fixup($node, $ctx); ',
             undef,
             $ctx);
 
     # always label the left/right sides of nested loop
-    treeMap($plantree, 
+    treeMap($plantree,
             'nestedloop_fixup($node, $ctx); ',
             undef,
             $ctx);
 
     if (defined($glob_edge) && length($glob_edge))
     {
-        treeMap($plantree, 
+        treeMap($plantree,
                 'get_rows_out($node, $ctx, $glob_edge); ',
                 undef,
                 $ctx);
@@ -1883,7 +1883,7 @@ sub dotkid
         if (($docrunch != 0 ) && (scalar(@{$node->{child}} > 10)))
         {
             my $maxi = scalar(@{$node->{child}});
-            
+
             $maxi -= 2;
 
             for my $ii (2..$maxi)
@@ -1955,7 +1955,7 @@ sub dotlabel_detail
     {
         $frst = "first row: " . $node->{to_first};
     }
-    
+
     my $slice = $node->{slice};
     $slice = " "
         unless (defined($slice));
@@ -1969,7 +1969,7 @@ sub dotlabel_detail
         if (exists($node->{memory}))
         {
             $memstuff = " | { {" . $node->{memory} . "} } ";
-            # make multiline - split on comma and "Work_mem" 
+            # make multiline - split on comma and "Work_mem"
             # (using the vertical bar formatting character)
             $memstuff =~ s/\,/\,\| /gm;
             $memstuff =~ s/Work\_mem/\| Work\_mem/gm;
@@ -2000,9 +2000,9 @@ sub dotlabel
     my $color = scalar(@{$colortable});
     $color = $node->{slice}  if (exists($node->{slice}));
     $color =~ s/slice//;
-    
+
     $color = ($color) % (scalar(@{$colortable}));
-    
+
     # build list of node attributes
     my @attrlist;
     push @attrlist, "shape=record";
@@ -2022,7 +2022,7 @@ sub dotlabel
         my $edgecol = $glob_divcol{rdbu11}->[$node->{color_rank}];
         my $fillcol = $colortable->[$color];
 
-        if (defined($glob_statcolor)) 
+        if (defined($glob_statcolor))
         {
             if ($glob_statcolor =~ m/^t$/i)
             {
@@ -2100,27 +2100,27 @@ sub makedotfile
         print $outfh "   ranksep=.75; size = \"7.5,7.5\";\n\n \n";
         print $outfh "   {\n node [shape=plaintext, fontsize=16];\n";
         print $outfh "/* the time-line graph */\n";
-        
+
         print $outfh join(' -> ', @{$time_list} ), ";\n";
         print $outfh "}\n";
-        
+
         print $outfh "node [shape=box];\n";
-        
+
         while ( my ($kk, $vv) = each(%{$parse_ctx->{h_to_startoff}}))
         {
             print $outfh '{ rank = same; ' . $kk . '; ' . join("; ", @{$vv}) . "; }\n";
         }
-        
+
     }
 
     print $outfh "rankdir=$direction;\n";
 
     dotkid($plantree);
-    
+
     dotlabel($plantree);
-    
+
     print $outfh "\n}\n";
-    
+
 }
 
 1;

--- a/src/test/regress/gpdiff.pl
+++ b/src/test/regress/gpdiff.pl
@@ -2,7 +2,7 @@
 #
 # $Header$
 #
-# Copyright (c) 2007, 2008, 2009 GreenPlum.  All rights reserved.  
+# Copyright (c) 2007, 2008, 2009 GreenPlum.  All rights reserved.
 # Author: Jeffrey I Cohen
 #
 #
@@ -25,7 +25,7 @@ use atmsort;
 
 =head1 NAME
 
-B<gpdiff.pl> - GreenPlum diff 
+B<gpdiff.pl> - GreenPlum diff
 
 =head1 SYNOPSIS
 
@@ -33,7 +33,7 @@ B<gpdiff.pl> [options] logfile [logfile...]
 
 Options:
 
-Normally, gpdiff takes the standard "diff" options and passes them 
+Normally, gpdiff takes the standard "diff" options and passes them
 directly to the diff program.  Try `diff --help' for more information
 on the standard options.  The following options are specific to gpdiff:
 
@@ -53,14 +53,14 @@ on the standard options.  The following options are specific to gpdiff:
     Print a brief help message and exits.
 
 =item B<-man>
-    
+
     Prints the manual page and exits.
 
 =item B<-version>
 
     Prints the gpdiff version and underlying diff version
 
-=item B<-gpd_ignore_headers> 
+=item B<-gpd_ignore_headers>
 
 gpdiff/atmsort expect Postgresql "psql-style" output for SELECT
 statements, with a two line header composed of the column names,
@@ -70,10 +70,10 @@ some formatting to adjust the column widths to match the size of the
 row output.  Setting this parameter causes gpdiff to ignore any
 differences in the column naming and format widths globally.
 
-=item B<-gpd_ignore_plans> 
+=item B<-gpd_ignore_plans>
 
 Specify this option to ignore any explain plan diffs between the
-input files. This will completely ignore any plan content in 
+input files. This will completely ignore any plan content in
 the input files thus masking differences in plans between the input files.
 
 =item B<-gpd_init> <file>
@@ -82,26 +82,26 @@ Specify an initialization file containing a series of directives
 (mainly for match_subs) that get applied to the input files.  To
 specify multiple initialization files, use multiple gpd_init arguments, eg:
 
-  -gpd_init file1 -gpd_init file2 
+  -gpd_init file1 -gpd_init file2
 
 =back
 
 =head1 DESCRIPTION
 
-gpdiff compares files using diff after processing them with atmsort.pl. 
-This comparison is designed to ignore certain Greenplum-specific 
+gpdiff compares files using diff after processing them with atmsort.pl.
+This comparison is designed to ignore certain Greenplum-specific
 informational messages, as well as handle the cases where query output
 order may differ for a multi-segment Greenplum database versus a
 single Postgresql instance.  Type "atmsort.pl --man" for more details.
-gpdiff is invoked by pg_regress as part of "make install-check".  
-In this case the diff options are something like: 
+gpdiff is invoked by pg_regress as part of "make install-check".
+In this case the diff options are something like:
 
  "-w -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE:".
 
-Like diff, gpdiff can compare two files, a file and directory, a 
+Like diff, gpdiff can compare two files, a file and directory, a
 directory and file, and two directories.  However, when gpdiff compares
 two directories, it only returns the exit status of the diff
-comparison of the final two files.  
+comparison of the final two files.
 
 =head1 BUGS
 
@@ -119,7 +119,7 @@ potential erroneous comparison.
 
 Jeffrey I Cohen
 
-Copyright (c) 2007, 2008, 2009 GreenPlum.  All rights reserved.  
+Copyright (c) 2007, 2008, 2009 GreenPlum.  All rights reserved.
 
 Address bug reports and comments to: jcohen@greenplum.com
 
@@ -143,9 +143,7 @@ my $glob_init_file = [];
 sub gpdiff_files
 {
     my ($f1, $f2, $d2d) = @_;
-
     my $need_equiv = 0;
-
     my @tmpfils;
 
     # need gnu diff on solaris
@@ -158,18 +156,17 @@ sub gpdiff_files
     {
         my $tmpnam;
 
-        for (;;) 
+        for (;;)
         {
             my $tmpfh;
-        
+
             $tmpnam = tmpnam();
             sysopen($tmpfh, $tmpnam, O_RDWR | O_CREAT | O_EXCL) && last;
         }
 
         push @tmpfils, $tmpnam;
-        
     }
-        
+
     my $newf1 = shift @tmpfils;
     my $newf2 = shift @tmpfils;
 
@@ -178,24 +175,24 @@ sub gpdiff_files
     if (defined($d2d) && exists($d2d->{equiv}))
     {
         # assume f1 and f2 are the same...
-	atmsort::atmsort_init(%glob_atmsort_args, DO_EQUIV => 'compare');
-	atmsort::run($f1, $newf1);
+        atmsort::atmsort_init(%glob_atmsort_args, DO_EQUIV => 'compare');
+        atmsort::run($f1, $newf1);
 
-	atmsort::atmsort_init(%glob_atmsort_args, DO_EQUIV => 'make');
-	atmsort::run($f2, $newf2);
+        atmsort::atmsort_init(%glob_atmsort_args, DO_EQUIV => 'make');
+        atmsort::run($f2, $newf2);
     }
     else
     {
-	atmsort::atmsort_init(%glob_atmsort_args);
-	atmsort::run($f1, $newf1);
-	print "$f1 - $newf1\n";
-	atmsort::run($f2, $newf2);
-	print "$f2 - $newf2\n";
+        atmsort::atmsort_init(%glob_atmsort_args);
+        atmsort::run($f1, $newf1);
+        print "$f1 - $newf1\n";
+        atmsort::run($f2, $newf2);
+        print "$f2 - $newf2\n";
     }
 
     my $args = join(" ", @ARGV, $newf1, $newf2);
 
-#	print "args: $args\n";
+#   print "args: $args\n";
 
     my $outi =`$ATMDIFF $args`;
 
@@ -259,7 +256,6 @@ sub gpdiff_files
     }
 
     return ($stat);
-
 }
 
 sub filefunc
@@ -277,29 +273,24 @@ sub filefunc
         my $dir = $f1;
         my ($dir_h, $stat);
 
-        if ( opendir($dir_h, $dir) ) 
+        if ( opendir($dir_h, $dir) )
         {
             my $fnam;
             while ($fnam = readdir($dir_h))
             {
                 # ignore ., ..
-                next
-                    unless ($fnam !~ m/^(\.)(\.)*$/);
+                next unless ($fnam !~ m/^(\.)(\.)*$/);
 
-                my $absname =
-                    File::Spec->rel2abs(
-                                        File::Spec->catfile(
-                                                            $dir,
-                                                            $fnam
-                                                            ));
+                my $absname = File::Spec->rel2abs(
+                                 File::Spec->catfile($dir, $fnam));
 
                 # specify that is a directory comparison
                 $d2d = {} unless (defined($d2d));
                 $d2d->{dir} = 1;
                 $stat = filefunc($absname, $f2, $d2d);
-            } # end while
+            }
             closedir $dir_h;
-        } # end if open
+        }
         return $stat;
     }
 
@@ -309,16 +300,10 @@ sub filefunc
         my $stat;
         my @foo = File::Spec->splitpath($f1);
 
-        return 0
-            unless (scalar(@foo));
+        return 0 unless (scalar(@foo));
         my $basenam = $foo[-1];
 
-        my $fnam = 
-            File::Spec->rel2abs(
-                                File::Spec->catfile(
-                                                    $f2,
-                                                    $basenam
-                                                    ));
+        my $fnam = File::Spec->rel2abs(File::Spec->catfile( $f2, $basenam));
 
         $stat = filefunc($f1, $fnam, $d2d);
 
@@ -331,16 +316,10 @@ sub filefunc
         my $stat;
         my @foo = File::Spec->splitpath($f2);
 
-        return 0
-            unless (scalar(@foo));
+        return 0 unless (scalar(@foo));
         my $basenam = $foo[-1];
 
-        my $fnam = 
-            File::Spec->rel2abs(
-                                File::Spec->catfile(
-                                                    $f1,
-                                                    $basenam
-                                                    ));
+        my $fnam = File::Spec->rel2abs( File::Spec->catfile( $f1, $basenam));
 
         $stat = filefunc($fnam, $f2, $d2d);
 
@@ -352,117 +331,110 @@ sub filefunc
 
 if (1)
 {
-    my $man			= 0;
-    my $help		= 0;
-    my $verzion		= 0;
-    my $pmsg		= "";
-	my @arg2;              # arg list for diff
-	my %init_dup;
+    my $man         = 0;
+    my $help        = 0;
+    my $verzion     = 0;
+    my $pmsg        = "";
+    my @arg2;              # arg list for diff
+    my %init_dup;
 
 #    getatm();
 
     # check for man or help args
     if (scalar(@ARGV))
     {
-		my $argc = -1;
-		my $maxarg = scalar(@ARGV);
+        my $argc = -1;
+        my $maxarg = scalar(@ARGV);
 
-		while (($argc+1) < $maxarg)
-		{
-			$argc++;
-			my $arg = $ARGV[$argc];
+        while (($argc+1) < $maxarg)
+        {
+            $argc++;
+            my $arg = $ARGV[$argc];
 
-			unless ($arg =~ m/^\-/)
-			{
-				# even if no dash, might be a value for a dash arg...
-				push @arg2, $arg;
-				next;
-			}
-			
-    		# ENGINF-180: ignore header formatting
-                        if ($arg =~ 
-				m/^\-(\-)*(gpd\_ignore\_headers|gp\_ignore\_headers)$/i)
-			{
-				$glob_ignore_headers = 1;
-				next;
-			}
-                        if ($arg =~ 
-				m/^\-(\-)*(gpd\_ignore\_plans|gp\_ignore\_plans)$/i)
-			{
-				$glob_ignore_plans = 1;
-				next;
-			}
-			if ($arg =~ 
-				m/^\-(\-)*(gpd\_init|gp\_init)(\=)*(.*)$/i)
-			{
-				if ($arg =~ m/\=/) # check if "=filename"
-				{
-					my @foo = split (/\=/, $arg, 2);
+            unless ($arg =~ m/^\-/)
+            {
+                # even if no dash, might be a value for a dash arg...
+                push @arg2, $arg;
+                next;
+            }
 
-					die "no init file"
-						unless (2 == scalar(@foo));
+            # ENGINF-180: ignore header formatting
+            if ($arg =~ m/^\-(\-)*(gpd\_ignore\_headers|gp\_ignore\_headers)$/i)
+            {
+                $glob_ignore_headers = 1;
+                next;
+            }
+            if ($arg =~ m/^\-(\-)*(gpd\_ignore\_plans|gp\_ignore\_plans)$/i)
+            {
+                $glob_ignore_plans = 1;
+                next;
+            }
+            if ($arg =~ m/^\-(\-)*(gpd\_init|gp\_init)(\=)*(.*)$/i)
+            {
+                if ($arg =~ m/\=/) # check if "=filename"
+                {
+                    my @foo = split (/\=/, $arg, 2);
 
-					my $init_file = pop @foo;
+                    die "no init file" unless (2 == scalar(@foo));
 
-					# ENGINF-200: allow multiple init files
-					if (exists($init_dup{$init_file}))
-					{
-						warn "duplicate init file \'$init_file\', skipping...";
-					}
-					else
-					{
-						push @{$glob_init_file}, $init_file;
-						
-						$init_dup{$init_file} = 1;
-					}
+                    my $init_file = pop @foo;
 
-				}
-				else # next arg must be init file
-				{
-					$argc++;
+                    # ENGINF-200: allow multiple init files
+                    if (exists($init_dup{$init_file}))
+                    {
+                        warn "duplicate init file \'$init_file\', skipping...";
+                    }
+                    else
+                    {
+                        push @{$glob_init_file}, $init_file;
 
-					die "no init file"
-						unless (defined($ARGV[$argc]));
+                        $init_dup{$init_file} = 1;
+                    }
+                }
+                else # next arg must be init file
+                {
+                    $argc++;
 
-					my $init_file = $ARGV[$argc];
+                    die "no init file" unless (defined($ARGV[$argc]));
 
-					# ENGINF-200: allow multiple init files
-					if (exists($init_dup{$init_file}))
-					{
-						warn "duplicate init file \'$init_file\', skipping...";
-					}
-					else
-					{
-						push @{$glob_init_file}, $init_file;
+                    my $init_file = $ARGV[$argc];
 
-						$init_dup{$init_file} = 1;
-					}
+                    # ENGINF-200: allow multiple init files
+                    if (exists($init_dup{$init_file}))
+                    {
+                        warn "duplicate init file \'$init_file\', skipping...";
+                    }
+                    else
+                    {
+                        push @{$glob_init_file}, $init_file;
 
-				}
-				next;
-			}
-			if ($arg =~ m/^\-(\-)*(v|version)$/)
-			{
-				$verzion = 1;
-				next;
-			}
-			if ($arg =~ m/^\-(\-)*(man|help|\?)$/i)
-			{
-				if ($arg =~ m/man/i)
-				{
-					$man = 1;
-				}
-				else
-				{
-					$help = 1;
-				}
-				next;
-			}
+                        $init_dup{$init_file} = 1;
+                    }
+                }
+                next;
+            }
+            if ($arg =~ m/^\-(\-)*(v|version)$/)
+            {
+                $verzion = 1;
+                next;
+            }
+            if ($arg =~ m/^\-(\-)*(man|help|\?)$/i)
+            {
+                if ($arg =~ m/man/i)
+                {
+                    $man = 1;
+                }
+                else
+                {
+                    $help = 1;
+                }
+                next;
+            }
 
-			# put all "dash" args on separate list for diff
-			push @arg2, $arg;
+            # put all "dash" args on separate list for diff
+            push @arg2, $arg;
 
-		} # end for
+        } # end for
     }
     else
     {
@@ -513,41 +485,39 @@ if (1)
             print STDERR "gpdiff: $fname: No such file or directory\n";
         }
     }
-    exit(2)
-        unless ((-e $f1) && (-e $f2));
+    exit(2) unless ((-e $f1) && (-e $f2));
 
-	# use the "stripped" arg list for diff
-	@ARGV = ();
+    # use the "stripped" arg list for diff
+    @ARGV = ();
 
-	# remove the filenames
-	pop @arg2;
-	pop @arg2;
+    # remove the filenames
+    pop @arg2;
+    pop @arg2;
 
-	push(@ARGV, @arg2);
+    push(@ARGV, @arg2);
 
-	# ENGINF-180: tell atmsort to ignore header formatting (globally)
-	if ($glob_ignore_headers)
-	{
-	    $glob_atmsort_args{IGNORE_HEADERS} = 1;
-	}
+    # ENGINF-180: tell atmsort to ignore header formatting (globally)
+    if ($glob_ignore_headers)
+    {
+        $glob_atmsort_args{IGNORE_HEADERS} = 1;
+    }
 
-	# Tell atmsort to ignore plan content if -gpd_ignore_plans is set
-	if ($glob_ignore_plans)
-	{
-	    $glob_atmsort_args{IGNORE_PLANS} = 1;
-	}
+    # Tell atmsort to ignore plan content if -gpd_ignore_plans is set
+    if ($glob_ignore_plans)
+    {
+        $glob_atmsort_args{IGNORE_PLANS} = 1;
+    }
 
-	# ENGINF-200: allow multiple init files
-	if (defined($glob_init_file) && scalar(@{$glob_init_file}))
-	{
-		# MPP-12262: test here, because we don't get status for atmsort call
-		for my $init_file (@{$glob_init_file})
-		{
-			die "no such file: $init_file"
-				unless (-e $init_file);
-		}
-		@{$glob_atmsort_args{INIT_FILES}} = @{$glob_init_file};
-	}
+    # ENGINF-200: allow multiple init files
+    if (defined($glob_init_file) && scalar(@{$glob_init_file}))
+    {
+        # MPP-12262: test here, because we don't get status for atmsort call
+        for my $init_file (@{$glob_init_file})
+        {
+            die "no such file: $init_file" unless (-e $init_file);
+        }
+        @{$glob_atmsort_args{INIT_FILES}} = @{$glob_init_file};
+    }
 
 
     exit(filefunc($f1, $f2));


### PR DESCRIPTION
Fix dead loop issue.

Replace tab with spaces.

Also remove trailing white spaces.