### PR TITLE
Consolidate on ip instead of mix of ip and ifconfig for ip4 and ip6 detection

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -449,13 +449,13 @@ CHK_PARAMS () {
 		fi
 		# Get IP address of the master host
 
-		MASTER_IP_ADDRESS_ALL=(`$IFCONFIG $IFCONFIG_TXT |$GREP "inet "|$GREP -v "127.0.0"|$AWK '{print $2}'|$CUT -d: -f2`)
+		MASTER_IP_ADDRESS_ALL=(`$IPV4_ADDR_LIST_CMD | $GREP inet | $GREP -v 127.0.0 | $AWK '{print $2}' | $CUT -d'/' -f1`)
 		ERROR_CHK $? "obtain IP address of Master host" 2
-		MASTER_IPV6_LOCAL_ADDRESS_ALL=(`$IPV6_ADDR_LIST_CMD |$GREP inet6|$AWK '{print $2}' |$CUT -d'/' -f1`)
+		MASTER_IPV6_LOCAL_ADDRESS_ALL=(`$IPV6_ADDR_LIST_CMD | $GREP inet6 | $AWK '{print $2}' | $CUT -d'/' -f1`)
 		MASTER_IP_ADDRESS=(`$ECHO ${MASTER_IP_ADDRESS_ALL[@]} ${MASTER_IPV6_LOCAL_ADDRESS_ALL[@]}|$TR ' ' '\n'|$SORT -u|$TR '\n' ' '`)
 		LOG_MSG "[INFO]:-Master IP address array = ${MASTER_IP_ADDRESS[@]}"
 		if [ x"" != x"$STANDBY_HOSTNAME" ];then
-			STANDBY_IP_ADDRESS_ALL=(`$TRUSTED_SHELL $STANDBY_HOSTNAME "$IFCONFIG $IFCONFIG_TXT |$GREP \"inet \"|$GREP -v \"127.0.0\"|$AWK '{print \\$2}'|$CUT -d: -f2" 2>>$LOG_FILE`) 
+			STANDBY_IP_ADDRESS_ALL=(`$TRUSTED_SHELL $STANDBY_HOSTNAME "$IPV4_ADDR_LIST_CMD |$GREP inet|$GREP -v \"127.0.0\"|$AWK '{print \\$2}'|$CUT -d'/' -f1" 2>>$LOG_FILE`) 
             STANDBY_IPV6_ADDRESS_ALL=(`$TRUSTED_SHELL $STANDBY_HOSTNAME "$IPV6_ADDR_LIST_CMD |$GREP inet6|$AWK '{print \\$2}' |$CUT -d'/' -f1" 2>>$LOG_FILE`)
 			STANDBY_IP_ADDRESS=(`$ECHO ${STANDBY_IP_ADDRESS_ALL[@]} ${STANDBY_IPV6_ADDRESS_ALL[@]}|$TR ' ' '\n'|$SORT -u|$TR '\n' ' '`)
 			ERROR_CHK $? "obtain IP address of standby Master host" 2

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -341,7 +341,6 @@ class FreeBsdPlatform(GenericPlatform):
     
         
 """ if self.SYSTEM == 'sunos':
-            self.IFCONFIG_TXT='-a inet'
             self.PS_TXT='ef'
             self.LIB_TYPE='LD_LIBRARY_PATH'
             self.ZCAT='gzcat'
@@ -352,7 +351,6 @@ class FreeBsdPlatform(GenericPlatform):
             self.DF=findCmdInPath('df')
             self.DU_TXT='-s'
         elif self.SYSTEM == 'linux':
-            self.IFCONFIG_TXT=''
             self.PS_TXT='ax'
             self.LIB_TYPE='LD_LIBRARY_PATH'
             self.PG_METHOD='ident sameuser'
@@ -361,7 +359,6 @@ class FreeBsdPlatform(GenericPlatform):
             self.DF='%s -P' % findCmdInPath('df')
             self.DU_TXT='c'
         elif self.SYSTEM == 'darwin':
-            self.IFCONFIG_TXT=''
             self.PS_TXT='ax'
             self.LIB_TYPE='DYLD_LIBRARY_PATH'
             self.PG_METHOD='ident sameuser'
@@ -370,7 +367,6 @@ class FreeBsdPlatform(GenericPlatform):
             self.DF='%s -P' % findCmdInPath('df')
             self.DU_TXT='-c'
         elif self.SYSTEM == 'freebsd':
-            self.IFCONFIG_TXT=''
             self.PS_TXT='ax'
             self.LIB_TYPE='LD_LIBRARY_PATH'
             self.PG_METHOD='ident sameuser'

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1630,25 +1630,30 @@ PING_HOST () {
 	if [ x"" == x"$PING_EXIT" ];then PING_EXIT=0;fi
 	case $OS_TYPE in
 		darwin )
-			$PING $PING_TIME $TARGET_HOST > /dev/null 2>&1 || $PING6 $PING_TIME $TARGET_HOST > /dev/null 2>&1 ;;
+			$PING $PING_TIME $TARGET_HOST > /dev/null 2>&1 || $PING6 $PING_TIME $TARGET_HOST > /dev/null 2>&1 
+                        ;;
 		linux )
-			$PING $TARGET_HOST $PING_TIME > /dev/null 2>&1 || $PING6 $TARGET_HOST $PING_TIME > /dev/null 2>&1 ;;
+			$PING $TARGET_HOST $PING_TIME > /dev/null 2>&1 || $PING6 $TARGET_HOST $PING_TIME > /dev/null 2>&1 
+                        ;;
 		* )
 			$PING $TARGET_HOST $PING_TIME > /dev/null 2>&1
 	esac
 	RETVAL=$?
 	case $RETVAL in
-		0) LOG_MSG "[INFO]:-$TARGET_HOST contact established" ;;
+		0) LOG_MSG "[INFO]:-$TARGET_HOST contact established" 
+                   ;;
 		1) if [ $PING_EXIT -eq 0 ];then
 			ERROR_EXIT "[FATAL]:-Unable to contact $TARGET_HOST" 2
 		   else
 		        LOG_MSG "[WARN]:-Unable to contact $TARGET_HOST" 1
-		   fi ;;
+		   fi 
+                   ;;
 		2) if [ $PING_EXIT -eq 0 ];then
 		 	ERROR_EXIT "[FATAL]:-Unknown host $TARGET_HOST" 2
 		   else
 			LOG_MSG "[WARN]:-Unknown host $TARGET_HOST" 1
-		   fi ;;
+		   fi 
+                   ;;
 	esac
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
 	return $RETVAL
@@ -1961,7 +1966,7 @@ fi
 #Set up OS type for scripts to change command lines
 OS_TYPE=`uname -s|tr '[A-Z]' '[a-z]'`
 case $OS_TYPE in
-	sunos ) IFCONFIG_TXT="-a inet"
+	sunos ) IPV4_ADDR_LIST_CMD="$IFCONFIG -a4"
 		IPV6_ADDR_LIST_CMD="$IFCONFIG -a6"
 		PS_TXT="-ef"
 		LIB_TYPE="LD_LIBRARY_PATH"
@@ -1977,7 +1982,7 @@ case $OS_TYPE in
 		# Multi-byte tr needed on Solaris to handle [:upper:], [:lower:], etc.
 		MBTR=/usr/xpg4/bin/tr
 		DU_TXT="-s" ;;
-	linux ) IFCONFIG_TXT=""
+	linux ) IPV4_ADDR_LIST_CMD="`findCmdInPath ip` -4 address show"
 		IPV6_ADDR_LIST_CMD="`findCmdInPath ip` -6 address show"
 		PS_TXT="ax"
 		LIB_TYPE="LD_LIBRARY_PATH"
@@ -1990,7 +1995,7 @@ case $OS_TYPE in
 		DF="`findCmdInPath df` -P"
 		ID=`whoami`
 		DU_TXT="-c" ;;
-	darwin ) IFCONFIG_TXT=""
+	darwin ) IPV4_ADDR_LIST_CMD="$IFCONFIG -a inet"
 		IPV6_ADDR_LIST_CMD="$IFCONFIG -a inet6"
 		PS_TXT="ax"
 		LIB_TYPE="DYLD_LIBRARY_PATH"
@@ -2000,12 +2005,12 @@ case $OS_TYPE in
 		HOST_ARCH_TYPE="uname -m"
 		NOLINE_ECHO=$ECHO
 		DEFAULT_LOCALE_SETTING=en_US.utf-8
-        PING6=`findCmdInPath ping6`
+        	PING6=`findCmdInPath ping6`
 		PING_TIME="-c 1"
 		DF="`findCmdInPath df` -P"
 		DU_TXT="-c" ;;	
-	freebsd ) IFCONFIG_TXT=""
-		PS_TXT="ax"
+	freebsd ) IPV4_ADDR_LIST_CMD="$IFCONFIG -a inet"
+		IPV6_ADDR_LIST_CMD="$IFCONFIG -a inet6"
 		LIB_TYPE="LD_LIBRARY_PATH"
 		PG_METHOD="ident"
 		HOST_ARCH_TYPE="uname -m"

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -198,7 +198,7 @@ PROCESS_QE () {
     fi
 
     # Add all local IPV4 addresses
-    SEGMENT_IPV4_LOCAL_ADDRESS_ALL=(`$TRUSTED_SHELL $GP_HOSTADDRESS "$IFCONFIG $IFCONFIG_TXT |$GREP \"inet \"|$GREP -v \"127.0.0\"|$AWK '{print \\$2}'|$CUT -d: -f2"`)
+    SEGMENT_IPV4_LOCAL_ADDRESS_ALL=(`$TRUSTED_SHELL $GP_HOSTADDRESS "$IPV4_ADDR_LIST_CMD | $GREP inet | $GREP -v \"127.0.0\" | $AWK '{print \\$2}' | $CUT -d'/' -f1"`)
     for ADDR in "${SEGMENT_IPV4_LOCAL_ADDRESS_ALL[@]}"
     do
 	# MPP-15889
@@ -207,7 +207,7 @@ PROCESS_QE () {
     done
 
     # Add all local IPV6 addresses
-    SEGMENT_IPV6_LOCAL_ADDRESS_ALL=(`$TRUSTED_SHELL $GP_HOSTADDRESS "$IPV6_ADDR_LIST_CMD | $GREP inet6 | $AWK '{print \\$2}' |$CUT -d'/' -f1"`)
+    SEGMENT_IPV6_LOCAL_ADDRESS_ALL=(`$TRUSTED_SHELL $GP_HOSTADDRESS "$IPV6_ADDR_LIST_CMD | $GREP inet6 | $AWK '{print \\$2}' | $CUT -d'/' -f1"`)
     for ADDR in "${SEGMENT_IPV6_LOCAL_ADDRESS_ALL[@]}"
     do
 	# MPP-15889


### PR DESCRIPTION
Using ifconfig for ipv4 detection and ip show for ipv6 detection doesn't make sense when it can be consolidated down to using one tool possibly removing an installation dependency 