### PR TITLE
add GUC to control writable external table buffer size based on Chaos…

### DIFF
--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -2295,7 +2295,7 @@ static size_t curl_fwrite(char *buf, int nbytes, URL_FILE* file, CopyState pstat
 	 */
 	if(!curl->out.ptr)
 	{
-		const int bufsize = 64 * 1024 * sizeof(char);
+		const int bufsize = writable_external_table_bufsize * 1024 * sizeof(char);
 		MemoryContext oldcontext = CurrentMemoryContext;
 		
 		MemoryContextSwitchTo(CurTransactionContext); /* TODO: is there a better cxt to use? */

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -584,6 +584,8 @@ bool		gp_plpgsql_clear_cache_always = false;
  */
 char	   *gp_default_storage_options = NULL;
 
+int			writable_external_table_bufsize = 64;
+
 struct config_bool ConfigureNamesBool_gp[] =
 {
 	{
@@ -3426,6 +3428,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&readable_external_table_timeout,
 		0, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"writable_external_table_bufsize", PGC_USERSET, EXTERNAL_TABLES,
+			gettext_noop("Buffer size in kilo bytes for writable external table before writing data to gpfdist."),
+			gettext_noop("Valid value is between 32K and 128M: [32, 131072]."),
+			GUC_UNIT_KB | GUC_NOT_IN_SAMPLE
+		},
+		&writable_external_table_bufsize,
+		64, 32, 131072, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -500,6 +500,8 @@ extern char  *gp_default_storage_options;
  */
 extern int log_count_recovered_files_batch;
 
+extern int writable_external_table_bufsize;
+
 /* Storage option names */
 #define SOPT_FILLFACTOR    "fillfactor"
 #define SOPT_APPENDONLY    "appendonly"


### PR DESCRIPTION
add GUC to control writable external table buffer size based on ChaosEternal's experiment at https://github.com/greenplum-db/gpdb/pull/211