### PR TITLE
Add more installcheck test coverage for AO/CO tables.

### DIFF
--- a/src/test/regress/bugbuster/expected/tpch_aopart.out
+++ b/src/test/regress/bugbuster/expected/tpch_aopart.out
@@ -1,0 +1,1604 @@
+\c tpch_heap
+-- Create table region
+CREATE TABLE aopart_REGION (
+    R_REGIONKEY INTEGER,
+    R_NAME CHAR(25),
+    R_COMMENT VARCHAR(152)
+    )
+partition by range (r_regionkey) (partition p1 start('0') end('5'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r_regionkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "aopart_region_1_prt_p1" for table "aopart_region"
+insert into aopart_region select * from region;
+select count(*) from aopart_region;
+ count 
+-------
+     5
+(1 row)
+
+ANALYZE aopart_REGION;
+-- Create table nation
+CREATE TABLE aopart_NATION (
+    N_NATIONKEY INTEGER,
+    N_NAME CHAR(25),
+    N_REGIONKEY INTEGER,
+    N_COMMENT VARCHAR(152)
+    )
+partition by range (n_nationkey)
+subpartition by range (n_regionkey) subpartition template (start('0') end('1') inclusive,start('1') exclusive)
+(partition p1 start('0') end('10') WITH (appendonly=true,checksum=true,compresslevel=9), partition p2 start('10') end('25') WITH (checksum=false,appendonly=true,compresslevel=7));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'n_nationkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "aopart_nation_1_prt_p1" for table "aopart_nation"
+NOTICE:  CREATE TABLE will create partition "aopart_nation_1_prt_p2" for table "aopart_nation"
+NOTICE:  CREATE TABLE will create partition "aopart_nation_1_prt_p1_2_prt_1" for table "aopart_nation_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "aopart_nation_1_prt_p1_2_prt_2" for table "aopart_nation_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "aopart_nation_1_prt_p2_2_prt_1" for table "aopart_nation_1_prt_p2"
+NOTICE:  CREATE TABLE will create partition "aopart_nation_1_prt_p2_2_prt_2" for table "aopart_nation_1_prt_p2"
+insert into aopart_nation select * from nation;
+select count(*) from aopart_nation;
+ count 
+-------
+    25
+(1 row)
+
+ANALYZE aopart_NATION;
+-- Create table customer
+CREATE TABLE aopart_CUSTOMER (
+    C_CUSTKEY INTEGER,
+    C_NAME VARCHAR(25),
+    C_ADDRESS VARCHAR(40),
+    C_NATIONKEY INTEGER,
+    C_PHONE CHAR(15),
+    C_ACCTBAL decimal,
+    C_MKTSEGMENT CHAR(10),
+    C_COMMENT VARCHAR(117)
+    )
+    WITH (appendonly=true,checksum=false,compresslevel=1)
+    partition by list (c_mktsegment)
+    (partition p1 values('BUILDING','FURNITURE'), partition p2 values('MACHINERY'), partition p3 values('AUTOMOBILE'), partition p4 values('HOUSEHOLD'), partition p5 values(null));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c_custkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "aopart_customer_1_prt_p1" for table "aopart_customer"
+NOTICE:  CREATE TABLE will create partition "aopart_customer_1_prt_p2" for table "aopart_customer"
+NOTICE:  CREATE TABLE will create partition "aopart_customer_1_prt_p3" for table "aopart_customer"
+NOTICE:  CREATE TABLE will create partition "aopart_customer_1_prt_p4" for table "aopart_customer"
+NOTICE:  CREATE TABLE will create partition "aopart_customer_1_prt_p5" for table "aopart_customer"
+insert into aopart_customer select * from customer;
+select count(*) from aopart_customer;
+ count 
+-------
+  1500
+(1 row)
+
+ANALYZE aopart_CUSTOMER;
+-- Create table part
+CREATE TABLE aopart_part (
+    P_PARTKEY INTEGER,
+    P_NAME VARCHAR(55),
+    P_MFGR CHAR(25),
+    P_BRAND CHAR(10),
+    P_TYPE VARCHAR(25),
+    P_SIZE integer,
+    P_CONTAINER CHAR(10),
+    P_RETAILPRICE decimal,
+    P_COMMENT VARCHAR(23)
+    )
+    WITH (blocksize=16384,appendonly=true,checksum=false,compresstype=zlib,compresslevel=1)
+    partition by list (p_brand)
+    (partition p1 values('Brand#45','Brand#31','Brand#25') WITH (appendonly=true,checksum=true,compresslevel=5,compresstype=zlib), partition p2 values('Brand#34','Brand#22','Brand#21','Brand#55','Brand#32','Brand#13','Brand#35','Brand#51','Brand#24','Brand#43','Brand#54','Brand#33','Brand#23','Brand#14','Brand#53','Brand#15','Brand#52','Brand#44','Brand#41','Brand#42','Brand#11','Brand#12'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'p_partkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "aopart_part_1_prt_p1" for table "aopart_part"
+NOTICE:  CREATE TABLE will create partition "aopart_part_1_prt_p2" for table "aopart_part"
+insert into aopart_part select * from part;
+select count(*) from aopart_part;
+ count 
+-------
+  2000
+(1 row)
+
+ANALYZE aopart_part;
+-- Create table supplier
+CREATE TABLE aopart_supplier (
+    S_SUPPKEY INTEGER,
+    S_NAME CHAR(25),
+    S_ADDRESS VARCHAR(40),
+    S_NATIONKEY INTEGER,
+    S_PHONE CHAR(15),
+    S_ACCTBAL decimal,
+    S_COMMENT VARCHAR(101)
+    )
+    WITH (blocksize=32768,appendonly=true,checksum=true,compresslevel=2)
+    partition by range (s_nationkey)
+(partition p1 start('0') end('25') every(12));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's_suppkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "aopart_supplier_1_prt_p1_1" for table "aopart_supplier"
+NOTICE:  CREATE TABLE will create partition "aopart_supplier_1_prt_p1_2" for table "aopart_supplier"
+NOTICE:  CREATE TABLE will create partition "aopart_supplier_1_prt_p1_3" for table "aopart_supplier"
+insert into aopart_supplier select * from supplier;
+select count(*) from aopart_supplier;
+ count 
+-------
+   100
+(1 row)
+
+ANALYZE aopart_supplier;
+-- Create table partsupp
+CREATE TABLE aopart_PARTSUPP (
+    PS_PARTKEY INTEGER,
+    PS_SUPPKEY INTEGER,
+    PS_AVAILQTY integer,
+    PS_SUPPLYCOST decimal,
+    PS_COMMENT VARCHAR(199)
+    )
+    WITH (checksum=false,appendonly=true,blocksize=49152,compresslevel=8)
+    partition by range (ps_partkey)
+(partition p1 start('1') end('9214980'), partition p2 start('9214980') end('43244457') exclusive , partition p3 end('60489818'), partition p4 start('60489818') end('63663358') inclusive WITH (appendonly=true,checksum=false,compresstype=zlib,compresslevel=1), partition p5 end('100000001') WITH (checksum=true,appendonly=true,compresstype=zlib,compresslevel=1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'ps_partkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "aopart_partsupp_1_prt_p1" for table "aopart_partsupp"
+NOTICE:  CREATE TABLE will create partition "aopart_partsupp_1_prt_p2" for table "aopart_partsupp"
+NOTICE:  CREATE TABLE will create partition "aopart_partsupp_1_prt_p3" for table "aopart_partsupp"
+NOTICE:  CREATE TABLE will create partition "aopart_partsupp_1_prt_p4" for table "aopart_partsupp"
+NOTICE:  CREATE TABLE will create partition "aopart_partsupp_1_prt_p5" for table "aopart_partsupp"
+insert into aopart_partsupp select * from partsupp;
+select count(*) from aopart_partsupp;
+ count 
+-------
+  8000
+(1 row)
+
+ANALYZE aopart_PARTSUPP;
+-- Create table orders
+CREATE TABLE aopart_ORDERS (
+    O_ORDERKEY INT8,
+    O_CUSTKEY INTEGER,
+    O_ORDERSTATUS CHAR(1),
+    O_TOTALPRICE decimal,
+    O_ORDERDATE date,
+    O_ORDERPRIORITY CHAR(15),
+    O_CLERK CHAR(15),
+    O_SHIPPRIORITY integer,
+    O_COMMENT VARCHAR(79)
+    )
+    partition by range (o_orderkey) subpartition by range (o_orderdate), subpartition by list (o_orderstatus) subpartition template (values('F','O','P'))
+    (partition p1 start('1') end('6000001') every(2000000)
+    (subpartition sp1 start('1992-01-01') ,subpartition sp2 start('1996-08-03') end('1998-08-03')));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'o_orderkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_1" for table "aopart_orders"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_2" for table "aopart_orders"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_3" for table "aopart_orders"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_1_2_prt_sp1" for table "aopart_orders_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_1_2_prt_sp2" for table "aopart_orders_1_prt_p1_1"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_1_2_prt_sp1_3_prt_1" for table "aopart_orders_1_prt_p1_1_2_prt_sp1"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_1_2_prt_sp2_3_prt_1" for table "aopart_orders_1_prt_p1_1_2_prt_sp2"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_2_2_prt_sp1" for table "aopart_orders_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_2_2_prt_sp2" for table "aopart_orders_1_prt_p1_2"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_2_2_prt_sp1_3_prt_1" for table "aopart_orders_1_prt_p1_2_2_prt_sp1"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_2_2_prt_sp2_3_prt_1" for table "aopart_orders_1_prt_p1_2_2_prt_sp2"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_3_2_prt_sp1" for table "aopart_orders_1_prt_p1_3"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_3_2_prt_sp2" for table "aopart_orders_1_prt_p1_3"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_3_2_prt_sp1_3_prt_1" for table "aopart_orders_1_prt_p1_3_2_prt_sp1"
+NOTICE:  CREATE TABLE will create partition "aopart_orders_1_prt_p1_3_2_prt_sp2_3_prt_1" for table "aopart_orders_1_prt_p1_3_2_prt_sp2"
+insert into aopart_orders select * from orders;
+select count(*) from aopart_orders;
+ count 
+-------
+ 15000
+(1 row)
+
+ANALYZE aopart_ORDERS;
+-- Create table lineitem
+CREATE TABLE aopart_LINEITEM (
+    L_ORDERKEY INT8,
+    L_PARTKEY INTEGER,
+    L_SUPPKEY INTEGER,
+    L_LINENUMBER integer,
+    L_QUANTITY decimal,
+    L_EXTENDEDPRICE decimal,
+    L_DISCOUNT decimal,
+    L_TAX decimal,
+    L_RETURNFLAG CHAR(1),
+    L_LINESTATUS CHAR(1),
+    L_SHIPDATE date,
+    L_COMMITDATE date,
+    L_RECEIPTDATE date,
+    L_SHIPINSTRUCT CHAR(25),
+    L_SHIPMODE CHAR(10),
+    L_COMMENT VARCHAR(44)
+    )
+    WITH (appendonly=true,checksum=false,compresslevel=3)
+    partition by list (l_tax)
+    subpartition by range (l_suppkey) subpartition template (start('1') end('5000001') every(1666666))
+    ,subpartition by range (l_commitdate) subpartition template (start('1992-01-31') end('1998-11-01') every(interval '15 months'))
+    ,subpartition by list (l_discount) subpartition template (
+    values('0','0.1'),
+    values('0.06','0.01','0.02','0.07','0.08') WITH (appendonly=true,checksum=false,compresstype=zlib,compresslevel=1),
+    values('0.09','0.05','0.04','0.03'))
+    (partition p1 values('0','0.08') WITH (compresslevel=1,compresstype=zlib,appendonly=true,checksum=true), partition p2 values('0.07','0.01','0.06','0.05','0.02','0.04','0.03'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'l_orderkey' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1" for table "aopart_lineitem"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2" for table "aopart_lineitem"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1" for table "aopart_lineitem_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2" for table "aopart_lineitem_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3" for table "aopart_lineitem_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4" for table "aopart_lineitem_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_4" for table "aopart_lineitem_1_prt_p1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_5" for table "aopart_lineitem_1_prt_p1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_6" for table "aopart_lineitem_1_prt_p1_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_1_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_1_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_1_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_2_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_2_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_2_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_3_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_3_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_3_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_4_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_4_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_4_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_5_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_5_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_5_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_6_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_6_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_6_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_1_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_4" for table "aopart_lineitem_1_prt_p1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_5" for table "aopart_lineitem_1_prt_p1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_6" for table "aopart_lineitem_1_prt_p1_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_1_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_1_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_1_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_2_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_2_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_2_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_3_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_3_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_3_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_4_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_4_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_4_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_5_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_5_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_5_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_6_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_6_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_6_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_2_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_4" for table "aopart_lineitem_1_prt_p1_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_5" for table "aopart_lineitem_1_prt_p1_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_6" for table "aopart_lineitem_1_prt_p1_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_1_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_1_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_1_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_2_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_2_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_2_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_3_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_3_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_3_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_4_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_4_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_4_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_5_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_5_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_5_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_6_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_6_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_6_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_3_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_4" for table "aopart_lineitem_1_prt_p1_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_5" for table "aopart_lineitem_1_prt_p1_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_6" for table "aopart_lineitem_1_prt_p1_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_1_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_1_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_1_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_2_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_2_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_2_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_3_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_3_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_3_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_4_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_4_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_4_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_5_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_5_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_5_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_6_4_prt_1" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_6_4_prt_2" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_6_4_prt_3" for table "aopart_lineitem_1_prt_p1_2_prt_4_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1" for table "aopart_lineitem_1_prt_p2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2" for table "aopart_lineitem_1_prt_p2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3" for table "aopart_lineitem_1_prt_p2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4" for table "aopart_lineitem_1_prt_p2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_4" for table "aopart_lineitem_1_prt_p2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_5" for table "aopart_lineitem_1_prt_p2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_6" for table "aopart_lineitem_1_prt_p2_2_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_1_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_1_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_1_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_2_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_2_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_2_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_3_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_3_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_3_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_4_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_4_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_4_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_5_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_5_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_5_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_6_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_6_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_6_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_1_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_4" for table "aopart_lineitem_1_prt_p2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_5" for table "aopart_lineitem_1_prt_p2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_6" for table "aopart_lineitem_1_prt_p2_2_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_1_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_1_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_1_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_2_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_2_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_2_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_3_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_3_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_3_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_4_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_4_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_4_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_5_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_5_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_5_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_6_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_6_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_6_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_2_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_4" for table "aopart_lineitem_1_prt_p2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_5" for table "aopart_lineitem_1_prt_p2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_6" for table "aopart_lineitem_1_prt_p2_2_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_1_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_1_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_1_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_2_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_2_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_2_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_3_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_3_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_3_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_4_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_4_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_4_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_5_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_5_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_5_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_6_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_6_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_6_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_3_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_4" for table "aopart_lineitem_1_prt_p2_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_5" for table "aopart_lineitem_1_prt_p2_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_6" for table "aopart_lineitem_1_prt_p2_2_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_1_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_1_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_1_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_1"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_2_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_2_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_2_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_2"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_3_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_3_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_3_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_3"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_4_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_4_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_4_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_4"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_5_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_5_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_5_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_5"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_6_4_prt_1" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_6_4_prt_2" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_6"
+NOTICE:  CREATE TABLE will create partition "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_6_4_prt_3" for table "aopart_lineitem_1_prt_p2_2_prt_4_3_prt_6"
+insert into aopart_lineitem select * from lineitem;
+select count(*) from aopart_lineitem;
+ count 
+-------
+ 60175
+(1 row)
+
+create view revenue (supplier_no, total_revenue) as
+    select l_suppkey,
+           sum(l_extendedprice * (1 - l_discount))
+    from aopart_lineitem
+    where l_shipdate >= date '1-jan-1996'
+          and l_shipdate < date '1-jan-1996' + interval '3 month'
+    group by l_suppkey;
+ANALYZE aopart_LINEITEM;
+select 'TPCH QUERY 01', l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price,
+    sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge,
+    avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order
+    from aopart_lineitem where l_shipdate <= date '1998-12-01' - interval '90 day' group by l_returnflag, l_linestatus
+    order by l_returnflag, l_linestatus;
+   ?column?    | l_returnflag | l_linestatus |  sum_qty  | sum_base_price | sum_disc_price |    sum_charge     |       avg_qty       |     avg_price      |        avg_disc        | count_order 
+---------------+--------------+--------------+-----------+----------------+----------------+-------------------+---------------------+--------------------+------------------------+-------------
+ TPCH QUERY 01 | A            | F            | 380456.00 |   532348211.65 | 505822441.4861 |  526165934.000839 | 25.5751546114546921 | 35785.709306937349 | 0.05008133906964237698 |       14876
+ TPCH QUERY 01 | N            | F            |   8971.00 |    12384801.37 |  11798257.2080 |   12282485.056933 | 25.7787356321839080 | 35588.509683908046 | 0.04775862068965517241 |         348
+ TPCH QUERY 01 | N            | O            | 742802.00 |  1041502841.45 | 989737518.6346 | 1029418531.523350 | 25.4549878345498783 | 35691.129209074398 | 0.04993111956409992804 |       29181
+ TPCH QUERY 01 | R            | F            | 381449.00 |   534594445.35 | 507996454.4067 |  528524219.358903 | 25.5971681653469333 | 35874.006532680177 | 0.04982753992752650651 |       14902
+(4 rows)
+
+select 'TPCH QUERY 02', s.s_acctbal,s.s_name,n.n_name,p.p_partkey,p.p_mfgr,s.s_address,s.s_phone,s.s_comment
+    from aopart_supplier s, aopart_partsupp ps, aopart_nation n, aopart_region r, aopart_part p,
+        (select p_partkey, min(ps_supplycost) as min_ps_cost
+            from aopart_part, aopart_partsupp , aopart_supplier,aopart_nation, aopart_region
+            where p_partkey=ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey and
+                  n_regionkey = r_regionkey and r_name = 'EUROPE'
+            group by p_partkey) g
+    where p.p_partkey = ps.ps_partkey and g.p_partkey = p.p_partkey and g. min_ps_cost = ps.ps_supplycost and
+          s.s_suppkey = ps.ps_suppkey and p.p_size = 15 and p.p_type like '%BRASS' and s.s_nationkey = n.n_nationkey and
+          n.n_regionkey = r.r_regionkey and r.r_name = 'EUROPE' order by s. s_acctbal desc,n.n_name,s.s_name,p.p_partkey limit 100;
+   ?column?    | s_acctbal |          s_name           |          n_name           | p_partkey |          p_mfgr           |                s_address                |     s_phone     |                                            s_comment                                            
+---------------+-----------+---------------------------+---------------------------+-----------+---------------------------+-----------------------------------------+-----------------+-------------------------------------------------------------------------------------------------
+ TPCH QUERY 02 |   4186.95 | Supplier#000000077        | GERMANY                   |       249 | Manufacturer#4            | wVtcr0uH3CyrSiWMLsqnB09Syo,UuZxPMeBghlY | 17-281-345-4863 | the slyly final asymptotes. blithely pending theodoli
+ TPCH QUERY 02 |   1883.37 | Supplier#000000086        | ROMANIA                   |      1015 | Manufacturer#4            | J1fgg5QaqnN                             | 29-903-665-7065 | cajole furiously special, final requests: furiously spec
+ TPCH QUERY 02 |   1687.81 | Supplier#000000017        | ROMANIA                   |      1634 | Manufacturer#2            | c2d,ESHRSkK3WYnxpgw6aOqN0q              | 29-601-884-9219 | eep against the furiously bold ideas. fluffily bold packa
+ TPCH QUERY 02 |    287.16 | Supplier#000000052        | ROMANIA                   |       323 | Manufacturer#4            | WCk XCHYzBA1dvJDSol4ZJQQcQN,            | 29-974-934-4713 | dolites are slyly against the furiously regular packages. ironic, final deposits cajole quickly
+(4 rows)
+
+select 'TPCH QUERY 03', l_orderkey,sum(l_extendedprice*(1-l_discount)) as revenue,o_orderdate, o_shippriority
+    from aopart_customer,aopart_orders,aopart_lineitem
+    where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and
+          o_orderdate < date '15-mar-1995' and l_shipdate > date '15-mar-1995'
+    group by l_orderkey,o_orderdate,o_shippriority order by revenue desc,o_orderdate limit 10;
+   ?column?    | l_orderkey |   revenue   | o_orderdate | o_shippriority 
+---------------+------------+-------------+-------------+----------------
+ TPCH QUERY 03 |      47714 | 267010.5894 | 03-11-1995  |              0
+ TPCH QUERY 03 |      22276 | 266351.5562 | 01-29-1995  |              0
+ TPCH QUERY 03 |      32965 | 263768.3414 | 02-25-1995  |              0
+ TPCH QUERY 03 |      21956 | 254541.1285 | 02-02-1995  |              0
+ TPCH QUERY 03 |       1637 | 243512.7981 | 02-08-1995  |              0
+ TPCH QUERY 03 |      10916 | 241320.0814 | 03-11-1995  |              0
+ TPCH QUERY 03 |      30497 | 208566.6969 | 02-07-1995  |              0
+ TPCH QUERY 03 |        450 | 205447.4232 | 03-05-1995  |              0
+ TPCH QUERY 03 |      47204 | 204478.5213 | 03-13-1995  |              0
+ TPCH QUERY 03 |       9696 | 201502.2188 | 02-20-1995  |              0
+(10 rows)
+
+select 'TPCH QUERY 04',o_orderpriority,count (distinct o_orderkey) as order_count
+    from aopart_orders left join aopart_lineitem on l_orderkey = o_orderkey
+    where o_orderdate >= date '1-jul-1993' and o_orderdate < date '1-jul-1993' + interval '3 month' and
+          l_commitdate < l_receiptdate and l_orderkey is not null
+    group by o_orderpriority order by o_orderpriority;
+   ?column?    | o_orderpriority | order_count 
+---------------+-----------------+-------------
+ TPCH QUERY 04 | 1-URGENT        |          93
+ TPCH QUERY 04 | 2-HIGH          |         103
+ TPCH QUERY 04 | 3-MEDIUM        |         109
+ TPCH QUERY 04 | 4-NOT SPECIFIED |         102
+ TPCH QUERY 04 | 5-LOW           |         128
+(5 rows)
+
+select 'TPCH QUERY 05',n_name, sum(l_extendedprice * (1 - l_discount)) as revenue
+    from aopart_customer, aopart_orders, aopart_lineitem, aopart_supplier, aopart_nation, aopart_region
+    where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and
+          s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'ASIA' and o_orderdate >= date '1-jan-1994' and
+          o_orderdate < date '1-jan-1994' + interval '1 year'
+    group by n_name order by revenue desc;
+   ?column?    |          n_name           |   revenue    
+---------------+---------------------------+--------------
+ TPCH QUERY 05 | VIETNAM                   | 1000926.6999
+ TPCH QUERY 05 | CHINA                     |  740210.7570
+ TPCH QUERY 05 | JAPAN                     |  660651.2425
+ TPCH QUERY 05 | INDONESIA                 |  566379.5276
+ TPCH QUERY 05 | INDIA                     |  422874.6844
+(5 rows)
+
+select 'TPCH QUERY 06',sum(l_extendedprice*l_discount) as revenue
+    from aopart_lineitem where l_shipdate >= date '1-jan-1994' and l_shipdate < date '1-jan-1994' + interval '1 year' and
+         l_discount between 0.06 - 0.01 and 0.06 + 0.01 and l_quantity < 24;
+   ?column?    |   revenue    
+---------------+--------------
+ TPCH QUERY 06 | 1193053.2253
+(1 row)
+
+select 'TPCH QUERY 07',supp_nation,cust_nation,l_year, sum(volume) as revenue
+    from (
+        select n1.n_name as supp_nation,n2.n_name as cust_nation, extract(year from l_shipdate) as l_year,
+               l_extendedprice * (1 - l_discount) as volume
+        from aopart_supplier,aopart_lineitem,aopart_orders,aopart_customer,aopart_nation n1,aopart_nation n2
+        where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and
+              c_nationkey = n2.n_nationkey and ( (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY') or (n1.n_name = 'GERMANY' and
+              n2.n_name = 'FRANCE')) and l_shipdate between date '1995-01-01' and date '1996-12-31') as shipping
+    group by supp_nation,cust_nation,l_year order by supp_nation,cust_nation,l_year;
+   ?column?    |        supp_nation        |        cust_nation        | l_year |   revenue   
+---------------+---------------------------+---------------------------+--------+-------------
+ TPCH QUERY 07 | FRANCE                    | GERMANY                   |   1995 | 268068.5774
+ TPCH QUERY 07 | FRANCE                    | GERMANY                   |   1996 | 303862.2980
+ TPCH QUERY 07 | GERMANY                   | FRANCE                    |   1995 | 621159.4882
+ TPCH QUERY 07 | GERMANY                   | FRANCE                    |   1996 | 379095.8854
+(4 rows)
+
+select 'TPCH QUERY 08',o_year, sum(case when nation = 'BRAZIL' then volume else 0 end) / sum(volume) as mkt_share
+    from (
+        select extract(year from o_orderdate) as o_year, l_extendedprice * (1-l_discount) as volume, n2.n_name as nation
+            from aopart_part,aopart_supplier,aopart_lineitem,aopart_orders,aopart_customer,aopart_nation n1,aopart_nation n2,aopart_region
+            where p_partkey = l_partkey and s_suppkey = l_suppkey and l_orderkey = o_orderkey and o_custkey = c_custkey and
+                  c_nationkey = n1.n_nationkey and n1.n_regionkey = r_regionkey and r_name = 'AMERICA' and s_nationkey = n2.n_nationkey
+                  and o_orderdate between date '1995-01-01' and date '1996-12-31' and p_type = 'ECONOMY ANODIZED STEEL') as all_nations
+    group by o_year order by o_year;
+   ?column?    | o_year |         mkt_share          
+---------------+--------+----------------------------
+ TPCH QUERY 08 |   1995 | 0.000000000000000000000000
+ TPCH QUERY 08 |   1996 | 0.000000000000000000000000
+(2 rows)
+
+select 'TPCH QUERY 09',nation,o_year,sum(amount) as sum_profit
+    from (
+        select n_name as nation,extract(year from o_orderdate) as o_year,
+               l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+            from aopart_part,aopart_supplier,aopart_lineitem,aopart_partsupp,aopart_orders,aopart_nation
+            where s_suppkey = l_suppkey and ps_suppkey = l_suppkey and ps_partkey = l_partkey and p_partkey = l_partkey and
+            o_orderkey = l_orderkey and s_nationkey = n_nationkey and p_name like '%green%') as profit
+    group by nation,o_year order by nation,o_year desc;
+   ?column?    |          nation           | o_year |  sum_profit  
+---------------+---------------------------+--------+--------------
+ TPCH QUERY 09 | ALGERIA                   |   1998 |  386617.8283
+ TPCH QUERY 09 | ALGERIA                   |   1997 |  401601.1258
+ TPCH QUERY 09 | ALGERIA                   |   1996 |  156938.7971
+ TPCH QUERY 09 | ALGERIA                   |   1995 |  486706.0631
+ TPCH QUERY 09 | ALGERIA                   |   1994 |  426573.4415
+ TPCH QUERY 09 | ALGERIA                   |   1993 |  448371.4336
+ TPCH QUERY 09 | ALGERIA                   |   1992 |  285188.4503
+ TPCH QUERY 09 | ARGENTINA                 |   1998 |  136458.3471
+ TPCH QUERY 09 | ARGENTINA                 |   1997 |  423877.6754
+ TPCH QUERY 09 | ARGENTINA                 |   1996 |  325019.6263
+ TPCH QUERY 09 | ARGENTINA                 |   1995 |  399583.4009
+ TPCH QUERY 09 | ARGENTINA                 |   1994 |  374046.7888
+ TPCH QUERY 09 | ARGENTINA                 |   1993 |  351669.5325
+ TPCH QUERY 09 | ARGENTINA                 |   1992 |  312412.4307
+ TPCH QUERY 09 | BRAZIL                    |   1998 |  265032.7654
+ TPCH QUERY 09 | BRAZIL                    |   1997 |  275700.7887
+ TPCH QUERY 09 | BRAZIL                    |   1996 |  490362.6267
+ TPCH QUERY 09 | BRAZIL                    |   1995 |  349754.1082
+ TPCH QUERY 09 | BRAZIL                    |   1994 |  348798.4066
+ TPCH QUERY 09 | BRAZIL                    |   1993 |  457273.7693
+ TPCH QUERY 09 | BRAZIL                    |   1992 |  280563.4508
+ TPCH QUERY 09 | CANADA                    |   1998 |  249632.9034
+ TPCH QUERY 09 | CANADA                    |   1997 |  486581.6822
+ TPCH QUERY 09 | CANADA                    |   1996 |  359393.5226
+ TPCH QUERY 09 | CANADA                    |   1995 |  243051.8308
+ TPCH QUERY 09 | CANADA                    |   1994 |  188897.4377
+ TPCH QUERY 09 | CANADA                    |   1993 |  546007.0343
+ TPCH QUERY 09 | CANADA                    |   1992 |  275013.2650
+ TPCH QUERY 09 | CHINA                     |   1998 |  391223.3132
+ TPCH QUERY 09 | CHINA                     |   1997 |  585354.2015
+ TPCH QUERY 09 | CHINA                     |   1996 |  555841.0120
+ TPCH QUERY 09 | CHINA                     |   1995 |  864856.4126
+ TPCH QUERY 09 | CHINA                     |   1994 |  669658.4851
+ TPCH QUERY 09 | CHINA                     |   1993 |  621317.0197
+ TPCH QUERY 09 | CHINA                     |   1992 |  932500.7559
+ TPCH QUERY 09 | EGYPT                     |   1998 |  367340.0376
+ TPCH QUERY 09 | EGYPT                     |   1997 |  958524.1565
+ TPCH QUERY 09 | EGYPT                     |   1996 |  417700.6911
+ TPCH QUERY 09 | EGYPT                     |   1995 |  852185.4611
+ TPCH QUERY 09 | EGYPT                     |   1994 |  442097.3675
+ TPCH QUERY 09 | EGYPT                     |   1993 |  677948.0185
+ TPCH QUERY 09 | EGYPT                     |   1992 |  666425.4212
+ TPCH QUERY 09 | ETHIOPIA                  |   1998 |  146634.8925
+ TPCH QUERY 09 | ETHIOPIA                  |   1997 |  264122.6167
+ TPCH QUERY 09 | ETHIOPIA                  |   1996 |  193275.0975
+ TPCH QUERY 09 | ETHIOPIA                  |   1995 |  220253.5131
+ TPCH QUERY 09 | ETHIOPIA                  |   1994 |  296634.2600
+ TPCH QUERY 09 | ETHIOPIA                  |   1993 |  304224.8129
+ TPCH QUERY 09 | ETHIOPIA                  |   1992 |  297588.3116
+ TPCH QUERY 09 | FRANCE                    |   1998 |   72506.5000
+ TPCH QUERY 09 | FRANCE                    |   1997 |  237462.1240
+ TPCH QUERY 09 | FRANCE                    |   1996 |  151017.7675
+ TPCH QUERY 09 | FRANCE                    |   1995 |  296667.9453
+ TPCH QUERY 09 | FRANCE                    |   1994 |  233805.7419
+ TPCH QUERY 09 | FRANCE                    |   1993 |  168968.1550
+ TPCH QUERY 09 | FRANCE                    |   1992 |  127349.1738
+ TPCH QUERY 09 | GERMANY                   |   1998 |  223811.2759
+ TPCH QUERY 09 | GERMANY                   |   1997 |  661263.7764
+ TPCH QUERY 09 | GERMANY                   |   1996 |  482126.6721
+ TPCH QUERY 09 | GERMANY                   |   1995 |  571466.4843
+ TPCH QUERY 09 | GERMANY                   |   1994 |  322330.4404
+ TPCH QUERY 09 | GERMANY                   |   1993 |  428314.7853
+ TPCH QUERY 09 | GERMANY                   |   1992 |  273675.9499
+ TPCH QUERY 09 | INDIA                     |   1998 |  418144.1956
+ TPCH QUERY 09 | INDIA                     |   1997 |  859947.3428
+ TPCH QUERY 09 | INDIA                     |   1996 |  515838.8397
+ TPCH QUERY 09 | INDIA                     |   1995 |  631351.5802
+ TPCH QUERY 09 | INDIA                     |   1994 |  798279.5615
+ TPCH QUERY 09 | INDIA                     |   1993 |  767946.7017
+ TPCH QUERY 09 | INDIA                     |   1992 |  797101.9729
+ TPCH QUERY 09 | INDONESIA                 |   1998 |  386787.9168
+ TPCH QUERY 09 | INDONESIA                 |   1997 |  311837.4839
+ TPCH QUERY 09 | INDONESIA                 |   1996 |  421631.7918
+ TPCH QUERY 09 | INDONESIA                 |   1995 |  479331.3577
+ TPCH QUERY 09 | INDONESIA                 |   1994 |  602376.9040
+ TPCH QUERY 09 | INDONESIA                 |   1993 |  496450.6942
+ TPCH QUERY 09 | INDONESIA                 |   1992 |  561262.1781
+ TPCH QUERY 09 | IRAN                      |   1998 |    8996.5540
+ TPCH QUERY 09 | IRAN                      |   1997 |  201653.8389
+ TPCH QUERY 09 | IRAN                      |   1996 |  281658.4382
+ TPCH QUERY 09 | IRAN                      |   1995 |   50873.1323
+ TPCH QUERY 09 | IRAN                      |   1994 |   53387.1992
+ TPCH QUERY 09 | IRAN                      |   1993 |  107749.9627
+ TPCH QUERY 09 | IRAN                      |   1992 |   67888.7176
+ TPCH QUERY 09 | IRAQ                      |   1998 |  113434.1032
+ TPCH QUERY 09 | IRAQ                      |   1997 |   86656.8062
+ TPCH QUERY 09 | IRAQ                      |   1996 |  359937.8761
+ TPCH QUERY 09 | IRAQ                      |   1995 |  218221.7756
+ TPCH QUERY 09 | IRAQ                      |   1994 |  360489.8843
+ TPCH QUERY 09 | IRAQ                      |   1993 |  559990.6546
+ TPCH QUERY 09 | IRAQ                      |   1992 |  211655.9396
+ TPCH QUERY 09 | JAPAN                     |   1998 |  278531.8011
+ TPCH QUERY 09 | JAPAN                     |   1997 |  426945.7933
+ TPCH QUERY 09 | JAPAN                     |   1996 |  501942.5698
+ TPCH QUERY 09 | JAPAN                     |   1995 |  474025.8492
+ TPCH QUERY 09 | JAPAN                     |   1994 |  706404.4339
+ TPCH QUERY 09 | JAPAN                     |   1993 |  695412.9084
+ TPCH QUERY 09 | JAPAN                     |   1992 |  613125.5417
+ TPCH QUERY 09 | JORDAN                    |   1998 |   73080.7362
+ TPCH QUERY 09 | JORDAN                    |   1997 |  117104.2978
+ TPCH QUERY 09 | JORDAN                    |   1996 |   94740.7164
+ TPCH QUERY 09 | JORDAN                    |   1995 |  164684.4569
+ TPCH QUERY 09 | JORDAN                    |   1994 |   51403.2065
+ TPCH QUERY 09 | JORDAN                    |   1993 |   38718.7839
+ TPCH QUERY 09 | JORDAN                    |   1992 |  132028.5385
+ TPCH QUERY 09 | KENYA                     |   1998 |  351661.8184
+ TPCH QUERY 09 | KENYA                     |   1997 |  542347.9571
+ TPCH QUERY 09 | KENYA                     |   1996 |  466964.0397
+ TPCH QUERY 09 | KENYA                     |   1995 |  795396.7551
+ TPCH QUERY 09 | KENYA                     |   1994 |  740881.7388
+ TPCH QUERY 09 | KENYA                     |   1993 |  603341.1861
+ TPCH QUERY 09 | KENYA                     |   1992 |  774761.2393
+ TPCH QUERY 09 | MOROCCO                   |   1998 |  118171.3902
+ TPCH QUERY 09 | MOROCCO                   |   1997 |   96442.7008
+ TPCH QUERY 09 | MOROCCO                   |   1996 |  118984.8785
+ TPCH QUERY 09 | MOROCCO                   |   1995 |  158240.6598
+ TPCH QUERY 09 | MOROCCO                   |   1994 |  148951.6794
+ TPCH QUERY 09 | MOROCCO                   |   1993 |   48279.6548
+ TPCH QUERY 09 | MOROCCO                   |   1992 |  146068.2550
+ TPCH QUERY 09 | MOZAMBIQUE                |   1998 |  343227.8816
+ TPCH QUERY 09 | MOZAMBIQUE                |   1997 |  831834.1044
+ TPCH QUERY 09 | MOZAMBIQUE                |   1996 |  888199.0121
+ TPCH QUERY 09 | MOZAMBIQUE                |   1995 | 1249272.9387
+ TPCH QUERY 09 | MOZAMBIQUE                |   1994 |  594096.0637
+ TPCH QUERY 09 | MOZAMBIQUE                |   1993 | 1200185.0713
+ TPCH QUERY 09 | MOZAMBIQUE                |   1992 |  994120.0362
+ TPCH QUERY 09 | PERU                      |   1998 |  352324.2789
+ TPCH QUERY 09 | PERU                      |   1997 |  319502.2255
+ TPCH QUERY 09 | PERU                      |   1996 |  391644.9686
+ TPCH QUERY 09 | PERU                      |   1995 |  360028.0705
+ TPCH QUERY 09 | PERU                      |   1994 |  460058.1291
+ TPCH QUERY 09 | PERU                      |   1993 |  382460.0831
+ TPCH QUERY 09 | PERU                      |   1992 |  312613.1714
+ TPCH QUERY 09 | ROMANIA                   |   1998 |  340984.6297
+ TPCH QUERY 09 | ROMANIA                   |   1997 |  444095.1884
+ TPCH QUERY 09 | ROMANIA                   |   1996 |  426472.5967
+ TPCH QUERY 09 | ROMANIA                   |   1995 |  616350.9394
+ TPCH QUERY 09 | ROMANIA                   |   1994 |  430563.1943
+ TPCH QUERY 09 | ROMANIA                   |   1993 |  769406.9533
+ TPCH QUERY 09 | ROMANIA                   |   1992 |  543722.1295
+ TPCH QUERY 09 | RUSSIA                    |   1998 |  217747.8262
+ TPCH QUERY 09 | RUSSIA                    |   1997 |  644719.5017
+ TPCH QUERY 09 | RUSSIA                    |   1996 |  501019.7684
+ TPCH QUERY 09 | RUSSIA                    |   1995 |  717528.7447
+ TPCH QUERY 09 | RUSSIA                    |   1994 |  441262.6350
+ TPCH QUERY 09 | RUSSIA                    |   1993 |  529422.5932
+ TPCH QUERY 09 | RUSSIA                    |   1992 |  469683.7369
+ TPCH QUERY 09 | SAUDI ARABIA              |   1998 |   57980.2356
+ TPCH QUERY 09 | SAUDI ARABIA              |   1997 |   17173.1210
+ TPCH QUERY 09 | SAUDI ARABIA              |   1996 |   14229.6253
+ TPCH QUERY 09 | SAUDI ARABIA              |   1995 |   98053.2309
+ TPCH QUERY 09 | SAUDI ARABIA              |   1993 |   42289.6310
+ TPCH QUERY 09 | SAUDI ARABIA              |   1992 |   50978.9572
+ TPCH QUERY 09 | UNITED KINGDOM            |   1998 |  127808.1215
+ TPCH QUERY 09 | UNITED KINGDOM            |   1997 |  407935.6606
+ TPCH QUERY 09 | UNITED KINGDOM            |   1996 |  499957.5199
+ TPCH QUERY 09 | UNITED KINGDOM            |   1995 |  480575.5026
+ TPCH QUERY 09 | UNITED KINGDOM            |   1994 |  513252.8116
+ TPCH QUERY 09 | UNITED KINGDOM            |   1993 |  697570.9412
+ TPCH QUERY 09 | UNITED KINGDOM            |   1992 |  361516.4116
+ TPCH QUERY 09 | UNITED STATES             |   1998 |  503864.6963
+ TPCH QUERY 09 | UNITED STATES             |   1997 |  649175.2847
+ TPCH QUERY 09 | UNITED STATES             |   1996 |  831723.1557
+ TPCH QUERY 09 | UNITED STATES             |   1995 |  902131.2862
+ TPCH QUERY 09 | UNITED STATES             |   1994 |  460768.5468
+ TPCH QUERY 09 | UNITED STATES             |   1993 |  656092.8661
+ TPCH QUERY 09 | UNITED STATES             |   1992 |  714228.6231
+ TPCH QUERY 09 | VIETNAM                   |   1998 |  578857.0410
+ TPCH QUERY 09 | VIETNAM                   |   1997 |  596114.8585
+ TPCH QUERY 09 | VIETNAM                   |   1996 |  832979.0530
+ TPCH QUERY 09 | VIETNAM                   |   1995 |  757862.0438
+ TPCH QUERY 09 | VIETNAM                   |   1994 | 1003275.5371
+ TPCH QUERY 09 | VIETNAM                   |   1993 |  461389.0037
+ TPCH QUERY 09 | VIETNAM                   |   1992 |  820665.7064
+(174 rows)
+
+select 'TPCH QUERY 10', c_custkey,c_name,sum(l_extendedprice * (1 - l_discount)) as revenue, c_acctbal,n_name,c_address,c_phone,c_comment
+    from aopart_customer,aopart_orders,aopart_lineitem,aopart_nation
+    where c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate >= date '1-oct-1993' and o_orderdate < date '1-oct-1993' +
+          interval '3 month' and l_returnflag = 'R' and c_nationkey = n_nationkey
+    group by c_custkey,c_name,c_acctbal,c_phone,n_name,c_address,c_comment order by revenue desc limit 20;
+   ?column?    | c_custkey |       c_name       |   revenue   | c_acctbal |          n_name           |                c_address                 |     c_phone     |                                                      c_comment                                                       
+---------------+-----------+--------------------+-------------+-----------+---------------------------+------------------------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------
+ TPCH QUERY 10 |       679 | Customer#000000679 | 378211.3252 |   1394.44 | IRAN                      | IJf1FlZL9I9m,rvofcoKy5pRUOjUQV           | 20-146-696-9508 | ely pending frays boost carefully
+ TPCH QUERY 10 |      1201 | Customer#000001201 | 374331.5340 |   5165.39 | IRAN                      | LfCSVKWozyWOGDW02g9UX,XgH5YU2o5ql1zBrN   | 20-825-400-1187 | lyly pending packages. special requests sleep-- platelets use blithely after the instructions. sometimes even id
+ TPCH QUERY 10 |       422 | Customer#000000422 | 366451.0126 |   -272.14 | INDONESIA                 | AyNzZBvmIDo42JtjP9xzaK3pnvkh Qc0o08ssnvq | 19-299-247-2444 | eposits; furiously ironic packages accordi
+ TPCH QUERY 10 |       334 | Customer#000000334 | 360370.7550 |   -405.91 | EGYPT                     | OPN1N7t4aQ23TnCpc                        | 14-947-291-5002 | fully busily special ideas. carefully final excuses lose slyly carefully express accounts. even, ironic platelets ar
+ TPCH QUERY 10 |       805 | Customer#000000805 | 359448.9036 |    511.69 | IRAN                      | wCKx5zcHvwpSffyc9qfi9dvqcm9LT,cLAG       | 20-732-989-5653 | busy sentiments. pending packages haggle among the express requests-- slyly regular excuses above the slyl
+ TPCH QUERY 10 |       932 | Customer#000000932 | 341608.2753 |   6553.37 | JORDAN                    | HN9Ap0NsJG7Mb8O                          | 23-300-708-7927 | packages boost slyly along the furiously express foxes. ev
+ TPCH QUERY 10 |       853 | Customer#000000853 | 341236.6246 |   -444.73 | BRAZIL                    | U0 9PrwAgWK8AE0GHmnCGtH9BTexWWv87k       | 12-869-161-3468 | yly special deposits wake alongside of
+ TPCH QUERY 10 |       872 | Customer#000000872 | 338328.7808 |   -858.61 | PERU                      | vLP7iNZBK4B,HANFTKabVI3AO Y9O8H          | 27-357-139-7164 |  detect. packages wake slyly express foxes. even deposits ru
+ TPCH QUERY 10 |       737 | Customer#000000737 | 338185.3365 |   2501.74 | CHINA                     | NdjG1k243iCLSoy1lYqMIrpvuH1Uf75          | 28-658-938-1102 | ding to the final platelets. regular packages against the carefully final ideas hag
+ TPCH QUERY 10 |      1118 | Customer#000001118 | 319875.7280 |   4130.18 | IRAQ                      | QHg,DNvEVXaYoCdrywazjAJ                  | 21-583-715-8627 | y regular requests above the blithely ironic accounts use slyly bold packages: regular pinto beans eat carefully spe
+ TPCH QUERY 10 |       223 | Customer#000000223 | 319564.2750 |   7476.20 | SAUDI ARABIA              | ftau6Pk,brboMyEl,,kFm                    | 30-193-643-1517 | al, regular requests run furiously blithely silent packages. blithely ironic accounts across the furious
+ TPCH QUERY 10 |       808 | Customer#000000808 | 314774.6167 |   5561.93 | ROMANIA                   | S2WkSKCGtnbhcFOp6MWcuB3rzFlFemVNrg       | 29-531-319-7726 |  unusual deposits. furiously even packages against the furiously even ac
+ TPCH QUERY 10 |       478 | Customer#000000478 | 299651.8026 |   -210.40 | ARGENTINA                 | clyq458DIkXXt4qLyHlbe,n JueoniF          | 11-655-291-2694 | o the foxes. ironic requests sleep. c
+ TPCH QUERY 10 |      1441 | Customer#000001441 | 294705.3935 |   9465.15 | UNITED KINGDOM            | u0YYZb46w,pwKo5H9vz d6B9zK4BOHhG jx      | 33-681-334-4499 | nts haggle quietly quickly final accounts. slyly regular accounts among the sl
+ TPCH QUERY 10 |      1478 | Customer#000001478 | 294431.9178 |   9701.54 | GERMANY                   | x7HDvJDDpR3MqZ5vg2CanfQ1hF0j4            | 17-420-484-5959 | ng the furiously bold foxes. even notornis above the unusual 
+ TPCH QUERY 10 |       211 | Customer#000000211 | 287905.6368 |   4198.72 | JORDAN                    | URhlVPzz4FqXem                           | 23-965-335-9471 | furiously regular foxes boost fluffily special ideas. carefully regular dependencies are. slyly ironic 
+ TPCH QUERY 10 |       197 | Customer#000000197 | 283190.4807 |   9860.22 | ARGENTINA                 | UeVqssepNuXmtZ38D                        | 11-107-312-6585 | ickly final accounts cajole. furiously re
+ TPCH QUERY 10 |      1030 | Customer#000001030 | 282557.3566 |   6359.27 | INDIA                     | Xpt1BiB5h9o                              | 18-759-877-1870 | ding to the slyly unusual accounts. even requests among the evenly
+ TPCH QUERY 10 |      1049 | Customer#000001049 | 281134.1117 |   8747.99 | INDONESIA                 | bZ1OcFhHaIZ5gMiH                         | 19-499-258-2851 | uriously according to the furiously silent packages
+ TPCH QUERY 10 |      1094 | Customer#000001094 | 274877.4440 |   2544.49 | BRAZIL                    | OFz0eedTmPmXk2 3XM9v9Mcp13NVC0PK         | 12-234-721-9871 | tes serve blithely quickly pending foxes. express, quick accounts
+(20 rows)
+
+select 'TPCH QUERY 11', ps_partkey,sum(ps_supplycost * ps_availqty) as value
+    from aopart_partsupp,aopart_supplier,aopart_nation
+    where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY'
+    group by ps_partkey having sum(ps_supplycost * ps_availqty) > (
+        select sum(ps_supplycost * ps_availqty) * .0001
+            from aopart_partsupp,aopart_supplier,aopart_nation
+            where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY')
+    order by value desc;
+   ?column?    | ps_partkey |    value    
+---------------+------------+-------------
+ TPCH QUERY 11 |       1376 | 13271249.89
+ TPCH QUERY 11 |        788 |  9498648.06
+ TPCH QUERY 11 |       1071 |  9388264.40
+ TPCH QUERY 11 |       1768 |  9207199.75
+ TPCH QUERY 11 |       1168 |  8881908.96
+ TPCH QUERY 11 |       1084 |  8709494.16
+ TPCH QUERY 11 |       1415 |  8471489.56
+ TPCH QUERY 11 |       1338 |  8293841.12
+ TPCH QUERY 11 |        124 |  8203209.30
+ TPCH QUERY 11 |       1232 |  8111663.34
+ TPCH QUERY 11 |       1643 |  7975862.75
+ TPCH QUERY 11 |       1952 |  7936947.61
+ TPCH QUERY 11 |       1944 |  7880018.60
+ TPCH QUERY 11 |       1884 |  7513422.84
+ TPCH QUERY 11 |        942 |  7511018.76
+ TPCH QUERY 11 |        670 |  7299956.80
+ TPCH QUERY 11 |       1532 |  7222347.20
+ TPCH QUERY 11 |       1052 |  7158586.00
+ TPCH QUERY 11 |        455 |  7064285.84
+ TPCH QUERY 11 |       1176 |  7060670.89
+ TPCH QUERY 11 |        143 |  7037648.64
+ TPCH QUERY 11 |       1653 |  6949533.70
+ TPCH QUERY 11 |       1140 |  6929464.08
+ TPCH QUERY 11 |       1076 |  6877472.96
+ TPCH QUERY 11 |       2000 |  6720009.38
+ TPCH QUERY 11 |        348 |  6681307.34
+ TPCH QUERY 11 |        810 |  6576640.95
+ TPCH QUERY 11 |        943 |  6458641.70
+ TPCH QUERY 11 |        720 |  6391330.27
+ TPCH QUERY 11 |       1748 |  6341530.40
+ TPCH QUERY 11 |       1241 |  6304944.66
+ TPCH QUERY 11 |       1384 |  6279261.12
+ TPCH QUERY 11 |       1784 |  6247863.25
+ TPCH QUERY 11 |        984 |  6136927.00
+ TPCH QUERY 11 |        445 |  6127784.28
+ TPCH QUERY 11 |       1976 |  6079237.08
+ TPCH QUERY 11 |       1609 |  6022720.80
+ TPCH QUERY 11 |       1563 |  5978195.08
+ TPCH QUERY 11 |        452 |  5838052.00
+ TPCH QUERY 11 |        222 |  5737162.24
+ TPCH QUERY 11 |       1629 |  5703117.12
+ TPCH QUERY 11 |       1454 |  5694804.18
+ TPCH QUERY 11 |       1082 |  5681981.25
+ TPCH QUERY 11 |        691 |  5633589.72
+ TPCH QUERY 11 |       1474 |  5614673.64
+ TPCH QUERY 11 |       1900 |  5591905.36
+ TPCH QUERY 11 |        262 |  5553285.32
+ TPCH QUERY 11 |       1876 |  5517997.59
+ TPCH QUERY 11 |       1027 |  5490916.00
+ TPCH QUERY 11 |       1833 |  5451495.00
+ TPCH QUERY 11 |        513 |  5374426.22
+ TPCH QUERY 11 |        752 |  5358919.70
+ TPCH QUERY 11 |       1367 |  5352773.25
+ TPCH QUERY 11 |        543 |  5189101.68
+ TPCH QUERY 11 |       1144 |  5174388.56
+ TPCH QUERY 11 |        403 |  5126118.15
+ TPCH QUERY 11 |       1406 |  5121886.44
+ TPCH QUERY 11 |        320 |  5072099.76
+ TPCH QUERY 11 |       1940 |  5069178.40
+ TPCH QUERY 11 |       1503 |  5050895.50
+ TPCH QUERY 11 |       1437 |  5039590.60
+ TPCH QUERY 11 |        743 |  5039271.42
+ TPCH QUERY 11 |         82 |  4995939.00
+ TPCH QUERY 11 |        916 |  4994730.10
+ TPCH QUERY 11 |        732 |  4932809.82
+ TPCH QUERY 11 |        356 |  4879860.09
+ TPCH QUERY 11 |       1592 |  4831242.60
+ TPCH QUERY 11 |       1043 |  4825921.31
+ TPCH QUERY 11 |        132 |  4781984.14
+ TPCH QUERY 11 |       1006 |  4733954.64
+ TPCH QUERY 11 |        497 |  4711173.60
+ TPCH QUERY 11 |       1008 |  4565588.85
+ TPCH QUERY 11 |       1370 |  4563830.10
+ TPCH QUERY 11 |        216 |  4561143.80
+ TPCH QUERY 11 |         34 |  4501982.71
+ TPCH QUERY 11 |       1908 |  4417931.80
+ TPCH QUERY 11 |        982 |  4391495.46
+ TPCH QUERY 11 |       1652 |  4358793.14
+ TPCH QUERY 11 |        614 |  4356657.45
+ TPCH QUERY 11 |       1552 |  4355541.70
+ TPCH QUERY 11 |        359 |  4353566.87
+ TPCH QUERY 11 |       1104 |  4347515.90
+ TPCH QUERY 11 |        198 |  4315049.00
+ TPCH QUERY 11 |        998 |  4167784.88
+ TPCH QUERY 11 |       1543 |  4159568.16
+ TPCH QUERY 11 |       1308 |  4153124.95
+ TPCH QUERY 11 |        474 |  4123819.20
+ TPCH QUERY 11 |       1394 |  4122729.33
+ TPCH QUERY 11 |        271 |  4095180.96
+ TPCH QUERY 11 |        908 |  4088856.20
+ TPCH QUERY 11 |       1135 |  4045014.13
+ TPCH QUERY 11 |       1632 |  4010794.90
+ TPCH QUERY 11 |       1362 |  3982060.16
+ TPCH QUERY 11 |        158 |  3941881.65
+ TPCH QUERY 11 |       1852 |  3923035.02
+ TPCH QUERY 11 |       1556 |  3896709.54
+ TPCH QUERY 11 |        584 |  3843848.30
+ TPCH QUERY 11 |        885 |  3826021.16
+ TPCH QUERY 11 |        376 |  3781201.96
+ TPCH QUERY 11 |        712 |  3749696.80
+ TPCH QUERY 11 |          2 |  3743241.43
+ TPCH QUERY 11 |        676 |  3735715.20
+ TPCH QUERY 11 |       1832 |  3709008.60
+ TPCH QUERY 11 |       1955 |  3702794.70
+ TPCH QUERY 11 |         68 |  3690702.41
+ TPCH QUERY 11 |       1435 |  3659114.10
+ TPCH QUERY 11 |       1443 |  3656762.84
+ TPCH QUERY 11 |       1278 |  3653100.66
+ TPCH QUERY 11 |       1920 |  3647892.54
+ TPCH QUERY 11 |        423 |  3602031.80
+ TPCH QUERY 11 |        818 |  3589047.60
+ TPCH QUERY 11 |        779 |  3559597.53
+ TPCH QUERY 11 |        485 |  3558511.44
+ TPCH QUERY 11 |        552 |  3555470.10
+ TPCH QUERY 11 |       1269 |  3510427.65
+ TPCH QUERY 11 |       1602 |  3492117.70
+ TPCH QUERY 11 |        426 |  3486888.02
+ TPCH QUERY 11 |       1452 |  3480825.60
+ TPCH QUERY 11 |        756 |  3469373.70
+ TPCH QUERY 11 |        832 |  3447746.46
+ TPCH QUERY 11 |       1493 |  3446867.40
+ TPCH QUERY 11 |       1650 |  3417752.58
+ TPCH QUERY 11 |        205 |  3403046.25
+ TPCH QUERY 11 |         93 |  3361425.89
+ TPCH QUERY 11 |         76 |  3342081.82
+ TPCH QUERY 11 |       1759 |  3303050.40
+ TPCH QUERY 11 |        886 |  3302180.70
+ TPCH QUERY 11 |       1544 |  3288573.16
+ TPCH QUERY 11 |       1932 |  3270900.40
+ TPCH QUERY 11 |        489 |  3253368.30
+ TPCH QUERY 11 |        594 |  3177408.57
+ TPCH QUERY 11 |        184 |  3177162.05
+ TPCH QUERY 11 |        950 |  3165213.01
+ TPCH QUERY 11 |       1124 |  3143279.36
+ TPCH QUERY 11 |        106 |  3099021.98
+ TPCH QUERY 11 |       1964 |  3016553.10
+ TPCH QUERY 11 |        384 |  2964262.77
+ TPCH QUERY 11 |        974 |  2959497.10
+ TPCH QUERY 11 |        964 |  2951329.45
+ TPCH QUERY 11 |       1984 |  2907345.36
+ TPCH QUERY 11 |        200 |  2895688.32
+ TPCH QUERY 11 |        683 |  2829476.95
+ TPCH QUERY 11 |       1564 |  2816506.56
+ TPCH QUERY 11 |        546 |  2788059.64
+ TPCH QUERY 11 |        502 |  2780828.64
+ TPCH QUERY 11 |        396 |  2778421.39
+ TPCH QUERY 11 |        203 |  2761439.88
+ TPCH QUERY 11 |        866 |  2753031.20
+ TPCH QUERY 11 |       1743 |  2743889.49
+ TPCH QUERY 11 |       1041 |  2738083.92
+ TPCH QUERY 11 |       1432 |  2713412.16
+ TPCH QUERY 11 |         43 |  2587359.58
+ TPCH QUERY 11 |        941 |  2587091.52
+ TPCH QUERY 11 |       1890 |  2558739.69
+ TPCH QUERY 11 |       1866 |  2545838.40
+ TPCH QUERY 11 |        747 |  2511745.32
+ TPCH QUERY 11 |        776 |  2506489.89
+ TPCH QUERY 11 |        554 |  2505417.25
+ TPCH QUERY 11 |       1210 |  2490820.92
+ TPCH QUERY 11 |       1239 |  2405206.30
+ TPCH QUERY 11 |        443 |  2382150.05
+ TPCH QUERY 11 |       1661 |  2370574.16
+ TPCH QUERY 11 |       1079 |  2363505.11
+ TPCH QUERY 11 |       1329 |  2305870.42
+ TPCH QUERY 11 |       1691 |  2261159.92
+ TPCH QUERY 11 |       1247 |  2239553.28
+ TPCH QUERY 11 |       1752 |  2230055.76
+ TPCH QUERY 11 |        150 |  2217043.59
+ TPCH QUERY 11 |       1814 |  2213635.20
+ TPCH QUERY 11 |        289 |  2187160.45
+ TPCH QUERY 11 |       1400 |  2139845.10
+ TPCH QUERY 11 |       1898 |  2130114.96
+ TPCH QUERY 11 |       1809 |  2122758.72
+ TPCH QUERY 11 |        884 |  2107479.56
+ TPCH QUERY 11 |       1038 |  2096868.97
+ TPCH QUERY 11 |       1318 |  2051302.44
+ TPCH QUERY 11 |        524 |  2035262.22
+ TPCH QUERY 11 |        414 |  2029692.45
+ TPCH QUERY 11 |        298 |  2026981.74
+ TPCH QUERY 11 |       1996 |  2020953.54
+ TPCH QUERY 11 |       1742 |  2019190.80
+ TPCH QUERY 11 |       1620 |  2010112.00
+ TPCH QUERY 11 |        877 |  1956429.18
+ TPCH QUERY 11 |       1332 |  1919029.56
+ TPCH QUERY 11 |       1536 |  1859318.15
+ TPCH QUERY 11 |       1116 |  1852588.28
+ TPCH QUERY 11 |        447 |  1817951.32
+ TPCH QUERY 11 |       1676 |  1802306.08
+ TPCH QUERY 11 |       1911 |  1779646.44
+ TPCH QUERY 11 |       1459 |  1767602.30
+ TPCH QUERY 11 |        576 |  1761838.75
+ TPCH QUERY 11 |       1273 |  1754235.01
+ TPCH QUERY 11 |        583 |  1725649.92
+ TPCH QUERY 11 |        532 |  1682311.48
+ TPCH QUERY 11 |       1732 |  1652831.20
+ TPCH QUERY 11 |       1572 |  1650953.52
+ TPCH QUERY 11 |       1889 |  1638443.72
+ TPCH QUERY 11 |        476 |  1631154.06
+ TPCH QUERY 11 |       1221 |  1629883.46
+ TPCH QUERY 11 |       1792 |  1606346.10
+ TPCH QUERY 11 |        243 |  1603235.16
+ TPCH QUERY 11 |        328 |  1569826.72
+ TPCH QUERY 11 |       1999 |  1553706.00
+ TPCH QUERY 11 |       1611 |  1529857.01
+ TPCH QUERY 11 |        643 |  1512838.80
+ TPCH QUERY 11 |       1276 |  1467567.28
+ TPCH QUERY 11 |       1823 |  1462293.00
+ TPCH QUERY 11 |          1 |  1456050.96
+ TPCH QUERY 11 |         27 |  1425832.40
+ TPCH QUERY 11 |        632 |  1408087.26
+ TPCH QUERY 11 |       1184 |  1406101.78
+ TPCH QUERY 11 |        252 |  1379186.35
+ TPCH QUERY 11 |        392 |  1354813.18
+ TPCH QUERY 11 |       1215 |  1344383.20
+ TPCH QUERY 11 |         26 |  1337002.89
+ TPCH QUERY 11 |         84 |  1334146.71
+ TPCH QUERY 11 |        784 |  1327297.01
+ TPCH QUERY 11 |       1803 |  1327045.06
+ TPCH QUERY 11 |        352 |  1326102.34
+ TPCH QUERY 11 |        165 |  1289075.76
+ TPCH QUERY 11 |        176 |  1285866.20
+ TPCH QUERY 11 |       1314 |  1244173.26
+ TPCH QUERY 11 |       1701 |  1239095.44
+ TPCH QUERY 11 |        844 |  1225696.05
+ TPCH QUERY 11 |       1988 |  1216798.33
+ TPCH QUERY 11 |       1847 |  1202012.13
+ TPCH QUERY 11 |       1706 |  1184125.10
+ TPCH QUERY 11 |        744 |  1182820.80
+ TPCH QUERY 11 |        230 |  1165932.30
+ TPCH QUERY 11 |        418 |  1078321.44
+ TPCH QUERY 11 |        174 |  1060584.80
+ TPCH QUERY 11 |       1073 |  1028449.89
+ TPCH QUERY 11 |       1726 |  1018673.04
+ TPCH QUERY 11 |       1206 |  1002319.49
+ TPCH QUERY 11 |       1343 |   998105.76
+ TPCH QUERY 11 |        952 |   997684.24
+ TPCH QUERY 11 |        484 |   991530.93
+ TPCH QUERY 11 |        932 |   980620.68
+ TPCH QUERY 11 |        843 |   978862.92
+ TPCH QUERY 11 |       1841 |   962131.86
+ TPCH QUERY 11 |        494 |   957575.34
+ TPCH QUERY 11 |        659 |   954291.05
+ TPCH QUERY 11 |        251 |   939764.70
+ TPCH QUERY 11 |       1413 |   936951.94
+ TPCH QUERY 11 |        572 |   906111.99
+ TPCH QUERY 11 |         32 |   894484.09
+ TPCH QUERY 11 |          9 |   893905.92
+ TPCH QUERY 11 |       1498 |   890887.85
+ TPCH QUERY 11 |       1790 |   878923.64
+ TPCH QUERY 11 |       1670 |   854046.43
+ TPCH QUERY 11 |        876 |   842245.67
+ TPCH QUERY 11 |       1758 |   841275.42
+ TPCH QUERY 11 |        930 |   832963.68
+ TPCH QUERY 11 |        284 |   826642.60
+ TPCH QUERY 11 |       1710 |   811504.38
+ TPCH QUERY 11 |       1047 |   791214.45
+ TPCH QUERY 11 |        653 |   788974.21
+ TPCH QUERY 11 |        315 |   770526.05
+ TPCH QUERY 11 |       1734 |   763569.40
+ TPCH QUERY 11 |       1017 |   715302.72
+ TPCH QUERY 11 |       1305 |   713351.43
+ TPCH QUERY 11 |         77 |   688865.82
+ TPCH QUERY 11 |       1512 |   682434.15
+ TPCH QUERY 11 |        276 |   680239.04
+ TPCH QUERY 11 |       1284 |   671225.94
+ TPCH QUERY 11 |       1356 |   665716.83
+ TPCH QUERY 11 |        800 |   663414.65
+ TPCH QUERY 11 |        117 |   639650.88
+ TPCH QUERY 11 |        652 |   635629.28
+ TPCH QUERY 11 |         57 |   630987.44
+ TPCH QUERY 11 |       1426 |   628241.25
+ TPCH QUERY 11 |       1196 |   622427.16
+ TPCH QUERY 11 |         51 |   622249.54
+ TPCH QUERY 11 |       1846 |   621068.80
+ TPCH QUERY 11 |        601 |   615942.60
+ TPCH QUERY 11 |        645 |   607985.84
+ TPCH QUERY 11 |        684 |   571490.70
+ TPCH QUERY 11 |        465 |   570337.40
+ TPCH QUERY 11 |        562 |   567651.24
+ TPCH QUERY 11 |        387 |   556634.76
+ TPCH QUERY 11 |       1152 |   555989.28
+ TPCH QUERY 11 |       1202 |   553818.18
+ TPCH QUERY 11 |       1112 |   552658.68
+ TPCH QUERY 11 |        304 |   535868.16
+ TPCH QUERY 11 |        368 |   526995.84
+ TPCH QUERY 11 |       1800 |   526711.11
+ TPCH QUERY 11 |       1148 |   515702.16
+ TPCH QUERY 11 |        225 |   513587.57
+ TPCH QUERY 11 |        324 |   500954.58
+ TPCH QUERY 11 |        586 |   499475.58
+ TPCH QUERY 11 |       1576 |   494401.05
+ TPCH QUERY 11 |       1484 |   462396.27
+ TPCH QUERY 11 |        126 |   461263.74
+ TPCH QUERY 11 |       1132 |   455492.24
+ TPCH QUERY 11 |        622 |   449685.60
+ TPCH QUERY 11 |       1160 |   448183.06
+ TPCH QUERY 11 |       1352 |   439967.04
+ TPCH QUERY 11 |         18 |   426442.08
+ TPCH QUERY 11 |          7 |   414558.20
+ TPCH QUERY 11 |        833 |   398540.87
+ TPCH QUERY 11 |       1694 |   376443.98
+ TPCH QUERY 11 |        650 |   370900.99
+ TPCH QUERY 11 |       1504 |   370815.90
+ TPCH QUERY 11 |        432 |   370528.52
+ TPCH QUERY 11 |        612 |   367894.50
+ TPCH QUERY 11 |        542 |   367653.66
+ TPCH QUERY 11 |        456 |   360911.32
+ TPCH QUERY 11 |         52 |   358792.36
+ TPCH QUERY 11 |       1346 |   350637.43
+ TPCH QUERY 11 |         59 |   342221.48
+ TPCH QUERY 11 |       1107 |   341805.20
+ TPCH QUERY 11 |       1171 |   334938.04
+ TPCH QUERY 11 |       1062 |   326445.90
+ TPCH QUERY 11 |        592 |   313081.75
+ TPCH QUERY 11 |       1750 |   312229.33
+ TPCH QUERY 11 |       1843 |   309456.95
+ TPCH QUERY 11 |        180 |   308539.84
+ TPCH QUERY 11 |        899 |   301989.50
+ TPCH QUERY 11 |       1180 |   293452.50
+ TPCH QUERY 11 |        522 |   291601.75
+ TPCH QUERY 11 |        249 |   282520.32
+ TPCH QUERY 11 |       1584 |   278559.38
+ TPCH QUERY 11 |       1404 |   276057.90
+ TPCH QUERY 11 |       1265 |   271079.76
+ TPCH QUERY 11 |        154 |   269641.42
+ TPCH QUERY 11 |       1295 |   265566.56
+ TPCH QUERY 11 |       1523 |   263158.90
+ TPCH QUERY 11 |       1635 |   254834.56
+ TPCH QUERY 11 |       1776 |   234181.20
+ TPCH QUERY 11 |       1097 |   234113.55
+ TPCH QUERY 11 |       1258 |   233500.61
+ TPCH QUERY 11 |        621 |   233431.30
+ TPCH QUERY 11 |        152 |   229781.60
+ TPCH QUERY 11 |        278 |   216372.84
+ TPCH QUERY 11 |        232 |   211879.92
+ TPCH QUERY 11 |       1684 |   201386.22
+ TPCH QUERY 11 |       1243 |   199587.54
+ TPCH QUERY 11 |        976 |   197432.10
+ TPCH QUERY 11 |        819 |   191475.90
+ TPCH QUERY 11 |       1943 |   191247.76
+ TPCH QUERY 11 |        853 |   189232.64
+ TPCH QUERY 11 |        400 |   188941.20
+ TPCH QUERY 11 |        639 |   186533.28
+ TPCH QUERY 11 |        851 |   184103.16
+ TPCH QUERY 11 |        909 |   175099.00
+ TPCH QUERY 11 |        257 |   169033.44
+ TPCH QUERY 11 |       1445 |   164888.68
+ TPCH QUERY 11 |       1855 |   164614.81
+ TPCH QUERY 11 |       1252 |   158680.90
+ TPCH QUERY 11 |       1014 |   156465.82
+ TPCH QUERY 11 |       1717 |   148325.75
+ TPCH QUERY 11 |       1032 |   146408.40
+ TPCH QUERY 11 |        780 |   136296.26
+ TPCH QUERY 11 |        918 |   135268.32
+ TPCH QUERY 11 |        690 |   133826.88
+ TPCH QUERY 11 |        711 |   113268.84
+ TPCH QUERY 11 |        332 |   112181.30
+ TPCH QUERY 11 |       1596 |   110565.00
+ TPCH QUERY 11 |        295 |    97604.25
+(359 rows)
+
+select 'TPCH QUERY 12', l_shipmode, sum(case when o_orderpriority ='1-URGENT' or o_orderpriority ='2-HIGH' then 1 else 0 end) as
+       high_line_count, sum(case when o_orderpriority <> '1-URGENT' and o_orderpriority <> '2-HIGH' then 1 else 0 end) as low_line_count
+    from aopart_orders, aopart_lineitem
+    where o_orderkey = l_orderkey and l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and
+          l_receiptdate >= date '1-jan-1994' and l_receiptdate < date '1-jan-1994' + interval '1 year'
+    group by l_shipmode order by l_shipmode;
+   ?column?    | l_shipmode | high_line_count | low_line_count 
+---------------+------------+-----------------+----------------
+ TPCH QUERY 12 | MAIL       |              64 |             86
+ TPCH QUERY 12 | SHIP       |              61 |             96
+(2 rows)
+
+select 'TPCH QUERY 13', c_count, count(*) as custdist
+    from (
+        select c_custkey, count(o_orderkey)
+            from aopart_customer left outer join aopart_orders on c_custkey = o_custkey and o_comment not like '%special%requests%'
+            group by c_custkey ) as c_orders (c_custkey, c_count)
+    group by c_count order by custdist desc,c_count desc;
+   ?column?    | c_count | custdist 
+---------------+---------+----------
+ TPCH QUERY 13 |       0 |      500
+ TPCH QUERY 13 |      11 |       68
+ TPCH QUERY 13 |      10 |       64
+ TPCH QUERY 13 |      12 |       62
+ TPCH QUERY 13 |       9 |       62
+ TPCH QUERY 13 |       8 |       61
+ TPCH QUERY 13 |      14 |       54
+ TPCH QUERY 13 |      13 |       52
+ TPCH QUERY 13 |       7 |       49
+ TPCH QUERY 13 |      20 |       48
+ TPCH QUERY 13 |      21 |       47
+ TPCH QUERY 13 |      16 |       46
+ TPCH QUERY 13 |      15 |       45
+ TPCH QUERY 13 |      19 |       44
+ TPCH QUERY 13 |      17 |       41
+ TPCH QUERY 13 |      18 |       38
+ TPCH QUERY 13 |      22 |       33
+ TPCH QUERY 13 |       6 |       33
+ TPCH QUERY 13 |      24 |       30
+ TPCH QUERY 13 |      23 |       27
+ TPCH QUERY 13 |      25 |       21
+ TPCH QUERY 13 |      27 |       17
+ TPCH QUERY 13 |      26 |       15
+ TPCH QUERY 13 |       5 |       14
+ TPCH QUERY 13 |      28 |        6
+ TPCH QUERY 13 |       4 |        6
+ TPCH QUERY 13 |      32 |        5
+ TPCH QUERY 13 |      29 |        5
+ TPCH QUERY 13 |      30 |        2
+ TPCH QUERY 13 |       3 |        2
+ TPCH QUERY 13 |      31 |        1
+ TPCH QUERY 13 |       2 |        1
+ TPCH QUERY 13 |       1 |        1
+(33 rows)
+
+select 'TPCH QUERY 14', 100.00 * sum(case when p_type like 'PROMO%' then l_extendedprice*(1-l_discount) else 0 end) /
+       sum(l_extendedprice * (1 - l_discount)) as promo_revenue 
+    from aopart_lineitem,aopart_part
+    where l_partkey = p_partkey and l_shipdate >= date '1-sep-1995' and l_shipdate < date '1-sep-1995' + interval '1 month';
+   ?column?    |    promo_revenue    
+---------------+---------------------
+ TPCH QUERY 14 | 15.4865458122840715
+(1 row)
+
+select 'TPCH QUERY 15',s_suppkey, s_name, s_address, s_phone, total_revenue
+    from aopart_supplier,revenue
+    where s_suppkey = supplier_no and total_revenue = ( select max(total_revenue) from revenue ) order by s_suppkey;
+   ?column?    | s_suppkey |          s_name           |              s_address               |     s_phone     | total_revenue 
+---------------+-----------+---------------------------+--------------------------------------+-----------------+---------------
+ TPCH QUERY 15 |        21 | Supplier#000000021        | 81CavellcrJ0PQ3CPBID0Z0JwyJm0ka5igEs | 12-253-590-5816 |  1161099.4636
+(1 row)
+
+select 'TPCH QUERY 16a', p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt
+    from aopart_part, aopart_partsupp left join aopart_supplier on (ps_suppkey=s_suppkey and s_comment like '%Customer%Complaints%' )
+    where p_partkey = ps_partkey and p_brand <> 'Brand#45' and p_type not like 'MEDIUM POLISHED%' and
+          p_size in (49, 14, 23, 45, 19, 3, 36, 9) and s_suppkey is null
+    group by p_brand, p_type, p_size order by supplier_cnt desc, p_brand, p_type, p_size;
+    ?column?    |  p_brand   |          p_type           | p_size | supplier_cnt 
+----------------+------------+---------------------------+--------+--------------
+ TPCH QUERY 16a | Brand#14   | PROMO BRUSHED STEEL       |      9 |            8
+ TPCH QUERY 16a | Brand#35   | SMALL POLISHED COPPER     |     14 |            8
+ TPCH QUERY 16a | Brand#22   | LARGE BURNISHED TIN       |     36 |            6
+ TPCH QUERY 16a | Brand#11   | ECONOMY BURNISHED NICKEL  |     49 |            4
+ TPCH QUERY 16a | Brand#11   | LARGE PLATED TIN          |     23 |            4
+ TPCH QUERY 16a | Brand#11   | MEDIUM ANODIZED BRASS     |     45 |            4
+ TPCH QUERY 16a | Brand#11   | MEDIUM BRUSHED BRASS      |     45 |            4
+ TPCH QUERY 16a | Brand#11   | PROMO ANODIZED BRASS      |      3 |            4
+ TPCH QUERY 16a | Brand#11   | PROMO ANODIZED BRASS      |     49 |            4
+ TPCH QUERY 16a | Brand#11   | PROMO ANODIZED TIN        |     45 |            4
+ TPCH QUERY 16a | Brand#11   | PROMO BURNISHED BRASS     |     36 |            4
+ TPCH QUERY 16a | Brand#11   | SMALL ANODIZED TIN        |     45 |            4
+ TPCH QUERY 16a | Brand#11   | SMALL PLATED COPPER       |     45 |            4
+ TPCH QUERY 16a | Brand#11   | STANDARD POLISHED NICKEL  |     45 |            4
+ TPCH QUERY 16a | Brand#11   | STANDARD POLISHED TIN     |     45 |            4
+ TPCH QUERY 16a | Brand#12   | ECONOMY BURNISHED COPPER  |     45 |            4
+ TPCH QUERY 16a | Brand#12   | LARGE ANODIZED TIN        |     45 |            4
+ TPCH QUERY 16a | Brand#12   | LARGE BURNISHED BRASS     |     19 |            4
+ TPCH QUERY 16a | Brand#12   | LARGE PLATED STEEL        |     36 |            4
+ TPCH QUERY 16a | Brand#12   | MEDIUM PLATED BRASS       |     23 |            4
+ TPCH QUERY 16a | Brand#12   | PROMO BRUSHED COPPER      |     14 |            4
+ TPCH QUERY 16a | Brand#12   | PROMO BURNISHED BRASS     |     49 |            4
+ TPCH QUERY 16a | Brand#12   | SMALL ANODIZED COPPER     |     23 |            4
+ TPCH QUERY 16a | Brand#12   | STANDARD ANODIZED BRASS   |      3 |            4
+ TPCH QUERY 16a | Brand#12   | STANDARD BURNISHED TIN    |     23 |            4
+ TPCH QUERY 16a | Brand#12   | STANDARD PLATED STEEL     |     36 |            4
+ TPCH QUERY 16a | Brand#13   | ECONOMY PLATED STEEL      |     23 |            4
+ TPCH QUERY 16a | Brand#13   | ECONOMY POLISHED BRASS    |      9 |            4
+ TPCH QUERY 16a | Brand#13   | ECONOMY POLISHED COPPER   |      9 |            4
+ TPCH QUERY 16a | Brand#13   | LARGE ANODIZED TIN        |     19 |            4
+ TPCH QUERY 16a | Brand#13   | LARGE BURNISHED TIN       |     49 |            4
+ TPCH QUERY 16a | Brand#13   | LARGE POLISHED BRASS      |      3 |            4
+ TPCH QUERY 16a | Brand#13   | MEDIUM ANODIZED STEEL     |     36 |            4
+ TPCH QUERY 16a | Brand#13   | MEDIUM PLATED COPPER      |     19 |            4
+ TPCH QUERY 16a | Brand#13   | PROMO BRUSHED COPPER      |     49 |            4
+ TPCH QUERY 16a | Brand#13   | PROMO PLATED TIN          |     19 |            4
+ TPCH QUERY 16a | Brand#13   | SMALL BRUSHED NICKEL      |     19 |            4
+ TPCH QUERY 16a | Brand#13   | SMALL BURNISHED BRASS     |     45 |            4
+ TPCH QUERY 16a | Brand#14   | ECONOMY ANODIZED STEEL    |     19 |            4
+ TPCH QUERY 16a | Brand#14   | ECONOMY BURNISHED TIN     |     23 |            4
+ TPCH QUERY 16a | Brand#14   | ECONOMY PLATED STEEL      |     45 |            4
+ TPCH QUERY 16a | Brand#14   | ECONOMY PLATED TIN        |      9 |            4
+ TPCH QUERY 16a | Brand#14   | LARGE ANODIZED NICKEL     |      9 |            4
+ TPCH QUERY 16a | Brand#14   | LARGE BRUSHED NICKEL      |     45 |            4
+ TPCH QUERY 16a | Brand#14   | SMALL ANODIZED NICKEL     |     45 |            4
+ TPCH QUERY 16a | Brand#14   | SMALL BURNISHED COPPER    |     14 |            4
+ TPCH QUERY 16a | Brand#14   | SMALL BURNISHED TIN       |     23 |            4
+ TPCH QUERY 16a | Brand#15   | ECONOMY ANODIZED STEEL    |     36 |            4
+ TPCH QUERY 16a | Brand#15   | ECONOMY BRUSHED BRASS     |     36 |            4
+ TPCH QUERY 16a | Brand#15   | ECONOMY BURNISHED BRASS   |     14 |            4
+ TPCH QUERY 16a | Brand#15   | ECONOMY PLATED STEEL      |     45 |            4
+ TPCH QUERY 16a | Brand#15   | LARGE ANODIZED BRASS      |     45 |            4
+ TPCH QUERY 16a | Brand#15   | LARGE ANODIZED COPPER     |      3 |            4
+ TPCH QUERY 16a | Brand#15   | MEDIUM ANODIZED COPPER    |      9 |            4
+ TPCH QUERY 16a | Brand#15   | MEDIUM PLATED TIN         |      9 |            4
+ TPCH QUERY 16a | Brand#15   | PROMO POLISHED TIN        |     49 |            4
+ TPCH QUERY 16a | Brand#15   | SMALL POLISHED STEEL      |     19 |            4
+ TPCH QUERY 16a | Brand#15   | STANDARD BURNISHED STEEL  |     45 |            4
+ TPCH QUERY 16a | Brand#15   | STANDARD PLATED NICKEL    |     19 |            4
+ TPCH QUERY 16a | Brand#15   | STANDARD PLATED TIN       |      3 |            4
+ TPCH QUERY 16a | Brand#21   | ECONOMY ANODIZED STEEL    |     19 |            4
+ TPCH QUERY 16a | Brand#21   | ECONOMY BRUSHED TIN       |     49 |            4
+ TPCH QUERY 16a | Brand#21   | LARGE BURNISHED COPPER    |     19 |            4
+ TPCH QUERY 16a | Brand#21   | MEDIUM ANODIZED TIN       |      9 |            4
+ TPCH QUERY 16a | Brand#21   | MEDIUM BURNISHED STEEL    |     23 |            4
+ TPCH QUERY 16a | Brand#21   | PROMO BRUSHED STEEL       |     23 |            4
+ TPCH QUERY 16a | Brand#21   | PROMO BURNISHED COPPER    |     19 |            4
+ TPCH QUERY 16a | Brand#21   | STANDARD PLATED BRASS     |     49 |            4
+ TPCH QUERY 16a | Brand#21   | STANDARD POLISHED TIN     |     36 |            4
+ TPCH QUERY 16a | Brand#22   | ECONOMY BURNISHED NICKEL  |     19 |            4
+ TPCH QUERY 16a | Brand#22   | LARGE ANODIZED STEEL      |      3 |            4
+ TPCH QUERY 16a | Brand#22   | LARGE BURNISHED STEEL     |     23 |            4
+ TPCH QUERY 16a | Brand#22   | LARGE BURNISHED STEEL     |     45 |            4
+ TPCH QUERY 16a | Brand#22   | LARGE BURNISHED TIN       |     45 |            4
+ TPCH QUERY 16a | Brand#22   | LARGE POLISHED NICKEL     |     19 |            4
+ TPCH QUERY 16a | Brand#22   | MEDIUM ANODIZED TIN       |      9 |            4
+ TPCH QUERY 16a | Brand#22   | MEDIUM BRUSHED BRASS      |     14 |            4
+ TPCH QUERY 16a | Brand#22   | MEDIUM BRUSHED COPPER     |      3 |            4
+ TPCH QUERY 16a | Brand#22   | MEDIUM BRUSHED COPPER     |     45 |            4
+ TPCH QUERY 16a | Brand#22   | MEDIUM BURNISHED TIN      |     19 |            4
+ TPCH QUERY 16a | Brand#22   | MEDIUM BURNISHED TIN      |     23 |            4
+ TPCH QUERY 16a | Brand#22   | MEDIUM PLATED BRASS       |     49 |            4
+ TPCH QUERY 16a | Brand#22   | PROMO BRUSHED BRASS       |      9 |            4
+ TPCH QUERY 16a | Brand#22   | PROMO BRUSHED STEEL       |     36 |            4
+ TPCH QUERY 16a | Brand#22   | SMALL BRUSHED NICKEL      |      3 |            4
+ TPCH QUERY 16a | Brand#22   | SMALL BURNISHED STEEL     |     23 |            4
+ TPCH QUERY 16a | Brand#22   | STANDARD PLATED NICKEL    |      3 |            4
+ TPCH QUERY 16a | Brand#22   | STANDARD PLATED TIN       |     19 |            4
+ TPCH QUERY 16a | Brand#23   | ECONOMY BRUSHED COPPER    |      9 |            4
+ TPCH QUERY 16a | Brand#23   | LARGE ANODIZED COPPER     |     14 |            4
+ TPCH QUERY 16a | Brand#23   | LARGE PLATED BRASS        |     49 |            4
+ TPCH QUERY 16a | Brand#23   | MEDIUM BRUSHED NICKEL     |      3 |            4
+ TPCH QUERY 16a | Brand#23   | PROMO ANODIZED COPPER     |     19 |            4
+ TPCH QUERY 16a | Brand#23   | PROMO BURNISHED COPPER    |     14 |            4
+ TPCH QUERY 16a | Brand#23   | PROMO POLISHED BRASS      |     14 |            4
+ TPCH QUERY 16a | Brand#23   | SMALL BRUSHED BRASS       |     49 |            4
+ TPCH QUERY 16a | Brand#23   | SMALL BRUSHED COPPER      |     45 |            4
+ TPCH QUERY 16a | Brand#23   | SMALL BURNISHED COPPER    |     49 |            4
+ TPCH QUERY 16a | Brand#23   | SMALL PLATED BRASS        |     36 |            4
+ TPCH QUERY 16a | Brand#23   | SMALL POLISHED BRASS      |      9 |            4
+ TPCH QUERY 16a | Brand#23   | STANDARD BRUSHED TIN      |      3 |            4
+ TPCH QUERY 16a | Brand#23   | STANDARD PLATED BRASS     |      9 |            4
+ TPCH QUERY 16a | Brand#23   | STANDARD PLATED STEEL     |     36 |            4
+ TPCH QUERY 16a | Brand#23   | STANDARD PLATED TIN       |     19 |            4
+ TPCH QUERY 16a | Brand#24   | ECONOMY BRUSHED BRASS     |     36 |            4
+ TPCH QUERY 16a | Brand#24   | ECONOMY PLATED COPPER     |     36 |            4
+ TPCH QUERY 16a | Brand#24   | LARGE PLATED NICKEL       |     36 |            4
+ TPCH QUERY 16a | Brand#24   | MEDIUM PLATED STEEL       |     19 |            4
+ TPCH QUERY 16a | Brand#24   | PROMO POLISHED BRASS      |     14 |            4
+ TPCH QUERY 16a | Brand#24   | SMALL ANODIZED COPPER     |      3 |            4
+ TPCH QUERY 16a | Brand#24   | STANDARD BRUSHED BRASS    |     14 |            4
+ TPCH QUERY 16a | Brand#24   | STANDARD BRUSHED STEEL    |     14 |            4
+ TPCH QUERY 16a | Brand#24   | STANDARD POLISHED NICKEL  |     14 |            4
+ TPCH QUERY 16a | Brand#25   | ECONOMY BURNISHED TIN     |     19 |            4
+ TPCH QUERY 16a | Brand#25   | ECONOMY PLATED NICKEL     |     23 |            4
+ TPCH QUERY 16a | Brand#25   | LARGE ANODIZED NICKEL     |     23 |            4
+ TPCH QUERY 16a | Brand#25   | LARGE BRUSHED NICKEL      |     19 |            4
+ TPCH QUERY 16a | Brand#25   | LARGE BURNISHED TIN       |     49 |            4
+ TPCH QUERY 16a | Brand#25   | MEDIUM BURNISHED NICKEL   |     49 |            4
+ TPCH QUERY 16a | Brand#25   | MEDIUM PLATED BRASS       |     45 |            4
+ TPCH QUERY 16a | Brand#25   | PROMO ANODIZED TIN        |      3 |            4
+ TPCH QUERY 16a | Brand#25   | PROMO BURNISHED COPPER    |     45 |            4
+ TPCH QUERY 16a | Brand#25   | PROMO PLATED NICKEL       |      3 |            4
+ TPCH QUERY 16a | Brand#25   | SMALL BURNISHED COPPER    |      3 |            4
+ TPCH QUERY 16a | Brand#25   | SMALL PLATED TIN          |     36 |            4
+ TPCH QUERY 16a | Brand#25   | STANDARD ANODIZED TIN     |      9 |            4
+ TPCH QUERY 16a | Brand#25   | STANDARD PLATED NICKEL    |     36 |            4
+ TPCH QUERY 16a | Brand#31   | ECONOMY BURNISHED COPPER  |     36 |            4
+ TPCH QUERY 16a | Brand#31   | ECONOMY PLATED STEEL      |     23 |            4
+ TPCH QUERY 16a | Brand#31   | LARGE PLATED NICKEL       |     14 |            4
+ TPCH QUERY 16a | Brand#31   | MEDIUM BURNISHED COPPER   |      3 |            4
+ TPCH QUERY 16a | Brand#31   | MEDIUM PLATED TIN         |     36 |            4
+ TPCH QUERY 16a | Brand#31   | PROMO ANODIZED NICKEL     |      9 |            4
+ TPCH QUERY 16a | Brand#31   | PROMO POLISHED TIN        |     23 |            4
+ TPCH QUERY 16a | Brand#31   | SMALL ANODIZED COPPER     |      3 |            4
+ TPCH QUERY 16a | Brand#31   | SMALL ANODIZED COPPER     |     45 |            4
+ TPCH QUERY 16a | Brand#31   | SMALL BRUSHED NICKEL      |     23 |            4
+ TPCH QUERY 16a | Brand#31   | SMALL PLATED COPPER       |     36 |            4
+ TPCH QUERY 16a | Brand#32   | ECONOMY ANODIZED COPPER   |     36 |            4
+ TPCH QUERY 16a | Brand#32   | ECONOMY PLATED COPPER     |      9 |            4
+ TPCH QUERY 16a | Brand#32   | LARGE ANODIZED STEEL      |     14 |            4
+ TPCH QUERY 16a | Brand#32   | MEDIUM ANODIZED STEEL     |     49 |            4
+ TPCH QUERY 16a | Brand#32   | MEDIUM BURNISHED BRASS    |      9 |            4
+ TPCH QUERY 16a | Brand#32   | MEDIUM BURNISHED BRASS    |     49 |            4
+ TPCH QUERY 16a | Brand#32   | PROMO BRUSHED STEEL       |     23 |            4
+ TPCH QUERY 16a | Brand#32   | PROMO BURNISHED TIN       |     45 |            4
+ TPCH QUERY 16a | Brand#32   | SMALL ANODIZED TIN        |      9 |            4
+ TPCH QUERY 16a | Brand#32   | SMALL BRUSHED COPPER      |      3 |            4
+ TPCH QUERY 16a | Brand#32   | SMALL PLATED COPPER       |     45 |            4
+ TPCH QUERY 16a | Brand#32   | SMALL POLISHED STEEL      |     36 |            4
+ TPCH QUERY 16a | Brand#32   | SMALL POLISHED TIN        |     45 |            4
+ TPCH QUERY 16a | Brand#32   | STANDARD PLATED STEEL     |     36 |            4
+ TPCH QUERY 16a | Brand#33   | ECONOMY BURNISHED COPPER  |     14 |            4
+ TPCH QUERY 16a | Brand#33   | ECONOMY POLISHED BRASS    |     14 |            4
+ TPCH QUERY 16a | Brand#33   | LARGE BRUSHED TIN         |     36 |            4
+ TPCH QUERY 16a | Brand#33   | MEDIUM ANODIZED BRASS     |      3 |            4
+ TPCH QUERY 16a | Brand#33   | MEDIUM BURNISHED COPPER   |     14 |            4
+ TPCH QUERY 16a | Brand#33   | MEDIUM PLATED STEEL       |     49 |            4
+ TPCH QUERY 16a | Brand#33   | PROMO PLATED STEEL        |     49 |            4
+ TPCH QUERY 16a | Brand#33   | PROMO PLATED TIN          |     49 |            4
+ TPCH QUERY 16a | Brand#33   | PROMO POLISHED STEEL      |      9 |            4
+ TPCH QUERY 16a | Brand#33   | SMALL ANODIZED COPPER     |     23 |            4
+ TPCH QUERY 16a | Brand#33   | SMALL BRUSHED STEEL       |      3 |            4
+ TPCH QUERY 16a | Brand#33   | SMALL BURNISHED NICKEL    |      3 |            4
+ TPCH QUERY 16a | Brand#33   | STANDARD PLATED NICKEL    |     36 |            4
+ TPCH QUERY 16a | Brand#34   | ECONOMY ANODIZED TIN      |     49 |            4
+ TPCH QUERY 16a | Brand#34   | LARGE ANODIZED BRASS      |     23 |            4
+ TPCH QUERY 16a | Brand#34   | LARGE BRUSHED COPPER      |     23 |            4
+ TPCH QUERY 16a | Brand#34   | LARGE BURNISHED TIN       |     49 |            4
+ TPCH QUERY 16a | Brand#34   | LARGE PLATED BRASS        |     45 |            4
+ TPCH QUERY 16a | Brand#34   | MEDIUM BRUSHED COPPER     |      9 |            4
+ TPCH QUERY 16a | Brand#34   | MEDIUM BRUSHED TIN        |     14 |            4
+ TPCH QUERY 16a | Brand#34   | MEDIUM BURNISHED NICKEL   |      3 |            4
+ TPCH QUERY 16a | Brand#34   | SMALL ANODIZED STEEL      |     23 |            4
+ TPCH QUERY 16a | Brand#34   | SMALL BRUSHED TIN         |      9 |            4
+ TPCH QUERY 16a | Brand#34   | SMALL PLATED BRASS        |     14 |            4
+ TPCH QUERY 16a | Brand#34   | STANDARD ANODIZED NICKEL  |     36 |            4
+ TPCH QUERY 16a | Brand#34   | STANDARD BRUSHED TIN      |     19 |            4
+ TPCH QUERY 16a | Brand#34   | STANDARD BURNISHED TIN    |     23 |            4
+ TPCH QUERY 16a | Brand#34   | STANDARD PLATED NICKEL    |     36 |            4
+ TPCH QUERY 16a | Brand#35   | PROMO BURNISHED BRASS     |      3 |            4
+ TPCH QUERY 16a | Brand#35   | PROMO BURNISHED STEEL     |     14 |            4
+ TPCH QUERY 16a | Brand#35   | PROMO PLATED BRASS        |     19 |            4
+ TPCH QUERY 16a | Brand#35   | STANDARD ANODIZED NICKEL  |     14 |            4
+ TPCH QUERY 16a | Brand#35   | STANDARD ANODIZED STEEL   |     23 |            4
+ TPCH QUERY 16a | Brand#35   | STANDARD BRUSHED BRASS    |      3 |            4
+ TPCH QUERY 16a | Brand#35   | STANDARD BRUSHED NICKEL   |     49 |            4
+ TPCH QUERY 16a | Brand#35   | STANDARD PLATED STEEL     |     14 |            4
+ TPCH QUERY 16a | Brand#41   | MEDIUM ANODIZED NICKEL    |      9 |            4
+ TPCH QUERY 16a | Brand#41   | MEDIUM BRUSHED TIN        |      9 |            4
+ TPCH QUERY 16a | Brand#41   | MEDIUM PLATED STEEL       |     19 |            4
+ TPCH QUERY 16a | Brand#41   | PROMO ANODIZED NICKEL     |      9 |            4
+ TPCH QUERY 16a | Brand#41   | SMALL ANODIZED STEEL      |     45 |            4
+ TPCH QUERY 16a | Brand#41   | SMALL POLISHED COPPER     |     14 |            4
+ TPCH QUERY 16a | Brand#41   | STANDARD ANODIZED NICKEL  |      9 |            4
+ TPCH QUERY 16a | Brand#41   | STANDARD ANODIZED TIN     |     36 |            4
+ TPCH QUERY 16a | Brand#41   | STANDARD ANODIZED TIN     |     49 |            4
+ TPCH QUERY 16a | Brand#41   | STANDARD BRUSHED TIN      |     45 |            4
+ TPCH QUERY 16a | Brand#41   | STANDARD PLATED TIN       |     49 |            4
+ TPCH QUERY 16a | Brand#42   | ECONOMY BRUSHED COPPER    |     14 |            4
+ TPCH QUERY 16a | Brand#42   | LARGE ANODIZED NICKEL     |     49 |            4
+ TPCH QUERY 16a | Brand#42   | MEDIUM PLATED TIN         |     45 |            4
+ TPCH QUERY 16a | Brand#42   | PROMO BRUSHED STEEL       |     19 |            4
+ TPCH QUERY 16a | Brand#42   | PROMO BURNISHED TIN       |     49 |            4
+ TPCH QUERY 16a | Brand#42   | PROMO PLATED STEEL        |     19 |            4
+ TPCH QUERY 16a | Brand#42   | PROMO PLATED STEEL        |     45 |            4
+ TPCH QUERY 16a | Brand#42   | STANDARD BURNISHED NICKEL |     49 |            4
+ TPCH QUERY 16a | Brand#42   | STANDARD PLATED COPPER    |     19 |            4
+ TPCH QUERY 16a | Brand#43   | ECONOMY ANODIZED COPPER   |     19 |            4
+ TPCH QUERY 16a | Brand#43   | ECONOMY ANODIZED NICKEL   |     49 |            4
+ TPCH QUERY 16a | Brand#43   | ECONOMY PLATED TIN        |     19 |            4
+ TPCH QUERY 16a | Brand#43   | ECONOMY POLISHED TIN      |     45 |            4
+ TPCH QUERY 16a | Brand#43   | LARGE BURNISHED COPPER    |      3 |            4
+ TPCH QUERY 16a | Brand#43   | LARGE POLISHED TIN        |     45 |            4
+ TPCH QUERY 16a | Brand#43   | MEDIUM ANODIZED BRASS     |     14 |            4
+ TPCH QUERY 16a | Brand#43   | MEDIUM ANODIZED COPPER    |     36 |            4
+ TPCH QUERY 16a | Brand#43   | MEDIUM ANODIZED COPPER    |     49 |            4
+ TPCH QUERY 16a | Brand#43   | MEDIUM BURNISHED TIN      |     23 |            4
+ TPCH QUERY 16a | Brand#43   | PROMO BRUSHED BRASS       |     36 |            4
+ TPCH QUERY 16a | Brand#43   | PROMO BURNISHED STEEL     |      3 |            4
+ TPCH QUERY 16a | Brand#43   | PROMO POLISHED BRASS      |     19 |            4
+ TPCH QUERY 16a | Brand#43   | SMALL BRUSHED NICKEL      |      9 |            4
+ TPCH QUERY 16a | Brand#43   | SMALL POLISHED STEEL      |     19 |            4
+ TPCH QUERY 16a | Brand#43   | STANDARD ANODIZED BRASS   |      3 |            4
+ TPCH QUERY 16a | Brand#43   | STANDARD PLATED TIN       |     14 |            4
+ TPCH QUERY 16a | Brand#44   | ECONOMY ANODIZED NICKEL   |     36 |            4
+ TPCH QUERY 16a | Brand#44   | ECONOMY POLISHED NICKEL   |     23 |            4
+ TPCH QUERY 16a | Brand#44   | LARGE ANODIZED BRASS      |     19 |            4
+ TPCH QUERY 16a | Brand#44   | LARGE BRUSHED TIN         |      3 |            4
+ TPCH QUERY 16a | Brand#44   | MEDIUM BRUSHED STEEL      |     19 |            4
+ TPCH QUERY 16a | Brand#44   | MEDIUM BURNISHED COPPER   |     45 |            4
+ TPCH QUERY 16a | Brand#44   | MEDIUM BURNISHED NICKEL   |     23 |            4
+ TPCH QUERY 16a | Brand#44   | MEDIUM PLATED COPPER      |     14 |            4
+ TPCH QUERY 16a | Brand#44   | SMALL ANODIZED COPPER     |     23 |            4
+ TPCH QUERY 16a | Brand#44   | SMALL ANODIZED TIN        |     45 |            4
+ TPCH QUERY 16a | Brand#44   | SMALL PLATED COPPER       |     19 |            4
+ TPCH QUERY 16a | Brand#44   | STANDARD ANODIZED COPPER  |      3 |            4
+ TPCH QUERY 16a | Brand#44   | STANDARD ANODIZED NICKEL  |     36 |            4
+ TPCH QUERY 16a | Brand#51   | ECONOMY ANODIZED STEEL    |      9 |            4
+ TPCH QUERY 16a | Brand#51   | ECONOMY PLATED NICKEL     |     49 |            4
+ TPCH QUERY 16a | Brand#51   | ECONOMY POLISHED COPPER   |      9 |            4
+ TPCH QUERY 16a | Brand#51   | ECONOMY POLISHED STEEL    |     49 |            4
+ TPCH QUERY 16a | Brand#51   | LARGE BURNISHED BRASS     |     19 |            4
+ TPCH QUERY 16a | Brand#51   | LARGE POLISHED STEEL      |     19 |            4
+ TPCH QUERY 16a | Brand#51   | MEDIUM ANODIZED TIN       |     14 |            4
+ TPCH QUERY 16a | Brand#51   | PROMO BRUSHED BRASS       |     23 |            4
+ TPCH QUERY 16a | Brand#51   | PROMO POLISHED STEEL      |     49 |            4
+ TPCH QUERY 16a | Brand#51   | SMALL BRUSHED TIN         |     36 |            4
+ TPCH QUERY 16a | Brand#51   | SMALL POLISHED STEEL      |     49 |            4
+ TPCH QUERY 16a | Brand#51   | STANDARD BRUSHED COPPER   |      3 |            4
+ TPCH QUERY 16a | Brand#51   | STANDARD BRUSHED NICKEL   |     19 |            4
+ TPCH QUERY 16a | Brand#51   | STANDARD BURNISHED COPPER |     19 |            4
+ TPCH QUERY 16a | Brand#52   | ECONOMY ANODIZED BRASS    |     14 |            4
+ TPCH QUERY 16a | Brand#52   | ECONOMY ANODIZED COPPER   |     36 |            4
+ TPCH QUERY 16a | Brand#52   | ECONOMY BURNISHED NICKEL  |     19 |            4
+ TPCH QUERY 16a | Brand#52   | ECONOMY BURNISHED STEEL   |     36 |            4
+ TPCH QUERY 16a | Brand#52   | ECONOMY PLATED TIN        |     23 |            4
+ TPCH QUERY 16a | Brand#52   | LARGE BRUSHED NICKEL      |     19 |            4
+ TPCH QUERY 16a | Brand#52   | LARGE BURNISHED TIN       |     45 |            4
+ TPCH QUERY 16a | Brand#52   | LARGE PLATED STEEL        |      9 |            4
+ TPCH QUERY 16a | Brand#52   | LARGE PLATED TIN          |      9 |            4
+ TPCH QUERY 16a | Brand#52   | LARGE POLISHED NICKEL     |     36 |            4
+ TPCH QUERY 16a | Brand#52   | MEDIUM BURNISHED TIN      |     45 |            4
+ TPCH QUERY 16a | Brand#52   | SMALL ANODIZED NICKEL     |     36 |            4
+ TPCH QUERY 16a | Brand#52   | SMALL ANODIZED STEEL      |      9 |            4
+ TPCH QUERY 16a | Brand#52   | SMALL BRUSHED STEEL       |     23 |            4
+ TPCH QUERY 16a | Brand#52   | SMALL BURNISHED NICKEL    |     14 |            4
+ TPCH QUERY 16a | Brand#52   | STANDARD POLISHED STEEL   |     19 |            4
+ TPCH QUERY 16a | Brand#53   | LARGE BURNISHED NICKEL    |     23 |            4
+ TPCH QUERY 16a | Brand#53   | LARGE PLATED BRASS        |      9 |            4
+ TPCH QUERY 16a | Brand#53   | LARGE PLATED STEEL        |     49 |            4
+ TPCH QUERY 16a | Brand#53   | MEDIUM BRUSHED COPPER     |      3 |            4
+ TPCH QUERY 16a | Brand#53   | MEDIUM BRUSHED STEEL      |     45 |            4
+ TPCH QUERY 16a | Brand#53   | SMALL BRUSHED BRASS       |     36 |            4
+ TPCH QUERY 16a | Brand#53   | STANDARD PLATED STEEL     |     45 |            4
+ TPCH QUERY 16a | Brand#54   | ECONOMY ANODIZED BRASS    |      9 |            4
+ TPCH QUERY 16a | Brand#54   | ECONOMY BRUSHED TIN       |     19 |            4
+ TPCH QUERY 16a | Brand#54   | ECONOMY POLISHED BRASS    |     49 |            4
+ TPCH QUERY 16a | Brand#54   | LARGE ANODIZED BRASS      |     49 |            4
+ TPCH QUERY 16a | Brand#54   | LARGE BURNISHED BRASS     |     49 |            4
+ TPCH QUERY 16a | Brand#54   | LARGE BURNISHED TIN       |     14 |            4
+ TPCH QUERY 16a | Brand#54   | LARGE POLISHED BRASS      |     19 |            4
+ TPCH QUERY 16a | Brand#54   | MEDIUM BURNISHED STEEL    |      3 |            4
+ TPCH QUERY 16a | Brand#54   | SMALL BURNISHED STEEL     |     19 |            4
+ TPCH QUERY 16a | Brand#54   | SMALL PLATED BRASS        |     23 |            4
+ TPCH QUERY 16a | Brand#54   | SMALL PLATED TIN          |     14 |            4
+ TPCH QUERY 16a | Brand#55   | LARGE BRUSHED NICKEL      |      9 |            4
+ TPCH QUERY 16a | Brand#55   | LARGE PLATED TIN          |      9 |            4
+ TPCH QUERY 16a | Brand#55   | LARGE POLISHED STEEL      |     36 |            4
+ TPCH QUERY 16a | Brand#55   | MEDIUM BRUSHED TIN        |     45 |            4
+ TPCH QUERY 16a | Brand#55   | PROMO BRUSHED STEEL       |     36 |            4
+ TPCH QUERY 16a | Brand#55   | PROMO BURNISHED STEEL     |     14 |            4
+ TPCH QUERY 16a | Brand#55   | SMALL PLATED COPPER       |     45 |            4
+ TPCH QUERY 16a | Brand#55   | STANDARD ANODIZED BRASS   |     36 |            4
+ TPCH QUERY 16a | Brand#55   | STANDARD BRUSHED COPPER   |      3 |            4
+ TPCH QUERY 16a | Brand#55   | STANDARD BRUSHED STEEL    |     19 |            4
+(296 rows)
+
+select 'TPCH QUERY 17a', sum(l_extendedprice) / 7.0 as avg_yearly
+    from aopart_lineitem l, aopart_part, ( select l_partkey, avg(l_quantity) as avg_qty from aopart_lineitem group by l_partkey ) g
+    where p_partkey = l.l_partkey and p_partkey = g.l_partkey and l.l_quantity < 0.2* g.avg_qty and p_brand = 'Brand#23' and
+          p_container = 'JUMBO PACK';
+    ?column?    |      avg_yearly       
+----------------+-----------------------
+ TPCH QUERY 17a | 3547.7957142857142857
+(1 row)
+
+select c_name, c_custkey, o_orderkey,'TPCH QUERY 18', o_orderdate, o_totalprice, sum(l_quantity)
+    from aopart_customer, aopart_orders, aopart_lineitem
+    where o_orderkey in ( select l_orderkey from aopart_lineitem group by l_orderkey having sum(l_quantity) > 300 ) and
+          c_custkey = o_custkey and o_orderkey = l_orderkey
+    group by c_name,c_custkey,o_orderkey,o_orderdate,o_totalprice order by o_totalprice desc,o_orderdate;
+       c_name       | c_custkey | o_orderkey |   ?column?    | o_orderdate | o_totalprice |  sum   
+--------------------+-----------+------------+---------------+-------------+--------------+--------
+ Customer#000000667 |       667 |      29158 | TPCH QUERY 18 | 10-21-1995  |    439687.23 | 305.00
+ Customer#000000178 |       178 |       6882 | TPCH QUERY 18 | 04-09-1997  |    422359.65 | 303.00
+(2 rows)
+
+select 'TPCH QUERY 19',sum(l_extendedprice* (1 - l_discount)) as revenue
+    from aopart_lineitem, aopart_part
+    where p_partkey = l_partkey and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON' and
+          ( ( p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and l_quantity >= 1 and
+          l_quantity <= 1 + 10 and p_size between 1 and 15 ) or ( p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX',
+          'MED PKG', 'MED PACK') and l_quantity >= 10 and l_quantity <= 10 + 10 and p_size between 1 and 15 ) or ( p_brand = 'Brand#34'
+          and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') and l_quantity >= 20 and l_quantity <= 20 + 10 and
+          p_size between 1 and 15 ) );
+   ?column?    |  revenue   
+---------------+------------
+ TPCH QUERY 19 | 22923.0280
+(1 row)
+
+select 'TPCH QUERY 20',s_name,s_address
+    from aopart_supplier, aopart_nation
+    where s_suppkey in (
+        select ps_suppkey from aopart_partsupp, (
+            select sum(l_quantity) as qty_sum, l_partkey, l_suppkey
+                from aopart_lineitem
+                where l_shipdate >= date '1-jan-1994' and l_shipdate < date '1-jan-1994' + interval '1 year'
+                group by l_partkey, l_suppkey ) g
+        where g.l_partkey = ps_partkey and g.l_suppkey = ps_suppkey and ps_availqty > 0.5*g.qty_sum and ps_partkey in (select p_partkey
+              from aopart_part where p_name like 'forest%' )) and s_nationkey = n_nationkey and n_name = 'CANADA' order by s_name;
+   ?column?    |          s_name           |           s_address            
+---------------+---------------------------+--------------------------------
+ TPCH QUERY 20 | Supplier#000000013        | HK71HQyWoqRWOX8GI FpgAifW,2PoH
+(1 row)
+
+select 'TPCH QUERY 21',s_name, count( distinct (l1.l_orderkey||l1.l_linenumber)) as numwait
+    from aopart_supplier, aopart_orders, aopart_nation, aopart_lineitem l1 left join aopart_lineitem l2 on (l2.l_orderkey = l1.l_orderkey
+         and l2.l_suppkey <> l1.l_suppkey) left join (
+        select l3.l_orderkey,l3.l_suppkey
+            from aopart_lineitem l3
+            where l3.l_receiptdate > l3.l_commitdate) l4
+    on (l4.l_orderkey = l1.l_orderkey and l4.l_suppkey <> l1.l_suppkey)
+    where s_suppkey = l1.l_suppkey and o_orderkey = l1.l_orderkey and o_orderstatus = 'F' and l1.l_receiptdate > l1.l_commitdate and
+          l2.l_orderkey is not null and l4.l_orderkey is null and s_nationkey = n_nationkey and n_name = 'SAUDI ARABIA'
+    group by s_name order by numwait desc, s_name limit 100;
+   ?column?    |          s_name           | numwait 
+---------------+---------------------------+---------
+ TPCH QUERY 21 | Supplier#000000074        |       9
+(1 row)
+
+select 'TPCH QUERY 22',cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal
+    from (
+        select substring(c_phone from 1 for 2) as cntrycode, c_acctbal
+            from aopart_customer left join aopart_orders on c_custkey = o_custkey
+            where substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17') and c_acctbal > (
+                  select avg(c_acctbal) from aopart_customer where c_acctbal > 0.00 and substring(c_phone from 1 for 2) in ('13', '31',
+                  '23', '29', '30', '18', '17') ) and o_custkey is null ) as custsale
+    group by cntrycode order by cntrycode;
+   ?column?    | cntrycode | numcust | totacctbal 
+---------------+-----------+---------+------------
+ TPCH QUERY 22 | 13        |      10 |   75359.29
+ TPCH QUERY 22 | 17        |       8 |   62288.98
+ TPCH QUERY 22 | 18        |      14 |  111072.45
+ TPCH QUERY 22 | 23        |       5 |   40458.86
+ TPCH QUERY 22 | 29        |      11 |   88722.85
+ TPCH QUERY 22 | 30        |      17 |  122189.33
+ TPCH QUERY 22 | 31        |       8 |   66313.16
+(7 rows)
+
+checkpoint;

--- a/src/test/regress/bugbuster/known_good_schedule
+++ b/src/test/regress/bugbuster/known_good_schedule
@@ -10,7 +10,7 @@ test: spi
 test: security
 test: load_tpch sirv_functions view xpath
 # these tests depend on load_tpch
-test: tpch_query hashagg gpsort
+test: tpch_query tpch_aopart hashagg gpsort
 test: bkup_gp
 test: mpp-11333
 test: codecoverage

--- a/src/test/regress/bugbuster/sql/tpch_aopart.sql
+++ b/src/test/regress/bugbuster/sql/tpch_aopart.sql
@@ -1,0 +1,321 @@
+\c tpch_heap
+
+-- Create table region
+CREATE TABLE aopart_REGION (
+    R_REGIONKEY INTEGER,
+    R_NAME CHAR(25),
+    R_COMMENT VARCHAR(152)
+    )
+partition by range (r_regionkey) (partition p1 start('0') end('5'));
+insert into aopart_region select * from region;
+select count(*) from aopart_region;
+ANALYZE aopart_REGION;
+
+-- Create table nation
+CREATE TABLE aopart_NATION (
+    N_NATIONKEY INTEGER,
+    N_NAME CHAR(25),
+    N_REGIONKEY INTEGER,
+    N_COMMENT VARCHAR(152)
+    )
+partition by range (n_nationkey)
+subpartition by range (n_regionkey) subpartition template (start('0') end('1') inclusive,start('1') exclusive)
+(partition p1 start('0') end('10') WITH (appendonly=true,checksum=true,compresslevel=9), partition p2 start('10') end('25') WITH (checksum=false,appendonly=true,compresslevel=7));
+
+insert into aopart_nation select * from nation;
+select count(*) from aopart_nation;
+ANALYZE aopart_NATION;
+
+-- Create table customer
+CREATE TABLE aopart_CUSTOMER (
+    C_CUSTKEY INTEGER,
+    C_NAME VARCHAR(25),
+    C_ADDRESS VARCHAR(40),
+    C_NATIONKEY INTEGER,
+    C_PHONE CHAR(15),
+    C_ACCTBAL decimal,
+    C_MKTSEGMENT CHAR(10),
+    C_COMMENT VARCHAR(117)
+    )
+    WITH (appendonly=true,checksum=false,compresslevel=1)
+    partition by list (c_mktsegment)
+    (partition p1 values('BUILDING','FURNITURE'), partition p2 values('MACHINERY'), partition p3 values('AUTOMOBILE'), partition p4 values('HOUSEHOLD'), partition p5 values(null));
+
+insert into aopart_customer select * from customer;
+select count(*) from aopart_customer;
+ANALYZE aopart_CUSTOMER;
+
+-- Create table part
+CREATE TABLE aopart_part (
+    P_PARTKEY INTEGER,
+    P_NAME VARCHAR(55),
+    P_MFGR CHAR(25),
+    P_BRAND CHAR(10),
+    P_TYPE VARCHAR(25),
+    P_SIZE integer,
+    P_CONTAINER CHAR(10),
+    P_RETAILPRICE decimal,
+    P_COMMENT VARCHAR(23)
+    )
+    WITH (blocksize=16384,appendonly=true,checksum=false,compresstype=zlib,compresslevel=1)
+    partition by list (p_brand)
+    (partition p1 values('Brand#45','Brand#31','Brand#25') WITH (appendonly=true,checksum=true,compresslevel=5,compresstype=zlib), partition p2 values('Brand#34','Brand#22','Brand#21','Brand#55','Brand#32','Brand#13','Brand#35','Brand#51','Brand#24','Brand#43','Brand#54','Brand#33','Brand#23','Brand#14','Brand#53','Brand#15','Brand#52','Brand#44','Brand#41','Brand#42','Brand#11','Brand#12'));
+
+insert into aopart_part select * from part;
+select count(*) from aopart_part;
+ANALYZE aopart_part;
+
+-- Create table supplier
+CREATE TABLE aopart_supplier (
+    S_SUPPKEY INTEGER,
+    S_NAME CHAR(25),
+    S_ADDRESS VARCHAR(40),
+    S_NATIONKEY INTEGER,
+    S_PHONE CHAR(15),
+    S_ACCTBAL decimal,
+    S_COMMENT VARCHAR(101)
+    )
+    WITH (blocksize=32768,appendonly=true,checksum=true,compresslevel=2)
+    partition by range (s_nationkey)
+(partition p1 start('0') end('25') every(12));
+insert into aopart_supplier select * from supplier;
+select count(*) from aopart_supplier;
+ANALYZE aopart_supplier;
+
+-- Create table partsupp
+CREATE TABLE aopart_PARTSUPP (
+    PS_PARTKEY INTEGER,
+    PS_SUPPKEY INTEGER,
+    PS_AVAILQTY integer,
+    PS_SUPPLYCOST decimal,
+    PS_COMMENT VARCHAR(199)
+    )
+    WITH (checksum=false,appendonly=true,blocksize=49152,compresslevel=8)
+    partition by range (ps_partkey)
+(partition p1 start('1') end('9214980'), partition p2 start('9214980') end('43244457') exclusive , partition p3 end('60489818'), partition p4 start('60489818') end('63663358') inclusive WITH (appendonly=true,checksum=false,compresstype=zlib,compresslevel=1), partition p5 end('100000001') WITH (checksum=true,appendonly=true,compresstype=zlib,compresslevel=1));
+insert into aopart_partsupp select * from partsupp;
+select count(*) from aopart_partsupp;
+ANALYZE aopart_PARTSUPP;
+
+-- Create table orders
+CREATE TABLE aopart_ORDERS (
+    O_ORDERKEY INT8,
+    O_CUSTKEY INTEGER,
+    O_ORDERSTATUS CHAR(1),
+    O_TOTALPRICE decimal,
+    O_ORDERDATE date,
+    O_ORDERPRIORITY CHAR(15),
+    O_CLERK CHAR(15),
+    O_SHIPPRIORITY integer,
+    O_COMMENT VARCHAR(79)
+    )
+    partition by range (o_orderkey) subpartition by range (o_orderdate), subpartition by list (o_orderstatus) subpartition template (values('F','O','P'))
+    (partition p1 start('1') end('6000001') every(2000000)
+    (subpartition sp1 start('1992-01-01') ,subpartition sp2 start('1996-08-03') end('1998-08-03')));
+insert into aopart_orders select * from orders;
+select count(*) from aopart_orders;
+ANALYZE aopart_ORDERS;
+
+-- Create table lineitem
+CREATE TABLE aopart_LINEITEM (
+    L_ORDERKEY INT8,
+    L_PARTKEY INTEGER,
+    L_SUPPKEY INTEGER,
+    L_LINENUMBER integer,
+    L_QUANTITY decimal,
+    L_EXTENDEDPRICE decimal,
+    L_DISCOUNT decimal,
+    L_TAX decimal,
+    L_RETURNFLAG CHAR(1),
+    L_LINESTATUS CHAR(1),
+    L_SHIPDATE date,
+    L_COMMITDATE date,
+    L_RECEIPTDATE date,
+    L_SHIPINSTRUCT CHAR(25),
+    L_SHIPMODE CHAR(10),
+    L_COMMENT VARCHAR(44)
+    )
+    WITH (appendonly=true,checksum=false,compresslevel=3)
+    partition by list (l_tax)
+    subpartition by range (l_suppkey) subpartition template (start('1') end('5000001') every(1666666))
+    ,subpartition by range (l_commitdate) subpartition template (start('1992-01-31') end('1998-11-01') every(interval '15 months'))
+    ,subpartition by list (l_discount) subpartition template (
+    values('0','0.1'),
+    values('0.06','0.01','0.02','0.07','0.08') WITH (appendonly=true,checksum=false,compresstype=zlib,compresslevel=1),
+    values('0.09','0.05','0.04','0.03'))
+    (partition p1 values('0','0.08') WITH (compresslevel=1,compresstype=zlib,appendonly=true,checksum=true), partition p2 values('0.07','0.01','0.06','0.05','0.02','0.04','0.03'));
+insert into aopart_lineitem select * from lineitem;
+select count(*) from aopart_lineitem;
+
+create view revenue (supplier_no, total_revenue) as
+    select l_suppkey,
+           sum(l_extendedprice * (1 - l_discount))
+    from aopart_lineitem
+    where l_shipdate >= date '1-jan-1996'
+          and l_shipdate < date '1-jan-1996' + interval '3 month'
+    group by l_suppkey;
+ANALYZE aopart_LINEITEM;
+
+select 'TPCH QUERY 01', l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price,
+    sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge,
+    avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order
+    from aopart_lineitem where l_shipdate <= date '1998-12-01' - interval '90 day' group by l_returnflag, l_linestatus
+    order by l_returnflag, l_linestatus;
+
+select 'TPCH QUERY 02', s.s_acctbal,s.s_name,n.n_name,p.p_partkey,p.p_mfgr,s.s_address,s.s_phone,s.s_comment
+    from aopart_supplier s, aopart_partsupp ps, aopart_nation n, aopart_region r, aopart_part p,
+        (select p_partkey, min(ps_supplycost) as min_ps_cost
+            from aopart_part, aopart_partsupp , aopart_supplier,aopart_nation, aopart_region
+            where p_partkey=ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey and
+                  n_regionkey = r_regionkey and r_name = 'EUROPE'
+            group by p_partkey) g
+    where p.p_partkey = ps.ps_partkey and g.p_partkey = p.p_partkey and g. min_ps_cost = ps.ps_supplycost and
+          s.s_suppkey = ps.ps_suppkey and p.p_size = 15 and p.p_type like '%BRASS' and s.s_nationkey = n.n_nationkey and
+          n.n_regionkey = r.r_regionkey and r.r_name = 'EUROPE' order by s. s_acctbal desc,n.n_name,s.s_name,p.p_partkey limit 100;
+
+select 'TPCH QUERY 03', l_orderkey,sum(l_extendedprice*(1-l_discount)) as revenue,o_orderdate, o_shippriority
+    from aopart_customer,aopart_orders,aopart_lineitem
+    where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and
+          o_orderdate < date '15-mar-1995' and l_shipdate > date '15-mar-1995'
+    group by l_orderkey,o_orderdate,o_shippriority order by revenue desc,o_orderdate limit 10;
+
+select 'TPCH QUERY 04',o_orderpriority,count (distinct o_orderkey) as order_count
+    from aopart_orders left join aopart_lineitem on l_orderkey = o_orderkey
+    where o_orderdate >= date '1-jul-1993' and o_orderdate < date '1-jul-1993' + interval '3 month' and
+          l_commitdate < l_receiptdate and l_orderkey is not null
+    group by o_orderpriority order by o_orderpriority;
+
+select 'TPCH QUERY 05',n_name, sum(l_extendedprice * (1 - l_discount)) as revenue
+    from aopart_customer, aopart_orders, aopart_lineitem, aopart_supplier, aopart_nation, aopart_region
+    where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and
+          s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'ASIA' and o_orderdate >= date '1-jan-1994' and
+          o_orderdate < date '1-jan-1994' + interval '1 year'
+    group by n_name order by revenue desc;
+
+select 'TPCH QUERY 06',sum(l_extendedprice*l_discount) as revenue
+    from aopart_lineitem where l_shipdate >= date '1-jan-1994' and l_shipdate < date '1-jan-1994' + interval '1 year' and
+         l_discount between 0.06 - 0.01 and 0.06 + 0.01 and l_quantity < 24;
+
+select 'TPCH QUERY 07',supp_nation,cust_nation,l_year, sum(volume) as revenue
+    from (
+        select n1.n_name as supp_nation,n2.n_name as cust_nation, extract(year from l_shipdate) as l_year,
+               l_extendedprice * (1 - l_discount) as volume
+        from aopart_supplier,aopart_lineitem,aopart_orders,aopart_customer,aopart_nation n1,aopart_nation n2
+        where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and
+              c_nationkey = n2.n_nationkey and ( (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY') or (n1.n_name = 'GERMANY' and
+              n2.n_name = 'FRANCE')) and l_shipdate between date '1995-01-01' and date '1996-12-31') as shipping
+    group by supp_nation,cust_nation,l_year order by supp_nation,cust_nation,l_year;
+
+select 'TPCH QUERY 08',o_year, sum(case when nation = 'BRAZIL' then volume else 0 end) / sum(volume) as mkt_share
+    from (
+        select extract(year from o_orderdate) as o_year, l_extendedprice * (1-l_discount) as volume, n2.n_name as nation
+            from aopart_part,aopart_supplier,aopart_lineitem,aopart_orders,aopart_customer,aopart_nation n1,aopart_nation n2,aopart_region
+            where p_partkey = l_partkey and s_suppkey = l_suppkey and l_orderkey = o_orderkey and o_custkey = c_custkey and
+                  c_nationkey = n1.n_nationkey and n1.n_regionkey = r_regionkey and r_name = 'AMERICA' and s_nationkey = n2.n_nationkey
+                  and o_orderdate between date '1995-01-01' and date '1996-12-31' and p_type = 'ECONOMY ANODIZED STEEL') as all_nations
+    group by o_year order by o_year;
+
+select 'TPCH QUERY 09',nation,o_year,sum(amount) as sum_profit
+    from (
+        select n_name as nation,extract(year from o_orderdate) as o_year,
+               l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+            from aopart_part,aopart_supplier,aopart_lineitem,aopart_partsupp,aopart_orders,aopart_nation
+            where s_suppkey = l_suppkey and ps_suppkey = l_suppkey and ps_partkey = l_partkey and p_partkey = l_partkey and
+            o_orderkey = l_orderkey and s_nationkey = n_nationkey and p_name like '%green%') as profit
+    group by nation,o_year order by nation,o_year desc;
+
+select 'TPCH QUERY 10', c_custkey,c_name,sum(l_extendedprice * (1 - l_discount)) as revenue, c_acctbal,n_name,c_address,c_phone,c_comment
+    from aopart_customer,aopart_orders,aopart_lineitem,aopart_nation
+    where c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate >= date '1-oct-1993' and o_orderdate < date '1-oct-1993' +
+          interval '3 month' and l_returnflag = 'R' and c_nationkey = n_nationkey
+    group by c_custkey,c_name,c_acctbal,c_phone,n_name,c_address,c_comment order by revenue desc limit 20;
+
+select 'TPCH QUERY 11', ps_partkey,sum(ps_supplycost * ps_availqty) as value
+    from aopart_partsupp,aopart_supplier,aopart_nation
+    where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY'
+    group by ps_partkey having sum(ps_supplycost * ps_availqty) > (
+        select sum(ps_supplycost * ps_availqty) * .0001
+            from aopart_partsupp,aopart_supplier,aopart_nation
+            where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY')
+    order by value desc;
+
+select 'TPCH QUERY 12', l_shipmode, sum(case when o_orderpriority ='1-URGENT' or o_orderpriority ='2-HIGH' then 1 else 0 end) as
+       high_line_count, sum(case when o_orderpriority <> '1-URGENT' and o_orderpriority <> '2-HIGH' then 1 else 0 end) as low_line_count
+    from aopart_orders, aopart_lineitem
+    where o_orderkey = l_orderkey and l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and
+          l_receiptdate >= date '1-jan-1994' and l_receiptdate < date '1-jan-1994' + interval '1 year'
+    group by l_shipmode order by l_shipmode;
+
+select 'TPCH QUERY 13', c_count, count(*) as custdist
+    from (
+        select c_custkey, count(o_orderkey)
+            from aopart_customer left outer join aopart_orders on c_custkey = o_custkey and o_comment not like '%special%requests%'
+            group by c_custkey ) as c_orders (c_custkey, c_count)
+    group by c_count order by custdist desc,c_count desc;
+
+select 'TPCH QUERY 14', 100.00 * sum(case when p_type like 'PROMO%' then l_extendedprice*(1-l_discount) else 0 end) /
+       sum(l_extendedprice * (1 - l_discount)) as promo_revenue 
+    from aopart_lineitem,aopart_part
+    where l_partkey = p_partkey and l_shipdate >= date '1-sep-1995' and l_shipdate < date '1-sep-1995' + interval '1 month';
+
+select 'TPCH QUERY 15',s_suppkey, s_name, s_address, s_phone, total_revenue
+    from aopart_supplier,revenue
+    where s_suppkey = supplier_no and total_revenue = ( select max(total_revenue) from revenue ) order by s_suppkey;
+
+select 'TPCH QUERY 16a', p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt
+    from aopart_part, aopart_partsupp left join aopart_supplier on (ps_suppkey=s_suppkey and s_comment like '%Customer%Complaints%' )
+    where p_partkey = ps_partkey and p_brand <> 'Brand#45' and p_type not like 'MEDIUM POLISHED%' and
+          p_size in (49, 14, 23, 45, 19, 3, 36, 9) and s_suppkey is null
+    group by p_brand, p_type, p_size order by supplier_cnt desc, p_brand, p_type, p_size;
+
+select 'TPCH QUERY 17a', sum(l_extendedprice) / 7.0 as avg_yearly
+    from aopart_lineitem l, aopart_part, ( select l_partkey, avg(l_quantity) as avg_qty from aopart_lineitem group by l_partkey ) g
+    where p_partkey = l.l_partkey and p_partkey = g.l_partkey and l.l_quantity < 0.2* g.avg_qty and p_brand = 'Brand#23' and
+          p_container = 'JUMBO PACK';
+
+select c_name, c_custkey, o_orderkey,'TPCH QUERY 18', o_orderdate, o_totalprice, sum(l_quantity)
+    from aopart_customer, aopart_orders, aopart_lineitem
+    where o_orderkey in ( select l_orderkey from aopart_lineitem group by l_orderkey having sum(l_quantity) > 300 ) and
+          c_custkey = o_custkey and o_orderkey = l_orderkey
+    group by c_name,c_custkey,o_orderkey,o_orderdate,o_totalprice order by o_totalprice desc,o_orderdate;
+
+select 'TPCH QUERY 19',sum(l_extendedprice* (1 - l_discount)) as revenue
+    from aopart_lineitem, aopart_part
+    where p_partkey = l_partkey and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON' and
+          ( ( p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and l_quantity >= 1 and
+          l_quantity <= 1 + 10 and p_size between 1 and 15 ) or ( p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX',
+          'MED PKG', 'MED PACK') and l_quantity >= 10 and l_quantity <= 10 + 10 and p_size between 1 and 15 ) or ( p_brand = 'Brand#34'
+          and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') and l_quantity >= 20 and l_quantity <= 20 + 10 and
+          p_size between 1 and 15 ) );
+
+select 'TPCH QUERY 20',s_name,s_address
+    from aopart_supplier, aopart_nation
+    where s_suppkey in (
+        select ps_suppkey from aopart_partsupp, (
+            select sum(l_quantity) as qty_sum, l_partkey, l_suppkey
+                from aopart_lineitem
+                where l_shipdate >= date '1-jan-1994' and l_shipdate < date '1-jan-1994' + interval '1 year'
+                group by l_partkey, l_suppkey ) g
+        where g.l_partkey = ps_partkey and g.l_suppkey = ps_suppkey and ps_availqty > 0.5*g.qty_sum and ps_partkey in (select p_partkey
+              from aopart_part where p_name like 'forest%' )) and s_nationkey = n_nationkey and n_name = 'CANADA' order by s_name;
+
+select 'TPCH QUERY 21',s_name, count( distinct (l1.l_orderkey||l1.l_linenumber)) as numwait
+    from aopart_supplier, aopart_orders, aopart_nation, aopart_lineitem l1 left join aopart_lineitem l2 on (l2.l_orderkey = l1.l_orderkey
+         and l2.l_suppkey <> l1.l_suppkey) left join (
+        select l3.l_orderkey,l3.l_suppkey
+            from aopart_lineitem l3
+            where l3.l_receiptdate > l3.l_commitdate) l4
+    on (l4.l_orderkey = l1.l_orderkey and l4.l_suppkey <> l1.l_suppkey)
+    where s_suppkey = l1.l_suppkey and o_orderkey = l1.l_orderkey and o_orderstatus = 'F' and l1.l_receiptdate > l1.l_commitdate and
+          l2.l_orderkey is not null and l4.l_orderkey is null and s_nationkey = n_nationkey and n_name = 'SAUDI ARABIA'
+    group by s_name order by numwait desc, s_name limit 100;
+
+select 'TPCH QUERY 22',cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal
+    from (
+        select substring(c_phone from 1 for 2) as cntrycode, c_acctbal
+            from aopart_customer left join aopart_orders on c_custkey = o_custkey
+            where substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17') and c_acctbal > (
+                  select avg(c_acctbal) from aopart_customer where c_acctbal > 0.00 and substring(c_phone from 1 for 2) in ('13', '31',
+                  '23', '29', '30', '18', '17') ) and o_custkey is null ) as custsale
+    group by cntrycode order by cntrycode;
+checkpoint;

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -1706,6 +1706,56 @@ select * from ao1;
  cc   |    3 | 5    | 
 (4 rows)
 
+alter table ao1 alter column col2 set default 2;
+select adsrc from pg_attrdef pdef, pg_attribute pattr
+    where pdef.adrelid='ao1'::regclass and pdef.adrelid=pattr.attrelid and pdef.adnum=pattr.attnum and pattr.attname='col2';
+ adsrc
+-------
+ 2
+(1 row)
+
+alter table ao1 rename col2 to col2_renamed;
+-- check dropping column
+alter table ao1 drop column col4;
+select attname from pg_attribute where attrelid='ao1'::regclass and attname='col4';
+ attname
+---------
+(0 rows)
+
+-- change the storage type of a column
+alter table ao1 alter column col3 set storage plain;
+select attname, attstorage from pg_attribute where attrelid='ao1'::regclass and attname='col3';
+ attname | attstorage
+---------+------------
+ col3    | p
+(1 row)
+
+alter table ao1 alter column col3 set storage main;
+select attname, attstorage from pg_attribute where attrelid='ao1'::regclass and attname='col3';
+ attname | attstorage
+---------+------------
+ col3    | m
+(1 row)
+
+alter table ao1 alter column col3 set storage external;
+select attname, attstorage from pg_attribute where attrelid='ao1'::regclass and attname='col3';
+ attname | attstorage
+---------+------------
+ col3    | e
+(1 row)
+
+alter table ao1 alter column col3 set storage extended;
+select attname, attstorage from pg_attribute where attrelid='ao1'::regclass and attname='col3';
+ attname | attstorage
+---------+------------
+ col3    | x
+(1 row)
+
+-- cannot set reloption appendonly
+alter table ao1 set (appendonly=true, compresslevel=5, fillfactor=50);
+ERROR:  cannot SET reloption "appendonly"
+alter table ao1 reset (appendonly, compresslevel, fillfactor);
+ERROR:  cannot SET reloption "appendonly"
 ---
 --- check catalog contents after alter table on AO tables 
 ---
@@ -2040,6 +2090,139 @@ select * from testbug_char5 order by 1,2;
  201208 |    3333 | 1     | 2    
 (9 rows)
 
+-- Test exchanging partition and then rolling back
+begin work;
+create table testbug_char5_exchange (timest character varying(6), user_id numeric(16,0) NOT NULL, tag1 char(5), tag2 char(5))
+  with (appendonly=true, compresstype=zlib, compresslevel=3) distributed by (user_id);
+insert into testbug_char5_exchange values ('201205', 3333, '2', '2');
+alter table testbug_char5 truncate partition part201205;
+select count(*) from testbug_char5;
+ count
+-------
+     7
+(1 row)
+
+alter table testbug_char5 exchange partition part201205 with table testbug_char5_exchange;
+select count(*) from testbug_char5;
+ count
+-------
+     8
+(1 row)
+
+rollback work;
+select count(*) from testbug_char5;
+ count
+-------
+     9
+(1 row)
+
+-- Test AO hybrid partitioning scheme (range and list) w/ subpartitions
+create table ao_multi_level_part_table (date date, region text, region1 text, amount decimal(10,2))
+  with (appendonly=true, compresstype=zlib, compresslevel=1)
+  partition by range(date) subpartition by list(region) (
+    partition part1 start(date '2008-01-01') end(date '2009-01-01')
+      (subpartition usa values ('usa'), subpartition asia values ('asia'), default subpartition def),
+    partition part2 start(date '2009-01-01') end(date '2010-01-01')
+      (subpartition usa values ('usa'), subpartition asia values ('asia')));
+-- insert some data
+insert into ao_multi_level_part_table values ('2008-02-02', 'usa', 'Texas', 10.05), ('2008-03-03', 'asia', 'China', 1.01);
+insert into ao_multi_level_part_table values ('2009-02-02', 'usa', 'Utah', 10.05), ('2009-03-03', 'asia', 'Japan', 1.01);
+-- add a partition that is not a default partition
+alter table ao_multi_level_part_table add partition part3 start(date '2010-01-01') end(date '2012-01-01') with (appendonly=true)
+  (subpartition usa values ('usa'), subpartition asia values ('asia'), default subpartition def);
+-- Add default partition (defaults to heap storage unless set with AO)
+alter table ao_multi_level_part_table add default partition yearYYYY (default subpartition def);
+select count(*) from pg_appendonly where relid='ao_multi_level_part_table_1_prt_yearyyyy'::regclass;
+ count
+-------
+     0
+(1 row)
+
+alter table ao_multi_level_part_table drop partition yearYYYY;
+NOTICE:  dropped partition "yearyyyy" for relation "ao_multi_level_part_table" and its children
+alter table ao_multi_level_part_table add default partition yearYYYY with (appendonly=true) (default subpartition def);
+select count(*) from pg_appendonly where relid='ao_multi_level_part_table_1_prt_yearyyyy'::regclass;
+ count
+-------
+     1
+(1 row)
+
+-- index on atts 1, 4
+create index ao_mlp_idx on ao_multi_level_part_table(date, amount);
+select indexname from pg_indexes where tablename='ao_multi_level_part_table';
+ indexname
+------------
+ ao_mlp_idx
+(1 row)
+
+alter index ao_mlp_idx rename to ao_mlp_idx_renamed;
+select indexname from pg_indexes where tablename='ao_multi_level_part_table';
+     indexname
+--------------------
+ ao_mlp_idx_renamed
+(1 row)
+
+-- truncate partitions until table is empty
+select * from ao_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2008 | usa    | Texas   |  10.05
+ 02-02-2009 | usa    | Utah    |  10.05
+ 03-03-2008 | asia   | China   |   1.01
+ 03-03-2009 | asia   | Japan   |   1.01
+(4 rows)
+
+truncate ao_multi_level_part_table_1_prt_part1_2_prt_asia;
+select * from ao_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2008 | usa    | Texas   |  10.05
+ 02-02-2009 | usa    | Utah    |  10.05
+ 03-03-2009 | asia   | Japan   |   1.01
+(3 rows)
+
+alter table ao_multi_level_part_table truncate partition for (rank(1));
+NOTICE:  truncated partition "part1" for relation "ao_multi_level_part_table" and its children
+select * from ao_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2009 | usa    | Utah    |  10.05
+ 03-03-2009 | asia   | Japan   |   1.01
+(2 rows)
+
+alter table ao_multi_level_part_table alter partition part2 truncate partition usa;
+NOTICE:  truncated partition "usa" for partition "part2" of relation "ao_multi_level_part_table"
+select * from ao_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 03-03-2009 | asia   | Japan   |   1.01
+(1 row)
+
+alter table ao_multi_level_part_table truncate partition part2;
+NOTICE:  truncated partition "part2" for relation "ao_multi_level_part_table" and its children
+select * from ao_multi_level_part_table;
+ date | region | region1 | amount
+------+--------+---------+--------
+(0 rows)
+
+-- drop column in the partition table
+select count(*) from pg_attribute where attrelid='ao_multi_level_part_table'::regclass and attname = 'region1';
+ count
+-------
+     1
+(1 row)
+
+alter table ao_multi_level_part_table drop column region1;
+select count(*) from pg_attribute where attrelid='ao_multi_level_part_table'::regclass and attname = 'region1';
+ count
+-------
+     0
+(1 row)
+
+-- splitting top partition of a multi-level partition should not work
+alter table ao_multi_level_part_table split partition part3 at (date '2011-01-01') into (partition part3, partition part4);
+ERROR:  cannot split partition with child partitions
+HINT:  Try splitting the child partitions.
 --
 -- Check index scan
 --
@@ -2147,6 +2330,37 @@ set search_path=public;
 drop schema if exists mpp17582 cascade;
 NOTICE:  drop cascades to table mpp17582.load
 NOTICE:  drop cascades to table mpp17582.dim
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_yearyyyy_2_prt_def
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_yearyyyy
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_def
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_def
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_2_prt_asia_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_asia
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_2_prt_usa_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_usa
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part3
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_2_prt_asia_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_asia
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_2_prt_usa_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_usa
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part2
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_def
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_def
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_2_prt_asia_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_asia
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_2_prt_usa_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_usa
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part1
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table
 NOTICE:  drop cascades to table mpp17582.testbug_char5_1_prt_part201208
 NOTICE:  drop cascades to constraint testbug_char5_1_prt_part201208_check on table mpp17582.testbug_char5_1_prt_part201208
 NOTICE:  drop cascades to append only table mpp17582.testbug_char5_1_prt_part201207

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -440,6 +440,13 @@ alter table addcol1_renamed rename to addcol1;
 -- try renaming columns and see if stuff still works
 alter table addcol1 rename column f to f_renamed;
 alter table addcol1 alter column f_renamed set default 10;
+select adsrc from pg_attrdef pdef, pg_attribute pattr
+    where pdef.adrelid='addcol1'::regclass and pdef.adrelid=pattr.attrelid and pdef.adnum=pattr.attnum and pattr.attname='f_renamed';
+ adsrc
+-------
+ 10
+(1 row)
+
 insert into addcol1 values (999);
 select a, f_renamed from addcol1 where a = 999;
   a  | f_renamed
@@ -449,6 +456,11 @@ select a, f_renamed from addcol1 where a = 999;
 
 -- try dropping and adding back the column
 alter table addcol1 drop column f_renamed;
+select attname from pg_attribute where attrelid='addcol1'::regclass and attname='f_renamed';
+ attname
+---------
+(0 rows)
+
 alter table addcol1 add column f_renamed int default 20;
 select a, f_renamed from addcol1 where a = 999;
   a  | f_renamed
@@ -482,6 +494,41 @@ ERROR:  append-only tables do not support unique indexes
 alter table addcol1 add constraint tpkey primary key(a);
 ERROR:  append-only tables do not support unique indexes
 alter table addcol1 add constraint tcheck check (a is not null);
+-- test changing the storage type of a column
+alter table addcol1 alter column f_renamed type varchar(7);
+alter table addcol1 alter column f_renamed set storage plain;
+select attname, attstorage from pg_attribute where attrelid='addcol1'::regclass and attname='f_renamed';
+  attname  | attstorage
+-----------+------------
+ f_renamed | p
+(1 row)
+
+alter table addcol1 alter column f_renamed set storage main;
+select attname, attstorage from pg_attribute where attrelid='addcol1'::regclass and attname='f_renamed';
+  attname  | attstorage
+-----------+------------
+ f_renamed | m
+(1 row)
+
+alter table addcol1 alter column f_renamed set storage external;
+select attname, attstorage from pg_attribute where attrelid='addcol1'::regclass and attname='f_renamed';
+  attname  | attstorage
+-----------+------------
+ f_renamed | e
+(1 row)
+
+alter table addcol1 alter column f_renamed set storage extended;
+select attname, attstorage from pg_attribute where attrelid='addcol1'::regclass and attname='f_renamed';
+  attname  | attstorage
+-----------+------------
+ f_renamed | x
+(1 row)
+
+-- cannot set reloption appendonly
+alter table addcol1 set (appendonly=true, compresslevel=5, fillfactor=50);
+ERROR:  cannot SET reloption "appendonly"
+alter table addcol1 reset (appendonly, compresslevel, fillfactor);
+ERROR:  cannot SET reloption "appendonly"
 -- test some aocs partition table altering
 create table alter_aocs_part_table (a int, b int) with (appendonly=true, orientation=column) distributed by (a)
     partition by range(b) (start (1) end (5) exclusive every (1), default partition foo);
@@ -512,9 +559,173 @@ alter table alter_aocs_part_table exchange partition for (rank(1)) with table al
 create table alter_aocs_heap_table (a int, b int) distributed by (a);
 insert into alter_aocs_heap_table values (3,3);
 alter table alter_aocs_part_table exchange partition for (rank(2)) with table alter_aocs_heap_table;
+-- Test truncating and exchanging partition and then rolling back
+begin work;
+create table alter_aocs_ptable_exchange (a int, b int) with (appendonly=true, orientation=column) distributed by (a);
+insert into alter_aocs_ptable_exchange values (3,3), (3,3), (3,3);
+alter table alter_aocs_part_table truncate partition for (rank(2));
+select count(*) from alter_aocs_part_table;
+ count
+-------
+     8
+(1 row)
+
+alter table alter_aocs_part_table exchange partition for (rank(2)) with table alter_aocs_ptable_exchange;
+select count(*) from alter_aocs_part_table;
+ count
+-------
+    11
+(1 row)
+
+rollback work;
+select count(*) from alter_aocs_part_table;
+ count
+-------
+     9
+(1 row)
+
+-- Test AO hybrid partitioning scheme (range and list) w/ subpartitions
+create table aocs_multi_level_part_table (date date, region text, region1 text, amount decimal(10,2))
+  with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+  partition by range(date) subpartition by list(region) (
+    partition part1 start(date '2008-01-01') end(date '2009-01-01')
+      (subpartition usa values ('usa'), subpartition asia values ('asia'), default subpartition def),
+    partition part2 start(date '2009-01-01') end(date '2010-01-01')
+      (subpartition usa values ('usa'), subpartition asia values ('asia')));
+-- insert some data
+insert into aocs_multi_level_part_table values ('2008-02-02', 'usa', 'Texas', 10.05), ('2008-03-03', 'asia', 'China', 1.01);
+insert into aocs_multi_level_part_table values ('2009-02-02', 'usa', 'Utah', 10.05), ('2009-03-03', 'asia', 'Japan', 1.01);
+-- add a partition that is not a default partition
+alter table aocs_multi_level_part_table add partition part3 start(date '2010-01-01') end(date '2012-01-01')
+  with (appendonly=true, orientation=column)
+  (subpartition usa values ('usa'), subpartition asia values ('asia'), default subpartition def);
+-- Add default partition (defaults to heap storage unless set with AO)
+alter table aocs_multi_level_part_table add default partition yearYYYY (default subpartition def);
+select count(*) from pg_appendonly where relid='aocs_multi_level_part_table_1_prt_yearyyyy'::regclass;
+ count
+-------
+     0
+(1 row)
+
+alter table aocs_multi_level_part_table drop partition yearYYYY;
+NOTICE:  dropped partition "yearyyyy" for relation "aocs_multi_level_part_table" and its children
+alter table aocs_multi_level_part_table add default partition yearYYYY with (appendonly=true, orientation=column) (default subpartition def);
+select count(*) from pg_appendonly where relid='aocs_multi_level_part_table_1_prt_yearyyyy'::regclass;
+ count
+-------
+     1
+(1 row)
+
+-- index on atts 1, 4
+create index ao_mlp_idx on aocs_multi_level_part_table(date, amount);
+select indexname from pg_indexes where tablename='aocs_multi_level_part_table';
+ indexname
+------------
+ ao_mlp_idx
+(1 row)
+
+alter index ao_mlp_idx rename to ao_mlp_idx_renamed;
+select indexname from pg_indexes where tablename='aocs_multi_level_part_table';
+     indexname
+--------------------
+ ao_mlp_idx_renamed
+(1 row)
+
+-- truncate partitions until table is empty
+select * from aocs_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2008 | usa    | Texas   |  10.05
+ 02-02-2009 | usa    | Utah    |  10.05
+ 03-03-2008 | asia   | China   |   1.01
+ 03-03-2009 | asia   | Japan   |   1.01
+(4 rows)
+
+truncate aocs_multi_level_part_table_1_prt_part1_2_prt_asia;
+select * from aocs_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2008 | usa    | Texas   |  10.05
+ 02-02-2009 | usa    | Utah    |  10.05
+ 03-03-2009 | asia   | Japan   |   1.01
+(3 rows)
+
+alter table aocs_multi_level_part_table truncate partition for (rank(1));
+NOTICE:  truncated partition "part1" for relation "aocs_multi_level_part_table" and its children
+select * from aocs_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2009 | usa    | Utah    |  10.05
+ 03-03-2009 | asia   | Japan   |   1.01
+(2 rows)
+
+alter table aocs_multi_level_part_table alter partition part2 truncate partition usa;
+NOTICE:  truncated partition "usa" for partition "part2" of relation "aocs_multi_level_part_table"
+select * from aocs_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 03-03-2009 | asia   | Japan   |   1.01
+(1 row)
+
+alter table aocs_multi_level_part_table truncate partition part2;
+NOTICE:  truncated partition "part2" for relation "aocs_multi_level_part_table" and its children
+select * from aocs_multi_level_part_table;
+ date | region | region1 | amount
+------+--------+---------+--------
+(0 rows)
+
+-- drop column in the partition table
+select count(*) from pg_attribute where attrelid='aocs_multi_level_part_table'::regclass and attname = 'region1';
+ count
+-------
+     1
+(1 row)
+
+alter table aocs_multi_level_part_table drop column region1;
+select count(*) from pg_attribute where attrelid='aocs_multi_level_part_table'::regclass and attname = 'region1';
+ count
+-------
+     0
+(1 row)
+
+-- splitting top partition of a multi-level partition should not work
+alter table aocs_multi_level_part_table split partition part3 at (date '2011-01-01') into (partition part3, partition part4);
+ERROR:  cannot split partition with child partitions
+HINT:  Try splitting the child partitions.
 -- cleanup so as not to affect other installcheck tests
 -- (e.g. column_compression).
 drop schema aocs_addcol cascade;
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_yearyyyy_2_prt_def
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_yearyyyy
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part3_2_prt_def
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part3_check on append only columnar table aocs_multi_level_part_table_1_prt_part3_2_prt_def
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part3_2_prt_asia
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part3_check on append only columnar table aocs_multi_level_part_table_1_prt_part3_2_prt_asia
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part3_2_prt_asia_check on append only columnar table aocs_multi_level_part_table_1_prt_part3_2_prt_asia
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part3_2_prt_usa
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part3_check on append only columnar table aocs_multi_level_part_table_1_prt_part3_2_prt_usa
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part3_2_prt_usa_check on append only columnar table aocs_multi_level_part_table_1_prt_part3_2_prt_usa
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part3
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part3_check on append only columnar table aocs_multi_level_part_table_1_prt_part3
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part2_2_prt_asia
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part2_check on append only columnar table aocs_multi_level_part_table_1_prt_part2_2_prt_asia
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part2_2_prt_asia_check on append only columnar table aocs_multi_level_part_table_1_prt_part2_2_prt_asia
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part2_2_prt_usa
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part2_check on append only columnar table aocs_multi_level_part_table_1_prt_part2_2_prt_usa
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part2_2_prt_usa_check on append only columnar table aocs_multi_level_part_table_1_prt_part2_2_prt_usa
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part2
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part2_check on append only columnar table aocs_multi_level_part_table_1_prt_part2
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part1_2_prt_def
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part1_check on append only columnar table aocs_multi_level_part_table_1_prt_part1_2_prt_def
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part1_2_prt_asia
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part1_check on append only columnar table aocs_multi_level_part_table_1_prt_part1_2_prt_asia
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part1_2_prt_asia_check on append only columnar table aocs_multi_level_part_table_1_prt_part1_2_prt_asia
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part1_2_prt_usa
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part1_check on append only columnar table aocs_multi_level_part_table_1_prt_part1_2_prt_usa
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part1_2_prt_usa_check on append only columnar table aocs_multi_level_part_table_1_prt_part1_2_prt_usa
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table_1_prt_part1
+NOTICE:  drop cascades to constraint aocs_multi_level_part_table_1_prt_part1_check on append only columnar table aocs_multi_level_part_table_1_prt_part1
+NOTICE:  drop cascades to append only columnar table aocs_multi_level_part_table
 NOTICE:  drop cascades to table alter_aocs_part_table_1_prt_4
 NOTICE:  drop cascades to constraint alter_aocs_part_table_1_prt_4_check on table alter_aocs_part_table_1_prt_4
 NOTICE:  drop cascades to append only table alter_aocs_part_table_1_prt_3

--- a/src/test/regress/expected/alter_table_optimizer.out
+++ b/src/test/regress/expected/alter_table_optimizer.out
@@ -1723,6 +1723,56 @@ select * from ao1;
  dd   |    4 | 5    | 
 (4 rows)
 
+alter table ao1 alter column col2 set default 2;
+select adsrc from pg_attrdef pdef, pg_attribute pattr
+    where pdef.adrelid='ao1'::regclass and pdef.adrelid=pattr.attrelid and pdef.adnum=pattr.attnum and pattr.attname='col2';
+ adsrc
+-------
+ 2
+(1 row)
+
+alter table ao1 rename col2 to col2_renamed;
+-- check dropping column
+alter table ao1 drop column col4;
+select attname from pg_attribute where attrelid='ao1'::regclass and attname='col4';
+ attname
+---------
+(0 rows)
+
+-- change the storage type of a column
+alter table ao1 alter column col3 set storage plain;
+select attname, attstorage from pg_attribute where attrelid='ao1'::regclass and attname='col3';
+ attname | attstorage
+---------+------------
+ col3    | p
+(1 row)
+
+alter table ao1 alter column col3 set storage main;
+select attname, attstorage from pg_attribute where attrelid='ao1'::regclass and attname='col3';
+ attname | attstorage
+---------+------------
+ col3    | m
+(1 row)
+
+alter table ao1 alter column col3 set storage external;
+select attname, attstorage from pg_attribute where attrelid='ao1'::regclass and attname='col3';
+ attname | attstorage
+---------+------------
+ col3    | e
+(1 row)
+
+alter table ao1 alter column col3 set storage extended;
+select attname, attstorage from pg_attribute where attrelid='ao1'::regclass and attname='col3';
+ attname | attstorage
+---------+------------
+ col3    | x
+(1 row)
+
+-- cannot set reloption appendonly
+alter table ao1 set (appendonly=true, compresslevel=5, fillfactor=50);
+ERROR:  cannot SET reloption "appendonly"
+alter table ao1 reset (appendonly, compresslevel, fillfactor);
+ERROR:  cannot SET reloption "appendonly"
 ---
 --- check catalog contents after alter table on AO tables 
 ---
@@ -2057,6 +2107,139 @@ select * from testbug_char5 order by 1,2;
  201208 |    3333 | 1     | 2    
 (9 rows)
 
+-- Test exchanging partition and then rolling back
+begin work;
+create table testbug_char5_exchange (timest character varying(6), user_id numeric(16,0) NOT NULL, tag1 char(5), tag2 char(5))
+  with (appendonly=true, compresstype=zlib, compresslevel=3) distributed by (user_id);
+insert into testbug_char5_exchange values ('201205', 3333, '2', '2');
+alter table testbug_char5 truncate partition part201205;
+select count(*) from testbug_char5;
+ count
+-------
+     7
+(1 row)
+
+alter table testbug_char5 exchange partition part201205 with table testbug_char5_exchange;
+select count(*) from testbug_char5;
+ count
+-------
+     8
+(1 row)
+
+rollback work;
+select count(*) from testbug_char5;
+ count
+-------
+     9
+(1 row)
+
+-- Test AO hybrid partitioning scheme (range and list) w/ subpartitions
+create table ao_multi_level_part_table (date date, region text, region1 text, amount decimal(10,2))
+  with (appendonly=true, compresstype=zlib, compresslevel=1)
+  partition by range(date) subpartition by list(region) (
+    partition part1 start(date '2008-01-01') end(date '2009-01-01')
+      (subpartition usa values ('usa'), subpartition asia values ('asia'), default subpartition def),
+    partition part2 start(date '2009-01-01') end(date '2010-01-01')
+      (subpartition usa values ('usa'), subpartition asia values ('asia')));
+-- insert some data
+insert into ao_multi_level_part_table values ('2008-02-02', 'usa', 'Texas', 10.05), ('2008-03-03', 'asia', 'China', 1.01);
+insert into ao_multi_level_part_table values ('2009-02-02', 'usa', 'Utah', 10.05), ('2009-03-03', 'asia', 'Japan', 1.01);
+-- add a partition that is not a default partition
+alter table ao_multi_level_part_table add partition part3 start(date '2010-01-01') end(date '2012-01-01') with (appendonly=true)
+  (subpartition usa values ('usa'), subpartition asia values ('asia'), default subpartition def);
+-- Add default partition (defaults to heap storage unless set with AO)
+alter table ao_multi_level_part_table add default partition yearYYYY (default subpartition def);
+select count(*) from pg_appendonly where relid='ao_multi_level_part_table_1_prt_yearyyyy'::regclass;
+ count
+-------
+     0
+(1 row)
+
+alter table ao_multi_level_part_table drop partition yearYYYY;
+NOTICE:  dropped partition "yearyyyy" for relation "ao_multi_level_part_table" and its children
+alter table ao_multi_level_part_table add default partition yearYYYY with (appendonly=true) (default subpartition def);
+select count(*) from pg_appendonly where relid='ao_multi_level_part_table_1_prt_yearyyyy'::regclass;
+ count
+-------
+     1
+(1 row)
+
+-- index on atts 1, 4
+create index ao_mlp_idx on ao_multi_level_part_table(date, amount);
+select indexname from pg_indexes where tablename='ao_multi_level_part_table';
+ indexname
+------------
+ ao_mlp_idx
+(1 row)
+
+alter index ao_mlp_idx rename to ao_mlp_idx_renamed;
+select indexname from pg_indexes where tablename='ao_multi_level_part_table';
+     indexname
+--------------------
+ ao_mlp_idx_renamed
+(1 row)
+
+-- truncate partitions until table is empty
+select * from ao_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2008 | usa    | Texas   |  10.05
+ 02-02-2009 | usa    | Utah    |  10.05
+ 03-03-2008 | asia   | China   |   1.01
+ 03-03-2009 | asia   | Japan   |   1.01
+(4 rows)
+
+truncate ao_multi_level_part_table_1_prt_part1_2_prt_asia;
+select * from ao_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2008 | usa    | Texas   |  10.05
+ 02-02-2009 | usa    | Utah    |  10.05
+ 03-03-2009 | asia   | Japan   |   1.01
+(3 rows)
+
+alter table ao_multi_level_part_table truncate partition for (rank(1));
+NOTICE:  truncated partition "part1" for relation "ao_multi_level_part_table" and its children
+select * from ao_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2009 | usa    | Utah    |  10.05
+ 03-03-2009 | asia   | Japan   |   1.01
+(2 rows)
+
+alter table ao_multi_level_part_table alter partition part2 truncate partition usa;
+NOTICE:  truncated partition "usa" for partition "part2" of relation "ao_multi_level_part_table"
+select * from ao_multi_level_part_table;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 03-03-2009 | asia   | Japan   |   1.01
+(1 row)
+
+alter table ao_multi_level_part_table truncate partition part2;
+NOTICE:  truncated partition "part2" for relation "ao_multi_level_part_table" and its children
+select * from ao_multi_level_part_table;
+ date | region | region1 | amount
+------+--------+---------+--------
+(0 rows)
+
+-- drop column in the partition table
+select count(*) from pg_attribute where attrelid='ao_multi_level_part_table'::regclass and attname = 'region1';
+ count
+-------
+     1
+(1 row)
+
+alter table ao_multi_level_part_table drop column region1;
+select count(*) from pg_attribute where attrelid='ao_multi_level_part_table'::regclass and attname = 'region1';
+ count
+-------
+     0
+(1 row)
+
+-- splitting top partition of a multi-level partition should not work
+alter table ao_multi_level_part_table split partition part3 at (date '2011-01-01') into (partition part3, partition part4);
+ERROR:  cannot split partition with child partitions
+HINT:  Try splitting the child partitions.
 --
 -- Check index scan
 --
@@ -2164,6 +2347,37 @@ set search_path=public;
 drop schema if exists mpp17582 cascade;
 NOTICE:  drop cascades to table mpp17582.load
 NOTICE:  drop cascades to table mpp17582.dim
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_yearyyyy_2_prt_def
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_yearyyyy
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_def
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_def
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_2_prt_asia_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_asia
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_2_prt_usa_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3_2_prt_usa
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part3
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part3_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part3
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_2_prt_asia_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_asia
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_2_prt_usa_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2_2_prt_usa
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part2
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part2_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part2
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_def
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_def
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_asia
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_2_prt_asia_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_asia
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_usa
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_2_prt_usa_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1_2_prt_usa
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table_1_prt_part1
+NOTICE:  drop cascades to constraint ao_multi_level_part_table_1_prt_part1_check on append only table mpp17582.ao_multi_level_part_table_1_prt_part1
+NOTICE:  drop cascades to append only table mpp17582.ao_multi_level_part_table
 NOTICE:  drop cascades to table mpp17582.testbug_char5_1_prt_part201208
 NOTICE:  drop cascades to constraint testbug_char5_1_prt_part201208_check on table mpp17582.testbug_char5_1_prt_part201208
 NOTICE:  drop cascades to append only table mpp17582.testbug_char5_1_prt_part201207

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -114,4 +114,8 @@ s/^NOTICE:.*drop cascades to.*/^NOTICE: drop cascades to /
 # Mask out some numbers (parts of partition names) that vary from run to run.
 m/overlaps existing partition "r\d+"/
 s/overlaps existing partition "r\d+"/partition "r##########"/
+
+# Mask out some numbers (part of temp table schema) that vary from run to run.
+m/Table "pg_temp_\d+.temp/
+s/Table "pg_temp_\d+.temp/Table "pg_temp_#####/
 -- end_matchsubs

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -94,6 +94,7 @@ INSERT INTO tenk_aocs1 SELECT * FROM tenk_heap_for_aocs;
 INSERT INTO tenk_aocs2 SELECT * FROM tenk_heap_for_aocs;
 INSERT INTO tenk_aocs3 SELECT * FROM tenk_heap_for_aocs;
 INSERT INTO tenk_aocs4 SELECT * FROM tenk_heap_for_aocs;
+INSERT INTO tenk_aocs5 SELECT * FROM tenk_heap_for_aocs;
 
 -- mix and match some
 INSERT INTO tenk_aocs1 SELECT * FROM tenk_aocs1;
@@ -273,6 +274,18 @@ INSERT INTO aocs_with_domain_constraint (id, vc1) VALUES (4, NULL);
 -- JOIN
 SELECT count(*) FROM tenk_aocs1 t1, tenk_aocs2 t2 where t1.unique1 = t2.unique2;
 SELECT count(*) FROM tenk_aocs1 t1, tenk_heap_for_aocs t2 where t1.unique1 = t2.unique2;
+SELECT count(*) FROM tenk_aocs1 t1 INNER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_aocs1 t1 LEFT OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_aocs1 t1 RIGHT OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_aocs1 t1 FULL OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_aocs1 t1 INNER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+SELECT count(*) FROM tenk_aocs1 t1 LEFT OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+SELECT count(*) FROM tenk_aocs1 t1 RIGHT OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+SELECT count(*) FROM tenk_aocs1 t1 FULL OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+
+CREATE TABLE empty_aocs_table_for_join (like tenk_heap_for_aocs) with (appendonly=true, orientation=column) distributed by(unique1);
+SELECT count(*) FROM tenk_aocs1 t1 INNER JOIN empty_aocs_table_for_join t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_aocs1 t1 LEFT OUTER JOIN empty_aocs_table_for_join t2 ON (t1.unique1 = t2.unique2);
 
 -- EXCEPT
 SELECT unique1 FROM tenk_aocs1 EXCEPT SELECT unique1 FROM tenk_aocs1;
@@ -307,6 +320,23 @@ insert into co values (9,2,'b'), (10,2,'bb'), (11,2,'bbb'), (12,2,'bbbb'),
 	(13,5,'aaaaa'), (14,6,'aaaaaa'), (15,7,'aaaaaaa'), (16,8,'aaaaaaaa');
 select * from co where j = 2;
 
+create index co_ij on co (i, j) with (fillfactor=10);
+alter index co_ij set (fillfactor=20);
+reindex index co_ij;
+select indexname from pg_indexes where tablename = 'co' order by indexname;
+alter table co alter j type bigint;
+alter table co rename j to j_renamed;
+alter table co drop column j_renamed;
+select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'co' order by attname, tablename;
+create index co_i on co (i) where i = 9;
+analyze co;
+select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'co' order by attname, tablename;
+select indexname from pg_indexes where tablename = 'co' order by indexname;
+select * from co where i = 9;
+alter index co_i rename to co_i_renamed;
+select indexname from pg_indexes where tablename = 'co' order by indexname;
+drop index if exists co_i_renamed;
+
 drop table if exists co;
 create table co (i int, j int, k varchar) with(appendonly=true, orientation=column);
 insert into co values (1,1,'a'), (2,2,'aa'), (3,3,'aaa'), (4,4,'aaaa'),
@@ -331,6 +361,51 @@ select j,i from co where k = 'aaa' or k = 'bbb';
 -- Test clustering errors out
 cluster co_j_cluster on co_j;
 
+-- TEMP TABLES w/ INDEXES
+create temp table temp_tenk_aocs5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    as select * from tenk_aocs5 distributed by (unique1);
+create index temp_even_index on temp_tenk_aocs5 (even);
+select count(*) from temp_tenk_aocs5;
+select tablename, indexname, indexdef from pg_indexes where tablename = 'temp_tenk_aocs5';
+insert into temp_tenk_aocs5(unique1, unique2) values (99998888, 99998888);
+update temp_tenk_aocs5 set unique2 = 99998889 where unique2 = 99998888;
+delete from temp_tenk_aocs5 where unique2 = 99998889;
+select count(*) from temp_tenk_aocs5;
+truncate table temp_tenk_aocs5;
+vacuum analyze temp_tenk_aocs5;
+\d temp_tenk_aocs5
+insert into temp_tenk_aocs5(unique1, unique2) values (99998888, 99998888);
+select unique1 from temp_tenk_aocs5;
+
+-- TEMP TABLES w/ COMMIT DROP AND USING PREPARE
+begin;
+prepare tenk_aocs5_prep(int4) as select * from tenk_aocs5 where unique1 > 8000;
+create temp table tenk_aocs5_temp_drop with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit drop as execute tenk_aocs5_prep(8095);
+select count(*) from tenk_aocs5_temp_drop;
+commit;
+select count(*) from tenk_aocs5_temp_drop;
+
+-- TEMP TABLES w/ COMMIT DELETE ROWS
+begin;
+create temp table tenk_aocs5_temp_delete_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit delete rows as select * from tenk_aocs5 where unique1 > 8000 distributed by (unique1);
+select count(*) from tenk_aocs5_temp_delete_rows;
+commit;
+select count(*) from tenk_aocs5_temp_delete_rows;
+
+-- TEMP TABLES w/ COMMIT PRESERVE ROWS
+begin;
+create temp table tenk_aocs5_temp_pres_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit preserve rows as select * from tenk_aocs5 where unique1 > 8000 distributed by (unique1);
+select count(*) from tenk_aocs5_temp_pres_rows;
+commit;
+select count(*) from tenk_aocs5_temp_pres_rows;
+
+-- RULES
+create rule aocs_rule_update as on insert to tenk_aocs5 do instead update foo_aocs set two=2;
+create rule aocs_rule_delete as on insert to tenk_aocs5 do instead delete from foo_aocs where unique1=1;
+
 ---------------------
 -- UAO
 ---------------------
@@ -342,6 +417,7 @@ DELETE FROM tenk_aocs1 WHERE unique1 = 1;
 select count(*) from gp_toolkit.__gp_aocsseg_name('tenk_aocs1') where modcount > 0;
 -- UPDATE
 UPDATE tenk_aocs1 SET unique2 = 1 WHERE unique2 = 2;
+UPDATE tenk_aocs1 SET two = 2;
 -- modcount after UPDATE must increment to flag table should be included in
 -- incremental backup
 select count(*) from gp_toolkit.__gp_aocsseg_name('tenk_aocs1') where modcount > 1;
@@ -400,3 +476,22 @@ insert into aocs_unknown
 select i, 'unknown' from generate_series(1, 10)i;
 
 select * from aocs_unknown;
+
+-- Check compression and distribution
+create table aocs_compress_table (id int, v varchar)
+    with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1) distributed by (id);
+create table aocs_compress_results(table_size int, aocs_compress_id_index_size int, aocs_compress_v_index_size int) distributed randomly;
+create index aocs_compress_id_index on aocs_compress_table (id);
+create index aocs_compress_v_index on aocs_compress_table (v);
+insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'), pg_relation_size('aocs_compress_id_index'), pg_relation_size('aocs_compress_v_index'));
+
+insert into aocs_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
+insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'), pg_relation_size('aocs_compress_id_index'), pg_relation_size('aocs_compress_v_index'));
+
+select get_ao_compression_ratio('aocs_compress_table');
+select get_ao_distribution('aocs_compress_table');
+
+truncate table aocs_compress_table; -- after truncate, reclaim space from the table and index
+insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'), pg_relation_size('aocs_compress_id_index'), pg_relation_size('aocs_compress_v_index'));
+
+select count(*) from (select distinct * from aocs_compress_results) temp; -- should give 2 after reclaiming space

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -32,6 +32,10 @@ CREATE TABLE tenk_ao6 (like tenk_heap) with (appendonly=false, compresslevel=6, 
 CREATE TABLE tenk_ao7 (like tenk_heap) with (appendonly=true, compresslevel=16, compresstype=zlib) distributed by(unique1);
 CREATE TABLE tenk_ao8 (like tenk_heap) with (appendonly=true, blocksize=100) distributed by(unique1);
 CREATE TABLE tenk_ao9 (like tenk_heap) with (appendonly=true, compresslevel=0, compresstype=zlib) distributed by(unique1);
+-- these should not work without appendonly=true
+CREATE TABLE tenk_ao10 (like tenk_heap) with (compresslevel=5);
+CREATE TABLE tenk_ao11 (like tenk_heap) with (blocksize=8192);
+CREATE TABLE tenk_ao12 (like tenk_heap) with (appendonly=false,blocksize=8192);
 
 -------------------- 
 -- catalog checks
@@ -234,6 +238,18 @@ SELECT count(*) FROM tenk_ao4;
 -- JOIN
 SELECT count(*) FROM tenk_ao1 t1, tenk_ao2 t2 where t1.unique1 = t2.unique2;
 SELECT count(*) FROM tenk_ao1 t1, tenk_heap t2 where t1.unique1 = t2.unique2;
+SELECT count(*) FROM tenk_ao1 t1 INNER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_ao1 t1 LEFT OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_ao1 t1 RIGHT OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_ao1 t1 FULL OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_ao1 t1 INNER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+SELECT count(*) FROM tenk_ao1 t1 LEFT OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+SELECT count(*) FROM tenk_ao1 t1 RIGHT OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+SELECT count(*) FROM tenk_ao1 t1 FULL OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+
+CREATE TABLE empty_ao_table_for_join (like tenk_heap) with (appendonly=true) distributed by(unique1);
+SELECT count(*) FROM tenk_ao1 t1 INNER JOIN empty_ao_table_for_join t2 ON (t1.unique1 = t2.unique2);
+SELECT count(*) FROM tenk_ao1 t1 LEFT OUTER JOIN empty_ao_table_for_join t2 ON (t1.unique1 = t2.unique2);
 
 -- EXCEPT
 SELECT unique1 FROM tenk_ao1 EXCEPT SELECT unique1 FROM tenk_ao1;
@@ -270,6 +286,23 @@ insert into ao values (9,2,'b'), (10,2,'bb'), (11,2,'bbb'), (12,2,'bbbb'),
 	(13,5,'aaaaa'), (14,6,'aaaaaa'), (15,7,'aaaaaaa'), (16,8,'aaaaaaaa');
 select * from ao where j = 2;
 
+create index ao_ij on ao (i, j) with (fillfactor=10);
+alter index ao_ij set (fillfactor=20);
+reindex index ao_ij;
+select indexname from pg_indexes where tablename = 'ao' order by indexname;
+alter table ao alter j type bigint;
+alter table ao rename j to j_renamed;
+alter table ao drop column j_renamed;
+select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'ao' order by attname, tablename;
+create index ao_i on ao (i) where i = 9;
+analyze ao;
+select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'ao' order by attname, tablename;
+select indexname from pg_indexes where tablename = 'ao' order by indexname;
+select * from ao where i = 9;
+alter index ao_i rename to ao_i_renamed;
+select indexname from pg_indexes where tablename = 'ao' order by indexname;
+drop index if exists ao_i_renamed;
+
 drop table if exists ao;
 create table ao (i int, j int, k varchar) with(appendonly=true);
 insert into ao values (1,1,'a'), (2,2,'aa'), (3,3,'aaa'), (4,4,'aaaa'),
@@ -286,6 +319,53 @@ insert into ao values (9,2,'b'), (10,2,'bb'), (11,2,'bbb'), (12,2,'bbbb'),
 	(13,5,'aaaaa'), (14,6,'aaaaaa'), (15,7,'aaaaaaa'), (16,8,'aaaaaaaa');
 select * from ao where j = 2;
 
+-- Test clustering errors out
+cluster ao_j_cluster on ao_j;
+
+-- TEMP TABLES w/ INDEXES
+create temp table temp_tenk_ao5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    as select * from tenk_ao5 distributed by (unique1);
+create index temp_even_index on temp_tenk_ao5 (even);
+select count(*) from temp_tenk_ao5;
+select tablename, indexname, indexdef from pg_indexes where tablename = 'temp_tenk_ao5';
+insert into temp_tenk_ao5(unique1, unique2) values (99998888, 99998888);
+update temp_tenk_ao5 set unique2 = 99998889 where unique2 = 99998888;
+delete from temp_tenk_ao5 where unique2 = 99998889;
+select count(*) from temp_tenk_ao5;
+truncate table temp_tenk_ao5;
+vacuum analyze temp_tenk_ao5;
+\d temp_tenk_ao5
+insert into temp_tenk_ao5(unique1, unique2) values (99998888, 99998888);
+select unique1 from temp_tenk_ao5;
+
+-- TEMP TABLES w/ COMMIT DROP AND USING PREPARE
+begin;
+prepare tenk_ao5_prep(int4) as select * from tenk_ao5 where unique1 > 8000;
+create temp table tenk_ao5_temp_drop with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit drop as execute tenk_ao5_prep(8095);
+select count(*) from tenk_ao5_temp_drop;
+commit;
+select count(*) from tenk_ao5_temp_drop;
+
+-- TEMP TABLES w/ COMMIT DELETE ROWS
+begin;
+create temp table tenk_ao5_temp_delete_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit delete rows as select * from tenk_ao5 where unique1 > 8000 distributed by (unique1);
+select count(*) from tenk_ao5_temp_delete_rows;
+commit;
+select count(*) from tenk_ao5_temp_delete_rows;
+
+-- TEMP TABLES w/ COMMIT PRESERVE ROWS
+begin;
+create temp table tenk_ao5_temp_pres_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit preserve rows as select * from tenk_ao5 where unique1 > 8000 distributed by (unique1);
+select count(*) from tenk_ao5_temp_pres_rows;
+commit;
+select count(*) from tenk_ao5_temp_pres_rows;
+
+-- RULES
+create rule ao_rule_update as on insert to tenk_ao5 do instead update foo_ao set two=2;
+create rule ao_rule_delete as on insert to tenk_ao5 do instead delete from foo_ao where unique1=1;
 
 ---------------------
 -- UAO
@@ -301,6 +381,7 @@ select count(*) from tenk_ao1;
 -- UPDATE
 select count(*) from tenk_ao1 where unique2 < 0;
 UPDATE tenk_ao1 SET unique2 = -unique1 WHERE unique2 <= 5;
+UPDATE tenk_ao1 SET two = 2;
 -- modcount after UPDATE must increment to flag table should be included in
 -- incremental backup
 select count(*) from gp_toolkit.__gp_aoseg_name('tenk_ao1') where modcount > 1;
@@ -353,6 +434,26 @@ INSERT INTO ao_selection VALUES (generate_series(1,100000), generate_series(1,10
 SELECT count(*) from gp_fastsequence WHERE objid IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class WHERE relname='ao_selection'));
 INSERT INTO ao_selection values (generate_series(1,100000), generate_series(1,10000));
 SELECT count(*) FROM gp_fastsequence WHERE objid IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class WHERE relname='ao_selection'));
+
+-- Check compression and distribution
+create table ao_compress_table (id int, v varchar)
+    with (appendonly=true, compresstype=zlib, compresslevel=1) distributed by (id);
+create table ao_compress_results(table_size int, ao_compress_id_index_size int, ao_compress_v_index_size int) distributed randomly;
+create index ao_compress_id_index on ao_compress_table (id);
+create index ao_compress_v_index on ao_compress_table (v);
+insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
+
+insert into ao_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
+insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
+
+select get_ao_compression_ratio('ao_compress_table');
+select get_ao_distribution('ao_compress_table');
+
+truncate table ao_compress_table; -- after truncate, reclaim space from the table and index
+insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
+
+select count(*) from (select distinct * from ao_compress_results) temp; -- should give 2 after reclaiming space
+
 -------------------- 
 -- supported sql 
 --------------------

--- a/src/test/regress/input/partindex_test.source
+++ b/src/test/regress/input/partindex_test.source
@@ -200,8 +200,9 @@ order by partcons;
 --
 -- ************************************************************
 -- * Scenario 3
--- * 	- multi-level partitions 
--- * 	- dropped columns 
+-- * 	- multi-level partitions
+-- * 	- truncate partition
+-- * 	- dropped columns
 -- ************************************************************
 --
 create table part_table3
@@ -227,11 +228,27 @@ subpartition by list(region)
 	)
 );
 
+-- insert some data
+insert into part_table3 values ('2008-02-02', 'usa', 'Texas', 10.05), ('2008-03-03', 'asia', 'China', 1.01);
+insert into part_table3 values ('2009-02-02', 'usa', 'Texas', 10.05), ('2009-03-03', 'asia', 'China', 1.01);
+
 -- index on atts 1, 4
 create index i1 on part_table3(date, amount); 
 select indKey, defaultLevels, partCons from gp_build_logical_index('part_table3'::regclass)
 as index(logicalIndexOid Oid, nColumns smallint, indKey text, indUnique bool, indPred text, indExprs text, partCons text, defaultLevels text, indType int2);
 
+-- truncate partitions until table is empty
+select * from part_table3;
+truncate part_table3_1_prt_part1_2_prt_asia;
+select * from part_table3;
+alter table part_table3 truncate partition for (rank(1));
+select * from part_table3;
+alter table part_table3 alter partition part2 truncate partition usa;
+select * from part_table3;
+alter table part_table3 truncate partition part2;
+select * from part_table3;
+
+-- drop column region1
 alter table part_table3 drop column region1;  
 select indKey, defaultLevels, partCons from gp_build_logical_index('part_table3'::regclass)
 as index(logicalIndexOid Oid, nColumns smallint, indKey text, indUnique bool, indPred text, indExprs text, partCons text, defaultLevels text, indType int2);

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -134,6 +134,7 @@ INSERT INTO tenk_aocs1 SELECT * FROM tenk_heap_for_aocs;
 INSERT INTO tenk_aocs2 SELECT * FROM tenk_heap_for_aocs;
 INSERT INTO tenk_aocs3 SELECT * FROM tenk_heap_for_aocs;
 INSERT INTO tenk_aocs4 SELECT * FROM tenk_heap_for_aocs;
+INSERT INTO tenk_aocs5 SELECT * FROM tenk_heap_for_aocs;
 -- mix and match some
 INSERT INTO tenk_aocs1 SELECT * FROM tenk_aocs1;
 INSERT INTO tenk_aocs2 SELECT * FROM tenk_aocs3;
@@ -505,6 +506,67 @@ SELECT count(*) FROM tenk_aocs1 t1, tenk_heap_for_aocs t2 where t1.unique1 = t2.
  10000
 (1 row)
 
+SELECT count(*) FROM tenk_aocs1 t1 INNER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
+SELECT count(*) FROM tenk_aocs1 t1 LEFT OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
+SELECT count(*) FROM tenk_aocs1 t1 RIGHT OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
+SELECT count(*) FROM tenk_aocs1 t1 FULL OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
+SELECT count(*) FROM tenk_aocs1 t1 INNER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+ count
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM tenk_aocs1 t1 LEFT OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+ count
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM tenk_aocs1 t1 RIGHT OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+ count
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM tenk_aocs1 t1 FULL OUTER JOIN tenk_aocs2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+ count
+-------
+     1
+(1 row)
+
+CREATE TABLE empty_aocs_table_for_join (like tenk_heap_for_aocs) with (appendonly=true, orientation=column) distributed by (unique1);
+SELECT count(*) FROM tenk_aocs1 t1 INNER JOIN empty_aocs_table_for_join t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM tenk_aocs1 t1 LEFT OUTER JOIN empty_aocs_table_for_join t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
 -- EXCEPT
 SELECT unique1 FROM tenk_aocs1 EXCEPT SELECT unique1 FROM tenk_aocs1;
  unique1 
@@ -568,6 +630,62 @@ select * from co where j = 2;
  12 | 2 | bbbb
 (6 rows)
 
+create index co_ij on co (i, j) with (fillfactor=10);
+alter index co_ij set (fillfactor=20);
+reindex index co_ij;
+select indexname from pg_indexes where tablename = 'co' order by indexname;
+ indexname
+-----------
+ co_ij
+ co_j
+ co_jk
+ co_k
+(4 rows)
+
+alter table co alter j type bigint;
+ERROR:  cannot alter indexed column
+HINT:  DROP the index first, and recreate it after the ALTER
+alter table co rename j to j_renamed;
+alter table co drop column j_renamed;
+select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'co' order by attname, tablename;
+ tablename | attname | avg_width | n_distinct
+-----------+---------+-----------+------------
+ co        | i       |         4 |         -1
+ co        | k       |         5 |         -1
+(2 rows)
+
+create index co_i on co (i) where i = 9;
+analyze co;
+select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'co' order by attname, tablename;
+ tablename | attname | avg_width | n_distinct
+-----------+---------+-----------+------------
+ co        | i       |         4 |  -0.666667
+ co        | k       |         5 |       -0.5
+(2 rows)
+
+select indexname from pg_indexes where tablename = 'co' order by indexname;
+ indexname
+-----------
+ co_i
+ co_k
+(2 rows)
+
+select * from co where i = 9;
+ i | k
+---+---
+ 9 | b
+ 9 | b
+(2 rows)
+
+alter index co_i rename to co_i_renamed;
+select indexname from pg_indexes where tablename = 'co' order by indexname;
+  indexname
+--------------
+ co_i_renamed
+ co_k
+(2 rows)
+
+drop index if exists co_i_renamed;
 drop table if exists co;
 create table co (i int, j int, k varchar) with(appendonly=true, orientation=column);
 insert into co values (1,1,'a'), (2,2,'aa'), (3,3,'aaa'), (4,4,'aaaa'),
@@ -629,6 +747,120 @@ select j,i from co where k = 'aaa' or k = 'bbb';
 -- Test clustering errors out
 cluster co_j_cluster on co_j;
 ERROR:  "co_j" is an index
+-- TEMP TABLES w/ INDEXES
+create temp table temp_tenk_aocs5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    as select * from tenk_aocs5 distributed by (unique1);
+create index temp_even_index on temp_tenk_aocs5 (even);
+select count(*) from temp_tenk_aocs5;
+ count
+-------
+ 10000
+(1 row)
+
+select tablename, indexname, indexdef from pg_indexes where tablename = 'temp_tenk_aocs5';
+    tablename    |    indexname    |                              indexdef
+-----------------+-----------------+--------------------------------------------------------------------
+ temp_tenk_aocs5 | temp_even_index | CREATE INDEX temp_even_index ON temp_tenk_aocs5 USING btree (even)
+(1 row)
+
+insert into temp_tenk_aocs5(unique1, unique2) values (99998888, 99998888);
+update temp_tenk_aocs5 set unique2 = 99998889 where unique2 = 99998888;
+delete from temp_tenk_aocs5 where unique2 = 99998889;
+select count(*) from temp_tenk_aocs5;
+ count
+-------
+ 10000
+(1 row)
+
+truncate table temp_tenk_aocs5;
+vacuum analyze temp_tenk_aocs5;
+\d temp_tenk_aocs5
+Append-Only Columnar Table "pg_temp_274.temp_tenk_aocs5"
+   Column    |  Type   | Modifiers
+-------------+---------+-----------
+ unique1     | integer |
+ unique2     | integer |
+ two         | integer |
+ four        | integer |
+ ten         | integer |
+ twenty      | integer |
+ hundred     | integer |
+ thousand    | integer |
+ twothousand | integer |
+ fivethous   | integer |
+ tenthous    | integer |
+ odd         | integer |
+ even        | integer |
+ stringu1    | name    |
+ stringu2    | name    |
+ string4     | name    |
+Checksum: t
+Indexes:
+    "temp_even_index" btree (even)
+Distributed by: (unique1)
+
+insert into temp_tenk_aocs5(unique1, unique2) values (99998888, 99998888);
+select unique1 from temp_tenk_aocs5;
+ unique1
+----------
+ 99998888
+(1 row)
+
+-- TEMP TABLES w/ COMMIT DROP AND USING PREPARE
+begin;
+prepare tenk_aocs5_prep(int4) as select * from tenk_aocs5 where unique1 > 8000;
+create temp table tenk_aocs5_temp_drop with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit drop as execute tenk_aocs5_prep(8095);
+select count(*) from tenk_aocs5_temp_drop;
+ count
+-------
+  1999
+(1 row)
+
+commit;
+select count(*) from tenk_aocs5_temp_drop;
+ERROR:  relation "tenk_aocs5_temp_drop" does not exist
+LINE 1: select count(*) from tenk_aocs5_temp_drop;
+                             ^
+-- TEMP TABLES w/ COMMIT DELETE ROWS
+begin;
+create temp table tenk_aocs5_temp_delete_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit delete rows as select * from tenk_aocs5 where unique1 > 8000 distributed by (unique1);
+select count(*) from tenk_aocs5_temp_delete_rows;
+ count
+-------
+  1999
+(1 row)
+
+commit;
+select count(*) from tenk_aocs5_temp_delete_rows;
+ count
+-------
+     0
+(1 row)
+
+-- TEMP TABLES w/ COMMIT PRESERVE ROWS
+begin;
+create temp table tenk_aocs5_temp_pres_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit preserve rows as select * from tenk_aocs5 where unique1 > 8000 distributed by (unique1);
+select count(*) from tenk_aocs5_temp_pres_rows;
+ count
+-------
+  1999
+(1 row)
+
+commit;
+select count(*) from tenk_aocs5_temp_pres_rows;
+ count
+-------
+  1999
+(1 row)
+
+-- RULES
+create rule aocs_rule_update as on insert to tenk_aocs5 do instead update foo_aocs set two=2;
+ERROR:  relation "foo_aocs" does not exist
+create rule aocs_rule_delete as on insert to tenk_aocs5 do instead delete from foo_aocs where unique1=1;
+ERROR:  relation "foo_aocs" does not exist
 ---------------------
 -- UAO
 ---------------------
@@ -650,6 +882,7 @@ select count(*) from gp_toolkit.__gp_aocsseg_name('tenk_aocs1') where modcount >
 
 -- UPDATE
 UPDATE tenk_aocs1 SET unique2 = 1 WHERE unique2 = 2;
+UPDATE tenk_aocs1 SET two = 2;
 -- modcount after UPDATE must increment to flag table should be included in
 -- incremental backup
 select count(*) from gp_toolkit.__gp_aocsseg_name('tenk_aocs1') where modcount > 1;
@@ -731,4 +964,33 @@ select * from aocs_unknown;
   9 | unknown | 
  10 | unknown | 
 (10 rows)
+
+-- Check compression and distribution
+create table aocs_compress_table (id int, v varchar)
+    with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1) distributed by (id);
+create table aocs_compress_results(table_size int, aocs_compress_id_index_size int, aocs_compress_v_index_size int) distributed randomly;
+create index aocs_compress_id_index on aocs_compress_table (id);
+create index aocs_compress_v_index on aocs_compress_table (v);
+insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'), pg_relation_size('aocs_compress_id_index'), pg_relation_size('aocs_compress_v_index'));
+insert into aocs_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
+insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'), pg_relation_size('aocs_compress_id_index'), pg_relation_size('aocs_compress_v_index'));
+select get_ao_compression_ratio('aocs_compress_table');
+ get_ao_compression_ratio
+--------------------------
+                     1.26
+(1 row)
+
+select get_ao_distribution('aocs_compress_table');
+ get_ao_distribution
+---------------------
+ (0,1)
+(1 row)
+
+truncate table aocs_compress_table; -- after truncate, reclaim space from the table and index
+insert into aocs_compress_results values (pg_relation_size('aocs_compress_table'), pg_relation_size('aocs_compress_id_index'), pg_relation_size('aocs_compress_v_index'));
+select count(*) from (select distinct * from aocs_compress_results) temp; -- should give 2 after reclaiming space
+ count
+-------
+     2
+(1 row)
 

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -35,6 +35,13 @@ CREATE TABLE tenk_ao8 (like tenk_heap) with (appendonly=true, blocksize=100) dis
 ERROR:  block size must be between 8KB and 2MB and be an 8KB multiple. Got 100
 CREATE TABLE tenk_ao9 (like tenk_heap) with (appendonly=true, compresslevel=0, compresstype=zlib) distributed by(unique1);
 ERROR:  compresstype can't be used with compresslevel 0
+-- these should not work without appendonly=true
+CREATE TABLE tenk_ao10 (like tenk_heap) with (compresslevel=5);
+ERROR:  invalid option 'compresslevel' for base relation. Only valid for Append Only relations
+CREATE TABLE tenk_ao11 (like tenk_heap) with (blocksize=8192);
+ERROR:  invalid option 'blocksize' for base relation. Only valid for Append Only relations
+CREATE TABLE tenk_ao12 (like tenk_heap) with (appendonly=false,blocksize=8192);
+ERROR:  invalid option 'blocksize' for base relation. Only valid for Append Only relations
 -------------------- 
 -- catalog checks
 --------------------
@@ -462,6 +469,67 @@ SELECT count(*) FROM tenk_ao1 t1, tenk_heap t2 where t1.unique1 = t2.unique2;
  10000
 (1 row)
 
+SELECT count(*) FROM tenk_ao1 t1 INNER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
+SELECT count(*) FROM tenk_ao1 t1 LEFT OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
+SELECT count(*) FROM tenk_ao1 t1 RIGHT OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
+SELECT count(*) FROM tenk_ao1 t1 FULL OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
+SELECT count(*) FROM tenk_ao1 t1 INNER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+ count
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM tenk_ao1 t1 LEFT OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+ count
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM tenk_ao1 t1 RIGHT OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+ count
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM tenk_ao1 t1 FULL OUTER JOIN tenk_ao2 t2 ON (t1.unique1 = t2.unique2) where t1.unique1 = 8095;
+ count
+-------
+     1
+(1 row)
+
+CREATE TABLE empty_ao_table_for_join (like tenk_heap) with (appendonly=true) distributed by(unique1);
+SELECT count(*) FROM tenk_ao1 t1 INNER JOIN empty_ao_table_for_join t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM tenk_ao1 t1 LEFT OUTER JOIN empty_ao_table_for_join t2 ON (t1.unique1 = t2.unique2);
+ count
+-------
+ 10000
+(1 row)
+
 -- EXCEPT
 SELECT unique1 FROM tenk_ao1 EXCEPT SELECT unique1 FROM tenk_ao1;
  unique1 
@@ -531,6 +599,62 @@ select * from ao where j = 2;
  10 | 2 | bb
 (6 rows)
 
+create index ao_ij on ao (i, j) with (fillfactor=10);
+alter index ao_ij set (fillfactor=20);
+reindex index ao_ij;
+select indexname from pg_indexes where tablename = 'ao' order by indexname;
+ indexname
+-----------
+ ao_ij
+ ao_j
+ ao_jk
+ ao_k
+(4 rows)
+
+alter table ao alter j type bigint;
+ERROR:  cannot alter indexed column
+HINT:  DROP the index first, and recreate it after the ALTER
+alter table ao rename j to j_renamed;
+alter table ao drop column j_renamed;
+select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'ao' order by attname, tablename;
+ tablename | attname | avg_width | n_distinct
+-----------+---------+-----------+------------
+ ao        | i       |         4 |         -1
+ ao        | k       |         5 |         -1
+(2 rows)
+
+create index ao_i on ao (i) where i = 9;
+analyze ao;
+select tablename, attname, avg_width, n_distinct from pg_stats where tablename = 'ao' order by attname, tablename;
+ tablename | attname | avg_width | n_distinct
+-----------+---------+-----------+------------
+ ao        | i       |         4 |  -0.666667
+ ao        | k       |         5 |       -0.5
+(2 rows)
+
+select indexname from pg_indexes where tablename = 'ao' order by indexname;
+ indexname
+-----------
+ ao_i
+ ao_k
+(2 rows)
+
+select * from ao where i = 9;
+ i | k
+---+---
+ 9 | b
+ 9 | b
+(2 rows)
+
+alter index ao_i rename to ao_i_renamed;
+select indexname from pg_indexes where tablename = 'ao' order by indexname;
+  indexname
+--------------
+ ao_i_renamed
+ ao_k
+(2 rows)
+
+drop index if exists ao_i_renamed;
 drop table if exists ao;
 create table ao (i int, j int, k varchar) with(appendonly=true);
 insert into ao values (1,1,'a'), (2,2,'aa'), (3,3,'aaa'), (4,4,'aaaa'),
@@ -567,6 +691,123 @@ select * from ao where j = 2;
  10 | 2 | bb
 (6 rows)
 
+-- Test clustering errors out
+cluster ao_j_cluster on ao_j;
+ERROR:  "ao_j" is an index
+-- TEMP TABLES w/ INDEXES
+create temp table temp_tenk_ao5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    as select * from tenk_ao5 distributed by (unique1);
+create index temp_even_index on temp_tenk_ao5 (even);
+select count(*) from temp_tenk_ao5;
+ count
+-------
+     0
+(1 row)
+
+select tablename, indexname, indexdef from pg_indexes where tablename = 'temp_tenk_ao5';
+   tablename   |    indexname    |                             indexdef
+---------------+-----------------+------------------------------------------------------------------
+ temp_tenk_ao5 | temp_even_index | CREATE INDEX temp_even_index ON temp_tenk_ao5 USING btree (even)
+(1 row)
+
+insert into temp_tenk_ao5(unique1, unique2) values (99998888, 99998888);
+update temp_tenk_ao5 set unique2 = 99998889 where unique2 = 99998888;
+delete from temp_tenk_ao5 where unique2 = 99998889;
+select count(*) from temp_tenk_ao5;
+ count
+-------
+     0
+(1 row)
+
+truncate table temp_tenk_ao5;
+vacuum analyze temp_tenk_ao5;
+\d temp_tenk_ao5
+Append-Only Columnar Table "pg_temp_274.temp_tenk_ao5"
+   Column    |  Type   | Modifiers
+-------------+---------+-----------
+ unique1     | integer |
+ unique2     | integer |
+ two         | integer |
+ four        | integer |
+ ten         | integer |
+ twenty      | integer |
+ hundred     | integer |
+ thousand    | integer |
+ twothousand | integer |
+ fivethous   | integer |
+ tenthous    | integer |
+ odd         | integer |
+ even        | integer |
+ stringu1    | name    |
+ stringu2    | name    |
+ string4     | name    |
+Checksum: t
+Indexes:
+    "temp_even_index" btree (even)
+Distributed by: (unique1)
+
+insert into temp_tenk_ao5(unique1, unique2) values (99998888, 99998888);
+select unique1 from temp_tenk_ao5;
+ unique1
+----------
+ 99998888
+(1 row)
+
+-- TEMP TABLES w/ COMMIT DROP AND USING PREPARE
+begin;
+prepare tenk_ao5_prep(int4) as select * from tenk_ao5 where unique1 > 8000;
+create temp table tenk_ao5_temp_drop with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit drop as execute tenk_ao5_prep(8095);
+select count(*) from tenk_ao5_temp_drop;
+ count
+-------
+     0
+(1 row)
+
+commit;
+select count(*) from tenk_ao5_temp_drop;
+ERROR:  relation "tenk_ao5_temp_drop" does not exist
+LINE 1: select count(*) from tenk_ao5_temp_drop;
+                             ^
+-- TEMP TABLES w/ COMMIT DELETE ROWS
+begin;
+create temp table tenk_ao5_temp_delete_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit delete rows as select * from tenk_ao5 where unique1 > 8000 distributed by (unique1);
+select count(*) from tenk_ao5_temp_delete_rows;
+ count
+-------
+     0
+(1 row)
+
+commit;
+select count(*) from tenk_ao5_temp_delete_rows;
+ count
+-------
+     0
+(1 row)
+
+-- TEMP TABLES w/ COMMIT PRESERVE ROWS
+begin;
+create temp table tenk_ao5_temp_pres_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+    on commit preserve rows as select * from tenk_ao5 where unique1 > 8000 distributed by (unique1);
+select count(*) from tenk_ao5_temp_pres_rows;
+ count
+-------
+     0
+(1 row)
+
+commit;
+select count(*) from tenk_ao5_temp_pres_rows;
+ count
+-------
+     0
+(1 row)
+
+-- RULES
+create rule ao_rule_update as on insert to tenk_ao5 do instead update foo_ao set two=2;
+ERROR:  relation "foo_ao" does not exist
+create rule ao_rule_delete as on insert to tenk_ao5 do instead delete from foo_ao where unique1=1;
+ERROR:  relation "foo_ao" does not exist
 ---------------------
 -- UAO
 ---------------------
@@ -606,6 +847,7 @@ select count(*) from tenk_ao1 where unique2 < 0;
 (1 row)
 
 UPDATE tenk_ao1 SET unique2 = -unique1 WHERE unique2 <= 5;
+UPDATE tenk_ao1 SET two = 2;
 -- modcount after UPDATE must increment to flag table should be included in
 -- incremental backup
 select count(*) from gp_toolkit.__gp_aoseg_name('tenk_ao1') where modcount > 1;
@@ -701,6 +943,35 @@ SELECT count(*) FROM gp_fastsequence WHERE objid IN (SELECT segrelid FROM pg_app
  count 
 -------
      1
+(1 row)
+
+-- Check compression and distribution
+create table ao_compress_table (id int, v varchar)
+    with (appendonly=true, compresstype=zlib, compresslevel=1) distributed by (id);
+create table ao_compress_results(table_size int, ao_compress_id_index_size int, ao_compress_v_index_size int) distributed randomly;
+create index ao_compress_id_index on ao_compress_table (id);
+create index ao_compress_v_index on ao_compress_table (v);
+insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
+insert into ao_compress_table (id, v) values (1, 'ifyouwantto99knowwhatist8329histhenkeepreadingit;;untilyou]findoutyoureyeshurtandyoustil0ldontknow103kwhatitisdoyouunderstandmeyetandifyoustillwanttoknowthenyoupleasekeepreading');
+insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
+select get_ao_compression_ratio('ao_compress_table');
+ get_ao_compression_ratio
+--------------------------
+                     1.27
+(1 row)
+
+select get_ao_distribution('ao_compress_table');
+ get_ao_distribution
+---------------------
+ (0,1)
+(1 row)
+
+truncate table ao_compress_table; -- after truncate, reclaim space from the table and index
+insert into ao_compress_results values (pg_relation_size('ao_compress_table'), pg_relation_size('ao_compress_id_index'), pg_relation_size('ao_compress_v_index'));
+select count(*) from (select distinct * from ao_compress_results) temp; -- should give 2 after reclaiming space
+ count
+-------
+     2
 (1 row)
 
 -------------------- 

--- a/src/test/regress/output/partindex_test.source
+++ b/src/test/regress/output/partindex_test.source
@@ -539,8 +539,9 @@ order by partcons;
 --
 -- ************************************************************
 -- * Scenario 3
--- * 	- multi-level partitions 
--- * 	- dropped columns 
+-- * 	- multi-level partitions
+-- *  - truncate partition
+-- * 	- dropped columns
 -- ************************************************************
 --
 create table part_table3
@@ -574,6 +575,9 @@ NOTICE:  CREATE TABLE will create partition "part_table3_1_prt_part1_2_prt_asia"
 NOTICE:  CREATE TABLE will create partition "part_table3_1_prt_part1_2_prt_def" for table "part_table3_1_prt_part1"
 NOTICE:  CREATE TABLE will create partition "part_table3_1_prt_part2_2_prt_usa" for table "part_table3_1_prt_part2"
 NOTICE:  CREATE TABLE will create partition "part_table3_1_prt_part2_2_prt_asia" for table "part_table3_1_prt_part2"
+-- insert some data
+insert into part_table3 values ('2008-02-02', 'usa', 'Texas', 10.05), ('2008-03-03', 'asia', 'China', 1.01);
+insert into part_table3 values ('2009-02-02', 'usa', 'Texas', 10.05), ('2009-03-03', 'asia', 'China', 1.01);
 -- index on atts 1, 4
 create index i1 on part_table3(date, amount); 
 NOTICE:  building index for child partition "part_table3_1_prt_part1"
@@ -590,6 +594,50 @@ as index(logicalIndexOid Oid, nColumns smallint, indKey text, indUnique bool, in
  1 4    |               | 
 (1 row)
 
+-- truncate partitions until table is empty
+select * from part_table3;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2008 | usa    | Texas   |  10.05
+ 02-02-2009 | usa    | Texas   |  10.05
+ 03-03-2008 | asia   | China   |   1.01
+ 03-03-2009 | asia   | China   |   1.01
+(4 rows)
+
+truncate part_table3_1_prt_part1_2_prt_asia;
+select * from part_table3;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2008 | usa    | Texas   |  10.05
+ 02-02-2009 | usa    | Texas   |  10.05
+ 03-03-2009 | asia   | China   |   1.01
+(3 rows)
+
+alter table part_table3 truncate partition for (rank(1));
+NOTICE:  truncated partition "part1" for relation "part_table3" and its children
+select * from part_table3;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 02-02-2009 | usa    | Texas   |  10.05
+ 03-03-2009 | asia   | China   |   1.01
+(2 rows)
+
+alter table part_table3 alter partition part2 truncate partition usa;
+NOTICE:  truncated partition "usa" for partition "part2" of relation "part_table3"
+select * from part_table3;
+    date    | region | region1 | amount
+------------+--------+---------+--------
+ 03-03-2009 | asia   | China   |   1.01
+(1 row)
+
+alter table part_table3 truncate partition part2;
+NOTICE:  truncated partition "part2" for relation "part_table3" and its children
+select * from part_table3;
+ date | region | region1 | amount
+------+--------+---------+--------
+(0 rows)
+
+-- drop column region1
 alter table part_table3 drop column region1;  
 select indKey, defaultLevels, partCons from gp_build_logical_index('part_table3'::regclass)
 as index(logicalIndexOid Oid, nColumns smallint, indKey text, indUnique bool, indPred text, indExprs text, partCons text, defaultLevels text, indType int2);


### PR DESCRIPTION
Most of these test additions are inspired from Pivotal's internal
testing and needed to be added to the open source installcheck to
give the community more test coverage on AO/CO tables.  This commit
mostly adds extra coverage for indexes and partition tables.