### PR TITLE
Remove inaccurate assertion.

### DIFF
--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -1,0 +1,66 @@
+-- Test DELETE and UPDATE on an inherited table.
+-- The special aspect of this table is that the inherited table has
+-- a different distribution key. 'p' table's distribution key matches
+-- that of 'r', but 'p2's doesn't. Test that the planner adds a Motion
+-- node correctly for p2.
+create table todelete (a int) distributed by (a);
+create table parent (a int, b int, c int) distributed by (a);
+create table child (a int, b int, c int) inherits (parent) distributed by (b);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+NOTICE:  merging column "c" with inherited definition
+insert into parent select g, g, g from generate_series(1,5) g;
+insert into child select g, g, g from generate_series(6,10) g;
+insert into todelete select generate_series(3,4);
+delete from parent using todelete where parent.a = todelete.a;
+insert into todelete select generate_series(5,7);
+update parent set c=c+100 from todelete where parent.a = todelete.a;
+select * from parent;
+ a  | b  |  c  
+----+----+-----
+  1 |  1 |   1
+  5 |  5 | 105
+  9 |  9 |   9
+  7 |  7 | 107
+  2 |  2 |   2
+  8 |  8 |   8
+ 10 | 10 |  10
+  6 |  6 | 106
+(8 rows)
+
+drop table todelete;
+drop table child;
+drop table parent;
+-- This is similar to the above, but with a partitioned table (which is
+-- implemented by inheritance) rather than an explicitly inherited table.
+-- The scans on some of the partitions degenerate into Result nodes with
+-- False one-time filter, which don't need a Motion node.
+create table todelete (a int, b int) distributed by (a);
+create table target (a int, b int, c int)
+        distributed by (a)
+        partition by range (c) (start(1) end(5) every(1), default partition extra);
+NOTICE:  CREATE TABLE will create partition "target_1_prt_extra" for table "target"
+NOTICE:  CREATE TABLE will create partition "target_1_prt_2" for table "target"
+NOTICE:  CREATE TABLE will create partition "target_1_prt_3" for table "target"
+NOTICE:  CREATE TABLE will create partition "target_1_prt_4" for table "target"
+NOTICE:  CREATE TABLE will create partition "target_1_prt_5" for table "target"
+insert into todelete select g, g % 4 from generate_series(1, 10) g;
+insert into target select g, 0, 3 from generate_series(1, 5) g;
+insert into target select g, 0, 1 from generate_series(1, 5) g;
+delete from target where c = 3 and a in (select b from todelete);
+insert into todelete values (1, 5);
+update target set b=target.b+100 where c = 3 and a in (select b from todelete);
+select * from target;
+ a |  b  | c 
+---+-----+---
+ 2 |   0 | 1
+ 4 |   0 | 1
+ 4 |   0 | 3
+ 1 |   0 | 1
+ 3 |   0 | 1
+ 5 |   0 | 1
+ 5 | 100 | 3
+(7 rows)
+
+drop table todelete;
+drop table target;

--- a/src/test/regress/sql/update_gp.sql
+++ b/src/test/regress/sql/update_gp.sql
@@ -1,0 +1,50 @@
+-- Test DELETE and UPDATE on an inherited table.
+-- The special aspect of this table is that the inherited table has
+-- a different distribution key. 'p' table's distribution key matches
+-- that of 'r', but 'p2's doesn't. Test that the planner adds a Motion
+-- node correctly for p2.
+create table todelete (a int) distributed by (a);
+create table parent (a int, b int, c int) distributed by (a);
+create table child (a int, b int, c int) inherits (parent) distributed by (b);
+
+insert into parent select g, g, g from generate_series(1,5) g;
+insert into child select g, g, g from generate_series(6,10) g;
+
+insert into todelete select generate_series(3,4);
+
+delete from parent using todelete where parent.a = todelete.a;
+
+insert into todelete select generate_series(5,7);
+
+update parent set c=c+100 from todelete where parent.a = todelete.a;
+
+select * from parent;
+
+drop table todelete;
+drop table child;
+drop table parent;
+
+-- This is similar to the above, but with a partitioned table (which is
+-- implemented by inheritance) rather than an explicitly inherited table.
+-- The scans on some of the partitions degenerate into Result nodes with
+-- False one-time filter, which don't need a Motion node.
+create table todelete (a int, b int) distributed by (a);
+create table target (a int, b int, c int)
+        distributed by (a)
+        partition by range (c) (start(1) end(5) every(1), default partition extra);
+
+insert into todelete select g, g % 4 from generate_series(1, 10) g;
+insert into target select g, 0, 3 from generate_series(1, 5) g;
+insert into target select g, 0, 1 from generate_series(1, 5) g;
+
+delete from target where c = 3 and a in (select b from todelete);
+
+insert into todelete values (1, 5);
+
+update target set b=target.b+100 where c = 3 and a in (select b from todelete);
+
+select * from target;
+
+drop table todelete;
+drop table target;
+


### PR DESCRIPTION
When DELETEing or UPDATEing an inherited table, some tables in the
inheritance tree might need an explicit Motion node to bring the targeted
tuples back to the segment where they reside, and some might not. The code
to build the plan handled that correctly, but this assertion incorrecly
assumed that it's all or nothing.

Remove the assertion, as it doesn't seem very useful in the first place.
The code that inserted the Motion nodes is just above the assertion, and
the assertion was basically just testing the same thing that the code
just did, and not some general invariant that should always hold.

Fixes issue #332