### PR TITLE
Remove dead code

### DIFF
--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -391,7 +391,6 @@ extern TupleTableSlot *ExecStoreVirtualTuple(TupleTableSlot *slot);
 extern TupleTableSlot *ExecStoreAllNullTuple(TupleTableSlot *slot);
 
 extern HeapTuple ExecCopySlotHeapTuple(TupleTableSlot *slot);
-extern HeapTuple ExecCopySlotHeapTupleTo(TupleTableSlot *slot, MemoryContext pctxt, char *dest, unsigned int *len);
 extern MemTuple ExecCopySlotMemTuple(TupleTableSlot *slot);
 extern MemTuple ExecCopySlotMemTupleTo(TupleTableSlot *slot, MemoryContext pctxt, char *dest, unsigned int *len);
 


### PR DESCRIPTION
`ExecCopySlotHeapTupleTo()` is not used anywhere (anymore) AFAICT so it seems safe to remove.