### PR TITLE
Silence compiler warnings

### DIFF
--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -42,7 +42,8 @@ CreateAOAuxiliaryTable(
 	char aoauxiliary_relname[NAMEDATALEN];
 	char aoauxiliary_idxname[NAMEDATALEN];
 	bool shared_relation;
-	Oid relOid, aoauxiliary_relid, aoauxiliary_idxid;
+	Oid relOid, aoauxiliary_relid = InvalidOid;
+	Oid aoauxiliary_idxid;
 	ObjectAddress baseobject;
 	ObjectAddress aoauxiliaryobject;
 

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4221,7 +4221,7 @@ reconstruct_pathkeys(PlannerInfo *root, List *pathkeys, int *resno_map,
 	foreach(i, pathkeys)
 	{
 		PathKey    *pathkey = (PathKey *) lfirst(i);
-		bool		found;
+		bool		found = false;
 
 		foreach(j, pathkey->pk_eclass->ec_members)
 		{

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -4375,13 +4375,11 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 
 	        if (buf->nRetry == 0)
 	        {
-	            /* newRTT = buf->conn->rtt * (1 - RTT_COEFFICIENT) + ackTime * RTT_COEFFICIENT; */
 	        	newRTT = buf->conn->rtt - (buf->conn->rtt >> RTT_SHIFT_COEFFICIENT) + (ackTime >> RTT_SHIFT_COEFFICIENT);
 	        	newRTT = Min(MAX_RTT, Max(newRTT, MIN_RTT));
 	        	buf->conn->rtt = newRTT;
 
-	        	/* newDEV = buf->conn->dev * (1 - DEV_COEFFICIENT) + DEV_COEFFICIENT * abs(ackTime - newRTT); */
-	        	newDEV = buf->conn->dev - (buf->conn->dev >> DEV_SHIFT_COEFFICIENT) + (abs(ackTime - newRTT) >> DEV_SHIFT_COEFFICIENT);
+				newDEV = buf->conn->dev - (buf->conn->dev >> DEV_SHIFT_COEFFICIENT) + ((ackTime - newRTT) >> DEV_SHIFT_COEFFICIENT);
 	        	newDEV = Min(MAX_DEV, Max(newDEV, MIN_DEV));
 	        	buf->conn->dev = newDEV;
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -11008,17 +11008,15 @@ ATExecSetTableSpace_AppendOnly(
 
 	if (Debug_persistent_print)
 		elog(Persistent_DebugPrintLevel(), 
-			 "ALTER TABLE SET TABLESPACE: pg_appendonly entry for Append-Only %u/%u/%u, segment file #%d "
+			 "ALTER TABLE SET TABLESPACE: pg_appendonly entry for Append-Only %u/%u/%u, "
 			 "segrelid %u, segidxid %u, "
-			 "persistent TID %s and serial number " INT64_FORMAT,
+			 "persistent TID %s",
 			 rel->rd_node.spcNode,
 			 rel->rd_node.dbNode,
 			 rel->rd_node.relNode,
-			 segmentFileNum,
 			 aoEntry->segrelid,
 			 aoEntry->segidxid,
-			 ItemPointerToString(&oldPersistentTid),
-			 oldPersistentSerialNum);	
+			 ItemPointerToString(&oldPersistentTid));
 
 	/*
 	 * Loop through segment files

--- a/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/backend/utils/adt/pgstatfuncs.c
@@ -448,7 +448,6 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 		bool		nulls[13];
 		HeapTuple	tuple;
 		PgBackendStatus *beentry;
-		SockAddr	zero_clientaddr;
 
 		MemSet(values, 0, sizeof(values));
 		MemSet(nulls, 0, sizeof(nulls));
@@ -489,6 +488,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 		/* Values only available to same user or superuser */
 		if (superuser() || beentry->st_userid == GetUserId())
 		{
+			SockAddr	zero_clientaddr;
 			bool		waiting;
 
 			if (*(beentry->st_activity) == '\0')
@@ -521,7 +521,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 			/* A zeroed client addr means we don't know */
 			memset(&zero_clientaddr, 0, sizeof(zero_clientaddr));
 			if (memcmp(&(beentry->st_clientaddr), &zero_clientaddr,
-					   sizeof(zero_clientaddr) == 0))
+					   sizeof(zero_clientaddr)) == 0)
 			{
 				nulls[9] = true;
 				nulls[10] = true;
@@ -814,7 +814,7 @@ pg_stat_get_backend_client_addr(PG_FUNCTION_ARGS)
 	/* A zeroed client addr means we don't know */
 	memset(&zero_clientaddr, 0, sizeof(zero_clientaddr));
 	if (memcmp(&(beentry->st_clientaddr), &zero_clientaddr,
-			   sizeof(zero_clientaddr) == 0))
+			   sizeof(zero_clientaddr)) == 0)
 		PG_RETURN_NULL();
 
 	switch (beentry->st_clientaddr.addr.ss_family)
@@ -860,7 +860,7 @@ pg_stat_get_backend_client_port(PG_FUNCTION_ARGS)
 	/* A zeroed client addr means we don't know */
 	memset(&zero_clientaddr, 0, sizeof(zero_clientaddr));
 	if (memcmp(&(beentry->st_clientaddr), &zero_clientaddr,
-			   sizeof(zero_clientaddr) == 0))
+			   sizeof(zero_clientaddr)) == 0)
 		PG_RETURN_NULL();
 
 	switch (beentry->st_clientaddr.addr.ss_family)

--- a/src/backend/utils/sort/tuplesort_mkheap.c
+++ b/src/backend/utils/sort/tuplesort_mkheap.c
@@ -92,21 +92,6 @@ static inline int PARENT(int n)
     Assert(n > 0);
     return (n-1) >> 1;
 }
-static inline int SIBLING(int n)
-{
-    Assert(n > 0);
-    return ((n-1) ^ 1) + 1;
-}
-static inline bool ISLEFT(int n)
-{
-    Assert(n > 0);
-    return (n & 1) != 0;
-}
-static inline bool ISRIGHT(int n)
-{
-    Assert(n > 0);
-    return (n & 1) == 0;
-}
 
 /*
  * Heap compare.

--- a/src/bin/gpmirrortransition/gpmirrortransition.c
+++ b/src/bin/gpmirrortransition/gpmirrortransition.c
@@ -24,12 +24,6 @@
  */
 
 
-static inline bool
-isEmpty(char *str)
-{
-	return str == NULL || str[0] == '\0';
-}
-
 static bool
 gpCheckForNeedToExitFn(void)
 {


### PR DESCRIPTION
Fixes a set of compiler warnings of both cosmetic (things that can't happen etc) and real nature. This does alter a debug log printing that seemed incorrect but I might be missing something.