### PR TITLE
Couple of fixes

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -919,12 +919,7 @@ void AOCSFileSegInfoAddVpe(Relation prel, AppendOnlyEntry *aoEntry, int32 segno,
 				d[Anum_pg_aocs_vpinfo-1]);
 		struct varlena *dv = pg_detoast_datum(v);
 		Assert(VARSIZE(dv) == aocs_vpinfo_size(nvp - num_newcols));
-		oldvpinfo = create_aocs_vpinfo(nvp - num_newcols);
-		memcpy(oldvpinfo, dv, aocs_vpinfo_size(nvp - num_newcols));
-		if(dv!=v)
-		{
-			pfree(dv);
-		}
+		oldvpinfo = (AOCSVPInfo *)dv;
 		Assert(oldvpinfo->nEntry + num_newcols == nvp);
 		/* copy existing columns' eofs to new vpinfo */
 		for (i = 0; i < oldvpinfo->nEntry; ++i)
@@ -940,6 +935,10 @@ void AOCSFileSegInfoAddVpe(Relation prel, AppendOnlyEntry *aoEntry, int32 segno,
 			newvpinfo->entry[i].eof_uncompressed =
 					desc->dsw[j]->eofUncompress;
 		}
+		if(dv!=v)
+		{
+			pfree(dv);
+		}
 	}
 	d[Anum_pg_aocs_vpinfo-1] = PointerGetDatum(newvpinfo);
 	null[Anum_pg_aocs_vpinfo-1] = false;
@@ -952,10 +951,6 @@ void AOCSFileSegInfoAddVpe(Relation prel, AppendOnlyEntry *aoEntry, int32 segno,
 
 	pfree(newtup);
 	pfree(newvpinfo);
-	if (!empty)
-	{
-		pfree(oldvpinfo);
-	}
 
 	index_endscan(scan);
 	/*

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1841,6 +1841,7 @@ checkIODataDirectory(void)
 	int fd;
 	char filename[MAXPGPATH];
 	int size = BLCKSZ + BLCKSZ;
+	int magic_len = strlen(FTS_PROBE_MAGIC_STRING) + 1;
 	char *data = malloc(size);
 	if (data == NULL)
 	{
@@ -1876,8 +1877,7 @@ checkIODataDirectory(void)
 							errmsg("FTS: could not create file \"%s\": %m", 
 								filename)));
 				}
-				int len = strlen(FTS_PROBE_MAGIC_STRING);
-				strncpy(dataAligned, FTS_PROBE_MAGIC_STRING, len);
+				strncpy(dataAligned, FTS_PROBE_MAGIC_STRING, magic_len);
 				if (write(fd, dataAligned, BLCKSZ) != BLCKSZ)
 				{
 					ereport(LOG, (errcode_for_file_access(), 
@@ -1910,11 +1910,9 @@ checkIODataDirectory(void)
 			break;
 		}
 
-		if (strncmp(dataAligned, FTS_PROBE_MAGIC_STRING, strlen(FTS_PROBE_MAGIC_STRING)) != 0)
+		if (strncmp(dataAligned, FTS_PROBE_MAGIC_STRING, magic_len) != 0)
 		{
-			ereport(LOG, (errmsg("FTS: Failed to compare read data (%s) "
-					"from file with MAGIC (%s)",
-	                                data, FTS_PROBE_MAGIC_STRING)));
+			ereport(LOG, (errmsg("FTS: Read corrupted data from \"%s\" file", filename)));
 			failure = true;
 			break;
 		}


### PR DESCRIPTION
1] Found during code browsing, can avoid allocating separate memory for vpinfo, use just pointer. Not big of a problem but better to avoid.
2] Coverity issue to include null terminator.