### PR TITLE
Fix haltWork() can not stop a thread in time which slow down gpinitsystem

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -180,7 +180,7 @@ class Worker(Thread):
     name=None
     logger=None
     
-    def __init__(self,name,pool,timeout=5):
+    def __init__(self,name,pool,timeout=0.1):
         self.name=name
         self.pool=pool
         self.timeout=timeout
@@ -192,7 +192,7 @@ class Worker(Thread):
         try_count = 0
         while True:
             try:
-                if try_count == 5:
+                if try_count == 100:
                     self.logger.debug("[%s] try and get work from queue..." % self.name)
                     try_count = 0
                 


### PR DESCRIPTION
Worker is the basic thread class used by gpdb utilities, if there are no commands in queue for Worker to consume, thread will be blocking for 5 seconds even though haltWork() is called. This fix change default timeout to 0.1 so thread can detect shouldStop flag immediately.