### PR TITLE
Remove unused upgrade check during backend startup and recovery.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6545,16 +6545,6 @@ StartupXLOG(void)
 	else if (ControlFile->state != DB_SHUTDOWNED)
 		InRecovery = true;
 
-	/*
-	 * We need to create the pg_distributedlog directory if we are
-	 * upgrading from before 3.1.1.4 patch.
-	 *
-	 * Force a recovery to replay into the distributed log the
-	 * recent distributed transaction commits.
-	 */
-	if (DistributedLog_UpgradeCheck(InRecovery))
-		InRecovery = true;
-
 	if (InRecovery && !IsUnderPostmaster)
 	{
 		ereport(FATAL,


### PR DESCRIPTION
This check ensured that distributed transaction log does not have
missing pages, and if it does, initializes them to zero.  This was only
relevant in old Greeplum releases and is no longer required.