### PR TITLE
Avoid loading of block directory entries for columns that are not pro…

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1233,7 +1233,8 @@ aocs_fetch_init(Relation relation,
 		aocsFetchDesc->totalSegfiles,
 		aocsFetchDesc->relation,
 		relation->rd_att->natts,
-		true);
+		true,
+			proj);
 
 	Assert(relation->rd_att != NULL);
 

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2235,7 +2235,8 @@ appendonly_fetch_init(
 						aoFetchDesc->totalSegfiles,
 						aoFetchDesc->relation,
 						1,
-						false);
+						false,
+						NULL);
 
 	AppendOnlyVisimap_Init(&aoFetchDesc->visibilityMap,
 						aoentry->visimaprelid,

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2143,7 +2143,8 @@ vacuum_appendonly_indexes(Relation aoRelation,
 			totalSegfiles,
 			aoRelation,
 			1,
-			RelationIsAoCols(aoRelation));
+			RelationIsAoCols(aoRelation),
+			NULL);
 
 	/* Clean/scan index relation(s) */
 	if (Irel != NULL)

--- a/src/include/cdb/cdbappendonlyblockdirectory.h
+++ b/src/include/cdb/cdbappendonlyblockdirectory.h
@@ -90,7 +90,8 @@ typedef struct AppendOnlyBlockDirectory
 	Relation blkdirIdx;
 	int numColumnGroups;
 	bool isAOCol;
-	
+	bool *proj; /* projected columns, used only if isAOCol = TRUE */
+
 	MemoryContext memoryContext;
 	
 	int				totalSegfiles;
@@ -182,7 +183,8 @@ extern void AppendOnlyBlockDirectory_Init_forSearch(
 	int totalSegfiles,
 	Relation aoRel,
 	int numColumnGroups,
-	bool isAOCol);
+	bool isAOCol,
+	bool *proj);
 extern void AppendOnlyBlockDirectory_Init_addCol(
 	AppendOnlyBlockDirectory *blockDirectory,
 	AppendOnlyEntry *aoEntry,

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -283,7 +283,11 @@ select * from co where j = 2;
 insert into co values (9,2,'b'), (10,2,'bb'), (11,2,'bbb'), (12,2,'bbbb'),
 	(13,5,'aaaaa'), (14,6,'aaaaaa'), (15,7,'aaaaaaa'), (16,8,'aaaaaaaa');
 select * from co where j = 2;
-
+-- Select specific columns.  This covers the case when block directory
+-- entries for only specific columns need to be loaded during index
+-- scan.
+select i from co where j = 2;
+select j,i from co where k = 'aaa' or k = 'bbb';
 
 ---------------------
 -- UAO

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -544,6 +544,28 @@ select * from co where j = 2;
  11 | 2 | bbb
 (6 rows)
 
+-- Select specific columns.  This covers the case when block directory
+-- entries for only specific columns need to be loaded during index
+-- scan.
+select i from co where j = 2;
+ i  
+----
+  9
+ 11
+  2
+ 10
+ 10
+ 12
+(6 rows)
+
+select j,i from co where k = 'aaa' or k = 'bbb';
+ j | i  
+---+----
+ 3 |  3
+ 3 | 11
+ 2 | 11
+(3 rows)
+
 ---------------------
 -- UAO
 ---------------------


### PR DESCRIPTION
…jected.

This change applies only to column oriented tables (CO).  It reads
block directory entries for only those columns that appear in project
list (e.g. select clause).