### PR TITLE
GPHDFS triggers kinit storm in large clusters

### DIFF
--- a/gpAux/extensions/gphdfs/Makefile
+++ b/gpAux/extensions/gphdfs/Makefile
@@ -126,6 +126,7 @@ gnet-1.0-javadoc.tar:  $(JAR_FILES)
 install-jars: $(JAR_FILES)
 	$(INSTALL_PROGRAM) dist/*.jar '$(DESTDIR)$(libdir)/hadoop/'
 	$(INSTALL_PROGRAM) hadoop_env.sh$(X) '$(DESTDIR)$(libdir)/hadoop/hadoop_env.sh$(X)'
+	$(INSTALL_PROGRAM) jaas.conf$(X) '$(DESTDIR)$(libdir)/hadoop/jaas.conf$(X)'
 
 .PHONY: install-javadocs
 install-javadocs: $(JAVADOC_TARS)
@@ -148,6 +149,7 @@ installdirs:
 uninstall:
 	rm -f '$(DESTDIR)$(bindir)/*.jar'
 	rm -f '$(DESTDIR)$(bindir)/hadoop_env.sh$(X)'
+	rm -f '$(DESTDIR)$(bindir)/jaas.conf$(X)'
 	rm -f '$(DESTDIR)$(datadir)/cdb_init.d/gphdfs.sql'
 
 clean: clean-extras

--- a/gpAux/extensions/gphdfs/hadoop_env.sh
+++ b/gpAux/extensions/gphdfs/hadoop_env.sh
@@ -1,5 +1,6 @@
 export GP_JAVA_OPT='-Xmx1000m -XX:+DisplayVMOutputToStderr'
 export PATH=$JAVA_HOME/bin:$PATH
+export KRB5CCNAME=$GP_SEG_DATADIR/gpdb-gphdfs.krb5cc
 JAVA=$JAVA_HOME/bin/java
 CLASSPATH="$GPHOME"/"$GP_HADOOP_CONN_JARDIR"/$GP_HADOOP_CONN_VERSION.jar
 export HADOOP_COMMON_HOME="${HADOOP_HOME}"
@@ -113,11 +114,9 @@ fi
 JAVA_LIBRARY_PATH=''
 if [ -d "${HADOOP_HOME}/build/native" -o -d "${HADOOP_HOME}/lib/native" ]; then
   JAVA_PLATFORM=`CLASSPATH=${CLASSPATH} ${JAVA} -Xmx32m ${HADOOP_JAVA_PLATFORM_OPTS} org.apache.hadoop.util.PlatformName | sed -e "s/ /_/g"`
-  
   if [ -d "$HADOOP_HOME/build/native" ]; then
     JAVA_LIBRARY_PATH=${HADOOP_HOME}/build/native/${JAVA_PLATFORM}/lib
   fi
-  
   if [ -d "${HADOOP_HOME}/lib/native" ]; then
     if [ "x$JAVA_LIBRARY_PATH" != "x" ]; then
       JAVA_LIBRARY_PATH=${JAVA_LIBRARY_PATH}:${HADOOP_HOME}/lib/native/${JAVA_PLATFORM}

--- a/gpAux/extensions/gphdfs/jaas.conf
+++ b/gpAux/extensions/gphdfs/jaas.conf
@@ -1,0 +1,5 @@
+gphdfs {
+  com.sun.security.auth.module.Krb5LoginModule required
+  doNotPrompt=true
+  useTicketCache=true;
+};

--- a/gpAux/extensions/gphdfs/src/java/1.1/com/emc/greenplum/gpdb/hdfsconnector/ConnectorUtil.java
+++ b/gpAux/extensions/gphdfs/src/java/1.1/com/emc/greenplum/gpdb/hdfsconnector/ConnectorUtil.java
@@ -15,14 +15,20 @@
 
 package com.emc.greenplum.gpdb.hdfsconnector;
 
-import com.emc.greenplum.gpdb.hadoop.io.GPDBWritable;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.SecurityUtil;
 
 import java.net.URI;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.net.InetAddress;
+import java.util.Set;
 
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosTicket;
 
 /**
  * This is a common utility for the GPDB side Hadoop connector. Routines common to
@@ -38,7 +44,7 @@ public class ConnectorUtil
 	 * Hadoop fs.default.name and set it in the conf.
 	 * MapR's URI starts with maprfs:///
 	 * Hadoop's URI starts with hdfs://
-	 * 
+	 *
 	 * @param conf the configuration
 	 * @param inputURI the external table URI
 	 * @param connVer the Hadoop Connector version
@@ -48,9 +54,9 @@ public class ConnectorUtil
 		/**
 		 * Parse the URI and reconstruct the destination URI
 		 * Scheme could be hdfs or maprfs
-		 * 
+		 *
 		 * NOTE: Unless the version is MR, we're going to use ordinary
-		 * hdfs://. 		 * 
+		 * hdfs://. 		 *
 		 * NOTE: MapR isn't really an URI because of its "///" notation.
 		 * MapR also does not use port.
 		 */
@@ -62,25 +68,106 @@ public class ConnectorUtil
 	    	conf.set("fs.default.name", uri);
 	    }
 	}
-	
-	protected static final String HADOOP_SECURITY_USER_KEYTAB_FILE = 
+
+	protected static final String HADOOP_SECURITY_USER_KEYTAB_FILE =
 		"com.emc.greenplum.gpdb.hdfsconnector.security.user.keytab.file";
-	protected static final String HADOOP_SECURITY_USERNAME = 
+	protected static final String HADOOP_SECURITY_USERNAME =
 		"com.emc.greenplum.gpdb.hdfsconnector.security.user.name";
+	protected static final String HADOOP_DISABLE_KINIT =
+		"com.emc.greenplum.gpdb.hdfsconnector.security.disable.kinit";
 
 	/**
-	 * Helper routine to login to secure Hadoop. If it's not configured to use
-	 * security (in the core-site.xml), then UserGroupInformation.loginUserFromKeytab
-	 * would do nothing.
-	 * 
-	 * @param conf the configuration
-	 */
-	protected static void loginSecureHadoop(Configuration conf) throws IOException
+	* Helper routine to login to secure Hadoop. If it's not configured to use
+	* security (in the core-site.xml) then return
+	*
+	* Create a LoginContext using config in $GPHOME/lib/hadoop/jaas.conf and search for a valid TGT
+	* which matches HADOOP_SECURITY_USERNAME.
+	* Check if the TGT needs to be renewed or recreated and use installed kinit command to handle the
+	* credential cache
+	*
+	* @param conf the configuration
+	*/
+	protected static void loginSecureHadoop(Configuration conf) throws IOException, InterruptedException
 	{
-	    String principalName  = conf.get(HADOOP_SECURITY_USERNAME);
-	    String keytabFilename = conf.get(HADOOP_SECURITY_USER_KEYTAB_FILE);
-	    SecurityUtil.login(conf,
-	    		HADOOP_SECURITY_USER_KEYTAB_FILE,
-	    		HADOOP_SECURITY_USERNAME);
+		// if security config does not exist then assume no security
+		if ( conf.get(HADOOP_SECURITY_USERNAME) == null || conf.get(HADOOP_SECURITY_USER_KEYTAB_FILE) == null ) {
+			return;
+		}
+
+		String principal = SecurityUtil.getServerPrincipal( conf.get(HADOOP_SECURITY_USERNAME), InetAddress.getLocalHost().getCanonicalHostName() );
+		String JaasConf = System.getenv("GPHOME") + "/lib/hadoop/jaas.conf";
+		System.setProperty("java.security.auth.login.config", JaasConf);
+		Boolean kinitDisabled = conf.getBoolean(HADOOP_DISABLE_KINIT, false);
+
+		/*
+			Attempt to find the TGT from the users ticket cache and check if its a valid TGT
+			If the TGT needs to be renewed or recreated then we use kinit binary command so the cache can be persisted
+			allowing future queries to reuse cached TGT's
+
+			If user disables kinit then we fail back SecurityUtil.login which will always perform a AS_REQ
+			followed by a TGS_REQ to the KDC and set the global login context.  the problem with this method is if you have 300
+			or more GPDB segments then every gphdfs query will issue 300 AS_REQ to the KDC and may result in intermittent failures
+			or longer running queries if the KDC can not keep up with the demand
+		*/
+		try {
+			LoginContext login = new LoginContext("gphdfs");
+			login.login();
+			Subject subject = login.getSubject();
+			Set<KerberosTicket> tickets = subject.getPrivateCredentials(KerberosTicket.class);
+
+			// find the TGT that matches the configured principal
+			for (KerberosTicket ticket : tickets) {
+				if ( ticket.getClient().toString().equals(principal) ) {
+					long start = ticket.getStartTime().getTime();
+					long end = ticket.getEndTime().getTime();
+					long current = System.currentTimeMillis();
+					Long rtime = start +  (long) ((end - start) * .8); // compute start time of ticket plus 80% to find the refresh window
+
+					if ( current <= rtime && ticket.isCurrent() ) { // Ticket is current so no further action required
+						return;
+					} else if ( current >= rtime && ticket.isRenewable() && !kinitDisabled ) { // Ticket needs to be renewed and is renewable
+						String[] kinitRefresh = {"kinit", "-R"};
+						Process kinitRenew = Runtime.getRuntime().exec(kinitRefresh);
+						int rt = kinitRenew.waitFor();
+						if ( rt == 0 ) {
+							return;
+						}
+
+					}
+					break;
+				}
+			}
+		} catch (LoginException e) {
+			if ( kinitDisabled ) {
+				SecurityUtil.login(conf,HADOOP_SECURITY_USER_KEYTAB_FILE,HADOOP_SECURITY_USERNAME);
+				return;
+			}
+			// if kinit is not disabled then do nothing because we will request a new TGT and update the ticket cache
+		}
+
+		// fail back to securityutil if kinit is disabled
+		if ( kinitDisabled ) { // login from keytab
+			SecurityUtil.login(conf,HADOOP_SECURITY_USER_KEYTAB_FILE,HADOOP_SECURITY_USERNAME);
+			return;
+		}
+
+		// if we made it here then there is not a current TGT found in cache that matches the principal and we need to request a new TGT
+		String[] kinitCmd = {"kinit", "-kt", conf.get(HADOOP_SECURITY_USER_KEYTAB_FILE), principal};
+		try {
+			Process kinit = Runtime.getRuntime().exec(kinitCmd);
+			int rt = kinit.waitFor();
+			if ( rt != 0 ) {
+				BufferedReader errOut = new BufferedReader(new InputStreamReader(kinit.getErrorStream()));
+				String line;
+				String errOutput = "";
+				while( (line = errOut.readLine()) != null ) {
+					errOutput += line;
+				}
+				throw new IOException(String.format("Failed to Acquire TGT using command \"kinit -kt\" with configured keytab and principal settings:\n%s", errOutput));
+			}
+		} catch (InterruptedException e) {
+			throw new InterruptedException(String.format("command \"kinit -kt\" with configured keytab and principal settings:\n%s", e.getMessage()));
+		}
 	}
+
 }

--- a/gpAux/extensions/gphdfs/src/java/1.2/com/emc/greenplum/gpdb/hdfsconnector/ConnectorUtil.java
+++ b/gpAux/extensions/gphdfs/src/java/1.2/com/emc/greenplum/gpdb/hdfsconnector/ConnectorUtil.java
@@ -20,7 +20,15 @@ import org.apache.hadoop.security.SecurityUtil;
 
 import java.net.URI;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.net.InetAddress;
+import java.util.Set;
 
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosTicket;
 
 /**
  * This is a common utility for the GPDB side Hadoop connector. Routines common to
@@ -30,13 +38,13 @@ import java.io.IOException;
  *
  */
 public class ConnectorUtil
-{	
+{
 	/**
 	 * Helper routine to translate the External table URI to the actual
 	 * Hadoop fs.default.name and set it in the conf.
 	 * MapR's URI starts with maprfs:///
 	 * Hadoop's URI starts with hdfs://
-	 * 
+	 *
 	 * @param conf the configuration
 	 * @param inputURI the external table URI
 	 * @param connVer the Hadoop Connector version
@@ -46,9 +54,9 @@ public class ConnectorUtil
 		/**
 		 * Parse the URI and reconstruct the destination URI
 		 * Scheme could be hdfs or maprfs
-		 * 
+		 *
 		 * NOTE: Unless the version is MR, we're going to use ordinary
-		 * hdfs://. 
+		 * hdfs://.
 		 */
 		if (connVer.startsWith("gpmr")) {
 			conf.set("fs.maprfs.impl", "com.mapr.fs.MapRFileSystem");
@@ -63,27 +71,109 @@ public class ConnectorUtil
 		}
 	}
 
-	protected static final String HADOOP_SECURITY_USER_KEYTAB_FILE = 
+	protected static final String HADOOP_SECURITY_USER_KEYTAB_FILE =
 		"com.emc.greenplum.gpdb.hdfsconnector.security.user.keytab.file";
-	protected static final String HADOOP_SECURITY_USERNAME = 
+	protected static final String HADOOP_SECURITY_USERNAME =
 		"com.emc.greenplum.gpdb.hdfsconnector.security.user.name";
+	protected static final String HADOOP_DISABLE_KINIT =
+		"com.emc.greenplum.gpdb.hdfsconnector.security.disable.kinit";
 
 	/**
 	 * Helper routine to login to secure Hadoop. If it's not configured to use
-	 * security (in the core-site.xml), then UserGroupInformation.loginUserFromKeytab
-	 * would do nothing.
-	 * 
+	 * security (in the core-site.xml) then return
+	 *
+	 * Create a LoginContext using config in $GPHOME/lib/hadoop/jaas.conf and search for a valid TGT
+	 * which matches HADOOP_SECURITY_USERNAME.
+	 * Check if the TGT needs to be renewed or recreated and use installed kinit command to handle the
+	 * credential cache
+	 *
 	 * @param conf the configuration
 	 */
-	protected static void loginSecureHadoop(Configuration conf) throws IOException
+	protected static void loginSecureHadoop(Configuration conf) throws IOException, InterruptedException
 	{
-	    String principalName  = conf.get(HADOOP_SECURITY_USERNAME);
-	    String keytabFilename = conf.get(HADOOP_SECURITY_USER_KEYTAB_FILE);
-	    SecurityUtil.login(conf,
-	    		HADOOP_SECURITY_USER_KEYTAB_FILE,
-	    		HADOOP_SECURITY_USERNAME);
+		// if security config does not exist then assume no security
+		if ( conf.get(HADOOP_SECURITY_USERNAME) == null || conf.get(HADOOP_SECURITY_USER_KEYTAB_FILE) == null ) {
+			return;
+		}
+
+		String principal = SecurityUtil.getServerPrincipal( conf.get(HADOOP_SECURITY_USERNAME), InetAddress.getLocalHost().getCanonicalHostName() );
+		String jaasConf = System.getenv("GPHOME") + "/lib/hadoop/jaas.conf";
+		System.setProperty("java.security.auth.login.config", jaasConf);
+		Boolean kinitDisabled = conf.getBoolean(HADOOP_DISABLE_KINIT, false);
+
+		/*
+			Attempt to find the TGT from the users ticket cache and check if its a valid TGT
+			If the TGT needs to be renewed or recreated then we use kinit binary command so the cache can be persisted
+			allowing future queries to reuse cached TGT's
+
+			If user disables kinit then we fail back SecurityUtil.login which will always perform a AS_REQ
+			followed by a TGS_REQ to the KDC and set the global login context.  the problem with this method is if you have 300
+			or more GPDB segments then every gphdfs query will issue 300 AS_REQ to the KDC and may result in intermittent failures
+			or longer running queries if the KDC can not keep up with the demand
+		*/
+		try {
+			LoginContext login = new LoginContext("gphdfs");
+			login.login();
+			Subject subject = login.getSubject();
+			Set<KerberosTicket> tickets = subject.getPrivateCredentials(KerberosTicket.class);
+
+			// find the TGT that matches the configured principal
+			for (KerberosTicket ticket : tickets) {
+				if ( ticket.getClient().toString().equals(principal) ) {
+					long start = ticket.getStartTime().getTime();
+					long end = ticket.getEndTime().getTime();
+					long current = System.currentTimeMillis();
+					Long rtime = start +  (long) ((end - start) * .8); // compute start time of ticket plus 80% to find the refresh window
+
+					if ( current <= rtime && ticket.isCurrent() ) { // Ticket is current so no further action required
+						return;
+					} else if ( current >= rtime && ticket.isRenewable() && !kinitDisabled ) { // Ticket needs to be renewed and is renewable
+						String[] kinitRefresh = {"kinit", "-R"};
+						Process kinitRenew = Runtime.getRuntime().exec(kinitRefresh);
+						int rt = kinitRenew.waitFor();
+						if ( rt == 0 ) {
+							return;
+						}
+
+					}
+					break;
+				}
+			}
+		} catch (LoginException | InterruptedException e) {
+			if ( kinitDisabled ) {
+				SecurityUtil.login(conf,HADOOP_SECURITY_USER_KEYTAB_FILE,HADOOP_SECURITY_USERNAME);
+				return;
+			}
+			/* if kinit is not disabled then do nothing because we will request a new TGT and update the ticket cache
+			* regardless if login or kinit refresh failed initially
+			*/
+		}
+
+		// fail back to securityutil if kinit is disabled
+		if ( kinitDisabled ) { // login from keytab
+			SecurityUtil.login(conf,HADOOP_SECURITY_USER_KEYTAB_FILE,HADOOP_SECURITY_USERNAME);
+			return;
+		}
+
+		// if we made it here then there is not a current TGT found in cache that matches the principal and we need to request a new TGT
+		String[] kinitCmd = {"kinit", "-kt", conf.get(HADOOP_SECURITY_USER_KEYTAB_FILE), principal};
+		try {
+			Process kinit = Runtime.getRuntime().exec(kinitCmd);
+			int rt = kinit.waitFor();
+			if ( rt != 0 ) {
+				BufferedReader errOut = new BufferedReader(new InputStreamReader(kinit.getErrorStream()));
+				String line;
+				String errOutput = "";
+				while( (line = errOut.readLine()) != null ) {
+					errOutput += line;
+				}
+				throw new IOException(String.format("Failed to Acquire TGT using command \"kinit -kt\" with configured keytab and principal settings:\n%s", errOutput));
+			}
+		} catch (InterruptedException e) {
+			throw new InterruptedException(String.format("command \"kinit -kt\" with configured keytab and principal settings:\n%s", e.getMessage()));
+		}
 	}
-	
+
 	/**
 	 * transfter val to boolean
 	 */


### PR DESCRIPTION

In a case where GPDB cluster has 600 primary segments every gphdfs query will result in 600 AS_REQ sent to the KDC followed by 600 TGS_REQ for hdfs service credentials.  This is exponentially increased by the number of running queries.   This will cause intermittent failures due to KDC request timeouts as a result of the AS_REQ being sent.  
  To resolve this we need to create and manage the credential cache so GPDB segment will attempt to reuse TGT from cache and renew/reinit as needed. 