### PR TITLE
Fix GPDB with --enable-orca on OSX.

### DIFF
--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -16,16 +16,21 @@
 
 UNAME = $(shell uname)
 UNAME_P = $(shell uname -p)
+UNAME_M = $(shell uname -m)
 
 UNAME_ALL = $(UNAME).$(UNAME_P)
 
 # shared lib support
 ifeq (Darwin, $(UNAME))
-	ARCH_FLAGS = -m32
 	LDSFX = dylib
 else
-	ARCH_FLAGS = -m64
 	LDSFX = so
+endif
+
+ifeq (x86_64, $(UNAME_M))
+	ARCH_FLAGS = -m64
+else
+	ARCH_FLAGS = -m32
 endif
 
 ##-------------------------------------------------------------------------------------

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -218,6 +218,9 @@ endif
 	$(INSTALL_DATA) $(srcdir)/libpq/pg_ident.conf.sample '$(DESTDIR)$(datadir)/pg_ident.conf.sample'
 	$(INSTALL_DATA) $(srcdir)/utils/misc/postgresql.conf.sample '$(DESTDIR)$(datadir)/postgresql.conf.sample'
 	$(INSTALL_DATA) $(srcdir)/access/transam/recovery.conf.sample '$(DESTDIR)$(datadir)/recovery.conf.sample'
+ifeq ($(enable_orca), yes)
+	$(MAKE) -C gpopt $@ INSTLOC=$(DESTDIR)$(libdir)
+endif
 
 install-bin: postgres $(POSTGRES_IMP) installdirs
 	$(INSTALL_PROGRAM) postgres$(X) '$(DESTDIR)$(bindir)/postgres$(X)'

--- a/src/backend/gpopt/Makefile
+++ b/src/backend/gpopt/Makefile
@@ -38,3 +38,5 @@ endif
 
 all:
 	 $(CXX)  $(ARCH_FLAGS) $(LDLIBFLAGS) -L$(LIBGPOS)/$(OBJDIR_DEFAULT) -lgpos -L$(XERCES_LIBDIR) -lxerces-c-3.1 -L$(OPTIMIZER)/libnaucrates/$(OBJDIR_DEFAULT) -lnaucrates -L$(OPTIMIZER)/libgpdbcost/$(OBJDIR_DEFAULT) -lgpdbcost -L$(OPTIMIZER)/libgpopt/$(OBJDIR_DEFAULT) -lgpopt -lpthread  -o libdxltranslators.$(LDSFX) $(shell find . -name '*.o' ! -name 'SUBSYS.o')
+install:
+	cp $(BLD_TOP)/../src/backend/gpopt/libdxltranslators.$(LDSFX) $(INSTLOC);

--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -10,6 +10,8 @@
 
 UNAME = $(shell uname)
 UNAME_P = $(shell uname -p)
+UNAME_M = $(shell uname -m)
+
 ARCH_OS = GPOS_$(UNAME)
 ARCH_CPU = GPOS_$(UNAME_P)
 
@@ -19,8 +21,9 @@ else
 	GPOPT_flags = -g3 -DGPOS_DEBUG
 endif
 
-ARCH_BIT = GPOS_64BIT
-ifeq (Darwin, $(UNAME))
+ifeq (x86_64, $(UNAME_M))
+	ARCH_BIT = GPOS_64BIT
+else
 	ARCH_BIT = GPOS_32BIT
 endif
 


### PR DESCRIPTION
This is a baby step to straight out the OSX build for the open source community.

The changes here are fixing up the makefile and also install the proper libdxltranslators after the build using `make install`.

After apply this patch, we still cannot build with 'gpfdist' yet, since, we are using deprecated functions, and `-Werror` is in place and caused failure on OSX.

There would be separate PR just focusing on getting the `gpfdist` fixed. Before that, please work around by `configure` with `--disable-gpfdist`.

Thanks,
Shin