### PR TITLE
Removing redundant recheck(re-evaluate bitmap qual) that happens in bitmap rescan for ao/aocs

### DIFF
--- a/src/backend/executor/execBitmapAOScan.c
+++ b/src/backend/executor/execBitmapAOScan.c
@@ -282,8 +282,16 @@ void
 BitmapAOScanReScan(ScanState *scanState)
 {
 	/*
+	 * AO doesn't need rechecking every tuple once it resolves
+	 * from the bitmap page, except when it deals with lossy
+	 * bitmap, which is handled via scanState->isLossyBitmapPage.
+	 */
+	BitmapTableScanState *node = (BitmapTableScanState *)(scanState);
+	node->recheckTuples = false;
+
+	/*
 	 * As per the existing implementation from nodeBitmapAppendOnlyScan.c
-	 * for rescanning of AO, we don't have anything specific
+	 * for rescanning of AO, we don't have anything else
 	 * to do here (the refactored BitmapTableScan takes care of everything).
 	 */
 }

--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -301,6 +301,19 @@ BitmapTableScanBeginPartition(ScanState *node, AttrNumber *attMap)
 	}
 
 	scanState->needNewBitmapPage = true;
+	/*
+	 * In some cases, the BitmapTableScan needs to re-evaluate the
+	 * bitmap qual. This is determined by the recheckTuples and
+	 * isLossyBitmapPage flags, as well as the type of table.
+	 * The appropriate type of BitmapIndexScan will set this flag
+	 * as follows:
+	 *  Table/Index Type  Lossy    Recheck
+	 *	Heap                1        1
+	 * 	Ao/Lossy            1        0
+	 *	Ao/Non-Lossy        0        0
+	 *	Aocs/Lossy          1        0
+	 *	Aocs/Non-Lossy      0        0
+	 */
 	scanState->recheckTuples = true;
 
 	getBitmapTableScanMethod(node->tableType)->beginScanMethod(node);

--- a/src/test/regress/expected/bitmapscan_ao.out
+++ b/src/test/regress/expected/bitmapscan_ao.out
@@ -1,0 +1,162 @@
+-- start-ignore
+drop schema if exists bm_ao cascade;
+NOTICE:  schema "bm_ao" does not exist, skipping
+create schema bm_ao;
+set search_path to bm_ao;
+-- end_ignore
+CREATE TABLE outer_table (
+    flex_value_id numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    language character varying(4) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_update_date date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_updated_by numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    creation_date date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    created_by numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_update_login numeric(10,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    description character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    source_lang character varying(4) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    flex_value_meaning character varying(150) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    legalhold character varying(5) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    legaldescription character varying(255) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    dataowner character varying(255) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    purgedate date ENCODING (compresstype=None,compresslevel=1,blocksize=32768)
+)
+WITH (appendonly=true, orientation=column, compresstype=None) DISTRIBUTED BY (flex_value_id);
+set allow_system_table_mods="DML";
+UPDATE pg_class
+SET
+	relpages = 1::int,
+	reltuples = 0.0::real
+WHERE relname = 'outer_table' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'ofa_applsys');
+UPDATE pg_class
+SET
+	relpages = 64::int,
+	reltuples = 61988.0::real
+WHERE relname = 'outer_table' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'applsys');
+CREATE TABLE inner_table (
+    flex_value_set_id numeric(10,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    flex_value_id numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    flex_value character varying(150) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_update_date date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_updated_by numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    creation_date date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    created_by numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_update_login numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    enabled_flag character varying(1) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    summary_flag character varying(1) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    start_date_active date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    end_date_active date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    parent_flex_value_low character varying(60) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    parent_flex_value_high character varying(60) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    structured_hierarchy_level numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    hierarchy_level character varying(30) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    compiled_value_attributes character varying(2000) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    value_category character varying(30) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute1 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute2 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute3 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute4 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute5 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute6 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute7 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute8 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute9 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute10 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute11 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute12 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute13 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute14 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute15 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute16 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute17 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute18 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute19 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute20 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute21 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute22 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute23 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute24 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute25 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute26 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute27 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute28 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute29 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute30 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute31 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute32 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute33 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute34 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute35 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute36 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute37 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute38 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute39 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute40 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute41 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute42 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute43 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute44 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute45 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute46 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute47 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute48 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute49 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute50 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute_sort_order numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    legalhold character varying(5) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    legaldescription character varying(255) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    dataowner character varying(255) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    purgedate date ENCODING (compresstype=None,compresslevel=1,blocksize=32768)
+)
+WITH (appendonly=true, orientation=column, compresstype=None) DISTRIBUTED BY (flex_value_set_id ,flex_value_id);
+CREATE INDEX inner_table_idx ON inner_table USING btree (flex_value_id);
+UPDATE pg_class
+SET
+	relpages = 64::int,
+	reltuples = 30994.0::real
+WHERE relname = 'inner_table' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'applsys');
+insert into outer_table values(12345,'ZHS');
+insert into outer_table values(012345,'ZHS');
+insert into inner_table values(54321,12345);
+insert into inner_table values(654321,123456);
+CREATE TABLE foo(fid numeric(10,0));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'fid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into foo VALUES(54321);
+-- start_ignore
+set optimizer_segments=64;
+set optimizer_enable_bitmapscan=on; 
+select disable_xform('CXformInnerJoin2HashJoin');
+            disable_xform             
+--------------------------------------
+ CXformInnerJoin2HashJoin is disabled
+(1 row)
+
+select disable_xform('CXformInnerJoin2IndexGetApply');
+               disable_xform               
+-------------------------------------------
+ CXformInnerJoin2IndexGetApply is disabled
+(1 row)
+
+-- end_ignore
+SELECT fid FROM
+(SELECT b1.flex_value_set_id, b1.flex_value_id
+FROM
+inner_table b1,
+outer_table c1
+WHERE
+b1.flex_value_id = c1.flex_value_id 
+and c1.language = 'ZHS') bar,
+foo
+WHERE foo.fid = bar.flex_value_set_id;
+  fid  
+-------
+ 54321
+ 54321
+(2 rows)
+
+-- start_ignore
+drop schema bm_ao cascade;
+NOTICE:  drop cascades to table foo
+NOTICE:  drop cascades to append only columnar table inner_table
+NOTICE:  drop cascades to append only columnar table outer_table
+-- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -16,7 +16,7 @@
 #
 
 ignore: leastsquares
-test: opr_sanity_gp decode_expr bitmapscan case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy
+test: opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy
 test: filter gpctas gpdist matrix toast sublink sirv_functions table_functions olap_setup
 
 test: dispatch

--- a/src/test/regress/sql/bitmapscan_ao.sql
+++ b/src/test/regress/sql/bitmapscan_ao.sql
@@ -1,0 +1,157 @@
+-- start-ignore
+
+drop schema if exists bm_ao cascade;
+create schema bm_ao;
+set search_path to bm_ao;
+
+-- end_ignore
+
+CREATE TABLE outer_table (
+    flex_value_id numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    language character varying(4) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_update_date date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_updated_by numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    creation_date date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    created_by numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_update_login numeric(10,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    description character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    source_lang character varying(4) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    flex_value_meaning character varying(150) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    legalhold character varying(5) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    legaldescription character varying(255) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    dataowner character varying(255) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    purgedate date ENCODING (compresstype=None,compresslevel=1,blocksize=32768)
+)
+WITH (appendonly=true, orientation=column, compresstype=None) DISTRIBUTED BY (flex_value_id);
+
+
+set allow_system_table_mods="DML";
+UPDATE pg_class
+SET
+	relpages = 1::int,
+	reltuples = 0.0::real
+WHERE relname = 'outer_table' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'ofa_applsys');
+UPDATE pg_class
+SET
+	relpages = 64::int,
+	reltuples = 61988.0::real
+WHERE relname = 'outer_table' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'applsys');
+
+CREATE TABLE inner_table (
+    flex_value_set_id numeric(10,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    flex_value_id numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    flex_value character varying(150) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_update_date date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_updated_by numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    creation_date date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    created_by numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    last_update_login numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    enabled_flag character varying(1) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    summary_flag character varying(1) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    start_date_active date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    end_date_active date ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    parent_flex_value_low character varying(60) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    parent_flex_value_high character varying(60) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    structured_hierarchy_level numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    hierarchy_level character varying(30) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    compiled_value_attributes character varying(2000) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    value_category character varying(30) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute1 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute2 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute3 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute4 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute5 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute6 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute7 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute8 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute9 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute10 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute11 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute12 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute13 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute14 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute15 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute16 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute17 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute18 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute19 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute20 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute21 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute22 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute23 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute24 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute25 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute26 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute27 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute28 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute29 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute30 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute31 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute32 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute33 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute34 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute35 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute36 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute37 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute38 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute39 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute40 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute41 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute42 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute43 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute44 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute45 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute46 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute47 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute48 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute49 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute50 character varying(240) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    attribute_sort_order numeric(15,0) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    legalhold character varying(5) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    legaldescription character varying(255) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    dataowner character varying(255) ENCODING (compresstype=None,compresslevel=1,blocksize=32768),
+    purgedate date ENCODING (compresstype=None,compresslevel=1,blocksize=32768)
+)
+WITH (appendonly=true, orientation=column, compresstype=None) DISTRIBUTED BY (flex_value_set_id ,flex_value_id);
+
+CREATE INDEX inner_table_idx ON inner_table USING btree (flex_value_id);
+UPDATE pg_class
+SET
+	relpages = 64::int,
+	reltuples = 30994.0::real
+WHERE relname = 'inner_table' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'applsys');
+
+
+insert into outer_table values(12345,'ZHS');
+insert into outer_table values(012345,'ZHS');
+insert into inner_table values(54321,12345);
+insert into inner_table values(654321,123456);
+
+CREATE TABLE foo(fid numeric(10,0));
+insert into foo VALUES(54321);
+
+-- start_ignore
+
+set optimizer_segments=64;
+set optimizer_enable_bitmapscan=on; 
+select disable_xform('CXformInnerJoin2HashJoin');
+select disable_xform('CXformInnerJoin2IndexGetApply');
+
+-- end_ignore
+
+
+SELECT fid FROM
+(SELECT b1.flex_value_set_id, b1.flex_value_id
+FROM
+inner_table b1,
+outer_table c1
+WHERE
+b1.flex_value_id = c1.flex_value_id 
+and c1.language = 'ZHS') bar,
+foo
+WHERE foo.fid = bar.flex_value_set_id;
+
+
+-- start_ignore
+drop schema bm_ao cascade;
+-- end_ignore


### PR DESCRIPTION
In some cases, the BitmapTableScan needs to re-evaluate the bitmap qual. This is determined by the recheckTuples and isLossyBitmapPage flags, as well as the type of table.
The appropriate type of BitmapIndexScan will set this flag  as follows:
	   Table/Index Type  Lossy    Recheck
	 	Heap                1        1
	  	Ao/Lossy            1        0
	 	Ao/Non-Lossy        0        0
	 	Aocs/Lossy          1        0
	 	Aocs/Non-Lossy      0        0

In this commit, we fix Ao / Aocs non-lossy to not recheck during rescan by resetting the flag to false.

@gcaragea @foyzur @armenatzoglou @hardikar Please take a look when you get chance
