### PR TITLE
Fixing the bug with deleting non-existent record from Python global dict

### DIFF
--- a/src/pl/plpython/plpython.c
+++ b/src/pl/plpython/plpython.c
@@ -1454,13 +1454,21 @@ static void
 PLy_function_delete_args(PLyProcedure *proc)
 {
 	int			i;
+	PyObject	*arg;
 
 	if (!proc->argnames)
 		return;
 
 	for (i = 0; i < proc->nargs; i++)
-		if (proc->argnames[i])
-			PyDict_DelItemString(proc->globals, proc->argnames[i]);
+		if (proc->argnames[i]) {
+			arg = PyString_FromString(proc->argnames[i]);
+
+			/* Deleting the item only if it exists in the dictionaty */
+			if (PyDict_Contains(proc->globals, arg)) {
+				PyDict_DelItem(proc->globals, arg);
+			}
+			Py_DECREF(arg);
+		}
 }
 
 /*
@@ -1982,12 +1990,12 @@ PLy_procedure_munge_source(const char *name, const char *src)
 				}
 			}
 
-			pyelog(INFO, "After searching the start of the string, index is: %d sf is: %d endquote is: %c", i, sf, cendquote); 
+			pyelog(INFO, "After searching the start of the string, index is: %d sf is: %d endquote is: %c", (int)i, sf, cendquote);
 
 			/* now copy all characters to the destination buffer if we see the beginning of a string */ 
 			while (sf != STRING_BEGIN_NOT_YET && sf != STRING_SEEN_END && i < olen)
 			{
-				pyelog(INFO, "copying src[%d]=%c", i, src[i]); 
+				pyelog(INFO, "copying src[%d]=%c", (int)i, src[i]);
 
 				BOUNDED_PTR_ASSIGN_INC(mp, mrc + mlen, src[i]); 
 
@@ -2016,7 +2024,7 @@ PLy_procedure_munge_source(const char *name, const char *src)
 				i++; 
 			}
 
-			pyelog(INFO, "After searching the END of the string, index is: %d sf is: %d", i, sf); 
+			pyelog(INFO, "After searching the END of the string, index is: %d sf is: %d", (int)i, sf);
 
 			if (i == olen) 
 				break; 


### PR DESCRIPTION
Fixing the issue #492:

The issue can be reproduced with this simple code:
```
CREATE OR REPLACE FUNCTION func1(var_cause_bug int4[]) RETURNS SETOF int4 AS $$
for el in var_cause_bug:
    yield el
$$ LANGUAGE plpythonu;

CREATE OR REPLACE FUNCTION func2() RETURNS int4 AS $$
return 1
$$ LANGUAGE plpythonu;

select func1(array[1,2,3]), func1(array[1,2,3]);
select func2();
```
You would see the following output:
```
vagrant=# select func1(array[1,2,3]), func1(array[1,2,3]);
 func1 | func1 
-------+-------
     1 |     1
     2 |     2
     3 |     3
(3 rows)

vagrant=# select func2();
ERROR:  could not compile PL/Python function "func2" (plpython.c:4648)
DETAIL:  KeyError: 'var_cause_bug'
```
This PR also fixes warning messages raised by elog function due to the attempt to print unsigned int with %d