### PR TITLE
Remove duplicate entry of bfv_legacy from greenplum_schedule

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -75,7 +75,7 @@ test: filespace trig auth_constraint role rle portals_updatable plpgsql_cache ti
 # direct dispatch tests
 test: bfv_dd bfv_dd_multicolumn bfv_dd_types
 
-test: catalog bfv_catalog bfv_legacy bfv_index
+test: catalog bfv_catalog bfv_index
  
 test: aggregate_with_groupingsets gp_optimizer 
 


### PR DESCRIPTION
In the recent work to port tests from tinc to icg a duplicate entry for this testsuite snuck in. I assume this was an oversight and that there is no rationale for running `bfv_legacy` twice?

@vraghavan78 @ashwinstar @xinzweb since you guys have been hacking here, does this PR make sense?