### PR TITLE
Align used_segspace pointer to a 64-bit boundary even on 32 bit archs

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_segmentspace.c
+++ b/src/backend/utils/workfile_manager/workfile_segmentspace.c
@@ -37,7 +37,7 @@ WorkfileSegspace_Init(void)
 	 * Make sure it is 64-bit aligned, since we will are using 64 bit
 	 * atomic operations on it
 	 */
-	used_segspace = (pg_atomic_uint64 *)(TYPEALIGN(8, shmem_base));
+	used_segspace = (pg_atomic_uint64 *)(TYPEALIGN(sizeof(pg_atomic_uint64), shmem_base));
 	Assert(0 == used_segspace->value);
 }
 

--- a/src/backend/utils/workfile_manager/workfile_segmentspace.c
+++ b/src/backend/utils/workfile_manager/workfile_segmentspace.c
@@ -19,7 +19,7 @@
 #define WORKFILE_SEGSPACE_SHMEM_NAME "WorkfileSegspace"
 
 /* Pointer to the shared memory counter with the total used diskspace across segment */
-static int64 *used_segspace = NULL;
+static pg_atomic_uint64 *used_segspace = NULL;
 
 /*
  * Initialize shared memory area for the WorkfileSegspace module
@@ -33,8 +33,12 @@ WorkfileSegspace_Init(void)
 			WorkfileSegspace_ShMemSize(),
 			&attach);
 
-	used_segspace = (int64 *)shmem_base;
-	Assert(0 == *used_segspace);
+	/*
+	 * Make sure it is 64-bit aligned, since we will are using 64 bit
+	 * atomic operations on it
+	 */
+	used_segspace = (pg_atomic_uint64 *)(TYPEALIGN(8, shmem_base));
+	Assert(0 == used_segspace->value);
 }
 
 /*
@@ -43,7 +47,12 @@ WorkfileSegspace_Init(void)
 Size
 WorkfileSegspace_ShMemSize(void)
 {
-	return sizeof(*used_segspace);
+	/*
+	 * Reserve 16 bytes instead of just 8. In case the pointer returned
+	 * is not 64-bit aligned, we'll align it after allocation, and we might
+	 * need the extra space.
+	 */
+	return 2 * sizeof(*used_segspace);
 }
 
 /*
@@ -58,7 +67,7 @@ WorkfileSegspace_Reserve(int64 bytes_to_reserve)
 {
 	Assert(NULL != used_segspace);
 
-	int64 total = pg_atomic_add_fetch_u64((pg_atomic_uint64 *)used_segspace, bytes_to_reserve);
+	int64 total = pg_atomic_add_fetch_u64(used_segspace, bytes_to_reserve);
 	Assert(total >= (int64) 0);
 
 	if (gp_workfile_limit_per_segment == 0)
@@ -81,7 +90,7 @@ WorkfileSegspace_Reserve(int64 bytes_to_reserve)
 		{
 
 			/* Revert the reserved space */
-			(void) pg_atomic_sub_fetch_u64((pg_atomic_uint64 *)used_segspace, bytes_to_reserve);
+			(void) pg_atomic_sub_fetch_u64(used_segspace, bytes_to_reserve);
 
 			CHECK_FOR_INTERRUPTS();
 
@@ -97,7 +106,7 @@ WorkfileSegspace_Reserve(int64 bytes_to_reserve)
 				 */
 				elog(gp_workfile_caching_loglevel,
 						"Failed to reserved size " INT64_FORMAT ". Reverted back to total " INT64_FORMAT,
-						bytes_to_reserve, *used_segspace);
+						bytes_to_reserve, used_segspace->value);
 
 				/* Set diskfull to true to stop any further attempts to write more data */
 				WorkfileDiskspace_SetFull(true /* isFull */);
@@ -106,7 +115,7 @@ WorkfileSegspace_Reserve(int64 bytes_to_reserve)
 			}
 
 			/* Try to reserve again */
-			total = pg_atomic_add_fetch_u64((pg_atomic_uint64 *)used_segspace, bytes_to_reserve);
+			total = pg_atomic_add_fetch_u64(used_segspace, bytes_to_reserve);
 			Assert(total >= (int64) 0);
 
 			if (total <= max_allowed_diskspace)
@@ -150,7 +159,7 @@ WorkfileSegspace_Commit(int64 commit_bytes, int64 reserved_bytes)
 #if USE_ASSERT_CHECKING
 	int64 total = 
 #endif
-	pg_atomic_sub_fetch_u64((pg_atomic_uint64 *)used_segspace, (reserved_bytes - commit_bytes));
+	pg_atomic_sub_fetch_u64(used_segspace, (reserved_bytes - commit_bytes));
 	Assert(total >= (int64) 0);
 }
 
@@ -161,7 +170,7 @@ int64
 WorkfileSegspace_GetSize()
 {
 	Assert(NULL != used_segspace);
-	return *used_segspace;
+	return used_segspace->value;
 }
 
 /* EOF */


### PR DESCRIPTION
When running a test on OS X using a 32 bit build, I get the following assertion:

```
gcaragea=# select * from mpp_23802_gp_workfile_mgr_reset_segspace;
ERROR:  Unexpected internal error (atomics.h:525)  (seg1 slice1 gcaragea-mbp.local:40071 pid=75621) (cdbdisp.c:1326)
DETAIL:
UnalignedPointer("(((intptr_t) ((uintptr_t)(ptr)) + ((8) - 1)) & ~((intptr_t) ((8) - 1))) != (uintptr_t)(ptr)", File: "../../../src/include/port/atomics.h", Line: 525)
```
This is caused by trying to use pg_atomic_sub_fetch_u64() on a int64 pointer. Here's the top of stack trace:

```
(lldb) bt
* thread #1: tid = 0xe2d09, 0x97742ace libsystem_kernel.dylib`__select + 10, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x97742ace libsystem_kernel.dylib`__select + 10
    frame #1: 0x008c33bb postgres`pg_usleep(microsec=30000000) + 126 at pgsleep.c:43
    frame #2: 0x00687880 postgres`elog_debug_linger(edata=0x00bc3ac0) + 370 at elog.c:4088
    frame #3: 0x0067fe03 postgres`errfinish(dummy=0) + 383 at elog.c:602
    frame #4: 0x0067dba4 postgres`ExceptionalCondition(conditionName=0x00a4dd68, errorType=0x00a4dc64, fileName=0x00a4dc40, lineNumber=525) + 272 at assert.c:48
    frame #5: 0x004e3b5a postgres`pg_atomic_sub_fetch_u64(ptr=0x0fe7de5c, sub_=0) + 99 at atomics.h:525
    frame #6: 0x007116e1 postgres`WorkfileSegspace_Commit(commit_bytes=0, reserved_bytes=0) + 225 at workfile_segmentspace.c:153
    frame #7: 0x117fcc6c gp_workfile_mgr.so`gp_workfile_mgr_reset_segspace(fcinfo=0xbff097d0) + 51 at gp_workfile_cache_clear.c:68
```

The used_segspace pointer we are trying to atomically increment points to shared memory, and is therefore allocated in ShmemAlloc, but using 32 bit alignment.
