### PR TITLE
Remove ALTER LANGUAGE plpgsql  from DMLstmt test.

### DIFF
--- a/src/test/regress/bugbuster/sql/DMLstmnt.sql
+++ b/src/test/regress/bugbuster/sql/DMLstmnt.sql
@@ -90,11 +90,6 @@ DROP GROUP market;
 DROP USER jona11;
 DROP USER jona12;
 
-ALTER LANGUAGE plpgsql  RENAME TO plsamples;
-ALTER LANGUAGE plsamples  RENAME TO plpgsql;
--- commentting the drop in the test case. Since jetpack is made implicit we cannot drop language plpgsql
--- DROP LANGUAGE plsamples;
-
 select unnest('{}'::text[]);
 
 drop table mpp_r6756 cascade; --ignore


### PR DESCRIPTION
Edit:
Separate DMLstmnt from parallelized schedule to avoid conflicts with functions.
DMLstmnt alters the name of plpgsql and causes functions to fail, since
there will be a short time where plpgsql will not exist.

Changed to removing ALTER LANGUAGE  instead.