### PR TITLE
Porting Statistics and Cardinality Estimation Tests to ICG

### DIFF
--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -1,0 +1,502 @@
+create language plpythonu;
+create or replace function check_row_count(query text, expected integer) returns text as
+$$
+output = plpy.execute(query)
+rows = output[0]['QUERY PLAN'].split('rows=')[1].split()[0]
+if int(rows) == expected:
+	return "true"
+return "false"
+$$
+language plpythonu;
+set optimizer = on;
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+create table foo (a int, b int) distributed by (a);
+insert into foo values (1,1);
+insert into foo values (0,1);
+insert into foo values (2,1);
+insert into foo values (null,1);
+analyze foo;
+-- current statistics
+select stanullfrac, stadistinct, stanumbers1 from pg_statistic where starelid='foo'::regclass and staattnum=1;
+ stanullfrac | stadistinct | stanumbers1 
+-------------+-------------+-------------
+        0.25 |          -1 | 
+(1 row)
+
+-- exercise the translator
+select check_row_count('explain select * from foo where a is not null and b >= 1;', 3);
+ check_row_count 
+-----------------
+ true
+(1 row)
+
+drop table foo;
+DROP TABLE IF EXISTS foo2;
+NOTICE:  table "foo2" does not exist, skipping
+create table foo2(a int) distributed by (a);
+insert into foo2 select generate_series(1,5);
+insert into foo2 select 1 from generate_series(1,5);
+insert into foo2 select 2 from generate_series(1,4);
+insert into foo2 select 3 from generate_series(1,3);
+insert into foo2 select 4 from generate_series(1,2);
+insert into foo2 select 5 from generate_series(1,1);
+analyze foo2;
+-- current stats
+select stanumbers1, stavalues1 from pg_statistic where starelid='foo2'::regclass;
+       stanumbers1       | stavalues1  
+-------------------------+-------------
+ {0.3,0.25,0.2,0.15,0.1} | {1,2,3,4,5}
+(1 row)
+
+select check_row_count('explain select a from foo2 where a > 1 order by a;', 14);
+ check_row_count 
+-----------------
+ true
+(1 row)
+
+-- change stats manually so that MCV and MCF numbers do not match
+set allow_system_table_mods=DML;
+update pg_statistic set stavalues1='{6,3,1,5,4,2}'::int[] where starelid='foo2'::regclass;
+-- excercise the translator
+select check_row_count('explain select a from foo2 where a > 1 order by a;', 8);
+ check_row_count 
+-----------------
+ true
+(1 row)
+
+--
+-- test missing statistics
+--
+set gp_create_table_random_default_distribution=off;
+drop table if exists foo3;
+NOTICE:  table "foo3" does not exist, skipping
+create table foo3(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select * from gp_toolkit.gp_stats_missing where smischema = 'public' AND  smitable = 'foo';
+ smischema | smitable | smisize | smicols | smirecs 
+-----------+----------+---------+---------+---------
+(0 rows)
+
+--
+-- for Orca's Split Operator ensure that the columns needed for stats derivation is correct
+--
+set optimizer=on;
+set gp_create_table_random_default_distribution=off;
+drop table if exists bar_dml;
+NOTICE:  table "bar_dml" does not exist, skipping
+CREATE TABLE bar_dml (
+    vtrg character varying(6) NOT NULL,
+    tec_schuld_whg character varying(3) NOT NULL,
+    inv character varying(11) NOT NULL,
+    zed_id character varying(6) NOT NULL,
+    mkl_id character varying(6) NOT NULL,
+    zj integer NOT NULL,
+    folio integer NOT NULL,
+    zhlg_typ character varying(1) NOT NULL,
+    zhlg character varying(8) NOT NULL,
+    ant_zhlg double precision,
+    zuordn_sys_dat character varying(11),
+    zhlg_whg_bilkurs numeric(15,8),
+    tec_whg_bilkurs numeric(15,8),
+    zhlg_ziel_id character varying(1) NOT NULL,
+    btg_tec_whg_gesh numeric(13,2),
+    btg_tec_whg_makl numeric(13,2),
+    btg_zhlg_whg numeric(13,2),
+    zhlg_typ_org character varying(1),
+    zhlg_org character varying(8),
+    upd_dat date
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+update bar_dml set (zhlg_org, zhlg_typ_org) = (zhlg, zhlg_typ);
+drop table bar_dml;
+reset optimizer;
+--
+-- Cardinality estimation when there is no histogram and MCV
+--
+drop table if exists foo3;
+create table foo3 (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo3 select i from generate_series(1,99) i;
+insert into foo3 values (NULL);
+analyze foo3;
+select stanullfrac, stadistinct, stanumbers1 from pg_statistic where starelid='foo3'::regclass and staattnum=1;
+ stanullfrac | stadistinct | stanumbers1 
+-------------+-------------+-------------
+        0.01 |          -1 | 
+(1 row)
+
+select check_row_count('explain select a from foo3 where a > 888;', 1);
+ check_row_count 
+-----------------
+ true
+(1 row)
+
+--
+-- Testing that the merging of memo groups inside Orca does not crash cardinality estimation inside Orca
+--
+set optimizer = on;
+drop table if exists t1 cascade;
+NOTICE:  table "t1" does not exist, skipping
+create table t1(c1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1 values(1);
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo group by v;
+ v 
+---
+ 1
+(1 row)
+
+select v from (select max(c1) as v, 1 as r from t1 union all select 1 as v, 2 as r ) as foo group by v;
+ v 
+---
+ 1
+(1 row)
+
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo;
+ v 
+---
+ 1
+ 1
+(2 rows)
+
+select disable_xform('CXformPushGbBelowUnionAll');
+             disable_xform             
+---------------------------------------
+ CXformPushGbBelowUnionAll is disabled
+(1 row)
+
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo group by v;
+ v 
+---
+ 1
+(1 row)
+
+select enable_xform('CXformPushGbBelowUnionAll');
+             enable_xform             
+--------------------------------------
+ CXformPushGbBelowUnionAll is enabled
+(1 row)
+
+select disable_xform('CXformPushGbBelowUnion');
+           disable_xform            
+------------------------------------
+ CXformPushGbBelowUnion is disabled
+(1 row)
+
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo group by v;
+ v 
+---
+ 1
+(1 row)
+
+select enable_xform('CXformPushGbBelowUnion');
+           enable_xform            
+-----------------------------------
+ CXformPushGbBelowUnion is enabled
+(1 row)
+
+select disable_xform('CXformSimplifyGbAgg');
+          disable_xform          
+---------------------------------
+ CXformSimplifyGbAgg is disabled
+(1 row)
+
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo group by v;
+ v 
+---
+ 1
+(1 row)
+
+select enable_xform('CXformSimplifyGbAgg');
+          enable_xform          
+--------------------------------
+ CXformSimplifyGbAgg is enabled
+(1 row)
+
+reset optimizer;
+--
+-- test the generation of histogram boundaries for numeric and real data types
+--
+drop table if exists foo_real;
+NOTICE:  table "foo_real" does not exist, skipping
+create table foo_real (a int4, b real) distributed randomly;
+insert into foo_real values (0, 'Infinity');
+insert into foo_real values (0, '-Infinity');
+insert into foo_real values (0, 'NaN');
+insert into foo_real values (0, 'Infinity');
+insert into foo_real values (0, '-Infinity');
+insert into foo_real values (0, 'NaN');
+insert into foo_real values (0, 'Infinity');
+insert into foo_real values (0, '-Infinity');
+insert into foo_real values (0, 'NaN');
+insert into foo_real values (0, 'Infinity');
+insert into foo_real values (0, '-Infinity');
+insert into foo_real values (0, 'NaN');
+INSERT INTO foo_real VALUES (0, '0');
+INSERT INTO foo_real VALUES (1, '0');
+INSERT INTO foo_real VALUES (2, '-34338492.215397047');
+INSERT INTO foo_real VALUES (3, '4.31');
+INSERT INTO foo_real VALUES (4, '7799461.4119');
+INSERT INTO foo_real VALUES (5, '16397.038491');
+INSERT INTO foo_real VALUES (6, '93901.57763026');
+INSERT INTO foo_real VALUES (7, '-83028485');
+INSERT INTO foo_real VALUES (8, '74881');
+INSERT INTO foo_real VALUES (9, '-24926804.045047420');
+INSERT INTO foo_real VALUES (0, '0');
+INSERT INTO foo_real VALUES (1, '0');
+INSERT INTO foo_real VALUES (2, '-34338492.215397047');
+INSERT INTO foo_real VALUES (3, '4.31');
+INSERT INTO foo_real VALUES (4, '7799461.4119');
+INSERT INTO foo_real VALUES (5, '16397.038491');
+INSERT INTO foo_real VALUES (6, '93901.57763026');
+INSERT INTO foo_real VALUES (7, '-83028485');
+INSERT INTO foo_real VALUES (8, '74881');
+INSERT INTO foo_real VALUES (9, '-24926804.045047420');
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (9, '-24926804.045047420');
+INSERT INTO foo_real VALUES (0, '0');
+INSERT INTO foo_real VALUES (1, '0');
+INSERT INTO foo_real VALUES (2, '-34338492.215397047');
+INSERT INTO foo_real VALUES (3, '4.31');
+INSERT INTO foo_real VALUES (4, '7799461.4119');
+INSERT INTO foo_real VALUES (5, '16397.038491');
+INSERT INTO foo_real VALUES (6, '93901.57763026');
+INSERT INTO foo_real VALUES (7, '-83028485');
+INSERT INTO foo_real VALUES (8, '74881');
+INSERT INTO foo_real VALUES (9, '-24926804.045047420');
+ANALYZE foo_real;
+select histogram_bounds from pg_stats where tablename = 'foo_real' and attname = 'b';
+ histogram_bounds 
+------------------
+ 
+(1 row)
+
+select most_common_vals from pg_stats where tablename = 'foo_real' and attname = 'b';
+                                            most_common_vals                                            
+--------------------------------------------------------------------------------------------------------
+ {0,-Infinity,-2.49268e+07,Infinity,NaN,-8.30285e+07,-3.43385e+07,4.31,16397,74881,93901.6,7.79946e+06}
+(1 row)
+
+drop table if exists foo_numeric;
+NOTICE:  table "foo_numeric" does not exist, skipping
+create table foo_numeric (a int4, b numeric) distributed randomly;
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+INSERT INTO foo_numeric VALUES (0, '0');
+INSERT INTO foo_numeric VALUES (1, '0');
+INSERT INTO foo_numeric VALUES (2, '-34338492.215397047');
+INSERT INTO foo_numeric VALUES (3, '4.31');
+INSERT INTO foo_numeric VALUES (4, '7799461.4119');
+INSERT INTO foo_numeric VALUES (5, '16397.038491');
+INSERT INTO foo_numeric VALUES (6, '93901.57763026');
+INSERT INTO foo_numeric VALUES (7, '-83028485');
+INSERT INTO foo_numeric VALUES (8, '74881');
+INSERT INTO foo_numeric VALUES (9, '-24926804.045047420');
+INSERT INTO foo_numeric VALUES (0, '0');
+INSERT INTO foo_numeric VALUES (1, '0');
+INSERT INTO foo_numeric VALUES (2, '-34338492.215397047');
+INSERT INTO foo_numeric VALUES (3, '4.31');
+INSERT INTO foo_numeric VALUES (4, '7799461.4119');
+INSERT INTO foo_numeric VALUES (5, '16397.038491');
+INSERT INTO foo_numeric VALUES (6, '93901.57763026');
+INSERT INTO foo_numeric VALUES (7, '-83028485');
+INSERT INTO foo_numeric VALUES (8, '74881');
+INSERT INTO foo_numeric VALUES (9, '-24926804.045047420');
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (9, '-24926804.045047420');
+INSERT INTO foo_numeric VALUES (0, '0');
+INSERT INTO foo_numeric VALUES (1, '0');
+INSERT INTO foo_numeric VALUES (2, '-34338492.215397047');
+INSERT INTO foo_numeric VALUES (3, '4.31');
+INSERT INTO foo_numeric VALUES (4, '7799461.4119');
+INSERT INTO foo_numeric VALUES (5, '16397.038491');
+INSERT INTO foo_numeric VALUES (6, '93901.57763026');
+INSERT INTO foo_numeric VALUES (7, '-83028485');
+INSERT INTO foo_numeric VALUES (8, '74881');
+INSERT INTO foo_numeric VALUES (9, '-24926804.045047420');
+INSERT INTO foo_numeric SELECT i,i FROM generate_series(1,30) i;
+ANALYZE foo_numeric;
+select histogram_bounds from pg_stats where tablename = 'foo_numeric' and attname = 'b';
+                            histogram_bounds                             
+-------------------------------------------------------------------------
+ {1,2,3,4,5,6,7,9,10,11,12,13,14,16,17,18,19,20,21,23,24,25,26,27,28,30}
+(1 row)
+
+select most_common_vals from pg_stats where tablename = 'foo_numeric' and attname = 'b';
+                                               most_common_vals                                                
+---------------------------------------------------------------------------------------------------------------
+ {NaN,0,-24926804.045047420,-83028485,-34338492.215397047,4.31,16397.038491,74881,93901.57763026,7799461.4119}
+(1 row)
+
+reset gp_create_table_random_default_distribution;
+--
+-- Ensure that VACUUM ANALYZE does not result in incorrect statistics
+--
+DROP TABLE IF EXISTS T25289_T1;
+NOTICE:  table "t25289_t1" does not exist, skipping
+CREATE TABLE T25289_T1 (c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO T25289_T1 VALUES (1);
+DELETE FROM T25289_T1;
+ANALYZE T25289_T1;
+DROP TABLE T25289_T1;
+--
+-- expect NO more notice after customer run VACUUM FULL
+-- 
+DROP TABLE IF EXISTS T25289_T2;
+NOTICE:  table "t25289_t2" does not exist, skipping
+CREATE TABLE T25289_T2 (c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO T25289_T2 VALUES (1);
+DELETE FROM T25289_T2;
+VACUUM FULL;
+ANALYZE T25289_T2;
+DROP TABLE T25289_T2;
+--
+-- expect NO notice during analyze if table doesn't have empty pages
+--
+DROP TABLE IF EXISTS T25289_T3;
+NOTICE:  table "t25289_t3" does not exist, skipping
+CREATE TABLE T25289_T3 (c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO T25289_T3 VALUES (1);
+ANALYZE T25289_T3;
+DROP TABLE IF EXISTS T25289_T3;
+--
+-- expect NO notice when analyzing append only tables
+-- 
+DROP TABLE IF EXISTS T25289_T4;
+NOTICE:  table "t25289_t4" does not exist, skipping
+CREATE TABLE T25289_T4 (c int, d int)
+WITH (APPENDONLY=ON) DISTRIBUTED BY (c)
+PARTITION BY RANGE(d) (START(1) END (100) EVERY(1));
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_1" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_2" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_3" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_4" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_5" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_6" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_7" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_8" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_9" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_10" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_11" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_12" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_13" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_14" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_15" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_16" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_17" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_18" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_19" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_20" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_21" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_22" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_23" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_24" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_25" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_26" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_27" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_28" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_29" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_30" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_31" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_32" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_33" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_34" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_35" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_36" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_37" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_38" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_39" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_40" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_41" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_42" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_43" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_44" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_45" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_46" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_47" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_48" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_49" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_50" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_51" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_52" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_53" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_54" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_55" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_56" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_57" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_58" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_59" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_60" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_61" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_62" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_63" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_64" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_65" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_66" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_67" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_68" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_69" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_70" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_71" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_72" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_73" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_74" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_75" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_76" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_77" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_78" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_79" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_80" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_81" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_82" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_83" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_84" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_85" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_86" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_87" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_88" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_89" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_90" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_91" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_92" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_93" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_94" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_95" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_96" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_97" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_98" for table "t25289_t4"
+NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_99" for table "t25289_t4"
+ANALYZE T25289_T4;
+DROP TABLE IF EXISTS T25289_T4;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -79,6 +79,8 @@ test: aggregate_with_groupingsets gp_optimizer
 test: nested_case_null
 test: bfv_cte bfv_joins
 
+test: bfv_statistic
+
 ignore: tpch500GB_orca
 
 # XXX: This test depends on libgpoptudfs library, which includes ORCA helper

--- a/src/test/regress/sql/bfv_statistic.sql
+++ b/src/test/regress/sql/bfv_statistic.sql
@@ -1,0 +1,322 @@
+create language plpythonu;
+
+create or replace function check_row_count(query text, expected integer) returns text as
+$$
+output = plpy.execute(query)
+rows = output[0]['QUERY PLAN'].split('rows=')[1].split()[0]
+if int(rows) == expected:
+	return "true"
+return "false"
+$$
+language plpythonu;
+
+set optimizer = on;
+
+DROP TABLE IF EXISTS foo;
+create table foo (a int, b int) distributed by (a);
+insert into foo values (1,1);
+insert into foo values (0,1);
+insert into foo values (2,1);
+insert into foo values (null,1);
+analyze foo;
+
+-- current statistics
+select stanullfrac, stadistinct, stanumbers1 from pg_statistic where starelid='foo'::regclass and staattnum=1;
+
+-- exercise the translator
+select check_row_count('explain select * from foo where a is not null and b >= 1;', 3);
+drop table foo;
+
+DROP TABLE IF EXISTS foo2;
+create table foo2(a int) distributed by (a);
+insert into foo2 select generate_series(1,5);
+insert into foo2 select 1 from generate_series(1,5);
+insert into foo2 select 2 from generate_series(1,4);
+insert into foo2 select 3 from generate_series(1,3);
+insert into foo2 select 4 from generate_series(1,2);
+insert into foo2 select 5 from generate_series(1,1);
+
+analyze foo2;
+-- current stats
+select stanumbers1, stavalues1 from pg_statistic where starelid='foo2'::regclass;
+
+select check_row_count('explain select a from foo2 where a > 1 order by a;', 14);
+
+-- change stats manually so that MCV and MCF numbers do not match
+set allow_system_table_mods=DML;
+update pg_statistic set stavalues1='{6,3,1,5,4,2}'::int[] where starelid='foo2'::regclass;
+
+-- excercise the translator
+select check_row_count('explain select a from foo2 where a > 1 order by a;', 8);
+
+--
+-- test missing statistics
+--
+
+set gp_create_table_random_default_distribution=off;
+drop table if exists foo3;
+create table foo3(a int);
+
+select * from gp_toolkit.gp_stats_missing where smischema = 'public' AND  smitable = 'foo';
+
+--
+-- for Orca's Split Operator ensure that the columns needed for stats derivation is correct
+--
+
+set optimizer=on;
+set gp_create_table_random_default_distribution=off;
+
+drop table if exists bar_dml;
+
+CREATE TABLE bar_dml (
+    vtrg character varying(6) NOT NULL,
+    tec_schuld_whg character varying(3) NOT NULL,
+    inv character varying(11) NOT NULL,
+    zed_id character varying(6) NOT NULL,
+    mkl_id character varying(6) NOT NULL,
+    zj integer NOT NULL,
+    folio integer NOT NULL,
+    zhlg_typ character varying(1) NOT NULL,
+    zhlg character varying(8) NOT NULL,
+    ant_zhlg double precision,
+    zuordn_sys_dat character varying(11),
+    zhlg_whg_bilkurs numeric(15,8),
+    tec_whg_bilkurs numeric(15,8),
+    zhlg_ziel_id character varying(1) NOT NULL,
+    btg_tec_whg_gesh numeric(13,2),
+    btg_tec_whg_makl numeric(13,2),
+    btg_zhlg_whg numeric(13,2),
+    zhlg_typ_org character varying(1),
+    zhlg_org character varying(8),
+    upd_dat date
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+update bar_dml set (zhlg_org, zhlg_typ_org) = (zhlg, zhlg_typ);
+
+drop table bar_dml;
+
+reset optimizer;
+
+--
+-- Cardinality estimation when there is no histogram and MCV
+--
+
+drop table if exists foo3;
+create table foo3 (a int);
+
+insert into foo3 select i from generate_series(1,99) i;
+insert into foo3 values (NULL);
+analyze foo3;
+
+select stanullfrac, stadistinct, stanumbers1 from pg_statistic where starelid='foo3'::regclass and staattnum=1;
+
+select check_row_count('explain select a from foo3 where a > 888;', 1);
+
+--
+-- Testing that the merging of memo groups inside Orca does not crash cardinality estimation inside Orca
+--
+
+set optimizer = on;
+drop table if exists t1 cascade;
+
+create table t1(c1 int);
+insert into t1 values(1);
+
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo group by v;
+
+select v from (select max(c1) as v, 1 as r from t1 union all select 1 as v, 2 as r ) as foo group by v;
+
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo;
+
+select disable_xform('CXformPushGbBelowUnionAll');
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo group by v;
+select enable_xform('CXformPushGbBelowUnionAll');
+
+select disable_xform('CXformPushGbBelowUnion');
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo group by v;
+select enable_xform('CXformPushGbBelowUnion');
+
+select disable_xform('CXformSimplifyGbAgg');
+select v from (select max(c1) as v, 1 as r from t1 union select 1 as v, 2 as r ) as foo group by v;
+select enable_xform('CXformSimplifyGbAgg');
+
+reset optimizer;
+
+--
+-- test the generation of histogram boundaries for numeric and real data types
+--
+
+drop table if exists foo_real;
+create table foo_real (a int4, b real) distributed randomly;
+
+insert into foo_real values (0, 'Infinity');
+insert into foo_real values (0, '-Infinity');
+insert into foo_real values (0, 'NaN');
+insert into foo_real values (0, 'Infinity');
+insert into foo_real values (0, '-Infinity');
+insert into foo_real values (0, 'NaN');
+insert into foo_real values (0, 'Infinity');
+insert into foo_real values (0, '-Infinity');
+insert into foo_real values (0, 'NaN');
+insert into foo_real values (0, 'Infinity');
+insert into foo_real values (0, '-Infinity');
+insert into foo_real values (0, 'NaN');
+INSERT INTO foo_real VALUES (0, '0');
+INSERT INTO foo_real VALUES (1, '0');
+INSERT INTO foo_real VALUES (2, '-34338492.215397047');
+INSERT INTO foo_real VALUES (3, '4.31');
+INSERT INTO foo_real VALUES (4, '7799461.4119');
+INSERT INTO foo_real VALUES (5, '16397.038491');
+INSERT INTO foo_real VALUES (6, '93901.57763026');
+INSERT INTO foo_real VALUES (7, '-83028485');
+INSERT INTO foo_real VALUES (8, '74881');
+INSERT INTO foo_real VALUES (9, '-24926804.045047420');
+INSERT INTO foo_real VALUES (0, '0');
+INSERT INTO foo_real VALUES (1, '0');
+INSERT INTO foo_real VALUES (2, '-34338492.215397047');
+INSERT INTO foo_real VALUES (3, '4.31');
+INSERT INTO foo_real VALUES (4, '7799461.4119');
+INSERT INTO foo_real VALUES (5, '16397.038491');
+INSERT INTO foo_real VALUES (6, '93901.57763026');
+INSERT INTO foo_real VALUES (7, '-83028485');
+INSERT INTO foo_real VALUES (8, '74881');
+INSERT INTO foo_real VALUES (9, '-24926804.045047420');
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (10, NULL);
+INSERT INTO foo_real VALUES (9, '-24926804.045047420');
+INSERT INTO foo_real VALUES (0, '0');
+INSERT INTO foo_real VALUES (1, '0');
+INSERT INTO foo_real VALUES (2, '-34338492.215397047');
+INSERT INTO foo_real VALUES (3, '4.31');
+INSERT INTO foo_real VALUES (4, '7799461.4119');
+INSERT INTO foo_real VALUES (5, '16397.038491');
+INSERT INTO foo_real VALUES (6, '93901.57763026');
+INSERT INTO foo_real VALUES (7, '-83028485');
+INSERT INTO foo_real VALUES (8, '74881');
+INSERT INTO foo_real VALUES (9, '-24926804.045047420');
+
+ANALYZE foo_real;
+
+select histogram_bounds from pg_stats where tablename = 'foo_real' and attname = 'b';
+
+select most_common_vals from pg_stats where tablename = 'foo_real' and attname = 'b';
+
+drop table if exists foo_numeric;
+create table foo_numeric (a int4, b numeric) distributed randomly;
+
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+insert into foo_numeric values (0, 'NaN');
+INSERT INTO foo_numeric VALUES (0, '0');
+INSERT INTO foo_numeric VALUES (1, '0');
+INSERT INTO foo_numeric VALUES (2, '-34338492.215397047');
+INSERT INTO foo_numeric VALUES (3, '4.31');
+INSERT INTO foo_numeric VALUES (4, '7799461.4119');
+INSERT INTO foo_numeric VALUES (5, '16397.038491');
+INSERT INTO foo_numeric VALUES (6, '93901.57763026');
+INSERT INTO foo_numeric VALUES (7, '-83028485');
+INSERT INTO foo_numeric VALUES (8, '74881');
+INSERT INTO foo_numeric VALUES (9, '-24926804.045047420');
+INSERT INTO foo_numeric VALUES (0, '0');
+INSERT INTO foo_numeric VALUES (1, '0');
+INSERT INTO foo_numeric VALUES (2, '-34338492.215397047');
+INSERT INTO foo_numeric VALUES (3, '4.31');
+INSERT INTO foo_numeric VALUES (4, '7799461.4119');
+INSERT INTO foo_numeric VALUES (5, '16397.038491');
+INSERT INTO foo_numeric VALUES (6, '93901.57763026');
+INSERT INTO foo_numeric VALUES (7, '-83028485');
+INSERT INTO foo_numeric VALUES (8, '74881');
+INSERT INTO foo_numeric VALUES (9, '-24926804.045047420');
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (10, NULL);
+INSERT INTO foo_numeric VALUES (9, '-24926804.045047420');
+INSERT INTO foo_numeric VALUES (0, '0');
+INSERT INTO foo_numeric VALUES (1, '0');
+INSERT INTO foo_numeric VALUES (2, '-34338492.215397047');
+INSERT INTO foo_numeric VALUES (3, '4.31');
+INSERT INTO foo_numeric VALUES (4, '7799461.4119');
+INSERT INTO foo_numeric VALUES (5, '16397.038491');
+INSERT INTO foo_numeric VALUES (6, '93901.57763026');
+INSERT INTO foo_numeric VALUES (7, '-83028485');
+INSERT INTO foo_numeric VALUES (8, '74881');
+INSERT INTO foo_numeric VALUES (9, '-24926804.045047420');
+INSERT INTO foo_numeric SELECT i,i FROM generate_series(1,30) i;
+
+ANALYZE foo_numeric;
+
+select histogram_bounds from pg_stats where tablename = 'foo_numeric' and attname = 'b';
+
+select most_common_vals from pg_stats where tablename = 'foo_numeric' and attname = 'b';
+
+reset gp_create_table_random_default_distribution;
+
+--
+-- Ensure that VACUUM ANALYZE does not result in incorrect statistics
+--
+
+DROP TABLE IF EXISTS T25289_T1;
+
+CREATE TABLE T25289_T1 (c int);
+INSERT INTO T25289_T1 VALUES (1);
+DELETE FROM T25289_T1;
+ANALYZE T25289_T1;
+
+DROP TABLE T25289_T1;
+
+--
+-- expect NO more notice after customer run VACUUM FULL
+-- 
+DROP TABLE IF EXISTS T25289_T2;
+
+CREATE TABLE T25289_T2 (c int);
+INSERT INTO T25289_T2 VALUES (1);
+DELETE FROM T25289_T2;
+VACUUM FULL;
+ANALYZE T25289_T2;
+
+DROP TABLE T25289_T2;
+
+--
+-- expect NO notice during analyze if table doesn't have empty pages
+--
+
+DROP TABLE IF EXISTS T25289_T3;
+
+CREATE TABLE T25289_T3 (c int);
+INSERT INTO T25289_T3 VALUES (1);
+ANALYZE T25289_T3;
+
+DROP TABLE IF EXISTS T25289_T3;
+
+--
+-- expect NO notice when analyzing append only tables
+-- 
+
+DROP TABLE IF EXISTS T25289_T4;
+
+CREATE TABLE T25289_T4 (c int, d int)
+WITH (APPENDONLY=ON) DISTRIBUTED BY (c)
+PARTITION BY RANGE(d) (START(1) END (100) EVERY(1));
+ANALYZE T25289_T4;
+
+DROP TABLE IF EXISTS T25289_T4;


### PR DESCRIPTION
There are several test suites that are in TINC and cdbfast that are not visible to the OSS community.
This lack of visibility causes a lot of pain when the tests fails and we have to chase the root cause.

To avoid, this the query optimizer team is planning to:

Clean up these test suites
Move these tests to pg_regress (particularly installcheck-good)
Once this initial effort is done, if needed we can do another pass to optimize these tests.