### PR TITLE
Fix ICG bfv_subquery and bfv_legacy test error

### DIFF
--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -69,8 +69,10 @@ where a = (select x.a from (select distinct a from bfv_subquery_s2 where bfv_sub
  1 | 1
 (1 row)
 
+-- start_ignore
 DROP FUNCTION IF EXISTS csq_f(a int);
 NOTICE:  function csq_f(pg_catalog.int4) does not exist, skipping
+-- end_ignore
 CREATE FUNCTION csq_f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL;
 --start_ignore
 DROP TABLE IF EXISTS csq_r;

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -69,8 +69,10 @@ where a = (select x.a from (select distinct a from bfv_subquery_s2 where bfv_sub
  1 | 1
 (1 row)
 
+-- start_ignore
 DROP FUNCTION IF EXISTS csq_f(a int);
 NOTICE:  function csq_f(pg_catalog.int4) does not exist, skipping
+-- end_ignore
 CREATE FUNCTION csq_f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL;
 --start_ignore
 DROP TABLE IF EXISTS csq_r;

--- a/src/test/regress/sql/bfv_subquery.sql
+++ b/src/test/regress/sql/bfv_subquery.sql
@@ -52,7 +52,9 @@ insert into bfv_subquery_s2 values (1,1);
 select * from bfv_subquery_r2 
 where a = (select x.a from (select distinct a from bfv_subquery_s2 where bfv_subquery_s2.b = bfv_subquery_r2	.b) x);
 
+-- start_ignore
 DROP FUNCTION IF EXISTS csq_f(a int);
+-- end_ignore
 CREATE FUNCTION csq_f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL;
 
 --start_ignore


### PR DESCRIPTION
This fix makes master tests green.

@vraghavan78 @xinzweb @oarap Please take a look.
Sorry about the irrelevant diffs that is caused by text editor. I am going to change my text editor.