### PR TITLE
fix rpath of bianry to correct value.

### DIFF
--- a/src/bin/pg_dump/cdb/Makefile
+++ b/src/bin/pg_dump/cdb/Makefile
@@ -31,7 +31,7 @@ endif
 ifeq ($(enable_netbackup), yes)
 NETBACKUPLIB75 += -L../../../../gpAux/ext/rhel5_x86_64/Netbackup/nbu75/lib -lxbsa64 -lnbclientcST -lnbbasecST -lvxcPBXST
 NETBACKUPLIB71 += -L../../../../gpAux/ext/rhel5_x86_64/Netbackup/nbu71/lib -lxbsa64 -lnbclientcST -lnbbasecST -lvxcPBXST
-GPBSALIB += -L$(top_builddir)/src/bin/pg_dump/cdb -lgpbsa -Wl,-rpath-link,'../../../../gpAux/ext/rhel5_x86_64/Netbackup/nbu75/lib'
+GPBSALIB += -L$(top_builddir)/src/bin/pg_dump/cdb -lgpbsa -Wl,-rpath-link,\$$ORIGIN/..:\$$ORIGIN/../lib
 override CFLAGS += -I$(top_builddir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu75/include
 endif
 
@@ -70,10 +70,10 @@ gpddboost: cdb_ddboost_util.o cdb_backup_status.o cdb_seginst.o cdb_backup_state
 	$(CC) $(CFLAGS) cdb_ddboost_util.o cdb_backup_status.o cdb_seginst.o cdb_backup_state.o cdb_table.o cdb_dump_util.o $(libpq) $(LDFLAGS) $(LIBS) $(DDBOOSTLIB) -o $@
 
 libgpbsa75.so: cdb_bsa_util.c $(libpq_builddir)/libpq.a
-	$(CC) $(CFLAGS) -fPIC cdb_bsa_util.c $(libpq) $(LDFLAGS) -shared $(LIBS) $(DDBOOSTLIB) $(NETBACKUPLIB75) -o $@
+	$(CC) $(CFLAGS) -fPIC cdb_bsa_util.c $(libpq_builddir)/libpq.a $(LDFLAGS) -shared $(LIBS) $(DDBOOSTLIB) $(NETBACKUPLIB75) -o $@
 
 libgpbsa71.so: cdb_bsa_util.c $(libpq_builddir)/libpq.a
-	$(CC) $(CFLAGS) -fPIC cdb_bsa_util.c $(libpq) $(LDFLAGS) -shared $(LIBS) $(DDBOOSTLIB) $(NETBACKUPLIB71) -o $@
+	$(CC) $(CFLAGS) -fPIC cdb_bsa_util.c $(libpq_builddir)/libpq.a $(LDFLAGS) -shared $(LIBS) $(DDBOOSTLIB) $(NETBACKUPLIB71) -o $@
 
 libgpbsa.so: libgpbsa75.so
 	cp libgpbsa75.so libgpbsa.so

--- a/src/makefiles/Makefile.linux
+++ b/src/makefiles/Makefile.linux
@@ -2,7 +2,7 @@ AROPT = crs
 export_dynamic = -Wl,-E
 # Use --enable-new-dtags to generate DT_RUNPATH instead of DT_RPATH.
 # This allows LD_LIBRARY_PATH to still work when needed.
-rpath = -Wl,-rpath,'$(rpathdir)',--enable-new-dtags
+rpath = -Wl,-rpath,\$$ORIGIN/../lib,--enable-new-dtags
 allow_nonpic_in_shlib = yes
 DLSUFFIX = .so
 

--- a/src/pl/plperl/GNUmakefile
+++ b/src/pl/plperl/GNUmakefile
@@ -58,7 +58,7 @@ PSQLDIR = $(bindir)
 
 # where to find xsubpp for building XS.
 XSUBPPDIR = $(shell $(PERL) -e 'use List::Util qw(first); print first { -r "$$_/ExtUtils/xsubpp" } @INC')
-
+rpath = -Wl,-rpath,'$(rpathdir)',--enable-new-dtags
 include $(top_srcdir)/src/Makefile.shlib
 
 plperl.o: perlchunks.h plperl_opmask.h

--- a/src/pl/plpython/Makefile
+++ b/src/pl/plpython/Makefile
@@ -71,7 +71,7 @@ REGRESS = plpython_schema plpython_populate plpython_function plpython_test \
 	plpython_returns plpython_error plpython_drop
 # where to find psql for running the tests
 PSQLDIR = $(bindir)
-
+rpath=-Wl,-rpath,'$(rpathdir)',--enable-new-dtags
 include $(top_srcdir)/src/Makefile.shlib
 
 


### PR DESCRIPTION
The old value of rpath is an absolute path on build host, which is
not exist on target machine. Change it to relative path.
After this commit, LD_LIBRARY_PATH could be removed. Problem is that
we still have a lot of extra dependency for enterprise building, so
LD_LIBRARY_PATH is still kept.