### PR TITLE
Generate installcheck-good schedules from autoconf settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ build.sh
 *.swp
 
 VERSION
+src/test/regress/greenplum_schedule

--- a/configure
+++ b/configure
@@ -626,6 +626,7 @@ ac_includes_default="\
 #endif"
 
 ac_subst_vars='LTLIBOBJS
+ICG_DEPENDENCIES
 vpath_build
 SGMLSPL
 COLLATEINDEX
@@ -6261,6 +6262,7 @@ done
       esac
     done
   fi
+  ICG_DEPENDENCIES="--dependency libxml "$ICG_DEPENDENCIES
 fi
 
 
@@ -7739,6 +7741,7 @@ else
 $as_echo "$perl_embed_ldflags" >&6; }
 fi
 
+  ICG_DEPENDENCIES="--dependency perl "$ICG_DEPENDENCIES
 fi
 
 if test "$with_python" = yes; then
@@ -7858,6 +7861,7 @@ $as_echo "no" >&6; }
 fi
 
 
+  ICG_DEPENDENCIES="--dependency python "$ICG_DEPENDENCIES
 fi
 
 ZIC=
@@ -15656,6 +15660,7 @@ else
 $as_echo "done" >&6; }
   fi
 fi
+
 
 
 

--- a/configure.in
+++ b/configure.in
@@ -904,6 +904,7 @@ if test "$with_libxml" = yes ; then
       esac
     done
   fi
+  ICG_DEPENDENCIES="--dependency libxml "$ICG_DEPENDENCIES
 fi
 
 AC_SUBST(with_libxml)
@@ -1031,11 +1032,13 @@ if test "$with_perl" = yes; then
   fi
   PGAC_CHECK_PERL_CONFIGS([archlibexp,privlibexp,useshrplib])
   PGAC_CHECK_PERL_EMBED_LDFLAGS
+  ICG_DEPENDENCIES="--dependency perl "$ICG_DEPENDENCIES
 fi
 
 if test "$with_python" = yes; then
   PGAC_PATH_PYTHON
   PGAC_CHECK_PYTHON_EMBED_SETUP
+  ICG_DEPENDENCIES="--dependency python "$ICG_DEPENDENCIES
 fi
 
 ZIC=
@@ -2158,6 +2161,7 @@ else
 fi
 AC_SUBST(vpath_build)
 
+AC_SUBST(ICG_DEPENDENCIES)
 
 AC_CONFIG_FILES([GNUmakefile src/Makefile.global])
 

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -215,6 +215,7 @@ have_docbook	= @have_docbook@
 DOCBOOKSTYLE	= @DOCBOOKSTYLE@
 COLLATEINDEX	= @COLLATEINDEX@
 
+ICG_DEPENDENCIES	= @ICG_DEPENDENCIES@
 
 ##########################################################################
 #

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -59,7 +59,7 @@ LIBS := $(filter-out -lreadline -ledit -ltermcap -lncurses -lcurses -lcurl -lssl
 
 # Build regression test driver
 
-all: submake-libpgport pg_regress$(X)
+all: submake-libpgport pg_regress$(X) greenplum_schedule
 
 pg_regress$(X): pg_regress.o pg_regress_main.o
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
@@ -169,6 +169,9 @@ check: all upg2-setup ugpart-setup
 installcheck: all upg2-setup ugpart-setup
 	$(pg_regress_call)  --psqldir=$(PSQLDIR) --schedule=$(srcdir)/serial_schedule --srcdir=$(abs_srcdir)
 
+%_schedule: %_schedule.in
+	./gensched.pl $(ICG_DEPENDENCIES) < $< > $@
+
 installcheck-good: all
 	if [ -z "$(INSTALLCHECK_GOOD_KERBEROS)" ]; then \
 	$(pg_regress_call)  --psqldir=$(PSQLDIR) --schedule=$(srcdir)/parallel_schedule --schedule=$(srcdir)/greenplum_schedule --srcdir=$(abs_srcdir); \
@@ -267,6 +270,7 @@ clean distclean maintainer-clean: clean-lib
 	rm -f gmon.out
 	rm -f $(upg2_temp_files)
 	rm -f $(srcdir)/sql/cppudf.sql
+	rm -f greenplum_schedule
 ifeq ($(PORTNAME), cygwin)
 	rm -f regress.def
 endif

--- a/src/test/regress/gensched.pl
+++ b/src/test/regress/gensched.pl
@@ -1,0 +1,85 @@
+#!/usr/bin/perl -w
+#
+# gensched.pl
+#	 Resolves configured dependencies on test definitions in schedule files
+#	 based on the dependencies passed as command line parameters and outputs
+#	 a schedule file for use with pg_regress. Reads STDIN and outputs onto
+#	 STDOUT for file generation.
+#
+#	 Usage:
+#		./gensched.pl --dependency foo,bar < input > output
+#
+use Getopt::Long;
+use strict;
+
+my @dependencies = ();
+my %dependencies;
+
+GetOptions('dependency=s' => \@dependencies, 'usage|help' => \&usage);
+@dependencies = split(/,/, join(',', @dependencies));
+$dependencies{$_}++ for (@dependencies);
+
+sub usage
+{
+	print "$0 [--dependency X,Y..,Z] < input_file > output_file\n";
+	exit 1;
+}
+
+while (<>)
+{
+	# Preserve comments and blank lines in the output
+	if (/^\s*(#.*)?$/)
+	{
+		print;
+		next;
+	}
+
+	# Resolve dependencies in both test and ignore blocks as we want the output
+	# schedule to be free from all dependency information
+	if (/^\s*(test|ignore)\s*:\s*(.+){1}$/)
+	{
+		my @input = ();
+		my @ignore = ();
+		my @tests = ();
+		my $header = $1;
+		my $test_row = $2;
+
+		# We can't just split the line of tests on whitespace since we need to
+		# support all the following constructs: test test(foo) test(foo, bar)
+		# test(foo,bar)
+		push(@input, $&)
+			while ($test_row =~ /([^(\s]+(\([^)\s,]+(\s*,\s*[^)\s,]+)*\))?)/g);
+
+T_LOOP:	foreach my $t (@input)
+		{
+			# Only look at tests with dependencies, other tests can be output
+			# immediately
+			if ($t =~ /.+\)$/)
+			{
+				# For tests with dependencies, resolve against the passed set of
+				# available dependencies and output test with satisfied
+				# dependencies as test, else into an ignore block.
+				$t =~ /([^(]+)\(([^)]+)\)/;
+				$t = $1;
+				my @deps = split(/,\s*/, $2);
+
+				foreach my $d (@deps)
+				{
+					push(@ignore, $t) && next T_LOOP
+						unless defined($dependencies{$d});
+				}
+			}
+			push(@tests, $t);
+		}
+		# Output the tests that satisfy all the dependencies (if any)
+		print $header . ": " . join(" ", @tests) . "\n" unless !scalar(@tests);
+		if (scalar(@ignore) > 0)
+		{
+			print "# Tests ignored due to dependencies not fulfilled\n";
+			print "ignore: " . join(" ", @ignore) . "\n";
+		}
+	}
+}
+
+exit 0;
+__END__

--- a/src/test/regress/greenplum_schedule.in
+++ b/src/test/regress/greenplum_schedule.in
@@ -15,9 +15,13 @@
 #   hitting max_connections limit on segments.
 #
 
+# The xml test suite has been moved from the parallel schedule to here in
+# order to support autoconf generated dependency checking for testruns
+test: xml(libxml)
+
 ignore: leastsquares
-test: opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy
-test: filter gpctas gpdist matrix toast sublink sirv_functions table_functions olap_setup
+test: opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile naivebayes join_gp union_gp(python) gpcopy
+test: filter gpctas gpdist matrix toast sublink sirv_functions(python) table_functions(python, perl) olap_setup
 
 test: dispatch
 
@@ -31,7 +35,7 @@ test: sort_finish_pending
 
 test: gpdiffcheck gptokencheck information_schema gp_hashagg sequence_gp tidscan
 
-test: rangefuncs_cdb gp_dqa external_table subselect_gp indexjoin distributed_transactions olap_group olap_window_seq with_clause as_alias regex_gp partition1
+test: rangefuncs_cdb(perl) gp_dqa external_table subselect_gp indexjoin distributed_transactions olap_group olap_window_seq with_clause as_alias regex_gp partition1
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests. Unfortunately, 'partition' also assumes that there
@@ -58,7 +62,7 @@ test: vacuum_gp
 # ERROR:  parameter "gp_interconnect_type" cannot be set after connection start
 
 ignore: gp_portal_error
-test: partition_indexing column_compression eagerfree mapred gpparams tidycat aocs co_nestloop_idxscan  gpdtm_plpgsql alter_table_aocs alter_distribution_policy ic aoco_privileges
+test: partition_indexing column_compression eagerfree mapred(mapred, python, perl) gpparams tidycat aocs co_nestloop_idxscan  gpdtm_plpgsql alter_table_aocs alter_distribution_policy ic aoco_privileges
 ignore: icudp_full
 ignore: gp_delete_as_trunc
 
@@ -73,7 +77,7 @@ test: filespace trig auth_constraint role rle portals_updatable plpgsql_cache ti
 # direct dispatch tests
 test: bfv_dd bfv_dd_multicolumn bfv_dd_types
 
-test: catalog bfv_catalog bfv_index bfv_olap bfv_aggregate bfv_partition DML_over_joins
+test: catalog bfv_catalog(python) bfv_index(python) bfv_olap bfv_aggregate(python) bfv_partition(python) DML_over_joins
  
 test: aggregate_with_groupingsets gp_optimizer 
 
@@ -87,14 +91,14 @@ test: qp_misc
 
 test: qp_misc_jiras
 
-test: bfv_cte bfv_joins bfv_statistic bfv_subquery bfv_planner bfv_legacy
+test: bfv_cte bfv_joins bfv_statistic(python) bfv_subquery(python) bfv_planner bfv_legacy(python)
 
-test: qp_executor qp_olap_windowerr qp_olap_window qp_derived_table qp_bitmapscan
-test: qp_functions qp_misc_rio_join_small qp_misc_rio
+test: qp_executor qp_olap_windowerr qp_olap_window(python) qp_derived_table qp_bitmapscan
+test: qp_functions qp_misc_rio_join_small qp_misc_rio(python)
 
 test: qp_correlated_query qp_targeted_dispatch
 
-test: qp_dpe qp_subquery qp_functions_idf qp_regexp qp_resource_queue
+test: qp_dpe(python) qp_subquery qp_functions_idf(python) qp_regexp qp_resource_queue
 
 test: qp_gist_indexes2 qp_gist_indexes3 qp_gist_indexes4
 

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -112,7 +112,7 @@ test: select_views portals_p2 cluster dependency guc
 # The sixth group of parallel test
 # ----------
 # "plpgsql" cannot run concurrently with "rules"
-test: limit copy2 temp domain rangefuncs prepare without_oid conversion truncate alter_table sequence polymorphism rowtypes xml
+test: limit copy2 temp domain rangefuncs prepare without_oid conversion truncate alter_table sequence polymorphism rowtypes
 
 # 83MERGE_FIXME: the largeobject test is temporarily disabled due to test errors
 # test: largeobject


### PR DESCRIPTION
As posted to gpdb-dev@ earlier:

In between sorting out merge conflicts from upstream I had a look at making `installcheck-good` be set up based on the options passed to `./configure` and the dependencies per each testsuite.  This was surprisingly trickier to get right than anticipated (as is so often the case) but I think I have a proposal to
discuss.  The hard part is not the code itself but to keep the schedule files, and the dependency management in them, easy to work with and maintain the readability of the files.

The schedule files are turned into .in files which are processed at make all into schedules with the supported testsuites kept as `test:` rows and the ones with unresolved dependencies moved to `ignore:` rows. Dependencies are set per test by suffixing the testname with a list in parenthesis:
```
test: aaa bbb(foo bar) ccc(foo)
```
Here, test aaa has no dependencies, bbb depends on `--with-foo` and `--with-bar` and ccc depends on `--with-foo`.  The exact names of the dependencies aren’t limited to the featurename as they are set in autoconf but it’s probably a good idea to maintain the name.  In the example above the following sequence would not cause bbb to be marked as FAILED as it would simply not be executed at all:
```
./configure --with-foo
make install
make -C gpAux/gpdemo cluster
make installcheck-good
```
I first implemented this in autoconf with M4sh but it became quite unreadable so I started over using Perl which is the language used for most tools in `src/test/regress`.  I was hoping to avoid introducing more bespoke tools but writing this in M4sh or make would become less maintainable.  The result is a
new small tool called [gensched.pl](https://github.com/danielgustafsson/gpdb/blob/configure_icg/src/test/regress/gensched.pl) which takes the features set in autoconf as parameters, reads the .in file on STDIN and outputs the schedule on STDOUT (invocation can be seen in the regress GNUMakefile).

With something like this in place we obviously need to ensure that tests only depend on their core features and not (too many) auxilliary ones which would cause tests to be skipped (which today would fail instead which arguably isn’t better).