### PR TITLE
Create CI directory and add stub Concourse pipeline for GPDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ throughout the codebase, but a few larger additions worth noting:
   manual is distributed separately (see http://gpdb.docs.pivotal.io),
   and only the reference pages used to build man pages are here.
 
+* __ci/__
+
+  Contains configuration files for the GPDB continuous integration system.
+ 
+
 * __src/backend/cdb/__
 
   Contains larger Greenplum-specific backend modules. For example,

--- a/ci/gpdb_5.0.yml
+++ b/ci/gpdb_5.0.yml
@@ -1,0 +1,15 @@
+---
+jobs:
+- name: placeholder-job
+  plan:
+  - task: placeholder-task
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: ubuntu
+          tag: '14.04'
+      run:
+        path: echo
+        args: ["This is the gpdb-5.0 stub pipeline"]


### PR DESCRIPTION
* We're proposing a top-level directory, which seems like the most sensible place for CI configs. It doesn't  appear to belong in any of the existing directories.
* This initial GPDB job is a placeholder.

See [Concourse](http://concourse.ci) for additional details about the Concourse continuous integration system.