### PR TITLE
Fixing PL/Java regression tests

### DIFF
--- a/gpAux/extensions/pljava/Makefile
+++ b/gpAux/extensions/pljava/Makefile
@@ -47,6 +47,16 @@ export TAR				:= /bin/tar
 OS := $(shell uname -s)
 MACHINE := $(shell uname -m)
 
+ifndef JAVA_HOME
+	$(error JAVA_HOME is not set)
+else
+	export JAVA=${JAVA_HOME}/bin/java
+	export JAVAC=${JAVA_HOME}/bin/javac
+	export JAVAH=${JAVA_HOME}/bin/javah
+	export JAR=${JAVA_HOME}/bin/jar
+	export JAVADOC=${JAVA_HOME}/bin/javadoc
+endif
+
 .PHONY: all clean docs javadoc install uninstall depend release \
 	c_all c_install c_uninstall c_depend \
 	pljava_all pljava_javadoc \
@@ -105,12 +115,7 @@ test_all: test_%:
 
 
 test:
-	@-gpconfig -c pljava_classpath -v \'$(PWD)/build/\'
-	@-echo 'host    all         test                 0.0.0.0/0 trust' >> $(MASTER_DATA_DIRECTORY)/pg_hba.conf
-	@-echo 'local   all         test                trust' >> $(MASTER_DATA_DIRECTORY)/pg_hba.conf
-	@-gpstop -ar
-	cd src && \
-	../../../../src/test/regress/pg_regress  --dbname=test --create-role=test pljava 
+	@$(MAKE) -C tests
 
 # GPDB: we've hacked the c_install rule in the sub-makefile to install
 # examples.jar too. So examples.jar must be built before c_install.
@@ -124,4 +129,3 @@ c_all c_install c_uninstall c_depend: c_%: pljava_all
 release: all docs javadoc
 	@-mkdir -p $(TARGETDIR)/distrib
 	@$(MAKE) -r -C $(TARGETDIR) -f $(PROJDIR)/packaging/Makefile $@
-

--- a/gpAux/extensions/pljava/src/java/examples/org/postgresql/example/Parameters.java
+++ b/gpAux/extensions/pljava/src/java/examples/org/postgresql/example/Parameters.java
@@ -15,7 +15,7 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
-import java.util.logging.*;
+import java.util.logging.Logger;
 
 /**
  * Some methods used for testing parameter and return value coersion and resolution
@@ -36,7 +36,7 @@ public class Parameters
 		}
 		else
 		{
-            Logger.getAnonymousLogger().config(msg);
+			Logger.getAnonymousLogger().config(msg);
 		}
 	}
 

--- a/gpAux/extensions/pljava/src/java/examples/org/postgresql/example/Parameters.java
+++ b/gpAux/extensions/pljava/src/java/examples/org/postgresql/example/Parameters.java
@@ -15,7 +15,7 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
-import java.util.logging.Logger;
+import java.util.logging.*;
 
 /**
  * Some methods used for testing parameter and return value coersion and resolution
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
  */
 public class Parameters
 {
-	static void log(String msg)
+    static void log(String msg)
 	{
 		// GCJ has a somewhat serious bug (reported)
 		//
@@ -36,8 +36,7 @@ public class Parameters
 		}
 		else
 		{
-			System.out.println("DUMMY: " + msg);
-			Logger.getAnonymousLogger().info(msg);
+            Logger.getAnonymousLogger().config(msg);
 		}
 	}
 
@@ -280,6 +279,12 @@ public class Parameters
 		}
 		log(buf.toString());
 		return intArray;
+	}
+
+    public static String print(String value)
+	{
+        log("string " + value);
+        return value;
 	}
 
 	public static void print(Date time)

--- a/gpAux/extensions/pljava/src/java/examples/org/postgresql/example/SPIActions.java
+++ b/gpAux/extensions/pljava/src/java/examples/org/postgresql/example/SPIActions.java
@@ -38,7 +38,7 @@ public class SPIActions
 			System.out.println(msg);
 		}
 		else
-			Logger.getAnonymousLogger().info(msg);
+			Logger.getAnonymousLogger().config(msg);
 	}
 
 	private static final String SP_CHECKSTATE = "sp.checkState";
@@ -96,7 +96,7 @@ public class SPIActions
 		{
 			log("It failed allright. Everything OK then");
 			log("Rolling back to anonymous savepoint");
-			
+
 			nextState(currentSession, 2, 3);
 			conn.rollback(sp);
 			nextState(currentSession, 4, 5);
@@ -149,7 +149,7 @@ public class SPIActions
                 log("Expected: OK; Retrieved: " + rs.getString(1));
             }
             rs.close();
-            stmt.close();                
+            stmt.close();
 			nextState(currentSession, 2, 3);
 			conn.releaseSavepoint(sp);
 			nextState(currentSession, 4, 5);
@@ -200,7 +200,7 @@ public class SPIActions
 				int id = rs.getInt(1);
 				String name = rs.getString(2);
 				int empSal = rs.getInt(3);
-				
+
 				insert.setInt(1, id);
 				insert.setString(2, name);
 				insert.setInt(3, empSal);

--- a/gpAux/extensions/pljava/tests/Makefile
+++ b/gpAux/extensions/pljava/tests/Makefile
@@ -1,0 +1,21 @@
+#-------------------------------------------------------------------------
+# Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
+# Distributed under the terms shown in the file COPYRIGHT
+# found in the root folder of this project or at
+# http://eng.tada.se/osprojects/COPYRIGHT.html
+#
+# @author Thomas Hallgren
+#
+#-------------------------------------------------------------------------
+
+PLJAVADIR = $(shell $(SHELL) -c pwd)/..
+TOPDIR    = ../../../..
+REGRESS   = pljava_install pljava_test
+
+.PHONY: all test
+
+all: test
+
+test:
+	@-gpconfig -c pljava_classpath -v \'$(PLJAVADIR)/build/\'
+	$(TOPDIR)/src/test/regress/pg_regress --dbname=pljava $(REGRESS)

--- a/gpAux/extensions/pljava/tests/expected/pljava_install.out
+++ b/gpAux/extensions/pljava/tests/expected/pljava_install.out
@@ -1,0 +1,4 @@
+CREATE FUNCTION pljava_call_handler()  RETURNS language_handler AS 'pljava' LANGUAGE C;
+CREATE FUNCTION pljavau_call_handler() RETURNS language_handler AS 'pljava' LANGUAGE C;
+CREATE TRUSTED LANGUAGE java HANDLER pljava_call_handler;
+CREATE LANGUAGE javaU HANDLER pljavau_call_handler;

--- a/gpAux/extensions/pljava/tests/expected/pljava_test.out
+++ b/gpAux/extensions/pljava/tests/expected/pljava_test.out
@@ -1,0 +1,432 @@
+CREATE SCHEMA javatest;
+set search_path=javatest,public;
+CREATE TABLE javatest.test AS SELECT 1 as i distributed by (i);
+CREATE FUNCTION javatest.print(char)
+  RETURNS char
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print('a'::char);
+ print 
+-------
+ a
+(1 row)
+
+  SELECT javatest.print('a'::char) FROM javatest.test;
+ print 
+-------
+ a
+(1 row)
+
+  SELECT * FROM javatest.print('a'::char);
+ print 
+-------
+ a
+(1 row)
+
+CREATE FUNCTION javatest.print(varchar)
+  RETURNS varchar
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print('abc'::varchar);
+ print 
+-------
+ abc
+(1 row)
+
+  SELECT javatest.print('abc'::varchar) FROM javatest.test;
+ print 
+-------
+ abc
+(1 row)
+
+  SELECT * FROM javatest.print('abc'::varchar);
+ print 
+-------
+ abc
+(1 row)
+
+CREATE FUNCTION javatest.print(bytea)
+  RETURNS bytea
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print('a'::bytea);
+ print 
+-------
+ a
+(1 row)
+
+  SELECT javatest.print('a'::bytea) FROM javatest.test;
+ print 
+-------
+ a
+(1 row)
+
+  SELECT * FROM javatest.print('a'::bytea);
+ print 
+-------
+ a
+(1 row)
+
+CREATE FUNCTION javatest.print(int2)
+  RETURNS int2
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print(2::int2);
+ print 
+-------
+     2
+(1 row)
+
+  SELECT javatest.print(2::int2) FROM javatest.test;
+ print 
+-------
+     2
+(1 row)
+
+  SELECT * FROM javatest.print(2::int2);
+ print 
+-------
+     2
+(1 row)
+
+CREATE FUNCTION javatest.print(int2[])
+  RETURNS int2[]
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print('{2}'::int2[]);
+ print 
+-------
+ {2}
+(1 row)
+
+  SELECT javatest.print('{2}'::int2[]) FROM javatest.test;
+ print 
+-------
+ {2}
+(1 row)
+
+  SELECT * FROM javatest.print('{2}'::int2[]);
+ print 
+-------
+ {2}
+(1 row)
+
+CREATE FUNCTION javatest.print(int4)
+  RETURNS int4
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print(4::int4);
+ print 
+-------
+     4
+(1 row)
+
+  SELECT javatest.print(4::int4) FROM javatest.test;
+ print 
+-------
+     4
+(1 row)
+
+  SELECT * FROM javatest.print(4::int4);
+ print 
+-------
+     4
+(1 row)
+
+CREATE FUNCTION javatest.print(int4[])
+  RETURNS int4[]
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print('{4}'::int4[]);
+ print 
+-------
+ {4}
+(1 row)
+
+  SELECT javatest.print('{4}'::int4[]) FROM javatest.test;
+ print 
+-------
+ {4}
+(1 row)
+
+  SELECT * FROM javatest.print('{4}'::int4[]);
+ print 
+-------
+ {4}
+(1 row)
+
+CREATE FUNCTION javatest.print(int8)
+  RETURNS int8
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print(8::int8);
+ print 
+-------
+     8
+(1 row)
+
+  SELECT javatest.print(8::int8) FROM javatest.test;
+ print 
+-------
+     8
+(1 row)
+
+  SELECT * FROM javatest.print(8::int8);
+ print 
+-------
+     8
+(1 row)
+
+CREATE FUNCTION javatest.print(int8[])
+  RETURNS int8[]
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print('{8}'::int8[]);
+ print 
+-------
+ {8}
+(1 row)
+
+  SELECT javatest.print('{8}'::int8[]) FROM javatest.test;
+ print 
+-------
+ {8}
+(1 row)
+
+  SELECT * FROM javatest.print('{8}'::int8[]);
+ print 
+-------
+ {8}
+(1 row)
+
+CREATE FUNCTION javatest.print(real)
+  RETURNS real
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print(4.4::real);
+ print 
+-------
+   4.4
+(1 row)
+
+  SELECT javatest.print(4.4::real) FROM javatest.test;
+ print 
+-------
+   4.4
+(1 row)
+
+  SELECT * FROM javatest.print(4.4::real);
+ print 
+-------
+   4.4
+(1 row)
+
+CREATE FUNCTION javatest.print(real[])
+  RETURNS real[]
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print('{4.4}'::real[]);
+ print 
+-------
+ {4.4}
+(1 row)
+
+  SELECT javatest.print('{4.4}'::real[]) FROM javatest.test;
+ print 
+-------
+ {4.4}
+(1 row)
+
+  SELECT * FROM javatest.print('{4.4}'::real[]);
+ print 
+-------
+ {4.4}
+(1 row)
+
+CREATE FUNCTION javatest.print(double precision)
+  RETURNS double precision
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print(8.8::double precision);
+ print 
+-------
+   8.8
+(1 row)
+
+  SELECT javatest.print(8.8::double precision) FROM javatest.test;
+ print 
+-------
+   8.8
+(1 row)
+
+  SELECT * FROM javatest.print(8.8::double precision);
+ print 
+-------
+   8.8
+(1 row)
+
+CREATE FUNCTION javatest.print(double precision[])
+  RETURNS double precision[]
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+  SELECT javatest.print('{8.8}'::double precision[]);
+ print 
+-------
+ {8.8}
+(1 row)
+
+  SELECT javatest.print('{8.8}'::double precision[]) FROM javatest.test;
+ print 
+-------
+ {8.8}
+(1 row)
+
+  SELECT * FROM javatest.print('{8.8}'::double precision[]);
+ print 
+-------
+ {8.8}
+(1 row)
+
+CREATE FUNCTION javatest.printObj(int[])
+  RETURNS int[]
+  AS 'org.postgresql.example.Parameters.print(java.lang.Integer[])'
+  LANGUAGE java;
+  SELECT javatest.printObj('{4}'::int[]);
+ printobj 
+----------
+ {4}
+(1 row)
+
+  SELECT javatest.printObj('{4}'::int[]) FROM javatest.test;
+ printobj 
+----------
+ {4}
+(1 row)
+
+  SELECT * FROM javatest.printObj('{4}'::int[]);
+ printobj 
+----------
+ {4}
+(1 row)
+
+CREATE FUNCTION javatest.java_addOne(int)
+  RETURNS int
+  AS 'org.postgresql.example.Parameters.addOne(java.lang.Integer)'
+  IMMUTABLE LANGUAGE java;
+  SELECT javatest.java_addOne(1);
+ java_addone 
+-------------
+           2
+(1 row)
+
+  SELECT javatest.java_addOne(1) FROM javatest.test;
+ java_addone 
+-------------
+           2
+(1 row)
+
+  SELECT * FROM javatest.java_addOne(1);
+ java_addone 
+-------------
+           2
+(1 row)
+
+CREATE FUNCTION javatest.nullOnEven(int)
+  RETURNS int
+  AS 'org.postgresql.example.Parameters.nullOnEven'
+  IMMUTABLE LANGUAGE java;
+  SELECT javatest.nullOnEven(1);
+ nulloneven 
+------------
+          1
+(1 row)
+
+  SELECT javatest.nullOnEven(2);
+ nulloneven 
+------------
+           
+(1 row)
+
+  SELECT javatest.nullOnEven(1) FROM javatest.test;
+ nulloneven 
+------------
+          1
+(1 row)
+
+  SELECT javatest.nullOnEven(2) FROM javatest.test;
+ nulloneven 
+------------
+           
+(1 row)
+
+  SELECT * FROM javatest.nullOnEven(1);
+ nulloneven 
+------------
+          1
+(1 row)
+
+  SELECT * FROM javatest.nullOnEven(2);
+ nulloneven 
+------------
+           
+(1 row)
+
+/*
+ * This function should fail since file system access is
+ * prohibited when the language is trusted.
+ */
+CREATE FUNCTION javatest.create_temp_file_trusted()
+  RETURNS varchar
+  AS 'org.postgresql.example.Security.createTempFile'
+  LANGUAGE java;
+  SELECT javatest.create_temp_file_trusted();
+ERROR:  java.lang.ExceptionInInitializerError (JNICalls.c:70)
+  SELECT javatest.create_temp_file_trusted() FROM javatest.test;
+ERROR:  java.lang.ExceptionInInitializerError (JNICalls.c:70)  (seg0 slice1 gpdbvagrant.pivotal.io:40000 pid=1822) (cdbdisp.c:1324)
+  SELECT * FROM javatest.create_temp_file_trusted();
+ERROR:  java.lang.NoClassDefFoundError: Could not initialize class java.io.File$LazyInitialization (JNICalls.c:70)
+CREATE FUNCTION javatest.transferPeople(int)
+  RETURNS int
+  AS 'org.postgresql.example.SPIActions.transferPeopleWithSalary'
+  LANGUAGE java;
+  CREATE TABLE javatest.employees1(
+    id        int PRIMARY KEY,
+    name      varchar(200),
+    salary    int
+    );
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "employees1_pkey" for table "employees1"
+  CREATE TABLE javatest.employees2(
+    id            int PRIMARY KEY,
+    name          varchar(200),
+    salary        int,
+    transferDay   date,
+    transferTime  time
+    );
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "employees2_pkey" for table "employees2"
+  insert into employees1 values (1, 'Adam', 100);
+  insert into employees1 values (2, 'Brian', 200);
+  insert into employees1 values (3, 'Caleb', 300);
+  insert into employees1 values (4, 'David', 400);
+  SELECT javatest.transferPeople(1);
+ transferpeople 
+----------------
+              4
+(1 row)
+
+  SELECT * FROM employees1;
+ id | name | salary 
+----+------+--------
+(0 rows)
+
+  SELECT id,name, salary FROM employees2;
+ id | name  | salary 
+----+-------+--------
+  2 | Brian |    200
+  4 | David |    400
+  1 | Adam  |    100
+  3 | Caleb |    300
+(4 rows)
+
+  SELECT javatest.transferPeople(1) FROM javatest.test;  -- should error
+ERROR:  function cannot execute on segment because it accesses relation "javatest.employees1" (functions.c:155)  (seg0 slice1 gpdbvagrant.pivotal.io:40000 pid=1822) (cdbdisp.c:1324)
+DETAIL:  SQL statement "SELECT id, name, salary FROM employees1 WHERE salary > $1"

--- a/gpAux/extensions/pljava/tests/sql/pljava_install.sql
+++ b/gpAux/extensions/pljava/tests/sql/pljava_install.sql
@@ -1,0 +1,4 @@
+CREATE FUNCTION pljava_call_handler()  RETURNS language_handler AS 'pljava' LANGUAGE C;
+CREATE FUNCTION pljavau_call_handler() RETURNS language_handler AS 'pljava' LANGUAGE C;
+CREATE TRUSTED LANGUAGE java HANDLER pljava_call_handler;
+CREATE LANGUAGE javaU HANDLER pljavau_call_handler;

--- a/gpAux/extensions/pljava/tests/sql/pljava_test.sql
+++ b/gpAux/extensions/pljava/tests/sql/pljava_test.sql
@@ -1,25 +1,25 @@
-CREATE FUNCTION pljava_call_handler()  RETURNS language_handler AS 'pljava' LANGUAGE C;
-CREATE FUNCTION pljavau_call_handler() RETURNS language_handler AS 'pljava' LANGUAGE C;
-CREATE TRUSTED LANGUAGE java HANDLER pljava_call_handler;
-CREATE LANGUAGE javaU HANDLER pljavau_call_handler;
-\c test test
-DROP SCHEMA javatest CASCADE;
-alter database test owner to test;
 CREATE SCHEMA javatest;
 set search_path=javatest,public;
-#set pljava.classpath='examples.jar';
-set log_min_messages=info;  -- XXX
 
 CREATE TABLE javatest.test AS SELECT 1 as i distributed by (i);
 
-CREATE FUNCTION javatest.print("char")
-  RETURNS "char"
+CREATE FUNCTION javatest.print(char)
+  RETURNS char
   AS 'org.postgresql.example.Parameters.print'
   LANGUAGE java;
 
   SELECT javatest.print('a'::char);
   SELECT javatest.print('a'::char) FROM javatest.test;
   SELECT * FROM javatest.print('a'::char);
+
+CREATE FUNCTION javatest.print(varchar)
+  RETURNS varchar
+  AS 'org.postgresql.example.Parameters.print'
+  LANGUAGE java;
+
+  SELECT javatest.print('abc'::varchar);
+  SELECT javatest.print('abc'::varchar) FROM javatest.test;
+  SELECT * FROM javatest.print('abc'::varchar);
 
 CREATE FUNCTION javatest.print(bytea)
   RETURNS bytea
@@ -164,7 +164,7 @@ CREATE FUNCTION javatest.create_temp_file_trusted()
   SELECT javatest.create_temp_file_trusted();
   SELECT javatest.create_temp_file_trusted() FROM javatest.test;
   SELECT * FROM javatest.create_temp_file_trusted();
- 
+
 
 
 CREATE FUNCTION javatest.transferPeople(int)
@@ -174,7 +174,7 @@ CREATE FUNCTION javatest.transferPeople(int)
 
   CREATE TABLE javatest.employees1(
     id        int PRIMARY KEY,
-    name      varchar(200),	
+    name      varchar(200),
     salary    int
     );
 


### PR DESCRIPTION
Fixing PL/Java regression tests to work properly. Old version didn't work at all and even didn't have "expected" results. This patch moves regression testing into "tests" directory with a separate makefile referred from the main one for "test" scenario. Tests passing
Had to change logging as "INFO" is always printed to the client and it contains timestamp, which makes pg_regress crazy because it cannot compare them in a right way