### PR TITLE
Pass parser state when resolving type name, like in upstream.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -11918,7 +11918,7 @@ transformColumnType(ParseState *pstate, ColumnDef *column)
 	/*
 	 * All we really need to do here is verify that the type is valid.
 	 */
-	Type		ctype = typenameType(NULL, column->typname);
+	Type		ctype = typenameType(pstate, column->typname);
 
 	ReleaseType(ctype);
 }


### PR DESCRIPTION
The user-visible effect is that you get error position in the original
query for some error messages, like the "type \"%s\" is only a shell"
error, if you try to use a shell type in CREATE TABLE, for example.

Not sure why this was different from upstream in GPDB, but seems prudent
to fix.