### PR TITLE
Fix nested case expression

### DIFF
--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -3137,10 +3137,20 @@ ExecEvalCase(CaseExprState *caseExpr, ExprContext *econtext,
 
 	if (caseExpr->arg)
 	{
+		/*
+		 * caseValue_datum and caseValue_isNull from econtext store the results of case
+		 * expression. caseValue_isNull will be true if caseValue_datum store null value.
+		 * Both caseValue_datum and caseValue_isNull should change at same time and they shouldn't
+		 * go out of sync.
+		 * Hence pass temporary variable(caseValue_isNull) and once evaluation is done,
+		 * update the caseValue_isNull from econtext.
+		 */
+		bool caseValue_isNull = false;
 		econtext->caseValue_datum = ExecEvalExpr(caseExpr->arg,
 												 econtext,
-												 &econtext->caseValue_isNull,
+												 &caseValue_isNull,
 												 NULL);
+		econtext->caseValue_isNull = caseValue_isNull;
 	}
 
 	/*

--- a/src/test/regress/expected/nested_case_null.out
+++ b/src/test/regress/expected/nested_case_null.out
@@ -1,0 +1,23 @@
+---
+--- Drop existing table
+---
+DROP TABLE IF EXISTS t;
+---
+--- Create new table t
+---
+CREATE TABLE t(pid INT, wid INT, state CHARACTER VARYING(30));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'pid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+---
+--- Insert a row and keep state as empty
+---
+INSERT INTO t VALUES(1, 1);
+---
+--- use nested decode
+---
+SELECT DECODE(DECODE(state, '', NULL, state), '-', NULL, state) AS state FROM t;
+ state 
+-------
+ 
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -74,6 +74,8 @@ test: filespace trig auth_constraint role rle portals_updatable plpgsql_cache ti
 
 test: aggregate_with_groupingsets gp_optimizer 
 
+test: nested_case_null
+
 ignore: tpch500GB_orca
 
 # XXX: This test depends on libgpoptudfs library, which includes ORCA helper

--- a/src/test/regress/sql/nested_case_null.sql
+++ b/src/test/regress/sql/nested_case_null.sql
@@ -1,0 +1,19 @@
+---
+--- Drop existing table
+---
+DROP TABLE IF EXISTS t;
+
+---
+--- Create new table t
+---
+CREATE TABLE t(pid INT, wid INT, state CHARACTER VARYING(30));
+
+---
+--- Insert a row and keep state as empty
+---
+INSERT INTO t VALUES(1, 1);
+
+---
+--- use nested decode
+---
+SELECT DECODE(DECODE(state, '', NULL, state), '-', NULL, state) AS state FROM t;


### PR DESCRIPTION
Example sql that cause issue:
select decode(decode(state, '', null, state), '-', null, state) as state from t
column 'state' from table 't' have null values.
Because of above sql, we do case expression evaluation
case expression is evaluated in following line:
econtext->caseValue_datum will have actual results out of case expression and econtext->caseValue_isNull flag says if that value is null or not.
```
econtext->caseValue_datum = ExecEvalExpr(caseExpr->arg,
econtext,
&econtext->caseValue_isNull,
NULL);
```
This ExecEvalExpr will call below function which reset isNull flag (econtext->caseValue_isNull) to false to begin with.

```
static Datum
ExecEvalDistinct(FuncExprState fcache,
ExprContext econtext,
bool isNull,
ExprDoneCond isDone)
{
Datum result;
FunctionCallInfoData fcinfo;
ExprDoneCond argDone;
List *argList;
/ Set default values for result flags: non-null, not a set result /
*isNull = false;
```

At the end of evaluation econtext->caseValue_datum and econtext_caseValue_isNull flag will have the results of inner decode.
When outer decode begin to execute in ExecEvalDisting we reset isNull to false (econtext->caseValue_isNull). This is an issue because it erase the inner decode results. (i.e) when we parse the argument we get the flag results from econtext->caseValue_isNull as shown below but this has been reset to false already.
```
/*
ExecEvalCaseTestExpr
*
Return the value stored by CASE.
/
static Datum
ExecEvalCaseTestExpr(ExprState exprstate,
ExprContext econtext,
bool isNull, ExprDoneCond isDone)
{
if (isDone) isDone = ExprSingleResult;
*isNull = econtext->caseValue_isNull;
return econtext->caseValue_datum;
}
```
To fix this, we have to pass local temp variable by pointer instead of econtext->caseValue_isNull. This also make sure both caseValue_datum and caseValue_isNull from econtext changes at the same time and don't go out of sync like above.

@foyzur @gcaragea @armenatzoglou  Please have a look when you get chance