### PR TITLE
Clean up some loose ends with the removal of error table feature.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2564,7 +2564,7 @@ CopyFromDispatch(CopyState cstate)
 	Datum	   *values;
 	bool	   *nulls;
 	int		   *attr_offsets;
-	int			total_rejeted_from_qes = 0;
+	int			total_rejected_from_qes = 0;
 	bool		isnull;
 	bool	   *isvarlena;
 	ResultRelInfo *resultRelInfo;
@@ -3493,7 +3493,7 @@ CopyFromDispatch(CopyState cstate)
 	 * databases Now we would like to end the copy command on
 	 * all segment databases across the cluster.
 	 */
-	total_rejeted_from_qes = cdbCopyEnd(cdbCopy);
+	total_rejected_from_qes = cdbCopyEnd(cdbCopy);
 
 	/*
 	 * If we quit the processing loop earlier due to a
@@ -3545,12 +3545,8 @@ CopyFromDispatch(CopyState cstate)
 	{
 		int total_rejected = 0;
 		int total_rejected_from_qd = cstate->cdbsreh->rejectcount;
-		
-		/* if used errtable, QD bad rows were sent to QEs and counted there. ignore QD count */
-		if (cstate->cdbsreh)
-			total_rejected_from_qd = 0;
-		
-		total_rejected = total_rejected_from_qd + total_rejeted_from_qes;
+
+		total_rejected = total_rejected_from_qd + total_rejected_from_qes;
 		cstate->processed -= total_rejected;
 
 		/* emit a NOTICE with number of rejected rows */

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1621,18 +1621,13 @@ PortalRunMulti(Portal portal, bool isTopLevel,
 			 * process utility functions (create, destroy, etc..)
 			 *
 			 * These are assumed canSetTag if they're the only stmt in the
-			 * portal, with the following exception:
-			 *
-			 *  A COPY FROM that specifies a non-existent error table, will
-			 *  be transformed (parse_analyze) into a (CreateStmt, CopyStmt).
-			 *  XXX Maybe this should be treated like DECLARE CURSOR?
+			 * portal.
 			 */
-			if (list_length(portal->stmts) == 1 || portal->sourceTag == T_CopyStmt)
+			if (list_length(portal->stmts) == 1)
 				PortalRunUtility(portal, stmt, isTopLevel, dest, completionTag);
 			else
 				PortalRunUtility(portal, stmt, isTopLevel, altdest, NULL);
 		}
-		
 
 		/*
 		 * Increment command counter between queries, but not after the last

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -86,8 +86,8 @@ typedef enum ErrLocType
 typedef enum CopyErrMode
 {
 	ALL_OR_NOTHING,	/* Either all rows or no rows get loaded (the default) */
-	SREH_IGNORE,	/* Sreh - ignore errors (REJECT but no error table) */
-	SREH_LOG		/* Sreh - log errors in an error table */
+	SREH_IGNORE,	/* Sreh - ignore errors (REJECT, but don't log errors) */
+	SREH_LOG		/* Sreh - log errors */
 } CopyErrMode;
 
 


### PR DESCRIPTION
Commit 3fd4bd9c6634d90f23099bdce75a910ba2813fad removed the feature to
log errors in COPY FORM or reading an external table to a table. This
cleans up some leftover changes (vs upstream) that were related to that,
but are no longer needed. Also fix typo in variable name.

@asubramanya, can you have a look, please?