### PR TITLE
Fix "variable not found in subplan target list" error.

### DIFF
--- a/src/include/cdb/cdbpullup.h
+++ b/src/include/cdb/cdbpullup.h
@@ -101,32 +101,7 @@ bool
 cdbpullup_exprHasSubplanRef(Expr *expr);
 
 
-/*
- * cdbpullup_findPathKeyInTargetList
- *
- * Searches the equivalence class 'pathkey' for a PathKey that
- * uses no rels outside the 'relids' set, and either is a member of
- * 'targetlist', or uses no Vars that are not in 'targetlist'.
- *
- * If found, returns the chosen PathKey and sets the output variables,
- * otherwise returns NULL.
- *
- * 'pathkey' is a List of PathKey.
- * 'targetlist' is a List of TargetEntry or merely a List of Expr.
- *
- * NB: We ignore the presence or absence of a RelabelType node atop either 
- * expr in determining whether a PathKey expr matches a targetlist expr.  
- *
- * (A RelabelType node might have been placed atop a PathKey's expr to 
- * match its type to the sortop's input operand type, when the types are 
- * binary compatible but not identical... such as VARCHAR and TEXT.  The 
- * RelabelType node merely documents the representational equivalence but 
- * does not affect the semantics.  A RelabelType node might also be found 
- * atop an argument of a function or operator, but generally not atop a 
- * targetlist expr.)
- */
-PathKey *
-cdbpullup_findPathKeyInTargetList(PathKey *item, List *targetlist);
+extern Expr *cdbpullup_findPathKeyExprInTargetList(PathKey *item, List *targetlist);
 
 
 /*

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -178,6 +178,38 @@ select * from int4_tbl a join int4_tbl b on (a.f1 = (select f1 from int4_tbl c w
   2147483647 |  2147483647
 (5 rows)
 
+--
+-- Test case where a Motion hash key is only needed for the redistribution,
+-- and not returned in the final result set. There was a bug at one point where
+-- tjoin.c1 was used as the hash key in a Motion node, but it was not added
+-- to the sub-plans target list, causing a "variable not found in subplan
+-- target list" error.
+--
+create table tjoin1(dk integer, id integer) distributed by (dk);
+create table tjoin2(dk integer, id integer, t text) distributed by (dk);
+create table tjoin3(dk integer, id integer, t text) distributed by (dk);
+insert into tjoin1 values (1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3);
+insert into tjoin2 values (1, 1, '1-1'), (1, 2, '1-2'), (2, 1, '2-1'), (2, 2, '2-2');
+insert into tjoin3 values (1, 1, '1-1'), (2, 1, '2-1');
+select tjoin1.id, tjoin2.t, tjoin3.t
+from tjoin1
+left outer join (tjoin2 left outer join tjoin3 on tjoin2.id=tjoin3.id) on tjoin1.id=tjoin3.id;
+ id |  t  |  t  
+----+-----+-----
+  1 | 2-1 | 2-1
+  1 | 2-1 | 1-1
+  1 | 1-1 | 2-1
+  1 | 1-1 | 1-1
+  3 |     | 
+  1 | 2-1 | 2-1
+  1 | 2-1 | 1-1
+  1 | 1-1 | 2-1
+  1 | 1-1 | 1-1
+  3 |     | 
+  2 |     | 
+  2 |     | 
+(12 rows)
+
 set enable_hashjoin to off;
 -- Disable hashjoin forms fo ORCA
 select disable_xform('CXformInnerJoin2HashJoin');
@@ -277,6 +309,9 @@ select enable_xform('CXformLeftSemiJoin2HashJoin');
 (1 row)
 
 drop schema pred cascade;
+NOTICE:  drop cascades to table tjoin3
+NOTICE:  drop cascades to table tjoin2
+NOTICE:  drop cascades to table tjoin1
 NOTICE:  drop cascades to table int4_tbl
 NOTICE:  drop cascades to table hjn_test
 NOTICE:  drop cascades to table t2

--- a/src/test/regress/expected/join_gp_1.out
+++ b/src/test/regress/expected/join_gp_1.out
@@ -180,6 +180,38 @@ select * from int4_tbl a join int4_tbl b on (a.f1 = (select f1 from int4_tbl c w
  -2147483647 | -2147483647
 (5 rows)
 
+--
+-- Test case where a Motion hash key is only needed for the redistribution,
+-- and not returned in the final result set. There was a bug at one point where
+-- tjoin.c1 was used as the hash key in a Motion node, but it was not added
+-- to the sub-plans target list, causing a "variable not found in subplan
+-- target list" error.
+--
+create table tjoin1(dk integer, id integer) distributed by (dk);
+create table tjoin2(dk integer, id integer, t text) distributed by (dk);
+create table tjoin3(dk integer, id integer, t text) distributed by (dk);
+insert into tjoin1 values (1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3);
+insert into tjoin2 values (1, 1, '1-1'), (1, 2, '1-2'), (2, 1, '2-1'), (2, 2, '2-2');
+insert into tjoin3 values (1, 1, '1-1'), (2, 1, '2-1');
+select tjoin1.id, tjoin2.t, tjoin3.t
+from tjoin1
+left outer join (tjoin2 left outer join tjoin3 on tjoin2.id=tjoin3.id) on tjoin1.id=tjoin3.id;
+ id |  t  |  t  
+----+-----+-----
+  1 | 2-1 | 2-1
+  1 | 2-1 | 1-1
+  1 | 1-1 | 2-1
+  1 | 1-1 | 1-1
+  3 |     | 
+  1 | 2-1 | 2-1
+  1 | 2-1 | 1-1
+  1 | 1-1 | 2-1
+  1 | 1-1 | 1-1
+  3 |     | 
+  2 |     | 
+  2 |     | 
+(12 rows)
+
 set enable_hashjoin to off;
 -- Disable hashjoin forms fo ORCA
 select disable_xform('CXformInnerJoin2HashJoin');
@@ -279,6 +311,9 @@ select enable_xform('CXformLeftSemiJoin2HashJoin');
 (1 row)
 
 drop schema pred cascade;
+NOTICE:  drop cascades to table tjoin3
+NOTICE:  drop cascades to table tjoin2
+NOTICE:  drop cascades to table tjoin1
 NOTICE:  drop cascades to table int4_tbl
 NOTICE:  drop cascades to table hjn_test
 NOTICE:  drop cascades to table t2

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -74,6 +74,26 @@ select count(*) from hjn_test, (select 3 as bar) foo where least (foo.bar,(array
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar, least(4,10)) and hjn_test.j = least(4,10);
 select * from int4_tbl a join int4_tbl b on (a.f1 = (select f1 from int4_tbl c where c.f1=b.f1));
 
+--
+-- Test case where a Motion hash key is only needed for the redistribution,
+-- and not returned in the final result set. There was a bug at one point where
+-- tjoin.c1 was used as the hash key in a Motion node, but it was not added
+-- to the sub-plans target list, causing a "variable not found in subplan
+-- target list" error.
+--
+create table tjoin1(dk integer, id integer) distributed by (dk);
+create table tjoin2(dk integer, id integer, t text) distributed by (dk);
+create table tjoin3(dk integer, id integer, t text) distributed by (dk);
+
+insert into tjoin1 values (1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3);
+insert into tjoin2 values (1, 1, '1-1'), (1, 2, '1-2'), (2, 1, '2-1'), (2, 2, '2-2');
+insert into tjoin3 values (1, 1, '1-1'), (2, 1, '2-1');
+
+select tjoin1.id, tjoin2.t, tjoin3.t
+from tjoin1
+left outer join (tjoin2 left outer join tjoin3 on tjoin2.id=tjoin3.id) on tjoin1.id=tjoin3.id;
+
+
 set enable_hashjoin to off;
 -- Disable hashjoin forms fo ORCA
 select disable_xform('CXformInnerJoin2HashJoin');


### PR DESCRIPTION
Some test queries in the TINC/cdbfast test suite were failing with that
error, after merging the equivalence classes path. The problem was that
the Motion node's hash key was not present in the subplan's target list.

As mentioned in the comment, I'm not sure what's supposed to happen if
the Motion node's subplan is not projection-capable. I could not come
up with a query where that'd happen. There might be some other mechanism
that prevents that from being a problem; notably, all join plans are
projection-capable.