### PR TITLE
Make functions in gp_toolkit to execute on all nodes as intended.

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -521,7 +521,7 @@ external_insert_init(Relation rel)
 	/*
 	 * Get the pg_exttable information for this table
 	 */
-	extentry = GetExtTableEntry(RelationGetRelid(rel));
+	extentry = GetExtTableEntry(RelationGetRelid(rel), false);
 
 	/*
 	 * allocate and initialize the insert descriptor

--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -27,6 +27,7 @@
 #include "catalog/pg_auth_members.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_database.h"
+#include "catalog/pg_exttable.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_pltemplate.h"
 #include "catalog/pg_resqueue.h"
@@ -625,29 +626,6 @@ IsAoSegmentNamespace(Oid namespaceId)
 	return namespaceId == PG_AOSEGMENT_NAMESPACE;
 }
 
-/**
- * Method determines if a relation is master-only or distributed among segments.
- * Input:
- * 	relationOid
- * Output:
- * 	true if masteronly
- */
-bool
-isMasterOnly(Oid relationOid)
-{
-	Assert(relationOid != InvalidOid);
-	Oid				schemaOid = get_rel_namespace(relationOid);
-	GpPolicy		*distributionPolicy = GpPolicyFetch(CurrentMemoryContext, relationOid);
-	
-	bool masterOnly = (Gp_role == GP_ROLE_UTILITY 
-			|| IsSystemNamespace(schemaOid)
-			|| IsToastNamespace(schemaOid)
-			|| IsAoSegmentNamespace(schemaOid)
-			|| (distributionPolicy == NULL)
-			|| (distributionPolicy->ptype == POLICYTYPE_ENTRY));
-	
-	return masterOnly;
-}
 /*
  * IsReservedName
  *		True iff name starts with the pg_ prefix.

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2155,8 +2155,6 @@ void
 heap_drop_with_catalog(Oid relid)
 {
 	Relation	rel;
-	const struct GpPolicy *policy;
-	bool		removePolicy = false;
 	bool		is_part_child = false;
 	bool		is_appendonly_rel;
 	bool		is_external_rel;
@@ -2171,16 +2169,6 @@ heap_drop_with_catalog(Oid relid)
 
 	is_appendonly_rel = (RelationIsAoRows(rel) || RelationIsAoCols(rel));
 	is_external_rel = RelationIsExternal(rel);
-
-	/*
- 	 * Get the distribution policy and figure out if it is to be removed.
- 	 */
-	policy = rel->rd_cdbpolicy;
-	if (policy &&
-		policy->ptype == POLICYTYPE_PARTITIONED &&
-		Gp_role == GP_ROLE_DISPATCH &&
-		relkind == RELKIND_RELATION)
-		removePolicy = true;
 
 	/*
 	 * Schedule unlinking of the relation's physical file at commit.
@@ -2260,9 +2248,9 @@ heap_drop_with_catalog(Oid relid)
 		RemoveExtTableEntry(relid);
 
 	/*
- 	 * delete distribution policy if present
+ 	 * Remove distribution policy, if any.
  	 */
-	if (removePolicy)
+	if (relkind == RELKIND_RELATION)
 		GpPolicyRemove(relid);
 
 	/*

--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -11,6 +11,7 @@
 #include "postgres.h"
 #include "miscadmin.h"
 #include "catalog/catquery.h" 
+#include "catalog/pg_exttable.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/indexing.h"
 #include "utils/builtins.h"
@@ -89,13 +90,51 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 	Relation	gp_policy_rel;
 	cqContext	cqc;
 	HeapTuple	gp_policy_tuple = NULL;
-	size_t		nb;
 
 	/*
 	 * Skip if qExec or utility mode.
 	 */
 	if (Gp_role != GP_ROLE_DISPATCH)
-		return NULL;
+	{
+		policy = (GpPolicy *) MemoryContextAlloc(mcxt, SizeOfGpPolicy(0));
+		policy->ptype = POLICYTYPE_ENTRY;
+		policy->nattrs = 0;
+	}
+
+	/*
+	 * EXECUTE-type external tables have an "ON ..." specification, stored
+	 * in pg_exttable.location. See if it's "MASTER_ONLY". Other types of
+	 * external tables have a gp_distribution_policy row, like normal tables.
+	 */
+	if (get_rel_relstorage(tbloid) == RELSTORAGE_EXTERNAL)
+	{
+		/*
+		 * An external table really should have a pg_exttable entry, but there's
+		 * currently a transient state during creation of an external table,
+		 * where the pg_class entry has been created, and its loaded into
+		 * the relcache, before the pg_exttable entry has been created.
+		 * Silently ignore missing pg_exttable rows to cope with that.
+		 */
+		ExtTableEntry *e = GetExtTableEntry(tbloid, true);
+
+		if (e && e->command)
+		{
+			char	   *on_clause = (char *) strVal(linitial(e->locations));
+
+			policy = (GpPolicy *) MemoryContextAlloc(mcxt, SizeOfGpPolicy(0));
+			if (strcmp(on_clause, "MASTER_ONLY") == 0)
+			{
+				policy->ptype = POLICYTYPE_ENTRY;
+				policy->nattrs = 0;
+			}
+			else
+			{
+				policy->ptype = POLICYTYPE_PARTITIONED;
+				policy->nattrs = 0;
+			}
+			return policy;
+		}
+	}
 
 	/*
 	 * We need to read the gp_distribution_policy table
@@ -112,9 +151,8 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 				ObjectIdGetDatum(tbloid)));
 
 	/*
-	 * Read first (and only ) tuple
+	 * Read first (and only) tuple
 	 */
-
 	if (HeapTupleIsValid(gp_policy_tuple))
 	{
 		bool		isNull;
@@ -128,7 +166,7 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 		 */
 		attr = heap_getattr(gp_policy_tuple, Anum_gp_policy_attrnums, 
 							RelationGetDescr(gp_policy_rel), &isNull);
-		
+
 		/*
 		 * Get distribution keys only if this table has a policy.
 		 */
@@ -137,10 +175,9 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 			extract_INT2OID_array(attr, &nattrs, &attrnums);
 			Assert(nattrs >= 0);
 		}
-			
+
 		/* Create an GpPolicy object. */
-		nb = sizeof(*policy) - sizeof(policy->attrs) + nattrs * sizeof(policy->attrs[0]);
-		policy = (GpPolicy *)MemoryContextAlloc(mcxt, nb);
+		policy = (GpPolicy *) MemoryContextAlloc(mcxt, SizeOfGpPolicy(nattrs));
 		policy->ptype = POLICYTYPE_PARTITIONED;
 		policy->nattrs = nattrs;
 		for (i = 0; i < nattrs; i++)
@@ -152,14 +189,12 @@ GpPolicyFetch(MemoryContext mcxt, Oid tbloid)
 	/*
 	 * Cleanup the scan and relation objects.
 	 */
-
 	heap_close(gp_policy_rel, AccessShareLock);
 
 	/* Interpret absence of a valid policy row as POLICYTYPE_ENTRY */
 	if (policy == NULL)
 	{
-	    nb = sizeof(*policy) - sizeof(policy->attrs);
-    	policy = (GpPolicy *)MemoryContextAlloc(mcxt, nb);
+		policy = (GpPolicy *) MemoryContextAlloc(mcxt, SizeOfGpPolicy(0));
 		policy->ptype = POLICYTYPE_ENTRY;
 		policy->nattrs = 0;
 	}
@@ -365,8 +400,8 @@ GpPolicyReplace(Oid tbloid, const GpPolicy *policy)
 
 /*
  * Removes the policy of a table from the gp_distribution_policy table
- *
- * Callers must check that there actually *is* a policy for the relation.
+
+ * Does nothing if the policy doesn't exist.
  */
 void
 GpPolicyRemove(Oid tbloid)
@@ -380,17 +415,11 @@ GpPolicyRemove(Oid tbloid)
 	gp_policy_rel = heap_open(GpPolicyRelationId, RowExclusiveLock);
 
 	/* Delete the policy entry from the catalog. */
-	if (0 == caql_getcount(
-				caql_addrel(cqclr(&cqc), gp_policy_rel),
-				cql("DELETE FROM gp_distribution_policy "
-					" WHERE localoid = :1 ",
-					ObjectIdGetDatum(tbloid))))
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("distribution policy for relation \"%d\" does not exist",
-						tbloid)));
-	}
+	(void) caql_getcount(
+		caql_addrel(cqclr(&cqc), gp_policy_rel),
+		cql("DELETE FROM gp_distribution_policy "
+			" WHERE localoid = :1 ",
+			ObjectIdGetDatum(tbloid)));
 
 	/*
      * Close the gp_distribution_policy relcache entry without unlocking.

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -259,9 +259,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 	    Assert(rte->rtekind == RTE_RELATION);
 
 	    targetPolicy = GpPolicyFetch(CurrentMemoryContext, rte->relid);
-
-        if (targetPolicy)
-            targetPolicyType = targetPolicy->ptype;
+		targetPolicyType = targetPolicy->ptype;
     }
 
 	switch (query->commandType)

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -8116,7 +8116,7 @@ is_exchangeable(Relation rel, Relation oldrel, Relation newrel, bool throw)
 								"with external table")));
 		}
 
-		ExtTableEntry *extEntry = GetExtTableEntry(newrel->rd_id);
+		ExtTableEntry *extEntry = GetExtTableEntry(newrel->rd_id, false);
 		if (extEntry && extEntry->iswritable)
 		{
 			congruent = FALSE;

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1452,7 +1452,7 @@ static void analyzeEstimateIndexpages(Oid relationOid, Oid indexOid, float4 *ind
 		
 	initStringInfo(&sqlstmt);
 	
-	if (isMasterOnly(relationOid))
+	if (GpPolicyFetch(CurrentMemoryContext, relationOid)->ptype == POLICYTYPE_ENTRY)
 	{
 		appendStringInfo(&sqlstmt, "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] "
 				"from pg_class c where c.oid=%d", indexOid);		
@@ -1514,7 +1514,7 @@ static void analyzeEstimateReltuplesRelpages(Oid relationOid, float4 *relTuples,
 
 		initStringInfo(&sqlstmt);
 
-		if (isMasterOnly(singleOid))
+		if (GpPolicyFetch(CurrentMemoryContext, singleOid)->ptype == POLICYTYPE_ENTRY)
 		{
 			appendStringInfo(&sqlstmt, "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] "
 					"from pg_class c where c.oid=%d", singleOid);

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3421,7 +3421,7 @@ CopyFromDispatch(CopyState cstate)
 					 * policy should be PARTITIONED (normal tables) or
 					 * ENTRY
 					 */
-					if (!part_policy || part_policy->ptype == POLICYTYPE_UNDEFINED)
+					if (!part_policy)
 					{
 						elog(FATAL, "Bad or undefined policy. (%p)", part_policy);
 					}

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1231,6 +1231,16 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 							locationUris);
 
 		/*
+		 * DefineRelation loaded the new relation into relcache, but the
+		 * relcache contains the distribution policy, which in turn depends on
+		 * the contents of pg_exttable, for EXECUTE-type external tables
+		 * (see GpPolicyFetch()). Now that we have created the pg_exttable
+		 * entry, invalidate the relcache, so that it gets loaded with the
+		 * correct information.
+		 */
+		RelationCacheInvalidateEntry(reloid);
+
+		/*
 		 * record a dependency between the external table and its error table (if one exists)
 		 */
 		if (singlerowerrorDesc && singlerowerrorDesc->errtable)

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -67,7 +67,6 @@
 #include "cdb/cdbmotion.h"
 #include "cdb/cdbsreh.h"
 #include "cdb/memquota.h"
-#include "catalog/catalog.h" // isMasterOnly()
 #include "executor/spi.h"
 #include "utils/elog.h"
 #include "miscadmin.h"
@@ -1740,7 +1739,7 @@ InitRootSlices(QueryDesc *queryDesc)
 					int idx = list_nth_int(resultRelations, 0);
 					Assert (idx > 0);
 					Oid reloid = getrelid(idx, queryDesc->plannedstmt->rtable);
-					if (!isMasterOnly(reloid))
+					if (GpPolicyFetch(CurrentMemoryContext, reloid)->ptype != POLICYTYPE_ENTRY)
 					{
 						slice->gangType = GANGTYPE_PRIMARY_WRITER;
 						slice->gangSize = getgpsegmentCount();

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -356,7 +356,7 @@ get_external_relation_info(Oid relationObjectId, RelOptInfo *rel)
 	/*
 	 * Get the pg_exttable fields for this table
 	 */
-	extentry = GetExtTableEntry(relationObjectId);
+	extentry = GetExtTableEntry(relationObjectId, false);
 	
 	rel->locationlist = extentry->locations;	
 	rel->execcommand = extentry->command;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -209,12 +209,6 @@ static void transformColumnDefinition(ParseState *pstate,
 static void transformTableConstraint(ParseState *pstate,
 						 CreateStmtContext *cxt,
 						 Constraint *constraint);
-static void transformETDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
-									 List *distributedBy, GpPolicy **policyp,
-									 List *likeDistributedBy,
-									 bool bQuiet,
-									 bool iswritable,
-									 bool onmaster);
 static void transformDistributedBy(ParseState *pstate,
 								   CreateStmtContext *cxt,
 								   List *distributedBy,
@@ -2181,10 +2175,8 @@ transformCreateExternalStmt(ParseState *pstate, CreateExternalStmt *stmt,
 	CreateStmtContext cxt;
 	Query	   *q;
 	ListCell   *elements;
-	ExtTableTypeDesc	*exttypeDesc = NULL;
 	List  	   *likeDistributedBy = NIL;
 	bool	    bQuiet = false;	/* shut up transformDistributedBy messages */
-	bool		onmaster = false;
 	bool		iswritable = stmt->iswritable;
 
 	cxt.stmtType = "CREATE EXTERNAL TABLE";
@@ -2249,34 +2241,25 @@ transformCreateExternalStmt(ParseState *pstate, CreateExternalStmt *stmt,
 	}
 
 	/*
-	 * Check if this is an EXECUTE ON MASTER table. We'll need this information
-	 * in transformExternalDistributedBy. While at it, we also check if an error
-	 * table or LOG ERRORS is attempted to be used on ON MASTER table and error if so.
+	 * Forbid LOG ERRORS and ON MASTER combination.
 	 */
-	if(!iswritable)
+	if (!iswritable && stmt->exttypedesc->exttabletype == EXTTBL_TYPE_EXECUTE)
 	{
-		exttypeDesc = (ExtTableTypeDesc *)stmt->exttypedesc;
+		ListCell   *exec_location_opt;
 
-		if(exttypeDesc->exttabletype == EXTTBL_TYPE_EXECUTE)
+		foreach(exec_location_opt, stmt->exttypedesc->on_clause)
 		{
-			ListCell   *exec_location_opt;
+			DefElem    *defel = (DefElem *) lfirst(exec_location_opt);
 
-			foreach(exec_location_opt, exttypeDesc->on_clause)
+			if (strcmp(defel->defname, "master") == 0)
 			{
-				DefElem    *defel = (DefElem *) lfirst(exec_location_opt);
+				SingleRowErrorDesc *srehDesc = (SingleRowErrorDesc *)stmt->sreh;
 
-				if (strcmp(defel->defname, "master") == 0)
-				{
-					SingleRowErrorDesc *srehDesc = (SingleRowErrorDesc *)stmt->sreh;
-
-					onmaster = true;
-
-					if(srehDesc && (srehDesc->errtable || srehDesc->into_file))
-						ereport(ERROR,
-								(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-								 errmsg("External web table with ON MASTER clause "
-										"cannot use LOG ERRORS feature.")));
-				}
+				if(srehDesc && (srehDesc->errtable || srehDesc->into_file))
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+							 errmsg("External web table with ON MASTER clause "
+									"cannot use LOG ERRORS feature.")));
 			}
 		}
 	}
@@ -2289,8 +2272,39 @@ transformCreateExternalStmt(ParseState *pstate, CreateExternalStmt *stmt,
 		transformSingleRowErrorHandling(pstate, &cxt,
 										(SingleRowErrorDesc *) stmt->sreh);
 
-	transformETDistributedBy(pstate, &cxt, stmt->distributedBy, &stmt->policy,
-							 likeDistributedBy, bQuiet, iswritable, onmaster);
+	/*
+	 * Handle DISTRIBUTED BY clause, if any.
+	 *
+	 * Don't create a policy row for EXECUTE type external tables. They have
+	 * an "ON <segment spec>" clause.
+	 *
+	 * WET: by default we distribute RANDOMLY, or by the distribution key
+	 * of the LIKE table if exists. However, if DISTRIBUTED BY was
+	 * specified we use it by calling the regular transformDistributedBy and
+	 * handle it like we would for non external tables.
+	 */
+	if (list_length(stmt->distributedBy) > 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+				 errmsg("Readable external tables can\'t specify a DISTRIBUTED BY clause.")));
+
+	if (stmt->exttypedesc->exttabletype != EXTTBL_TYPE_EXECUTE)
+	{
+		if(stmt->distributedBy == NIL && likeDistributedBy == NIL)
+		{
+			/*
+			 * defaults to DISTRIBUTED RANDOMLY irrespective of the
+			 * gp_create_table_random_default_distribution guc.
+			 */
+			stmt->policy = createRandomDistribution(MaxPolicyAttributeNumber);
+		}
+		else
+		{
+			/* regular DISTRIBUTED BY transformation */
+			transformDistributedBy(pstate, &cxt, stmt->distributedBy, &stmt->policy,
+								   likeDistributedBy, bQuiet);
+		}
+	}
 
 	Assert(cxt.ckconstraints == NIL);
 	Assert(cxt.fkconstraints == NIL);
@@ -2572,78 +2586,6 @@ transformTableConstraint(ParseState *pstate, CreateStmtContext *cxt,
 }
 
 
-
-/*
- * transformETDistributedBy - transform DISTRIBUTED BY clause for
- * external tables.
- *
- * WET: by default we distribute RANDOMLY, or by the distribution key
- * of the LIKE table if exists. However, if DISTRIBUTED BY was
- * specified we use it by calling the regular transformDistributedBy and
- * handle it like we would for non external tables.
- *
- * RET: We always create a random distribution policy entry *unless*
- * this is an EXECUTE table with ON MASTER specified, in which case
- * we create no policy so that the master will be accessed.
- */
-static void
-transformETDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
-						 List *distributedBy, GpPolicy **policyp,
-						 List *likeDistributedBy,
-						 bool bQuiet,
-						 bool iswritable,
-						 bool onmaster)
-{
-	int			maxattrs = MaxPolicyAttributeNumber;
-	GpPolicy*	p = NULL;
-
-	/*
-	 * utility mode creates can't have a policy.  Only the QD can have policies
-	 */
-	if (Gp_role != GP_ROLE_DISPATCH)
-	{
-		*policyp = NULL;
-		return;
-	}
-
-	if(!iswritable && list_length(distributedBy) > 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-				 errmsg("Readable external tables can\'t specify a DISTRIBUTED BY clause.")));
-
-	if(iswritable)
-	{
-		/* WET */
-
-		if(distributedBy == NIL && likeDistributedBy == NIL)
-		{
-			/* defaults to DISTRIBUTED RANDOMLY irrespective of the gp_create_table_random_default_distribution guc */
-			*policyp = createRandomDistribution(maxattrs);
-		}
-		else
-		{
-			/* regular DISTRIBUTED BY transformation */
-			transformDistributedBy(pstate, cxt, distributedBy, policyp,
-								   likeDistributedBy, bQuiet);
-		}
-	}
-	else
-	{
-		/* RET */
-
-		if(onmaster)
-		{
-			p = NULL;
-		}
-		else
-		{
-			/* defaults to DISTRIBUTED RANDOMLY */
-			p = createRandomDistribution(maxattrs);
-		}
-
-		*policyp = p;
-	}
-}
 
 /****************stmt->policy*********************/
 static void
@@ -12370,13 +12312,15 @@ transformSingleRowErrorHandling(ParseState *pstate, CreateStmtContext *cxt,
 /*
  * create a policy with random distribution
  */
-GpPolicy *createRandomDistribution(int maxattrs)
+GpPolicy *
+createRandomDistribution(int maxattrs)
 {
-        GpPolicy*       p = NULL;
-        p = (GpPolicy *) palloc(sizeof(GpPolicy) + maxattrs * sizeof(p->attrs[0]));
-        p->ptype = POLICYTYPE_PARTITIONED;
-        p->nattrs = 0;
-        p->attrs[0] = 1;
+	GpPolicy   *p;
 
-        return p;
+	p = (GpPolicy *) palloc(SizeOfGpPolicy(maxattrs));
+	p->ptype = POLICYTYPE_PARTITIONED;
+	p->nattrs = 0;
+	p->attrs[0] = 1;
+
+	return p;
 }

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4531,7 +4531,7 @@ CreateExternalStmt:	CREATE OptWritable EXTERNAL OptWeb OptTemp TABLE qualified_n
 							$7->istemp = $5;
 							n->relation = $7;
 							n->tableElts = $9;
-							n->exttypedesc = $11;
+							n->exttypedesc = (ExtTableTypeDesc *) $11;
 							n->format = $13;
 							n->formatOpts = $14;
 							n->encoding = $15;

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -874,7 +874,7 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 			Oid reloid = RelationGetRelid(pstate->p_target_relation);
 			ExtTableEntry* 	extentry;
 			
-			extentry = GetExtTableEntry(reloid);
+			extentry = GetExtTableEntry(reloid, false);
 			
 			if(!extentry->iswritable)
 				ereport(ERROR,

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -39,9 +39,6 @@ extern bool IsSystemNamespace(Oid namespaceId);
 extern bool IsToastNamespace(Oid namespaceId);
 extern bool IsAoSegmentNamespace(Oid namespaceId);
 
-
-extern bool isMasterOnly(Oid relationOid);
-
 extern bool IsReservedName(const char *name);
 extern char* GetReservedPrefix(const char *name);
 

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -54,9 +54,8 @@ CATALOG(gp_distribution_policy,5002) BKI_WITHOUT_OIDS
  */
 typedef enum GpPolicyType
 {
-	POLICYTYPE_UNDEFINED,
 	POLICYTYPE_PARTITIONED,		/* Tuples partitioned onto segment database. */
-	POLICYTYPE_ENTRY			/* Tuples stored on enty database. */
+	POLICYTYPE_ENTRY			/* Tuples stored on entry database. */
 } GpPolicyType;
 
 /*
@@ -67,8 +66,7 @@ typedef enum GpPolicyType
  * A GpPolicy is typically palloc'd with space for nattrs integer
  * attribute numbers (attrs) in addition to sizeof(GpPolicy).
  */
-typedef
-struct GpPolicy
+typedef struct GpPolicy
 {
 	GpPolicyType ptype;
 
@@ -76,6 +74,8 @@ struct GpPolicy
 	int			nattrs;
 	AttrNumber	attrs[1];		/* the first of nattrs attribute numbers.  */
 } GpPolicy;
+
+#define SizeOfGpPolicy(nattrs)	(offsetof(GpPolicy, attrs) + sizeof(AttrNumber) * (nattrs))
 
 /*
  * GpPolicyCopy -- Return a copy of a GpPolicy object.

--- a/src/include/catalog/pg_exttable.h
+++ b/src/include/catalog/pg_exttable.h
@@ -128,8 +128,7 @@ typedef struct ExtTableEntry
 
 /* No initial contents. */
 
-extern void
-InsertExtTableEntry(Oid 	tbloid, 
+extern void InsertExtTableEntry(Oid 	tbloid,
 					bool 	iswritable,
 					bool 	isweb,
 					bool	issreh,
@@ -143,11 +142,9 @@ InsertExtTableEntry(Oid 	tbloid,
 					Datum	locationExec,
 					Datum	locationUris);
 
-extern ExtTableEntry*
-GetExtTableEntry(Oid relid);
+extern ExtTableEntry *GetExtTableEntry(Oid relid, bool noerror);
 
-extern void
-RemoveExtTableEntry(Oid relid);
+extern void RemoveExtTableEntry(Oid relid);
 
 #define fmttype_is_custom(c) (c == 'b' || c == 'a' || c == 'p')
 #define fmttype_is_avro(c) (c == 'a')

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1456,7 +1456,7 @@ typedef enum ExtTableType
 	EXTTBL_TYPE_EXECUTE			/* table defined with EXECUTE clause */
 } ExtTableType;
 
-typedef struct ExtTableTypeDesc
+typedef struct
 {
 	NodeTag			type;
 	ExtTableType	exttabletype;
@@ -1470,7 +1470,7 @@ typedef struct CreateExternalStmt
 	NodeTag		type;
 	RangeVar   *relation;		/* external relation to create */
 	List	   *tableElts;		/* column definitions (list of ColumnDef) */
-	Node	   *exttypedesc;    /* LOCATION or EXECUTE information */
+	ExtTableTypeDesc *exttypedesc;    /* LOCATION or EXECUTE information */
 	char	   *format;			/* data format name */
 	List	   *formatOpts;		/* List of DefElem nodes for data format */
 	bool		isweb;

--- a/src/test/regress/bugbuster/expected/jetpack.out
+++ b/src/test/regress/bugbuster/expected/jetpack.out
@@ -259,3 +259,17 @@ where pg.relfilenode=gsopai.sopaidpartitionoid and pg.relname like 'gptoolkit_us
  gptoolkit_user_table_ao_1_prt_p2         | t             | t              |                          0
 (6 rows)
 
+-- Test __gp_localid and __gp_masterid functions. The output of __gp_localid
+-- depends on the number of segments, so just check that it returns something.
+select count(*) from gp_toolkit.__gp_localid;
+ count 
+-------
+     2
+(1 row)
+
+select * from gp_toolkit.__gp_masterid;
+ masterid 
+----------
+       -1
+(1 row)
+

--- a/src/test/regress/bugbuster/sql/jetpack.sql
+++ b/src/test/regress/bugbuster/sql/jetpack.sql
@@ -96,3 +96,8 @@ select pg.relname,
        sopaidpartitionindexessize
 from pg_class pg,gp_toolkit.gp_size_of_partition_and_indexes_disk gsopai
 where pg.relfilenode=gsopai.sopaidpartitionoid and pg.relname like 'gptoolkit_user_table_ao%';
+
+-- Test __gp_localid and __gp_masterid functions. The output of __gp_localid
+-- depends on the number of segments, so just check that it returns something.
+select count(*) from gp_toolkit.__gp_localid;
+select * from gp_toolkit.__gp_masterid;


### PR DESCRIPTION
Moving the installation of gp_toolkit.sql into initdb, in commit f8910c3c,
broke all the functions that are supposed to execute on all nodes, like
gp_toolkit.__gp_localid. After that change, gp_toolkit.sql was executed
in utility mode, and the gp_distribution_policy entries for those functions
were not created as a result.

To fix, change the code so that gp_distribution_policy entries are never
never created, or consulted, for EXECUTE-type external tables. They have
more fine-grained information in pg_exttable.location field anyway, so rely
on that instead. With this change, there is no difference in whether an
EXECUTE-type external table is created in utility mode or not. We would
still have similar problems if gp_toolkit contained other kinds of
external tables, but it doesn't.

This removes the isMasterOnly() function and changes all its callers to
call GpPolicyFetch() directly instead. Some places used GpPolicyFetch()
directly to check if a table is distributed, so this just makes that the
canonical way to do it. The check for system schemas that used to be in
isMasterOnly() are no longer performed, but they should've unnecessary in
the first place. System tables don't have gp_distribution_policy entries,
so they'll be treated as master-only even without that check.