### PR TITLE
Fix regression in pathkey reconstruction from EC merge

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4221,7 +4221,6 @@ reconstruct_pathkeys(PlannerInfo *root, List *pathkeys, int *resno_map,
 	foreach(i, pathkeys)
 	{
 		PathKey    *pathkey = (PathKey *) lfirst(i);
-		bool		found;
 
 		foreach(j, pathkey->pk_eclass->ec_members)
 		{
@@ -4245,12 +4244,9 @@ reconstruct_pathkeys(PlannerInfo *root, List *pathkeys, int *resno_map,
 										  pathkey->pk_nulls_first);
 
 				new_pathkeys = lappend(new_pathkeys, new_pathkey);
-				found = true;
 				break;
 			}
 		}
-		if (!found)
-			elog(ERROR, "could not find path key item in subplan's target list");
 	}
 
 	new_pathkeys = canonicalize_pathkeys(root, new_pathkeys);


### PR DESCRIPTION
When fixing a few compiler warnings in #338 initializing `found = false;` in `reconstruct_pathkeys()` seemed a proper and harmless fix. Applying it caused an unexpected test failure though and looking at why I think we introduced a regression in the EC merge. Finding the `tle` in the loop is a case for breaking the loop early but not finding isn't a failure case unless I'm mistaken. This `elog()` breaks the following query in the gp_dqa testcase when `found` is properly initiated to false before the loop.
```SQL
select count(distinct c), count(distinct dt), i from dqa_t1 group by i;
```
When not initialized at all the variable was likely to (while not guaranteed) not be false and the test didnt fail.