### PR TITLE
Fix gpdiff.pl multiple init_file processing issue

### DIFF
--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -124,7 +124,7 @@ sub atmsort_init
     init_match_subs();
     init_matchignores();
 
-	_process_init_files();
+    _process_init_files();
 }
 
 sub _process_init_files

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -123,6 +123,37 @@ sub atmsort_init
 
     init_match_subs();
     init_matchignores();
+
+	_process_init_files();
+}
+
+sub _process_init_files
+{
+    # allow multiple init files
+    if (@glob_init)
+    {
+        my $devnullfh;
+        my $init_file_fh;
+
+        open $devnullfh, "> /dev/null" or die "can't open /dev/null: $!";
+
+        for my $init_file (@glob_init)
+        {
+            die "no such file: $init_file"
+            unless (-e $init_file);
+
+            # Perform initialization from this init_file by passing it
+            # to bigloop. Open the file, and pass that as the input file
+            # handle, and redirect output to /dev/null.
+            open $init_file_fh, "< $init_file" or die "could not open $init_file: $!";
+
+            atmsort_bigloop($init_file_fh, $devnullfh);
+
+            close $init_file_fh;
+        }
+
+        close $devnullfh;
+    }
 }
 
 my $glob_match_then_sub_fnlist;
@@ -214,7 +245,7 @@ sub _build_match_subs
             push @{$glob_match_then_sub_fnlist},
             [$fn1, $bigdef, $cmt, $defi->[0], $defi->[1]];
 
-            if ($glob_verbose)
+            if ($glob_verbose && defined $atmsort_outfh)
             {
                 print $atmsort_outfh "GP_IGNORE: Defined $cmt\t$defi->[0]\t$defi->[1]\n"
             }
@@ -307,7 +338,6 @@ sub match_then_subs
         else
         {
             my $subs = &$fn1($ini);
-
             unless ($subs eq $ini)
             {
                 print $atmsort_outfh "GP_IGNORE: was: $ini";
@@ -374,8 +404,8 @@ sub _build_match_ignores
             # store the function pointer and the text of the function
             # definition
             push @{$glob_match_then_ignore_fnlist},
-            [$fn1, $bigdef, $cmt, $defi, "(ignore)"];
-            if ($glob_verbose)
+                    [$fn1, $bigdef, $cmt, $defi, "(ignore)"];
+            if ($glob_verbose && defined $atmsort_outfh)
             {
                 print $atmsort_outfh "GP_IGNORE: Defined $cmt\t$defi\n"
             }
@@ -1618,31 +1648,6 @@ sub run_fhs
     my $infh = shift;
     my $outfh = shift;
 
-    # allow multiple init files
-    if (@glob_init)
-    {
-        my $devnullfh;
-        my $init_file_fh;
-
-        open $devnullfh, "> /dev/null" or die "can't open /dev/null: $!";
-
-        for my $init_file (@glob_init)
-        {
-            die "no such file: $init_file"
-            unless (-e $init_file);
-
-            # Perform initialization from this init_file by passing it
-            # to bigloop. Open the file, and pass that as the input file
-            # handle, and redirect output to /dev/null.
-            open $init_file_fh, "< $init_file" or die "could not open $init_file: $!";
-
-            atmsort_bigloop($init_file_fh, $devnullfh);
-
-            close $init_file_fh;
-        }
-
-        close $devnullfh;
-    }
 
     # loop over input file.
     atmsort_bigloop($infh, $outfh);

--- a/src/test/regress/gpdiff.pl
+++ b/src/test/regress/gpdiff.pl
@@ -40,6 +40,7 @@ on the standard options.  The following options are specific to gpdiff:
     -help                 brief help message
     -man                  full documentation
     -version              print gpdiff version and underlying diff version
+    -verbose              print verbose info
     -gpd_ignore_headers   ignore header lines in query output
     -gpd_ignore_plans     ignore explain plan content in input files
     -gpd_init <file>      load initialization file
@@ -59,6 +60,10 @@ on the standard options.  The following options are specific to gpdiff:
 =item B<-version>
 
     Prints the gpdiff version and underlying diff version
+
+=item B<-verbose>
+
+    Prints verbose information.
 
 =item B<-gpd_ignore_headers>
 
@@ -334,6 +339,7 @@ if (1)
     my $man         = 0;
     my $help        = 0;
     my $verzion     = 0;
+    my $verbose     = 0;
     my $pmsg        = "";
     my @arg2;              # arg list for diff
     my %init_dup;
@@ -418,6 +424,11 @@ if (1)
                 $verzion = 1;
                 next;
             }
+            if ($arg =~ m/^\-(\-)*(V|verbose)$/)
+            {
+                $verbose = 1;
+                next;
+            }
             if ($arg =~ m/^\-(\-)*(man|help|\?)$/i)
             {
                 if ($arg =~ m/man/i)
@@ -496,6 +507,11 @@ if (1)
 
     push(@ARGV, @arg2);
 
+    if ($verbose)
+    {
+        $glob_atmsort_args{VERBOSE} = 1;
+    }
+
     # ENGINF-180: tell atmsort to ignore header formatting (globally)
     if ($glob_ignore_headers)
     {
@@ -518,7 +534,6 @@ if (1)
         }
         @{$glob_atmsort_args{INIT_FILES}} = @{$glob_init_file};
     }
-
 
     exit(filefunc($f1, $f2));
 }


### PR DESCRIPTION
atmsort.pm will process init_file multiple times, thus will duplicate rules in init_file.

Also add -verbose option to gpdiff.pl