### PR TITLE
Check EOF values for AO/CO before updating aoseg table.

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -701,34 +701,58 @@ UpdateFileSegInfo_internal(Relation parentrel,
 	new_record_nulls = palloc0(sizeof(bool) * pg_aoseg_dsc->natts);
 	new_record_repl = palloc0(sizeof(bool) * pg_aoseg_dsc->natts);
 
+	old_eof = fastgetattr(tuple,
+			Anum_pg_aoseg_eof,
+			pg_aoseg_dsc,
+			&isNull);
+
+	if(isNull)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("got invalid pg_aoseg eof value: NULL")));
+
+	/*
+	 * For AO by design due to append-only nature,
+	 * new end-of-file (EOF) to be recorded in aoseg table has to be greater
+	 * than currently stored EOF value, as new writes must move it forward only.
+	 * If new end-of-file value is less than currently stored end-of-file
+	 * something is incorrect and updating the same will yeild incorrect result
+	 * during reads. Hence abort the write transaction trying to update the
+	 * incorrect EOF value.
+	 */
 	if (eof < 0)
 	{
-		old_eof = fastgetattr(tuple,
-								Anum_pg_aoseg_eof,
-								pg_aoseg_dsc,
-								&isNull);
-
-		if(isNull)
-			ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				errmsg("got invalid pg_aoseg eof value: NULL")));
 
 		eof = DatumGetFloat8(old_eof);
 	}
+	else if (eof < DatumGetFloat8(old_eof))
+	{
+		elog(ERROR, "Unexpected compressed EOF for relation %s, relfilenode %u, segment file %d. "
+			"EOF " INT64_FORMAT " to be updated cannot be smaller than current EOF %f in pg_aoseg",
+			RelationGetRelationName(parentrel), parentrel->rd_node.relNode,
+			segno, eof, DatumGetFloat8(old_eof));
+	}
+
+	old_eof_uncompressed = fastgetattr(tuple,
+			Anum_pg_aoseg_eofuncompressed,
+			pg_aoseg_dsc,
+			&isNull);
+
+	if(isNull)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("got invalid pg_aoseg eofuncompressed value: NULL")));
 
 	if (eof_uncompressed < 0)
 	{
-		old_eof_uncompressed = fastgetattr(tuple,
-								Anum_pg_aoseg_eofuncompressed,
-								pg_aoseg_dsc,
-								&isNull);
-
-		if(isNull)
-			ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				errmsg("got invalid pg_aoseg eofuncompressed value: NULL")));
-
 		eof_uncompressed = DatumGetFloat8(old_eof_uncompressed);
+	}
+	else if (eof_uncompressed < DatumGetFloat8(old_eof_uncompressed))
+	{
+		elog(ERROR, "Unexpected EOF for relation %s, relfilenode %u, segment file %d."
+			"EOF " INT64_FORMAT " to be updated cannot be smaller than current EOF %f in pg_aoseg",
+			RelationGetRelationName(parentrel), parentrel->rd_node.relNode,
+			segno, eof_uncompressed, DatumGetFloat8(old_eof_uncompressed));
 	}
 	
 	/* get the current tuple count so we can add to it */


### PR DESCRIPTION
For AO/CO tables due to functional nature, new EOF value to be updated
must always be greater than current value. Currently, this check is
performed on persistent table update but it happens as part of Commit-Prepared.
So its super too late to take any action, even if we detect it can only PANIC
the system and already resulted in data corruption for reads as aoseg has been
updated and transaction commited. Hence moving the check while updating the
aoseg table, when such case is detected now transaction can be aborted without
impacting the system or already loaded data in table.