### PR TITLE
Fix initialization of Plan node in remove_unused_initplans_helper

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -2656,7 +2656,7 @@ static void remove_unused_initplans_helper(Plan *plan, Bitmapset **usedParams, B
 		}
 		case T_SubPlan:
 		{
-			SubPlan *subplan = (SubPlan *) subplan;
+			SubPlan *subplan = (SubPlan *) plan;
 			find_params_walker((Node *) subplan->testexpr, &context);
 			find_params_walker((Node *) subplan->args, &context);
 			break;


### PR DESCRIPTION
In `remove_unused_initplans_helper()` it doesn't seem entirely correct to initialize `subplan` with itself and then dereference when plan type is `T_SubPlan`.