### PR TITLE
Don't interpret error string as printf format string.

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_dump_util.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.c
@@ -536,7 +536,7 @@ ReadBackendBackupFileError(PGconn *pConn, const char *pszBackupDirectory, const 
 	else
 	{
 		char *res = PQgetvalue(pRes, 0, 0);
-		appendPQExpBuffer(pszRtn, res);
+		appendPQExpBufferStr(pszRtn, res);
 		if (strstr(res, "ERROR:") || strstr(res, "[ERROR]"))
 		{
 			status = -1;


### PR DESCRIPTION
Compiler warned about this, and quite correctly.

@tangp3, this was introduced by commit 08f4ada7. Can you have a look, and push if this looks OK, pleaes?