### PR TITLE
Fixed schema level dump with prefix option

### DIFF
--- a/gpMgmt/bin/gppylib/operations/dump.py
+++ b/gpMgmt/bin/gppylib/operations/dump.py
@@ -877,6 +877,7 @@ class DumpDatabase(Operation):
         These options get passed-through gp_dump to gp_dump_agent.
         Commented out lines use escaping that would be reasonable, if gp_dump escaped properly.
         """
+        should_dump_schema = self.include_schema_file is not None
         if self.dump_schema:
             logger.info("Adding schema name %s" % self.dump_schema)
             dump_line += " -n \"\\\"%s\\\"\"" % self.dump_schema
@@ -893,11 +894,11 @@ class DumpDatabase(Operation):
             schema, table = split_fqn(dump_table)
             dump_line += " --exclude-table=\"\\\"%s\\\"\".\"\\\"%s\\\"\"" % (schema, table)
             #dump_line += " --exclude-table=\"%s\".\"%s\"" % (schema, table)
-        if self.include_dump_tables_file is not None:
+        if self.include_dump_tables_file is not None and not should_dump_schema:
             dump_line += " --table-file=%s" % self.include_dump_tables_file
         if self.exclude_dump_tables_file is not None:
             dump_line += " --exclude-table-file=%s" % self.exclude_dump_tables_file
-        if self.include_schema_file is not None and not self.dump_prefix:
+        if should_dump_schema:
             dump_line += " --schema-file=%s" % self.include_schema_file
 
         for opt in self.output_options:

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
@@ -985,9 +985,9 @@ class DumpTestCase(unittest.TestCase):
         self.assertEqual(ts_key[0:8], DUMP_DATE)
 
     def test_create_dump_line_00(self):
-        self.dumper.include_schema_file = '/tmp/foo'
+        self.dumper.include_schema_file = '/tmp/schema_file'
         output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
-        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt --schema-file=/tmp/foo"""
+        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file"""
         self.assertEquals(output, expected_output)
 
     def test00_create_dump_line_with_prefix(self):
@@ -1017,6 +1017,13 @@ class DumpTestCase(unittest.TestCase):
         self.dumper.netbackup_schedule = "test_schedule"
         output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
         expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --netbackup-service-host=mdw --netbackup-policy=test_policy --netbackup-schedule=test_schedule"""
+        self.assertEquals(output, expected_output)
+
+    def test_create_dump_line_with_prefix_schema_level_dump(self):
+        self.dumper.dump_prefix = 'foo_'
+        self.dumper.include_schema_file = '/tmp/schema_file '
+        output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
+        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file """
         self.assertEquals(output, expected_output)
 
     def test_get_backup_dir_with_master_data_dir(self):


### PR DESCRIPTION
In the gpcrondump, schema-level dump was failing where if gpcrondump is given the -s option with --prefix option, the dump will not have the CREATE SCHEMA statement in the dump file.  This will make it so that the non-public tables will be restored in public schema if the schemas do not exist (e.g. with gpdbrestore -e option).

With the current fix, gpcrondump will dump the create schema statement correctly in the dump file and during restores, tables will be restores in the mentioned schema.