### PR TITLE
Release ErrorData after logging to error table

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -808,7 +808,7 @@ else \
 	}\
 \
 	HandleSingleRowError(pstate->cdbsreh); \
-\
+	FreeErrorData(edata);\
 	if (errmsg_is_a_copy && !IsRejectLimitReached(pstate->cdbsreh)) \
 		pfree(pstate->cdbsreh->errmsg); \
 }


### PR DESCRIPTION
If we dont' free these error data, it would cause OOM if there are a
lot of bad data imporetd from external table