### PR TITLE
Update gpfdist.c

### DIFF
--- a/gpAux/extensions/gpfdist/gpfdist.c
+++ b/gpAux/extensions/gpfdist/gpfdist.c
@@ -3435,12 +3435,22 @@ int gpfdist_init(int argc, const char* const argv[])
 	/* redirect stderr and stdout to log */
 	if (opt.l)
 	{
-		FILE *f // ignored. required by -Werror=unused-result
+		FILE *f;
 		f = freopen(opt.l, "a", stderr);
+		if (f == null)
+		{
+			fprintf(stderr, "Failed to redirect stderr to log.")
+			return -1;
+		}
 #ifndef WIN32
 		setlinebuf(stderr);
 #endif
 		f = freopen(opt.l, "a", stdout);
+		if (f == null)
+		{
+			fprintf(stderr, "Failed to redirect stdout to log.")
+			return -1;
+		}
 #ifndef WIN32
 		setlinebuf(stdout);
 #endif

--- a/gpAux/extensions/gpfdist/gpfdist.c
+++ b/gpAux/extensions/gpfdist/gpfdist.c
@@ -3435,11 +3435,12 @@ int gpfdist_init(int argc, const char* const argv[])
 	/* redirect stderr and stdout to log */
 	if (opt.l)
 	{
-		freopen(opt.l, "a", stderr);
+		FILE *f // ignored. required by -Werror=unused-result
+		f = freopen(opt.l, "a", stderr);
 #ifndef WIN32
 		setlinebuf(stderr);
 #endif
-		freopen(opt.l, "a", stdout);
+		f = freopen(opt.l, "a", stdout);
 #ifndef WIN32
 		setlinebuf(stdout);
 #endif

--- a/gpAux/extensions/gpfdist/gpfdist.c
+++ b/gpAux/extensions/gpfdist/gpfdist.c
@@ -3435,9 +3435,9 @@ int gpfdist_init(int argc, const char* const argv[])
 	/* redirect stderr and stdout to log */
 	if (opt.l)
 	{
-		FILE *f;
-		f = freopen(opt.l, "a", stderr);
-		if (f == null)
+		FILE *f_stderr;
+		f_stderr = freopen(opt.l, "a", stderr);
+		if (f_stderr == null)
 		{
 			fprintf(stderr, "Failed to redirect stderr to log.")
 			return -1;
@@ -3445,8 +3445,9 @@ int gpfdist_init(int argc, const char* const argv[])
 #ifndef WIN32
 		setlinebuf(stderr);
 #endif
-		f = freopen(opt.l, "a", stdout);
-		if (f == null)
+		FILE *f_stdout;
+		f_stdout = freopen(opt.l, "a", stdout);
+		if (f_stdout == null)
 		{
 			fprintf(stderr, "Failed to redirect stdout to log.")
 			return -1;

--- a/gpAux/extensions/gpfdist/gpfdist.c
+++ b/gpAux/extensions/gpfdist/gpfdist.c
@@ -3437,7 +3437,7 @@ int gpfdist_init(int argc, const char* const argv[])
 	{
 		FILE *f_stderr;
 		f_stderr = freopen(opt.l, "a", stderr);
-		if (f_stderr == null)
+		if (f_stderr == NULL)
 		{
 			fprintf(stderr, "Failed to redirect stderr to log.")
 			return -1;
@@ -3447,7 +3447,7 @@ int gpfdist_init(int argc, const char* const argv[])
 #endif
 		FILE *f_stdout;
 		f_stdout = freopen(opt.l, "a", stdout);
-		if (f_stdout == null)
+		if (f_stdout == NULL)
 		{
 			fprintf(stderr, "Failed to redirect stdout to log.")
 			return -1;

--- a/gpAux/extensions/gpfdist/gpfdist.c
+++ b/gpAux/extensions/gpfdist/gpfdist.c
@@ -3439,7 +3439,7 @@ int gpfdist_init(int argc, const char* const argv[])
 		f_stderr = freopen(opt.l, "a", stderr);
 		if (f_stderr == NULL)
 		{
-			fprintf(stderr, "Failed to redirect stderr to log.")
+			fprintf(stderr, "Failed to redirect stderr to log.");
 			return -1;
 		}
 #ifndef WIN32
@@ -3449,7 +3449,7 @@ int gpfdist_init(int argc, const char* const argv[])
 		f_stdout = freopen(opt.l, "a", stdout);
 		if (f_stdout == NULL)
 		{
-			fprintf(stderr, "Failed to redirect stdout to log.")
+			fprintf(stderr, "Failed to redirect stdout to log.");
 			return -1;
 		}
 #ifndef WIN32

--- a/gpAux/extensions/gpfdist/gpfdist.c
+++ b/gpAux/extensions/gpfdist/gpfdist.c
@@ -3439,7 +3439,7 @@ int gpfdist_init(int argc, const char* const argv[])
 		f_stderr = freopen(opt.l, "a", stderr);
 		if (f_stderr == NULL)
 		{
-			fprintf(stderr, "Failed to redirect stderr to log.");
+			fprintf(stderr, "Failed to redirect stderr to log. Error: %s", strerror(errno));
 			return -1;
 		}
 #ifndef WIN32
@@ -3449,7 +3449,7 @@ int gpfdist_init(int argc, const char* const argv[])
 		f_stdout = freopen(opt.l, "a", stdout);
 		if (f_stdout == NULL)
 		{
-			fprintf(stderr, "Failed to redirect stdout to log.");
+			fprintf(stderr, "Failed to redirect stdout to log. Error: %s", strerror(errno));
 			return -1;
 		}
 #ifndef WIN32


### PR DESCRIPTION
When compiling gpfdist on ubuntu, the compile fails because of the compiler flag to treat all warnings as errors.
You get a warning when calling freopen and not capturing the result of the call.
This change is simple gpfdist successfully compiles on Ubuntu 15.10 with the change.