### PR TITLE
Forbid DISTRIBUTED BY on an int2vector or aclitem column.

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1109,7 +1109,7 @@ cdb_make_pathkey_for_expr(PlannerInfo    *root,
      * sort-merge equijoin on a pair of exprs of the same type.
      */
 	if (eqopoid == InvalidOid || !op_mergejoinable(eqopoid))
-		elog(ERROR, "could not find = operator for type %u", typeoid);
+		elog(ERROR, "could not find mergejoinable = operator for type %u", typeoid);
 
 	mergeopfamilies = get_mergejoin_opfamilies(eqopoid);
 	foreach(lc, mergeopfamilies)

--- a/src/test/regress/expected/opr_sanity_gp.out
+++ b/src/test/regress/expected/opr_sanity_gp.out
@@ -1,0 +1,52 @@
+-- Additional GPDB-specific sanity checks.
+-- Test that all GPDB-hashable datatypes, i.e. those that you can use as the
+-- distribution key for a table, are also mergejoinable. (We use the same
+-- PathKey structure internally that is used to represent sort ordering, to
+-- represent the distribution columns.)
+--
+--- NB: This list of datatypes should match that in IsGreenplumDbHashable
+select * from pg_operator where oprname='=' and oprleft = oprright
+and not oprcanmerge
+and oprleft IN (
+  'int2'::regtype,
+  'int4'::regtype,
+  'int8'::regtype,
+  'float4'::regtype,
+  'float8'::regtype,
+  'numeric'::regtype,
+  'char'::regtype,
+  'bpchar '::regtype,
+  'text'::regtype,
+  'varchar'::regtype,
+  'bytea'::regtype,
+  'name'::regtype,
+  'oid'::regtype,
+  'tid'::regtype,
+  'regproc'::regtype,
+  'regprocedure'::regtype,
+  'regoper'::regtype,
+  'regoperator'::regtype,
+  'regclass'::regtype,
+  'regtype'::regtype,
+  'timestamp'::regtype,
+  'timestamptz'::regtype,
+  'date'::regtype,
+  'time'::regtype,
+  'timetz '::regtype,
+  'interval'::regtype,
+  'abstime'::regtype,
+  'reltime'::regtype,
+  'tinterval'::regtype,
+  'inet'::regtype,
+  'cidr'::regtype,
+  'macaddr'::regtype,
+  'bit'::regtype,
+  'varbit'::regtype,
+  'bool'::regtype,
+  'anyarray'::regtype,
+  'oidvector'::regtype,
+  'money'::regtype);
+ oprname | oprnamespace | oprowner | oprkind | oprcanmerge | oprcanhash | oprleft | oprright | oprresult | oprcom | oprnegate | oprcode | oprrest | oprjoin 
+---------+--------------+----------+---------+-------------+------------+---------+----------+-----------+--------+-----------+---------+---------+---------
+(0 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -16,7 +16,7 @@
 #
 
 ignore: leastsquares
-test: decode_expr bitmapscan case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy
+test: opr_sanity_gp decode_expr bitmapscan case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy
 test: filter gpctas gpdist matrix toast sublink sirv_functions table_functions olap_setup
 
 test: dispatch

--- a/src/test/regress/sql/opr_sanity_gp.sql
+++ b/src/test/regress/sql/opr_sanity_gp.sql
@@ -1,0 +1,50 @@
+-- Additional GPDB-specific sanity checks.
+
+
+-- Test that all GPDB-hashable datatypes, i.e. those that you can use as the
+-- distribution key for a table, are also mergejoinable. (We use the same
+-- PathKey structure internally that is used to represent sort ordering, to
+-- represent the distribution columns.)
+--
+--- NB: This list of datatypes should match that in IsGreenplumDbHashable
+select * from pg_operator where oprname='=' and oprleft = oprright
+and not oprcanmerge
+and oprleft IN (
+  'int2'::regtype,
+  'int4'::regtype,
+  'int8'::regtype,
+  'float4'::regtype,
+  'float8'::regtype,
+  'numeric'::regtype,
+  'char'::regtype,
+  'bpchar '::regtype,
+  'text'::regtype,
+  'varchar'::regtype,
+  'bytea'::regtype,
+  'name'::regtype,
+  'oid'::regtype,
+  'tid'::regtype,
+  'regproc'::regtype,
+  'regprocedure'::regtype,
+  'regoper'::regtype,
+  'regoperator'::regtype,
+  'regclass'::regtype,
+  'regtype'::regtype,
+  'timestamp'::regtype,
+  'timestamptz'::regtype,
+  'date'::regtype,
+  'time'::regtype,
+  'timetz '::regtype,
+  'interval'::regtype,
+  'abstime'::regtype,
+  'reltime'::regtype,
+  'tinterval'::regtype,
+  'inet'::regtype,
+  'cidr'::regtype,
+  'macaddr'::regtype,
+  'bit'::regtype,
+  'varbit'::regtype,
+  'bool'::regtype,
+  'anyarray'::regtype,
+  'oidvector'::regtype,
+  'money'::regtype);


### PR DESCRIPTION
int2vector and aclitem don't have B-tree operators, making them not
mergejoinable. In the merge of the equivalence classes patch, I made
cdb_make_pathkeys_for_expr() more strict on that, and it now throws
an error if it's passed a datatype that doesn't have a mergejoinable
= operator. It used to return a path key with InvalidOid as the sort
operator, but that seems like a recipe for bugs elsehere.

To fix, mandate that all gpdb-hashable datatypes must be mergejoinable.
int2vector and aclitem are not, so forbid using them in DISTRIBUTED BY.

This is a backwards-incompatible change, but hopefully no-one is using
int2vector or aclitem in user-tables, at least not as a distribution key.