### PR TITLE
Fix typo in the macro following the header guard

### DIFF
--- a/src/include/executor/execHHashagg.h
+++ b/src/include/executor/execHHashagg.h
@@ -14,7 +14,7 @@
  *-------------------------------------------------------------------------
  */
 #ifndef EXECHYBRIDHASHAGG_H
-#define EXECBYBRIDHASHAGG_H
+#define EXECHYBRIDHASHAGG_H
 
 #include "executor/nodeAgg.h" /* Must see AggStatePerGroupData. */
 #include "cdb/cdbpublic.h"    /* CdbExplain_Agg / CdbCellBuf */


### PR DESCRIPTION
A small keyboard-off-by-one typo in the macro following the header guard. Picked up by clang using `-Wheader-guard`.