### PR TITLE
Support arrays of composite types

### DIFF
--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -2927,7 +2927,7 @@ get_element_type(Oid typid)
 /*
  * get_array_type
  *
- *		Given the type OID, get the corresponding "true"  array type.
+ *		Given the type OID, get the corresponding "true" array type.
  *		Returns InvalidOid if no array type can be found.
  *
  */

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -156,7 +156,7 @@ CATALOG(pg_type,1247) BKI_BOOTSTRAP
 	/*
 	 * If there is a "true" array type having this type as element type,
 	 *  typarray links to it.  Zero if no associated "true" array type.
-	 */ 	 	 
+	 */
 	Oid			typarray;
 
 	/*
@@ -788,7 +788,7 @@ extern Oid TypeCreateWithOid(const char *typeName,
 		   Oid typmodoutProcedure,
 		   Oid analyzeProcedure,
 		   Oid elementType,
- 		   bool isImplicitArray,
+		   bool isImplicitArray,
 		   Oid arrayType,
 		   Oid baseType,
 		   const char *defaultTypeValue,
@@ -811,8 +811,8 @@ extern void GenerateTypeDependencies(Oid typeNamespace,
 						 Oid outputProcedure,
 						 Oid receiveProcedure,
 						 Oid sendProcedure,
-		   				 Oid typmodinProcedure,
-		   				 Oid typmodoutProcedure,
+						 Oid typmodinProcedure,
+						 Oid typmodoutProcedure,
 						 Oid analyzeProcedure,
 						 Oid elementType,
 						 bool isImplicitArray,

--- a/src/include/commands/typecmds.h
+++ b/src/include/commands/typecmds.h
@@ -40,7 +40,7 @@ extern void AlterTypeOwnerInternal(Oid typeOid, Oid newOwnerId,
 extern void AlterTypeNamespace(List *names, const char *newschema);
 extern void AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 									   bool isImplicitArray,
-						  			   bool errorOnTableType);
+									   bool errorOnTableType);
 extern void AlterType(AlterTypeStmt *stmt);
 extern void AlterType(AlterTypeStmt *stmt);
 

--- a/src/test/regress/expected/information_schema.out
+++ b/src/test/regress/expected/information_schema.out
@@ -85,7 +85,7 @@ where ordinal_position = 20;
  pg_catalog         | pg_statistic         | stavalues3         |               20
  pg_catalog         | pg_partitions        | parenttablespace   |               20
  information_schema | attributes           | datetime_precision |               20
- pg_catalog         | pg_type              | typstorage			|               20
+ pg_catalog         | pg_type              | typstorage         |               20
  pg_catalog         | pg_proc              | proargnames        |               20
  pg_catalog         | pg_class             | reltriggers        |               20
  pg_catalog         | pg_am                | ambuild            |               20

--- a/src/test/regress/expected/information_schema_optimizer.out
+++ b/src/test/regress/expected/information_schema_optimizer.out
@@ -85,7 +85,7 @@ where ordinal_position = 20;
  pg_catalog         | pg_statistic         | stavalues3         |               20
  pg_catalog         | pg_partitions        | parenttablespace   |               20
  information_schema | attributes           | datetime_precision |               20
- pg_catalog         | pg_type              | typstorage			|               20
+ pg_catalog         | pg_type              | typstorage         |               20
  pg_catalog         | pg_proc              | proargnames        |               20
  pg_catalog         | pg_class             | reltriggers        |               20
  pg_catalog         | pg_am                | ambuild            |               20

--- a/src/test/regress/expected/oidjoins.out
+++ b/src/test/regress/expected/oidjoins.out
@@ -721,6 +721,14 @@ WHERE	typelem != 0 AND
 ------+---------
 (0 rows)
 
+SELECT  ctid, typarray
+FROM    pg_catalog.pg_type fk
+WHERE   typarray != 0 AND
+    NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type pk WHERE pk.oid = fk.typarray);
+ ctid | typarray
+------+----------
+(0 rows)
+
 SELECT	ctid, typinput 
 FROM	pg_catalog.pg_type fk 
 WHERE	typinput != 0 AND 

--- a/src/test/regress/expected/type_sanity.out
+++ b/src/test/regress/expected/type_sanity.out
@@ -117,6 +117,16 @@ ORDER BY 1;
   30 | oidvector  |  54 | oidvectorin
 (2 rows)
 
+-- Make sure typarray points to a varlena array type of our own base
+SELECT p1.oid, p1.typname as basetype, p2.typname as arraytype,
+       p2.typelem, p2.typlen
+FROM   pg_type p1 LEFT JOIN pg_type p2 ON (p1.typarray = p2.oid)
+WHERE  p1.typarray <> 0 AND
+       (p2.oid IS NULL OR p2.typelem <> p1.oid OR p2.typlen <> -1);
+ oid | basetype | arraytype | typelem | typlen
+-----+----------+-----------+---------+--------
+(0 rows)
+
 -- Check for bogus typoutput routines
 -- As of 8.0, this check finds refcursor, which is borrowing
 -- other types' I/O routines

--- a/src/test/regress/sql/oidjoins.sql
+++ b/src/test/regress/sql/oidjoins.sql
@@ -361,6 +361,10 @@ SELECT	ctid, typelem
 FROM	pg_catalog.pg_type fk 
 WHERE	typelem != 0 AND 
 	NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type pk WHERE pk.oid = fk.typelem);
+SELECT  ctid, typarray 
+FROM    pg_catalog.pg_type fk 
+WHERE   typarray != 0 AND 
+	NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type pk WHERE pk.oid = fk.typarray);
 SELECT	ctid, typinput 
 FROM	pg_catalog.pg_type fk 
 WHERE	typinput != 0 AND 

--- a/src/test/regress/sql/type_sanity.sql
+++ b/src/test/regress/sql/type_sanity.sql
@@ -94,6 +94,13 @@ WHERE p1.typinput = p2.oid AND p1.typtype in ('b', 'p') AND
     (p2.oid = 'array_in'::regproc)
 ORDER BY 1;
 
+-- Make sure typarray points to a varlena array type of our own base
+SELECT p1.oid, p1.typname as basetype, p2.typname as arraytype,
+       p2.typelem, p2.typlen
+FROM   pg_type p1 LEFT JOIN pg_type p2 ON (p1.typarray = p2.oid)
+WHERE  p1.typarray <> 0 AND
+       (p2.oid IS NULL OR p2.typelem <> p1.oid OR p2.typlen <> -1);
+
 -- Check for bogus typoutput routines
 
 -- As of 8.0, this check finds refcursor, which is borrowing


### PR DESCRIPTION
Backport from upstream with this commit:

    commit bc8036fc666a8f846b1d4b2f935af7edd90eb5aa
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Fri May 11 17:57:14 2007 +0000

        Support arrays of composite types, including the rowtypes of regular tables
        and views (but not system catalogs, nor sequences or toast tables).  Get rid
        of the hardwired convention that a type's array type is named exactly "_type",
        instead using a new column pg_type.typarray to provide the linkage.  (It still
        will be named "_type", though, except in odd corner cases such as
        maximum-length type names.)

        Along the way, make tracking of owner and schema dependencies for types more
        uniform: a type directly created by the user has these dependencies, while a
        table rowtype or auto-generated array type does not have them, but depends on
        its parent object instead.

        David Fetter, Andrew Dunstan, Tom Lane