### PR TITLE
Properly check udpSignalGet() when setting return value

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -2698,7 +2698,7 @@ udpSignalTimeoutWait(UDPSignal *sig, pthread_cond_t *cond, pthread_mutex_t *mute
 	bool ret = ETIMEDOUT;
 	if (udpSignalPoll(sig, timeout))
 	{
-		if (udpSignalGet(sig));
+		if (udpSignalGet(sig))
 			ret = 0;
 	}
 	sig->sigId = NULL;


### PR DESCRIPTION
Remove superflous ";" to ensure that the return value is set based on the success of udpSignalGet(). Verified by lchang@. This only affects OS X builds.