### PR TITLE
Fix incorrect EOS warning message generated by direct-dispatch type queries

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -735,6 +735,10 @@ EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool flushCommLa
 		{
 			pCSEntry = &pMNEntry->ready_tuple_lists[i];
 
+			/*
+			 * QD should not expect end-of-stream comes from QEs who is not members of
+			 * direct dispatch 
+			 */
 			if (!pCSEntry->init)
 				continue;
 

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -735,6 +735,9 @@ EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool flushCommLa
 		{
 			pCSEntry = &pMNEntry->ready_tuple_lists[i];
 
+			if (!pCSEntry->init)
+				continue;
+
 			if (pMNEntry->preserve_order &&
 				gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 			{


### PR DESCRIPTION
QD should not expect end-of-stream comes from QEs who is not members of
direct dispatch and should not report warning message.