### PR TITLE
Added check that absolute path should be provided with -u option for gpcrondump

### DIFF
--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -237,6 +237,11 @@ class GpCronDump(Operation):
             logger.info("Bypassing disk space check as '-b' option is specified")
             self.free_space_percent = None
 
+        #Check if backup_dir contains the absolute path
+        if self.backup_dir is not None:
+            if not os.path.isabs(self.backup_dir):
+                raise Exception("\"%s\" is not an absolute path. Please specify the absolute path where the backup files will be placed on each host." % self.backup_dir)
+
         if self.ddboost:
             if (not self.replicate and self.max_streams is not None) or (self.replicate and self.max_streams is None):
                 raise ExceptionNoStackTraceNeeded("--max-streams must be specified along with --replicate")

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -3362,6 +3362,13 @@ Feature: Validate command line arguments
         Then gpdbrestore should print Table public.heap_table2 not found in backup to stdout
         Then gpdbrestore should not print Issue with 'ANALYZE' of restored table 'public.heap_table2' in 'bkdb' database to stdout
 
+    Scenario: Absolute path should be provided with -u option for gpcrondump
+        Given the test is initialized
+        And there is a "heap" table "heap_table" in "bkdb" with data
+        When the user runs "gpcrondump -a -x bkdb -u foo/db"
+        Then gpcrondump should return a return code of 2
+        And gpcrondump should print is not an absolute path to stdout
+
     @backupfire
     Scenario: Full Backup with option --schema-file with prefix option and Restore
         Given the test is initialized


### PR DESCRIPTION
Currently, gpcrondump is documented to require a fully-qualified path.  If given a relative path, it eventually fails with an obscure failure message. With this fix, gpcrondump will check for path and if an absolute path is not provided then dump will fail with the appropriate error.