### PR TITLE
Fix tuple memoryleak for fast sequence number.

### DIFF
--- a/src/backend/catalog/gp_fastsequence.c
+++ b/src/backend/catalog/gp_fastsequence.c
@@ -77,7 +77,6 @@ InsertFastSequenceEntry(Oid objid, int64 objmod, int64 lastSequence)
 		frozen_heap_insert(gp_fastsequence_rel, tuple);
 		CatalogUpdateIndexes(gp_fastsequence_rel, tuple);
 
-		heap_freetuple(tuple);
 		pfree(values);
 		pfree(nulls);
 	}
@@ -90,6 +89,8 @@ InsertFastSequenceEntry(Oid objid, int64 objmod, int64 lastSequence)
 							objmod,
 							lastSequence);
 	}
+
+	heap_freetuple(tuple);
 
 	/*
 	 * gp_fastsequence table locking for AO inserts uses bottom up approach
@@ -142,7 +143,6 @@ update_fastsequence(Relation gp_fastsequence_rel,
 
 		heap_freetuple(newTuple);
 	}
-
 	else
 	{
 #ifdef USE_ASSERT_CHECKING
@@ -234,6 +234,11 @@ int64 GetFastSequences(Oid objid, int64 objmod,
 	
 	update_fastsequence(gp_fastsequence_rel, tuple, tupleDesc,
 						objid, objmod, newLastSequence);
+
+	if (HeapTupleIsValid(tuple))
+	{
+		heap_freetuple(tuple);
+	}
 		
 	/* Refer to the comment at the end of InsertFastSequenceEntry. */
 	heap_close(gp_fastsequence_rel, RowExclusiveLock);


### PR DESCRIPTION
Every 100th AO or CO row insert in a transaction leaks 64 bytes
(gpgastsequence tuple) memory. Hence for transaction performing bulk
inserts to AO or CO table memory footprint keeps increasing, without
the fix.

Sample Repro:
```
create temp table t_0001 (agt_nr integer)
distributed randomly;

insert into t_0001
select
  generate_series(1,512)::integer as agt_nr
from generate_series(1,20000);

select 't_0001' as temptable, count(*) from t_0001;

create temp table t_0002
WITH (APPENDONLY=TRUE)
AS
select
  a.agt_nr
from    t_0001 a, t_0001 b
where   a.agt_nr = b.agt_nr
distributed randomly
;
```

When memory allocations are dumped reveals:
```
postgres=# select file, line, cnt, totalsize from (select file, line, count(1) as cnt, sum(size) as totalsize from memalloc group by file, line) tmpt order by totalsize desc limit 20;
                         file                         | line  |   cnt   | totalsize
------------------------------------------------------+-------+---------+-----------
 heaptuple.c                                          |   666 | 3139698 | 200952512
 tupdesc.c                                            |    64 |     212 |    217664
 catcache.c                                           |   750 |      39 |    193928
 xlog.c                                               | 11677 |       1 |    163904
 dynahash.c                                           |   221 |     104 |    125824
 md.c                                                 |  2224 |      68 |    119104
 cdbappendonlystoragewrite.c                          |   151 |       1 |     98304
 mcxt.c                                               |  1009 |     373 |     96288
 ../../../../src/include/cdb/cdbicudpfaultinjection.h |   533 |      11 |     84264
 mcxt.c                                               |  1283 |    1707 |     60988
 deadlock.c                                           |   179 |       1 |     48000
 cdbmirroredbufferpool.c                              |   731 |       1 |     32768
 buffile.c                                            |    87 |       1 |     32768
 relcache.c                                           |  1464 |     100 |     27200
 postmaster.c                                         |  2672 |       1 |     22088
 heaptuple.c                                          |   697 |     114 |     21536
 relcache.c                                           |   738 |      79 |     20000
 relcache.c                                           |  4198 |      39 |     19968
 relcache.c                                           |   760 |      78 |     19968
 deadlock.c                                           |   138 |       1 |     18000
(20 rows)


postgres=# select file, line, cnt, totalsize from (select file, line, count(1) as cnt, sum(size) as totalsize from memalloc group by file, line) tmpt order by totalsize desc limit 20;
                         file                         | line  |   cnt   | totalsize
------------------------------------------------------+-------+---------+-----------
 heaptuple.c                                          |   666 | 4648831 | 297537024
 tupdesc.c                                            |    64 |     212 |    217664
 catcache.c                                           |   750 |      39 |    193928
 xlog.c                                               | 11677 |       1 |    163904
 dynahash.c                                           |   221 |     104 |    125824
 md.c                                                 |  2224 |      68 |    119104
 cdbappendonlystoragewrite.c                          |   151 |       1 |     98304
 mcxt.c                                               |  1009 |     373 |     96288
 ../../../../src/include/cdb/cdbicudpfaultinjection.h |   533 |      11 |     84264
 mcxt.c                                               |  1283 |    1707 |     60988
 deadlock.c                                           |   179 |       1 |     48000
 nbtree.c                                             |   446 |       1 |     32808
 buffile.c                                            |    87 |       1 |     32768
 cdbmirroredbufferpool.c                              |   731 |       1 |     32768
 relcache.c                                           |  1464 |     100 |     27200
 postmaster.c                                         |  2672 |       1 |     22088
 heaptuple.c                                          |   697 |     114 |     21536
 relcache.c                                           |   738 |      79 |     20000
 relcache.c                                           |   760 |      78 |     19968
 relcache.c                                           |  4198 |      39 |     19968
(20 rows)


(lldb) bt
* thread #1: tid = 0x29011b, 0x00008209 postgres`heaptuple_copy_to(tuple=0x2f8d4f84, dest=0x00000000, destlen=0x00000000) + 178 at heaptuple.c:666, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #0: 0x00008209 postgres`heaptuple_copy_to(tuple=0x2f8d4f84, dest=0x00000000, destlen=0x00000000) + 178 at heaptuple.c:666
    frame #1: 0x00128272 postgres`heap_copytuple(tuple=0x2f8d4f84) + 33 at heapam.h:303
    frame #2: 0x0012935e postgres`caql_getfirst_only(pCtx0=0xbfffe344, pbOnly=0x00000000, pcql=0x2f8d4f00) + 490 at catquery.c:616
    frame #3: 0x0015b86f postgres`GetFastSequences(objid=505292, objmod=0, minSequence=464874301, numSequences=100) + 259 at gp_fastsequence.c:205
    frame #4: 0x000f7879 postgres`appendonly_insert(aoInsertDesc=0x063ac62c, instup=0x043cccac, tupleOid=0xbfffe598, aoTupleId=0xbfffe592) + 2641 at appendonlyam.c:3133
    frame #5: 0x0027ce1d postgres`intorel_receive(slot=0x0639d1b4, self=0x043cc53c) + 221 at execMain.c:4013
    frame #6: 0x0027b0db postgres`ExecSelect(slot=0x0639d1b4, dest=0x043cc53c, estate=0x0639c42c) + 26 at execMain.c:2838
    frame #7: 0x0027af3c postgres`ExecutePlan(estate=0x0639c42c, planstate=0x0639d5c8, operation=CMD_SELECT, numberTuples=0, direction=ForwardScanDirection, dest=0x043cc53c) + 1417 at execMain.c:2760
    frame #8: 0x002776ae postgres`ExecutorRun(queryDesc=0x0637bbe0, direction=ForwardScanDirection, count=0) + 933 at execMain.c:911
    frame #9: 0x00483010 postgres`ProcessQuery(portal=0x03bbb42c, stmt=0x06372448, params=0x00000000, dest=0x06378a24, completionTag=0xbfffe94e) + 854 at pquery.c:287
    frame #10: 0x00485524 postgres`PortalRunMulti(portal=0x03bbb42c, isTopLevel='\x01', dest=0x06378a24, altdest=0x06378a24, completionTag=0xbfffe94e) + 628 at pquery.c:1603
    frame #11: 0x004846f5 postgres`PortalRun(portal=0x03bbb42c, count=9223372036854775807, isTopLevel='\x01', dest=0x06378a24, altdest=0x06378a24, completionTag=0xbfffe94e) + 971 at pquery.c:1125
    frame #12: 0x0047a8d1 postgres`exec_mpp_query(query_string=0x033f6136, serializedQuerytree=0x00000000, serializedQuerytreelen=0, serializedPlantree=0x033f61cb, serializedPlantreelen=594, serializedParams=0x00000000, serializedParamslen=0, serializedSliceInfo=0x033f641d, serializedSliceInfolen=165, seqServerHost=0x033f64c2, seqServerPort=57930, localSlice=0) + 3641 at postgres.c:1293
    frame #13: 0x004817a1 postgres`PostgresMain(argc=1, argv=0x03b752cc, dbname=0x03b75264, username=0x03b75238) + 5557 at postgres.c:4824
    frame #14: 0x0040e7a4 postgres`BackendRun(port=0x02b9b870) + 702 at postmaster.c:6704
    frame #15: 0x0040dd65 postgres`BackendStartup(port=0x02b9b870) + 381 at postmaster.c:6391
    frame #16: 0x0040579d postgres`ServerLoop + 1122 at postmaster.c:2450
    frame #17: 0x00403919 postgres`PostmasterMain(argc=15, argv=0x02b9b460) + 5694 at postmaster.c:1526
    frame #18: 0x0032081c postgres`main(argc=15, argv=0x02b9b460) + 840 at main.c:206
    frame #19: 0x000024b5 postgres`start + 53
```

