### PR TITLE
Changing PL/Java logging handling

### DIFF
--- a/gpAux/extensions/pljava/docs/userguide.html
+++ b/gpAux/extensions/pljava/docs/userguide.html
@@ -641,10 +641,13 @@ set.</li>
 <h3><i><a name="Logging_">Logging</a></i></h3>
 <p>PL/Java uses the standard Java 1.4 Logger. Hence, you can write things like:</p>
 <pre>Logger.getAnonymousLogger().info( &quot;Time is &quot; + new Date(System.currentTimeMillis()));</pre>
-<p>At present, the logger is hardwired to a handler that maps the current state 
-of the PostgreSQL configuration setting log_min_messages to a valid Logger level 
-and that outputs all messages using the backend function elog(). The following 
-mapping apply between the Logger levels and the PostgreSQL backend levels.</p>
+<p>By default the logger is initialized with logging level of Level.FINEST, so
+all the log messages would be routed to the <code>elog()</code> function in the backend. This
+function in turn would output message to client log based on the
+<code>client_min_messages</code> setting and to server log based on <code>log_min_messages</code> setting.
+Be aware that INFO messages are always routed to the client regardless of the
+setting of <code>client_min_messages</code>. The following mapping apply between the Logger
+levels and the PostgreSQL backend levels:</p>
 <table border="0" width="43%" id="table8">
   <tr>
     <td><b>java.util.logging.Level</b></td>
@@ -663,6 +666,10 @@ mapping apply between the Logger levels and the PostgreSQL backend levels.</p>
     <td>INFO</td>
   </tr>
   <tr>
+    <td>CONFIG</td>
+    <td>LOG</td>
+  </tr>
+  <tr>
     <td>FINE</td>
     <td>DEBUG1</td>
   </tr>
@@ -675,6 +682,15 @@ mapping apply between the Logger levels and the PostgreSQL backend levels.</p>
     <td>DEBUG3</td>
   </tr>
 </table>
+<p>In case you want to limit the amount of messages routed from Java to backend,
+after creating Java logger call <code>setLevel()</code> on top of it, like this:</p>
+<pre>// Getting default logger that sends everything to GPDB backend
+Logger log = Logger.getAnonymousLogger();
+// Set level of logging for it - this would limit the messages sent to backend
+log.setLevel(Level.SEVERE);
+// This message won't reach the backend, as WARNING < SEVERE
+log.log(Level.WARNING, msg);
+</pre>
 <h2><a name="Security">Security</a></h2>
 <h3><i><a name="Installation">Installation</a></i></h3>
 <p>Only a PostgreSQL super user can install PL/Java. The PL/Java utility functions 

--- a/gpAux/extensions/pljava/src/java/pljava/org/postgresql/pljava/internal/ELogHandler.java
+++ b/gpAux/extensions/pljava/src/java/pljava/org/postgresql/pljava/internal/ELogHandler.java
@@ -89,6 +89,8 @@ public class ELogHandler extends Handler
 			pgLevel = LOG_WARNING;
 		else if(level.equals(Level.INFO))
 			pgLevel = LOG_INFO;
+		else if(level.equals(Level.CONFIG))
+			pgLevel = LOG_LOG;
 		else if(level.equals(Level.FINE))
 			pgLevel = LOG_DEBUG1;
 		else if(level.equals(Level.FINER))
@@ -123,7 +125,7 @@ public class ELogHandler extends Handler
 	{
 		Properties props = new Properties();
 		props.setProperty("handlers", ELogHandler.class.getName());
-		props.setProperty(".level", getPgLevel().getName());
+		props.setProperty(".level", Level.FINEST.getName());
 		ByteArrayOutputStream po = new ByteArrayOutputStream();
 		try
 		{
@@ -134,44 +136,6 @@ public class ELogHandler extends Handler
 		catch(IOException e)
 		{
 		}
-	}
-
-	/**
-	 * Obtains the &quot;log_min_messages&quot; configuration variable and
-	 * translates it into a {@link Level} object.
-	 * @return The Level that corresponds to the configuration variable.
-	 */
-	public static Level getPgLevel()
-	{
-		// We use this little trick to provide the correct config option
-		// without having to call back into the JNI code the first time
-		// around since that call will be a bit premature (it will come
-		// during JVM initialization and before the native method is
-		// registered).
-		//
-		String pgLevel = Backend.getConfigOption("log_min_messages");
-		Level level = Level.ALL;
-		if(pgLevel != null)
-		{	
-			pgLevel = pgLevel.toLowerCase().trim();
-			if(pgLevel.equals("panic") || pgLevel.equals("fatal"))
-				level = Level.OFF;
-			else if(pgLevel.equals("error"))
-				level = Level.SEVERE;
-			else if(pgLevel.equals("warning"))
-				level = Level.WARNING;
-			else if(pgLevel.equals("notice"))
-				level = Level.CONFIG;
-			else if(pgLevel.equals("info"))
-				level = Level.INFO;
-			else if(pgLevel.equals("debug1"))
-				level = Level.FINE;
-			else if(pgLevel.equals("debug2"))
-				level = Level.FINER;
-			else if(pgLevel.equals("debug3") || pgLevel.equals("debug4") || pgLevel.equals("debug5"))
-				level = Level.FINEST;
-		}
-		return level;
 	}
 
 	// Private method to configure an ELogHandler


### PR DESCRIPTION
Old implementation of PL/Java is counter-intuitive:
- First, logging level at Java level is affected by log_min_messages GPDB setting at the moment the first PL/Java function in the session is executed. After that moment you have completely no control of logging level you want to see on the client side or in server log, and the only option to get or remove these messages is to restart the session.
- Second, with the default setting of log_min_messages=warning, it behaves contrary to GPDB default behavior. GPDB always show INFO messages to client regarding of client_min_messages and log_min_messages settings. PL/Java reads log_min_messages and if it is above INFO then INFO is simply not sent to the backend

In my opinion this should be changed and the logging level should be controlled by GPDB GUC. This can be achieved in a following way:
- By default Java logger is initialized with log level of Level.FINEST, i.e. all the messages would be routed to GPDB backend. This way you can control with session-level settings (client_min_messages and log_min_messages) the level of logging granularity you want to see
- If you want to bound some messages at Java level from being send to GPDB backend (for example, for production use case), you can simply do following:
```java
// Getting default logger that sends everything to GPDB backend
Logger log = Logger.getAnonymousLogger();
// Set level of logging for it - this would limit the messages sent to backend
log.setLevel(Level.SEVERE);
// This message won't reach the backend, as WARNING < SEVERE
log.log(Level.WARNING, msg);
```
I understand that this might be considered as a change of behavior, but:
- If affects only logging
- By default the server log would be exactly the same, as log_min_messages is honored in new solution
- The only case when the log content won't be the same is when you set log_min_messages to restrictive value (ERROR, for example), make a first call to PL/Java and then set log_min_messages to permissive value (DEBUG, for example). Old solution would still produce no logs, while new one would produce them