### PR TITLE
Fix two bugs in the code to remove unneeded InitPlans

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -2693,6 +2693,12 @@ static void remove_unused_initplans_helper(Plan *plan, Bitmapset **usedParams, B
 			find_params_walker((Node *) motion->hashExpr, &context);
 			break;
 		}
+		case T_Window:
+		{
+			Window *w = (Window *) plan;
+			find_params_walker((Node *) w->windowKeys, &context);
+			break;
+		}
 		default:
 			break;
 	}

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -2716,64 +2716,42 @@ static void remove_unused_initplans_helper(Plan *plan, Bitmapset **usedParams, B
 
 	if (NIL != plan->initPlan)
 	{
-		/* gather initplans from current node, and keep track of their param ids */
-		List *paramids = NIL;
-		List *planids = NIL;
+		List	   *newInitPlans = NIL;
+		ListCell *lc;
 
-		ListCell *lc = NULL;
 		foreach (lc, plan->initPlan)
 		{
 			SubPlan *initplan = (SubPlan *) lfirst(lc);
+			ListCell *lc_paramid;
+			bool		anyused;
+
 			Assert(initplan->is_initplan);
-			Assert(1 == list_length(initplan->setParam));
 
-			planids = lappend_int(planids, initplan->plan_id);
-			paramids = lappend_int(paramids, linitial_int(initplan->setParam));
-		}
-
-		/* remove from these lists the params that are used */
-		int paramid = bms_first_from(context.paramids, 0);
-		while (0 <= paramid)
-		{
-			int index = list_find_int(paramids, paramid);
-			if (0 <= index)
+			/* Are any of this Init Plan's output parameters actually used? */
+			anyused = false;
+			foreach (lc_paramid, initplan->setParam)
 			{
-				int planid = list_nth_int(planids, index);
-				paramids = list_delete_int(paramids, paramid);
-				planids = list_delete_int(planids, planid);
+				int			paramid = lfirst_int(lc_paramid);
+
+				if (bms_is_member(paramid, context.paramids))
+				{
+					anyused = true;
+					break;
+				}
 			}
 
-			paramid = bms_first_from(context.paramids, paramid + 1);
-		}
-
-		/* delete unused initplans */
-		List *oldInitPlans = plan->initPlan;
-		plan->initPlan = NIL;
-
-		foreach (lc, oldInitPlans)
-		{
-			SubPlan *initplan = (SubPlan *) lfirst(lc);
-			if (0 > list_find_int(planids, initplan->plan_id))
-			{
-				plan->initPlan = lappend(plan->initPlan, initplan);
-			}
+			/* If none of its params are used, leave out from the new list */
+			if (anyused)
+				newInitPlans = lappend(newInitPlans, initplan);
 			else
-			{
-				pfree(initplan);
-			}
+				elog(DEBUG2, "removing unused InitPlan %s", initplan->plan_name);
 		}
 
 		/* remove unused params */
-		foreach (lc, paramids)
-		{
-			int paramid = lfirst_int(lc);
-			plan->allParam = bms_del_member(plan->allParam, paramid);
-		}
+		plan->allParam = bms_intersect(plan->allParam, context.paramids);
 
-		/* cleanup */
-		list_free(oldInitPlans);
-		list_free(planids);
-		list_free(paramids);
+		list_free(plan->initPlan);
+		plan->initPlan = newInitPlans;
 	}
 
 	Bitmapset *oldbms = *usedParams;

--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -489,6 +489,14 @@ expression_tree_walker(Node *node,
 					return true;
 			}
 			break;
+		case T_WindowKey:
+			{
+				WindowKey *wk = (WindowKey *) node;
+
+				if (walker((Node *) wk->frame, context))
+					return true;
+			}
+			break;
 		case T_WindowFrameEdge:
 			{
 				WindowFrameEdge *edge = (WindowFrameEdge *)node;
@@ -1005,7 +1013,8 @@ plan_tree_walker(Node *node,
 		case T_Window:
 			if (walk_plan_node_fields((Plan *) node, walker, context))
 				return true;
-			/* Other fields are simple items and lists of simple items. */
+			if (walker(((Window *) node)->windowKeys, context))
+				return true;
 			break;
 
 		case T_Unique:
@@ -1176,6 +1185,9 @@ plan_tree_walker(Node *node,
 		case T_PartBoundExpr:
 		case T_PartBoundInclusionExpr:
 		case T_PartBoundOpenExpr:
+		case T_WindowFrame:
+		case T_WindowFrameEdge:
+		case T_WindowKey:
 
 		default:
 			return expression_tree_walker(node, walker, context);

--- a/src/test/regress/expected/gp_optimizer_1.out
+++ b/src/test/regress/expected/gp_optimizer_1.out
@@ -6105,7 +6105,50 @@ select row_number() over(order by foo.a+ bar.a)/count(*) from orca.foo inner joi
 (400 rows)
 
 select count(*) over(partition by b order by a range between 1 preceding and (select count(*) from orca.bar) following) from orca.foo;
-ERROR:  no parameter found for initplan subquery (cdbsubplan.c:265)
+ count 
+-------
+    16
+    16
+    16
+    16
+    16
+    15
+    14
+    13
+    12
+    11
+    10
+     9
+     8
+     7
+     6
+     5
+     4
+     3
+     2
+     1
+    16
+    16
+    16
+    16
+    16
+    15
+    14
+    13
+    12
+    11
+    10
+     9
+     8
+     7
+     6
+     5
+     4
+     3
+     2
+     1
+(40 rows)
+
 select a+1, rank() over(partition by b+1 order by a+1) from orca.foo order by 1, 2;
  ?column? | rank 
 ----------+------

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1125,6 +1125,20 @@ from gp_configuration)) i order by 1;
 drop table if exists t1;
 drop table if exists t2;
 --
+-- Test Initplans that return multiple params.
+--
+create table initplan_test(i int, j int, m int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into initplan_test values (1,1,1);
+select * from initplan_test where row(j, m) = (select j, m from initplan_test where i = 1);
+ i | j | m 
+---+---+---
+ 1 | 1 | 1
+(1 row)
+
+drop table initplan_test;
+--
 -- apply parallelization for subplan MPP-24563
 --
 create table t1_mpp_24563 (id int, value int) distributed by (id);

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1105,6 +1105,20 @@ from gp_configuration)) i order by 1;
 drop table if exists t1;
 drop table if exists t2;
 --
+-- Test Initplans that return multiple params.
+--
+create table initplan_test(i int, j int, m int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into initplan_test values (1,1,1);
+select * from initplan_test where row(j, m) = (select j, m from initplan_test where i = 1);
+ i | j | m 
+---+---+---
+ 1 | 1 | 1
+(1 row)
+
+drop table initplan_test;
+--
 -- apply parallelization for subplan MPP-24563
 --
 create table t1_mpp_24563 (id int, value int) distributed by (id);

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -462,6 +462,15 @@ drop table if exists t1;
 drop table if exists t2;
 
 --
+-- Test Initplans that return multiple params.
+--
+create table initplan_test(i int, j int, m int);
+insert into initplan_test values (1,1,1);
+select * from initplan_test where row(j, m) = (select j, m from initplan_test where i = 1);
+
+drop table initplan_test;
+
+--
 -- apply parallelization for subplan MPP-24563
 --
 create table t1_mpp_24563 (id int, value int) distributed by (id);


### PR DESCRIPTION
These patches fix two bugs in the removal of unneeded InitPlans. One was reported by CK Tan on gpdb-dev, subject "bug report". The other was evident in the test query in gp_optimizer regression test.

I wonder if trying to remove unneeded InitPlans is really worth the trouble in the first place. Firstly, it happens very rarely: there is only one such query in the regression suite. Secondly, I believe that an InitPlan that isn't referenced will not be executed at runtime, so there's little harm in leaving it in the plan. Am I missing something?