### PR TITLE
Cleanup of the VARIADIC function parameter backporting patch.

### DIFF
--- a/src/test/regress/expected/variadic_parameters.out
+++ b/src/test/regress/expected/variadic_parameters.out
@@ -1,5 +1,9 @@
 -- -----------------------------------------------------------------
--- Test function variadic paramters 
+-- Test function variadic parameters
+--
+-- Most of these tests were backported from PostgreSQL 8.4's polymorphism and
+-- plpgsql tests. We should remove the redundant ones after we've merged with
+-- 8.4.
 -- -----------------------------------------------------------------
 -- test variadic polymorphic functions
 create or replace function myleast(variadic anyarray) returns anyelement as $$

--- a/src/test/regress/sql/variadic_parameters.sql
+++ b/src/test/regress/sql/variadic_parameters.sql
@@ -1,5 +1,9 @@
 -- -----------------------------------------------------------------
--- Test function variadic paramters 
+-- Test function variadic parameters
+--
+-- Most of these tests were backported from PostgreSQL 8.4's polymorphism and
+-- plpgsql tests. We should remove the redundant ones after we've merged with
+-- 8.4.
 -- -----------------------------------------------------------------
 
 -- test variadic polymorphic functions


### PR DESCRIPTION
My compiler was complaining that the newResult variable might be passed
to pfree() uninitialized. I didn't spend too much time investigating that,
however. Instead, I replaced the whole FuncnameGetCandidates() function
with the PostgreSQL 8.4 version, and then modified it so that it works
without default-parameter support, which we haven't backported. Keeping
the code as close as possible to the upstream version seems like a good
idea. This also fixed some spurious whitespace differences vs. the upstream
version.

In the passing, clean up the regression test a bit. There are no
replacement strings in it, so move it from input/output to sql/expected
directories, and also add a comment pointing out that the tests are
backported from other PostgreSQL tests.