### PR TITLE
Fix confusion between ordering and equality operators.

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -1935,7 +1935,7 @@ make_plan_for_one_dqa(PlannerInfo *root, MppGroupContext *ctx, int dqa_index,
 		gc = makeNode(GroupClause);
 		tle = get_tle_by_resno(ctx->sub_tlist,  dqaArg->base_index);
 		gc->tleSortGroupRef = tle->ressortgroupref;
-		gc->sortop = dqaArg_eqop;
+		gc->sortop = dqaArg_orderingop;
 
 		extendedGroupClause = list_copy(root->parse->groupClause);
 		extendedGroupClause = lappend(extendedGroupClause, gc);

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -13,6 +13,7 @@ from generate_series(0, 99) i;
 insert into dqa_t2 select i%34, i%45, (i%10) || '', '2009-06-10'::date + ( (i%56) || ' days')::interval
 from generate_series(0, 99) i;
 set gp_eager_agg_distinct_pruning=on;
+set enable_hashagg=on;
 set enable_groupagg=off;
 -- Distinct keys are distribution keys
 select count(distinct d) from dqa_t1;
@@ -913,6 +914,33 @@ select distinct A.a, sum(distinct A.b), count(distinct B.c) from gp_dqa_t1 A rig
   9 |   4 |     1
  10 |   0 |     1
 (10 rows)
+
+-- Most of the above test queries got planned as hash aggregates. Repeat
+-- a few of them as group aggregates
+set enable_hashagg=off;
+set enable_groupagg=on;
+select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
+ count | count | count 
+-------+-------+-------
+    23 |    10 |    34
+(1 row)
+
+select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
+ count | count | i  
+-------+-------+----
+     5 |     9 |  3
+     5 |     8 | 11
+     5 |     8 |  5
+     5 |     8 |  9
+     5 |     9 |  1
+     5 |     8 |  7
+     5 |     9 |  2
+     5 |     8 |  6
+     5 |     9 |  0
+     5 |     8 |  8
+     5 |     8 | 10
+     5 |     8 |  4
+(12 rows)
 
 -- cleanup
 drop table gp_dqa_t1;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -10,6 +10,7 @@ insert into dqa_t2 select i%34, i%45, (i%10) || '', '2009-06-10'::date + ( (i%56
 from generate_series(0, 99) i;
 
 set gp_eager_agg_distinct_pruning=on;
+set enable_hashagg=on;
 set enable_groupagg=off;
 
 -- Distinct keys are distribution keys
@@ -187,6 +188,15 @@ insert into gp_dqa_t2 select i , i %4 from generate_series(1,10) i;
 select distinct A.a, sum(distinct A.b), count(distinct B.c) from gp_dqa_t1 A left join gp_dqa_t2 B on (A.a = B.a) group by A.a order by A.a;
 
 select distinct A.a, sum(distinct A.b), count(distinct B.c) from gp_dqa_t1 A right join gp_dqa_t2 B on (A.a = B.a) group by A.a order by A.a;
+
+-- Most of the above test queries got planned as hash aggregates. Repeat
+-- a few of them as group aggregates
+set enable_hashagg=off;
+set enable_groupagg=on;
+
+select count(distinct d), count(distinct c), count(distinct dt) from dqa_t1;
+select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
+
 
 -- cleanup
 drop table gp_dqa_t1;


### PR DESCRIPTION
This code and bug was in 1f4ad703ebfb30025f64d4ff5d19af6e857ce7d3, and it
caused an "operator XXX is not a valid ordering operator" error.

The 'sortop' field in SortClause and GroupClause needs to be an ordering
operator, i.e. the "<" operator, while we use the "=" operator to represent
grouping in other places. Need to be careful to convert between the two
in right places.

Add a few tests for this in the gp_dqa test case. This was reproducible by
the existing queries, when you coerce the planner to choose sort+group
aggregates instead of hash aggregates.