### PR TITLE
Make relation size estimate use default in case ANALYZE statistics ar…

### DIFF
--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -402,8 +402,8 @@ cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 	reltuples = (double) rel->rd_rel->reltuples;
 
 	/*
-	 * Asking the QE for the size of the relation is a bit expensive.
-	 * Do we want to do it all the time?  Or only for tables that have never had analyze run?
+	 * Asking the QE for the size of the relation is a bit expensive. Hence we take defaults
+	 * relation size estimates.
 	 */
 
 	if (relpages > 0)
@@ -422,41 +422,11 @@ cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 	{
 
 		/*
-		 * Let's ask the QEs for the size of the relation.
-		 * In the future, it would be better to send the command to only one QE.
-		 *
-		 * NOTE: External tables should always have >0 values in pg_class
-		 * (created this way). Therefore we should never get here. However, as
-		 * a security measure (if values in pg_class were somehow changed) we
-		 * plug in our 1K pages 1M tuples estimate here as well, and skip
-		 * cdbRelSize as we can't calculate ext table size.
+		 * Put default estimates in case no statistics are available. This saves cost
+		 * of asking QEs
 		 */
-		if(!RelationIsExternal(rel))
-		{
-		    size = cdbRelSize(rel);
-		}
-		else
-		{
-			/*
-			 * Estimate a default of 1000 pages - see comment above.
-			 * NOTE: if you change this look at AddNewRelationTuple in heap.c).
-			 */
-			size = 1000 * BLCKSZ;
-		}
-
-
-		if (size < 0)
-		{
-			curpages = 100;
-			*default_stats_used = true;
-		}
-		else
-		{
-			curpages = size / BLCKSZ;  /* average blocks per primary segment DB */
-		}
-
-		if (curpages == 0 && size > 0)
-			curpages = 1;
+		 curpages = RelationIsExternal(rel) ? DEFAULT_EXTERNAL_TABLE_PAGES : DEFAULT_INTERNAL_TABLE_PAGES;
+		 *default_stats_used = true;
 	}
 
 	/* report estimated # pages */

--- a/src/include/optimizer/plancat.h
+++ b/src/include/optimizer/plancat.h
@@ -18,6 +18,8 @@
 #include "nodes/relation.h"
 #include "utils/relcache.h"
 
+#define DEFAULT_EXTERNAL_TABLE_PAGES 1000
+#define DEFAULT_INTERNAL_TABLE_PAGES 100
 
 extern void get_relation_info(PlannerInfo *root, Oid relationObjectId,
 				  bool inhparent, RelOptInfo *rel);


### PR DESCRIPTION
…e not available instead of asking QEs. This saves cost of the ask from QEs and makes planning a bit faster. Since we do not expect good plans in absence of statistics, we might as well use default estimates relation size as well