### PR TITLE
Fix xlogdump build

### DIFF
--- a/contrib/xlogdump/xlogdump.c
+++ b/contrib/xlogdump/xlogdump.c
@@ -721,7 +721,7 @@ help(void)
 	printf("  -T, --hide-timestamps     Do not print timestamps.\n");
 	printf("  -?, --help                Show this help.\n");
 	printf("\n");
-	printf("oid2name supplimental options:\n");
+	printf("oid2name supplemental options:\n");
 	printf("  -h, --host=HOST           database server host or socket directory\n");
 	printf("  -p, --port=PORT           database server port number\n");
 	printf("  -U, --user=NAME           database user name to connect\n");

--- a/contrib/xlogdump/xlogdump_rmgr.c
+++ b/contrib/xlogdump/xlogdump_rmgr.c
@@ -607,9 +607,14 @@ print_rmgr_standby(XLogRecPtr cur, XLogRecord *record, uint8 info)
 void
 print_rmgr_heap2(XLogRecPtr cur, XLogRecord *record, uint8 info)
 {
-	char spaceName[NAMEDATALEN];
-	char dbName[NAMEDATALEN];
-	char relName[NAMEDATALEN];
+	/*
+	 * 83MERGE_FIXME: re-enable the declaration of these variables when the
+	 * relevant changes are merged (see below).
+	 *
+	 * char spaceName[NAMEDATALEN];
+	 * char dbName[NAMEDATALEN];
+	 * char relName[NAMEDATALEN];
+	 */
 	char buf[1024];
 
 	switch (info)

--- a/contrib/xlogdump/xlogdump_statement.c
+++ b/contrib/xlogdump/xlogdump_statement.c
@@ -16,14 +16,6 @@
 
 static int printValue(const char *, const int, const attrib_t, const uint32);
 
-#if PG_VERSION_NUM < 80400
- #ifdef HAVE_INT64_TIMESTAMP
- typedef int64 TimeOffset;
- #else
- typedef double TimeOffset;
- #endif
-#endif
-
 #if PG_VERSION_NUM < 80300
 #define MaxHeapTupleSize  (BLCKSZ - MAXALIGN(sizeof(PageHeaderData)))
 #endif


### PR DESCRIPTION
Connecting xlogdump to the build in fdc309e broke the buildfarm due to the redefenition of `TimeOffset`, see log output below:
```
2/12/16 2:36:49 AM PST: At top level:
2/12/16 2:36:49 AM PST: cc1: warning: unrecognized command line option "-Wno-unused-but-set-variable"
2/12/16 2:36:49 AM PST: ccache gcc -m32 -march=i686 -O3 -funroll-loops -fargument-noalias-global -fno-omit-frame-pointer -g -finline-limit=1800 -std=gnu99  -Wall -Wmissing-prototypes -Wpointer-arith -Wendif-labels -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-but-set-variable -Wno-address -I/Volumes/data/royc1/tools/curl/7.44.0/dist/osx106_x86/include -DVERSION_STR=\""0.6devel"\" -I. -I../../src/interfaces/libpq -DDATADIR=\"/Volumes/data/pulse2-agent/agents/agent1/work/GPDB-master-opt-l1/osx106_x86/src/gpAux/greenplum-db-devel/share/postgresql\" -I. -I../../src/include -I/opt/tools_build/tools/libxml2/2.7.8/dist/osx105_x86/include/libxml2  -I/Volumes/data/pulse2-agent/agents/agent1/work/GPDB-master-opt-l1/osx106_x86/src/gpAux/ext/osx106_x86/include -I/Volumes/data/pulse2-agent/agents/agent1/work/GPDB-master-opt-l1/osx106_x86/src/gpAux/ext/osx106_x86/include/libxml2 -I/Volumes/data/pulse2-agent/agents/agent1/work/GPDB-master-opt-l1/osx106_x86/src/gpAux/ext/osx106_x86/libgpopt/include -I/Volumes/data/pulse2-agent/agents/agent1/work/GPDB-master-opt-l1/osx106_x86/src/gpAux/ext/osx106_x86/libgpos/include -I/Volumes/data/pulse2-agent/agents/agent1/work/GPDB-master-opt-l1/osx106_x86/src/gpAux/addon/src/include  -c -o xlogdump_statement.o xlogdump_statement.c
2/12/16 2:36:50 AM PST: xlogdump_statement.c:21: error: redefinition of typedef ‘TimeOffset’
2/12/16 2:36:50 AM PST: ../../src/include/utils/timestamp.h:50: note: previous declaration of ‘TimeOffset’ was here
2/12/16 2:36:50 AM PST: cc1: warning: unrecognized command line option "-Wno-unused-but-set-variable"
2/12/16 2:36:50 AM PST: make[2]: *** [xlogdump_statement.o] Error 1
2/12/16 2:36:50 AM PST: make[1]: *** [install] Error 2
2/12/16 2:36:50 AM PST: make: *** [dist] Error 2
```

This addresses the above error by simply removing the typedef altogether since it's already handled in `timestamp.h` which is included, also fixes three other warnings for unused variables (which are temporarily unused but will be used once we merge the relevant upstream changes).

Included is also a tiny typo fix in the help output. Crossing the beams aside, it seemed innocent enough to throw in here.