### PR TITLE
Fix memcmp() invocation in checkRelationAfterInvalidation

### DIFF
--- a/src/test/regress/regress.c
+++ b/src/test/regress/regress.c
@@ -2403,7 +2403,7 @@ checkRelationAfterInvalidation(PG_FUNCTION_ARGS)
 	RelationCacheInvalidate();
 	if (memcmp(&nodeinfo,
 			   &relation->rd_segfile0_relationnodeinfo,
-			   sizeof(struct RelationNodeInfo) != 0))
+			   sizeof(struct RelationNodeInfo)) != 0)
 		elog(ERROR, "node info does not match");
 
 	relation_close(relation, AccessShareLock);


### PR DESCRIPTION
Due to the misplaced conditional check, the byte string comparison in `checkRelationAfterInvalidation()` will only check the first byte of the passed byte strings.