### PR TITLE
Revert "abs() on an unsigned variable has no effect"

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -4375,11 +4375,13 @@ handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 
 	        if (buf->nRetry == 0)
 	        {
+	            /* newRTT = buf->conn->rtt * (1 - RTT_COEFFICIENT) + ackTime * RTT_COEFFICIENT; */
 	        	newRTT = buf->conn->rtt - (buf->conn->rtt >> RTT_SHIFT_COEFFICIENT) + (ackTime >> RTT_SHIFT_COEFFICIENT);
 	        	newRTT = Min(MAX_RTT, Max(newRTT, MIN_RTT));
 	        	buf->conn->rtt = newRTT;
 
-				newDEV = buf->conn->dev - (buf->conn->dev >> DEV_SHIFT_COEFFICIENT) + ((ackTime - newRTT) >> DEV_SHIFT_COEFFICIENT);
+	        	/* newDEV = buf->conn->dev * (1 - DEV_COEFFICIENT) + DEV_COEFFICIENT * abs(ackTime - newRTT); */
+	        	newDEV = buf->conn->dev - (buf->conn->dev >> DEV_SHIFT_COEFFICIENT) + (abs(ackTime - newRTT) >> DEV_SHIFT_COEFFICIENT);
 	        	newDEV = Min(MAX_DEV, Max(newDEV, MIN_DEV));
 	        	buf->conn->dev = newDEV;
 


### PR DESCRIPTION
This reverts commit 451e8a35c559c76e8a9b2f284796173b1bd0e8db which may
set conn->dev to a very large value and finally effect the retransmission
interval timeout of interconnect.