### PR TITLE
Revert unnecessary changes vs upstream in fd.c

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2386,7 +2386,7 @@ OpenOrCreateSubtransIdFile(DistributedTransactionId dxid)
 	{
 		subxip_file = OpenTemporaryFile(
 			Subtransaction_filename(dxid),
-			1, false, true, true, false);
+			false, true, true, false);
 		// What should be done if this fails ??
 	}
 }
@@ -2791,7 +2791,7 @@ GetSubXidsInXidBuffer(void)
 			subxip_file = OpenTemporaryFile(
 				Subtransaction_filename(
 					SharedLocalSnapshotSlot->QDxid),
-				1, false, false, false, false);
+				false, false, false, false);
 
 			if (subxip_file == 0)
 			{
@@ -2857,7 +2857,7 @@ ShowSubtransactionsForSharedSnapshot(void)
 			subxip_file = OpenTemporaryFile(
 				Subtransaction_filename(
 					SharedLocalSnapshotSlot->QDxid),
-				1, false, false, false, false);
+				false, false, false, false);
 
 			if (subxip_file == 0)
 			{

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -105,7 +105,7 @@ BufFileCreateTemp(const char *filePrefix, bool interXact)
 	File		pfile;
 	bool		closeAtEOXact = !interXact;
 
-	pfile = OpenTemporaryFile(filePrefix, 1, /* extentseqnum */
+	pfile = OpenTemporaryFile(filePrefix,
 							  true, /* makenameunique */
 							  true, /* create */
 							  true, /* delOnClose */
@@ -183,7 +183,7 @@ BufFileCreateTemp_ReaderWriter(const char *filePrefix, bool isWriter,
 							   bool interXact)
 {
 	bool closeAtEOXact = !interXact;
-	File pfile = OpenTemporaryFile(filePrefix, 1, /* extentseqnum */
+	File pfile = OpenTemporaryFile(filePrefix,
 								   false, /* makenameunique */
 								   isWriter, /* create */
 								   isWriter, /* delOnClose */

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1342,28 +1342,6 @@ FileSync(File file)
 	return returnCode;
 }
 
-/*
- * Get the size of a physical file by using fstat()
- *
- * Returns size in bytes if successful, < 0 otherwise
- */
-int64
-FileDiskSize(File file)
-{
-	int returnCode = 0;
-
-	returnCode = FileAccess(file);
-	if (returnCode < 0)
-		return returnCode;
-
-	struct stat buf;
-	returnCode = fstat(VfdCache[file].fd, &buf);
-	if (returnCode < 0)
-		return returnCode;
-
-	return (int64) buf.st_size;
-}
-
 int64
 FileSeek(File file, int64 offset, int whence)
 {
@@ -1425,6 +1403,28 @@ FileSeek(File file, int64 offset, int whence)
 		}
 	}
 	return VfdCache[file].seekPos;
+}
+
+/*
+ * Get the size of a physical file by using fstat()
+ *
+ * Returns size in bytes if successful, < 0 otherwise
+ */
+int64
+FileDiskSize(File file)
+{
+	int			returnCode = 0;
+	struct stat buf;
+
+	returnCode = FileAccess(file);
+	if (returnCode < 0)
+		return returnCode;
+
+	returnCode = fstat(VfdCache[file].fd, &buf);
+	if (returnCode < 0)
+		return returnCode;
+
+	return (int64) buf.st_size;
 }
 
 int64

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -54,9 +54,6 @@
 #include "storage/ipc.h"
 #include "utils/guc.h"
 #include "utils/workfile_mgr.h"
-
-/* Debug_filerep_print guc temporaly added for troubleshooting */
-#include "utils/guc.h"
 #include "utils/faultinjector.h"
 
 // Provide some indirection here in case we have problems with lseek and

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1549,6 +1549,20 @@ TryAgain:
 		errno = save_errno;
 	}
 
+	/*
+	 * TEMPORARY hack to log the Windows error code on fopen failures, in
+	 * hopes of diagnosing some hard-to-reproduce problems.
+	 */
+#ifdef WIN32
+	{
+		int			save_errno = errno;
+
+		elog(LOG, "Windows fopen(\"%s\",\"%s\") failed: code %lu, errno %d",
+			 name, mode, GetLastError(), save_errno);
+		errno = save_errno;
+	}
+#endif
+
 	return NULL;
 }
 

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -884,11 +884,10 @@ FileNameOpenFile(FileName fileName, int fileFlags, int fileMode)
  * should be unique to this particular OpenTemporaryFile() request and
  * distinct from any others in concurrent use on the same host.  As a
  * convenience for monitoring and debugging, the given 'fileName' string
- * and 'extentseqnum' are embedded in the file name.
+ * is embedded in the file name.
  *
- * If 'makenameunique' is false, then 'fileName' and 'extentseqnum' identify a
- * new or existing temporary file which other processes also could open and
- * share.
+ * If 'makenameunique' is false, then 'fileName' identify a new or existing
+ * temporary file which other processes also could open and share.
  *
  * If 'create' is true, a new file is created.  If successful, a valid vfd
  * index (>0) is returned; otherwise an error is thrown.
@@ -912,7 +911,6 @@ FileNameOpenFile(FileName fileName, int fileFlags, int fileMode)
  */
 File
 OpenTemporaryFile(const char   *fileName,
-                  int           extentseqnum,
                   bool          makenameunique,
                   bool          create,
                   bool          delOnClose,
@@ -937,18 +935,16 @@ OpenTemporaryFile(const char   *fileName,
 		 * database instance.
 		 */
 		snprintf(tempfilepath, sizeof(tempfilepath),
-				 "%s_%d_%04d.%ld",
+				 "%s_%d.%ld",
 				 tempfileprefix,
 				 MyProcPid,
-                 extentseqnum,
                  tempFileCounter++);
 	}
 	else
 	{
         snprintf(tempfilepath, sizeof(tempfilepath),
-				 "%s.%04d",
-				 tempfileprefix,
-				 extentseqnum);
+				 "%s",
+				 tempfileprefix);
 	}
 
     return OpenNamedFile(tempfilepath, create, delOnClose, closeAtEOXact);

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -65,7 +65,6 @@ extern File PathNameOpenFile(FileName fileName, int fileFlags, int fileMode);
 
 File
 OpenTemporaryFile(const char   *fileName,
-                  int           extentseqnum,
                   bool          makenameunique,
                   bool          create,
                   bool          delOnClose,

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -111,7 +111,6 @@ extern int	pg_fsync_no_writethrough(int fd);
 extern int	pg_fsync_writethrough(int fd);
 extern int	pg_fdatasync(int fd);
 extern int gp_retry_close(int fd);
-extern char *make_database_relative(const char *filename);
 
 /* Filename components for OpenTemporaryFile */
 #define PG_TEMP_FILES_DIR "pgsql_tmp"


### PR DESCRIPTION
To make merging easier.

@gcaragea, would you happen to remember the reason for the error message changes by any chance? I looked at the old git history before open sourcing, and the "file descriptor" -> "file handle" changes were made back in 2011 by your commit 670978c3, but I didn't see any rationale for the change.