### PR TITLE
Fixing an assertion failure and a potential double release of workfilee_queryspace queryEntry

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_queryspace.c
+++ b/src/backend/utils/workfile_manager/workfile_queryspace.c
@@ -311,7 +311,6 @@ WorkfileQueryspace_ReleaseEntry(void)
 	}
 
 	querySpaceNestingLevel--;
-	Assert(querySpaceNestingLevel >= 0);
 
 	if (querySpaceNestingLevel > 0)
 	{
@@ -322,15 +321,25 @@ WorkfileQueryspace_ReleaseEntry(void)
 		return;
 	}
 
+	int session_id = queryEntry->key.session_id;
+	int command_count = queryEntry->key.command_count;
+
 	bool deleted = SyncHTRelease(queryspace_Hashtable, queryEntry);
+
+	/*
+	 * Set the queryEntry to NULL as we may soon CHECK_FOR_INTERRUPTS, which can come back to this
+	 * method if an ERROR cleanup (e.g., because of a QueryCancelPending) invokes ExecutorEnd.
+	 * We don't want to release our queryEntry again.
+	 */
+	queryEntry = NULL;
 
 	if (deleted)
 	{
 		elog(gp_workfile_caching_loglevel, "Deleted entry for query (sessionid=%d, commandcnt=%d)",
-				queryEntry->key.session_id, queryEntry->key.command_count);
+				session_id, command_count);
 	}
 
-	queryEntry = NULL;
+	Assert(querySpaceNestingLevel >= 0);
 }
 
 /*

--- a/src/backend/utils/workfile_manager/workfile_queryspace.c
+++ b/src/backend/utils/workfile_manager/workfile_queryspace.c
@@ -339,7 +339,7 @@ WorkfileQueryspace_ReleaseEntry(void)
 				session_id, command_count);
 	}
 
-	Assert(querySpaceNestingLevel >= 0);
+	Assert(querySpaceNestingLevel == 0);
 }
 
 /*


### PR DESCRIPTION
During the execution of WorkfileQueryspace_ReleaseEntry() we decrement querySpaceNestingLevel and call SyncHTRelease() to actually release the entry (depending on the pinCount). At the end, we used to set the queryEntry to NULL that prevents future free. However, between the time SyncHTRelease() returns and the time we set queryEntry to NULL, we call elog(). If a QueryCancelPending happens we may throw an ERROR that can call ExecutorEnd, resulting in a re-entrance of WorkfileQueryspace_ReleaseEntry(). In debug build the querySpaceNestingLevel goes negative and we fail an assertion. In release build it is possible to first release the shared memory entry (queryEntry) and another session grabs the same entry (as it is now up for grab by another session) and because of the previous session's pointer still pointing to the entry, it may try to free the entry again (provided that the pinCount is 1, as maintained by the new session). This can result in double free, and a free by a session not even owning the entry.

This PR fixes this by setting the queryEntry to NULL before allowing any diversion (i.e., CHECK_FOR_INTERRUPTS). The assumption is, SyncHTRelease() is unlikely to CHECK_FOR_INTERRUPTS(). In fact, it has HOLD_INTERRUPTS() and RESUME_INTERRUPTS(), curtesy of LWLockAquire/LWLockRelease.