### PR TITLE
Fix disorder issue when selecting from views with order-by clauses.

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -954,6 +954,17 @@ pull_up_Flow(Plan *plan, Plan *subplan, bool withSort)
                                                      model_flow->numSortCols,
                                                      model_flow->sortColIdx,
                                                      &new_flow->sortColIdx);
+
+			/* preserve subplan sort attributes*/
+			if (new_flow->numSortCols < model_flow->numOrderbyCols)
+			{
+				new_flow->numOrderbyCols = new_flow->numSortCols;
+			}
+			else
+			{
+				new_flow->numOrderbyCols = model_flow->numOrderbyCols;
+			}
+
 		    if (new_flow->numSortCols > 0)
 			{
                 ARRAYCOPY(new_flow->sortOperators,
@@ -977,6 +988,9 @@ pull_up_Flow(Plan *plan, Plan *subplan, bool withSort)
             ARRAYCOPY(new_flow->nullsFirst,
                       model_flow->nullsFirst,
                       new_flow->numSortCols);
+
+			/* preserve subplan sort attributes*/
+            new_flow->numOrderbyCols = model_flow->numOrderbyCols;
 	    }
 	}   /* withSort */
 

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -461,6 +461,13 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 
                     Insist(focusPlan(plan, true, false));
                 }
+                else if (plan->flow->numOrderbyCols > 0 && plan->flow->numSortCols > 0)
+                {
+                    if (plan->flow->numSortCols > plan->flow->numOrderbyCols)
+                        plan->flow->numSortCols = plan->flow->numOrderbyCols;
+
+                    Insist(focusPlan(plan, true, false));
+                }
 
                 /* Use UNION RECEIVE.  Does not preserve ordering. */
                 else
@@ -963,7 +970,7 @@ apply_motion_mutator(Node *node, ApplyMotionState * context)
                                                            flow->numSortCols,
                                                            flow->sortColIdx,
                                                            flow->sortOperators,
-														   flow->nullsFirst,
+                                                           flow->nullsFirst,
                                                            true /* useExecutorVarFormat */);
             }
             else

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1911,6 +1911,7 @@ _copyFlow(Flow *from)
 	COPY_POINTER_FIELD(sortColIdx, from->numSortCols*sizeof(AttrNumber));
 	COPY_POINTER_FIELD(sortOperators, from->numSortCols*sizeof(Oid));
 	COPY_POINTER_FIELD(nullsFirst, from->numSortCols*sizeof(bool));
+	COPY_SCALAR_FIELD(numOrderbyCols);
 	COPY_NODE_FIELD(hashExpr);
 	COPY_NODE_FIELD(flow_before_req_move);
 

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -655,6 +655,8 @@ _outFlow(StringInfo str, Flow *node)
 	WRITE_OID_ARRAY(sortOperators, node->numSortCols);
 	WRITE_BOOL_ARRAY(nullsFirst, node->numSortCols);
 
+	WRITE_INT_FIELD(numOrderbyCols);
+
 	WRITE_NODE_FIELD(hashExpr);
 
 	WRITE_NODE_FIELD(flow_before_req_move);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1704,6 +1704,7 @@ _outFlow(StringInfo str, Flow *node)
 				appendStringInfo(str, " %u", node->sortOperators[i]);
 		}
 	}
+	WRITE_INT_FIELD(numOrderbyCols);
 
 	WRITE_NODE_FIELD(hashExpr);
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2136,6 +2136,8 @@ _readFlow(void)
 	READ_OID_ARRAY(sortOperators, local_node->numSortCols);
 	READ_BOOL_ARRAY(nullsFirst, local_node->numSortCols);
 
+	READ_INT_FIELD(numOrderbyCols);
+
 	READ_NODE_FIELD(hashExpr);
 	READ_NODE_FIELD(flow_before_req_move);
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2032,6 +2032,12 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			current_pathkeys = sort_pathkeys;
 			mark_sort_locus(result_plan);
 		}
+
+		/*
+ 		 * Update numOrderbyCols to length of sort_pathkeys.
+		 * For cdb: decide which sort attribute should be preserved by merge gather motion 
+ 		 */
+		result_plan->flow->numOrderbyCols = list_length(sort_pathkeys);
 	}
 
 	/*

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1335,6 +1335,8 @@ typedef struct Flow
 	AttrNumber	*sortColIdx;		/* their indexes in target list */
 	Oid			*sortOperators;		/* OID of operators to sort them by */
 	bool		*nullsFirst;
+
+	int			numOrderbyCols;		/* number of explicit order-by columns */
 	
 	/* If req_move is MOVEMENT_REPARTITION, these express the desired 
      * partitioning for a hash motion.  Else if flotype is FLOW_PARTITIONED,

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -1,0 +1,66 @@
+-- start_ignore
+drop table if exists sourcetable cascade;
+NOTICE:  table "sourcetable" does not exist, skipping
+drop view if exists v_sourcetable cascade;
+NOTICE:  view "v_sourcetable" does not exist, skipping
+drop view if exists v_sourcetable1 cascade;
+NOTICE:  view "v_sourcetable1" does not exist, skipping
+-- end_ignore
+create table sourcetable 
+(
+        cn int not null,
+        vn int not null,
+        pn int not null,
+        dt date not null,
+        qty int not null,
+        prc float not null,
+        primary key (cn, vn, pn)
+) distributed by (cn,vn,pn);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sourcetable_pkey" for table "sourcetable"
+insert into sourcetable values
+  ( 2, 40, 100, '1401-1-1', 1100, 2400),
+  ( 1, 10, 200, '1401-3-1', 1, 0),
+  ( 3, 40, 200, '1401-4-1', 1, 0),
+  ( 1, 20, 100, '1401-5-1', 1, 0),
+  ( 1, 30, 300, '1401-5-2', 1, 0),
+  ( 1, 50, 400, '1401-6-1', 1, 0),
+  ( 2, 50, 400, '1401-6-1', 1, 0),
+  ( 1, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 600, '1401-6-1', 12, 5),
+  ( 4, 40, 700, '1401-6-1', 1, 1),
+  ( 4, 40, 800, '1401-6-1', 1, 1);
+create view  v_sourcetable as select * from sourcetable order by vn;
+select * from v_sourcetable;
+ cn | vn | pn  |     dt     | qty  | prc  
+----+----+-----+------------+------+------
+  1 | 10 | 200 | 03-01-1401 |    1 |    0
+  1 | 20 | 100 | 05-01-1401 |    1 |    0
+  3 | 30 | 600 | 06-01-1401 |   12 |    5
+  1 | 30 | 500 | 06-01-1401 |   12 |    5
+  1 | 30 | 300 | 05-02-1401 |    1 |    0
+  3 | 30 | 500 | 06-01-1401 |   12 |    5
+  4 | 40 | 700 | 06-01-1401 |    1 |    1
+  2 | 40 | 100 | 01-01-1401 | 1100 | 2400
+  4 | 40 | 800 | 06-01-1401 |    1 |    1
+  3 | 40 | 200 | 04-01-1401 |    1 |    0
+  2 | 50 | 400 | 06-01-1401 |    1 |    0
+  1 | 50 | 400 | 06-01-1401 |    1 |    0
+(12 rows)
+
+create view v_sourcetable1 as SELECT sourcetable.qty, vn, pn FROM sourcetable union select sourcetable.qty, sourcetable.vn, sourcetable.pn from sourcetable order by qty;
+select * from v_sourcetable1;
+ qty  | vn | pn  
+------+----+-----
+    1 | 20 | 100
+    1 | 40 | 200
+    1 | 40 | 700
+    1 | 10 | 200
+    1 | 40 | 800
+    1 | 50 | 400
+    1 | 30 | 300
+   12 | 30 | 600
+   12 | 30 | 500
+ 1100 | 40 | 100
+(10 rows)
+

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -1,0 +1,36 @@
+-- start_ignore
+drop table if exists sourcetable cascade;
+drop view if exists v_sourcetable cascade;
+drop view if exists v_sourcetable1 cascade;
+-- end_ignore
+
+create table sourcetable 
+(
+        cn int not null,
+        vn int not null,
+        pn int not null,
+        dt date not null,
+        qty int not null,
+        prc float not null,
+        primary key (cn, vn, pn)
+) distributed by (cn,vn,pn);
+
+insert into sourcetable values
+  ( 2, 40, 100, '1401-1-1', 1100, 2400),
+  ( 1, 10, 200, '1401-3-1', 1, 0),
+  ( 3, 40, 200, '1401-4-1', 1, 0),
+  ( 1, 20, 100, '1401-5-1', 1, 0),
+  ( 1, 30, 300, '1401-5-2', 1, 0),
+  ( 1, 50, 400, '1401-6-1', 1, 0),
+  ( 2, 50, 400, '1401-6-1', 1, 0),
+  ( 1, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 500, '1401-6-1', 12, 5),
+  ( 3, 30, 600, '1401-6-1', 12, 5),
+  ( 4, 40, 700, '1401-6-1', 1, 1),
+  ( 4, 40, 800, '1401-6-1', 1, 1);
+
+create view  v_sourcetable as select * from sourcetable order by vn;
+select * from v_sourcetable;
+
+create view v_sourcetable1 as SELECT sourcetable.qty, vn, pn FROM sourcetable union select sourcetable.qty, sourcetable.vn, sourcetable.pn from sourcetable order by qty;
+select * from v_sourcetable1;


### PR DESCRIPTION
When applying motion, a merge other than normal gather motion should
be added on the top node if it has sort list, this can make sure that
tuples are still in order after gathered to QD. Only checking if top
level parsetree has sort clauses may miss the implicit order constraint
in a view.