### PR TITLE
Implement LO in MPP Way

### DIFF
--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -169,12 +169,7 @@ addToCdbHash(void *cdbHash, void *buf, size_t len)
 void
 cdbhash(CdbHash *h, Datum datum, Oid type)
 {
-  int i = 0;
-
-  for (i = 0; i < 100000; i++)
-    {
-    }
-	hashDatum(datum, type, addToCdbHash, (void*)h);
+  hashDatum(datum, type, addToCdbHash, (void*)h);
 }
 
 /*
@@ -237,7 +232,6 @@ hashDatum(Datum datum, Oid type, datumHashFunction hashFn, void *clientData)
 
 	void *tofree = NULL;
 
-	elog(WARNING,"hash1");
 	/*
 	 * Select the hash to be performed according to the field type we are adding to the
 	 * hash.

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -169,6 +169,11 @@ addToCdbHash(void *cdbHash, void *buf, size_t len)
 void
 cdbhash(CdbHash *h, Datum datum, Oid type)
 {
+  int i = 0;
+
+  for (i = 0; i < 100000; i++)
+    {
+    }
 	hashDatum(datum, type, addToCdbHash, (void*)h);
 }
 
@@ -232,6 +237,7 @@ hashDatum(Datum datum, Oid type, datumHashFunction hashFn, void *clientData)
 
 	void *tofree = NULL;
 
+	elog(WARNING,"hash1");
 	/*
 	 * Select the hash to be performed according to the field type we are adding to the
 	 * hash.

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -169,7 +169,7 @@ addToCdbHash(void *cdbHash, void *buf, size_t len)
 void
 cdbhash(CdbHash *h, Datum datum, Oid type)
 {
-  hashDatum(datum, type, addToCdbHash, (void*)h);
+	hashDatum(datum, type, addToCdbHash, (void*)h);
 }
 
 /*

--- a/src/backend/executor/execDML.c
+++ b/src/backend/executor/execDML.c
@@ -325,8 +325,8 @@ ExecInsert(TupleTableSlot *slot,
 		   DestReceiver *dest,
 		   EState *estate,
 		   PlanGenerator planGen,
-	   bool isUpdate,
-	   bool isExecLatefunc)
+		   bool isUpdate,
+		   bool isExecLatefunc)
 {
 	void		*tuple = NULL;
 	ResultRelInfo *resultRelInfo = NULL;
@@ -343,7 +343,7 @@ ExecInsert(TupleTableSlot *slot,
 
 	if (isExecLatefunc)
 	{
-	  List *args_list = estate->bypassPreprocessFunctionArgs;
+		List *args_list = estate->bypassPreprocessFunctionArgs;
 		List *args_string_list = estate->bypassPreprocessStringArgs;
 		List *bypass_location = estate->bypassLocation;
 		List *lomode = estate->loMode;
@@ -351,55 +351,55 @@ ExecInsert(TupleTableSlot *slot,
 		ListCell *lc_args;
 		ListCell *lc_location;
 		ListCell *lc_stringargs;
-		
+
 		lc_args = list_head(args_list);
 		lc_stringargs = list_head(args_string_list);
 		lc_location = list_head(bypass_location);
-		
+
 		Assert(list_length(lomode) == list_length(bypass_location));
-		
+
 		foreach(lc_lomode, lomode)
 		{
 			int current_lomode = lfirst_int(lc_lomode);
-			
-	  	if (current_lomode== 1)
-	  	{
-	    	int attnum;
-	    	int arg_value;
-	    	bool isnull;
 
-	    	attnum = -1;
-	    	arg_value = -1;
-	    	isnull = false;
+			if (current_lomode== 1)
+			{
+				int attnum;
+				int arg_value;
+				bool isnull;
 
-	    	attnum = lfirst_int(lc_location);
-				
+				attnum = -1;
+				arg_value = -1;
+				isnull = false;
+
+				attnum = lfirst_int(lc_location);
+
 				lc_location = lnext(lc_location);
 
-	    	Assert(attnum != -1);
+				Assert(attnum != -1);
 
-	    	arg_value = DatumGetUInt32(slot_getattr(slot, attnum, &isnull));
+				arg_value = DatumGetUInt32(slot_getattr(slot, attnum, &isnull));
 
-	    	Assert (isnull != true);
-	  		/* Parser should have set list values as Var attno for this function */
-	  		inv_create(arg_value);
-	  }
+				Assert (isnull != true);
+				/* Parser should have set list values as Var attno for this function */
+				inv_create(arg_value);
+			}
 			else if (current_lomode == 3)
 			{
 				A_Const *current_node = (A_Const *) linitial(lfirst(lc_args));
-			
+
 				char *args = (char *) current_node->val.val.ival;
 				int cur_location = lfirst_int(lc_location);
 				int arg_value = InvalidOid;
 				bool isnull = false;
-			
+
 				lc_args = lnext(lc_args);
 				lc_location = lnext(lc_location);
-			
+
 				arg_value = DatumGetUInt32(slot_getattr(slot, cur_location, &isnull));
-			
+
 				Assert(isnull != true);
-			
+
 				lo_import_internal(args, arg_value);
 		}
 	}

--- a/src/backend/executor/execDML.c
+++ b/src/backend/executor/execDML.c
@@ -20,7 +20,7 @@
 #include "utils/lsyscache.h"
 #include "parser/parsetree.h"
 #include "cdb/cdbvars.h"
-#include "storage/large_object.h" 
+#include "storage/large_object.h"
 
 /*
  * reconstructTupleValues
@@ -340,7 +340,6 @@ ExecInsert(TupleTableSlot *slot,
 	bool		rel_is_aocols = false;
 	bool		rel_is_external = false;
 
-	
 	if (isExecLatefunc)
 	{
 	  List *args_list = estate->bypassPreprocessFunctionArgs;
@@ -349,7 +348,7 @@ ExecInsert(TupleTableSlot *slot,
 	  Assert(list_length(args_list) == 1);
 
 	  /* Parser should have set list values as OID parameters for this function */
-	  inv_create(linitial(args_list));
+	  inv_create(linitial_oid(args_list));
 	}
 
 	/*

--- a/src/backend/executor/execDML.c
+++ b/src/backend/executor/execDML.c
@@ -361,22 +361,8 @@ ExecInsert(TupleTableSlot *slot,
 		foreach(lc_lomode, lomode)
 		{
 			int current_lomode = lfirst_int(lc_lomode);
-
-	  /* Specific hack for lo_create. Please modify for any new functions that use this machinery */
-	  //Assert(list_length(args_list) == 1);
-
-	  	if (current_lomode == 4)
-	  	{
-	    	Oid arg_value = linitial_oid(lfirst(lc_args));
-				
-				lc_args = lnext(lc_args);
-				lc_location = lnext(lc_location);
-
-        /* Parser should have set list values as OID parameters for this func\
-	       tion */
-	    	inv_create(arg_value);
-	  	}
-	  	else if (current_lomode== 1)
+			
+	  	if (current_lomode== 1)
 	  	{
 	    	int attnum;
 	    	int arg_value;
@@ -388,7 +374,6 @@ ExecInsert(TupleTableSlot *slot,
 
 	    	attnum = lfirst_int(lc_location);
 				
-				//lc_args = lnext(lc_args);
 				lc_location = lnext(lc_location);
 
 	    	Assert(attnum != -1);
@@ -399,23 +384,25 @@ ExecInsert(TupleTableSlot *slot,
 	  		/* Parser should have set list values as Var attno for this function */
 	  		inv_create(arg_value);
 	  }
-		else if (current_lomode == 3)
-		{
-			char *args = (char *) linitial(lfirst(lc_stringargs));
-			int cur_location = lfirst_int(lc_location);
-			int arg_value = InvalidOid;
-			bool isnull = false;
+			else if (current_lomode == 3)
+			{
+				A_Const *current_node = (A_Const *) linitial(lfirst(lc_args));
 			
-			lc_stringargs = lnext(lc_stringargs);
-			lc_location = lnext(lc_location);
+				char *args = (char *) current_node->val.val.ival;
+				int cur_location = lfirst_int(lc_location);
+				int arg_value = InvalidOid;
+				bool isnull = false;
 			
-			arg_value = DatumGetUInt32(slot_getattr(slot, cur_location, &isnull));
+				lc_args = lnext(lc_args);
+				lc_location = lnext(lc_location);
 			
-			Assert(isnull != true);
+				arg_value = DatumGetUInt32(slot_getattr(slot, cur_location, &isnull));
 			
-			lo_import_internal(args, arg_value);
+				Assert(isnull != true);
+			
+				lo_import_internal(args, arg_value);
 		}
-		}
+	}
 	}
 
 	/*

--- a/src/backend/executor/execDML.c
+++ b/src/backend/executor/execDML.c
@@ -347,8 +347,34 @@ ExecInsert(TupleTableSlot *slot,
 	  /* Specific hack for lo_create. Please modify for any new functions that use this machinery */
 	  Assert(list_length(args_list) == 1);
 
-	  /* Parser should have set list values as OID parameters for this function */
-	  inv_create(linitial_oid(args_list));
+	  if (estate->loMode == 1)
+	  {
+	    Oid arg_value = linitial_oid(args_list);
+
+            /* Parser should have set list values as OID parameters for this func\
+	       tion */
+	    inv_create(arg_value);
+	  }
+	  else if (estate->loMode == 2)
+	  {
+	    int attnum;
+	    int arg_value;
+	    bool isnull;
+
+	    attnum = -1;
+	    arg_value = -1;
+	    isnull = false;
+
+	    attnum = linitial_int(args_list);
+
+	    Assert(attnum != -1);
+
+	    arg_value = DatumGetUInt32(slot_getattr(slot, attnum, &isnull));
+
+	    Assert (isnull != true);
+	  /* Parser should have set list values as Var attno for this function */
+	  inv_create(arg_value);
+	  }
 	}
 
 	/*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -796,6 +796,8 @@ ExecutorRun(QueryDesc *queryDesc,
 	Assert(NULL != queryDesc->plannedstmt && NULL != queryDesc->plannedstmt->memoryAccount);
 
 	estate->bypassPreprocessFunctionArgs = queryDesc->late_execfunc_funcargs;
+	estate->bypassPreprocessStringArgs = queryDesc->late_execfunc_stringargs;
+	estate->bypassLocation = queryDesc->bypass_location;
 	estate->loMode = queryDesc->loMode;
 
 	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccount);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -796,6 +796,7 @@ ExecutorRun(QueryDesc *queryDesc,
 	Assert(NULL != queryDesc->plannedstmt && NULL != queryDesc->plannedstmt->memoryAccount);
 
 	estate->bypassPreprocessFunctionArgs = queryDesc->late_execfunc_funcargs;
+	estate->loMode = queryDesc->loMode;
 
 	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccount);
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -127,7 +127,7 @@ static TupleTableSlot *ExecutePlan(EState *estate, PlanState *planstate,
 			CmdType operation,
 			long numberTuples,
 			ScanDirection direction,
-				   DestReceiver *dest,
+			DestReceiver *dest,
 			bool isLateProcess);
 static void ExecSelect(TupleTableSlot *slot,
 		   DestReceiver *dest, EState *estate);
@@ -558,7 +558,6 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 					 * On return, gangs have been allocated and CDBProcess lists have
 					 * been filled in in the slice table.)
 					 */
-				  gp_singleton_segindex = 2;
 					AssignGangs(queryDesc, gp_singleton_segindex);
 				}
 
@@ -901,8 +900,8 @@ ExecutorRun(QueryDesc *queryDesc,
 								 CMD_SELECT,
 								 0,
 								 ForwardScanDirection,
-					     dest,
-					     false);
+					                         dest,
+					                         false);
 		}
 		else if (exec_identity == GP_ROOT_SLICE)
 		{
@@ -918,8 +917,8 @@ ExecutorRun(QueryDesc *queryDesc,
 								 operation,
 								 count,
 								 direction,
-					     dest,
-					     queryDesc->late_execfunc);
+					                         dest,
+					                         queryDesc->late_execfunc);
 		}
 		else
 		{

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -796,6 +796,8 @@ ExecutorRun(QueryDesc *queryDesc,
 
 	Assert(NULL != queryDesc->plannedstmt && NULL != queryDesc->plannedstmt->memoryAccount);
 
+	estate->bypassPreprocessFunctionArgs = queryDesc->late_execfunc_funcargs;
+
 	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccount);
 
 	/*
@@ -2767,7 +2769,7 @@ lnext:	;
 						break;
 
 					case CMD_INSERT:
-						ExecInsert(slot, dest, estate, PLANGEN_PLANNER, false /* isUpdate */);
+					  ExecInsert(slot, dest, estate, PLANGEN_PLANNER, false /* isUpdate */, isLateProcess);
 						result = NULL;
 						break;
 

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -104,7 +104,7 @@ ExecDML(DMLState *node)
 		 */
 		ExecInsert(node->cleanedUpSlot, NULL /* destReceiver */,
 				node->ps.state, PLANGEN_OPTIMIZER /* Plan origin */, 
-				isUpdate);
+			   isUpdate, false);
 	}
 	else /* DML_DELETE */
 	{

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -104,7 +104,7 @@ ExecDML(DMLState *node)
 		 */
 		ExecInsert(node->cleanedUpSlot, NULL /* destReceiver */,
 				node->ps.state, PLANGEN_OPTIMIZER /* Plan origin */, 
-			   isUpdate, false);
+			        isUpdate, false);
 	}
 	else /* DML_DELETE */
 	{

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -241,6 +241,8 @@ ExecMotion(MotionState * node)
 {
 	Motion	   *motion = (Motion *) node->ps.plan;
 
+	elog(WARNING,"motion1");
+
 	/*
 	 * at the top here we basically decide: -- SENDER vs. RECEIVER and --
 	 * SORTED vs. UNSORTED
@@ -1578,7 +1580,7 @@ doSendTuple(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot)
 	HeapTuple       tuple;
 	SendReturnCode  sendRC;
 	ExprContext    *econtext = node->ps.ps_ExprContext;
-	
+	elog(WARNING,"dosend1");
 	/* We got a tuple from the child-plan. */
 	node->numTuplesFromChild++;
 

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -241,8 +241,6 @@ ExecMotion(MotionState * node)
 {
 	Motion	   *motion = (Motion *) node->ps.plan;
 
-	elog(WARNING,"motion1");
-
 	/*
 	 * at the top here we basically decide: -- SENDER vs. RECEIVER and --
 	 * SORTED vs. UNSORTED
@@ -1580,7 +1578,7 @@ doSendTuple(Motion * motion, MotionState * node, TupleTableSlot *outerTupleSlot)
 	HeapTuple       tuple;
 	SendReturnCode  sendRC;
 	ExprContext    *econtext = node->ps.ps_ExprContext;
-	elog(WARNING,"dosend1");
+
 	/* We got a tuple from the child-plan. */
 	node->numTuplesFromChild++;
 

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -989,6 +989,7 @@ SubplanQueryDesc(QueryDesc * qd)
 	substmt->commandType = stmt->commandType;
 	substmt->canSetTag = stmt->canSetTag;
 	substmt->transientPlan = stmt->transientPlan;
+	substmt->bypassPreprocess = qd->late_execfunc;
 	substmt->planTree = stmt->planTree;
 	substmt->rtable = stmt->rtable;
 	substmt->resultRelations = stmt->resultRelations;

--- a/src/backend/libpq/be-fsstubs.c
+++ b/src/backend/libpq/be-fsstubs.c
@@ -85,7 +85,6 @@ static MemoryContext fscxt = NULL;
 
 static int	newLOfd(LargeObjectDesc *lobjCookie);
 static void deleteLOfd(int fd);
-static Oid	lo_import_internal(text *filename, Oid lobjOid);
 
 
 /*****************************************************************************
@@ -361,9 +360,11 @@ lowrite(PG_FUNCTION_ARGS)
 Datum
 lo_import(PG_FUNCTION_ARGS)
 {
+	Oid lobjId = get_new_oid();
+	
 	text	   *filename = PG_GETARG_TEXT_PP(0);
 
-	PG_RETURN_OID(lo_import_internal(filename, InvalidOid));
+	PG_RETURN_OID(ObjectIdGetDatum(lobjId));
 }
 
 /*
@@ -379,8 +380,8 @@ lo_import_with_oid(PG_FUNCTION_ARGS)
 	PG_RETURN_OID(lo_import_internal(filename, oid));
 }
 
-static Oid
-lo_import_internal(text *filename, Oid lobjOid)
+Oid
+lo_import_internal(char *filename, Oid lobjOid)
 {
 	File		fd;
 	int			nbytes,
@@ -403,13 +404,13 @@ lo_import_internal(text *filename, Oid lobjOid)
 	/*
 	 * open the file to be read in
 	 */
-	text_to_cstring_buffer(filename, fnamebuf, sizeof(fnamebuf));
-	fd = PathNameOpenFile(fnamebuf, O_RDONLY | PG_BINARY, 0666);
+	//text_to_cstring_buffer(filename, fnamebuf, sizeof(fnamebuf));
+	fd = PathNameOpenFile(filename, O_RDONLY | PG_BINARY, 0666);
 	if (fd < 0)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not open server file \"%s\": %m",
-						fnamebuf)));
+						filename)));
 
 	/*
 	 * create an inversion object

--- a/src/backend/libpq/be-fsstubs.c
+++ b/src/backend/libpq/be-fsstubs.c
@@ -241,16 +241,21 @@ lo_creat(PG_FUNCTION_ARGS)
 	 * ensure that AtEOXact_LargeObject knows there is state to clean up
 	 */
 	CreateFSContext();
-
-	lobjId = inv_create(InvalidOid);
-
+	
+  elog(WARNING,"Value1 %d", lobjId);
+	
 	PG_RETURN_OID(lobjId);
 }
 
 Datum
 lo_create(PG_FUNCTION_ARGS)
 {
-	Oid			lobjId = PG_GETARG_OID(0);
+	Oid	lobjId = PG_GETARG_OID(0);
+	
+	if (!OidIsValid(lobjId))
+	{
+		lobjId = get_new_oid();
+	}
 
 	/* NOTE: This is a dummy function which is just used for function presence. All processing is done in inv_create which is called independently */
 
@@ -258,7 +263,7 @@ lo_create(PG_FUNCTION_ARGS)
 	 * We don't actually need to store into fscxt, but create it anyway to
 	 * ensure that AtEOXact_LargeObject knows there is state to clean up
 	 */
-	//CreateFSContext(); /* is this really needed? */
+	CreateFSContext();
 
 	PG_RETURN_OID(lobjId);
 }

--- a/src/backend/libpq/be-fsstubs.c
+++ b/src/backend/libpq/be-fsstubs.c
@@ -404,7 +404,7 @@ lo_import_internal(char *filename, Oid lobjOid)
 	/*
 	 * open the file to be read in
 	 */
-	//text_to_cstring_buffer(filename, fnamebuf, sizeof(fnamebuf));
+	 
 	fd = PathNameOpenFile(filename, O_RDONLY | PG_BINARY, 0666);
 	if (fd < 0)
 		ereport(ERROR,

--- a/src/backend/libpq/be-fsstubs.c
+++ b/src/backend/libpq/be-fsstubs.c
@@ -257,9 +257,9 @@ lo_create(PG_FUNCTION_ARGS)
 	 * We don't actually need to store into fscxt, but create it anyway to
 	 * ensure that AtEOXact_LargeObject knows there is state to clean up
 	 */
-	CreateFSContext();
+	//CreateFSContext(); /* is this really needed? */
 
-	lobjId = inv_create(lobjId);
+	//lobjId = inv_create(lobjId);
 
 	PG_RETURN_OID(lobjId);
 }

--- a/src/backend/libpq/be-fsstubs.c
+++ b/src/backend/libpq/be-fsstubs.c
@@ -253,13 +253,13 @@ lo_create(PG_FUNCTION_ARGS)
 {
 	Oid			lobjId = PG_GETARG_OID(0);
 
+	/* NOTE: This is a dummy function which is just used for function presence. All processing is done in inv_create which is called independently */
+
 	/*
 	 * We don't actually need to store into fscxt, but create it anyway to
 	 * ensure that AtEOXact_LargeObject knows there is state to clean up
 	 */
 	//CreateFSContext(); /* is this really needed? */
-
-	//lobjId = inv_create(lobjId);
 
 	PG_RETURN_OID(lobjId);
 }

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -161,6 +161,7 @@ _copyPlannedStmt(PlannedStmt *from)
 	COPY_SCALAR_FIELD(transientPlan);
 	COPY_SCALAR_FIELD(bypassPreprocess);
 	COPY_NODE_FIELD(bypassPreprocessFuncArgs);
+	COPY_SCALAR_FIELD(loMode);
 
 	COPY_NODE_FIELD(planTree);
 	COPY_NODE_FIELD(rtable);
@@ -2650,6 +2651,7 @@ _copyQuery(Query *from)
 	COPY_SCALAR_FIELD(hasAggs);
 	COPY_SCALAR_FIELD(hasBypassPreprocess);
 	COPY_NODE_FIELD(bypassPreprocessFunctionArgs);
+	COPY_SCALAR_FIELD(loMode);
 	COPY_SCALAR_FIELD(hasWindFuncs);
 	COPY_SCALAR_FIELD(hasSubLinks);
 	COPY_NODE_FIELD(rtable);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -158,8 +158,9 @@ _copyPlannedStmt(PlannedStmt *from)
 	COPY_SCALAR_FIELD(commandType);
 	COPY_SCALAR_FIELD(planGen);
 	COPY_SCALAR_FIELD(canSetTag);
-	COPY_SCALAR_FIELD(bypassPreprocess);
 	COPY_SCALAR_FIELD(transientPlan);
+	COPY_SCALAR_FIELD(bypassPreprocess);
+	COPY_NODE_FIELD(bypassPreprocessFuncArgs);
 
 	COPY_NODE_FIELD(planTree);
 	COPY_NODE_FIELD(rtable);
@@ -2648,6 +2649,7 @@ _copyQuery(Query *from)
 	COPY_NODE_FIELD(intoClause);
 	COPY_SCALAR_FIELD(hasAggs);
 	COPY_SCALAR_FIELD(hasBypassPreprocess);
+	COPY_NODE_FIELD(bypassPreprocessFunctionArgs);
 	COPY_SCALAR_FIELD(hasWindFuncs);
 	COPY_SCALAR_FIELD(hasSubLinks);
 	COPY_NODE_FIELD(rtable);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -161,7 +161,9 @@ _copyPlannedStmt(PlannedStmt *from)
 	COPY_SCALAR_FIELD(transientPlan);
 	COPY_SCALAR_FIELD(bypassPreprocess);
 	COPY_NODE_FIELD(bypassPreprocessFuncArgs);
-	COPY_SCALAR_FIELD(loMode);
+	COPY_NODE_FIELD(bypassPreprocessStringArgs);
+	COPY_NODE_FIELD(bypassLocation);
+	COPY_NODE_FIELD(loMode);
 
 	COPY_NODE_FIELD(planTree);
 	COPY_NODE_FIELD(rtable);
@@ -2651,7 +2653,9 @@ _copyQuery(Query *from)
 	COPY_SCALAR_FIELD(hasAggs);
 	COPY_SCALAR_FIELD(hasBypassPreprocess);
 	COPY_NODE_FIELD(bypassPreprocessFunctionArgs);
-	COPY_SCALAR_FIELD(loMode);
+	COPY_NODE_FIELD(bypassPreprocessStringArgs);
+	COPY_NODE_FIELD(loMode);
+	COPY_NODE_FIELD(bypassLocation);
 	COPY_SCALAR_FIELD(hasWindFuncs);
 	COPY_SCALAR_FIELD(hasSubLinks);
 	COPY_NODE_FIELD(rtable);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -158,6 +158,7 @@ _copyPlannedStmt(PlannedStmt *from)
 	COPY_SCALAR_FIELD(commandType);
 	COPY_SCALAR_FIELD(planGen);
 	COPY_SCALAR_FIELD(canSetTag);
+	COPY_SCALAR_FIELD(bypassPreprocess);
 	COPY_SCALAR_FIELD(transientPlan);
 
 	COPY_NODE_FIELD(planTree);
@@ -1403,6 +1404,7 @@ _copyFuncExpr(FuncExpr *from)
 	COPY_SCALAR_FIELD(funcformat);
 	COPY_NODE_FIELD(args);
 	COPY_SCALAR_FIELD(is_tablefunc);
+	COPY_SCALAR_FIELD(bypass_preprocess);
 
 	return newnode;
 }
@@ -2645,6 +2647,7 @@ _copyQuery(Query *from)
 	COPY_SCALAR_FIELD(resultRelation);
 	COPY_NODE_FIELD(intoClause);
 	COPY_SCALAR_FIELD(hasAggs);
+	COPY_SCALAR_FIELD(hasBypassPreprocess);
 	COPY_SCALAR_FIELD(hasWindFuncs);
 	COPY_SCALAR_FIELD(hasSubLinks);
 	COPY_NODE_FIELD(rtable);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -806,6 +806,9 @@ _equalQuery(Query *a, Query *b)
 	COMPARE_SCALAR_FIELD(hasAggs);
 	COMPARE_SCALAR_FIELD(hasBypassPreprocess);
 	COMPARE_NODE_FIELD(bypassPreprocessFunctionArgs);
+	COMPARE_NODE_FIELD(bypassPreprocessStringArgs);
+	COMPARE_NODE_FIELD(loMode);
+	COMPARE_NODE_FIELD(bypassLocation);
 	COMPARE_SCALAR_FIELD(hasWindFuncs);
 	COMPARE_SCALAR_FIELD(hasSubLinks);
 	COMPARE_NODE_FIELD(rtable);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -805,6 +805,7 @@ _equalQuery(Query *a, Query *b)
 	COMPARE_NODE_FIELD(intoClause);
 	COMPARE_SCALAR_FIELD(hasAggs);
 	COMPARE_SCALAR_FIELD(hasBypassPreprocess);
+	COMPARE_NODE_FIELD(bypassPreprocessFunctionArgs);
 	COMPARE_SCALAR_FIELD(hasWindFuncs);
 	COMPARE_SCALAR_FIELD(hasSubLinks);
 	COMPARE_NODE_FIELD(rtable);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -804,6 +804,7 @@ _equalQuery(Query *a, Query *b)
 	COMPARE_SCALAR_FIELD(resultRelation);
 	COMPARE_NODE_FIELD(intoClause);
 	COMPARE_SCALAR_FIELD(hasAggs);
+	COMPARE_SCALAR_FIELD(hasBypassPreprocess);
 	COMPARE_SCALAR_FIELD(hasWindFuncs);
 	COMPARE_SCALAR_FIELD(hasSubLinks);
 	COMPARE_NODE_FIELD(rtable);

--- a/src/backend/nodes/makefuncs.c
+++ b/src/backend/nodes/makefuncs.c
@@ -331,6 +331,7 @@ makeFuncExpr(Oid funcid, Oid rettype, List *args, CoercionForm fformat)
 	funcexpr->funcformat = fformat;
 	funcexpr->args = args;
 	funcexpr->location = -1;
+	funcexpr->bypass_preprocess = false;
 
 	return funcexpr;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -356,6 +356,8 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(transientTypeRecords);
+
+	WRITE_BOOL_FIELD(bypassPreprocess);
 }
 
 static void
@@ -586,6 +588,7 @@ _outFuncExpr(StringInfo str, FuncExpr *node)
 	WRITE_ENUM_FIELD(funcformat, CoercionForm);
 	WRITE_NODE_FIELD(args);
 	WRITE_BOOL_FIELD(is_tablefunc);
+	WRITE_BOOL_FIELD(bypass_preprocess);
 }
 
 static void
@@ -901,6 +904,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_INT_FIELD(resultRelation);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_BOOL_FIELD(hasAggs);
+	WRITE_BOOL_FIELD(hasBypassPreprocess);
 	WRITE_BOOL_FIELD(hasWindFuncs);
 	WRITE_BOOL_FIELD(hasSubLinks);
 	WRITE_NODE_FIELD(rtable);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -329,7 +329,9 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_BOOL_FIELD(transientPlan);
 	WRITE_BOOL_FIELD(bypassPreprocess);
 	WRITE_NODE_FIELD(bypassPreprocessFuncArgs);
-	WRITE_INT_FIELD(loMode);
+	WRITE_NODE_FIELD(bypassPreprocessStringArgs);
+	WRITE_NODE_FIELD(bypassLocation);
+	WRITE_NODE_FIELD(loMode);
 
 	WRITE_NODE_FIELD(planTree);
 
@@ -907,7 +909,9 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_BOOL_FIELD(hasAggs);
 	WRITE_BOOL_FIELD(hasBypassPreprocess);
 	WRITE_NODE_FIELD(bypassPreprocessFunctionArgs);
-	WRITE_INT_FIELD(loMode);
+	WRITE_NODE_FIELD(bypassPreprocessStringArgs);
+	WRITE_NODE_FIELD(loMode);
+	WRITE_NODE_FIELD(bypassLocation);
 	WRITE_BOOL_FIELD(hasWindFuncs);
 	WRITE_BOOL_FIELD(hasSubLinks);
 	WRITE_NODE_FIELD(rtable);
@@ -2024,4 +2028,3 @@ nodeToBinaryStringFast(void *obj, int * length)
 	*length = str.len;
 	return str.data;
 }
-

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -327,6 +327,8 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_ENUM_FIELD(planGen, PlanGenerator);
 	WRITE_BOOL_FIELD(canSetTag);
 	WRITE_BOOL_FIELD(transientPlan);
+	WRITE_BOOL_FIELD(bypassPreprocess);
+	WRITE_NODE_FIELD(bypassPreprocessFuncArgs);
 
 	WRITE_NODE_FIELD(planTree);
 
@@ -356,8 +358,6 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 
 	WRITE_UINT64_FIELD(query_mem);
 	WRITE_NODE_FIELD(transientTypeRecords);
-
-	WRITE_BOOL_FIELD(bypassPreprocess);
 }
 
 static void
@@ -905,6 +905,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_BOOL_FIELD(hasAggs);
 	WRITE_BOOL_FIELD(hasBypassPreprocess);
+	WRITE_NODE_FIELD(bypassPreprocessFunctionArgs);
 	WRITE_BOOL_FIELD(hasWindFuncs);
 	WRITE_BOOL_FIELD(hasSubLinks);
 	WRITE_NODE_FIELD(rtable);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -329,6 +329,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_BOOL_FIELD(transientPlan);
 	WRITE_BOOL_FIELD(bypassPreprocess);
 	WRITE_NODE_FIELD(bypassPreprocessFuncArgs);
+	WRITE_INT_FIELD(loMode);
 
 	WRITE_NODE_FIELD(planTree);
 
@@ -906,6 +907,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_BOOL_FIELD(hasAggs);
 	WRITE_BOOL_FIELD(hasBypassPreprocess);
 	WRITE_NODE_FIELD(bypassPreprocessFunctionArgs);
+	WRITE_INT_FIELD(loMode);
 	WRITE_BOOL_FIELD(hasWindFuncs);
 	WRITE_BOOL_FIELD(hasSubLinks);
 	WRITE_NODE_FIELD(rtable);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1,4 +1,4 @@
-/*-------------------------------------------------------------------------
+/*
  *
  * outfuncs.c
  *	  Output functions for Postgres tree nodes.
@@ -300,7 +300,9 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_BOOL_FIELD(transientPlan);
 	WRITE_BOOL_FIELD(bypassPreprocess);
 	WRITE_NODE_FIELD(bypassPreprocessFuncArgs);
-	WRITE_INT_FIELD(loMode);
+	WRITE_NODE_FIELD(bypassPreprocessStringArgs);
+	WRITE_NODE_FIELD(bypassLocation);
+	WRITE_NODE_FIELD(loMode);
 	WRITE_NODE_FIELD(planTree);
 	WRITE_NODE_FIELD(rtable);
 	WRITE_NODE_FIELD(resultRelations);
@@ -3466,7 +3468,8 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_BOOL_FIELD(hasAggs);
 	WRITE_BOOL_FIELD(hasBypassPreprocess);
 	WRITE_NODE_FIELD(bypassPreprocessFunctionArgs);
-	WRITE_INT_FIELD(loMode);
+	WRITE_NODE_FIELD(bypassPreprocessStringArgs);
+	WRITE_NODE_FIELD(loMode);
 	WRITE_BOOL_FIELD(hasWindFuncs);
 	WRITE_BOOL_FIELD(hasSubLinks);
 	WRITE_NODE_FIELD(rtable);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -297,6 +297,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_ENUM_FIELD(commandType, CmdType);
 	WRITE_ENUM_FIELD(planGen, PlanGenerator);
 	WRITE_BOOL_FIELD(canSetTag);
+	WRITE_BOOL_FIELD(bypassPreprocess);
 	WRITE_BOOL_FIELD(transientPlan);
 	WRITE_NODE_FIELD(planTree);
 	WRITE_NODE_FIELD(rtable);
@@ -1301,6 +1302,11 @@ _outFuncExpr(StringInfo str, FuncExpr *node)
 	if (node->is_tablefunc)
 	{
 		WRITE_BOOL_FIELD(is_tablefunc);  /* GPDB */
+	}
+
+	if (node->bypass_preprocess)
+	{
+	       WRITE_BOOL_FIELD(bypass_preprocess);
 	}
 }
 #endif /* COMPILING_BINARY_FUNCS */
@@ -3456,6 +3462,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_INT_FIELD(resultRelation);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_BOOL_FIELD(hasAggs);
+	WRITE_BOOL_FIELD(hasBypassPreprocess);
 	WRITE_BOOL_FIELD(hasWindFuncs);
 	WRITE_BOOL_FIELD(hasSubLinks);
 	WRITE_NODE_FIELD(rtable);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -300,6 +300,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_BOOL_FIELD(transientPlan);
 	WRITE_BOOL_FIELD(bypassPreprocess);
 	WRITE_NODE_FIELD(bypassPreprocessFuncArgs);
+	WRITE_INT_FIELD(loMode);
 	WRITE_NODE_FIELD(planTree);
 	WRITE_NODE_FIELD(rtable);
 	WRITE_NODE_FIELD(resultRelations);
@@ -3465,6 +3466,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_BOOL_FIELD(hasAggs);
 	WRITE_BOOL_FIELD(hasBypassPreprocess);
 	WRITE_NODE_FIELD(bypassPreprocessFunctionArgs);
+	WRITE_INT_FIELD(loMode);
 	WRITE_BOOL_FIELD(hasWindFuncs);
 	WRITE_BOOL_FIELD(hasSubLinks);
 	WRITE_NODE_FIELD(rtable);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -297,8 +297,9 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_ENUM_FIELD(commandType, CmdType);
 	WRITE_ENUM_FIELD(planGen, PlanGenerator);
 	WRITE_BOOL_FIELD(canSetTag);
-	WRITE_BOOL_FIELD(bypassPreprocess);
 	WRITE_BOOL_FIELD(transientPlan);
+	WRITE_BOOL_FIELD(bypassPreprocess);
+	WRITE_NODE_FIELD(bypassPreprocessFuncArgs);
 	WRITE_NODE_FIELD(planTree);
 	WRITE_NODE_FIELD(rtable);
 	WRITE_NODE_FIELD(resultRelations);
@@ -3463,6 +3464,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_BOOL_FIELD(hasAggs);
 	WRITE_BOOL_FIELD(hasBypassPreprocess);
+	WRITE_NODE_FIELD(bypassPreprocessFunctionArgs);
 	WRITE_BOOL_FIELD(hasWindFuncs);
 	WRITE_BOOL_FIELD(hasSubLinks);
 	WRITE_NODE_FIELD(rtable);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -226,6 +226,7 @@ _readQuery(void)
 	READ_BOOL_FIELD(hasAggs);
 	READ_BOOL_FIELD(hasBypassPreprocess);
 	READ_NODE_FIELD(bypassPreprocessFunctionArgs);
+	READ_INT_FIELD(loMode);
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
 	READ_NODE_FIELD(rtable);
@@ -1461,6 +1462,7 @@ _readPlannedStmt(void)
 	READ_BOOL_FIELD(transientPlan);
 	READ_BOOL_FIELD(bypassPreprocess);
 	READ_NODE_FIELD(bypassPreprocessFuncArgs);
+	READ_INT_FIELD(loMode);
 	READ_NODE_FIELD(planTree);
 	READ_NODE_FIELD(rtable);
 	READ_NODE_FIELD(resultRelations);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -224,6 +224,7 @@ _readQuery(void)
 	READ_INT_FIELD(resultRelation);
 	READ_NODE_FIELD(intoClause);
 	READ_BOOL_FIELD(hasAggs);
+	READ_BOOL_FIELD(hasBypassPreprocess);
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
 	READ_NODE_FIELD(rtable);
@@ -833,6 +834,7 @@ _readFuncExpr(void)
 	READ_ENUM_FIELD(funcformat, CoercionForm);
 	READ_NODE_FIELD(args);
 	READ_BOOL_FIELD(is_tablefunc);
+	READ_BOOL_FIELD(bypass_preprocess);
 
 	READ_DONE();
 }
@@ -1455,6 +1457,7 @@ _readPlannedStmt(void)
 	READ_ENUM_FIELD(commandType, CmdType);
 	READ_ENUM_FIELD(planGen, PlanGenerator);
 	READ_BOOL_FIELD(canSetTag);
+	READ_BOOL_FIELD(bypassPreprocess);
 	READ_BOOL_FIELD(transientPlan);
 	READ_NODE_FIELD(planTree);
 	READ_NODE_FIELD(rtable);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -226,7 +226,9 @@ _readQuery(void)
 	READ_BOOL_FIELD(hasAggs);
 	READ_BOOL_FIELD(hasBypassPreprocess);
 	READ_NODE_FIELD(bypassPreprocessFunctionArgs);
-	READ_INT_FIELD(loMode);
+	READ_NODE_FIELD(bypassPreprocessStringArgs);
+	READ_NODE_FIELD(bypassLocation);
+	READ_NODE_FIELD(loMode);
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
 	READ_NODE_FIELD(rtable);
@@ -1462,7 +1464,9 @@ _readPlannedStmt(void)
 	READ_BOOL_FIELD(transientPlan);
 	READ_BOOL_FIELD(bypassPreprocess);
 	READ_NODE_FIELD(bypassPreprocessFuncArgs);
-	READ_INT_FIELD(loMode);
+	READ_NODE_FIELD(bypassPreprocessStringArgs);
+	READ_NODE_FIELD(bypassLocation);
+	READ_NODE_FIELD(loMode);
 	READ_NODE_FIELD(planTree);
 	READ_NODE_FIELD(rtable);
 	READ_NODE_FIELD(resultRelations);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -225,6 +225,7 @@ _readQuery(void)
 	READ_NODE_FIELD(intoClause);
 	READ_BOOL_FIELD(hasAggs);
 	READ_BOOL_FIELD(hasBypassPreprocess);
+	READ_NODE_FIELD(bypassPreprocessFunctionArgs);
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
 	READ_NODE_FIELD(rtable);
@@ -1457,8 +1458,9 @@ _readPlannedStmt(void)
 	READ_ENUM_FIELD(commandType, CmdType);
 	READ_ENUM_FIELD(planGen, PlanGenerator);
 	READ_BOOL_FIELD(canSetTag);
-	READ_BOOL_FIELD(bypassPreprocess);
 	READ_BOOL_FIELD(transientPlan);
+	READ_BOOL_FIELD(bypassPreprocess);
+	READ_NODE_FIELD(bypassPreprocessFuncArgs);
 	READ_NODE_FIELD(planTree);
 	READ_NODE_FIELD(rtable);
 	READ_NODE_FIELD(resultRelations);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -371,7 +371,7 @@ _readQuery(void)
 	READ_NODE_FIELD(loMode);
 	if (pg_strtok_peek_fldname("bypassLocation"))
 		READ_NODE_FIELD(bypassLocation);
-		
+
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
 	READ_NODE_FIELD(rtable);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -367,6 +367,7 @@ _readQuery(void)
 	READ_BOOL_FIELD(hasAggs);
 	READ_BOOL_FIELD(hasBypassPreprocess);
 	READ_NODE_FIELD(bypassPreprocessFunctionArgs);
+	READ_INT_FIELD(loMode);
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
 	READ_NODE_FIELD(rtable);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -366,6 +366,7 @@ _readQuery(void)
 
 	READ_BOOL_FIELD(hasAggs);
 	READ_BOOL_FIELD(hasBypassPreprocess);
+	READ_NODE_FIELD(bypassPreprocessFunctionArgs);
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
 	READ_NODE_FIELD(rtable);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -367,7 +367,11 @@ _readQuery(void)
 	READ_BOOL_FIELD(hasAggs);
 	READ_BOOL_FIELD(hasBypassPreprocess);
 	READ_NODE_FIELD(bypassPreprocessFunctionArgs);
-	READ_INT_FIELD(loMode);
+	READ_NODE_FIELD(bypassPreprocessStringArgs);
+	READ_NODE_FIELD(loMode);
+	if (pg_strtok_peek_fldname("bypassLocation"))
+		READ_NODE_FIELD(bypassLocation);
+		
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
 	READ_NODE_FIELD(rtable);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -365,6 +365,7 @@ _readQuery(void)
 	}
 
 	READ_BOOL_FIELD(hasAggs);
+	READ_BOOL_FIELD(hasBypassPreprocess);
 	READ_BOOL_FIELD(hasWindFuncs);
 	READ_BOOL_FIELD(hasSubLinks);
 	READ_NODE_FIELD(rtable);
@@ -1588,6 +1589,11 @@ _readFuncExpr(void)
 	if (pg_strtok_peek_fldname("is_tablefunc"))
 	{
 		READ_BOOL_FIELD(is_tablefunc);  /* GPDB */
+	}
+
+	if (pg_strtok_peek_fldname("bypass_preprocess"))
+	{
+	        READ_BOOL_FIELD(bypass_preprocess);
 	}
 
 	READ_DONE();

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -497,10 +497,10 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	
 	if (parse->hasBypassPreprocess)
 	{
-  	result->bypassPreprocess = true;
-	  result->bypassPreprocessFuncArgs = parse->bypassPreprocessFunctionArgs;
+		result->bypassPreprocess = true;
+		result->bypassPreprocessFuncArgs = parse->bypassPreprocessFunctionArgs;
 		result->bypassPreprocessStringArgs = parse->bypassPreprocessStringArgs;
-	  result->loMode = parse->loMode;
+		result->loMode = parse->loMode;
 		result->bypassLocation = parse->bypassLocation;
 	}
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -495,6 +495,9 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	
 	Assert(result->utilityStmt == NULL || IsA(result->utilityStmt, DeclareCursorStmt));
 	
+	if (parse->hasBypassPreprocess)
+          result->bypassPreprocess = true;
+
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		/*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -497,9 +497,11 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	
 	if (parse->hasBypassPreprocess)
 	{
-          result->bypassPreprocess = true;
+  	result->bypassPreprocess = true;
 	  result->bypassPreprocessFuncArgs = parse->bypassPreprocessFunctionArgs;
+		result->bypassPreprocessStringArgs = parse->bypassPreprocessStringArgs;
 	  result->loMode = parse->loMode;
+		result->bypassLocation = parse->bypassLocation;
 	}
 
 	if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -499,6 +499,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	{
           result->bypassPreprocess = true;
 	  result->bypassPreprocessFuncArgs = parse->bypassPreprocessFunctionArgs;
+	  result->loMode = parse->loMode;
 	}
 
 	if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -496,7 +496,10 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	Assert(result->utilityStmt == NULL || IsA(result->utilityStmt, DeclareCursorStmt));
 	
 	if (parse->hasBypassPreprocess)
+	{
           result->bypassPreprocess = true;
+	  result->bypassPreprocessFuncArgs = parse->bypassPreprocessFunctionArgs;
+	}
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{

--- a/src/backend/optimizer/plan/transform.c
+++ b/src/backend/optimizer/plan/transform.c
@@ -295,7 +295,7 @@ static bool is_sirv_funcexpr(FuncExpr *fe)
 			&& !contain_subplans((Node *) fe->args) /* Must not contain sublinks */
 			&& func_volatile(fe->funcid) == PROVOLATILE_VOLATILE /* Must be a volatile function */
 			&& fe->funcresulttype != RECORDOID /* Record types cannot be handled currently */
-		    && !fe->bypass_preprocess /* If preprocessing is not disabled explicitly */
+		        && !fe->bypass_preprocess /* If preprocessing is not disabled explicitly */
 			);
 
 	/**

--- a/src/backend/optimizer/plan/transform.c
+++ b/src/backend/optimizer/plan/transform.c
@@ -295,6 +295,7 @@ static bool is_sirv_funcexpr(FuncExpr *fe)
 			&& !contain_subplans((Node *) fe->args) /* Must not contain sublinks */
 			&& func_volatile(fe->funcid) == PROVOLATILE_VOLATILE /* Must be a volatile function */
 			&& fe->funcresulttype != RECORDOID /* Record types cannot be handled currently */
+		    && !fe->bypass_preprocess /* If preprocessing is not disabled explicitly */
 			);
 
 	/**

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -1823,8 +1823,12 @@ eval_const_expressions_mutator(Node *node,
 		 * Code for op/func reduction is pretty bulky, so split it out as a
 		 * separate function.
 		 */
-		simple = simplify_function(expr->funcid, expr->funcresulttype, &args,
-								   true, context);
+		if (!(expr->bypass_preprocess))
+			simple = simplify_function(expr->funcid, expr->funcresulttype, &args,
+								   	true, context);
+		else
+		  elog(WARNING,"condition4");
+
 		if (simple)				/* successfully simplified it */
 			return (Node *) simple;
 

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -1826,8 +1826,6 @@ eval_const_expressions_mutator(Node *node,
 		if (!(expr->bypass_preprocess))
 			simple = simplify_function(expr->funcid, expr->funcresulttype, &args,
 								   	true, context);
-		else
-		  elog(WARNING,"condition4");
 
 		if (simple)				/* successfully simplified it */
 			return (Node *) simple;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -900,12 +900,9 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 	ListCell   *icols;
 	ListCell   *attnos;
 	ListCell   *lc;
-	bool       isDelay;
 
 	qry->commandType = CMD_INSERT;
 	pstate->p_is_insert = true;
-
-	isDelay = false;
 
 	/*
 	 * We have three cases to deal with: DEFAULT VALUES (selectStmt == NULL),
@@ -1058,7 +1055,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 			/* CDB: In case of error, note which sublist is involved. */
 			pstate->p_breadcrumb.node = (Node *)sublist;
 
-			isDelay = ifDelayedFunctionCall(pstate, sublist);
+			getFuncArgs(pstate, sublist);
 
 			/* Do basic expression transformation (same as a ROW() expr) */
 			sublist = transformExpressionList(pstate, sublist);
@@ -1068,7 +1065,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 			  qry->hasBypassPreprocess = true;
 			  qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
 			}
-			  
+
 			/*
 			 * All the sublists must be the same length, *after*
 			 * transformation (which might expand '*' into multiple items).
@@ -1154,7 +1151,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 
 		Assert(list_length(valuesLists) == 1);
 
-		isDelay = ifDelayedFunctionCall(pstate, (List *) linitial(valuesLists));
+		getFuncArgs(pstate, (List *) linitial(valuesLists));
 
 		/* Do basic expression transformation (same as a ROW() expr) */
 		exprList = transformExpressionList(pstate,

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1064,7 +1064,10 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 			sublist = transformExpressionList(pstate, sublist);
 
 			if (pstate->p_bypasspreprocess)
+			{
 			  qry->hasBypassPreprocess = true;
+			  qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
+			}
 			  
 			/*
 			 * All the sublists must be the same length, *after*
@@ -1158,7 +1161,10 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 										   (List *) linitial(valuesLists));
 
 		if (pstate->p_bypasspreprocess)
+		{
                   qry->hasBypassPreprocess = true;
+		  qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
+		}
 
 		/* Prepare row for assignment to target table */
 		exprList = transformInsertRow(pstate, exprList,

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -992,6 +992,13 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 		selectQuery = transformStmt(sub_pstate, stmt->selectStmt,
 									extras_before, extras_after);
 
+		if (selectQuery->hasBypassPreprocess)
+		{
+		  qry->hasBypassPreprocess = true;
+		  qry->bypassPreprocessFunctionArgs = selectQuery->bypassPreprocessFunctionArgs;
+		  qry->loMode = 2;
+		}
+
 		release_pstate_resources(sub_pstate);
 		free_parsestate(sub_pstate);
 
@@ -1064,6 +1071,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 			{
 			  qry->hasBypassPreprocess = true;
 			  qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
+			  qry->loMode = 1;
 			}
 
 			/*
@@ -1161,6 +1169,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 		{
                   qry->hasBypassPreprocess = true;
 		  qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
+		  qry->loMode = 1;
 		}
 
 		/* Prepare row for assignment to target table */
@@ -4527,6 +4536,14 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 
 	/* transform targetlist */
 	qry->targetList = transformTargetList(pstate, stmt->targetList);
+
+	if (pstate->p_bypasspreprocess)
+	{
+	  getFuncArgs(pstate, qry->targetList);
+
+	  qry->hasBypassPreprocess = true;
+	  qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
+	}
 
 	/* mark column origins */
 	markTargetListOrigins(pstate, qry->targetList);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -995,8 +995,17 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 		if (selectQuery->hasBypassPreprocess)
 		{
 		  qry->hasBypassPreprocess = true;
-		  qry->bypassPreprocessFunctionArgs = selectQuery->bypassPreprocessFunctionArgs;
-		  qry->loMode = 2;
+		  //qry->bypassPreprocessFunctionArgs = selectQuery->bypassPreprocessFunctionArgs;
+			qry->bypassLocation = selectQuery->bypassPreprocessFunctionArgs;
+			
+			if (qry->loMode == NIL)
+			{
+		  	qry->loMode = list_make1_int(linitial(selectQuery->loMode));
+			}
+			else
+			{
+					qry->loMode = lappend_int(qry->loMode, linitial_int(selectQuery->loMode));
+			}
 		}
 
 		release_pstate_resources(sub_pstate);
@@ -1062,18 +1071,48 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 			/* CDB: In case of error, note which sublist is involved. */
 			pstate->p_breadcrumb.node = (Node *)sublist;
 
-			getFuncArgs(pstate, sublist);
-
-			/* Do basic expression transformation (same as a ROW() expr) */
-			sublist = transformExpressionList(pstate, sublist);
-
 			if (pstate->p_bypasspreprocess)
 			{
 			  qry->hasBypassPreprocess = true;
-			  qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
-			  qry->loMode = 1;
-			}
+				
+					if (qry->loMode == NIL)
+					{
+						if (pstate->p_lomode == NIL)
+						{
+			  			qry->loMode = list_make1_int(1);
+							
+							getFuncArgs(1, pstate, sublist);
+						}
+						else
+						{
+							qry->loMode = pstate->p_lomode;
+							
+							getFuncArgs(linitial_int(pstate->p_lomode), pstate, sublist);
+						}
+					}
+					else
+					{
+						if (pstate->p_lomode == NIL)
+						{
+							qry->loMode = lappend_int(qry->loMode, 1);
+							
+							getFuncArgs(1, pstate, sublist);
+						}
+						else
+						{
+							qry->loMode = lappend_int(qry->loMode, linitial_int(pstate->p_lomode));
+							
+							getFuncArgs(linitial_int(pstate->p_lomode), pstate, sublist);
+						}
+					}
+					
+					qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
+					qry->bypassPreprocessStringArgs = pstate->p_bypasspreprocessstringargs;
+				}
 
+			/* Do basic expression transformation (same as a ROW() expr) */
+			sublist = transformExpressionList(pstate, sublist);
+			
 			/*
 			 * All the sublists must be the same length, *after*
 			 * transformation (which might expand '*' into multiple items).
@@ -1099,6 +1138,8 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 										 icolumns, attrnos);
 
 			exprsLists = lappend(exprsLists, sublist);
+			
+			qry->bypassLocation = pstate->p_bypasslocation;
 		}
 
 		/* CDB: Clear error location. */
@@ -1159,23 +1200,55 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 
 		Assert(list_length(valuesLists) == 1);
 
-		getFuncArgs(pstate, (List *) linitial(valuesLists));
-
 		/* Do basic expression transformation (same as a ROW() expr) */
 		exprList = transformExpressionList(pstate,
 										   (List *) linitial(valuesLists));
 
 		if (pstate->p_bypasspreprocess)
 		{
-                  qry->hasBypassPreprocess = true;
-		  qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
-		  qry->loMode = 1;
+    	qry->hasBypassPreprocess = true;
+			
+				if (qry->loMode == NIL)
+				{
+					if (pstate->p_lomode == NIL)
+					{
+		  			qry->loMode = list_make1_int(1);
+
+						getFuncArgs(1, pstate, (List *) linitial(valuesLists));
+					}
+					else
+					{
+						qry->loMode = lappend_int(qry->loMode, linitial_int(pstate->p_lomode));
+						
+						getFuncArgs(linitial_int(pstate->p_lomode), pstate, (List *) linitial(valuesLists));
+					}
+				}
+				else
+				{
+					if (pstate->p_lomode == NIL)
+					{
+						qry->loMode = lappend_int(qry->loMode, 1);
+
+						getFuncArgs(1, pstate, (List *) linitial(valuesLists));
+					}
+					else
+					{
+						qry->loMode = lappend_int(qry->loMode, linitial_int(pstate->p_lomode));
+						
+						getFuncArgs(linitial_int(pstate->p_lomode), pstate, (List *) linitial(valuesLists));
+					}
+				}
+				
+				qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
+				qry->bypassPreprocessStringArgs = pstate->p_bypasspreprocessstringargs;
 		}
 
 		/* Prepare row for assignment to target table */
 		exprList = transformInsertRow(pstate, exprList,
 									  stmt->cols,
 									  icolumns, attrnos);
+										
+	  qry->bypassLocation = pstate->p_bypasslocation;
 	}
 
 	/*
@@ -1299,6 +1372,23 @@ transformInsertRow(ParseState *pstate, List *exprlist,
 	{
 		Expr	   *expr = (Expr *) lfirst(lc);
 		ResTarget  *col;
+		
+		if (IsA(expr, FuncExpr))
+		{
+			FuncExpr *fexpr = (FuncExpr *) expr;
+			
+			if (fexpr->bypass_preprocess == true)
+			{
+				if (pstate->p_bypasslocation == NIL)
+				{
+					pstate->p_bypasslocation = list_make1_int(lfirst_int(attnos));
+				}
+				else
+				{
+					pstate->p_bypasslocation = lappend_int(pstate->p_bypasslocation, lfirst_int(attnos));
+				}
+			}
+		}
 
 		col = (ResTarget *) lfirst(icols);
 		Assert(IsA(col, ResTarget));
@@ -4539,10 +4629,21 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 
 	if (pstate->p_bypasspreprocess)
 	{
-	  getFuncArgs(pstate, qry->targetList);
+	  getFuncArgs(1, pstate, qry->targetList);
 
 	  qry->hasBypassPreprocess = true;
 	  qry->bypassPreprocessFunctionArgs = pstate->p_bypasspreprocessfuncargs;
+		
+		if (qry->loMode == NIL)
+		{
+			qry->loMode = pstate->p_lomode;
+		}
+		else
+		{
+			qry->loMode = lappend_int(qry->loMode, linitial_int(pstate->p_lomode));
+		}
+		
+		qry->bypassLocation = pstate->p_bypasspreprocessfuncargs;
 	}
 
 	/* mark column origins */

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -995,8 +995,8 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt,
 		if (selectQuery->hasBypassPreprocess)
 		{
 		  qry->hasBypassPreprocess = true;
-		  //qry->bypassPreprocessFunctionArgs = selectQuery->bypassPreprocessFunctionArgs;
-			qry->bypassLocation = selectQuery->bypassPreprocessFunctionArgs;
+		  qry->bypassPreprocessFunctionArgs = selectQuery->bypassPreprocessFunctionArgs;
+			qry->bypassLocation = sub_pstate->p_bypasslocation;
 			
 			if (qry->loMode == NIL)
 			{
@@ -1372,23 +1372,6 @@ transformInsertRow(ParseState *pstate, List *exprlist,
 	{
 		Expr	   *expr = (Expr *) lfirst(lc);
 		ResTarget  *col;
-		
-		if (IsA(expr, FuncExpr))
-		{
-			FuncExpr *fexpr = (FuncExpr *) expr;
-			
-			if (fexpr->bypass_preprocess == true)
-			{
-				if (pstate->p_bypasslocation == NIL)
-				{
-					pstate->p_bypasslocation = list_make1_int(lfirst_int(attnos));
-				}
-				else
-				{
-					pstate->p_bypasslocation = lappend_int(pstate->p_bypasslocation, lfirst_int(attnos));
-				}
-			}
-		}
 
 		col = (ResTarget *) lfirst(icols);
 		Assert(IsA(col, ResTarget));

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -422,13 +422,9 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 
 		if (dataaccess == PRODATAACCESS_BYPASS)
 		{
-		  elog(WARNING,"condition1");
 		  funcexpr->bypass_preprocess = true;
 		  pstate->p_bypasspreprocess = true;
-		  
 		}
-		else
-		  elog(WARNING,"condition2");
 
 		funcexpr->funcid = funcid;
 		funcexpr->funcresulttype = rettype;

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -430,7 +430,7 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 			{
 				pstate->p_lomode = list_make1_int(3);
 			}
-			else if (funcid == 715)
+			else if (funcid == 715 | funcid == 957)
 			{
 				pstate->p_lomode = list_make1_int(1);
 			}

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -434,6 +434,15 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 			{
 				pstate->p_lomode = list_make1_int(1);
 			}
+			
+			if (pstate->p_bypasslocation == NIL)
+			{
+				pstate->p_bypasslocation = list_make1_int(pstate->current_location);
+			}
+			else
+			{
+				pstate->p_bypasslocation = lappend_int(pstate->p_bypasslocation, pstate->current_location);
+			}
 		}
 
 		funcexpr->funcid = funcid;

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -424,6 +424,16 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		{
 		  funcexpr->bypass_preprocess = true;
 		  pstate->p_bypasspreprocess = true;
+			
+			/* Dirty hack to avoid more catalog flags */
+			if (funcid == 764)  /* lo_import funcid */
+			{
+				pstate->p_lomode = list_make1_int(3);
+			}
+			else if (funcid == 715)
+			{
+				pstate->p_lomode = list_make1_int(1);
+			}
 		}
 
 		funcexpr->funcid = funcid;

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -416,6 +416,19 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 	if (fdresult == FUNCDETAIL_NORMAL && over == NULL)
 	{
 		FuncExpr   *funcexpr = makeNode(FuncExpr);
+		char dataaccess = PRODATAACCESS_NONE;
+
+		dataaccess = func_data_access(funcid);
+
+		if (dataaccess == PRODATAACCESS_BYPASS)
+		{
+		  elog(WARNING,"condition1");
+		  funcexpr->bypass_preprocess = true;
+		  pstate->p_bypasspreprocess = true;
+		  
+		}
+		else
+		  elog(WARNING,"condition2");
 
 		funcexpr->funcid = funcid;
 		funcexpr->funcresulttype = rettype;

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -1496,67 +1496,32 @@ getFuncArgs(int current_lomode, ParseState *pstate, List *exprlist)
       pstate->p_breadcrumb.node = (Node *)e;
 
       /* Currently handle only functions. */
-      /*if (IsA(e, FuncCall))
-      {
-	  FuncCall  *fref = (FuncCall *) e;
-	  ListCell *lc_internal;
-	  char *fname = NULL;
+    if (IsA(e, FuncCall))
+    {
+	  	FuncCall  *fref = (FuncCall *) e;
+	  	ListCell *lc_internal;
+	  	char *fname = NULL;
 
-	  foreach(lc_internal, fref->args)
-	  {
-	    Node *current_node = (Node *) lfirst(lc_internal);
+	  	foreach(lc_internal, fref->args)
+	  	{
+	    	Node *current_node = (Node *) lfirst(lc_internal);
 
-	    if (IsA(current_node, A_Const))
-	    {
-	      A_Const *current_const = (A_Const *) (current_node);
+	    	if (IsA(current_node, A_Const))
+	    	{
+	      	A_Const *current_const = (A_Const *) (current_node);
 
-	      if (pstate->p_bypasspreprocessfuncargs == NULL)
-	      {
-		pstate->p_bypasspreprocessfuncargs = list_make1_oid(current_const->val.val.ival);
-	      }
-	      else
-	      {
-		pstate->p_bypasspreprocessfuncargs = lappend_oid(pstate->p_bypasspreprocessfuncargs, (current_const->val.val.ival));
-	      }
-	    }
-	  }
-	}*/
-      if (IsA(e, TargetEntry))
-      {
-	TargetEntry *te = (TargetEntry *) (e);
-	Expr *expr_internal = (Expr *) (te->expr);
-
-	if (IsA(expr_internal, FuncExpr))
-	{
-	  FuncExpr *fe_expr = (FuncExpr *) (expr_internal);
-	  ListCell *lc_internal;
-
-	  foreach(lc_internal, fe_expr->args)
-	  {
-	    Node *node_internal = (Node *) (lfirst(lc_internal));
-
-	    if (IsA(node_internal, RelabelType))
-	    {
-	      RelabelType *rel_type = (RelabelType *) (node_internal);
-
-	      if (IsA((rel_type->arg), Var))
-	      {
-		  Var *var_internal = (Var *) (rel_type->arg);
-
-		  if (pstate->p_bypasspreprocessfuncargs == NIL)
-		  {
-		    pstate->p_bypasspreprocessfuncargs = list_make1_int((var_internal->varattno));
-		  }
-		  else
-		  {
-		    pstate->p_bypasspreprocessfuncargs = lappend_int(pstate->p_bypasspreprocessfuncargs, (var_internal->varattno));
-		  }
-	      }
-	    }
+	      	if (pstate->p_bypasspreprocessfuncargs == NULL)
+	      	{
+						pstate->p_bypasspreprocessfuncargs = list_make1(list_make1(current_const));
+	      	}
+	      	else
+	      	{
+						pstate->p_bypasspreprocessfuncargs = lappend(pstate->p_bypasspreprocessfuncargs, (list_make1(current_const)));
+	      	}
+	    	}
 	  }
 	}
-      }
-  }
+}
 
 
   /* CDB: Pop error location stack. */

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -15,6 +15,9 @@
 #include "postgres.h"
 
 #include "catalog/pg_type.h"
+#include "catalog/catquery.h"
+#include "catalog/pg_proc.h"
+#include "catalog/pg_proc_callback.h"
 #include "commands/dbcommands.h"
 #include "funcapi.h"
 #include "miscadmin.h"
@@ -1467,4 +1470,77 @@ FigureColnameInternal(Node *node, char **name)
 	}
 
 	return strength;
+}
+
+/*
+ * transformExpressionList()
+ *
+ * This is the identical transformation to transformTargetList, except that
+ * the input list elements are bare expressions without ResTarget decoration,
+ * and the output elements are likewise just expressions without TargetEntry
+ * decoration.We use this for ROW() and VALUES() constructs.
+ */
+bool
+ifDelayedFunctionCall(ParseState *pstate, List *exprlist)
+{
+  List   *result = NIL;
+  ListCell   *lc;
+  ParseStateBreadCrumb    savebreadcrumb;
+  bool isDelay;
+  HeapTuple       tup;
+  cqContext  *pcqCtx;
+
+  /* CDB: Push error location stack.  Must pop before return! */
+  Assert(pstate);
+  savebreadcrumb = pstate->p_breadcrumb;
+  pstate->p_breadcrumb.pop = &savebreadcrumb;
+
+  isDelay = false;
+
+  foreach(lc, exprlist)
+  {
+      Node   *e = (Node *) lfirst(lc);
+
+      /* CDB: Drop a breadcrumb in case of error. */
+      pstate->p_breadcrumb.node = (Node *)e;
+
+      /*
+       * Check for "something.*".  Depending on the complexity of the
+       * "something", the star could appear as the last name in ColumnRef,
+       * or as the last indirection item in A_Indirection.
+       */
+      if (IsA(e, FuncCall))
+      {
+	  FuncCall  *fref = (FuncCall *) e;
+	  char *fname = NULL;
+
+	 fname = strVal(llast(fref->funcname));
+
+	  pcqCtx = caql_beginscan(
+				  NULL,
+				  cql("SELECT * FROM pg_proc "
+				      " WHERE proname = :1 ",
+				      CStringGetDatum(fname)));
+
+	  tup = caql_getnext(pcqCtx);
+
+	  if (!HeapTupleIsValid(tup)) /* should not happen */
+	    elog(ERROR, "cache lookup failed for function %s", (char *) linitial(fref->funcname));
+
+	  char prodat1 = ((Form_pg_proc) GETSTRUCT(tup))->prodataaccess;
+
+	  if (((Form_pg_proc) GETSTRUCT(tup))->prodataaccess == 'b')
+	    elog(WARNING,"valfound1");
+
+	  caql_endscan(pcqCtx);
+
+	  elog(WARNING,"isde1");
+      }
+  }
+
+  /* CDB: Pop error location stack. */
+  Assert(pstate->p_breadcrumb.pop == &savebreadcrumb);
+  pstate->p_breadcrumb = savebreadcrumb;
+
+  return isDelay;
 }

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -1474,7 +1474,7 @@ FigureColnameInternal(Node *node, char **name)
  * Gets function arguments and puts them in parse state. This is used currently * only for late execution functions
  */
 void
-getFuncArgs(ParseState *pstate, List *exprlist)
+getFuncArgs(int current_lomode, ParseState *pstate, List *exprlist)
 {
   List   *result = NIL;
   ListCell   *lc;
@@ -1496,7 +1496,7 @@ getFuncArgs(ParseState *pstate, List *exprlist)
       pstate->p_breadcrumb.node = (Node *)e;
 
       /* Currently handle only functions. */
-      if (IsA(e, FuncCall))
+      /*if (IsA(e, FuncCall))
       {
 	  FuncCall  *fref = (FuncCall *) e;
 	  ListCell *lc_internal;
@@ -1520,8 +1520,8 @@ getFuncArgs(ParseState *pstate, List *exprlist)
 	      }
 	    }
 	  }
-      }
-      else if (IsA(e, TargetEntry))
+	}*/
+      if (IsA(e, TargetEntry))
       {
 	TargetEntry *te = (TargetEntry *) (e);
 	Expr *expr_internal = (Expr *) (te->expr);

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -1512,7 +1512,27 @@ ifDelayedFunctionCall(ParseState *pstate, List *exprlist)
       if (IsA(e, FuncCall))
       {
 	  FuncCall  *fref = (FuncCall *) e;
+	  ListCell *lc_internal;
 	  char *fname = NULL;
+
+	  foreach(lc_internal, fref->args)
+	  {
+	    Node *current_node = (Node *) lfirst(lc_internal);
+
+	    if (IsA(current_node, A_Const))
+	    {
+	      A_Const *current_const = (A_Const *) (current_node);
+
+	      if (pstate->p_bypasspreprocessfuncargs == NULL)
+	      {
+		pstate->p_bypasspreprocessfuncargs = list_make1_oid(current_const->val.val.ival);
+	      }
+	      else
+	      {
+		pstate->p_bypasspreprocessfuncargs = lappend_oid(pstate->p_bypasspreprocessfuncargs, (current_const->val.val.ival));
+	      }
+	    }
+	  }
 
 	 fname = strVal(llast(fref->funcname));
 

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -187,6 +187,7 @@ transformExpressionList(ParseState *pstate, List *exprlist)
 	List	   *result = NIL;
 	ListCell   *lc;
 	ParseStateBreadCrumb    savebreadcrumb;
+	int i = 0;
 
 	/* CDB: Push error location stack.  Must pop before return! */
 	Assert(pstate);
@@ -199,6 +200,9 @@ transformExpressionList(ParseState *pstate, List *exprlist)
 
 		/* CDB: Drop a breadcrumb in case of error. */
 		pstate->p_breadcrumb.node = (Node *)e;
+		
+		++i;
+		pstate->current_location = i;
 
 		/*
 		 * Check for "something.*".  Depending on the complexity of the

--- a/src/backend/storage/large_object/inv_api.c
+++ b/src/backend/storage/large_object/inv_api.c
@@ -219,12 +219,15 @@ inv_create(Oid lobjId)
 	 * use.  We can use the index on pg_largeobject for checking OID
 	 * uniqueness, even though it has additional columns besides OID.
 	 */
+	 
+	elog(WARNING,"Value before1 %d", lobjId);
+	
 	if (!OidIsValid(lobjId))
 	{
-		open_lo_relation();
-
-		lobjId = GetNewOidWithIndex(lo_heap_r, lo_index_r);
+		elog(ERROR, "Internal error. Invalid Oid in LO make object");
 	}
+	
+	elog(WARNING,"Value2 %d", lobjId);
 
 	/*
 	 * Create the LO by writing an empty first page for it in pg_largeobject

--- a/src/backend/storage/large_object/inv_api.c
+++ b/src/backend/storage/large_object/inv_api.c
@@ -91,6 +91,23 @@ open_lo_relation(void)
 }
 
 /*
+ * Get new OID for making new Large Object
+ */
+Oid
+get_new_oid()
+{
+	Oid lobjId;
+	
+	lobjId = InvalidOid;
+	
+	open_lo_relation();
+
+	lobjId = GetNewOidWithIndex(lo_heap_r, lo_index_r);
+	
+	return lobjId;
+}
+
+/*
  * Clean up at main transaction end
  */
 void

--- a/src/backend/storage/large_object/inv_api.c
+++ b/src/backend/storage/large_object/inv_api.c
@@ -202,7 +202,6 @@ inv_create(Oid lobjId)
 	 * use.  We can use the index on pg_largeobject for checking OID
 	 * uniqueness, even though it has additional columns besides OID.
 	 */
-  elog(WARNING,"invcre1");
 	if (!OidIsValid(lobjId))
 	{
 		open_lo_relation();

--- a/src/backend/storage/large_object/inv_api.c
+++ b/src/backend/storage/large_object/inv_api.c
@@ -202,6 +202,7 @@ inv_create(Oid lobjId)
 	 * use.  We can use the index on pg_largeobject for checking OID
 	 * uniqueness, even though it has additional columns besides OID.
 	 */
+  elog(WARNING,"invcre1");
 	if (!OidIsValid(lobjId))
 	{
 		open_lo_relation();

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -280,8 +280,10 @@ ProcessQuery(Portal portal,
 
 	if (stmt->bypassPreprocess)
 	{
-          queryDesc->late_execfunc = true;
+    queryDesc->late_execfunc = true;
 	  queryDesc->late_execfunc_funcargs = stmt->bypassPreprocessFuncArgs;
+		queryDesc->late_execfunc_stringargs = stmt->bypassPreprocessStringArgs;
+		queryDesc->bypass_location = stmt->bypassLocation;
 	  queryDesc->loMode = stmt->loMode;
 	}
 

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -106,6 +106,8 @@ CreateQueryDesc(PlannedStmt *plannedstmt,
 	qd->portal_name = NULL;
 
 	qd->gpmon_pkt = NULL;
+
+	qd->late_execfunc = plannedstmt->bypassPreprocess;
 	
     if (Gp_role != GP_ROLE_EXECUTE)
 	{
@@ -275,6 +277,9 @@ ProcessQuery(Portal portal,
 	 * Set up to collect AFTER triggers
 	 */
 	AfterTriggerBeginQuery();
+
+	if (stmt->bypassPreprocess)
+          queryDesc->late_execfunc = true;
 
 	/*
 	 * Call ExecutorStart to prepare the plan for execution

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -279,7 +279,10 @@ ProcessQuery(Portal portal,
 	AfterTriggerBeginQuery();
 
 	if (stmt->bypassPreprocess)
+	{
           queryDesc->late_execfunc = true;
+	  queryDesc->late_execfunc_funcargs = stmt->bypassPreprocessFuncArgs;
+	}
 
 	/*
 	 * Call ExecutorStart to prepare the plan for execution

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -282,6 +282,7 @@ ProcessQuery(Portal portal,
 	{
           queryDesc->late_execfunc = true;
 	  queryDesc->late_execfunc_funcargs = stmt->bypassPreprocessFuncArgs;
+	  queryDesc->loMode = stmt->loMode;
 	}
 
 	/*

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -4206,11 +4206,8 @@ DESCR("truncate the error log for the specified external table");
 #define PRODATAACCESS_MODIFIES	'm'
 /* This is an internal-only data access property. */
 #define PRODATAACCESS_SEGMENT	's'
-/*
- * This is a way to specify if current function should bypass
- * function preevaluation
- */
-#define PRODATAACCESS_BYPASS  'b'
+/* Bypass function preprocess */
+#define PRODATAACCESS_BYPASS	'b'
 
 /*
  * prototypes for functions in pg_proc.c

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -1318,7 +1318,7 @@ DATA(insert OID = 955 (  lowrite		   PGNSP PGUID 12 1 0 f f t f v 2 23 "23 17" _
 DESCR("large object write");
 DATA(insert OID = 956 (  lo_lseek		   PGNSP PGUID 12 1 0 f f t f v 3 23 "23 23 23" _null_ _null_ _null_	lo_lseek - _null_ ));
 DESCR("large object seek");
-DATA(insert OID = 957 (  lo_creat		   PGNSP PGUID 12 1 0 f f t f v 1 26 "23" _null_ _null_ _null_	lo_creat - _null_ ));
+DATA(insert OID = 957 (  lo_creat		   PGNSP PGUID 12 1 0 0 f f t f v 1 0 26 f "23" _null_ _null_ _null_	_null_ lo_creat - _null_ b ));
 DESCR("large object create");
 DATA(insert OID = 715 (  lo_create	  PGNSP PGUID 12 1 0 0 f f t f v 1 0 26 f "26" _null_ _null_ _null_ _null_ lo_create - _null_ b ));
 DESCR("large object create");

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -4206,8 +4206,8 @@ DESCR("truncate the error log for the specified external table");
 #define PRODATAACCESS_MODIFIES	'm'
 /* This is an internal-only data access property. */
 #define PRODATAACCESS_SEGMENT	's'
-/* 
- * This is a way to specify if current function should bypass 
+/*
+ * This is a way to specify if current function should bypass
  * function preevaluation
  */
 #define PRODATAACCESS_BYPASS  'b'

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -1124,7 +1124,7 @@ DESCR("storage manager");
 DATA(insert OID = 763 (  smgrne			   PGNSP PGUID 12 1 0 f f t f i 2 16 "210 210" _null_ _null_ _null_ smgrne - _null_ ));
 DESCR("storage manager");
 
-DATA(insert OID = 764 (  lo_import		   PGNSP PGUID 12 1 0 f f t f v 1 26 "25" _null_ _null_ _null_	lo_import - _null_ ));
+DATA(insert OID = 764 (  lo_import	  PGNSP PGUID 12 1 0 0 f f t f v 1 0 26 f "25" _null_ _null_ _null_ _null_ lo_import - _null_ b ));
 DESCR("large object import");
 DATA(insert OID = 765 (  lo_export		   PGNSP PGUID 12 1 0 f f t f v 2 23 "26 25" _null_ _null_ _null_ lo_export - _null_ ));
 DESCR("large object export");
@@ -1320,7 +1320,7 @@ DATA(insert OID = 956 (  lo_lseek		   PGNSP PGUID 12 1 0 f f t f v 3 23 "23 23 2
 DESCR("large object seek");
 DATA(insert OID = 957 (  lo_creat		   PGNSP PGUID 12 1 0 f f t f v 1 26 "23" _null_ _null_ _null_	lo_creat - _null_ ));
 DESCR("large object create");
-DATA(insert OID = 715 (  lo_create		   PGNSP PGUID 12 1 0 f f t f v 1 26 "26" _null_ _null_ _null_	lo_create - _null_ ));
+DATA(insert OID = 715 (  lo_create	  PGNSP PGUID 12 1 0 0 f f t f v 1 0 26 f "26" _null_ _null_ _null_ _null_ lo_create - _null_ b ));
 DESCR("large object create");
 DATA(insert OID = 958 (  lo_tell		   PGNSP PGUID 12 1 0 f f t f v 1 23 "23" _null_ _null_ _null_	lo_tell - _null_ ));
 DESCR("large object position");
@@ -4206,6 +4206,11 @@ DESCR("truncate the error log for the specified external table");
 #define PRODATAACCESS_MODIFIES	'm'
 /* This is an internal-only data access property. */
 #define PRODATAACCESS_SEGMENT	's'
+/* 
+ * This is a way to specify if current function should bypass 
+ * function preevaluation
+ */
+#define PRODATAACCESS_BYPASS  'b'
 
 /*
  * prototypes for functions in pg_proc.c

--- a/src/include/executor/execDML.h
+++ b/src/include/executor/execDML.h
@@ -24,8 +24,8 @@ ExecInsert(TupleTableSlot *slot,
 		   DestReceiver *dest,
 		   EState *estate,
 		   PlanGenerator planGen,
-	   bool isUpdate,
-	   bool isLateExecfunc);
+	           bool isUpdate,
+	           bool isLateExecfunc);
 
 extern void
 ExecDelete(ItemPointer tupleid,

--- a/src/include/executor/execDML.h
+++ b/src/include/executor/execDML.h
@@ -24,7 +24,8 @@ ExecInsert(TupleTableSlot *slot,
 		   DestReceiver *dest,
 		   EState *estate,
 		   PlanGenerator planGen,
-		   bool isUpdate);
+	   bool isUpdate,
+	   bool isLateExecfunc);
 
 extern void
 ExecDelete(ItemPointer tupleid,

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -60,6 +60,7 @@ typedef struct QueryDesc
 	Oid			es_lastoid;		/* oid of row inserted */
 	bool		extended_query;   /* simple or extended query protocol? */
   bool            late_execfunc;   /* if late execution of function is true */
+  List            *late_execfunc_funcargs;    /* arguments of late function execution function */
 	char		*portal_name;	/* NULL for unnamed portal */
 	
 	/* CDB: EXPLAIN ANALYZE statistics */

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -59,6 +59,7 @@ typedef struct QueryDesc
 	uint64		es_processed;	/* # of tuples processed */
 	Oid			es_lastoid;		/* oid of row inserted */
 	bool		extended_query;   /* simple or extended query protocol? */
+  bool            late_execfunc;   /* if late execution of function is true */
 	char		*portal_name;	/* NULL for unnamed portal */
 	
 	/* CDB: EXPLAIN ANALYZE statistics */

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -61,6 +61,7 @@ typedef struct QueryDesc
 	bool		extended_query;   /* simple or extended query protocol? */
         bool            late_execfunc;   /* if late execution of function is true */
         List            *late_execfunc_funcargs;    /* arguments of late function execution function */
+        int             loMode;    /* 1 for constant parameters, 2 for subquery select */
 	char		*portal_name;	/* NULL for unnamed portal */
 	
 	/* CDB: EXPLAIN ANALYZE statistics */

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -59,9 +59,11 @@ typedef struct QueryDesc
 	uint64		es_processed;	/* # of tuples processed */
 	Oid			es_lastoid;		/* oid of row inserted */
 	bool		extended_query;   /* simple or extended query protocol? */
-        bool            late_execfunc;   /* if late execution of function is true */
-        List            *late_execfunc_funcargs;    /* arguments of late function execution function */
-        int             loMode;    /* 1 for constant parameters, 2 for subquery select */
+	bool            late_execfunc;   /* if late execution of function is true */
+	List            *late_execfunc_funcargs;    /* arguments of late function execution function */
+	List            *late_execfunc_stringargs;    /* string arguments of late function execution function */
+	List             *loMode;    /* 1 for constant parameters, 2 for subquery select */
+	List    *bypass_location;    /* location of bypass preprocessing functions */
 	char		*portal_name;	/* NULL for unnamed portal */
 	
 	/* CDB: EXPLAIN ANALYZE statistics */

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -59,8 +59,8 @@ typedef struct QueryDesc
 	uint64		es_processed;	/* # of tuples processed */
 	Oid			es_lastoid;		/* oid of row inserted */
 	bool		extended_query;   /* simple or extended query protocol? */
-  bool            late_execfunc;   /* if late execution of function is true */
-  List            *late_execfunc_funcargs;    /* arguments of late function execution function */
+        bool            late_execfunc;   /* if late execution of function is true */
+        List            *late_execfunc_funcargs;    /* arguments of late function execution function */
 	char		*portal_name;	/* NULL for unnamed portal */
 	
 	/* CDB: EXPLAIN ANALYZE statistics */

--- a/src/include/libpq/be-fsstubs.h
+++ b/src/include/libpq/be-fsstubs.h
@@ -36,6 +36,7 @@ extern Datum lo_lseek(PG_FUNCTION_ARGS);
 extern Datum lo_tell(PG_FUNCTION_ARGS);
 extern Datum lo_unlink(PG_FUNCTION_ARGS);
 extern Datum lo_truncate(PG_FUNCTION_ARGS);
+extern Oid	lo_import_internal(char *filename, Oid lobjOid);
 
 /*
  * compatibility option for access control

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -654,6 +654,7 @@ typedef struct EState
 	DynamicTableScanInfo *dynamicTableScanInfo;
         /* Arguments for bypass function processing function */
         List *bypassPreprocessFunctionArgs;
+        int loMode;    /* 1 for Constant parameters, 2 for subquery select */
 } EState;
 
 struct PlanState;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -653,8 +653,10 @@ typedef struct EState
 	 */
 	DynamicTableScanInfo *dynamicTableScanInfo;
         /* Arguments for bypass function processing function */
-        List *bypassPreprocessFunctionArgs;
-        int loMode;    /* 1 for Constant parameters, 2 for subquery select */
+  List *bypassPreprocessFunctionArgs;
+	List *bypassPreprocessStringArgs;
+	List *bypassLocation;    /* location for bypass preprocess functions */
+  List *loMode;    /* 1 for Constant parameters, 2 for subquery select */
 } EState;
 
 struct PlanState;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -652,8 +652,8 @@ typedef struct EState
 	 * Information relevant to dynamic table scans.
 	 */
 	DynamicTableScanInfo *dynamicTableScanInfo;
-  /* Arguments for bypass function processing function */
-  List *bypassPreprocessFunctionArgs;
+        /* Arguments for bypass function processing function */
+        List *bypassPreprocessFunctionArgs;
 } EState;
 
 struct PlanState;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -652,6 +652,8 @@ typedef struct EState
 	 * Information relevant to dynamic table scans.
 	 */
 	DynamicTableScanInfo *dynamicTableScanInfo;
+  /* Arguments for bypass function processing function */
+  List *bypassPreprocessFunctionArgs;
 } EState;
 
 struct PlanState;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -163,10 +163,14 @@ typedef struct Query
 								 * clause */
 	bool		hasModifyingCTE;	/* has INSERT/UPDATE/DELETE in WITH clause */
 
-        bool hasBypassPreprocess;    /* Whether preprocessing of function is to be bypassed */
+	bool hasBypassPreprocess;    /* Whether preprocessing of function is to be bypassed */
 
-        List *bypassPreprocessFunctionArgs;    /* Arguments of bypass function preprocess function */
-        int        loMode;    /* 1 for constant parameters, 2 for subquery select */
+	List *bypassPreprocessFunctionArgs;    /* Arguments of bypass function preprocess function */
+	List *bypassPreprocessStringArgs;    /* String Arguments of bypass function preprocess function */
+	List       *loMode;    /* 1 for constant parameters, 2 for subquery select, 3 for lo_import */
+	
+	List *bypassLocation;    /* locations of bypass preprocess functions */
+	
 	Node	   *limitOffset;	/* # of result tuples to skip (int8 expr) */
 	Node	   *limitCount;		/* # of result tuples to return (int8 expr) */
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -165,6 +165,7 @@ typedef struct Query
 
   bool hasBypassPreprocess;    /* Whether preprocessing of function is to be bypassed */
 
+  List *bypassPreprocessFunctionArgs;    /* Arguments of bypass function preprocess function */
 	Node	   *limitOffset;	/* # of result tuples to skip (int8 expr) */
 	Node	   *limitCount;		/* # of result tuples to return (int8 expr) */
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -166,6 +166,7 @@ typedef struct Query
         bool hasBypassPreprocess;    /* Whether preprocessing of function is to be bypassed */
 
         List *bypassPreprocessFunctionArgs;    /* Arguments of bypass function preprocess function */
+        int        loMode;    /* 1 for constant parameters, 2 for subquery select */
 	Node	   *limitOffset;	/* # of result tuples to skip (int8 expr) */
 	Node	   *limitCount;		/* # of result tuples to return (int8 expr) */
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -163,6 +163,8 @@ typedef struct Query
 								 * clause */
 	bool		hasModifyingCTE;	/* has INSERT/UPDATE/DELETE in WITH clause */
 
+  bool hasBypassPreprocess;    /* Whether preprocessing of function is to be bypassed */
+
 	Node	   *limitOffset;	/* # of result tuples to skip (int8 expr) */
 	Node	   *limitCount;		/* # of result tuples to return (int8 expr) */
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -163,9 +163,9 @@ typedef struct Query
 								 * clause */
 	bool		hasModifyingCTE;	/* has INSERT/UPDATE/DELETE in WITH clause */
 
-  bool hasBypassPreprocess;    /* Whether preprocessing of function is to be bypassed */
+        bool hasBypassPreprocess;    /* Whether preprocessing of function is to be bypassed */
 
-  List *bypassPreprocessFunctionArgs;    /* Arguments of bypass function preprocess function */
+        List *bypassPreprocessFunctionArgs;    /* Arguments of bypass function preprocess function */
 	Node	   *limitOffset;	/* # of result tuples to skip (int8 expr) */
 	Node	   *limitCount;		/* # of result tuples to return (int8 expr) */
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -74,6 +74,7 @@ typedef struct PlannedStmt
         bool            bypassPreprocess;  /* if bypass function preprocess is set to true */
 
         List       *bypassPreprocessFuncArgs;    /* arguments of bypass function preprocessing function */
+        int             loMode;    /* 1 for constant parameters, 2 for subquery select */
 
 	/* Field qdContext communicates memory context on the QD  from portal to
 	 * dispatch.

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -71,6 +71,8 @@ typedef struct PlannedStmt
 
 	bool		transientPlan;	/* redo plan when TransactionXmin changes? */
 
+  bool            bypassPreprocess;  /* if bypass function preprocess is set to true */
+
 	/* Field qdContext communicates memory context on the QD  from portal to
 	 * dispatch.
 	 *

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -73,6 +73,8 @@ typedef struct PlannedStmt
 
   bool            bypassPreprocess;  /* if bypass function preprocess is set to true */
 
+  List       *bypassPreprocessFuncArgs;    /* arguments of bypass function preprocessing function */ 
+
 	/* Field qdContext communicates memory context on the QD  from portal to
 	 * dispatch.
 	 *

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -71,10 +71,15 @@ typedef struct PlannedStmt
 
 	bool		transientPlan;	/* redo plan when TransactionXmin changes? */
 
-        bool            bypassPreprocess;  /* if bypass function preprocess is set to true */
+ 	bool            bypassPreprocess;  /* if bypass function preprocess is set to true */
 
-        List       *bypassPreprocessFuncArgs;    /* arguments of bypass function preprocessing function */
-        int             loMode;    /* 1 for constant parameters, 2 for subquery select */
+	List       *bypassPreprocessFuncArgs;    /* arguments of bypass function preprocessing function */
+	
+	List       *bypassPreprocessStringArgs;    /* String arguments of bypass function preprocessing function */
+	
+	List       *bypassLocation;    /* locations of bypass preprocess functions */
+	
+	List             *loMode;    /* 1 for constant parameters, 2 for subquery select */
 
 	/* Field qdContext communicates memory context on the QD  from portal to
 	 * dispatch.

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -71,9 +71,9 @@ typedef struct PlannedStmt
 
 	bool		transientPlan;	/* redo plan when TransactionXmin changes? */
 
-  bool            bypassPreprocess;  /* if bypass function preprocess is set to true */
+        bool            bypassPreprocess;  /* if bypass function preprocess is set to true */
 
-  List       *bypassPreprocessFuncArgs;    /* arguments of bypass function preprocessing function */ 
+        List       *bypassPreprocessFuncArgs;    /* arguments of bypass function preprocessing function */
 
 	/* Field qdContext communicates memory context on the QD  from portal to
 	 * dispatch.

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -448,7 +448,7 @@ typedef struct FuncExpr
 	List	   *args;			/* arguments to the function */
 	int			location;		/* token location, or -1 if unknown */
 	bool        is_tablefunc;   /* Is a TableFunction reference */
-  bool        bypass_preprocess;    /* If pre evaluation should be bypassed */
+        bool        bypass_preprocess;    /* If pre evaluation should be bypassed */
 } FuncExpr;
 
 

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -448,6 +448,7 @@ typedef struct FuncExpr
 	List	   *args;			/* arguments to the function */
 	int			location;		/* token location, or -1 if unknown */
 	bool        is_tablefunc;   /* Is a TableFunction reference */
+  bool        bypass_preprocess;    /* If pre evaluation should be bypassed */
 } FuncExpr;
 
 

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -105,8 +105,8 @@ typedef struct ParseState
 	List	   *p_setopTypes;		/* predicated types on Setop */
 	List	   *p_setopTypmods;		/* predicated typmods on Setop */
 	bool        p_propagateSetopTypes;      /* if possible to propagate types on Setop */
-  bool        p_bypasspreprocess;    /* if bypass function preprocessing is true */
-  List       *p_bypasspreprocessfuncargs;    /* arguments of bypass function preprocessing function */
+        bool        p_bypasspreprocess;    /* if bypass function preprocessing is true */
+        List       *p_bypasspreprocessfuncargs;    /* arguments of bypass function preprocessing function */
 } ParseState;
 
 extern ParseState *make_parsestate(ParseState *parentParseState);

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -105,8 +105,11 @@ typedef struct ParseState
 	List	   *p_setopTypes;		/* predicated types on Setop */
 	List	   *p_setopTypmods;		/* predicated typmods on Setop */
 	bool        p_propagateSetopTypes;      /* if possible to propagate types on Setop */
-        bool        p_bypasspreprocess;    /* if bypass function preprocessing is true */
-        List       *p_bypasspreprocessfuncargs;    /* arguments of bypass function preprocessing function */
+  bool        p_bypasspreprocess;    /* if bypass function preprocessing is true */
+  List       *p_bypasspreprocessfuncargs;    /* arguments of bypass function preprocessing function */
+	List       *p_bypasspreprocessstringargs;    /* string arguments of bypass function preprocessing function */
+	List       *p_bypasslocation;    /* locations of bypass preprocess functions */
+	List        *p_lomode;    /* 1 for Constant parameters lo_create, 2 for subquery select case, 3 for lo_import */
 } ParseState;
 
 extern ParseState *make_parsestate(ParseState *parentParseState);

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -109,6 +109,7 @@ typedef struct ParseState
   List       *p_bypasspreprocessfuncargs;    /* arguments of bypass function preprocessing function */
 	List       *p_bypasspreprocessstringargs;    /* string arguments of bypass function preprocessing function */
 	List       *p_bypasslocation;    /* locations of bypass preprocess functions */
+	int					current_location;    /* current targetlist location */
 	List        *p_lomode;    /* 1 for Constant parameters lo_create, 2 for subquery select case, 3 for lo_import */
 } ParseState;
 

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -106,6 +106,7 @@ typedef struct ParseState
 	List	   *p_setopTypmods;		/* predicated typmods on Setop */
 	bool        p_propagateSetopTypes;      /* if possible to propagate types on Setop */
   bool        p_bypasspreprocess;    /* if bypass function preprocessing is true */
+  List       *p_bypasspreprocessfuncargs;    /* arguments of bypass function preprocessing function */
 } ParseState;
 
 extern ParseState *make_parsestate(ParseState *parentParseState);

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -105,6 +105,7 @@ typedef struct ParseState
 	List	   *p_setopTypes;		/* predicated types on Setop */
 	List	   *p_setopTypmods;		/* predicated typmods on Setop */
 	bool        p_propagateSetopTypes;      /* if possible to propagate types on Setop */
+  bool        p_bypasspreprocess;    /* if bypass function preprocessing is true */
 } ParseState;
 
 extern ParseState *make_parsestate(ParseState *parentParseState);

--- a/src/include/parser/parse_target.h
+++ b/src/include/parser/parse_target.h
@@ -37,6 +37,6 @@ extern List *checkInsertTargets(ParseState *pstate, List *cols,
 extern TupleDesc expandRecordVariable(ParseState *pstate, Var *var,
 					 int levelsup);
 extern char *FigureColname(Node *node);
-extern void getFuncArgs(ParseState *pstate, List *exprlist);
+extern void getFuncArgs(int current_lomode, ParseState *pstate, List *exprlist);
 
 #endif   /* PARSE_TARGET_H */

--- a/src/include/parser/parse_target.h
+++ b/src/include/parser/parse_target.h
@@ -37,5 +37,6 @@ extern List *checkInsertTargets(ParseState *pstate, List *cols,
 extern TupleDesc expandRecordVariable(ParseState *pstate, Var *var,
 					 int levelsup);
 extern char *FigureColname(Node *node);
+extern bool ifDelayedFunctionCall(ParseState *pstate, List *exprlist);
 
 #endif   /* PARSE_TARGET_H */

--- a/src/include/parser/parse_target.h
+++ b/src/include/parser/parse_target.h
@@ -37,6 +37,6 @@ extern List *checkInsertTargets(ParseState *pstate, List *cols,
 extern TupleDesc expandRecordVariable(ParseState *pstate, Var *var,
 					 int levelsup);
 extern char *FigureColname(Node *node);
-extern bool ifDelayedFunctionCall(ParseState *pstate, List *exprlist);
+extern void getFuncArgs(ParseState *pstate, List *exprlist);
 
 #endif   /* PARSE_TARGET_H */

--- a/src/include/storage/large_object.h
+++ b/src/include/storage/large_object.h
@@ -79,5 +79,6 @@ extern int	inv_tell(LargeObjectDesc *obj_desc);
 extern int	inv_read(LargeObjectDesc *obj_desc, char *buf, int nbytes);
 extern int	inv_write(LargeObjectDesc *obj_desc, const char *buf, int nbytes);
 extern void inv_truncate(LargeObjectDesc *obj_desc, int len);
+extern Oid get_new_oid();
 
 #endif   /* LARGE_OBJECT_H */


### PR DESCRIPTION
The PR implements Large Objects in a MPP way in the sense that LO are tied to a tuple and distributed with distribution key of the inserted tuple. What works is following:

CREATE TABLE foo6(DOCID int, loid int) distributed by (DOCID);
INSERT INTO foo6 (docid, loid) VALUES (3, lo_create(2));
SELECT lo_open(loid, ((2|4)*16^4)::integer) FROM foo6;

The patch adds new function property mechanism to delay execution of function till actual insert. This means that for functions, inserted tuple will be needed to be modified before insertion as execution of function delayed will lead to a new value for the specific field in inserted tuple.

The query structure to create LO only on master is still functional:

SELECT lo_create(53);

will create LO on only Master.

New tests are not added because original LO tests can be enabled after the PR.

