### PR TITLE
Make query interruptible by SIGTERM if hanging on send/recv call to/from client

### DIFF
--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -423,21 +423,9 @@ wloop:
 	else
 #endif
 	{
-		bool saved_ImmediateInterruptOK = ImmediateInterruptOK;
-		CommandDest saved_CommandDest = whereToSendOutput;
-
-		whereToSendOutput = DestNone;
-		ImmediateInterruptOK = true;
-
-		if (ProcDiePending)
-		{
-			CHECK_FOR_INTERRUPTS();
-		}
-
+		prepare_for_client_write();
 		n = send(port->sock, ptr, len, 0);
-
-		ImmediateInterruptOK = saved_ImmediateInterruptOK;
-		whereToSendOutput = saved_CommandDest;
+		client_write_ended();
 	}
 
 	return n;
@@ -493,6 +481,8 @@ my_sock_write(BIO *h, const char *buf, int size)
 {
 	int			res = 0;
 
+	prepare_for_client_write();
+
 	res = send(h->num, buf, size, 0);
 	if (res <= 0)
 	{
@@ -501,6 +491,8 @@ my_sock_write(BIO *h, const char *buf, int size)
 			BIO_set_retry_write(h);
 		}
 	}
+
+	client_write_ended();
 
 	return res;
 }

--- a/src/backend/libpq/pqcomm.c
+++ b/src/backend/libpq/pqcomm.c
@@ -96,6 +96,7 @@
 #include "utils/memutils.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbfilerepservice.h"
+#include "tcop/tcopprot.h"
 
 /*
  * Configuration options
@@ -139,6 +140,7 @@ static void pq_close(int code, Datum arg);
 static int	internal_putbytes(const char *s, size_t len);
 static int	internal_flush(void);
 static void pq_set_nonblocking(bool nonblocking);
+static bool pq_send_mutex_lock();
 
 #ifdef HAVE_UNIX_SOCKETS
 static int	Lock_AF_UNIX(unsigned short portNumber, char *unixSocketName);
@@ -1239,6 +1241,76 @@ pq_getmessage(StringInfo s, int maxlen)
 	return 0;
 }
 
+/*
+ * Wrapper of simple pthread locking functionality, using pthread_mutex_trylock
+ * and loop to make it interruptible when waiting the lock;
+ *
+ * return true if successfuly acquires the lock, false if unable to get the lock
+ * and interrupted by SIGTERM, otherwise, infinitely loop to acquire the mutex.
+ *
+ * If we are going to return false, we close the socket to client; this is crucial
+ * for exiting dispatch thread if it is stuck on sending NOTICE to client, and hence
+ * avoid mutex deadlock;
+ *
+ * NOTE: should not call CHECK_FOR_INTERRUPTS and ereport in this routine, since
+ * it is in multi-thread context;
+ */
+static bool
+pq_send_mutex_lock()
+{
+	int count = PQ_BUSY_TEST_COUNT_IN_EXITING;
+	int mutex_res;
+
+	do
+	{
+		mutex_res = pthread_mutex_trylock(&send_mutex);
+
+		if (mutex_res == 0)
+		{
+			return true;
+		}
+
+		if (mutex_res == EBUSY)
+		{
+			/* No need to acquire lock for TermSignalReceived, since we are in
+ 			 * a loop here */
+			if (TermSignalReceived || count < PQ_BUSY_TEST_COUNT_IN_EXITING)
+			{
+				/*
+ 				 * try PQ_BUSY_TEST_COUNT_IN_EXITING times before going to
+ 				 * close the socket, in case real concurrent writing is in
+ 				 * progress(compared to stuck send call in secure_write);
+ 				 *
+ 				 * It cannot help completely eliminate the false negative
+ 				 * cases, but giving the process is exiting, it is acceptable
+ 				 * to discard some messages, contrasted with the chance of
+ 				 * infinite stuck;
+ 				 */
+				if (count-- < 0)
+				{
+					/* On Redhat and Suse, simple closing the socket would not get
+					 * send() out of hanging state, shutdown() can do this(though not
+					 * explicitly mentioned in manual page); however, if send over a
+					 * socket which has been shutdown, process would be terminated by
+					 * SIGPIPE; to avoid this race condition, we set the socket to be
+					 * invalid before calling shutdown()
+					 *
+					 * On OSX, close() can get send() out of hanging state, while
+					 * shutdown() would lead to SIGPIPE */
+					int saved_fd = MyProcPort->sock;
+					MyProcPort->sock = -1;
+					whereToSendOutput = DestNone;
+#ifndef __darwin__
+					shutdown(saved_fd, SHUT_WR);
+#endif
+					closesocket(saved_fd);
+					return false;
+				}
+			}
+		}
+	} while (true);
+}
+
 
 /* --------------------------------
  *		pq_putbytes		- send bytes to connection (not flushed until pq_flush)
@@ -1253,10 +1325,14 @@ pq_putbytes(const char *s, size_t len)
 
 	/* Should only be called by old-style COPY OUT */
 	Assert(DoingCopyOut);
-    pthread_mutex_lock(&send_mutex);
+	if (!pq_send_mutex_lock())
+	{
+		return EOF;
+	}
+
 	res = internal_putbytes(s, len);
 
-    pthread_mutex_unlock(&send_mutex);
+	pthread_mutex_unlock(&send_mutex);
 	return res;
 }
 
@@ -1297,7 +1373,12 @@ pq_flush(void)
 	int			res;
 
 	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_DISPATCHAGENT) && IsUnderPostmaster)
-		pthread_mutex_lock(&send_mutex);
+	{
+		if (!pq_send_mutex_lock())
+		{
+			return EOF;
+		}
+	}
 	pq_set_nonblocking(false);
 	res = internal_flush();
 
@@ -1357,6 +1438,7 @@ internal_flush(void)
 				/* TDOO: what's this? */
 				HOLD_INTERRUPTS();
 
+				/* we can use ereport here, for the protection of send mutex */
 				ereport(COMMERROR,
 						(errcode_for_socket_access(),
 						 errmsg("could not send data to client: %m")));
@@ -1399,8 +1481,12 @@ pq_flush_if_writable(void)
 	if (PqSendPointer == PqSendStart)
 		return 0;
 	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_DISPATCHAGENT) && IsUnderPostmaster)
-		pthread_mutex_lock(&send_mutex);
-
+	{
+		if (!pq_send_mutex_lock())
+		{
+			return EOF;
+		}
+	}
 	/* Temporarily put the socket into non-blocking mode */
 	pq_set_nonblocking(true);
 
@@ -1446,9 +1532,7 @@ pq_is_send_pending(void)
  *
  *		We also suppress messages generated while pqcomm.c is busy.  This
  *		avoids any possibility of messages being inserted within other
- *		messages.  The only known trouble case arises if SIGQUIT occurs
- *		during a pqcomm.c routine --- quickdie() will try to send a warning
- *		message, and the most reasonable approach seems to be to drop it.
+ *		messages.
  *
  *		returns 0 if OK, EOF if trouble
  * --------------------------------
@@ -1462,13 +1546,18 @@ pq_putmessage(char msgtype, const char *s, size_t len)
 	}
 
 	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_DISPATCHAGENT) && IsUnderPostmaster)
-		pthread_mutex_lock(&send_mutex);
+	{
+		if (!pq_send_mutex_lock())
+		{
+			return EOF;
+		}
+	}
 
 	if (msgtype)
-    {
+	{
 		if (internal_putbytes(&msgtype, 1))
 			goto fail;
-    }
+	}
 
 	if (PG_PROTOCOL_MAJOR(FrontendProtocol) >= 3)
 	{
@@ -1530,9 +1619,13 @@ pq_putmessage_noblock(char msgtype, const char *s, size_t len)
 void
 pq_startcopyout(void)
 {
-    pthread_mutex_lock(&send_mutex);
+	if (!pq_send_mutex_lock())
+	{
+		/* no need to return a status, since socket has been closed in failed cases */
+		return;
+	}
 	DoingCopyOut = true;
-    pthread_mutex_unlock(&send_mutex);
+	pthread_mutex_unlock(&send_mutex);
 }
 
 /* --------------------------------
@@ -1553,9 +1646,12 @@ pq_endcopyout(bool errorAbort)
 	if (errorAbort)
 		pq_putbytes("\n\n\\.\n", 5);
 	/* in non-error case, copy.c will have emitted the terminator line */
-    pthread_mutex_lock(&send_mutex);
+	if (!pq_send_mutex_lock())
+	{
+		return;
+	}
 	DoingCopyOut = false;
-    pthread_mutex_unlock(&send_mutex);
+	pthread_mutex_unlock(&send_mutex);
 }
 
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -187,6 +187,8 @@ static const char *userDoption = NULL;	/* -D switch */
 
 static bool EchoQuery = false;	/* default don't echo */
 
+static bool DoingPqReading = false; /* in the middle of recv call of secure_read */
+
 extern pthread_t main_tid;
 #ifndef _WIN32
 pthread_t main_tid = (pthread_t)0;
@@ -570,6 +572,17 @@ ReadCommand(StringInfo inBuf)
  * non-reentrant libc functions.  This restriction makes it safe for us
  * to allow interrupt service routines to execute nontrivial code while
  * we are waiting for input.
+ *
+ * When waiting in the main loop, we can process any interrupt immediately
+ * in the signal handler. In any other read from the client, like in a COPY
+ * FROM STDIN, we can't safely process a query cancel signal, because we might
+ * be in the middle of sending a message to the client, and jumping out would
+ * violate the protocol. Or rather, pqcomm.c would detect it and refuse to
+ * send any more messages to the client. But handling a SIGTERM is OK, because
+ * we're terminating the backend and don't need to send any more messages
+ * anyway. That means that we might not be able to send an error message to
+ * the client, but that seems better than waiting indefinitely, in case the
+ * client is not responding.
  */
 void
 prepare_for_client_read(void)
@@ -588,6 +601,18 @@ prepare_for_client_read(void)
 		QueryFinishPending = false;
 		CHECK_FOR_INTERRUPTS();
 	}
+	else
+	{
+		DoingPqReading = true;
+		/* Allow die interrupts to be processed while waiting */
+		ImmediateDieOK = true;
+
+		/* Process the ones that already arrived */
+		if (ProcDiePending)
+		{
+			CHECK_FOR_INTERRUPTS();
+		}
+	}
 }
 
 /*
@@ -605,8 +630,48 @@ client_read_ended(void)
 		DisableNotifyInterrupt();
 		DisableCatchupInterrupt();
 	}
+	else
+	{
+		ImmediateDieOK = false;
+		DoingPqReading = false;
+	}
 }
 
+/*
+ * prepare_for_client_write -- set up to possibly block on client output
+ *
+ * Like prepare_for_client_read, but for writing.
+ *
+ * NOTE: this routine may be called in dispatch thread;
+ */
+void
+prepare_for_client_write(void)
+{
+	/* Only enable this on main thread */
+	if (pthread_equal(main_tid, pthread_self()))
+	{
+		/* Allow die interrupts to be processed while waiting */
+		ImmediateDieOK = true;
+
+		/* And don't forget to detect one that already arrived */
+		if (ProcDiePending)
+			CHECK_FOR_INTERRUPTS();
+	}
+}
+
+/*
+ * client_read_ended -- get out of the client-output state
+ *
+ * This is called just after low-level writes.
+ */
+void
+client_write_ended(void)
+{
+	if (pthread_equal(main_tid, pthread_self()))
+	{
+		ImmediateDieOK = false;
+	}
+}
 
 /*
  * Parse a query string and pass it through the rewriter.
@@ -3265,6 +3330,7 @@ die(SIGNAL_ARGS)
 	{
 		InterruptPending = true;
 		ProcDiePending = true;
+		TermSignalReceived = true;
 
 		/* although we don't strictly need to set this to true since the
 		 * ProcDiePending will occur first.  We set this anyway since the
@@ -3277,9 +3343,22 @@ die(SIGNAL_ARGS)
 		 * If it's safe to interrupt, and we're waiting for input or a lock,
 		 * service the interrupt immediately
 		 */
-		if (ImmediateInterruptOK && InterruptHoldoffCount == 0 &&
-			CritSectionCount == 0)
+		if ((ImmediateInterruptOK || ImmediateDieOK) &&
+			InterruptHoldoffCount == 0 && CritSectionCount == 0)
 		{
+			if (ImmediateDieOK && !DoingPqReading)
+			{
+				/*
+				 * Getting here indicates that we have been interrupted during a
+				 * data message is under sending to client, so close the connection
+				 * immediately, since sending any more bytes may cause self dead
+				 * lock(though we can handle this using pq_send_mutex_lock() now, it
+				 * is better to avoid the unnecessary cost).
+				 */
+				close(MyProcPort->sock);
+				whereToSendOutput = DestNone;
+			}
+
 			/* bump holdoff count to make ProcessInterrupts() a no-op */
 			/* until we are done getting ready for it */
 			InterruptHoldoffCount++;
@@ -3472,6 +3551,7 @@ ProcessInterrupts(void)
 		ProcDiePending = false;
 		QueryCancelPending = false;		/* ProcDie trumps QueryCancel */
 		ImmediateInterruptOK = false;	/* not idle anymore */
+		ImmediateDieOK = false;		/* prevent re-entry */
 		DisableNotifyInterrupt();
 		DisableCatchupInterrupt();
 

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -33,6 +33,8 @@ volatile bool QueryFinishPending = false;
 volatile bool ProcDiePending = false;
 volatile bool ClientConnectionLost = false;
 volatile bool ImmediateInterruptOK = false;
+volatile bool ImmediateDieOK = false;
+volatile bool TermSignalReceived = false;
 
 // Make these signed integers (instead of uint32) to detect garbage negative values.
 volatile int32 InterruptHoldoffCount = 0;

--- a/src/include/libpq/pqcomm.h
+++ b/src/include/libpq/pqcomm.h
@@ -223,4 +223,8 @@ typedef struct PrimaryMirrorTransitionPacket
 	uint32 dataLength;
 } PrimaryMirrorTransitionPacket;
 
+/* the number of times trying to acquire the send mutex for the front
+ * end connection after detecting process is exitting */
+#define PQ_BUSY_TEST_COUNT_IN_EXITING 5
+
 #endif   /* PQCOMM_H */

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -81,6 +81,8 @@ extern volatile bool ClientConnectionLost;
 
 /* these are marked volatile because they are examined by signal handlers: */
 extern volatile bool ImmediateInterruptOK;
+extern volatile bool ImmediateDieOK;
+extern volatile bool TermSignalReceived;
 extern PGDLLIMPORT volatile int32 InterruptHoldoffCount;
 extern PGDLLIMPORT volatile int32 CritSectionCount;
 

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -66,6 +66,8 @@ extern void StatementCancelHandler(SIGNAL_ARGS);
 extern void FloatExceptionHandler(SIGNAL_ARGS);
 extern void prepare_for_client_read(void);
 extern void client_read_ended(void);
+extern void prepare_for_client_write(void);
+extern void client_write_ended(void);
 extern void process_postgres_switches(int argc, char *argv[],
 						  GucContext ctx, const char **dbname);
 extern int	PostgresMain(int argc, char *argv[],


### PR DESCRIPTION
This is intended for scenarios where QD hangs sending data to client(
e.g, client is buggy not receiving data), or hangs waiting for data
from client(e.g, COPY foo FROM stdin);

There is a send mutex to prevent from sending a message to client when
another message is in the middle of sending, however, this send mutex
can lead to self deadlock in some cases, including this hanging send()
case; this commit also resolve this kind of self deadlock, at the cost of
discarding some message, which is acceptable when the process is dying.