### PR TITLE
When recovering in-doubt transactions, there were some transactions missed due to incorrect iterating logic.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -3194,7 +3194,7 @@ recoverInDoubtTransactions(void)
 
 	saved_currentGxact = currentGxact;
 
-	for (i = 0; i < *shmNumGxacts; i++)
+	for (i = 0; i < *shmNumGxacts; )
 	{
 		TMGXACT *gxact = shmGxactArray[i];
 
@@ -3203,11 +3203,13 @@ recoverInDoubtTransactions(void)
 		 */
 		if (saved_currentGxact != NULL && gxact == saved_currentGxact)
 		{
+			i++;
 			continue;
 		}
 		else if (gxact->state == DTX_STATE_ACTIVE_NOT_DISTRIBUTED)
 		{
 			/* should take care of other sessions. */
+			i++;
 			continue;
 		}
 
@@ -3246,6 +3248,9 @@ recoverInDoubtTransactions(void)
 
 		getTmLock();
 
+		/* This routine would call releaseGxact_UnderLocks, which
+		 * would decrease *shmNumGxacts and do a swap, so no need
+		 * to increase i */
 		doInsertForgetCommitted();
 
 		releaseTmLock();


### PR DESCRIPTION
When recovering in-doubt transactions, there were some transactions missed due to incorrect iterating logic.