### PR TITLE
Make functions in gp_toolkit to execute on all nodes as intended.

### DIFF
--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -27,6 +27,7 @@
 #include "catalog/pg_auth_members.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_database.h"
+#include "catalog/pg_exttable.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_pltemplate.h"
 #include "catalog/pg_resqueue.h"
@@ -624,29 +625,6 @@ IsAoSegmentNamespace(Oid namespaceId)
 	return namespaceId == PG_AOSEGMENT_NAMESPACE;
 }
 
-/**
- * Method determines if a relation is master-only or distributed among segments.
- * Input:
- * 	relationOid
- * Output:
- * 	true if masteronly
- */
-bool
-isMasterOnly(Oid relationOid)
-{
-	Assert(relationOid != InvalidOid);
-	Oid				schemaOid = get_rel_namespace(relationOid);
-	GpPolicy		*distributionPolicy = GpPolicyFetch(CurrentMemoryContext, relationOid);
-	
-	bool masterOnly = (Gp_role == GP_ROLE_UTILITY 
-			|| IsSystemNamespace(schemaOid)
-			|| IsToastNamespace(schemaOid)
-			|| IsAoSegmentNamespace(schemaOid)
-			|| (distributionPolicy == NULL)
-			|| (distributionPolicy->ptype == POLICYTYPE_ENTRY));
-	
-	return masterOnly;
-}
 /*
  * IsReservedName
  *		True iff name starts with the pg_ prefix.

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -259,9 +259,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 	    Assert(rte->rtekind == RTE_RELATION);
 
 	    targetPolicy = GpPolicyFetch(CurrentMemoryContext, rte->relid);
-
-        if (targetPolicy)
-            targetPolicyType = targetPolicy->ptype;
+		targetPolicyType = targetPolicy->ptype;
     }
 
 	switch (query->commandType)

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1452,7 +1452,7 @@ static void analyzeEstimateIndexpages(Oid relationOid, Oid indexOid, float4 *ind
 		
 	initStringInfo(&sqlstmt);
 	
-	if (isMasterOnly(relationOid))
+	if (GpPolicyFetch(CurrentMemoryContext, relationOid)->ptype == POLICYTYPE_ENTRY)
 	{
 		appendStringInfo(&sqlstmt, "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] "
 				"from pg_class c where c.oid=%d", indexOid);		
@@ -1514,7 +1514,7 @@ static void analyzeEstimateReltuplesRelpages(Oid relationOid, float4 *relTuples,
 
 		initStringInfo(&sqlstmt);
 
-		if (isMasterOnly(singleOid))
+		if (GpPolicyFetch(CurrentMemoryContext, singleOid)->ptype == POLICYTYPE_ENTRY)
 		{
 			appendStringInfo(&sqlstmt, "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] "
 					"from pg_class c where c.oid=%d", singleOid);

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3421,7 +3421,7 @@ CopyFromDispatch(CopyState cstate)
 					 * policy should be PARTITIONED (normal tables) or
 					 * ENTRY
 					 */
-					if (!part_policy || part_policy->ptype == POLICYTYPE_UNDEFINED)
+					if (!part_policy)
 					{
 						elog(FATAL, "Bad or undefined policy. (%p)", part_policy);
 					}

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1231,6 +1231,16 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 							locationUris);
 
 		/*
+		 * DefineRelation loaded the new relation into relcache, but the
+		 * relcache contains the distribution policy, which in turn depends on
+		 * the contents of pg_exttable, for EXECUTE-type external tables
+		 * (see GpPolicyFetch()). Now that we have created the pg_exttable
+		 * entry, invalidate the relcache, so that it gets loaded with the
+		 * correct information.
+		 */
+		CacheInvalidateRelcacheByRelid(reloid);
+
+		/*
 		 * record a dependency between the external table and its error table (if one exists)
 		 */
 		if (singlerowerrorDesc && singlerowerrorDesc->errtable)

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -67,7 +67,6 @@
 #include "cdb/cdbmotion.h"
 #include "cdb/cdbsreh.h"
 #include "cdb/memquota.h"
-#include "catalog/catalog.h" // isMasterOnly()
 #include "executor/spi.h"
 #include "utils/elog.h"
 #include "miscadmin.h"
@@ -1740,7 +1739,7 @@ InitRootSlices(QueryDesc *queryDesc)
 					int idx = list_nth_int(resultRelations, 0);
 					Assert (idx > 0);
 					Oid reloid = getrelid(idx, queryDesc->plannedstmt->rtable);
-					if (!isMasterOnly(reloid))
+					if (GpPolicyFetch(CurrentMemoryContext, reloid)->ptype != POLICYTYPE_ENTRY)
 					{
 						slice->gangType = GANGTYPE_PRIMARY_WRITER;
 						slice->gangSize = getgpsegmentCount();

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4531,7 +4531,7 @@ CreateExternalStmt:	CREATE OptWritable EXTERNAL OptWeb OptTemp TABLE qualified_n
 							$7->istemp = $5;
 							n->relation = $7;
 							n->tableElts = $9;
-							n->exttypedesc = $11;
+							n->exttypedesc = (ExtTableTypeDesc *) $11;
 							n->format = $13;
 							n->formatOpts = $14;
 							n->encoding = $15;

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -2402,9 +2402,6 @@ RelationClearRelation(Relation relation, bool rebuild)
 		/* pgstat_info must be preserved */
 		SWAPFIELD(struct PgStat_TableStatus *, pgstat_info);
 
-		/* preserve rd_cdbpolicy, as there are probably pointers to it */
-		SWAPFIELD(struct GpPolicy *, rd_cdbpolicy);
-
 		/* preserve persistent table information for the relation  */
 		SWAPFIELD(struct RelationNodeInfo, rd_segfile0_relationnodeinfo);
 

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -39,9 +39,6 @@ extern bool IsSystemNamespace(Oid namespaceId);
 extern bool IsToastNamespace(Oid namespaceId);
 extern bool IsAoSegmentNamespace(Oid namespaceId);
 
-
-extern bool isMasterOnly(Oid relationOid);
-
 extern bool IsReservedName(const char *name);
 extern char* GetReservedPrefix(const char *name);
 

--- a/src/include/catalog/gp_policy.h
+++ b/src/include/catalog/gp_policy.h
@@ -54,9 +54,8 @@ CATALOG(gp_distribution_policy,5002) BKI_WITHOUT_OIDS
  */
 typedef enum GpPolicyType
 {
-	POLICYTYPE_UNDEFINED,
 	POLICYTYPE_PARTITIONED,		/* Tuples partitioned onto segment database. */
-	POLICYTYPE_ENTRY			/* Tuples stored on enty database. */
+	POLICYTYPE_ENTRY			/* Tuples stored on entry database. */
 } GpPolicyType;
 
 /*
@@ -67,8 +66,7 @@ typedef enum GpPolicyType
  * A GpPolicy is typically palloc'd with space for nattrs integer
  * attribute numbers (attrs) in addition to sizeof(GpPolicy).
  */
-typedef
-struct GpPolicy
+typedef struct GpPolicy
 {
 	GpPolicyType ptype;
 
@@ -76,6 +74,8 @@ struct GpPolicy
 	int			nattrs;
 	AttrNumber	attrs[1];		/* the first of nattrs attribute numbers.  */
 } GpPolicy;
+
+#define SizeOfGpPolicy(nattrs)	(offsetof(GpPolicy, attrs) + sizeof(AttrNumber) * (nattrs))
 
 /*
  * GpPolicyCopy -- Return a copy of a GpPolicy object.

--- a/src/include/catalog/pg_exttable.h
+++ b/src/include/catalog/pg_exttable.h
@@ -128,8 +128,7 @@ typedef struct ExtTableEntry
 
 /* No initial contents. */
 
-extern void
-InsertExtTableEntry(Oid 	tbloid, 
+extern void InsertExtTableEntry(Oid 	tbloid,
 					bool 	iswritable,
 					bool 	isweb,
 					bool	issreh,
@@ -143,11 +142,10 @@ InsertExtTableEntry(Oid 	tbloid,
 					Datum	locationExec,
 					Datum	locationUris);
 
-extern ExtTableEntry*
-GetExtTableEntry(Oid relid);
+extern ExtTableEntry *GetExtTableEntry(Oid relid);
+extern ExtTableEntry *GetExtTableEntryIfExists(Oid relid);
 
-extern void
-RemoveExtTableEntry(Oid relid);
+extern void RemoveExtTableEntry(Oid relid);
 
 #define fmttype_is_custom(c) (c == 'b' || c == 'a' || c == 'p')
 #define fmttype_is_avro(c) (c == 'a')

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1456,7 +1456,7 @@ typedef enum ExtTableType
 	EXTTBL_TYPE_EXECUTE			/* table defined with EXECUTE clause */
 } ExtTableType;
 
-typedef struct ExtTableTypeDesc
+typedef struct
 {
 	NodeTag			type;
 	ExtTableType	exttabletype;
@@ -1470,7 +1470,7 @@ typedef struct CreateExternalStmt
 	NodeTag		type;
 	RangeVar   *relation;		/* external relation to create */
 	List	   *tableElts;		/* column definitions (list of ColumnDef) */
-	Node	   *exttypedesc;    /* LOCATION or EXECUTE information */
+	ExtTableTypeDesc *exttypedesc;    /* LOCATION or EXECUTE information */
 	char	   *format;			/* data format name */
 	List	   *formatOpts;		/* List of DefElem nodes for data format */
 	bool		isweb;

--- a/src/test/regress/bugbuster/expected/jetpack.out
+++ b/src/test/regress/bugbuster/expected/jetpack.out
@@ -259,3 +259,17 @@ where pg.relfilenode=gsopai.sopaidpartitionoid and pg.relname like 'gptoolkit_us
  gptoolkit_user_table_ao_1_prt_p2         | t             | t              |                          0
 (6 rows)
 
+-- Test __gp_localid and __gp_masterid functions. The output of __gp_localid
+-- depends on the number of segments, so just check that it returns something.
+select count(*) > 0 from gp_toolkit.__gp_localid;
+ ?column? 
+----------
+ t
+(1 row)
+
+select * from gp_toolkit.__gp_masterid;
+ masterid 
+----------
+       -1
+(1 row)
+

--- a/src/test/regress/bugbuster/sql/jetpack.sql
+++ b/src/test/regress/bugbuster/sql/jetpack.sql
@@ -96,3 +96,8 @@ select pg.relname,
        sopaidpartitionindexessize
 from pg_class pg,gp_toolkit.gp_size_of_partition_and_indexes_disk gsopai
 where pg.relfilenode=gsopai.sopaidpartitionoid and pg.relname like 'gptoolkit_user_table_ao%';
+
+-- Test __gp_localid and __gp_masterid functions. The output of __gp_localid
+-- depends on the number of segments, so just check that it returns something.
+select count(*) > 0 from gp_toolkit.__gp_localid;
+select * from gp_toolkit.__gp_masterid;


### PR DESCRIPTION
Moving the installation of gp_toolkit.sql into initdb, in commit f8910c3c,
broke all the functions that are supposed to execute on all nodes, like
gp_toolkit.__gp_localid. After that change, gp_toolkit.sql was executed
in utility mode, and the gp_distribution_policy entries for those functions
were not created as a result.

To fix, change the code so that gp_distribution_policy entries are never
never created, or consulted, for EXECUTE-type external tables. They have
more fine-grained information in pg_exttable.location field anyway, so rely
on that instead. With this change, there is no difference in whether an
EXECUTE-type external table is created in utility mode or not. We would
still have similar problems if gp_toolkit contained other kinds of
external tables, but it doesn't.

This removes the isMasterOnly() function and changes all its callers to
call GpPolicyFetch() directly instead. Some places used GpPolicyFetch()
directly to check if a table is distributed, so this just makes that the
canonical way to do it. The check for system schemas that used to be in
isMasterOnly() are no longer performed, but they should've unnecessary in
the first place. System tables don't have gp_distribution_policy entries,
so they'll be treated as master-only even without that check.