### PR TITLE
Fix a set of compiler warnings in gpopt

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1892,6 +1892,7 @@ gpdb::PvalMakeInteger
 		return makeInteger(i);
 	}
 	GP_WRAP_END;
+	return NULL;
 }
 
 Node *

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5676,7 +5676,6 @@ CTranslatorDXLToPlStmt::SetVarTypMod
 
 		if (IsA(pte->expr, Var))
 		{
-			pte->expr;
 			Var *var = (Var*) pte->expr;
 			var->vartypmod = *(*pdrgpi)[ul];
 		}

--- a/src/backend/gpopt/utils/funcs.cpp
+++ b/src/backend/gpopt/utils/funcs.cpp
@@ -1088,7 +1088,7 @@ RestoreQueryFromFile(PG_FUNCTION_ARGS)
 	CFileReader fr;
 	fr.Open(szFilename);
 	ULLONG ullSize = fr.UllSize();
-	elog(NOTICE, "(RestoreFromFile) Filesize is %d", ullSize);
+	elog(NOTICE, "(RestoreFromFile) Filesize is %llu", ullSize);
 
 	char *pcBuf = (char*) gpdb::GPDBAlloc(ullSize);
 	fr.UlpRead((BYTE*)pcBuf, ullSize);


### PR DESCRIPTION
From the department of _I got annoyed seeing those whizz past_ comes another few compiler warning fixes. Without altering functionality, fix a set of compiler warnings in gpopt: Properly return in non-void function, remove non-function invocation of variable and use the right formatter for `ULLONG` when printing.