### PR TITLE
The # of references to a CTE might change during planning.

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -777,25 +777,53 @@ void set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	List *pathkeys = NULL;
 	PlannerInfo *subroot = NULL;
 
-	/* If sharing is not allowed, we create a new subplan for this CTE. */
-	if (!root->config->gp_cte_sharing)
+	/*
+	 * If there is exactly one reference to this CTE in the query, or plan
+	 * sharing is disabled, create a new subplan for this CTE. It will
+	 * become simple subquery scan.
+	 *
+	 * NOTE: The check for "exactly one reference" is a bit fuzzy. The
+	 * references are counted in parse analysis phase, and it's possible
+	 * that we duplicate a reference during query planning. So the check
+	 * for number of references must be treated merely as a hint. If it
+	 * turns out that there are in fact multiple references to the same
+	 * CTE, even though we thought that there is only one, we might choose
+	 * a sub-optimal plan because we missed the opportunity to share the
+	 * subplan. That's acceptable for now.
+	 *
+	 * subquery tree will be modified if any qual is pushed down.
+	 * There's risk that it'd be confusing if the tree is used
+	 * later. At the moment InitPlan case uses the tree, but it
+	 * is called earlier than this pass always, so we don't avoid it.
+	 *
+	 * Also, we might want to think extracting "common"
+	 * qual expressions between multiple references, but
+	 * so far we don't support it.
+	 */
+	if (!root->config->gp_cte_sharing ||
+		(cte->cterefcount) == 1)
 	{
 		PlannerConfig *config = CopyPlannerConfig(root->config);
 
-		/**
-		 * Copy query node since subquery_planner may trash it and we need it intact
-		 * in case we need to create another plan for the CTE
+		/*
+		 * Having multiple SharedScans can lead to deadlocks. For now,
+		 * disallow sharing of ctes at lower levels.
+		 */
+		config->gp_cte_sharing = false;
+
+		/*
+		 * Copy query node since subquery_planner may trash it, and we need
+		 * it intact in case we need to create another plan for the CTE
 		 */
 		Query		  *subquery = (Query *) copyObject(cte->ctequery);
 
-		/**
-		 * Push down quals
+		/*
+		 * Push down quals, like we do in set_subquery_pathlist()
 		 */
 		subquery = push_down_restrict(root, rel, rte, rel->relid, subquery);
 
 		subplan = subquery_planner(cteroot->glob, subquery, cteroot,
 								   tuple_fraction, &subroot, config);
-		cteplaninfo->numNonSharedPlans++;
 
 		subrtable = subroot->parse->rtable;
 		pathkeys = subroot->query_pathkeys;
@@ -805,80 +833,47 @@ void set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		 * this plan.
 		 */
 	}
-	
-	/*
-	 * If we never generate a subplan for this CTE, generate one here.
-	 * This subplan will not be used by InitPlans, so that they can be
-	 * shared if this CTE is referenced multiple times (excluding in InitPlans).
-	 * We also generate all shared plans here.
-	 */
-	else if (cteplaninfo->subplans == NULL)
-	{
-		PlannerConfig *config = CopyPlannerConfig(root->config);
-
-		/**
-		 * Having multiple SharedScans can lead to deadlocks. For now,
-		 * disallow sharing of ctes at lower levels.
-		 */
-		config->gp_cte_sharing = false;
-		/**
-		 * Copy query node since subquery_planner may trash it and we need it intact
-		 * in case we need to create another plan for the CTE
-		 */
-
-		Query		  *subquery = (Query *) copyObject(cte->ctequery);
-
-		if ((cte->cterefcount - cteplaninfo->numNonSharedPlans) == 1)
-		{
-			/*
-			 * If this CTE is referenced only once,
-			 * it will become simple subquery scan.
-			 * In that case, we can push down quals in the same way
-			 * as set_subqeury_pathlist().
-			 *
-			 * subquery tree will be modified if any qual is pushed down.
-			 * There's risk that it'd be confusing if the tree is used
-			 * later. At the moment InitPlan case uses the tree, but it
-			 * is called earlier than this pass always, so we don't avoid it.
-			 *
-			 * Also, we might want to think extracting "common"
-			 * qual expressions between multiple references, but
-			 * so far we don't support it.
-			 */
-			subquery = push_down_restrict(root, rel, rte, rel->relid, subquery);
-		}
-		subplan = subquery_planner(cteroot->glob, subquery, cteroot,
-								   tuple_fraction, &subroot, config);
-
-		List *subplans = share_plan(cteroot, subplan,
-									cte->cterefcount);
-		
-		cteplaninfo->subplans = subplans;
-		cteplaninfo->subrtable = subroot->parse->rtable;
-		cteplaninfo->pathkeys = subroot->query_pathkeys;
-		cteplaninfo->nextPlanId = 0;
-		
-		subplan = list_nth(cteplaninfo->subplans, cteplaninfo->nextPlanId);
-		cteplaninfo->nextPlanId++;
-
-		subrtable = subroot->parse->rtable;
-		pathkeys = subroot->query_pathkeys;
-	}
-
-	/*
-	 * The subplan has been generated in advance (see the above). We simply find
-	 * the subplan in the list stored in cteplaninfo.
-	 */
 	else
 	{
-		Assert(root->config->gp_cte_sharing && cteplaninfo->subplans != NULL);
-		Assert(cteplaninfo->nextPlanId < list_length(cteplaninfo->subplans));
-		subplan = list_nth(cteplaninfo->subplans, cteplaninfo->nextPlanId);
+		/*
+		 * If we haven't created a subplan for this CTE yet, do it now.
+		 * This subplan will not be used by InitPlans, so that they can be
+		 * shared if this CTE is referenced multiple times (excluding in
+		 * InitPlans).
+		 */
+		if (cteplaninfo->shared_plan == NULL)
+		{
+			PlannerConfig *config = CopyPlannerConfig(root->config);
+
+			/*
+			 * Copy query node since subquery_planner may trash it and we need it intact
+			 * in case we need to create another plan for the CTE
+			 */
+			Query		  *subquery = (Query *) copyObject(cte->ctequery);
+
+			/*
+			 * Having multiple SharedScans can lead to deadlocks. For now,
+			 * disallow sharing of ctes at lower levels.
+			 */
+			config->gp_cte_sharing = false;
+
+			subplan = subquery_planner(cteroot->glob, subquery, cteroot,
+									   tuple_fraction, &subroot, config);
+
+			cteplaninfo->shared_plan = prepare_plan_for_sharing(cteroot, subplan);
+			cteplaninfo->subrtable = subroot->parse->rtable;
+			cteplaninfo->pathkeys = subroot->query_pathkeys;
+		}
+
+		/*
+		 * Create another ShareInputScan to reference the already-created
+		 * subplan.
+		 */
+		subplan = share_prepared_plan(cteroot, cteplaninfo->shared_plan);
 		subrtable = cteplaninfo->subrtable;
 		pathkeys = cteplaninfo->pathkeys;
-		cteplaninfo->nextPlanId++;
 	}
-		
+
 	rel->subplan = subplan;
 	rel->subrtable = subrtable;
 

--- a/src/backend/optimizer/plan/planshare.c
+++ b/src/backend/optimizer/plan/planshare.c
@@ -160,21 +160,18 @@ static ShareInputScan *make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 	return sisc;
 }
 
-List *share_plan(PlannerInfo *root, Plan *common, int numpartners)
+/*
+ * Prepare a subplan for sharing. This creates a Materialize node,
+ * or marks the existing Materialize or Sort node as shared. After
+ * this, you can call share_prepared_plan() as many times as you
+ * want to share this plan.
+ */
+Plan *
+prepare_plan_for_sharing(PlannerInfo *root, Plan *common)
 {
-	List *shared_nodes = NULL;
 	ShareType stype;
 	Plan *shared = common;
 	bool xslice = false;
-	int i;
-
-	Assert(numpartners > 0);
-	
-	if(numpartners == 1)
-	{
-		shared_nodes = lappend(shared_nodes, common);
-		return shared_nodes;
-	}
 
 	if (IsA(common, ShareInputScan))
 	{
@@ -220,14 +217,49 @@ List *share_plan(PlannerInfo *root, Plan *common, int numpartners)
 		m->share_type = stype;
 	}
 
-	for(i=0; i<numpartners; ++i)
+	return shared;
+}
+
+/*
+ * Create a ShareInputScan to scan the given subplan. The subplan
+ * must've been prepared for sharing by calling
+ * prepare_plan_for_sharing().
+ */
+Plan *
+share_prepared_plan(PlannerInfo *root, Plan *common)
+{
+	return (Plan *) make_shareinputscan(root, common);
+}
+
+/*
+ * A shorthand for prepare_plan_for_sharing() followed by
+ * 'numpartners' calls to share_prepared_plan().
+ */
+List *
+share_plan(PlannerInfo *root, Plan *common, int numpartners)
+{
+	List	   *shared_nodes = NIL;
+	Plan	   *shared;
+	int			i;
+
+	Assert(numpartners > 0);
+
+	if (numpartners == 1)
+		return list_make1(common);
+
+	shared = prepare_plan_for_sharing(root, common);
+
+	for (i = 0; i < numpartners; i++)
 	{
-		Plan *p = (Plan *) make_shareinputscan(root, shared);
+		Plan	   *p;
+
+		p = (Plan *) make_shareinputscan(root, shared);
 		shared_nodes = lappend(shared_nodes, p);
 	}
 
 	return shared_nodes;
 }
+
 
 /*
  * Return the total cost of sharing common numpartner times.

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -120,7 +120,7 @@ typedef struct CtePlanInfo
 	 * If a CTE is referenced multiple times, this list contains multiple plans,
 	 * each of which has ShareNode on top.
 	 */
-	List *subplans;
+	Plan *shared_plan;
 
 	/*
 	 * The rtable corresponding to the subplan.
@@ -131,16 +131,6 @@ typedef struct CtePlanInfo
 	 * The pathkeys corresponding to the subplan.
 	 */
 	List *pathkeys;
-
-	/*
-	 * The next plan id in subplans that should be used (starting with 0).
-	 */
-	int nextPlanId;
-
-	/*
-	 * Number of non-shared plans generated for this cte.
-	 */
-	int numNonSharedPlans;
 } CtePlanInfo;
 
 /*----------

--- a/src/include/optimizer/planshare.h
+++ b/src/include/optimizer/planshare.h
@@ -7,9 +7,13 @@
 #ifndef _PLANSHARE_H_
 #define _PLANSHARE_H_
 
-List *share_plan(PlannerInfo *root, Plan *common, int numpartners); 
-Cost cost_share_plan(Plan *common, PlannerInfo *root, int numpartners);
+#include "nodes/plannodes.h"
 
+extern List *share_plan(PlannerInfo *root, Plan *common, int numpartners);
+extern Cost cost_share_plan(Plan *common, PlannerInfo *root, int numpartners);
+
+extern Plan *prepare_plan_for_sharing(PlannerInfo *root, Plan *common);
+extern Plan *share_prepared_plan(PlannerInfo *root, Plan *common);
 
 #endif /* _PLANSHARE_H_ */
 

--- a/src/test/regress/expected/sublink.out
+++ b/src/test/regress/expected/sublink.out
@@ -15,3 +15,29 @@ SELECT * FROM v_xpect_triangle_de , ( SELECT lpad(s.a ::text, 2, '0'::text) AS a
 ----------+-----+-----+----------+------------
 (0 rows)
 
+--
+-- This bizarre looking query is reduced from a customer's query that used
+-- to cause an assertion failure or crash. The interesting property is that
+-- there are two references to cte_a in the query, inside cte_b, but after
+-- the planner has expanded both references to cte_b, there are now four
+-- references to cte_a, in the half-built plan tree.
+--
+WITH cte_a (col1, col2)
+AS
+(
+  VALUES (10, 123), (20, 234)
+)
+,
+cte_b AS
+(
+  SELECT (SELECT col1 FROM cte_a WHERE cte_a.col1 = lp.col1) as match1,
+	 (SELECT col1 FROM cte_a WHERE cte_a.col1 = lp.col2) as match2
+  FROM (SELECT 10 as col1, 20 as col2) as lp
+)
+SELECT *
+FROM cte_b as first, cte_b as second;
+ match1 | match2 | match1 | match2 
+--------+--------+--------+--------
+     10 |     20 |     10 |     20
+(1 row)
+


### PR DESCRIPTION
We count references to a CTE in parse analysis phase, but the way the
planner expands CTE references when gp_cte_sharing=off means that if there
is a references to a CTE, within another CTE, expanding references to the
outer CTE will also multiple the references to the inner CTE. So don't
assume that we can trust cterefercount in the planner. (It should be OK
for cterefcount's original purpose, to detect the case that there are no
references at all to a CTE, though.)

This fixes an assertion failure or crash, with the test query included
in the patch.