### PR TITLE
Fixing intermittent failure of external table test in ICG test [#115449419]

### DIFF
--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -446,7 +446,9 @@ UNION ALL
 SELECT e1.i, e2.j from exttab_cursor_2 e1 INNER JOIN exttab_cursor_2 e2 ON e1.i = e2.i
 UNION ALL
 SELECT e1.i, e2.j from exttab_cursor_2 e1 INNER JOIN exttab_cursor_2 e2 ON e1.i = e2.i;
+\set ECHO info
 COMMIT;
+\set ECHO all
 -- This should have the errors populated already
 SELECT count(*) > 0 FROM gp_read_error_log('exttab_cursor_2');
 

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -885,7 +885,7 @@ UNION ALL
 SELECT e1.i, e2.j from exttab_cursor_2 e1 INNER JOIN exttab_cursor_2 e2 ON e1.i = e2.i
 UNION ALL
 SELECT e1.i, e2.j from exttab_cursor_2 e1 INNER JOIN exttab_cursor_2 e2 ON e1.i = e2.i;
-COMMIT;
+\set ECHO info
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "j"  (seg0 slice3 @hostname@:40000 pid=95621)
 DETAIL:  External table exttab_cursor_2, line 7 of file://@hostname@@abs_srcdir@/data/exttab_more_errors.data: "error_1"
 -- This should have the errors populated already


### PR DESCRIPTION
There is an observed intermittent failure of ICG tests. The source of the failure is not the code but the test itself. This PR introduces a fix that resolve the external_table test's nondeterministic behavior. 