### PR TITLE
Use the socket module to retrieve the FQDN rather than commandline

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -121,6 +121,7 @@ valid_tokens = {
     "preload": {'parse_children': True, 'parent': 'gpload'},
     "truncate": {'parse_children': False, 'parent': 'preload'},
     "reuse_tables": {'parse_children': False, 'parent': 'preload'},
+    "fully_qualified_domain_name": {'parse_children': False, 'parent': 'preload'},
     "sql": {'parse_children': True, 'parent': 'gpload'},
     "before": {'parse_children': False, 'parent': 'sql'},
     "after": {'parse_children': False, 'parent': 'sql'},

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -110,6 +110,7 @@ valid_tokens = {
     "error_table": {'parse_children': True, 'parent': "input"},
     "log_errors": {'parse_children': False, 'parent': "input"},
     "header": {'parse_children': True, 'parent': "input"},
+    "fully_qualified_domain_name": {'parse_children': False, 'parent': 'input'},
     "output": {'parse_children': True, 'parent': "gpload"},
     "table": {'parse_children': True, 'parent': "output"}, 
     "mode": {'parse_children': True, 'parent': "output"},
@@ -121,7 +122,6 @@ valid_tokens = {
     "preload": {'parse_children': True, 'parent': 'gpload'},
     "truncate": {'parse_children': False, 'parent': 'preload'},
     "reuse_tables": {'parse_children': False, 'parent': 'preload'},
-    "fully_qualified_domain_name": {'parse_children': False, 'parent': 'preload'},
     "sql": {'parse_children': True, 'parent': 'gpload'},
     "before": {'parse_children': False, 'parent': 'sql'},
     "after": {'parse_children': False, 'parent': 'sql'},
@@ -1632,7 +1632,7 @@ class gpload:
             if not local_hostname:
                 # if fully_qualified_domain_name is defined and set to true we want to
                 # resolve the fqdn rather than just grabbing the hostname.
-                fqdn = self.getconfig(name+':fully_qualified_domain_name', bool, False)
+                fqdn = self.getconfig('gpload:input:fully_qualified_domain_name', bool, False)
                 if fqdn:
                     local_hostname = socket.getfqdn()
                 else:

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -51,6 +51,7 @@ except Exception, e:
 import hashlib
 import datetime,getpass,os,signal,socket,subprocess,threading,time,traceback,re
 import uuid
+import socket
 
 thePlatform = platform.system()
 if thePlatform in ['Windows', 'Microsoft']:
@@ -1628,15 +1629,13 @@ class gpload:
 
             # do default host, the current one
             if not local_hostname:
-                try:
-                    pipe = subprocess.Popen("hostname",
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.PIPE)
-                    result  = pipe.communicate();
-                except OSError, e:
-                    self.log(self.ERROR, "command failed: " + str(e))
-                
-                local_hostname = [result[0].strip()]
+                # if fully_qualified_domain_name is defined and set to true we want to
+                # resolve the fqdn rather than just grabbing the hostname.
+                fqdn = self.getconfig(name+':fully_qualified_domain_name', bool, False)
+                if fqdn:
+                    local_hostname = socket.getfqdn()
+                else:
+                    local_hostname = socket.gethostname()
 
             # build gpfdist parameters
             popenList = ['gpfdist']

--- a/gpMgmt/bin/gppylib/test/unit/allconfig.yml
+++ b/gpMgmt/bin/gppylib/test/unit/allconfig.yml
@@ -17,6 +17,7 @@ GPLOAD:
         - msg: text
     - FORMAT: csv
     - QUOTE: '"'
+    - FULLY_QUALIFIED_DOMAIN_NAME: true
   OUTPUT:
     - TABLE: test
     - MODE: merge
@@ -30,4 +31,3 @@ GPLOAD:
 
   PRELOAD:
     - REUSE_TABLES: true 
-    - FULLY_QUALIFIED_DOMAIN_NAME: true

--- a/gpMgmt/bin/gppylib/test/unit/allconfig.yml
+++ b/gpMgmt/bin/gppylib/test/unit/allconfig.yml
@@ -1,0 +1,33 @@
+VERSION: 1.0.0.1
+DATABASE: odbcdb 
+USER: gpadmin
+HOST: mdw
+PORT: 16789
+
+GPLOAD:
+  INPUT:
+    - SOURCE:
+        LOCAL_HOSTNAME:
+          - mdw
+        PORT: 1981
+        FILE:
+          - /data/home/gpadmin/yydzero/work/sample.csv
+    - COLUMNS:
+        - id: int
+        - msg: text
+    - FORMAT: csv
+    - QUOTE: '"'
+  OUTPUT:
+    - TABLE: test
+    - MODE: merge
+    - MATCH_COLUMNS:
+        - id
+    - UPDATE_COLUMNS:
+        - msg
+    - MAPPING:
+        id: id
+        msg: msg
+
+  PRELOAD:
+    - REUSE_TABLES: true 
+    - FULLY_QUALIFIED_DOMAIN_NAME: true

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
@@ -43,12 +43,12 @@ class GpLoadTestCase(unittest.TestCase):
         self.assertEqual(self.commit, expected_commit_value)
 
     def test_reuse_exttbl_with_errtbl_and_limit(self):
-	gploader = gpload(['-f', os.path.join(os.path.dirname(__file__), 'gpload_merge.yml')])
+        gploader = gpload(['-f', os.path.join(os.path.dirname(__file__), 'gpload_merge.yml')])
         gploader.read_config()
-	gploader.locations = [ 'gpfdist://localhost:8080/test' ]
+        gploader.locations = [ 'gpfdist://localhost:8080/test' ]
         rejectLimit = '9999'
 
-	sql = gploader.get_reuse_exttable_query('csv', 'header', None, {}, None, False)
+        sql = gploader.get_reuse_exttable_query('csv', 'header', None, {}, None, False)
         self.assertTrue('pgext.fmterrtbl IS NULL' in sql)
         self.assertTrue('pgext.rejectlimit IS NULL' in sql)
 
@@ -91,6 +91,14 @@ class GpLoadTestCase(unittest.TestCase):
          self.help_test_with_config(['--no_auto_trans', '-f', os.path.join(os.path.dirname(__file__), 'gpload_update.yml')],
                               False,
                               False)
+
+    def test_case_configvalue(self):
+        gploader = gpload(['-f', os.path.join(os.path.dirname(__file__), 'allconfig.yml')])
+        self.assertEqual(u'test', gploader.getconfig('gpload:output:table'))
+        self.assertEqual(1981, gploader.getconfig('gpload:input:source:port', int))
+        self.assertEqual(True, gploader.getconfig('gpload:preload:reuse_tables', bool))
+        self.assertEqual(False, gploader.getconfig('gpload:input:log_errors', bool, False))
+        self.assertEqual(True, gploader.getconfig('gpload:preload:fully_qualified_domain_name', bool))
 
 
 #------------------------------- Mainline --------------------------------

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpload.py
@@ -98,7 +98,7 @@ class GpLoadTestCase(unittest.TestCase):
         self.assertEqual(1981, gploader.getconfig('gpload:input:source:port', int))
         self.assertEqual(True, gploader.getconfig('gpload:preload:reuse_tables', bool))
         self.assertEqual(False, gploader.getconfig('gpload:input:log_errors', bool, False))
-        self.assertEqual(True, gploader.getconfig('gpload:preload:fully_qualified_domain_name', bool))
+        self.assertEqual(True, gploader.getconfig('gpload:input:fully_qualified_domain_name', bool))
 
 
 #------------------------------- Mainline --------------------------------


### PR DESCRIPTION
Pull request #294 seems to have stalled or been abandoned so I had a look at it rather than just closing since the gist of the change seems reasonable. In order to retrieve the FQDN in a portable manner the Python socket module seems the best bet. It also avoids the overhead of opening a command interpreter and pipe to get the information. I'm still not entirely convinced that we should grab the fqdn without for example a command line switch asking us to but I can see scenarios where fqdn would be desirable. 

So, the question is: do we want fqdn and if so, should that be default or behind a command line switch to gpload? Also, since I'm very much not a Python programmer this patch needs verification by the Python experts out there.