### PR TITLE
Fix open source GPDB build with --enable-orca on OSX

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -1257,13 +1257,6 @@ endif
 copyoptimizerlibs :
 ifneq "$(BLD_GPDB_BUILDSET)" "partial"
 ifeq "$(ORCA_CONFIG)" "--enable-orca"
-	# Copy GP Optimizer libraries 
-	echo "Copying Orca libraries";
-	for b in libnaucrates libgpdbcost libgpopt; do \
-		rm -f $(INSTLOC)/lib/$$b.$(LDSFX); \
-		echo "Copying $$b"; \
-		cp  $(OPTIMIZER)/$$b/$(OBJDIR_DEFAULT)/$$b.$(LDSFX) $(INSTLOC)/lib ; \
-	done
 	rm -f $(INSTLOC)/lib/libgpos.$(LDSFX);
 	cp $(LIBGPOS_LIBDIR)/libgpos.$(LDSFX) $(INSTLOC)/lib;
 	rm -f $(INSTLOC)/lib/libxerces-c-3.1.$(LDSFX);

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -15,9 +15,9 @@
 #-------------------------------------------------------------------------------------
 
 UNAME = $(shell uname)
-UNAME_P = $(shell uname -p)
+UNAME_M = $(shell uname -m)
 
-UNAME_ALL = $(UNAME).$(UNAME_P)
+UNAME_ALL = $(UNAME).$(UNAME_M)
 
 # shared lib support
 ifeq (Darwin, $(UNAME))

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -16,7 +16,6 @@
 
 UNAME = $(shell uname)
 UNAME_P = $(shell uname -p)
-UNAME_M = $(shell uname -m)
 
 UNAME_ALL = $(UNAME).$(UNAME_P)
 
@@ -27,11 +26,6 @@ else
 	LDSFX = so
 endif
 
-ifeq (x86_64, $(UNAME_M))
-	ARCH_FLAGS = -m64
-else
-	ARCH_FLAGS = -m32
-endif
 
 ##-------------------------------------------------------------------------------------
 ## dependent modules
@@ -45,8 +39,6 @@ endif
 # use 'make BLD_TYPE=debug' to work with debug build libraries of GP Optimizer
 BLD_TYPE=opt
 
-OBJDIR_DEFAULT = .obj.$(UNAME_ALL)$(ARCH_FLAGS).$(BLD_TYPE)
-
 GREP_SED_VAR = $(BLD_TOP)/releng/make/dependencies/ivy.xml | sed -e 's|\(.*\)rev="\(.*\)"[ \t]*conf\(.*\)|\2|'
 
 XERCES_VER  = $(shell grep "\"xerces-c\""    $(GREP_SED_VAR))
@@ -59,13 +51,8 @@ XERCES = $(BLD_TOP)/ext/$(BLD_ARCH)
 XERCES_LIBDIR = $(XERCES)/lib
 
 LIBGPOS = $(BLD_TOP)/ext/$(BLD_ARCH)/libgpos
-LIBGPOS_LIBDIR = $(LIBGPOS)/$(OBJDIR_DEFAULT)
 
 OPTIMIZER = $(BLD_TOP)/ext/$(BLD_ARCH)
-LIBGPOPT_LIBDIR = $(OPTIMIZER)/libgpopt/$(OBJDIR_DEFAULT)
-LIBGPOPTUDF_LIBDIR = $(OPTIMIZER)/libgpoptudf/$(OBJDIR_DEFAULT)
-LIBNAUCRATES_LIBDIR = $(OPTIMIZER)/libnaucrates/$(OBJDIR_DEFAULT)
-LIBGPDBCOST_LIBDIR = $(OPTIMIZER)/libgpdbcost/$(OBJDIR_DEFAULT)
 
 LIBSTDC++_BASEDIR = $(BLD_TOP)/ext/$(BLD_ARCH)
 

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -21,7 +21,7 @@ UNAME_ALL = $(UNAME).$(UNAME_P)
 
 # shared lib support
 ifeq (Darwin, $(UNAME))
-	ARCH_FLAGS = -m32
+	ARCH_FLAGS = -m64
 	LDSFX = dylib
 else
 	ARCH_FLAGS = -m64

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -16,16 +16,21 @@
 
 UNAME = $(shell uname)
 UNAME_P = $(shell uname -p)
+UNAME_M = $(shell uname -m)
 
 UNAME_ALL = $(UNAME).$(UNAME_P)
 
 # shared lib support
 ifeq (Darwin, $(UNAME))
-	ARCH_FLAGS = -m64
 	LDSFX = dylib
 else
-	ARCH_FLAGS = -m64
 	LDSFX = so
+endif
+
+ifeq (x86_64, $(UNAME_M))
+	ARCH_FLAGS = -m64
+else
+	ARCH_FLAGS = -m32
 endif
 
 ##-------------------------------------------------------------------------------------

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -218,6 +218,9 @@ endif
 	$(INSTALL_DATA) $(srcdir)/libpq/pg_ident.conf.sample '$(DESTDIR)$(datadir)/pg_ident.conf.sample'
 	$(INSTALL_DATA) $(srcdir)/utils/misc/postgresql.conf.sample '$(DESTDIR)$(datadir)/postgresql.conf.sample'
 	$(INSTALL_DATA) $(srcdir)/access/transam/recovery.conf.sample '$(DESTDIR)$(datadir)/recovery.conf.sample'
+ifeq ($(enable_orca),yes)
+	$(MAKE) -C gpopt $@ INSTLOC=$(DESKDIR)$(libdir)
+endif
 
 install-bin: postgres $(POSTGRES_IMP) installdirs
 	$(INSTALL_PROGRAM) postgres$(X) '$(DESTDIR)$(bindir)/postgres$(X)'

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -66,11 +66,11 @@ LIBS := $(filter-out -lreadline -ledit -ltermcap -lncurses -lcurses, $(LIBS))
 
 # adding orca libraries
 ifeq ($(enable_orca),yes)
-LIBS := $(LIBS) -L$(LIBGPOS)/$(OBJDIR_DEFAULT) -lgpos
+LIBS := $(LIBS) -lgpos
 LIBS := $(LIBS) -L$(XERCES_LIBDIR) -lxerces-c-3.1
-LIBS := $(LIBS) -L$(OPTIMIZER)/libnaucrates/$(OBJDIR_DEFAULT) -lnaucrates
-LIBS := $(LIBS) -L$(OPTIMIZER)/libgpdbcost/$(OBJDIR_DEFAULT) -lgpdbcost
-LIBS := $(LIBS) -L$(OPTIMIZER)/libgpopt/$(OBJDIR_DEFAULT) -lgpopt
+LIBS := $(LIBS) -lnaucrates
+LIBS := $(LIBS) -lgpdbcost
+LIBS := $(LIBS) -lgpopt
 LIBS := $(LIBS) -L$(top_builddir)/src/backend/gpopt -ldxltranslators
 endif
 

--- a/src/backend/gpopt/Makefile
+++ b/src/backend/gpopt/Makefile
@@ -37,4 +37,4 @@ endif
 
 
 all:
-	 $(CXX)  $(ARCH_FLAGS) $(LDLIBFLAGS) -L$(LIBGPOS)/$(OBJDIR_DEFAULT) -lgpos -L$(XERCES_LIBDIR) -lxerces-c-3.1 -L$(OPTIMIZER)/libnaucrates/$(OBJDIR_DEFAULT) -lnaucrates -L$(OPTIMIZER)/libgpdbcost/$(OBJDIR_DEFAULT) -lgpdbcost -L$(OPTIMIZER)/libgpopt/$(OBJDIR_DEFAULT) -lgpopt -lpthread  -o libdxltranslators.$(LDSFX) $(shell find . -name '*.o' ! -name 'SUBSYS.o')
+	 $(CXX)  $(ARCH_FLAGS) $(LDLIBFLAGS) -lgpos -L$(XERCES_LIBDIR) -lxerces-c-3.1 -lnaucrates -lgpdbcost -lgpopt -lpthread  -o libdxltranslators.$(LDSFX) $(shell find . -name '*.o' ! -name 'SUBSYS.o')

--- a/src/backend/gpopt/Makefile
+++ b/src/backend/gpopt/Makefile
@@ -38,3 +38,6 @@ endif
 
 all:
 	 $(CXX)  $(ARCH_FLAGS) $(LDLIBFLAGS) -lgpos -L$(XERCES_LIBDIR) -lxerces-c-3.1 -lnaucrates -lgpdbcost -lgpopt -lpthread  -o libdxltranslators.$(LDSFX) $(shell find . -name '*.o' ! -name 'SUBSYS.o')
+
+install:
+	cp $(BLD_TOP)/../src/backend/gpopt/libdxltranslators.$(LDSFX) $(INSTLOC);

--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -15,16 +15,16 @@ UNAME_M = $(shell uname -m)
 ARCH_OS = GPOS_$(UNAME)
 ARCH_CPU = GPOS_$(UNAME_P)
 
-ifeq (x86_64, $(UNAME_M))
-	ARCH_BIT = GPOS_64BIT
-else
-	ARCH_BIT = GPOS_32BIT
-endif
-
 ifeq "$(BLD_TYPE)" "opt"
 	GPOPT_flags = -O3 -fno-omit-frame-pointer -g3
 else
 	GPOPT_flags = -g3 -DGPOS_DEBUG
+endif
+
+ifeq (x86_64, $(UNAME_M))
+	ARCH_BIT = GPOS_64BIT
+else
+	ARCH_BIT = GPOS_32BIT
 endif
 
 BLD_FLAGS = -D$(ARCH_BIT) -D$(ARCH_CPU) -D$(ARCH_OS) $(GPOPT_flags)

--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -13,21 +13,18 @@ UNAME_P = $(shell uname -p)
 ARCH_OS = GPOS_$(UNAME)
 ARCH_CPU = GPOS_$(UNAME_P)
 
+ARCH_BIT = GPOS_64BIT
+
+ifeq ($(ARCH_BIT), GPOS_32BIT)
+       ARCH_FLAGS = -m32
+else
+       ARCH_FLAGS = -m64
+endif
+
 ifeq "$(BLD_TYPE)" "opt"
 	GPOPT_flags = -O3 -fno-omit-frame-pointer -g3
 else
 	GPOPT_flags = -g3 -DGPOS_DEBUG
-endif
-
-ARCH_BIT = GPOS_64BIT
-ifeq (Darwin, $(UNAME))
-	ARCH_BIT = GPOS_32BIT
-endif
-
-ifeq ($(ARCH_BIT), GPOS_32BIT)
-	ARCH_FLAGS = -m32
-else
-	ARCH_FLAGS = -m64
 endif
 
 BLD_FLAGS = $(ARCH_FLAGS) -D$(ARCH_BIT) -D$(ARCH_CPU) -D$(ARCH_OS) $(GPOPT_flags)

--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -10,15 +10,17 @@
 
 UNAME = $(shell uname)
 UNAME_P = $(shell uname -p)
+UNAME_M = $(shell uname -m)
+
 ARCH_OS = GPOS_$(UNAME)
 ARCH_CPU = GPOS_$(UNAME_P)
 
-ARCH_BIT = GPOS_64BIT
-
-ifeq ($(ARCH_BIT), GPOS_32BIT)
-       ARCH_FLAGS = -m32
+ifeq (x86_64, $(UNAME_M))
+	ARCH_BIT = GPOS_64BIT
+	ARCH_FLAGS = -m64
 else
-       ARCH_FLAGS = -m64
+	ARCH_BIT = GPOS_32BIT
+	ARCH_FLAGS = -m32
 endif
 
 ifeq "$(BLD_TYPE)" "opt"

--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -9,11 +9,10 @@
 ##-------------------------------------------------------------------------------------
 
 UNAME = $(shell uname)
-UNAME_P = $(shell uname -p)
 UNAME_M = $(shell uname -m)
 
 ARCH_OS = GPOS_$(UNAME)
-ARCH_CPU = GPOS_$(UNAME_P)
+ARCH_CPU = GPOS_$(UNAME_M)
 
 ifeq "$(BLD_TYPE)" "opt"
 	GPOPT_flags = -O3 -fno-omit-frame-pointer -g3

--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -17,10 +17,8 @@ ARCH_CPU = GPOS_$(UNAME_P)
 
 ifeq (x86_64, $(UNAME_M))
 	ARCH_BIT = GPOS_64BIT
-	ARCH_FLAGS = -m64
 else
 	ARCH_BIT = GPOS_32BIT
-	ARCH_FLAGS = -m32
 endif
 
 ifeq "$(BLD_TYPE)" "opt"
@@ -29,7 +27,7 @@ else
 	GPOPT_flags = -g3 -DGPOS_DEBUG
 endif
 
-BLD_FLAGS = $(ARCH_FLAGS) -D$(ARCH_BIT) -D$(ARCH_CPU) -D$(ARCH_OS) $(GPOPT_flags)
+BLD_FLAGS = -D$(ARCH_BIT) -D$(ARCH_CPU) -D$(ARCH_OS) $(GPOPT_flags)
 override CPPFLAGS := -fPIC $(CPPFLAGS)
 override CPPFLAGS := $(BLD_FLAGS)  $(CPPFLAGS)
 override CPPFLAGS := -DGPOS_VERSION=\"$(LIBGPOS_VER)\" $(CPPFLAGS)


### PR DESCRIPTION
After apply this patch, you still need to manually copy the
libdxltranslators.dylib from src/backend/gpopt/ directory
to installation directory (e.g. /usr/local/gpdb/lib)

    cp src/backend/gpopt/libdxltranslators.dylib /usr/local/gpdb/lib/

Signed-off-by: Atri Sharma <atsharma@pivotal.io>