### PR TITLE
Overhaul the lock related code of resource queue

### DIFF
--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -372,11 +372,7 @@ PortalCleanupHelper(Portal portal, volatile int *cleanupstate)
 	/* 
 	 * If resource scheduling is enabled, release the resource lock. 
 	 */
-	if (portal->releaseResLock)
-	{
-		portal->releaseResLock = false;
         ResUnLockPortal(portal);
-	}
 
 	/**
 	 * Clean up backend's backoff entry

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1847,7 +1847,7 @@ _SPI_pquery(QueryDesc * queryDesc, bool fire_triggers, long tcount)
 
 			/* 
 			 * Checking if we need to put this through resource queue.
-			 * Same as in pquery.c, except we check ActivePortal->releaseResLock.
+			 * Same as in pquery.c, except we check ActivePortal->holdingResLock.
 			 * If the Active portal already hold a lock on the queue, we cannot
 			 * acquire it again.
 			 */
@@ -1872,14 +1872,14 @@ _SPI_pquery(QueryDesc * queryDesc, bool fire_triggers, long tcount)
 				 */
 				if (ActivePortal)
 				{
-					if (!ActivePortal->releaseResLock)
+					if (!ActivePortal->holdingResLock)
 					{
 						/** TODO: siva - can we ever reach this point? */
 						ActivePortal->status = PORTAL_QUEUE;
 					
 						_SPI_assign_query_mem(queryDesc);
 
-						ActivePortal->releaseResLock =
+						ActivePortal->holdingResLock =
 							ResLockPortal(ActivePortal, queryDesc);
 						ActivePortal->status = PORTAL_ACTIVE;
 					} 
@@ -1898,7 +1898,7 @@ _SPI_pquery(QueryDesc * queryDesc, bool fire_triggers, long tcount)
 						 * allocated to the function scan operator.
 						 */
 						Assert(ActivePortal);
-						Assert(ActivePortal->releaseResLock);
+						Assert(ActivePortal->holdingResLock);
 
 						_SPI_assign_query_mem(queryDesc);
 					}

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -587,7 +587,7 @@ LockAcquire(const LOCKTAG *locktag,
 	{
 		if (Gp_role == GP_ROLE_EXECUTE && (gp_is_callback || !Gp_is_writer))
 		{	
-			if (lockHolderProcPtr == NULL || lockHolderProcPtr == MyProc)
+			if (lockHolderProcPtr == MyProc)
 			{
 				/* Find the guy who should manage our locks */
 				PGPROC * proc = FindProcByGpSessionId(gp_session_id);
@@ -605,19 +605,14 @@ LockAcquire(const LOCKTAG *locktag,
 					lockHolderProcPtr = proc;
 				}
 				else
-					elog(DEBUG1,"Could not find writer proc entry!");
+					elog(ERROR,"Could not find writer proc entry!");
 		
-					elog(DEBUG1,"Reader gang member trying to acquire a lock [%u,%u] %s %d",
+				elog(DEBUG1,"Reader gang member trying to acquire a lock [%u,%u] %s %d",
 						 locktag->locktag_field1, locktag->locktag_field2,
 						 lock_mode_names[lockmode], (int)locktag->locktag_type);
 			}
-				
 		}
 	}
-	
-	
-	
-	
 
 	/*
 	 * Otherwise we've got to mess with the shared lock table.
@@ -776,6 +771,19 @@ LockAcquire(const LOCKTAG *locktag,
 	}
 
 	/*
+	 * We shouldn't already hold the desired lock; else locallock table is
+	 * broken.
+	 */
+	if (proclock->holdMask & LOCKBIT_ON(lockmode))
+	{
+		LWLockRelease(partitionLock);
+		elog(ERROR, "lock %s on object %u/%u/%u is already held, locallock is corrupted",
+			 lock_mode_names[lockmode],
+			 lock->tag.locktag_field1, lock->tag.locktag_field2,
+			 lock->tag.locktag_field3);
+	}
+
+	/*
 	 * lock->nRequested and lock->requested[] count the total number of
 	 * requests, whether granted or waiting, so increment those immediately.
 	 * The other counts don't increment till we get the lock.
@@ -783,54 +791,7 @@ LockAcquire(const LOCKTAG *locktag,
 	lock->nRequested++;
 	lock->requested[lockmode]++;
 	Assert((lock->nRequested > 0) && (lock->requested[lockmode] > 0));
-
-	/*
-	 * We shouldn't already hold the desired lock; else locallock table is
-	 * broken.
-	 */
-	if (Gp_role != GP_ROLE_UTILITY)
-	{
-		if (proclock->holdMask & LOCKBIT_ON(lockmode))
-		{
-			elog(LOG, "lock %s on object %u/%u/%u is already held",
-				 lock_mode_names[lockmode],
-				 lock->tag.locktag_field1, lock->tag.locktag_field2,
-				 lock->tag.locktag_field3);
-			if (MyProc == lockHolderProcPtr)
-			{
-				elog(LOG, "writer found lock %s on object %u/%u/%u that it didn't know it held",
-						 lock_mode_names[lockmode],
-						 lock->tag.locktag_field1, lock->tag.locktag_field2,
-						 lock->tag.locktag_field3);
-				GrantLock(lock, proclock, lockmode);
-				GrantLockLocal(locallock, owner);
-			}
-			else
-			{
-				if (MyProc != lockHolderProcPtr)
-				{
-					elog(LOG, "reader found lock %s on object %u/%u/%u which is already held by writer",
-						 lock_mode_names[lockmode],
-						 lock->tag.locktag_field1, lock->tag.locktag_field2,
-						 lock->tag.locktag_field3);
-				}
-				lock->nRequested--;
-				lock->requested[lockmode]--;
-			}
-			LWLockRelease(partitionLock);
-			return LOCKACQUIRE_ALREADY_HELD;
-		}
-		
-	}
-	else
-	if (proclock->holdMask & LOCKBIT_ON(lockmode))
-	{
-		elog(LOG, "lock %s on object %u/%u/%u is already held",
-			 lockMethodTable->lockModeNames[lockmode],
-			 lock->tag.locktag_field1, lock->tag.locktag_field2,
-			 lock->tag.locktag_field3);
-		Insist(false);
-	}
+	
 	/*
 	 * If lock requested conflicts with locks requested by waiters, must join
 	 * wait queue.	Otherwise, check for conflict with already-held locks.
@@ -1374,7 +1335,7 @@ WaitOnLock(LOCALLOCK *locallock, ResourceOwner owner)
  * NB: this does not clean up any locallock object that may exist for the lock.
  */
 void
-RemoveFromWaitQueue(PGPROC *proc, uint32 hashcode)
+RemoveFromWaitQueue(PGPROC *proc, uint32 hashcode, bool wakeupNeeded)
 {
 	LOCK	   *waitLock = proc->waitLock;
 	PROCLOCK   *proclock = proc->waitProcLock;
@@ -1418,7 +1379,7 @@ RemoveFromWaitQueue(PGPROC *proc, uint32 hashcode)
 	 */
 	CleanUpLock(waitLock, proclock,
 				LockMethods[lockmethodid], hashcode,
-				true);
+				wakeupNeeded);
 }
 
 /*

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -258,7 +258,7 @@ ProcessQuery(Portal portal,
 		if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
 			queryDesc->plannedstmt->query_mem = ResourceQueueGetQueryMemoryLimit(queryDesc->plannedstmt, portal->queueId);
 		
-		portal->releaseResLock = ResLockPortal(portal, queryDesc);
+		portal->holdingResLock = ResLockPortal(portal, queryDesc);
 	}
 
 	portal->status = PORTAL_ACTIVE;
@@ -692,7 +692,7 @@ PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
 	/* Set up the sequence server */
 	SetupSequenceServer(seqServerHost, seqServerPort);
 
-	portal->releaseResLock = false;
+	portal->holdingResLock = false;
     
     /*
 	 * Set up global portal context pointers.  (Should we set QueryContext?)
@@ -794,7 +794,7 @@ PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
 					 */ 
 					if (SPI_context() && 
 						saveActivePortal && 
-						saveActivePortal->releaseResLock)
+						saveActivePortal->holdingResLock)
 					{
 						portal->status = PORTAL_QUEUE;
 						if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
@@ -806,7 +806,7 @@ PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
 						
 						if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
 							queryDesc->plannedstmt->query_mem = ResourceQueueGetQueryMemoryLimit(queryDesc->plannedstmt, portal->queueId);
-						portal->releaseResLock = ResLockPortal(portal, queryDesc);
+						portal->holdingResLock = ResLockPortal(portal, queryDesc);
 					}
 				}
 

--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -379,11 +379,7 @@ PortalDrop(Portal portal, bool isTopCommit)
 	 */
 	PortalHashTableDelete(portal);
 
-	if (portal->releaseResLock)
-	{
-		portal->releaseResLock = false;
-		ResUnLockPortal(portal);
-	}
+        ResUnLockPortal(portal);
 
 	/* let portalcmds.c clean up the state it knows about */
 	if (portal->cleanup)
@@ -866,9 +862,7 @@ AtExitCleanup_ResPortals(void)
 	{
 		Portal		portal = hentry->portal;
 
-		if (portal->releaseResLock)
-			ResUnLockPortal(portal);
-
+		ResUnLockPortal(portal);
 	}
 }
 

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -42,10 +42,11 @@ static bool ResIncrementRemove(ResPortalTag *portaltag);
 
 static void ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *incrementSet);
 
-static void ResLockUpdateLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementSet, bool increment, bool inError);
+static void ResLockUpdateLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementSet, bool increment);
 
 static void				ResGrantLock(LOCK *lock, PROCLOCK *proclock);
 static bool				ResUnGrantLock(LOCK *lock, PROCLOCK *proclock);
+static bool ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementSet, ResQueue queue);
 
 
 /*
@@ -263,7 +264,6 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		SHMQueueInsertBefore(&lock->procLocks, &proclock->lockLink);
 		SHMQueueInsertBefore(&(MyProc->myProcLocks[partition]), &proclock->procLink);
 		proclock->nLocks = 0;
-		SHMQueueInit(&(proclock->portalLinks));
 	}
 	else
 	{
@@ -290,7 +290,14 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 	PG_CATCH();
 	{
 		/* Something wrong happened - our RQ is gone. Release all locks and clean out */
-		LWLockReleaseAll();
+		lock->nRequested--;
+		lock->requested[lockmode]--;
+		Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
+
+		ResCleanUpLock(lock, proclock, hashcode, false);
+
+		LWLockRelease(ResQueueLock);
+		LWLockRelease(partitionLock);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -330,6 +337,12 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 	incrementSet = ResIncrementAdd(incrementSet, proclock, owner);
 	if (!incrementSet)
 	{
+		lock->nRequested--;
+		lock->requested[lockmode]--;
+		Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
+
+		ResCleanUpLock(lock, proclock, hashcode, false);
+
 		LWLockRelease(ResQueueLock);
 		LWLockRelease(partitionLock);
 		ereport(ERROR,
@@ -383,7 +396,7 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		 * queue, so record this in the local lock hash, and grant it.
 		 */
 		ResGrantLock(lock, proclock);
-		ResLockUpdateLimit(lock, proclock, incrementSet, true, false);
+		ResLockUpdateLimit(lock, proclock, incrementSet, true);
 
 		LWLockRelease(ResQueueLock);
 
@@ -397,8 +410,37 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 
 		/*
 		 * The requested lock will exhaust the limit for this resource queue,
-		 * so must wait.
+		 * so must wait. Before waiting, check the status of self deadlock.
 		 */
+		if (ResCheckSelfDeadLock(lock, proclock, incrementSet, queue))
+		{
+
+			ResPortalTag		portalTag;
+
+			/* Adjust the counters as we no longer want this lock. */
+			lock->nRequested--;
+			lock->requested[lockmode]--;
+			Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
+
+			/*
+ 		 	 * it is impossible to have proclock->nLocks == 0 here, so no need to call
+ 	 	 	 * RemoveLocalLock and ResCleanUpLock.
+ 	 	 	 */
+			Assert(proclock->nLocks > 0);
+
+			/* Kill off the increment. */
+			MemSet(&portalTag, 0, sizeof(ResPortalTag));
+			portalTag.pid = incrementSet->pid;
+			portalTag.portalId = incrementSet->portalId;
+
+			ResIncrementRemove(&portalTag);
+
+			LWLockRelease(ResQueueLock);
+			LWLockRelease(partitionLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_T_R_DEADLOCK_DETECTED),
+					 errmsg("deadlock detected, locking against self")));
+		}
 
 		/* Set bitmask of locks this process already holds on this object. */
 		MyProc->heldLocks = proclock->holdMask; /* Do we need to do this?*/
@@ -563,13 +605,13 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	incrementSet = ResIncrementFind(&portalTag);
 	if (!incrementSet)
 	{
-        elog(DEBUG1, "Resource queue %d: increment not found on unlock", locktag->locktag_field1);
-        if (proclock->nLocks == 0)
+		elog(DEBUG1, "Resource queue %d: increment not found on unlock", locktag->locktag_field1);
+		if (proclock->nLocks == 0)
 		{
-            RemoveLocalLock(locallock);
+			RemoveLocalLock(locallock);
 		}
-
-		ResCleanUpLock(lock, proclock, hashcode, true);
+		/* no need to do the wakeups */
+		ResCleanUpLock(lock, proclock, hashcode, false);
 		LWLockRelease(ResQueueLock);
 		LWLockRelease(partitionLock);
 		return false;			
@@ -579,7 +621,7 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	 * Un-grant the lock.
 	 */
 	ResUnGrantLock(lock, proclock);
-	ResLockUpdateLimit(lock, proclock, incrementSet, false, false);
+	ResLockUpdateLimit(lock, proclock, incrementSet, false);
 
 	/*
 	 * Perform clean-up, waking up any waiters!
@@ -781,7 +823,7 @@ ResLockCheckLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementS
  *	this function is called.
  */
 void
-ResLockUpdateLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementSet, bool increment, bool inError)
+ResLockUpdateLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementSet, bool increment)
 {
 	ResQueue 		queue;
 	ResLimit		limits;
@@ -1027,17 +1069,33 @@ ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *inc
 
 	/*
 	 * Now sleep.
-	 *
-	 * NOTE: self-deadlocks will throw (do a non-local return).
 	 */
-	if (ResProcSleep(ExclusiveLock, locallock, incrementSet) != STATUS_OK)
+	PG_TRY();
 	{
-		/*
-		 * We failed as a result of a deadlock, see CheckDeadLock(). Quit now.
-		 */
-		LWLockRelease(partitionLock);
-		DeadLockReport();
+		if (ResProcSleep(ExclusiveLock, locallock, incrementSet) != STATUS_OK)
+		{
+			/*
+			 * We failed as a result of a deadlock, see CheckDeadLock(). Quit now.
+			 */
+			awaitedLock = NULL;
+			LWLockRelease(partitionLock);
+			DeadLockReport();
+		}
 	}
+	PG_CATCH();
+	{
+		awaitedLock = NULL;
+		/* Report change to non-waiting status */
+		if (update_process_title)
+		{
+			set_ps_display(new_status, false);
+			pfree(new_status);
+		}
+		pgstat_report_waiting(PGBE_WAITING_NONE);
+
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
 	awaitedLock = NULL;
 
@@ -1133,7 +1191,7 @@ ResProcLockRemoveSelfAndWakeup(LOCK *lock)
 		if (status == STATUS_OK)
 		{
 			ResGrantLock(lock, (PROCLOCK *) proc->waitProcLock);
-			ResLockUpdateLimit(lock, (PROCLOCK *) proc->waitProcLock, incrementSet, true, false);
+			ResLockUpdateLimit(lock, (PROCLOCK *) proc->waitProcLock, incrementSet, true);
 
 			proc = ResProcWakeup(proc, STATUS_OK);
 		}
@@ -1259,10 +1317,9 @@ ResRemoveFromWaitQueue(PGPROC *proc, uint32 hashcode)
  * we need to signal that a self deadlock is about to occurr - modulo some
  * footwork for overcommit-able queues.
  */
-bool
-ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementSet)
+static bool
+ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementSet, ResQueue queue)
 {
-	ResQueue		queue;
 	ResLimit		limits;
 	int				i;
 	Cost			incrementTotals[NUM_RES_LIMIT_TYPES];
@@ -1272,11 +1329,9 @@ ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increme
 	bool			memoryThesholdOvercommitted = false;
 	bool			result = false;
 
-	/* Get the resource queue lock before checking the increments.*/
-	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
+	Assert(LWLockHeldExclusiveByMe(ResQueueLock));
 
 	/* Get the queue for this lock.*/
-	queue = GetResQueueFromLock(lock);
 	limits = queue->limits;
 
 	/* Get the increment totals and number of portals for this queue. */
@@ -1339,29 +1394,6 @@ ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *increme
 	{
 		result = false;
 	}
-
-	if (result)
-	{
-		/*
-		 * We're about to abort out of a partially completed lock
-		 * acquisition.
-		 *
-		 * In order to allow our ref-counts to figure out how to
-		 * clean things up we're going to "grant" the lock, which
-		 * will immediately be cleaned up when our caller throws
-		 * an ERROR.
-		 */
-		if (lock->nRequested > lock->nGranted)
-		{
-			/* we're no longer waiting. */
-			pgstat_report_waiting(PGBE_WAITING_NONE);
-			ResGrantLock(lock, proclock);
-			ResLockUpdateLimit(lock, proclock, incrementSet, true, true);
-		}
-		/* our caller will throw an ERROR. */
-	}
-
-	LWLockRelease(ResQueueLock);
 
 	return result;
 }
@@ -1452,7 +1484,6 @@ ResIncrementAdd(ResPortalIncrement *incSet, PROCLOCK *proclock, ResourceOwner ow
 		{
 			incrementSet->increments[i] = incSet->increments[i];
 		}
-		SHMQueueInsertBefore(&proclock->portalLinks, &incrementSet->portalLink);
 	}
 	else
 	{
@@ -1517,8 +1548,6 @@ ResIncrementRemove(ResPortalTag *portaltag)
 	{
 		return false;
 	}
-
-	SHMQueueDelete(&incrementSet->portalLink);
 
 	return true;
 }
@@ -1738,7 +1767,8 @@ pg_resqueue_status(PG_FUNCTION_ARGS)
 /**
  * This copies out the current state of resource queues.
  */
-static void BuildQueueStatusContext(QueueStatusContext *fctx)
+static void
+BuildQueueStatusContext(QueueStatusContext *fctx)
 {
 	LWLockId partitionLock;
 	int num_calls = 0;

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -358,8 +358,6 @@ typedef struct PROCLOCK
 	SHM_QUEUE	procLink;		/* list link in PGPROC's list of proclocks */
 	int			nLocks;			/* total number of times lock is held by 
 								   this process, used by resource scheduler */
-	SHM_QUEUE	portalLinks;	/* list of ResPortalIncrements for this 
-								   proclock, used by resource scheduler */
 } PROCLOCK;
 
 #define PROCLOCK_LOCKMETHOD(proclock) \
@@ -495,7 +493,7 @@ extern int LockCheckConflicts(LockMethod lockMethodTable,
 				   LOCK *lock, PROCLOCK *proclock, PGPROC *proc);
 extern void GrantLock(LOCK *lock, PROCLOCK *proclock, LOCKMODE lockmode);
 extern void GrantAwaitedLock(void);
-extern void RemoveFromWaitQueue(PGPROC *proc, uint32 hashcode);
+extern void RemoveFromWaitQueue(PGPROC *proc, uint32 hashcode, bool wakeupNeeded);
 extern void RemoveLocalLock(LOCALLOCK *locallock);
 extern Size LockShmemSize(void);
 extern LockData *GetLockStatusData(void);

--- a/src/include/utils/portal.h
+++ b/src/include/utils/portal.h
@@ -154,7 +154,10 @@ typedef struct PortalData
 
 	/* Status data */
 	PortalStatus status;		/* see above */
-	bool	releaseResLock;	/* true => resscheduler lock must be released */
+	bool	holdingResLock;	/* true => resscheduler lock must be released, however,
+				 * in an extreme case when a portal receives a SIGTERM just
+				 * after being granted the resource lock, the holding ResLock
+				 * is not set but it is indeed holding the ResLock */
 
 	/* If not NULL, Executor is active; call ExecutorEnd eventually: */
 	QueryDesc  *queryDesc;		/* info needed for executor invocation */

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -90,8 +90,6 @@ typedef struct ResPortalIncrement
 	ResourceOwner	owner;				/* Resource Owner. */
 	bool		isHold;					/* Holdable cursor? */
 	bool		isCommitted;			/* 1st commit complete? */
-	SHM_QUEUE	portalLink;				/* List link in PROCLOCKS list 
-										   of ResPortalIncrements. */
 	/* The increments - use Cost as it has a suitably large range. */
 	Cost		increments[NUM_RES_LIMIT_TYPES];
 } ResPortalIncrement;
@@ -142,7 +140,6 @@ extern ResQueue			GetResQueueFromLock(LOCK *lock);
 extern void				ResProcLockRemoveSelfAndWakeup(LOCK *lock);
 extern PGPROC 			*ResProcWakeup(PGPROC *proc, int waitStatus);
 extern void				ResRemoveFromWaitQueue(PGPROC *proc, uint32 hashcode);
-extern bool				ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incSet);
 
 extern ResPortalIncrement	*ResIncrementFind(ResPortalTag *portaltag);
 


### PR DESCRIPTION
In some error cases, the resource queue lock is not released, hence
leading to lock leak and inconsistent resource queue status; this commit
overhauls the resource queue locking code to complete the cleanups if error
or signal happens during acquiring resource queue lock; meanwhile, some
unnecessary code blocks are removed and unreasonable code are fixed to make
it easier for reading and understanding;