### PR TITLE
Support local configuration of synchronized folders in Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ lib*dll.defautom4te.cache
 **/test/*.t
 **/tags
 *.pyc
+**/vagrant-local.yml
 
 # Local excludes in root directory
 /GNUmakefile

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -75,6 +75,16 @@ While you are viewing the Vagrantfile, a few more things to notice here are:
 * Notice the parameter `config.vm.synced_folder`. This configuration requests
   that the code you checked out is mounted as `/gpdb` in the virtual machine.
   More on this later below.
+* Additional synced folders can be configured by adding a `vagrant-local.yml`
+  configuration file on the following format:
+
+```yaml
+synced_folder:
+    - local: /local/folder
+      shared: /folder/in/vagrant
+    - local: /another/local/folder
+      shared: /another/folder/in/vagrant
+```
 
 Once the command above (`vagrant up`) returns, we are ready to login to the
 virtual machine. Type in the following command into the terminal window

--- a/vagrant/centos/Vagrantfile
+++ b/vagrant/centos/Vagrantfile
@@ -1,4 +1,5 @@
 # Original Authors: Navneet Potti, Nabarun Nag and Jignesh Patel
+require 'yaml'
 
 # IP Address for the private VM network
 ip_address = "192.168.10.200"
@@ -24,6 +25,13 @@ Vagrant.configure(2) do |config|
 
   # Make the GPDB code folder will be visible as /gpdb in the virtual machine
   config.vm.synced_folder "../../.", "/gpdb"
+
+  if File.file?('vagrant-local.yml')
+    local_config = YAML::load_file('vagrant-local.yml')
+    local_config['synced_folder'].each do |folder|
+      config.vm.synced_folder folder['local'], folder['shared'] unless folder['local'].nil? or folder['shared'].nil?
+    end
+  end
 
   # Install packages that are needed to build and run GPDB
   config.vm.provision "shell", path: "vagrant-setup.sh"

--- a/vagrant/debian/Vagrantfile
+++ b/vagrant/debian/Vagrantfile
@@ -1,3 +1,5 @@
+require 'yaml'
+
 Vagrant.configure("2") do |config|
   config.vm.box     = 'debian/jessie64'
 
@@ -33,6 +35,14 @@ Vagrant.configure("2") do |config|
 
   nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
   config.vm.synced_folder "../..", "/gpdb",type: "nfs"
+
+  if File.file?('vagrant-local.yml')
+    local_config = YAML::load_file('vagrant-local.yml')
+    local_config['synced_folder'].each do |folder|
+      config.vm.synced_folder folder['local'], folder['shared'] unless folder['local'].nil? or folder['shared'].nil?
+    end
+  end
+
 
   config.vm.provision "shell", path: "vagrant-setup.sh"
   #config.vm.provision "shell", path: "vagrant-build.sh"


### PR DESCRIPTION
Add support to the vagrantfiles for having additional synced_folders locally without having to patch the Vagrantfile. Local folders are configured in a YAML file in the same directory as the Vagrantfile on the following format:

```YAML
synced_folder:
   - local: ../../../orca/gporca
     shared: /gporca
   - local: ../../../orca/gpos
     shared: /gpos
```

This is the first time I write any Ruby code so anyone with more experience might have suggestions on improvements.