### PR TITLE
Initializing uninitialized scalar variables in dml commands.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3189,7 +3189,7 @@ ExecDelete(ItemPointer tupleid,
 	Relation	resultRelationDesc;
 	HTSU_Result result;
 	ItemPointerData update_ctid;
-	TransactionId update_xmax;
+	TransactionId update_xmax = InvalidTransactionId;
 
 	/*
 	 * get information on the (current) result relation
@@ -3359,6 +3359,8 @@ ldelete:;
 			else if (!ItemPointerEquals(tupleid, &update_ctid))
 			{
 				TupleTableSlot *epqslot;
+
+				Assert(update_xmax != InvalidTransactionId);
 
 				epqslot = EvalPlanQual(estate,
 									   resultRelInfo->ri_RangeTableIndex,

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3607,7 +3607,7 @@ ExecUpdate(TupleTableSlot *slot,
 	Relation	resultRelationDesc;
 	HTSU_Result result;
 	ItemPointerData update_ctid;
-	TransactionId update_xmax;
+	TransactionId update_xmax = InvalidTransactionId;
 	AOTupleId	aoTupleId = AOTUPLEID_INIT;
 	TupleTableSlot *partslot = NULL;
 
@@ -3803,6 +3803,8 @@ lreplace:;
 				else if (!ItemPointerEquals(tupleid, &update_ctid))
 				{
 					TupleTableSlot *epqslot;
+
+					Assert(update_xmax != InvalidTransactionId);
 
 					epqslot = EvalPlanQual(estate,
 										   resultRelInfo->ri_RangeTableIndex,


### PR DESCRIPTION
This commit fixes coverity issues about using uninitialized scalar variables. 