### PR TITLE
Connect mapreduce to the build and make test pass

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -24,7 +24,7 @@ all:
 	$(MAKE) -C contrib/gp_internal_tools all
 	$(MAKE) -C contrib/gp_cancel_query all
 	$(MAKE) -C contrib/indexscan all
-	$(MAKE) -C gpAux/extensions mkgpfdist
+	$(MAKE) -C gpAux/extensions mkgpfdist mapreduce
 	@echo "All of Greenplum Database successfully made. Ready to install."
 
 install:
@@ -87,6 +87,7 @@ clean:
 	$(MAKE) -C contrib/gp_internal_tools $@
 	$(MAKE) -C contrib/gp_cancel_query $@
 	$(MAKE) -C contrib/indexscan $@
+	$(MAKE) -C gpAux/extensions $@
 # Garbage from autoconf:
 	@rm -rf autom4te.cache/
 
@@ -94,6 +95,7 @@ clean:
 # will be gone too soon.
 distclean maintainer-clean:
 #	-$(MAKE) -C doc $@
+	-$(MAKE) -C gpAux/extensions $@
 	-$(MAKE) -C contrib $@
 	-$(MAKE) -C config $@
 	-$(MAKE) -C src $@

--- a/configure
+++ b/configure
@@ -715,6 +715,7 @@ with_perl
 with_tcl
 enable_thread_safety
 INCLUDES
+enable_mapreduce
 enable_netbackup
 enable_ddboost
 enable_connectemc
@@ -828,6 +829,7 @@ enable_snmp
 enable_connectemc
 enable_ddboost
 enable_netbackup
+enable_mapreduce
 enable_thread_safety
 enable_thread_safety_force
 with_tcl
@@ -1498,6 +1500,7 @@ build with coverage testing instrumentation
   --enable-connectemc     enable connect emc support
   --enable-ddboost     enable connect emc support
   --enable-netbackup     enable NetBackup support
+  --enable-mapreduce     enable Greenplum Mapreduce support
   --disable-thread-safety  Do not make client libraries thread-safe
   --enable-thread-safety-force  force thread-safety despite thread test failure
   --disable-largefile     omit support for large files
@@ -5435,6 +5438,39 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_netbackup" >&5
 $as_echo "$enable_netbackup" >&6; }
+
+
+#
+# --enable-mapreduce enables GPMapreduce support
+#
+
+pgac_args="$pgac_args enable_mapreduce"
+
+# Check whether --enable-mapreduce was given.
+if test "${enable_mapreduce+set}" = set; then :
+  enableval=$enable_mapreduce;
+  case $enableval in
+    yes)
+
+$as_echo "#define USE_MAPREDUCE 1" >>confdefs.h
+
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --enable-mapreduce option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  enable_mapreduce=no
+
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: checking whether to build with Greenplum Mapreduce... $enable_mapreduce" >&5
+$as_echo "checking whether to build with Greenplum Mapreduce... $enable_mapreduce" >&6; }
 
 
 #
@@ -9972,6 +10008,22 @@ done
 
 fi
 
+if test "$enable_mapreduce" = yes; then
+  for ac_header in yaml.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "yaml.h" "ac_cv_header_yaml_h" "$ac_includes_default"
+if test "x$ac_cv_header_yaml_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_YAML_H 1
+_ACEOF
+
+else
+  as_fn_error $? "YAML includes required for Greenplum Mapreduce" "$LINENO" 5
+fi
+
+done
+
+fi
 
 
 ##

--- a/configure.in
+++ b/configure.in
@@ -662,6 +662,15 @@ AC_MSG_RESULT([$enable_netbackup])
 AC_SUBST(enable_netbackup)
 
 #
+# --enable-mapreduce enables GPMapreduce support
+#
+PGAC_ARG_BOOL(enable, mapreduce, no, [  --enable-mapreduce     enable Greenplum Mapreduce support],
+              [AC_DEFINE([USE_MAPREDUCE], 1,
+			             [Define to 1 to build with Mapreduce capabilities (--enable-mapreduce)])])
+AC_MSG_RESULT([checking whether to build with Greenplum Mapreduce... $enable_mapreduce])
+AC_SUBST(enable_mapreduce)
+
+#
 # Include directories
 #
 ac_save_IFS=$IFS
@@ -1295,6 +1304,9 @@ if test "$with_rt" = yes; then
 			 [AC_MSG_ERROR([header file <time.h> is required for realtime library support])])
 fi
 
+if test "$enable_mapreduce" = yes; then
+  AC_CHECK_HEADERS(yaml.h, [], [AC_MSG_ERROR([YAML includes required for Greenplum Mapreduce])])
+fi
 
 
 ##

--- a/gpAux/extensions/Makefile
+++ b/gpAux/extensions/Makefile
@@ -37,19 +37,31 @@ mkgpfdist:
 		echo "gpfdist disabled"; \
 	fi
 
-install: mkgpfdist
+mapreduce:
+	if [ "$(enable_mapreduce)" = "yes" ]; then \
+		echo "gpmapreduce enabled"; \
+		$(MAKE) -C gpmapreduce; \
+	fi
+
+install: mkgpfdist mapreduce
 	if [ "$(enable_gpfdist)" = "yes" ]; then \
 		if [ ! -d $(prefix)/bin ]; then \
 			mkdir -p $(prefix)/bin ; \
 		fi; \
 		cp -p gpfdist/gpfdist$(EXE_EXT) $(prefix)/bin/ ; \
+	fi; \
+	if [ "$(enable_mapreduce)" = "yes" ]; then \
+		$(MAKE) -C gpmapreduce install; \
 	fi
 
 clean:
-	@if [ -f gpfdist/GNUmakefile ]; then $(MAKE) -C gpfdist clean; fi
+	@if [ -f gpfdist/GNUmakefile ]; then $(MAKE) -C gpfdist clean; fi; \
+	if [ "$(enable_mapreduce)" = "yes" ]; then $(MAKE) -C gpmapreduce clean; fi
+
 
 distclean:
-	@if [ -f gpfdist/GNUmakefile ]; then $(MAKE) -C gpfdist clean; fi
+	@if [ -f gpfdist/GNUmakefile ]; then $(MAKE) -C gpfdist clean; fi; \
+	if [ "$(enable_mapreduce)" = "yes" ]; then $(MAKE) -C gpmapreduce distclean; fi
 
 .PHONY:
 mkgphdfs:

--- a/gpAux/extensions/gpmapreduce/Makefile
+++ b/gpAux/extensions/gpmapreduce/Makefile
@@ -18,10 +18,6 @@ SRCDIR= src
 BUILDDIR= src
 endif
 
-ifneq ($(PORTNAME), win32)
-override CFLAGS += $(PTHREAD_CFLAGS) -pthread
-endif
-
 override CPPFLAGS += $(BLD_CPPFLAGS_SOLARIS_OLD_VERSIONS) -DFRONTEND -I$(SRCDIR) -I$(INCDIR) -I$(libpq_srcdir)
 override LDFLAGS  += -lyaml
 

--- a/gpAux/extensions/gpmapreduce/include/except.h
+++ b/gpAux/extensions/gpmapreduce/include/except.h
@@ -1,6 +1,6 @@
 
 #ifndef EXCEPT_H
-#define EXECPT_H
+#define EXCEPT_H
 
 #ifndef SETJMP_H
 #include <setjmp.h>

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -187,6 +187,7 @@ enable_email		= @enable_email@
 enable_connectemc	= @enable_connectemc@
 enable_ddboost	    = @enable_ddboost@
 enable_netbackup	= @enable_netbackup@
+enable_mapreduce    = @enable_mapreduce@
 
 python_includespec	= @python_includespec@
 python_libdir		= @python_libdir@

--- a/src/test/regress/input/mapred.source
+++ b/src/test/regress/input/mapred.source
@@ -26,7 +26,7 @@ create language plpythonu;
 select * from pg_pltemplate;
 select lanname, lanispl, lanpltrusted from pg_language;
 
--- Check enviornment variables that should have been set by greenplum_path.sh
+-- Check environment variables that should have been set by greenplum_path.sh
 --
 -- 1) We need to check these on all segments and on the master.
 -- 2) We do this via external table rather than perl/python in case it is part
@@ -52,6 +52,7 @@ SELECT * FROM env WHERE var in (
 
 -- end_ignore
 
+-- start_ignore
 --
 -- Some checks to verify what versions of perl/python we have.
 -- If everything has been configured correctly this should be constant
@@ -78,7 +79,6 @@ CREATE OR REPLACE FUNCTION perl_version() returns text as $$
 return "Perl $]"
 $$ language plperlu NO SQL;
 
--- ignore
 SELECT perl_version() FROM env GROUP BY perl_version;
 
 
@@ -86,7 +86,6 @@ SELECT perl_version() FROM env GROUP BY perl_version;
 -- The following two checks need to be put into big ignore blocks
 -- because paths can be of differing lengths
 --
--- start_ignore
 
 CREATE OR REPLACE FUNCTION python_path() returns text as $$
 import sys

--- a/src/test/regress/output/mapred.source
+++ b/src/test/regress/output/mapred.source
@@ -42,7 +42,7 @@ select lanname, lanispl, lanpltrusted from pg_language;
  plpythonu | t       | f
 (6 rows)
 
--- Check enviornment variables that should have been set by greenplum_path.sh
+-- Check environment variables that should have been set by greenplum_path.sh
 --
 -- 1) We need to check these on all segments and on the master.
 -- 2) We do this via external table rather than perl/python in case it is part
@@ -79,6 +79,7 @@ SELECT * FROM env WHERE var in (
 (10 rows)
 
 -- end_ignore
+-- start_ignore
 --
 -- Some checks to verify what versions of perl/python we have.
 -- If everything has been configured correctly this should be constant
@@ -107,7 +108,6 @@ SELECT python_version() FROM env GROUP BY python_version;
 CREATE OR REPLACE FUNCTION perl_version() returns text as $$
 return "Perl $]"
 $$ language plperlu NO SQL;
--- ignore
 SELECT perl_version() FROM env GROUP BY perl_version;
  perl_version  
 ---------------
@@ -118,7 +118,6 @@ SELECT perl_version() FROM env GROUP BY perl_version;
 -- The following two checks need to be put into big ignore blocks
 -- because paths can be of differing lengths
 --
--- start_ignore
 CREATE OR REPLACE FUNCTION python_path() returns text as $$
 import sys
 return sys.path[0]


### PR DESCRIPTION
Growing increasingly annoyed at seeing `mapred ... FAILED` when hacking on the merges (and there have been questions why this fails on the mailinglist) I decided to see what it would take to get it working for the normal buildsequence of configure, make install, make installcheck-good. Turns out it was quite easy.

The gist of this patch is that it connects mapreduce to the build if so is desired and fixes the tests. To do this a new switch is added to autoconf, `--enable-mapreduce`, which connects the GPMapreduce extension to the build. If set to on the mapreduce extension in `gpAux/extensions` will be built and installed by the normal `make install`. Autoconf checks for libyaml has been added since it's a depedency for GPMapreduce. As a side effect, this will properly clean and distclean for gpfdist in `gpAux/extensions` as well. 

The Python and Perl version tests are moved in under ignore blocks to make the test less fragile. Testing for specific versions is not ideal IMO, if this is to be kept as a real test it should be rewritten to look for interpreters satisfying minimum version requirements rather then exact (although the value of that can be argued as well). Keeping the version output in the test seems valuable though since it can be good information when debugging where access is limited to the `regression.diffs` file. Also fixes a trivial typo in a comment.

GPMapreduce isn't really touched at all, the fixes there are limited to a broken header guard and removing the `-pthreads` compiler flag since it's not threaded (and unused flags cause warnings in clang).

With these patches applied, mapred tests pass with the following (+ the required `source` commands of course):
```
./configure --with-perl --with-python --enable-mapreduce
make install
make -C gpAux/gpdemo cluster
make installcheck-good
```