### PR TITLE
Fix bfv_catalog test by ignoring potential error in language creation

### DIFF
--- a/src/test/regress/expected/bfv_catalog.out
+++ b/src/test/regress/expected/bfv_catalog.out
@@ -1,5 +1,7 @@
 -- count number of certain operators in a given plan
+-- start_ignore
 create language plpythonu;
+-- end_ignore
 create or replace function count_operator(explain_query text, operator text) returns int as
 $$
 rv = plpy.execute(explain_query)

--- a/src/test/regress/sql/bfv_catalog.sql
+++ b/src/test/regress/sql/bfv_catalog.sql
@@ -1,5 +1,7 @@
 -- count number of certain operators in a given plan
+-- start_ignore
 create language plpythonu;
+-- end_ignore
 
 create or replace function count_operator(explain_query text, operator text) returns int as
 $$


### PR DESCRIPTION
The `bfv_catalog` test started failing with #359 due to plpython being installed already. We shouldn't error out if plpythonu already exists, it's required for the test to run but it's not the thing we're testing here, so add ignore blocks for this.

@vraghavan78 : what do you think about this?
