### PR TITLE
Fix coverity issue about Uninitialized scalar variable.

### DIFF
--- a/contrib/gp_sparse_vector/gp_sfv.c
+++ b/contrib/gp_sparse_vector/gp_sfv.c
@@ -223,6 +223,7 @@ SvecType *classify_document(char **features, int num_features, char **document, 
 		if (document[i] != NULL)
 		{
 		  item.key = document[i];
+		  item.data = NULL;
 		  if ((found_item = hsearch(item,FIND)) != NULL) {
 			/* Item is in the table */
 			histogram[*((int *)found_item->data)]++; //Increment the count at the appropriate ordinal


### PR DESCRIPTION
Coverity was complaining about item.data(item is a key value pair) not been reinitialized every time we to do an hsearch in a for loop . Setting item.data doesn't really matter because we are calling hsearch with FIND which only cares about the item.key and returns the appropriate item.data . But setting it to null is probably good practice so as to avoid any issues in the future.

