### PR TITLE
Added check for ordinal position not matching source and destination

### DIFF
--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -3612,7 +3612,7 @@ class GpTransfer(object):
         if len(src_tbl_columns) != len(dest_tbl_columns):
             return False
         for ordinal_pos in src_tbl_columns:
-            if src_tbl_columns[ordinal_pos] != dest_tbl_columns[ordinal_pos]:
+            if (ordinal_pos not in dest_tbl_columns) or (src_tbl_columns[ordinal_pos] != dest_tbl_columns[ordinal_pos]):
                 return False
         return True
 


### PR DESCRIPTION
Added check for Key value ordinal position not matching source and destination for Gptransfer

While running gptransfer with --partition-table option, user got KeyError: 83 as key value was not present in the dictionary. Therefore, added a check if the key value is not present in the dictionary then it will return error.