### PR TITLE
systemd IPC cleanup takes effect if gpadmin is not system user

### DIFF
--- a/gpMgmt/bin/gpseginstall
+++ b/gpMgmt/bin/gpseginstall
@@ -330,7 +330,7 @@ def checkUsernames():
 
 def getAddUserCommand():
     if isLinux:
-        return "useradd -m %s" % options.user
+        return "useradd -r -m %s" % options.user
     else:
         return "groupadd %s; useradd -d /export/home/%s -m -g %s -s /bin/bash %s" % (options.user, options.user, options.user, options.user)
 


### PR DESCRIPTION
Adding the -r flag to gpseginstall so that the accounts created on the segments are system accounts 

A note on this from the systemd perspective can be seen here
https://github.com/systemd/systemd/issues/2039

The gpadmin admin account on master should be created as a system account too. Should there be a check added to gpcheckos also to warn is it is not a system account?