### PR TITLE
Fixing buffer overwrite in window operator

### DIFF
--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -227,6 +227,17 @@ typedef struct WindowStatePerLevelData
 	FrameBufferEntry *curr_entry_buf;
 	FrameBufferEntry *trail_entry_buf;
 	FrameBufferEntry *lead_entry_buf;
+	
+	/* A char buffer to temporarily hold serialized data
+	* before writing them to the frame buffer.
+	*
+	* Use this pre-allocated buffer to avoid doing
+	* palloc/pfree many times.
+	*
+	* The size of this array is specified by 'max_size'.
+	*/
+	char *serial_array;
+	Size max_size;
 }	WindowStatePerLevelData;
 
 /*
@@ -1444,11 +1455,11 @@ appendToFrameBuffer(WindowStatePerLevel level_state,
 	ExprContext *econtext = wstate->ps.ps_ExprContext;
 
 	Assert(buffer->is_rows == level_state->is_rows);
-	MemSet(wstate->serial_array, 0, wstate->max_size);
+	MemSet(level_state->serial_array, 0, level_state->max_size);
 	serializeEntry(level_state, econtext,
-				   &(wstate->serial_array), &(wstate->max_size), &len);
+				   &(level_state->serial_array), &(level_state->max_size), &len);
 
-	ntuplestore_acc_put_data(buffer->writer, (void *)(wstate->serial_array), len);
+	ntuplestore_acc_put_data(buffer->writer, (void *)(level_state->serial_array), len);
 
 	adjustEdgesAfterAppend(level_state, wstate, last_peer);
 
@@ -3018,13 +3029,6 @@ makeWindowState(Window * window, EState *estate)
 											   ALLOCSET_DEFAULT_INITSIZE,
 											   ALLOCSET_DEFAULT_MAXSIZE);
 
-	/*
-	 * We allocate the buffer to be 1K initially, which should be sufficient
-	 * for most cases.
-	 */
-	wstate->serial_array = palloc0(FRAMEBUFFER_ENTRY_SIZE);
-	wstate->max_size = FRAMEBUFFER_ENTRY_SIZE;
-
 	return wstate;
 }
 
@@ -3056,6 +3060,9 @@ initializePartition(WindowState * wstate)
 		level_state->dense_rank = 1;
 		level_state->prior_rank = 1;
 		level_state->prior_dense_rank = 1;
+
+		level_state->serial_array = palloc0(FRAMEBUFFER_ENTRY_SIZE);
+		level_state->max_size = FRAMEBUFFER_ENTRY_SIZE;
 	}
 
 	/* Per-partition input buffer management reinitialzation. */
@@ -6042,10 +6049,10 @@ windowBufferNextLastAgg(WindowBufferCursor cursor)
 		 * memory.
 		 */
 		econtext->ecxt_scantuple = wstate->spare;
-		MemSet(wstate->serial_array, 0, wstate->max_size);
+		MemSet(level_state->serial_array, 0, level_state->max_size);
 		serializeEntry(level_state, econtext,
-					   &(wstate->serial_array), &(wstate->max_size), &len);
-		entry = deserializeEntry(level_state, entry, wstate->serial_array, len);
+					   &(level_state->serial_array), &(level_state->max_size), &len);
+		entry = deserializeEntry(level_state, entry, level_state->serial_array, len);
 		/* Get back the slot. */
 		econtext->ecxt_scantuple = slot;
 		/* We never use this again as it's the logical last row. */
@@ -6223,6 +6230,12 @@ ExecEndWindow(WindowState * node)
 
 		freeFrameBufferEntry(level_state->lead_entry_buf);
 		level_state->lead_entry_buf = NULL;
+
+		if (level_state->serial_array != NULL)
+		{
+			pfree(level_state->serial_array);
+			level_state->serial_array = NULL;
+		}
 	}
 
 	ExecEagerFreeWindow(node);
@@ -6241,8 +6254,6 @@ ExecEndWindow(WindowState * node)
 
 	if (node->cmpcontext != NULL)
 		MemoryContextDelete(node->cmpcontext);
-
-	pfree(node->serial_array);
 
 	if (node->numlevels > 0)
 		pfree(node->level_state);

--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -228,8 +228,9 @@ typedef struct WindowStatePerLevelData
 	FrameBufferEntry *trail_entry_buf;
 	FrameBufferEntry *lead_entry_buf;
 	
-	/* A char buffer to temporarily hold serialized data
-	* before writing them to the frame buffer.
+	/* A char buffer to temporarily hold serialized data before
+	*  writing them to the frame buffer, and keep deserialized
+	*  data when reading from the frame buffer.
 	*
 	* Use this pre-allocated buffer to avoid doing
 	* palloc/pfree many times.

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2367,17 +2367,6 @@ typedef struct WindowState
 
 	/* Indicate if any function need a peer count. */
 	bool		need_peercount;
-
-	/* A char buffer to temporarily hold serialized data
-	 * before writing them to the frame buffer.
-	 *
-	 * Use this pre-allocated buffer to avoid doing
-	 * palloc/pfree many times.
-	 *
-	 * The size of this array is specified by 'max_size'.
-	 */
-	char		*serial_array;
-	Size		max_size;
 } WindowState;
 
 /* ----------------

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -8138,3 +8138,29 @@ select stddev(n) over(order by d range between current row and interval '1 day' 
                      |  89 | 89.0000000000000000 | 89
 (3 rows)
 
+-- This test examines the case that a statement invokes multiple lead functions, which are not sorted regarding the rows that they use.
+-- For example, first lead retrieves data from one tuple ahead, second lead function retrieves data from two tuples ahead, while third one
+-- gets data from one tuple ahead again.
+DROP TABLE IF EXISTS empsalary;
+CREATE TABLE empsalary(
+  depname varchar,
+  empno bigint,
+  salary char(8),
+  enroll_date date
+);
+INSERT INTO empsalary VALUES('develop', 8, '6000', '2006/10/01');
+INSERT INTO empsalary VALUES('develop', 11, '5200', '2007/08/15');
+INSERT INTO empsalary VALUES('develop', 9, '4500', '2008/01/01');
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11
+from empsalary;
+ depname | empno |  salary  | enroll_date | qianzhi1 | qianzhi2 | qianzhi11
+---------+-------+----------+-------------+----------+----------+-----------
+ develop |     8 | 6000     | 10-01-2006  | 5200     | 4500     |        11
+ develop |    11 | 5200     | 08-15-2007  | 4500     |          |         9
+ develop |     9 | 4500     | 01-01-2008  |          |          |
+(3 rows)
+
+-- End of Test

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -8138,19 +8138,23 @@ select stddev(n) over(order by d range between current row and interval '1 day' 
                      |  89 | 89.0000000000000000 | 89
 (3 rows)
 
--- This test examines the case that a statement invokes multiple lead functions, which are not sorted regarding the rows that they use.
--- For example, first lead retrieves data from one tuple ahead, second lead function retrieves data from two tuples ahead, while third one
--- gets data from one tuple ahead again.
+-- This test examines the case that a statement invokes multiple lead functions,
+-- which are not sorted regarding the rows that they use and projected attributes are varlen.
 DROP TABLE IF EXISTS empsalary;
+NOTICE:  table "empsalary" does not exist, skipping
 CREATE TABLE empsalary(
   depname varchar,
   empno bigint,
   salary char(8),
   enroll_date date
 );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'depname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO empsalary VALUES('develop', 8, '6000', '2006/10/01');
 INSERT INTO empsalary VALUES('develop', 11, '5200', '2007/08/15');
 INSERT INTO empsalary VALUES('develop', 9, '4500', '2008/01/01');
+-- First lead retrieves data from one tuple ahead, second lead function retrieves data from two tuples ahead, while third one
+-- gets data from one tuple ahead again.
 select * ,
 lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
 lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
@@ -8161,6 +8165,69 @@ from empsalary;
  develop |     8 | 6000     | 10-01-2006  | 5200     | 4500     |        11
  develop |    11 | 5200     | 08-15-2007  | 4500     |          |         9
  develop |     9 | 4500     | 01-01-2008  |          |          |
+(3 rows)
+
+-- Lead functions are in order.
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2
+from empsalary;
+ depname | empno |  salary  | enroll_date | qianzhi1 | qianzhi11 | qianzhi2
+---------+-------+----------+-------------+----------+-----------+----------
+ develop |     8 | 6000     | 10-01-2006  | 5200     |        11 | 4500
+ develop |    11 | 5200     | 08-15-2007  | 4500     |         9 |
+ develop |     9 | 4500     | 01-01-2008  |          |           |
+(3 rows)
+
+DROP TABLE IF EXISTS empsalary;
+CREATE TABLE empsalary(
+  depname varchar,
+  empno bigint,
+  salary numeric(22, 6),
+  enroll_date date
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'depname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO empsalary VALUES('develop', 8, 6000, '2006/10/01');
+INSERT INTO empsalary VALUES('develop', 11, 5200, '2007/08/15');
+INSERT INTO empsalary VALUES('develop', 9, 4500, '2008/01/01');
+-- Similar to the first statement using numeric.
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11
+from empsalary;
+ depname | empno |   salary    | enroll_date |  qianzhi1   |  qianzhi2   | qianzhi11
+---------+-------+-------------+-------------+-------------+-------------+-----------
+ develop |     8 | 6000.000000 | 10-01-2006  | 5200.000000 | 4500.000000 |        11
+ develop |    11 | 5200.000000 | 08-15-2007  | 4500.000000 |             |         9
+ develop |     9 | 4500.000000 | 01-01-2008  |             |             |
+(3 rows)
+
+DROP TABLE IF EXISTS empsalary;
+CREATE TABLE empsalary(
+  depname varchar,
+  empno bigint,
+  salary int,
+  enroll_date date
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'depname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO empsalary VALUES('develop', 8, 6000, '2006/10/01');
+INSERT INTO empsalary VALUES('develop', 11, 5200, '2007/08/15');
+INSERT INTO empsalary VALUES('develop', 9, 4500, '2008/01/01');
+-- Similar to the first statement using int.
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11
+from empsalary;
+ depname | empno | salary | enroll_date | qianzhi1 | qianzhi2 | qianzhi11
+---------+-------+--------+-------------+----------+----------+-----------
+ develop |     8 |   6000 | 10-01-2006  |     5200 |     4500 |        11
+ develop |    11 |   5200 | 08-15-2007  |     4500 |          |         9
+ develop |     9 |   4500 | 01-01-2008  |          |          |
 (3 rows)
 
 -- End of Test

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -8148,19 +8148,23 @@ select stddev(n) over(order by d range between current row and interval '1 day' 
                      |  89 | 89.0000000000000000 | 89
 (3 rows)
 
--- This test examines the case that a statement invokes multiple lead functions, which are not sorted regarding the rows that they use.
--- For example, first lead retrieves data from one tuple ahead, second lead function retrieves data from two tuples ahead, while third one
--- gets data from one tuple ahead again.
+-- This test examines the case that a statement invokes multiple lead functions,
+-- which are not sorted regarding the rows that they use and projected attributes are varlen.
 DROP TABLE IF EXISTS empsalary;
+NOTICE:  table "empsalary" does not exist, skipping
 CREATE TABLE empsalary(
   depname varchar,
   empno bigint,
   salary char(8),
   enroll_date date
 );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'depname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO empsalary VALUES('develop', 8, '6000', '2006/10/01');
 INSERT INTO empsalary VALUES('develop', 11, '5200', '2007/08/15');
 INSERT INTO empsalary VALUES('develop', 9, '4500', '2008/01/01');
+-- First lead retrieves data from one tuple ahead, second lead function retrieves data from two tuples ahead, while third one
+-- gets data from one tuple ahead again.
 select * ,
 lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
 lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
@@ -8171,6 +8175,69 @@ from empsalary;
  develop |     8 | 6000     | 10-01-2006  | 5200     | 4500     |        11
  develop |    11 | 5200     | 08-15-2007  | 4500     |          |         9
  develop |     9 | 4500     | 01-01-2008  |          |          |
+(3 rows)
+
+-- Lead functions are in order.
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2
+from empsalary;
+ depname | empno |  salary  | enroll_date | qianzhi1 | qianzhi11 | qianzhi2
+---------+-------+----------+-------------+----------+-----------+----------
+ develop |     8 | 6000     | 10-01-2006  | 5200     |        11 | 4500
+ develop |    11 | 5200     | 08-15-2007  | 4500     |         9 |
+ develop |     9 | 4500     | 01-01-2008  |          |           |
+(3 rows)
+
+DROP TABLE IF EXISTS empsalary;
+CREATE TABLE empsalary(
+  depname varchar,
+  empno bigint,
+  salary numeric(22, 6),
+  enroll_date date
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'depname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO empsalary VALUES('develop', 8, 6000, '2006/10/01');
+INSERT INTO empsalary VALUES('develop', 11, 5200, '2007/08/15');
+INSERT INTO empsalary VALUES('develop', 9, 4500, '2008/01/01');
+-- Similar to the first statement using numeric.
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11
+from empsalary;
+ depname | empno |   salary    | enroll_date |  qianzhi1   |  qianzhi2   | qianzhi11
+---------+-------+-------------+-------------+-------------+-------------+-----------
+ develop |     8 | 6000.000000 | 10-01-2006  | 5200.000000 | 4500.000000 |        11
+ develop |    11 | 5200.000000 | 08-15-2007  | 4500.000000 |             |         9
+ develop |     9 | 4500.000000 | 01-01-2008  |             |             |
+(3 rows)
+
+DROP TABLE IF EXISTS empsalary;
+CREATE TABLE empsalary(
+  depname varchar,
+  empno bigint,
+  salary int,
+  enroll_date date
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'depname' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO empsalary VALUES('develop', 8, 6000, '2006/10/01');
+INSERT INTO empsalary VALUES('develop', 11, 5200, '2007/08/15');
+INSERT INTO empsalary VALUES('develop', 9, 4500, '2008/01/01');
+-- Similar to the first statement using int.
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11
+from empsalary;
+ depname | empno | salary | enroll_date | qianzhi1 | qianzhi2 | qianzhi11
+---------+-------+--------+-------------+----------+----------+-----------
+ develop |     8 |   6000 | 10-01-2006  |     5200 |     4500 |        11
+ develop |    11 |   5200 | 08-15-2007  |     4500 |          |         9
+ develop |     9 |   4500 | 01-01-2008  |          |          |
 (3 rows)
 
 -- End of Test

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -8148,3 +8148,29 @@ select stddev(n) over(order by d range between current row and interval '1 day' 
                      |  89 | 89.0000000000000000 | 89
 (3 rows)
 
+-- This test examines the case that a statement invokes multiple lead functions, which are not sorted regarding the rows that they use.
+-- For example, first lead retrieves data from one tuple ahead, second lead function retrieves data from two tuples ahead, while third one
+-- gets data from one tuple ahead again.
+DROP TABLE IF EXISTS empsalary;
+CREATE TABLE empsalary(
+  depname varchar,
+  empno bigint,
+  salary char(8),
+  enroll_date date
+);
+INSERT INTO empsalary VALUES('develop', 8, '6000', '2006/10/01');
+INSERT INTO empsalary VALUES('develop', 11, '5200', '2007/08/15');
+INSERT INTO empsalary VALUES('develop', 9, '4500', '2008/01/01');
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11
+from empsalary;
+ depname | empno |  salary  | enroll_date | qianzhi1 | qianzhi2 | qianzhi11
+---------+-------+----------+-------------+----------+----------+-----------
+ develop |     8 | 6000     | 10-01-2006  | 5200     | 4500     |        11
+ develop |    11 | 5200     | 08-15-2007  | 4500     |          |         9
+ develop |     9 | 4500     | 01-01-2008  |          |          |
+(3 rows)
+
+-- End of Test

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1547,3 +1547,26 @@ select stddev(n) over(order by d range between current row and interval '1 day' 
        sum(n) over(order by d range between current row and interval '1 day' following),
        avg(n) over(order by d range between current row and interval '1 day' following), n from olap_window_seq_test;
 
+-- This test examines the case that a statement invokes multiple lead functions, which are not sorted regarding the rows that they use.
+-- For example, first lead retrieves data from one tuple ahead, second lead function retrieves data from two tuples ahead, while third one 
+-- gets data from one tuple ahead again.  
+DROP TABLE IF EXISTS empsalary;
+CREATE TABLE empsalary(
+  depname varchar,
+  empno bigint,
+  salary char(8),
+  enroll_date date
+);
+
+INSERT INTO empsalary VALUES('develop', 8, '6000', '2006/10/01');
+INSERT INTO empsalary VALUES('develop', 11, '5200', '2007/08/15');
+INSERT INTO empsalary VALUES('develop', 9, '4500', '2008/01/01');
+
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11
+from empsalary;
+
+-- End of Test
+

--- a/src/test/regress/sql/olap_window_seq.sql
+++ b/src/test/regress/sql/olap_window_seq.sql
@@ -1547,9 +1547,8 @@ select stddev(n) over(order by d range between current row and interval '1 day' 
        sum(n) over(order by d range between current row and interval '1 day' following),
        avg(n) over(order by d range between current row and interval '1 day' following), n from olap_window_seq_test;
 
--- This test examines the case that a statement invokes multiple lead functions, which are not sorted regarding the rows that they use.
--- For example, first lead retrieves data from one tuple ahead, second lead function retrieves data from two tuples ahead, while third one 
--- gets data from one tuple ahead again.  
+-- This test examines the case that a statement invokes multiple lead functions, 
+-- which are not sorted regarding the rows that they use and projected attributes are varlen. 
 DROP TABLE IF EXISTS empsalary;
 CREATE TABLE empsalary(
   depname varchar,
@@ -1562,6 +1561,53 @@ INSERT INTO empsalary VALUES('develop', 8, '6000', '2006/10/01');
 INSERT INTO empsalary VALUES('develop', 11, '5200', '2007/08/15');
 INSERT INTO empsalary VALUES('develop', 9, '4500', '2008/01/01');
 
+-- First lead retrieves data from one tuple ahead, second lead function retrieves data from two tuples ahead, while third one 
+-- gets data from one tuple ahead again.  
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11
+from empsalary;
+
+-- Lead functions are in order. 
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2
+from empsalary;
+
+DROP TABLE IF EXISTS empsalary;
+CREATE TABLE empsalary(
+  depname varchar,
+  empno bigint,
+  salary numeric(22, 6),
+  enroll_date date
+);
+
+INSERT INTO empsalary VALUES('develop', 8, 6000, '2006/10/01');
+INSERT INTO empsalary VALUES('develop', 11, 5200, '2007/08/15');
+INSERT INTO empsalary VALUES('develop', 9, 4500, '2008/01/01');
+
+-- Similar to the first statement using numeric.
+select * ,
+lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
+lead(salary,2) over (partition by depname order by salary desc) qianzhi2,
+lead(empno,1) over (partition by depname order by salary desc) qianzhi11
+from empsalary;
+
+DROP TABLE IF EXISTS empsalary;
+CREATE TABLE empsalary(
+  depname varchar,
+  empno bigint,
+  salary int,
+  enroll_date date
+);
+
+INSERT INTO empsalary VALUES('develop', 8, 6000, '2006/10/01');
+INSERT INTO empsalary VALUES('develop', 11, 5200, '2007/08/15');
+INSERT INTO empsalary VALUES('develop', 9, 4500, '2008/01/01');
+
+-- Similar to the first statement using int. 
 select * ,
 lead(salary,1) over (partition by depname order by salary desc) qianzhi1,
 lead(salary,2) over (partition by depname order by salary desc) qianzhi2,


### PR DESCRIPTION
We have a list of window values, one per level that the window functions of each level processes. We extract these window values from tuple store. To do the extraction, we use a temporary buffer, called serial_array, to serialize and deserialize the tuples. During this process, we obtain winvalues (the list of input values for a level). If the data type of the winvalues for a level is byref, then it ends up holding a pointer to the serial_array. However, we have only one serial_array for the entire window operator. Therefore, if we have more than one level with byref data types, we may end up overwriting the serial_array when we process another level, corrupting the earlier level’s byref datum pointers. To fix this, we now have one serial_array per level.