### PR TITLE
Add caches to AO visibility map lookups, to speed up VACUUM

### DIFF
--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -573,9 +573,16 @@ AppendOnlyBlockDirectory_GetEntry(
 
 		index_endscan(idxScanDesc);
 
-		/* Load the minipage into cache */
+		/*
+		 * If this entry doesn't cover the requested tuple, it's not put into cache. We could
+		 * create a negative cache entry instead
+		 */
 		firstEntry = &minipageInfo->minipage->entry[0];
 		lastEntry = &minipageInfo->minipage->entry[minipageInfo->numMinipageEntries - 1];
+		if (rowNum >= lastEntry->firstRowNum + lastEntry->rowCount)
+			return false;
+
+		/* Load the minipage into cache */
 
 		cacheEntry = MemoryContextAlloc(blockDirectory->memoryContext,
 										sizeof(BlockDirCacheEntry));

--- a/src/include/access/appendonly_visimap.h
+++ b/src/include/access/appendonly_visimap.h
@@ -32,6 +32,21 @@
 #define APPENDONLY_VISIMAP_MAX_RANGE 32768
 #define APPENDONLY_VISIMAP_MAX_BITMAP_SIZE 4096
 
+
+struct AppendOnlyVisimapCacheEntry;
+typedef struct AppendOnlyVisimapCacheEntry AppendOnlyVisimapCacheEntry;
+
+struct AppendOnlyVisimapCacheEntry
+{
+	AppendOnlyVisimapCacheEntry *leftChild;
+	AppendOnlyVisimapCacheEntry *rightChild;
+
+	int32		segmentFileNum;
+	int64		firstRowNum;
+
+	Bitmapset  *bitmap;
+};
+
 /*
  * Data structure for the ao visibility map processing.
  *
@@ -56,6 +71,11 @@ typedef struct AppendOnlyVisimap
 	 * visibility map entries.
 	 */ 
 	AppendOnlyVisimapStore visimapStore;	
+
+	/*
+	 * Cache to speed up lookups
+	 */
+	AppendOnlyVisimapCacheEntry *cache;
 
 } AppendOnlyVisimap;
 

--- a/src/include/access/appendonly_visimap_entry.h
+++ b/src/include/access/appendonly_visimap_entry.h
@@ -79,6 +79,11 @@ typedef struct AppendOnlyVisimapEntry
 	 */
 	bool dirty;
 
+	/*
+	 * true if the 'bitmap' points at a cache, and should not be freed or modified.
+	 */
+	bool		cached;
+
 	/**
 	 * tuple id of the last loaded visibility map entry.
 	 * Is Invalid iff there is no current table or if the

--- a/src/include/cdb/cdbappendonlyblockdirectory.h
+++ b/src/include/cdb/cdbappendonlyblockdirectory.h
@@ -79,6 +79,27 @@ typedef struct MinipagePerColumnGroup
 #define NUM_MINIPAGE_ENTRIES (((MaxTupleSize)/8 - sizeof(HeapTupleHeaderData) - 64 * 3)\
 							  / sizeof(MinipageEntry))
 
+struct BlockDirCacheEntry;
+typedef struct BlockDirCacheEntry BlockDirCacheEntry;
+
+/*
+ * The key for these is (segmentFileNum, firstRowNum)
+ *
+ */
+struct BlockDirCacheEntry
+{
+	BlockDirCacheEntry *leftChild;
+	BlockDirCacheEntry *rightChild;
+
+	int			segmentFileNum;
+
+	int64		firstRowNum;	/* inclusive */
+	int64		lastRowNum;		/* exclusive */
+
+	Minipage   *minipage;
+};
+
+
 /*
  * Define a structure for the append-only relation block directory.
  */
@@ -106,6 +127,8 @@ typedef struct AppendOnlyBlockDirectory
 	 * Last minipage that contains an array of MinipageEntries.
 	 */
 	MinipagePerColumnGroup *minipages;
+
+	BlockDirCacheEntry **cacheRoots;
 
 	/*
 	 * Some temporary space to help form tuples to be inserted into


### PR DESCRIPTION
While porting the Updatable Append-Only tests from TINC (pull request #219), I noticed that the "index2" test case spends a large fraction of its time in appendonly_tid_reaped() function. That function is called by VACUUM for every index tuple, to check if the AO "tuple" is dead, and the index tuple should be removed. For heap tables, the corresponding tid_reaped() function is very cheap: it performs a binary search of an in-memory array of TIDs. appendonly_tid_reaped(), however, is very expensive. It performs two index lookups: one to check the "block directory", and another to check the visibility map, and checking the visibility map also involves decompressing a compressed bitmap. This shows up clearly in profiling.

To alleviate that, these patches add a simple cache to both of those lookups, to avoid having to probe the indexes every time. This reduces the runtime of the "index2" test from about 90 seconds to 66 seconds on my laptop. The remaining time is now spent in populating the test tables, rather than in VACUUM.

This is still work-in-progress. Needs cleanup and comments. Also, the caches are currently just simple binary search trees; should probably use some sort of a balanced tree to avoid degenerating. Also, entries are never removed from the caches, so these might consume an excessive amount of memory on a large table.

But what do you think of the general approach? Is caching the entries like this safe? I think it is, there is a limited form of caching in both places already, caching just the last-accessed entry, so caching more should be just as safe.