### PR TITLE
Remove 'set optimizer=on' from union_gp test

### DIFF
--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -1,49 +1,45 @@
 -- Additional GPDB-added tests for UNION
 create temp table t_union1 (a int, b int);
-select distinct a, null as c from t_union1 union select a, b from t_union1;
-ERROR:  UNION/INTERSECT/EXCEPT could not convert type text to integer
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 select distinct a, null::integer as c from t_union1 union select a, b from t_union1;
- a | c
+ a | c 
 ---+---
 (0 rows)
 
 drop table t_union1;
 select null union select distinct null;
- ?column?
+ ?column? 
 ----------
-
+ 
 (1 row)
 
-select 1 union select distinct null;
-ERROR:  UNION/INTERSECT/EXCEPT could not convert type text to integer
 select 1 union select distinct null::integer;
- ?column?
+ ?column? 
 ----------
-
         1
+         
 (2 rows)
 
 select 1 a, NULL b, NULL c UNION SELECT 2, 3, NULL UNION SELECT 3, NULL, 4;
- a | b | c
+ a | b | c 
 ---+---+---
- 1 |   |
- 2 | 3 |
+ 1 |   |  
+ 2 | 3 |  
  3 |   | 4
 (3 rows)
 
-select ARRAY[1, 2, 3] union select distinct null;
-ERROR:  UNION/INTERSECT/EXCEPT could not convert type text to integer[]
 select ARRAY[1, 2, 3] union select distinct null::integer[];
-  array
+  array  
 ---------
-
  {1,2,3}
+ 
 (2 rows)
 
 select 1 intersect (select 1, 2 union all select 3, 4);
 ERROR:  each INTERSECT query must have the same number of columns
 select 1 a, row_number() over (partition by 'a') union all (select 1 a , 2 b);
- a | row_number
+ a | row_number 
 ---+------------
  1 |          1
  1 |          2
@@ -53,7 +49,7 @@ select 1 a, row_number() over (partition by 'a') union all (select 1 a , 2 b);
 -- See MPP-7509
 select pg_typeof(a) from (select 'a'::information_schema.sql_identifier a union all
 select 'b'::information_schema.sql_identifier)a;
-     pg_typeof
+     pg_typeof     
 -------------------
  character varying
  character varying
@@ -70,36 +66,38 @@ select 'b'::information_schema.sql_identifier)a;
      union
      (select 1 union select distinct null::integer)
   )s2);
- a
+ a 
 ---
-
  1
+  
 (2 rows)
 
 -- Yet, we keep behaviors on text-like columns
 select pg_typeof(a) from(select 'foo' a union select 'foo'::name)s;
- pg_typeof
+ pg_typeof 
 -----------
  name
 (1 row)
 
 select pg_typeof(a) from(select 1 x, 'foo' a union
     select 1, 'foo' union select 1, 'foo'::name)s;
- pg_typeof
+ pg_typeof 
 -----------
  text
 (1 row)
 
 select pg_typeof(a) from(select 1 x, 'foo' a union
     (select 1, 'foo' union select 1, 'foo'::name))s;
- pg_typeof
+ pg_typeof 
 -----------
  name
 (1 row)
 
 CREATE TABLE union_ctas (a, b) AS SELECT 1, 2 UNION SELECT 1, 1 UNION SELECT 1, 1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT * FROM union_ctas;
- a | b
+ a | b 
 ---+---
  1 | 1
  1 | 2
@@ -108,9 +106,13 @@ SELECT * FROM union_ctas;
 DROP TABLE union_ctas;
 -- MPP-21075: push quals below union
 CREATE TABLE union_quals1 (a, b) AS SELECT i, i%2 from generate_series(1,10) i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE union_quals2 (a, b) AS SELECT i%2, i from generate_series(1,10) i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT * FROM (SELECT a, b from union_quals1 UNION SELECT b, a from union_quals2) as foo(a,b) where a > b order by a;
- a  | b
+ a  | b 
 ----+---
   2 | 0
   3 | 1
@@ -124,7 +126,7 @@ SELECT * FROM (SELECT a, b from union_quals1 UNION SELECT b, a from union_quals2
 (9 rows)
 
 SELECT * FROM (SELECT a, max(b) over() from union_quals1 UNION SELECT * from union_quals2) as foo(a,b) where b > 6 order by a,b;
- a | b
+ a | b  
 ---+----
  0 |  8
  0 | 10
@@ -134,29 +136,29 @@ SELECT * FROM (SELECT a, max(b) over() from union_quals1 UNION SELECT * from uni
 
 -- MPP-22266: different combinations of set operations and distinct
 select * from ((select 1, 'A' from (select distinct 'B') as foo) union (select 1, 'C')) as bar;
- ?column? | ?column?
+ ?column? | ?column? 
 ----------+----------
         1 | A
         1 | C
 (2 rows)
 
 select 1 union (select distinct null::integer union select '10');
- ?column?
+ ?column? 
 ----------
         1
        10
-
+         
 (3 rows)
 
 select 1 union (select 2 from (select distinct null::integer union select 1) as x);
- ?column?
+ ?column? 
 ----------
         1
         2
 (2 rows)
 
 select 1 union (select distinct 10 from (select 1, 3.0 union select distinct 2, null::integer) as foo);
- ?column?
+ ?column? 
 ----------
         1
        10
@@ -165,42 +167,42 @@ select 1 union (select distinct 10 from (select 1, 3.0 union select distinct 2, 
 select 1 union (select distinct '10' from (select 1, 3.0 union select distinct 2, null::integer) as foo);
 ERROR:  UNION/INTERSECT/EXCEPT could not convert type text to integer
 select distinct a from (select 'A' union select 'B') as foo(a);
- a
+ a 
 ---
  A
  B
 (2 rows)
 
 select distinct a from (select distinct 'A' union select 'B') as foo(a);
- a
+ a 
 ---
  A
  B
 (2 rows)
 
 select distinct a from (select distinct 'A' union select distinct 'B') as foo(a);
- a
+ a 
 ---
  A
  B
 (2 rows)
 
 select distinct a from (select  'A' from (select distinct 'C' ) as bar union select distinct 'B') as foo(a);
- a
+ a 
 ---
  A
  B
 (2 rows)
 
 select distinct a from (select  distinct 'A' from (select distinct 'C' ) as bar union select distinct 'B') as foo(a);
- a
+ a 
 ---
  A
  B
 (2 rows)
 
 select distinct a from (select  distinct 'A' from (select 'C' from (select distinct 'D') as bar1 ) as bar union select distinct 'B') as foo(a);
- a
+ a 
 ---
  A
  B
@@ -238,10 +240,9 @@ for i in range(len(rv)):
 return result
 $$
 language plpythonu;
-set optimizer = on;
 --
 -- N-ary UNION ALL results
--- @optimizer_mode on
+--
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION ALL SELECT 200, 200
@@ -254,7 +255,7 @@ UNION ALL
 UNION ALL
 (select d1 from T_constant)
 order by 1;
- a1
+ a1  
 -----
    1
    1
@@ -333,7 +334,7 @@ UNION ALL
 UNION ALL
 (select d1 from T_constant)
 order by 1;
- b1
+ b1  
 -----
    1
    1
@@ -412,7 +413,7 @@ UNION ALL
 UNION ALL
 (select d1 from T_constant)
 order by 1;
- c1
+ c1  
 -----
    1
    1
@@ -491,7 +492,7 @@ UNION ALL
 UNION ALL
 (select b1 from T_b2)
 order by 1;
- d1
+ d1  
 -----
    1
    1
@@ -560,7 +561,7 @@ order by 1;
 
 --
 -- N-ary UNION ALL explain
--- @optimizer_mode on
+--
 select count_operator('
 explain
 with T_constant (d1, d2) as(
@@ -576,7 +577,7 @@ UNION ALL
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -596,7 +597,7 @@ UNION ALL
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -616,7 +617,7 @@ UNION ALL
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -636,14 +637,14 @@ UNION ALL
 (select b1 from T_b2)
 order by 1;'
 , 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
 
 --
 -- N-ary UNION results
--- @optimizer_mode on
+--
 with T_constant (d1, d2) as(
 SELECT 100, 100
 UNION SELECT 200, 200
@@ -656,7 +657,7 @@ UNION
 UNION
 (select d1 from T_constant)
 order by 1;
- a1
+ a1  
 -----
    1
    2
@@ -705,7 +706,7 @@ UNION
 UNION ALL
 (select d1 from T_constant)
 order by 1;
- b1
+ b1  
 -----
    1
    2
@@ -754,7 +755,7 @@ UNION
 UNION ALL
 (select d1 from T_constant)
 order by 1;
- c1
+ c1  
 -----
    1
    2
@@ -803,7 +804,7 @@ UNION
 UNION
 (select b1 from T_b2)
 order by 1;
- d1
+ d1  
 -----
    1
    2
@@ -842,7 +843,7 @@ order by 1;
 
 --
 -- N-ary UNION explain
--- @optimizer_mode on
+--
 select count_operator('
 explain
 with T_constant (d1, d2) as(
@@ -858,7 +859,7 @@ UNION
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -878,7 +879,7 @@ UNION
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -898,7 +899,7 @@ UNION
 (select d1 from T_constant)
 order by 1;'
 , 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -918,16 +919,16 @@ UNION
 (select b1 from T_b2)
 order by 1;'
 , 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
 
 --
 -- Binary UNION ALL results
--- @optimizer_mode on
+--
 (select a1 from T_a1) UNION ALL (select b1 from T_b2) order by 1;
- a1
+ a1 
 ----
   1
   1
@@ -962,7 +963,7 @@ order by 1;'
 (30 rows)
 
 (select b1 from T_b2) UNION ALL (select a1 from T_a1) order by 1;
- b1
+ b1 
 ----
   1
   1
@@ -997,7 +998,7 @@ order by 1;'
 (30 rows)
 
 (select a1 from T_a1) UNION ALL (select c1 from T_random) order by 1;
- a1
+ a1 
 ----
   1
   1
@@ -1042,7 +1043,7 @@ order by 1;'
 (40 rows)
 
 (select c1 from T_random) UNION ALL (select a1 from T_a1) order by 1;
- c1
+ c1 
 ----
   1
   1
@@ -1087,7 +1088,7 @@ order by 1;'
 (40 rows)
 
 (select * from T_a1) UNION ALL (select * from T_b2) order by 1;
- a1 | a2
+ a1 | a2 
 ----+----
   1 |  1
   1 |  1
@@ -1122,7 +1123,7 @@ order by 1;'
 (30 rows)
 
 (select * from T_a1) UNION ALL (select * from T_random) order by 1;
- a1 | a2
+ a1 | a2 
 ----+----
   1 |  1
   1 |  1
@@ -1167,7 +1168,7 @@ order by 1;'
 (40 rows)
 
 (select * from T_b2) UNION ALL (select * from T_random) order by 1;
- b1 | b2
+ b1 | b2 
 ----+----
   1 |  1
   1 |  1
@@ -1226,7 +1227,7 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select a1 from T_a1) UNION ALL (select d1 from T_constant) order by 1;
- a1
+ a1  
 -----
    1
    2
@@ -1248,7 +1249,7 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select d1 from T_constant) UNION ALL (select a1 from T_a1) order by 1;
- d1
+ d1  
 -----
    1
    2
@@ -1270,7 +1271,7 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select c1 from T_random) UNION ALL (select d1 from T_constant) order by 1;
- c1
+ c1  
 -----
    1
    2
@@ -1312,7 +1313,7 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select d1 from T_constant) UNION ALL (select c1 from T_random) order by 1;
- d1
+ d1  
 -----
    1
    2
@@ -1351,45 +1352,45 @@ UNION ALL SELECT 300, 300)
 
 --
 -- Binary UNION ALL explain
--- @optimizer_mode on
+--
 select count_operator('explain (select a1 from T_a1) UNION ALL (select b1 from T_b2) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select b1 from T_b2) UNION ALL (select a1 from T_a1) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select a1 from T_a1) UNION ALL (select c1 from T_random) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select c1 from T_random) UNION ALL (select a1 from T_a1) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select * from T_a1) UNION ALL (select * from T_b2) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select * from T_a1) UNION ALL (select * from T_random) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select * from T_b2) UNION ALL (select * from T_random) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
@@ -1400,7 +1401,7 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select a1 from T_a1) UNION ALL (select d1 from T_constant) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -1411,7 +1412,7 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select d1 from T_constant) UNION ALL (select a1 from T_a1) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -1422,7 +1423,7 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select c1 from T_random) UNION ALL (select d1 from T_constant) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -1432,16 +1433,16 @@ SELECT 100, 100
 UNION ALL SELECT 200, 200
 UNION ALL SELECT 300, 300)
 (select d1 from T_constant) UNION ALL (select c1 from T_random) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
 
 --
 -- Binary UNION results
--- @optimizer_mode on
+--
 (select a1 from T_a1) UNION (select b1 from T_b2) order by 1;
- a1
+ a1 
 ----
   1
   2
@@ -1466,7 +1467,7 @@ UNION ALL SELECT 300, 300)
 (20 rows)
 
 (select b1 from T_b2) UNION (select a1 from T_a1) order by 1;
- b1
+ b1 
 ----
   1
   2
@@ -1491,7 +1492,7 @@ UNION ALL SELECT 300, 300)
 (20 rows)
 
 (select a1 from T_a1) UNION (select c1 from T_random) order by 1;
- a1
+ a1 
 ----
   1
   2
@@ -1526,7 +1527,7 @@ UNION ALL SELECT 300, 300)
 (30 rows)
 
 (select c1 from T_random) UNION (select a1 from T_a1) order by 1;
- c1
+ c1 
 ----
   1
   2
@@ -1561,7 +1562,7 @@ UNION ALL SELECT 300, 300)
 (30 rows)
 
 (select * from T_a1) UNION (select * from T_b2) order by 1;
- a1 | a2
+ a1 | a2 
 ----+----
   1 |  1
   2 |  2
@@ -1586,7 +1587,7 @@ UNION ALL SELECT 300, 300)
 (20 rows)
 
 (select * from T_a1) UNION (select * from T_random) order by 1;
- a1 | a2
+ a1 | a2 
 ----+----
   1 |  1
   2 |  2
@@ -1621,7 +1622,7 @@ UNION ALL SELECT 300, 300)
 (30 rows)
 
 (select * from T_b2) UNION (select * from T_random) order by 1;
- b1 | b2
+ b1 | b2 
 ----+----
   1 |  1
   2 |  2
@@ -1660,7 +1661,7 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select a1 from T_a1) UNION (select d1 from T_constant) order by 1;
- a1
+ a1  
 -----
    1
    2
@@ -1682,7 +1683,7 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select a1 from T_a1) order by 1;
- d1
+ d1  
 -----
    1
    2
@@ -1704,7 +1705,7 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select c1 from T_random) UNION (select d1 from T_constant) order by 1;
- c1
+ c1  
 -----
    1
    2
@@ -1746,7 +1747,7 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select c1 from T_random) order by 1;
- d1
+ d1  
 -----
    1
    2
@@ -1785,45 +1786,45 @@ UNION SELECT 300, 300)
 
 --
 -- Binary UNION explain
--- @optimizer_mode on
+--
 select count_operator('explain (select a1 from T_a1) UNION (select b1 from T_b2) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select b1 from T_b2) UNION (select a1 from T_a1) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select a1 from T_a1) UNION (select c1 from T_random) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select c1 from T_random) UNION (select a1 from T_a1) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select * from T_a1) UNION (select * from T_b2) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select * from T_a1) UNION (select * from T_random) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
 
 select count_operator('explain (select * from T_b2) UNION (select * from T_random) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               1
 (1 row)
@@ -1834,7 +1835,7 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select a1 from T_a1) UNION (select d1 from T_constant) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -1845,7 +1846,7 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select a1 from T_a1) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -1856,7 +1857,7 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select c1 from T_random) UNION (select d1 from T_constant) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
@@ -1866,1301 +1867,10 @@ SELECT 100, 100
 UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select c1 from T_random) order by 1;', 'APPEND');
- count_operator
+ count_operator 
 ----------------
               2
 (1 row)
-
-set optimizer = off;
---
--- N-ary UNION ALL results
--- @optimizer_mode off
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select a1 from T_a1)
-UNION ALL
-(select b1 from T_b2)
-UNION ALL
-(select c1 from T_random)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
- a1
------
-   1
-   1
-   1
-   2
-   2
-   2
-   3
-   3
-   3
-   4
-   4
-   4
-   5
-   5
-   5
-   6
-   6
-   6
-   7
-   7
-   7
-   8
-   8
-   8
-   9
-   9
-   9
-  10
-  10
-  10
-  11
-  11
-  12
-  12
-  13
-  13
-  14
-  14
-  15
-  15
-  16
-  16
-  17
-  17
-  18
-  18
-  19
-  19
-  20
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(63 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select b1 from T_b2)
-UNION ALL
-(select a1 from T_a1)
-UNION ALL
-(select c1 from T_random)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
- b1
------
-   1
-   1
-   1
-   2
-   2
-   2
-   3
-   3
-   3
-   4
-   4
-   4
-   5
-   5
-   5
-   6
-   6
-   6
-   7
-   7
-   7
-   8
-   8
-   8
-   9
-   9
-   9
-  10
-  10
-  10
-  11
-  11
-  12
-  12
-  13
-  13
-  14
-  14
-  15
-  15
-  16
-  16
-  17
-  17
-  18
-  18
-  19
-  19
-  20
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(63 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select c1 from T_random)
-UNION ALL
-(select a1 from T_a1)
-UNION ALL
-(select b1 from T_b2)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
- c1
------
-   1
-   1
-   1
-   2
-   2
-   2
-   3
-   3
-   3
-   4
-   4
-   4
-   5
-   5
-   5
-   6
-   6
-   6
-   7
-   7
-   7
-   8
-   8
-   8
-   9
-   9
-   9
-  10
-  10
-  10
-  11
-  11
-  12
-  12
-  13
-  13
-  14
-  14
-  15
-  15
-  16
-  16
-  17
-  17
-  18
-  18
-  19
-  19
-  20
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(63 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select d1 from T_constant)
-UNION ALL
-(select c1 from T_random)
-UNION ALL
-(select a1 from T_a1)
-UNION ALL
-(select b1 from T_b2)
-order by 1;
- d1
------
-   1
-   1
-   1
-   2
-   2
-   2
-   3
-   3
-   3
-   4
-   4
-   4
-   5
-   5
-   5
-   6
-   6
-   6
-   7
-   7
-   7
-   8
-   8
-   8
-   9
-   9
-   9
-  10
-  10
-  10
-  11
-  11
-  12
-  12
-  13
-  13
-  14
-  14
-  15
-  15
-  16
-  16
-  17
-  17
-  18
-  18
-  19
-  19
-  20
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(63 rows)
-
---
--- N-ary UNION results
--- @optimizer_mode off
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select a1 from T_a1)
-UNION
-(select b1 from T_b2)
-UNION
-(select c1 from T_random)
-UNION
-(select d1 from T_constant)
-order by 1;
- a1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(33 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select b1 from T_b2)
-UNION
-(select a1 from T_a1)
-UNION
-(select c1 from T_random)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
- b1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(33 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select c1 from T_random)
-UNION
-(select a1 from T_a1)
-UNION
-(select b1 from T_b2)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
- c1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(33 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select d1 from T_constant)
-UNION ALL
-(select c1 from T_random)
-UNION
-(select a1 from T_a1)
-UNION
-(select b1 from T_b2)
-order by 1;
- d1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(33 rows)
-
---
--- Binary UNION ALL results
--- @optimizer_mode off
-(select a1 from T_a1) UNION ALL (select b1 from T_b2) order by 1;
- a1
-----
-  1
-  1
-  2
-  2
-  3
-  3
-  4
-  4
-  5
-  5
-  6
-  6
-  7
-  7
-  8
-  8
-  9
-  9
- 10
- 10
- 11
- 12
- 13
- 14
- 15
- 16
- 17
- 18
- 19
- 20
-(30 rows)
-
-(select b1 from T_b2) UNION ALL (select a1 from T_a1) order by 1;
- b1
-----
-  1
-  1
-  2
-  2
-  3
-  3
-  4
-  4
-  5
-  5
-  6
-  6
-  7
-  7
-  8
-  8
-  9
-  9
- 10
- 10
- 11
- 12
- 13
- 14
- 15
- 16
- 17
- 18
- 19
- 20
-(30 rows)
-
-(select a1 from T_a1) UNION ALL (select c1 from T_random) order by 1;
- a1
-----
-  1
-  1
-  2
-  2
-  3
-  3
-  4
-  4
-  5
-  5
-  6
-  6
-  7
-  7
-  8
-  8
-  9
-  9
- 10
- 10
- 11
- 12
- 13
- 14
- 15
- 16
- 17
- 18
- 19
- 20
- 21
- 22
- 23
- 24
- 25
- 26
- 27
- 28
- 29
- 30
-(40 rows)
-
-(select c1 from T_random) UNION ALL (select a1 from T_a1) order by 1;
- c1
-----
-  1
-  1
-  2
-  2
-  3
-  3
-  4
-  4
-  5
-  5
-  6
-  6
-  7
-  7
-  8
-  8
-  9
-  9
- 10
- 10
- 11
- 12
- 13
- 14
- 15
- 16
- 17
- 18
- 19
- 20
- 21
- 22
- 23
- 24
- 25
- 26
- 27
- 28
- 29
- 30
-(40 rows)
-
-(select * from T_a1) UNION ALL (select * from T_b2) order by 1;
- a1 | a2
-----+----
-  1 |  1
-  1 |  1
-  2 |  2
-  2 |  2
-  3 |  3
-  3 |  3
-  4 |  4
-  4 |  4
-  5 |  0
-  5 |  0
-  6 |  1
-  6 |  1
-  7 |  2
-  7 |  2
-  8 |  3
-  8 |  3
-  9 |  4
-  9 |  4
- 10 |  0
- 10 |  0
- 11 |  1
- 12 |  2
- 13 |  3
- 14 |  4
- 15 |  0
- 16 |  1
- 17 |  2
- 18 |  3
- 19 |  4
- 20 |  0
-(30 rows)
-
-(select * from T_a1) UNION ALL (select * from T_random) order by 1;
- a1 | a2
-----+----
-  1 |  1
-  1 |  1
-  2 |  2
-  2 |  2
-  3 |  3
-  3 |  3
-  4 |  4
-  4 |  4
-  5 |  0
-  5 |  0
-  6 |  1
-  6 |  1
-  7 |  2
-  7 |  2
-  8 |  3
-  8 |  3
-  9 |  4
-  9 |  4
- 10 |  0
- 10 |  0
- 11 |  1
- 12 |  2
- 13 |  3
- 14 |  4
- 15 |  0
- 16 |  1
- 17 |  2
- 18 |  3
- 19 |  4
- 20 |  0
- 21 |  1
- 22 |  2
- 23 |  3
- 24 |  4
- 25 |  0
- 26 |  1
- 27 |  2
- 28 |  3
- 29 |  4
- 30 |  0
-(40 rows)
-
-(select * from T_b2) UNION ALL (select * from T_random) order by 1;
- b1 | b2
-----+----
-  1 |  1
-  1 |  1
-  2 |  2
-  2 |  2
-  3 |  3
-  3 |  3
-  4 |  4
-  4 |  4
-  5 |  0
-  5 |  0
-  6 |  1
-  6 |  1
-  7 |  2
-  7 |  2
-  8 |  3
-  8 |  3
-  9 |  4
-  9 |  4
- 10 |  0
- 10 |  0
- 11 |  1
- 11 |  1
- 12 |  2
- 12 |  2
- 13 |  3
- 13 |  3
- 14 |  4
- 14 |  4
- 15 |  0
- 15 |  0
- 16 |  1
- 16 |  1
- 17 |  2
- 17 |  2
- 18 |  3
- 18 |  3
- 19 |  4
- 19 |  4
- 20 |  0
- 20 |  0
- 21 |  1
- 22 |  2
- 23 |  3
- 24 |  4
- 25 |  0
- 26 |  1
- 27 |  2
- 28 |  3
- 29 |  4
- 30 |  0
-(50 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select a1 from T_a1) UNION ALL (select d1 from T_constant) order by 1;
- a1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
- 100
- 200
- 300
-(13 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select d1 from T_constant) UNION ALL (select a1 from T_a1) order by 1;
- d1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
- 100
- 200
- 300
-(13 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select c1 from T_random) UNION ALL (select d1 from T_constant) order by 1;
- c1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(33 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select d1 from T_constant) UNION ALL (select c1 from T_random) order by 1;
- d1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(33 rows)
-
---
--- Binary UNION results
--- @optimizer_mode off
-(select a1 from T_a1) UNION (select b1 from T_b2) order by 1;
- a1
-----
-  1
-  2
-  3
-  4
-  5
-  6
-  7
-  8
-  9
- 10
- 11
- 12
- 13
- 14
- 15
- 16
- 17
- 18
- 19
- 20
-(20 rows)
-
-(select b1 from T_b2) UNION (select a1 from T_a1) order by 1;
- b1
-----
-  1
-  2
-  3
-  4
-  5
-  6
-  7
-  8
-  9
- 10
- 11
- 12
- 13
- 14
- 15
- 16
- 17
- 18
- 19
- 20
-(20 rows)
-
-(select a1 from T_a1) UNION (select c1 from T_random) order by 1;
- a1
-----
-  1
-  2
-  3
-  4
-  5
-  6
-  7
-  8
-  9
- 10
- 11
- 12
- 13
- 14
- 15
- 16
- 17
- 18
- 19
- 20
- 21
- 22
- 23
- 24
- 25
- 26
- 27
- 28
- 29
- 30
-(30 rows)
-
-(select c1 from T_random) UNION (select a1 from T_a1) order by 1;
- c1
-----
-  1
-  2
-  3
-  4
-  5
-  6
-  7
-  8
-  9
- 10
- 11
- 12
- 13
- 14
- 15
- 16
- 17
- 18
- 19
- 20
- 21
- 22
- 23
- 24
- 25
- 26
- 27
- 28
- 29
- 30
-(30 rows)
-
-(select * from T_a1) UNION (select * from T_b2) order by 1;
- a1 | a2
-----+----
-  1 |  1
-  2 |  2
-  3 |  3
-  4 |  4
-  5 |  0
-  6 |  1
-  7 |  2
-  8 |  3
-  9 |  4
- 10 |  0
- 11 |  1
- 12 |  2
- 13 |  3
- 14 |  4
- 15 |  0
- 16 |  1
- 17 |  2
- 18 |  3
- 19 |  4
- 20 |  0
-(20 rows)
-
-(select * from T_a1) UNION (select * from T_random) order by 1;
- a1 | a2
-----+----
-  1 |  1
-  2 |  2
-  3 |  3
-  4 |  4
-  5 |  0
-  6 |  1
-  7 |  2
-  8 |  3
-  9 |  4
- 10 |  0
- 11 |  1
- 12 |  2
- 13 |  3
- 14 |  4
- 15 |  0
- 16 |  1
- 17 |  2
- 18 |  3
- 19 |  4
- 20 |  0
- 21 |  1
- 22 |  2
- 23 |  3
- 24 |  4
- 25 |  0
- 26 |  1
- 27 |  2
- 28 |  3
- 29 |  4
- 30 |  0
-(30 rows)
-
-(select * from T_b2) UNION (select * from T_random) order by 1;
- b1 | b2
-----+----
-  1 |  1
-  2 |  2
-  3 |  3
-  4 |  4
-  5 |  0
-  6 |  1
-  7 |  2
-  8 |  3
-  9 |  4
- 10 |  0
- 11 |  1
- 12 |  2
- 13 |  3
- 14 |  4
- 15 |  0
- 16 |  1
- 17 |  2
- 18 |  3
- 19 |  4
- 20 |  0
- 21 |  1
- 22 |  2
- 23 |  3
- 24 |  4
- 25 |  0
- 26 |  1
- 27 |  2
- 28 |  3
- 29 |  4
- 30 |  0
-(30 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select a1 from T_a1) UNION (select d1 from T_constant) order by 1;
- a1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
- 100
- 200
- 300
-(13 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select d1 from T_constant) UNION (select a1 from T_a1) order by 1;
- d1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
- 100
- 200
- 300
-(13 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select c1 from T_random) UNION (select d1 from T_constant) order by 1;
- c1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(33 rows)
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select d1 from T_constant) UNION (select c1 from T_random) order by 1;
- d1
------
-   1
-   2
-   3
-   4
-   5
-   6
-   7
-   8
-   9
-  10
-  11
-  12
-  13
-  14
-  15
-  16
-  17
-  18
-  19
-  20
-  21
-  22
-  23
-  24
-  25
-  26
-  27
-  28
-  29
-  30
- 100
- 200
- 300
-(33 rows)
 
 --
 -- Clean up
@@ -3168,4 +1878,3 @@ UNION SELECT 300, 300)
 DROP TABLE IF EXISTS T_a1 CASCADE;
 DROP TABLE IF EXISTS T_b2 CASCADE;
 DROP TABLE IF EXISTS T_random CASCADE;
-reset optimizer;

--- a/src/test/regress/sql/union_gp.sql
+++ b/src/test/regress/sql/union_gp.sql
@@ -1,18 +1,15 @@
 -- Additional GPDB-added tests for UNION
 
 create temp table t_union1 (a int, b int);
-select distinct a, null as c from t_union1 union select a, b from t_union1;
 select distinct a, null::integer as c from t_union1 union select a, b from t_union1;
 drop table t_union1;
 
 select null union select distinct null;
 
-select 1 union select distinct null;
 select 1 union select distinct null::integer;
 
 select 1 a, NULL b, NULL c UNION SELECT 2, 3, NULL UNION SELECT 3, NULL, 4;
 
-select ARRAY[1, 2, 3] union select distinct null;
 select ARRAY[1, 2, 3] union select distinct null::integer[];
 
 select 1 intersect (select 1, 2 union all select 3, 4);
@@ -99,11 +96,9 @@ return result
 $$
 language plpythonu;
 
-set optimizer = on;
-
 --
 -- N-ary UNION ALL results
--- @optimizer_mode on
+--
 
 with T_constant (d1, d2) as(
 SELECT 100, 100
@@ -159,7 +154,7 @@ order by 1;
 
 --
 -- N-ary UNION ALL explain
--- @optimizer_mode on
+--
 
 select count_operator('
 explain
@@ -227,7 +222,7 @@ order by 1;'
 
 --
 -- N-ary UNION results
--- @optimizer_mode on
+--
 
 with T_constant (d1, d2) as(
 SELECT 100, 100
@@ -283,7 +278,7 @@ order by 1;
 
 --
 -- N-ary UNION explain
--- @optimizer_mode on
+--
 
 select count_operator('
 explain
@@ -351,7 +346,7 @@ order by 1;'
 
 --
 -- Binary UNION ALL results
--- @optimizer_mode on
+--
 
 (select a1 from T_a1) UNION ALL (select b1 from T_b2) order by 1;
 
@@ -393,7 +388,7 @@ UNION ALL SELECT 300, 300)
 
 --
 -- Binary UNION ALL explain
--- @optimizer_mode on
+--
 
 select count_operator('explain (select a1 from T_a1) UNION ALL (select b1 from T_b2) order by 1;', 'APPEND');
 
@@ -438,7 +433,7 @@ UNION ALL SELECT 300, 300)
 
 --
 -- Binary UNION results
--- @optimizer_mode on
+--
 
 (select a1 from T_a1) UNION (select b1 from T_b2) order by 1;
 
@@ -480,7 +475,7 @@ UNION SELECT 300, 300)
 
 --
 -- Binary UNION explain
--- @optimizer_mode on
+--
 
 select count_operator('explain (select a1 from T_a1) UNION (select b1 from T_b2) order by 1;', 'APPEND');
 
@@ -523,205 +518,6 @@ UNION SELECT 200, 200
 UNION SELECT 300, 300)
 (select d1 from T_constant) UNION (select c1 from T_random) order by 1;', 'APPEND');
 
-
-set optimizer = off;
-
---
--- N-ary UNION ALL results
--- @optimizer_mode off
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select a1 from T_a1)
-UNION ALL
-(select b1 from T_b2)
-UNION ALL
-(select c1 from T_random)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select b1 from T_b2)
-UNION ALL
-(select a1 from T_a1)
-UNION ALL
-(select c1 from T_random)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select c1 from T_random)
-UNION ALL
-(select a1 from T_a1)
-UNION ALL
-(select b1 from T_b2)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select d1 from T_constant)
-UNION ALL
-(select c1 from T_random)
-UNION ALL
-(select a1 from T_a1)
-UNION ALL
-(select b1 from T_b2)
-order by 1;
-
---
--- N-ary UNION results
--- @optimizer_mode off
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select a1 from T_a1)
-UNION
-(select b1 from T_b2)
-UNION
-(select c1 from T_random)
-UNION
-(select d1 from T_constant)
-order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select b1 from T_b2)
-UNION
-(select a1 from T_a1)
-UNION
-(select c1 from T_random)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select c1 from T_random)
-UNION
-(select a1 from T_a1)
-UNION
-(select b1 from T_b2)
-UNION ALL
-(select d1 from T_constant)
-order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select d1 from T_constant)
-UNION ALL
-(select c1 from T_random)
-UNION
-(select a1 from T_a1)
-UNION
-(select b1 from T_b2)
-order by 1;
-
---
--- Binary UNION ALL results
--- @optimizer_mode off
-
-(select a1 from T_a1) UNION ALL (select b1 from T_b2) order by 1;
-
-(select b1 from T_b2) UNION ALL (select a1 from T_a1) order by 1;
-
-(select a1 from T_a1) UNION ALL (select c1 from T_random) order by 1;
-
-(select c1 from T_random) UNION ALL (select a1 from T_a1) order by 1;
-
-(select * from T_a1) UNION ALL (select * from T_b2) order by 1;
-
-(select * from T_a1) UNION ALL (select * from T_random) order by 1;
-
-(select * from T_b2) UNION ALL (select * from T_random) order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select a1 from T_a1) UNION ALL (select d1 from T_constant) order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select d1 from T_constant) UNION ALL (select a1 from T_a1) order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select c1 from T_random) UNION ALL (select d1 from T_constant) order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION ALL SELECT 200, 200
-UNION ALL SELECT 300, 300)
-(select d1 from T_constant) UNION ALL (select c1 from T_random) order by 1;
-
---
--- Binary UNION results
--- @optimizer_mode off
-
-(select a1 from T_a1) UNION (select b1 from T_b2) order by 1;
-
-(select b1 from T_b2) UNION (select a1 from T_a1) order by 1;
-
-(select a1 from T_a1) UNION (select c1 from T_random) order by 1;
-
-(select c1 from T_random) UNION (select a1 from T_a1) order by 1;
-
-(select * from T_a1) UNION (select * from T_b2) order by 1;
-
-(select * from T_a1) UNION (select * from T_random) order by 1;
-
-(select * from T_b2) UNION (select * from T_random) order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select a1 from T_a1) UNION (select d1 from T_constant) order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select d1 from T_constant) UNION (select a1 from T_a1) order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select c1 from T_random) UNION (select d1 from T_constant) order by 1;
-
-with T_constant (d1, d2) as(
-SELECT 100, 100
-UNION SELECT 200, 200
-UNION SELECT 300, 300)
-(select d1 from T_constant) UNION (select c1 from T_random) order by 1;
-
 --
 -- Clean up
 --
@@ -729,5 +525,3 @@ UNION SELECT 300, 300)
 DROP TABLE IF EXISTS T_a1 CASCADE;
 DROP TABLE IF EXISTS T_b2 CASCADE;
 DROP TABLE IF EXISTS T_random CASCADE;
-
-reset optimizer;


### PR DESCRIPTION
We run all regression tests with optimizer=on and optimizer=off in the buildfarm. So remove optimizer settings here.