### PR TITLE
Modify segment dump to exclude certain metadata.

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -4874,6 +4874,8 @@ Feature: Validate command line arguments
         When the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/create_metadata.sql testdb"
         And the user runs "gpcrondump -a -x testdb -K 30160101010101 -u /tmp"
         Then gpcrondump should return a return code of 0
+        And the full backup timestamp from gpcrondump is stored
+        And all the data from the remote segments in "testdb" are stored in path "/tmp" for "full"
         And verify that the file "/tmp/db_dumps/30160101/gp_dump_status_0_2_30160101010101" does not contain "reading indexes"
         And verify that the file "/tmp/db_dumps/30160101/gp_dump_status_1_1_30160101010101" contains "reading indexes"
         Given database "testdb" is dropped and recreated

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -4868,6 +4868,20 @@ Feature: Validate command line arguments
         And the file "/tmp/describe_ao_index_table_before" is removed from the system
         And the file "/tmp/describe_ao_index_table_after" is removed from the system
 
+    Scenario: Dump and Restore metadata
+        Given the database is running
+        And there are no backup files
+        Given database "testdb" is dropped and recreated
+        When the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/create_metadata.sql testdb"
+        When the user runs "gpcrondump -a -x testdb"
+        Then gpcrondump should return a return code of 0
+        And the timestamp from gpcrondump is stored
+        Given database "testdb" is dropped and recreated
+        When the user runs "gpdbrestore -a" with the stored timestamp
+        Then gpdbrestore should return a return code of 0
+        And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/check_metadata.sql testdb > /tmp/check_metadata.out"
+        Then verify that the contents of the files "/tmp/check_metadata.out" and "gppylib/test/behave/mgmt_utils/steps/data/check_metadata.ans" are identical
+
     Scenario: Restore -T for full dump should restore GRANT privileges for tablenames with English and multibyte (chinese) characters
         Given the database is running
         And there are no backup files

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/check_metadata.ans
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/check_metadata.ans
@@ -1,0 +1,54 @@
+                              Append-Only Columnar Table "public.aoco_table"
+ Column |  Type   | Modifiers | Storage | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+---------+------------------+-------------------+------------+-------------
+ a      | integer |           | plain   | none             | 0                 | 32768      | 
+ b      | integer |           | plain   | none             | 0                 | 32768      | 
+Checksum: t
+Indexes:
+    "idx_b" btree (b)
+Has OIDs: no
+Options: appendonly=true, orientation=column
+Distributed by: (a)
+
+              Table "public.heap_table"
+ Column |  Type   | Modifiers | Storage | Description 
+--------+---------+-----------+---------+-------------
+ a      | integer | not null  | plain   | 
+ b      | integer |           | plain   | 
+Indexes:
+    "idx_a" UNIQUE, btree (a)
+Triggers:
+    before_heap_ins_trig BEFORE INSERT ON heap_table FOR EACH ROW EXECUTE PROCEDURE trigger_func()
+Has OIDs: no
+Distributed by: (a)
+
+                            List of functions
+ Schema |     Name     | Result data type | Argument data types |  Type   
+--------+--------------+------------------+---------------------+---------
+ public | newcnt       | bigint           | "any"               | agg
+ public | trigger_func | trigger          |                     | trigger
+(2 rows)
+
+        tgname        | tgtype 
+----------------------+--------
+ before_heap_ins_trig |      7
+(1 row)
+
+       List of data types
+ Schema |  Name   | Description 
+--------+---------+-------------
+ public | complex | 
+(1 row)
+
+                             List of operators
+ Schema | Name | Left arg type | Right arg type | Result type | Description 
+--------+------+---------------+----------------+-------------+-------------
+ public | ##   | path          | path           | boolean     | intersect?
+(1 row)
+
+                List of conversions
+ Schema |  Name  | Source | Destination | Default? 
+--------+--------+--------+-------------+----------
+ public | myconv | LATIN1 | UTF8        | no
+(1 row)
+

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/check_metadata.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/check_metadata.sql
@@ -1,0 +1,18 @@
+-- Check table indexes, modifiers, and options
+\d+ aoco_table
+\d+ heap_table
+
+-- Check user-defined functions and aggregate functions
+\df
+
+-- Check triggers
+select tgname, tgtype from pg_trigger where tgname='before_heap_ins_trig';
+
+-- Check user-defined types
+\dT
+
+-- Check user-defined operators
+\do
+
+-- Check user-defined conversions
+\dc

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/create_metadata.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/create_metadata.sql
@@ -1,0 +1,38 @@
+-- Create some tables
+CREATE TABLE aoco_table (a int, b int) with (appendonly=true, orientation=column);
+CREATE TABLE heap_table (a int NOT NULL, b int);
+
+-- Create indexes
+CREATE UNIQUE INDEX idx_a ON heap_table USING btree (a);
+CREATE INDEX idx_b ON aoco_table USING btree (b);
+
+-- Create a function that will be used as the trigger
+CREATE FUNCTION trigger_func() RETURNS trigger LANGUAGE plpgsql NO SQL AS '
+BEGIN
+RAISE NOTICE ''trigger_func() called: action = %, when = %, level = %'', TG_OP, TG_WHEN, TG_LEVEL;
+RETURN NULL;
+END;';
+
+-- Create a trigger
+CREATE TRIGGER before_heap_ins_trig BEFORE INSERT ON heap_table
+FOR EACH ROW EXECUTE PROCEDURE trigger_func();
+
+-- Create a user-defined type
+CREATE TYPE complex AS (r real, i real);
+
+-- Create aggregate functions
+CREATE AGGREGATE newcnt ("any") (
+   sfunc = int8inc_any, stype = int8,
+   initcond = '0'
+);
+
+-- Create user-defined operator
+CREATE OPERATOR ## (
+   leftarg = path,
+   rightarg = path,
+   procedure = path_inter,
+   commutator = ##
+);
+
+-- Create user-defined conversion
+CREATE CONVERSION myconv FOR 'LATIN1' TO 'UTF8' FROM iso8859_1_to_utf8;

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -1157,7 +1157,7 @@ dumpMain(bool oids, const char *dumpencoding, int outputBlobs, int plainText, Re
 	 * Now scan the database and create DumpableObject structs for all the
 	 * objects we intend to dump. LOCK those objects in ACCESS SHARE mode.
 	 */
-	tblinfo = getSchemaData(&numTables);
+	tblinfo = getSchemaData(&numTables, g_role);
 
 	/*
 	 * If we got here it means we successfully got LOCKs on all our dumpable

--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -74,7 +74,7 @@ void		reset(void);
  *	  Collect information about all potentially dumpable objects
  */
 TableInfo *
-getSchemaData(int *numTablesPtr)
+getSchemaData(int *numTablesPtr, int g_role)
 {
 	NamespaceInfo *nsinfo;
 	AggInfo    *agginfo;
@@ -101,47 +101,50 @@ getSchemaData(int *numTablesPtr)
 		status_log_msg(LOGGER_INFO, progname, "reading schemas\n");
 	nsinfo = getNamespaces(&numNamespaces);
 
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading user-defined functions\n");
-	funinfo = getFuncs(&numFuncs);
-
-	/* this must be after getFuncs */
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading user-defined types\n");
-	typinfo = getTypes(&numTypes);
-
-	/* this must be after getFuncs */
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading type storage options\n");
-	typestorageoptions = getTypeStorageOptions(&numTypeStorageOptions);
-
-	/* this must be after getFuncs, too */
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading procedural languages\n");
-	proclanginfo = getProcLangs(&numProcLangs);
-
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading user-defined aggregate functions\n");
-	agginfo = getAggregates(&numAggregates);
-	
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading user-defined operators\n");
-	oprinfo = getOperators(&numOperators);
-
-	if (testExtProtocolSupport())
+	if(g_role == 1) // ROLE_MASTER
 	{
 		if(is_gpdump || g_verbose)
-			status_log_msg(LOGGER_INFO, progname, "reading user-defined external protocols\n");
-		ptcinfo = getExtProtocols(&numExtProtocols);
+			status_log_msg(LOGGER_INFO, progname, "reading user-defined functions\n");
+		funinfo = getFuncs(&numFuncs);
+
+		/* this must be after getFuncs */
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading user-defined types\n");
+		typinfo = getTypes(&numTypes);
+
+		/* this must be after getFuncs */
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading type storage options\n");
+		typestorageoptions = getTypeStorageOptions(&numTypeStorageOptions);
+
+		/* this must be after getFuncs, too */
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading procedural languages\n");
+		proclanginfo = getProcLangs(&numProcLangs);
+
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading user-defined aggregate functions\n");
+		agginfo = getAggregates(&numAggregates);
+
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading user-defined operators\n");
+		oprinfo = getOperators(&numOperators);
+
+		if (testExtProtocolSupport())
+		{
+			if(is_gpdump || g_verbose)
+				status_log_msg(LOGGER_INFO, progname, "reading user-defined external protocols\n");
+			ptcinfo = getExtProtocols(&numExtProtocols);
+		}
+
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading user-defined operator classes\n");
+		opcinfo = getOpclasses(&numOpclasses);
+
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading user-defined conversions\n");
+		convinfo = getConversions(&numConversions);
 	}
-
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading user-defined operator classes\n");
-	opcinfo = getOpclasses(&numOpclasses);
-
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading user-defined conversions\n");
-	convinfo = getConversions(&numConversions);
 
 	if(is_gpdump || g_verbose)
 		status_log_msg(LOGGER_INFO, progname, "reading user-defined tables\n");
@@ -172,17 +175,20 @@ getSchemaData(int *numTablesPtr)
 		status_log_msg(LOGGER_INFO, progname, "flagging inherited columns in subtables\n");
 	flagInhAttrs(tblinfo, numTables, inhinfo, numInherits);
 
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading indexes\n");
-	getIndexes(tblinfo, numTables);
+	if(g_role == 1) // ROLE_MASTER
+	{
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading indexes\n");
+		getIndexes(tblinfo, numTables);
 
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading constraints\n");
-	getConstraints(tblinfo, numTables);
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading constraints\n");
+		getConstraints(tblinfo, numTables);
 
-	if(is_gpdump || g_verbose)
-		status_log_msg(LOGGER_INFO, progname, "reading triggers\n");
-	getTriggers(tblinfo, numTables);
+		if(is_gpdump || g_verbose)
+			status_log_msg(LOGGER_INFO, progname, "reading triggers\n");
+		getTriggers(tblinfo, numTables);
+	}
 
 	*numTablesPtr = numTables;
 	return tblinfo;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -780,7 +780,7 @@ main(int argc, char **argv)
 	 * Now scan the database and create DumpableObject structs for all the
 	 * objects we intend to dump.
 	 */
-	tblinfo = getSchemaData(&numTables);
+	tblinfo = getSchemaData(&numTables, 1);
 
 	if (!schemaOnly)
 		getTableData(tblinfo, numTables, oids);

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -424,7 +424,7 @@ extern const char *EXT_PARTITION_NAME_POSTFIX;
  *	common utility functions
  */
 
-extern TableInfo *getSchemaData(int *numTablesPtr);
+extern TableInfo *getSchemaData(int *numTablesPtr, int g_role);
 
 typedef enum _OidOptions
 {


### PR DESCRIPTION
The dump process was checking the segments for several kinds of
metadata, such as indexes and triggers, even though they were not
being included in the dump.  The statements that were performing
these useless checks have been modified to only run on the master.

Authors: James McAtamney and Jimmy Yih