### PR TITLE
Fix copy of error message during external table error handling.

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -768,7 +768,6 @@ else \
 \
 	ErrorData	*edata; \
 	MemoryContext oldcontext;\
-	bool	errmsg_is_a_copy = false; \
 \
 	/* SREH must only handle data errors. all other errors must not be caught */\
 	if(ERRCODE_TO_CATEGORY(elog_geterrcode()) != ERRCODE_DATA_EXCEPTION)\
@@ -797,19 +796,18 @@ else \
 		pstate->cdbsreh->errmsg = (char *) palloc((strlen(edata->message) + \
 												   strlen(pstate->cur_attname) + \
 												   10 + 1) * sizeof(char)); \
-		errmsg_is_a_copy = true; \
 		sprintf(pstate->cdbsreh->errmsg, "%s, column %s", \
 				edata->message, \
 				pstate->cur_attname); \
 	}\
 	else\
 	{\
-		pstate->cdbsreh->errmsg = edata->message; \
+		pstate->cdbsreh->errmsg = pstrdup(edata->message); \
 	}\
 \
 	HandleSingleRowError(pstate->cdbsreh); \
 	FreeErrorData(edata);\
-	if (errmsg_is_a_copy && !IsRejectLimitReached(pstate->cdbsreh)) \
+	if (!IsRejectLimitReached(pstate->cdbsreh)) \
 		pfree(pstate->cdbsreh->errmsg); \
 }
 


### PR DESCRIPTION
If an error is encountered while reading data from external tables,
FILEAM_HANDLE_ERROR sets pstate->cdbsreh->errmsg to edata->errmsg. It then
invokes FreeErrorData(). pstate->cdbsreh->errmsg is used to print out the error
message if segment reject limit is reached. This is incorrect since the memory
region it points to is no longer valid.

This patch fixes the issue by using pstrdup to copy the error message instead
of assigning the pointer.