### PR TITLE
Add -B option to gpdiff so that pg_regress will ignore blank lines

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -70,8 +70,8 @@ static char gpstringsubsprog[MAXPGPATH];
 
 /* currently we can use the same diff switches on all platforms */
 /* MPP:  Add stuff to ignore all the extra NOTICE messages we give */
-const char *basic_diff_opts = "-w -I HINT: -I CONTEXT: -I GP_IGNORE:";
-const char *pretty_diff_opts = "-w -I HINT: -I CONTEXT: -I GP_IGNORE: -C3";
+const char *basic_diff_opts = "-B -w -I HINT: -I CONTEXT: -I GP_IGNORE:";
+const char *pretty_diff_opts = "-B -w -I HINT: -I CONTEXT: -I GP_IGNORE: -C3";
 
 /* options settable from command line */
 _stringlist *dblist = NULL;


### PR DESCRIPTION
This commit add -B option to diff so that we will ignore all blank lines.

```
 2016-03-01 17:19:08 ☆  localhost in /tmp
○ → cat a.txt
 TPCH QUERY 09 | VIETNAM                   |   1994 | 1003275.5371
 TPCH QUERY 09 | VIETNAM                   |   1993 |  461389.0037
 TPCH QUERY 09 | VIETNAM                   |   1992 |  820665.7064
(174 rows)

 2016-03-01 17:19:12 ☆  localhost in /tmp
○ → cat b.txt
 TPCH QUERY 09 | VIETNAM                   |   1994 | 1003275.5371
 TPCH QUERY 09 | VIETNAM                   |   1993 |  461389.0037
 TPCH QUERY 09 | VIETNAM                   |   1992 |  820665.7064
(174 rows)

GP_IGNORE:-- start_ignore
GP_IGNORE:-- -------------------------------------------------
GP_IGNORE:-- end test cases for 'file' protocol
GP_IGNORE:-- -------------------------------------------------
GP_IGNORE:-- end_ignore

 2016-03-01 17:19:14 ☆  localhost in /tmp
○ → diff -B  -w -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE a.txt b.t

 2016-03-01 17:20:16 ☆  localhost in /tmp
○ → diff -w -I NOTICE: -I HINT: -I CONTEXT: -I GP_IGNORE a.txt b.t
4a5,10
>
> GP_IGNORE:-- start_ignore
> GP_IGNORE:-- -------------------------------------------------
> GP_IGNORE:-- end test cases for 'file' protocol
> GP_IGNORE:-- -------------------------------------------------
> GP_IGNORE:-- end_ignore
```