### PR TITLE
Add missing header include to COptTasks

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -31,6 +31,7 @@
 #include "gpopt/translate/CContextDXLToPlStmt.h"
 #include "gpopt/translate/CTranslatorRelcacheToDXL.h"
 #include "gpopt/eval/CConstExprEvaluatorDXL.h"
+#include "gpopt/engine/CHint.h"
 
 #include "cdb/cdbvars.h"
 #include "utils/guc.h"


### PR DESCRIPTION
Unless I'm missing something, the 1.622 updates in b3668c40566574aef797ffbccc15c22465f107f7 adds a dependency on `CHint` without adding the required header file to build without warnings/errors.