### PR TITLE
Fallback to planner for command: ALTER TABLE SET DISTRIBUTED BY

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13645,6 +13645,15 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		if (!ldistro)
 			ldistro = make_dist_clause(rel);
 
+		/* force the use of legacy query optimizer, since PQO will not redistribute the tuples if the current and required
+		   distributions are both RANDOM even when reorganize is set to "true"*/
+		bool saveOptimizerGucValue = optimizer;
+		optimizer = false;
+
+		if (saveOptimizerGucValue)
+		{
+			elog(LOG, "ALTER SET DISTRIBUTED BY: falling back to legacy query optimizer to ensure re-distribution of tuples.");
+		}
 
 		/* Step (b) - build CTAS */
 		queryDesc = build_ctas_with_dist(rel, ldistro,
@@ -13671,10 +13680,13 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 
 			/* Restore the old snapshot */
 			ActiveSnapshot = saveSnapshot;
+			optimizer = saveOptimizerGucValue;
 		}
 		PG_CATCH();
 		{
 			ActiveSnapshot = saveSnapshot;
+			optimizer = saveOptimizerGucValue;
+
 			PG_RE_THROW();
 		}
 		PG_END_TRY();


### PR DESCRIPTION
When the user fires the following query: 

```
 alter table redist_test set with (reorganize=true) distributed  randomly;
```

The intention of the user is to force redistribute the tuple so that there is no skew. 

Under the hood, GPDB first creates a temp table via CTAS and then replaces the table with the temp table. Given that source table and the temp table are both random, Orca says random satisfies random and therefore no tuple relocation via motions is needed. This changes the expected behavior. 

The fix inside Orca is quite extensive, so the immediate stop gap is to fall back to the planner when we execute the CTAS.

@xinzweb @hsyuan @hlinnaka  please take a look