### PR TITLE
Refactor cdbsubselect

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -16,6 +16,7 @@
 #include "optimizer/subselect.h"        /* convert_testexpr() */
 #include "optimizer/tlist.h"
 #include "optimizer/prep.h"              /* canonicalize_qual() */
+#include "optimizer/subselect.h"
 #include "optimizer/var.h"              /* contain_vars_of_level_or_above() */
 #include "parser/parse_oper.h"          /* make_op() */
 #include "parser/parse_expr.h"
@@ -27,9 +28,6 @@
 #include "cdb/cdbsubselect.h"           /* me */
 #include "lib/stringinfo.h"
 #include "cdb/cdbpullup.h"
-
-static Node *
-pull_up_IN_clauses(PlannerInfo *root, List** rtrlist_inout, Node *clause);
 
 static Node *
 convert_IN_to_antijoin(PlannerInfo * root, List** rtrlist_inout, SubLink * sublink);
@@ -81,8 +79,6 @@ static bool find_nonnullable_vars_walker(Node *node, NonNullableVarsContext *con
 static bool is_attribute_nonnullable(Oid relationOid, AttrNumber attrNumber);
 static bool is_targetlist_nullable(Query *subq);
 static Node *make_outer_nonnull_clause(SubLink *sublink);
-
-static bool has_correlation_in_funcexpr_rte(List *rtable);
 
 #define DUMMY_COLUMN_NAME "zero"
 
@@ -158,7 +154,7 @@ cdbsubselect_flatten_sublinks(struct PlannerInfo *root, struct Node *jtnode)
 /*
  * cdbsubselect_drop_distinct
  */
-static void
+void
 cdbsubselect_drop_distinct(Query *subselect)
 {
     if (subselect->limitCount == NULL &&
@@ -178,7 +174,7 @@ cdbsubselect_drop_distinct(Query *subselect)
 /*
  * cdbsubselect_drop_orderby
  */
-static void
+void
 cdbsubselect_drop_orderby(Query *subselect)
 {
     if (subselect->limitCount == NULL &&
@@ -193,7 +189,7 @@ cdbsubselect_drop_orderby(Query *subselect)
 /*
  * cdbsubselect_add_rte_and_ininfo
  */
-static InClauseInfo *
+InClauseInfo *
 cdbsubselect_add_rte_and_ininfo(PlannerInfo    *root, 
                                 List          **rtrlist_inout, 
                                 Query          *subselect,
@@ -683,7 +679,7 @@ safe_to_convert_EXPR(SubLink *sublink, ConvertSubqueryToJoinContext * ctx1)
  *
  * Method attempts to convert an EXPR_SUBLINK of the form select * from T where a > (select 10*avg(x) from R where T.b=R.y)
  */
-static Node *
+Node *
 convert_EXPR_to_join(PlannerInfo *root, List** rtrlist_inout, OpExpr *opexp)
 {
 	Assert(root);
@@ -1016,160 +1012,6 @@ convert_EXISTS_to_join(PlannerInfo *root, List** rtrlist_inout, SubLink *sublink
     return limitqual;
 }                               /* convert_EXISTS_to_join */
 
-/*
- * convert_IN_to_join: can we convert an IN SubLink to join style?
- *
- * This function was formerly in subselect.c.
- */
-static Node *
-convert_IN_to_join(PlannerInfo *root, List** rtrlist_inout, SubLink *sublink)
-{
-	Query	   *subselect = (Query *) sublink->subselect;
-	List	   *in_operators;
-	int			rtindex;
-	InClauseInfo *ininfo;
-    bool        correlated;
-	Node	   *result;
-
-    Assert(IsA(subselect, Query));
-
-    cdbsubselect_drop_orderby(subselect);
-    cdbsubselect_drop_distinct(subselect);
-
-	/*
-	 * The combining operators and left-hand expressions mustn't be volatile.
-	 */
-	if (contain_volatile_functions(sublink->testexpr))
-		return (Node *)sublink;
-
-	/**
-	 * If subquery returns a set-returning function (SRF) in the targetlist, we
-	 * do not attempt to convert the IN to a join.
-	 */
-	
-	if (expression_returns_set((Node *) subselect->targetList))
-		return (Node *) sublink;
-
-	/**
-	 * If deeply correlated, then don't pull it up
-	 */
-	if (IsSubqueryMultiLevelCorrelated(subselect))
-		return (Node *) sublink;
-
-	/**
-	 * If there are CTEs, then the transformation does not work. Don't attempt to pullup.
-	 */
-	if (root->parse->cteList)
-		return (Node *) sublink;
-
-    /*
-     * If uncorrelated, and no Var nodes on lhs, the subquery will be executed
-     * only once.  It should become an InitPlan, but make_subplan() doesn't
-     * handle that case, so just flatten it for now.
-     * CDB TODO: Let it become an InitPlan, so its QEs can be recycled.
-     */
-    correlated = contain_vars_of_level_or_above(sublink->subselect, 1);
-
-    if (correlated)
-    {
-    	/**
-    	 * Under certain conditions, we do cannot pull up the subquery as a join.
-    	 */
-
-    	if (subselect->hasAggs
-    			|| (subselect->jointree->fromlist == NULL)
-    			|| subselect->havingQual
-    			|| subselect->groupClause
-    			|| subselect->hasWindFuncs
-    			|| subselect->distinctClause
-    			|| subselect->setOperations)
-    		return (Node *) sublink;
-    	
-    	/* do not pull subqueries with correlation in a func expr in the 
-    	   from clause of the subselect */
-    	if (has_correlation_in_funcexpr_rte(subselect->rtable))
-    	{
-    		return (Node *) sublink;
-    	}
-
-    	if (contain_subplans(subselect->jointree->quals))
-    	{
-    		return (Node *) sublink;
-    	}
-    }
-
-    /*
-	 * Okay, pull up the sub-select into top range table and jointree.
-	 *
-	 * We rely here on the assumption that the outer query has no references
-	 * to the inner (necessarily true, other than the Vars that we build
-	 * below). Therefore this is a lot easier than what pull_up_subqueries has
-	 * to go through.
-	 */
-    ininfo = cdbsubselect_add_rte_and_ininfo(root, rtrlist_inout, subselect, "IN_subquery");
-
-    /* Get the index of the subquery RTE that was just created. */
-	rtindex = list_length(root->parse->rtable);
-    Assert(rt_fetch(rtindex, root->parse->rtable)->subquery == subselect);
-
-    /*
-     * Uncorrelated "=ANY" subqueries can use JOIN_UNIQUE dedup technique.  We
-	 * expect that the test expression will be either a single OpExpr, or an
-	 * AND-clause containing OpExprs.  (If it's anything else then the parser
-	 * must have determined that the operators have non-equality-like
-	 * semantics.  In the OpExpr case we can't be sure what the operator's
-	 * semantics are like, and must check for ourselves.)
-     */
-    ininfo->try_join_unique = false;
-	in_operators = NIL;
-	if (!correlated &&
-        sublink->testexpr)
-    {
-		ininfo->try_join_unique = true;
-        if (IsA(sublink->testexpr, OpExpr))
-	    {
-			Oid			opno = ((OpExpr *) sublink->testexpr)->opno;
-		    List	   *opfamilies;
-		    List	   *opstrats;
-
-		    get_op_btree_interpretation(opno, &opfamilies, &opstrats);
-		    if (!list_member_int(opstrats, ROWCOMPARE_EQ))
-			    ininfo->try_join_unique = false;
-			in_operators = list_make1_oid(opno);
-	    }
-		else if (and_clause(sublink->testexpr))
-		{
-			ListCell   *lc;
-
-			/* OK, but we need to extract the per-column operator OIDs */
-			in_operators = NIL;
-			foreach(lc, ((BoolExpr *) sublink->testexpr)->args)
-			{
-				OpExpr *op = (OpExpr *) lfirst(lc);
-
-				if (!IsA(op, OpExpr))           /* probably shouldn't happen */
-					ininfo->try_join_unique = false;
-				in_operators = lappend_oid(in_operators, op->opno);
-			}
-        }
-		else
-			ininfo->try_join_unique = false;
-    }
-
-	ininfo->in_operators = in_operators;
-
-	/*
-	 * Build the result qual expression.  As a side effect,
-	 * ininfo->sub_targetlist is filled with a list of Vars representing the
-	 * subselect outputs.
-	 */
-	result = convert_testexpr(root, sublink->testexpr,
-							  rtindex,
-							  &ininfo->sub_targetlist);
-
-	return result;
-}                               /* convert_IN_to_join */
-
 
 /*
  * convert_sublink_to_join: can we convert a SubLink to join style?
@@ -1189,7 +1031,7 @@ convert_IN_to_join(PlannerInfo *root, List** rtrlist_inout, SubLink *sublink)
  * node is appended to the caller's List referenced by *rtrlist_inout, so the
  * caller can add it to the jointree.
  */
-static Node *
+Node *
 convert_sublink_to_join(PlannerInfo *root, List** rtrlist_inout, SubLink *sublink)
 {
     Node   *result = (Node *)sublink;
@@ -1981,139 +1823,11 @@ convert_IN_to_antijoin(PlannerInfo * root, List **rtrlist_inout __attribute__((u
 }
 
 /*
- * pull_up_IN_clauses
- *		Attempt to pull up top-level IN clauses to be treated like joins.
- *
- * A clause "foo IN (sub-SELECT)" appearing at the top level of WHERE can
- * be processed by pulling the sub-SELECT up to become a rangetable entry
- * and handling the implied equality comparisons as join operators (with
- * special join rules).
- * This optimization *only* works at the top level of WHERE, because
- * it cannot distinguish whether the IN ought to return FALSE or NULL in
- * cases involving NULL inputs.  This routine searches for such clauses
- * and does the necessary parsetree transformations if any are found.
- *
- * This routine has to run before preprocess_expression(), so the WHERE
- * clause is not yet reduced to implicit-AND format.  That means we need
- * to recursively search through explicit AND clauses, which are
- * probably only binary ANDs.  We stop as soon as we hit a non-AND item.
- *
- * Returns the possibly-modified version of the given qual-tree node.
- *
- * This function was formerly in prepjointree.c.
- */
-static Node *
-pull_up_IN_clauses(PlannerInfo * root, List **rtrlist_inout, Node *clause)
-{
-	if (clause == NULL)
-		return NULL;
-	if (IsA(clause, SubLink))
-	{
-		SubLink    *sublink = (SubLink *) clause;
-		Node	   *subst;
-
-		/* Is it a convertible IN clause?  If not, return it as-is */
-		subst = convert_sublink_to_join(root, rtrlist_inout, sublink);
-		return subst;
-	}
-	if (and_clause(clause))
-	{
-		List	   *newclauses = NIL;
-		ListCell   *l;
-
-		foreach(l, ((BoolExpr *) clause)->args)
-		{
-			Node	   *oldclause = (Node *) lfirst(l);
-			Node	   *newclause = pull_up_IN_clauses(root, rtrlist_inout, oldclause);
-
-			if (newclause)
-				newclauses = lappend(newclauses, newclause);
-		}
-		return (Node *) make_ands_explicit(newclauses);
-	}
-	if (not_clause(clause))
-	{
-		Node	   *arg = (Node *) get_notclausearg((Expr *) clause);
-
-		/*
-		 *	 We normalize NOT subqueries using the following axioms:
-		 *
-		 *		 val NOT IN (subq)		 =>  val <> ALL (subq)
-		 *		 NOT val op ANY (subq)	 =>  val op' ALL (subq)
-		 *		 NOT val op ALL (subq)	 =>  val op' ANY (subq)
-		 */
-
-		if (IsA(arg, SubLink))
-		{
-			SubLink    *sublink = (SubLink *) arg;
-
-			if (sublink->subLinkType == ANY_SUBLINK)
-			{
-				sublink->subLinkType = ALL_SUBLINK;
-				sublink->testexpr = (Node *) canonicalize_qual(
-									 make_notclause((Expr *) sublink->testexpr));
-			}
-			else if (sublink->subLinkType == ALL_SUBLINK)
-			{
-				sublink->subLinkType = ANY_SUBLINK;
-				sublink->testexpr = (Node *) canonicalize_qual(
-									 make_notclause((Expr *) sublink->testexpr));
-			}
-			else if (sublink->subLinkType == EXISTS_SUBLINK)
-			{
-				sublink->subLinkType = NOT_EXISTS_SUBLINK;
-			}
-			else
-			{
-				return clause;	/* do nothing for other sublinks */
-			}
-
-			return (Node *) pull_up_IN_clauses(root, rtrlist_inout, (Node *) sublink);
-		}
-		else if (not_clause(arg))
-		{
-			/* NOT NOT (expr) => (expr)  */
-			return (Node *) pull_up_IN_clauses(root, rtrlist_inout,
-									(Node *) get_notclausearg((Expr *) arg));
-		}
-		else if (or_clause(arg))
-		{
-			/* NOT OR (expr1) (expr2) => (expr1) AND (expr2) */
-			return (Node *) pull_up_IN_clauses(root, rtrlist_inout,
-									(Node *) canonicalize_qual((Expr *) clause));
-			
-		}
-	}
-
-	/**
-	 * (expr) op SUBLINK
-	 */
-	if (IsA(clause, OpExpr))
-	{
-		OpExpr *opexp = (OpExpr *) clause;
-
-		if (list_length(opexp->args) == 2)
-		{
-			/**
-			 * Check if second arg is sublink
-			 */
-			Node *rarg = list_nth(opexp->args, 1);
-
-			if (IsA(rarg, SubLink))
-			{
-				return (Node *) convert_EXPR_to_join(root, rtrlist_inout, opexp);
-			}
-		}
-	}
-	/* Stop if not an AND */
-	return clause;
-}
-
-/*
  * Check if there is a range table entry of type func expr whose arguments
  * are correlated
  */
-bool has_correlation_in_funcexpr_rte(List *rtable)
+bool
+has_correlation_in_funcexpr_rte(List *rtable)
 {
 	/* check if correlation occurs in a func expr in the from clause of the
 	   subselect */

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -66,11 +66,133 @@ static Node *find_jointree_node_for_rel(Node *jtnode, int relid);
 
 extern void UpdateScatterClause(Query *query, List *newtlist);
 
+
 /*
  * pull_up_IN_clauses
+ *		Attempt to pull up top-level IN clauses to be treated like joins.
  *
- * CDB: This function has been moved into cdbsubselect.c.
+ * A clause "foo IN (sub-SELECT)" appearing at the top level of WHERE can
+ * be processed by pulling the sub-SELECT up to become a rangetable entry
+ * and handling the implied equality comparisons as join operators (with
+ * special join rules).
+ * This optimization *only* works at the top level of WHERE, because
+ * it cannot distinguish whether the IN ought to return FALSE or NULL in
+ * cases involving NULL inputs.  This routine searches for such clauses
+ * and does the necessary parsetree transformations if any are found.
+ *
+ * This routine has to run before preprocess_expression(), so the WHERE
+ * clause is not yet reduced to implicit-AND format.  That means we need
+ * to recursively search through explicit AND clauses, which are
+ * probably only binary ANDs.  We stop as soon as we hit a non-AND item.
+ *
+ * Returns the possibly-modified version of the given qual-tree node.
  */
+Node *
+pull_up_IN_clauses(PlannerInfo * root, List **rtrlist_inout, Node *node)
+{
+	if (node == NULL)
+		return NULL;
+	if (IsA(node, SubLink))
+	{
+		SubLink    *sublink = (SubLink *) node;
+		Node	   *subst;
+
+		/* Is it a convertible IN clause?  If not, return it as-is */
+		subst = convert_sublink_to_join(root, rtrlist_inout, sublink);
+		return subst;
+	}
+	if (and_clause(node))
+	{
+		List	   *newclauses = NIL;
+		ListCell   *l;
+
+		foreach(l, ((BoolExpr *) node)->args)
+		{
+			Node	   *oldclause = (Node *) lfirst(l);
+			Node	   *newclause = pull_up_IN_clauses(root, rtrlist_inout, oldclause);
+
+			if (newclause)
+				newclauses = lappend(newclauses, newclause);
+		}
+		return (Node *) make_ands_explicit(newclauses);
+	}
+	if (not_clause(node))
+	{
+		Node	   *arg = (Node *) get_notclausearg((Expr *) node);
+
+		/*
+		 *	 We normalize NOT subqueries using the following axioms:
+		 *
+		 *		 val NOT IN (subq)		 =>  val <> ALL (subq)
+		 *		 NOT val op ANY (subq)	 =>  val op' ALL (subq)
+		 *		 NOT val op ALL (subq)	 =>  val op' ANY (subq)
+		 */
+
+		if (IsA(arg, SubLink))
+		{
+			SubLink    *sublink = (SubLink *) arg;
+
+			if (sublink->subLinkType == ANY_SUBLINK)
+			{
+				sublink->subLinkType = ALL_SUBLINK;
+				sublink->testexpr = (Node *) canonicalize_qual(
+									 make_notclause((Expr *) sublink->testexpr));
+			}
+			else if (sublink->subLinkType == ALL_SUBLINK)
+			{
+				sublink->subLinkType = ANY_SUBLINK;
+				sublink->testexpr = (Node *) canonicalize_qual(
+									 make_notclause((Expr *) sublink->testexpr));
+			}
+			else if (sublink->subLinkType == EXISTS_SUBLINK)
+			{
+				sublink->subLinkType = NOT_EXISTS_SUBLINK;
+			}
+			else
+			{
+				return node;	/* do nothing for other sublinks */
+			}
+
+			return (Node *) pull_up_IN_clauses(root, rtrlist_inout, (Node *) sublink);
+		}
+		else if (not_clause(arg))
+		{
+			/* NOT NOT (expr) => (expr)  */
+			return (Node *) pull_up_IN_clauses(root, rtrlist_inout,
+									(Node *) get_notclausearg((Expr *) arg));
+		}
+		else if (or_clause(arg))
+		{
+			/* NOT OR (expr1) (expr2) => (expr1) AND (expr2) */
+			return (Node *) pull_up_IN_clauses(root, rtrlist_inout,
+									(Node *) canonicalize_qual((Expr *) node));
+			
+		}
+	}
+
+	/**
+	 * (expr) op SUBLINK
+	 */
+	if (IsA(node, OpExpr))
+	{
+		OpExpr *opexp = (OpExpr *) node;
+
+		if (list_length(opexp->args) == 2)
+		{
+			/**
+			 * Check if second arg is sublink
+			 */
+			Node *rarg = list_nth(opexp->args, 1);
+
+			if (IsA(rarg, SubLink))
+			{
+				return (Node *) convert_EXPR_to_join(root, rtrlist_inout, opexp);
+			}
+		}
+	}
+	/* Stop if not an AND */
+	return node;
+}
 
 /*
  * pull_up_subqueries

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -25,6 +25,7 @@
 #include "nodes/makefuncs.h"
 #include "optimizer/clauses.h"
 #include "optimizer/prep.h"
+#include "optimizer/subselect.h"
 #include "optimizer/tlist.h"
 #include "optimizer/var.h"
 #include "parser/parse_expr.h"
@@ -222,7 +223,7 @@ Node *
 pull_up_subqueries(PlannerInfo *root, Node *jtnode,
 				   bool below_outer_join, bool append_rel_member)
 {
-    if (jtnode == NULL)
+	if (jtnode == NULL)
 		return NULL;
 	if (IsA(jtnode, RangeTblRef))
 	{
@@ -246,7 +247,8 @@ pull_up_subqueries(PlannerInfo *root, Node *jtnode,
 		 * If we are looking at an append-relation member, we can't pull it up
 		 * unless is_safe_append_member says so.
 		 */
-		if (rte->rtekind == RTE_SUBQUERY && !rte->forceDistRandom &&
+		if (rte->rtekind == RTE_SUBQUERY &&
+			!rte->forceDistRandom &&
 			is_simple_subquery(root, rte->subquery) &&
 			(!below_outer_join || has_nullable_targetlist(rte->subquery)) &&
 			(!append_rel_member || is_safe_append_member(rte->subquery)))

--- a/src/include/cdb/cdbsubselect.h
+++ b/src/include/cdb/cdbsubselect.h
@@ -15,4 +15,15 @@ struct PlannerInfo;                     /* #include "nodes/relation.h" */
 
 extern void cdbsubselect_flatten_sublinks(struct PlannerInfo *root, struct Node *jtnode);
 
+extern Node *convert_sublink_to_join(PlannerInfo *root, List** rtrlist_inout, SubLink *sublink);
+extern Node *convert_EXPR_to_join(PlannerInfo *root, List** rtrlist_inout, OpExpr *opexp);
+
+extern void cdbsubselect_drop_orderby(Query *subselect);
+extern void cdbsubselect_drop_distinct(Query *subselect);
+extern InClauseInfo *cdbsubselect_add_rte_and_ininfo(PlannerInfo *root,
+                                List **rtrlist_inout,
+                                Query *subselect,
+                                const char *aliasname);
+extern bool has_correlation_in_funcexpr_rte(List *rtable);
+
 #endif   /* CDBSUBSELECT_H */

--- a/src/include/cdb/cdbsubselect.h
+++ b/src/include/cdb/cdbsubselect.h
@@ -20,10 +20,6 @@ extern Node *convert_EXPR_to_join(PlannerInfo *root, List** rtrlist_inout, OpExp
 
 extern void cdbsubselect_drop_orderby(Query *subselect);
 extern void cdbsubselect_drop_distinct(Query *subselect);
-extern InClauseInfo *cdbsubselect_add_rte_and_ininfo(PlannerInfo *root,
-                                List **rtrlist_inout,
-                                Query *subselect,
-                                const char *aliasname);
 extern bool has_correlation_in_funcexpr_rte(List *rtable);
 
 #endif   /* CDBSUBSELECT_H */

--- a/src/include/optimizer/prep.h
+++ b/src/include/optimizer/prep.h
@@ -22,7 +22,7 @@
 /*
  * prototypes for prepjointree.c
  */
-//extern Node *pull_up_IN_clauses(PlannerInfo *root, Node *node);
+extern Node *pull_up_IN_clauses(PlannerInfo *root, List **rtrlist_inout, Node *node);
 extern Node *pull_up_subqueries(PlannerInfo *root, Node *jtnode,
 				   bool below_outer_join, bool append_rel_member);
 extern void reduce_outer_joins(PlannerInfo *root);

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -16,6 +16,7 @@
 #include "nodes/plannodes.h"
 #include "nodes/relation.h"
 
+extern Node *convert_IN_to_join(PlannerInfo *root, List **rtrlist_inout, SubLink *sublink);
 extern Node *convert_testexpr(PlannerInfo *root, Node *testexpr, int rtindex, List **righthandIds);
 extern Node *SS_replace_correlation_vars(PlannerInfo *root, Node *expr);
 extern Node *SS_process_sublinks(PlannerInfo *root, Node *expr, bool isQual);


### PR DESCRIPTION
This moves some code back to where it is in the upstream, to make merging slightly easier. And some other similar cleanup of unnecessary differences vs. upstream.