### PR TITLE
Renaming optimizer_release_mdcache GUC to optimizer_metadata_caching.

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -1105,7 +1105,7 @@ COptTasks::PvOptimizeTask
 	CRefCount::SafeRelease(pbsEnabled);
 	CRefCount::SafeRelease(pbsDisabled);
 	CRefCount::SafeRelease(pbsTraceFlags);
-	if (optimizer_release_mdcache)
+	if (!optimizer_metadata_caching)
 	{
 		CMDCache::Shutdown();
 	}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -497,7 +497,7 @@ int			optimizer_cost_model;
 bool		optimizer_print_query;
 bool		optimizer_print_plan;
 bool		optimizer_print_xform;
-bool		optimizer_release_mdcache;
+bool		optimizer_metadata_caching;
 int		optimizer_mdcache_size;
 bool		optimizer_disable_xform_result_printing;
 bool		optimizer_print_memo_after_exploration;
@@ -2755,12 +2755,12 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_release_mdcache", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Release MDCache after each query."),
+		{"optimizer_metadata_caching", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Cache metadata in MDCache."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
-		&optimizer_release_mdcache,
+		&optimizer_metadata_caching,
 		true, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -375,7 +375,7 @@ extern int  optimizer_cost_model;
 extern bool optimizer_print_query;
 extern bool optimizer_print_plan;
 extern bool optimizer_print_xform;
-extern bool optimizer_release_mdcache;
+extern bool optimizer_metadata_caching;
 extern int optimizer_mdcache_size;
 extern bool optimizer_disable_xform_result_printing;
 extern bool	optimizer_print_memo_after_exploration;

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -9698,7 +9698,7 @@ drop table idxscan_outer;
 drop table idxscan_inner;
 drop table if exists ggg;
 NOTICE:  table "ggg" does not exist, skipping
-set optimizer_release_mdcache=off;
+set optimizer_metadata_caching=on;
 create table ggg (a char(1), b char(2), d char(3));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/gp_optimizer_1.out
+++ b/src/test/regress/expected/gp_optimizer_1.out
@@ -9627,7 +9627,7 @@ drop table idxscan_outer;
 drop table idxscan_inner;
 drop table if exists ggg;
 NOTICE:  table "ggg" does not exist, skipping
-set optimizer_release_mdcache=off;
+set optimizer_metadata_caching=on;
 create table ggg (a char(1), b char(2), d char(3));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -1251,7 +1251,7 @@ drop table idxscan_outer;
 drop table idxscan_inner;
 
 drop table if exists ggg;
-set optimizer_release_mdcache=off;
+set optimizer_metadata_caching=on;
 
 create table ggg (a char(1), b char(2), d char(3));
 insert into ggg values ('x', 'a', 'c');


### PR DESCRIPTION
We rename optimizer_release_mdcache to a more intuitive name: optimizer_metadata_caching. When optimizer_metadata_caching=ON, then we cache metadata in optimizer side. Before this commit, we were doing the same thing by setting optimizer_release_mdcache = OFF.

This change requires documentation, since the gucs are external. 
Also, this commit updates the guc in ICG tests. 

Finally, a part of this story is to update all tinc tests that use optimizer_release_mdcache guc as well.