### PR TITLE
remove -Werror from gpfdist to fix OSX build

### DIFF
--- a/gpAux/extensions/gpfdist/configure
+++ b/gpAux/extensions/gpfdist/configure
@@ -3304,7 +3304,7 @@ if test -n "$APR_CONFIG"; then
   LIBS="$LIBS $apr_link_ld_libs"
 fi
 
-CFLAGS="-Werror $CFLAGS"
+CFLAGS="$CFLAGS"
 
 # If the 'apr-1-config --link-ld' produced correct output, -lapr-1 is already
 # in LIBS, hence AC_SEARCH_LIBS rather than AC_CHECK_LIB. (and the autoconf

--- a/gpAux/extensions/gpfdist/configure.ac
+++ b/gpAux/extensions/gpfdist/configure.ac
@@ -86,7 +86,7 @@ if test -n "$APR_CONFIG"; then
   LIBS="$LIBS $apr_link_ld_libs"
 fi
 
-CFLAGS="-Werror $CFLAGS"
+CFLAGS="$CFLAGS"
 
 # If the 'apr-1-config --link-ld' produced correct output, -lapr-1 is already
 # in LIBS, hence AC_SEARCH_LIBS rather than AC_CHECK_LIB. (and the autoconf


### PR DESCRIPTION
Current OSX got deprecated failures like below:

```
gcc -g -O2   -I/usr/bin/..//include/apr-1   -DDARWIN -DSIGPROCMASK_SETS_THREAD_MASK -DDARWIN_10 -I../../../src/include -I. -DGP_VERSION="4.3.99.00 build dev" -DGPFXDIST  -c -o gpfdist.o gpfdist.c
gpfdist.c:1843:11: warning: 'BIO_new' is deprecated: first deprecated in OS X 10.7 [-Wdeprecated-declarations]
                r->io = BIO_new(BIO_f_buffer());
                        ^
```

In the configure file for the `gpfdist`, we treat such warning as error using `-Werror`, hence, make filed.

To work around this issue and really let the OSX catch-up, we need to remove `-Werror` out of the configure for `gpfdisk`, then it can be built properly on OSX.

Please help me review that's the proper place to remove this error.

Also, as on-going effort, people should look at build warning, and fix them continuously. Thanks.