### PR TITLE
Fix crash-recovery of B-tree split records.

### DIFF
--- a/src/backend/access/nbtree/nbtxlog.c
+++ b/src/backend/access/nbtree/nbtxlog.c
@@ -452,9 +452,6 @@ btree_xlog_split(bool onleft, bool isroot,
 		}
 	}
 
-	MIRROREDLOCK_BUFMGR_UNLOCK;
-	// -------- MirroredLock ----------
-
 	/* We no longer need the right buffer. */
 	UnlockReleaseBuffer(rbuf);
 
@@ -480,6 +477,9 @@ btree_xlog_split(bool onleft, bool isroot,
 			UnlockReleaseBuffer(buffer);
 		}
 	}
+
+	MIRROREDLOCK_BUFMGR_UNLOCK;
+	// -------- MirroredLock ----------
 
 	/* The job ain't done till the parent link is inserted... */
 	log_incomplete_split(xlrec->node,


### PR DESCRIPTION
Merge of upstream B-tree split WAL-logging changes, broke the recovery
incase of Btree. The MirroredLock needs to held while manipulating
buffer.

Atleast saw this failure in UAO test mpp.gpdb.tests.storage.uao.uao_faultinjection.test_uao_fault_inject.UAO_FaultInjection_TestCase.test_uao_crash_compaction_before_cleanup_phase giving the stack trace during recovery (most likely other tests would be having failures due to same or more other issues.)
```
2016-02-08 04:26:30.556587 PST,"gpadmin","gptest",p2576,th73336608,"127.0.0.1","34995",2016-02-08 04:26:30 PST,0,con1133,,seg-1,,,,,"FATAL","57P03","the database system is starting up",,,,,,,0,,"postmaster.c",2941,
2016-02-08 04:26:30.582893 PST,,,p2573,th73336608,,,,0,,,seg-1,,,,,"FATAL","XX000","Mirrored lock must already be held (bufmgr.c:2719)",,,,,"xlog redo split_r: rel 1663/16384/2658 left 143, right 144, next 0, level 0, firstright 351
REDO PASS 3 @ 0/76F9F4A0; LSN 0/76FA0178: prev 0/76F9F3E8; xid 11394: Btree - split_r: rel 1663/16384/2658 left 143, right 144, next 0, level 0, firstright 351",,0,,"bufmgr.c",2719,"Stack trace:
1    0xb0ae4a postgres <symbol not found> (elog.c:502)
2    0xb0ce58 postgres elog_finish (elog.c:1446)
3    0x947ad5 postgres UnlockReleaseBuffer (bufmgr.c:2719)
4    0x53507b postgres <symbol not found> (nbtxlog.c:462)
5    0x535ed9 postgres btree_redo (nbtxlog.c:808)
6    0x55e0a1 postgres StartupXLOG_Pass3 (xlog.c:6149)
7    0x564851 postgres StartupProcessMain (xlog.c:11056)
8    0x5f47cd postgres AuxiliaryProcessMain (bootstrap.c:473)
9    0x8ee384 postgres <symbol not found> (postmaster.c:7338)
10   0x8f608c postgres <symbol not found> (postmaster.c:4558)
11   0x8f8d68 postgres <symbol not found> (postmaster.c:2423)
12   0x8fa6e0 postgres PostmasterMain (postmaster.c:7338)
13   0x7f67bf postgres main (main.c:206)
14   0x3c1e81ed1d libc.so.6 __libc_start_main (??:0)
15   0x4c3349 postgres <symbol not found> (??:0)
```

