### PR TITLE
Added check for restoration of nonexistent table

### DIFF
--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -442,7 +442,8 @@ class GpdbRestore(Operation):
 
         table_counts = []
         if len(self.restore_tables) > 0 or len(self.schema_level_restore_list) > 0:
-            self.restore_tables, self.schema_level_restore_list = validate_tablenames(self.restore_tables, self.schema_level_restore_list)
+            self.restore_tables, self.schema_level_restore_list = validate_tablenames(self.restore_tables, self.master_datadir, self.backup_dir, self.dump_dir,
+                                                                                      self.dump_prefix, restore_timestamp, self.schema_level_restore_list)
 
         if not self.db_host_path and not self.ddboost:
             report_filename = generate_report_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, restore_timestamp)

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -1167,7 +1167,7 @@ class ValidateSegments(Operation):
                 if not exists:
                     raise ExceptionNoStackTraceNeeded("No dump file on %s at %s" % (seg.getSegmentHostName(), path))
 
-def validate_tablenames(table_list, schema_level_restore_list=None):
+def validate_tablenames(table_list, master_data_dir, backup_dir, dump_dir, dump_prefix, timestamp, schema_level_restore_list=None):
     """
     verify table list, and schema list, resolve duplicates and overlaps
     """
@@ -1175,9 +1175,11 @@ def validate_tablenames(table_list, schema_level_restore_list=None):
     restore_table_list = []
     table_set = set()
 
+    # validate special characters
     check_funny_chars_in_names(schema_level_restore_list, is_full_qualified_name = False)
     check_funny_chars_in_names(table_list)
 
+    # validate schemas
     if schema_level_restore_list:
         schema_level_restore_list = list(set(schema_level_restore_list))
 
@@ -1186,11 +1188,28 @@ def validate_tablenames(table_list, schema_level_restore_list=None):
             raise Exception("No schema name supplied for %s, removing from list of tables to restore" % restore_table)
         schema, table = split_fqn(restore_table)
         # schema level restore will be handled before specific table restore, treat as duplicate
-        if (schema_level_restore_list and schema in schema_level_restore_list) or (schema, table) in table_set:
-            continue
-        else:
+        if not ((schema_level_restore_list and schema in schema_level_restore_list) or (schema, table) in table_set):
             table_set.add((schema, table))
             restore_table_list.append(restore_table)
+
+    # validate tables
+    filename = generate_metadata_filename(master_data_dir, backup_dir, dump_dir, dump_prefix, timestamp)
+    lines = get_lines_from_file(filename)
+
+    with open(filename) as fd:
+        for line in fd:
+            pattern = "-- Name: (.+); Type: (.+); Schema: (.+);"
+            match = search(pattern, line)
+            if match is None:
+                continue
+            name, type, schema = match.group(1), match.group(2), match.group(3)
+            if type == "TABLE":
+                schema = pg.escape_string(schema)
+                name = pg.escape_string(name)
+                dumped_table = '%s.%s' % (schema, name)
+                # no escaping needed, both restore_table_list and metadata file have un-escaped schema and table names
+                if dumped_table not in restore_table_list:
+                    raise Exception("Table %s not found in backup" % dumped_table)
 
     return restore_table_list, schema_level_restore_list 
 

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -2984,8 +2984,6 @@ Feature: Validate command line arguments
         And verify that the table "public.heap_index_table" in database "bkdb" is not analyzed
         And verify that the restored table "public.heap_table" in database "bkdb" is analyzed
 
-    @spl_char
-    @spl_char_1
     Scenario: Simple full backup and restore with special character
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3003,8 +3001,6 @@ Feature: Validate command line arguments
         And the directory "/tmp/special_table_data.out" is removed or does not exist
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 ""
 
-    @spl_char
-    @spl_char_2
     Scenario: Funny characters in the table name or schema name for gpcrondump
         Given the test is initialized
         And the database "testdb" does not exist
@@ -3038,8 +3034,6 @@ Feature: Validate command line arguments
         Then gpcrondump should return a return code of 2
         And gpcrondump should print Name has an invalid character "\\t" "\\n" "!" "," "." to stdout
 
-    @spl_char
-    @spl_char_3
     Scenario: Funny characters in the table name or schema name for gpdbrestore
         Given the test is initialized
         And database "testdb" exists
@@ -3064,8 +3058,6 @@ Feature: Validate command line arguments
         Then gpdbrestore should return a return code of 2
         And gpdbrestore should print Name has an invalid character to stdout
 
-    @spl_char
-    @spl_char_4
     Scenario: gpcrondump with -T option where table name, schema name and database name contains special character
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3085,8 +3077,6 @@ Feature: Validate command line arguments
         And verify that there is no table " co_T`~@#$%^&*()-+[{]}|\;: \'"/?><1 " in " DB`~@#$%^&*()_-+[{]}|\;: \'/?><;1 "
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 ""
 
-    @spl_char
-    @spl_char_5
     Scenario: gpcrondump with --exclude-table-file option where table name, schema name and database name contains special character
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3104,8 +3094,6 @@ Feature: Validate command line arguments
         And verify that there is no table " co_T`~@#$%^&*()-+[{]}|\;: \'"/?><1 " in " DB`~@#$%^&*()_-+[{]}|\;: \'/?><;1 "
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 ""
 
-    @spl_char
-    @spl_char_6
     Scenario: gpcrondump with --table-file option where table name, schema name and database name contains special character
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3125,8 +3113,6 @@ Feature: Validate command line arguments
         And verify that there is no table " co_T`~@#$%^&*()-+[{]}|\;: \'"/?><1 " in " DB`~@#$%^&*()_-+[{]}|\;: \'/?><;1 "
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 ""
 
-    @spl_char
-    @spl_char_7
     Scenario: gpcrondump with -t option where table name, schema name and database name contains special character
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3146,8 +3132,6 @@ Feature: Validate command line arguments
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 ""
 
 
-    @spl_char
-    @spl_char_8
     Scenario: gpcrondump with --schema-file, --exclude-schema-file, -s and -S option when schema name and database name contains special character
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3197,8 +3181,6 @@ Feature: Validate command line arguments
         And the directory "/tmp/specail_schema_data.out" is removed or does not exist
         And the directory "/tmp/specail_schema_data.ans" is removed or does not exist
 
-    @spl_char
-    @spl_char_9
     Scenario: Gpcrondump, --table-file, --exclude-table-file, --schema-file and --exclude-schema-file if file contains double quoted table and schema name then gpcrondump should error out finding table does not exists
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3222,8 +3204,6 @@ Feature: Validate command line arguments
         Then gpcrondump should return a return code of 0
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/drop_special_database.sql template1"
 
-    @spl_char
-    @spl_char_10
     Scenario: Gpdbrestore, --change-schema option does not work with -S schema level restore option
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3237,8 +3217,6 @@ Feature: Validate command line arguments
         And gpcrondump should print -S schema level restore does not work with --change-schema option to stdout
 
 
-    @spl_char
-    @spl_char_11
     Scenario: Gpdbrestore with --table-file, -T, --truncate and --change-schema options when table name, schema name and database name contains special character
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3278,8 +3256,6 @@ Feature: Validate command line arguments
         And the directory "/tmp/table_data.out" is removed or does not exist
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 ""
 
-    @spl_char
-    @spl_char_12
     Scenario: gpcrondump with --incremental option when table name, schema name and database name contains special character
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3305,8 +3281,6 @@ Feature: Validate command line arguments
         And the directory "/tmp/special_table_data.ans" is removed or does not exist
 
 
-    @spl_char
-    @spl_char_13
     Scenario: gpdbrestore, --redirect option with special db name, and all table name, schema name and database name contain special character
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3328,15 +3302,11 @@ Feature: Validate command line arguments
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 ""
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;2 ""
 
-    @spl_char
-    @spl_char_14
     Scenario: gpdbrestore, -s option with special chars
         Given the test is initialized
         When the user runs command "gpdbrestore -s " DB\`~@#\$%^&*()_-+[{]}|\\;:.;\n\t \\'/?><;2 ""
         Then gpdbrestore should print Name has an invalid character to stdout
 
-    @spl_char
-    @spl_char_15
     Scenario: gpdbrestore, -S option, schema level restore with special chars in schema name
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3357,8 +3327,6 @@ Feature: Validate command line arguments
         And the directory "/tmp/special_table_data.ans" is removed or does not exist
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 ""
 
-    @spl_char
-    @spl_char_16
     Scenario: gpdbrestore, --noplan option with special chars in database name, schema name, and table name
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
@@ -3382,6 +3350,17 @@ Feature: Validate command line arguments
         And the directory "/tmp/special_ao_table_data.out" is removed or does not exist
         And the directory "/tmp/special_ao_table_data.ans" is removed or does not exist
         And the user runs command "dropdb " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 ""
+
+	Scenario: Restoring a nonexistent table should fail with clear error message
+        Given the test is initialized
+        And there is a "heap" table "heap_table" in "bkdb" with data
+        When the user runs "gpcrondump -a -x bkdb"
+        Then gpcrondump should return a return code of 0
+        And the timestamp from gpcrondump is stored
+        When the user runs gpdbrestore with the stored timestamp and options "-T public.heap_table2"
+        Then gpdbrestore should return a return code of 2
+        Then gpdbrestore should print Table public.heap_table2 not found in backup to stdout
+        Then gpdbrestore should not print Issue with 'ANALYZE' of restored table 'public.heap_table2' in 'bkdb' database to stdout
 
     # THIS SHOULD BE THE LAST TEST
     @backupfire


### PR DESCRIPTION
Previously, gpdbrestore had no check to determine whether a table to be restored with the -T option existed in the dump, and the restore would either fail during the ANALYZE step with an unclear message or would succeed if --noanalyze was used.  This commit adds a check to fail early if a nonexistent table is passed to -T.