### PR TITLE
Change gpssh default sync_multiplier value from 0.5 to 1.0.

### DIFF
--- a/gpMgmt/bin/gppylib/util/ssh_utils.py
+++ b/gpMgmt/bin/gppylib/util/ssh_utils.py
@@ -184,7 +184,9 @@ class Session(cmd.Cmd):
             p = pxssh.pxssh(options={"StrictHostKeyChecking": "no",
                                      "BatchMode": "yes"})
             try:
-                p.login(host, self.userName, sync_multiplier=0.5)
+                # The sync_multiplier value is passed onto pexpect.pxssh which is used to determine timeout
+                # values for prompt verification after an ssh connection is established.
+                p.login(host, self.userName, sync_multiplier=1.0)
                 p.x_peer = host
                 p.x_pid = p.pid
                 good_list.append(p)


### PR DESCRIPTION
The sync_multiplier value is passed onto pexpect.pxssh which is used to determine timeout
values for ssh connection prompt verification.  The 0.5 value can be too fast in some
environments.  Changing it to 1.0 should help stabilize the initial connection stage.

Author: Jimmy Yih