### PR TITLE
cdbfast gist_indexes test migration to ICG [#116157035]

### DIFF
--- a/src/test/regress/expected/qp_gist_indexes3.out
+++ b/src/test/regress/expected/qp_gist_indexes3.out
@@ -1,0 +1,231 @@
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes3;
+set search_path to qp_gist_indexes3;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01CreateTable.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable3;
+NOTICE:  table "gisttable3" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable3(INTEGER);
+NOTICE:  function insertintogisttable3(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable3(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable3(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable3 (
+ id INTEGER,
+ property BOX,
+ poli POLYGON,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable3 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable3(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable3 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable3(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- ----------------------------------------------------------------------
+-- Test: test02Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable3(1, 2000);
+ insertmanyintogisttable3 
+--------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex3a ON GistTable3 USING GiST (property);
+CREATE INDEX GistIndex3b ON GistTable3 USING GiST (poli);
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable3(2001, 4000);
+ insertmanyintogisttable3 
+--------------------------
+ 
+(1 row)
+
+SELECT id, property AS "ProperTee" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test06VacuumFull.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Help test VACUUM and REINDEX with GiST indexes. 
+-- AUTHOR: mgilkey
+-- NOTES:
+--     1) We use start_ignore and end_ignore around the EXPLAIN plans.  We use 
+--        separate code look at whether the indexes were used by the 
+--        optimizer.
+-- end_ignore
+------------------------------------------------------------------------------
+-- Encourage the optimizer to use indexes rather than sequential table scans.
+SET enable_seqscan=False;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the coordinate values, not just the area,
+-- are the same.
+SELECT id, property AS "Property" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      Property       
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT id, property AS "Property" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.29..346.42 rows=5 width=36)
+   ->  Bitmap Heap Scan on gisttable3  (cost=100.29..346.42 rows=2 width=36)
+         Recheck Cond: property ~= '(999,999),(998,998)'::box
+         ->  Bitmap Index Scan on gistindex3a  (cost=0.00..100.29 rows=2 width=0)
+               Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+VACUUM ANALYZE GistTable3;
+SELECT id, property AS "ProperTee" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=36)
+   ->  Index Scan using gistindex3a on gisttable3  (cost=0.00..200.28 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test07Reindex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Help test VACUUM and REINDEX with GiST indexes. 
+-- AUTHOR: mgilkey
+-- NOTES:
+--     1) We use start_ignore and end_ignore around the EXPLAIN plans.  We use 
+--        separate code look at whether the indexes were used by the 
+--        optimizer.
+-- end_ignore
+------------------------------------------------------------------------------
+-- Encourage the optimizer to use indexes rather than sequential table scans.
+SET enable_seqscan=False;
+REINDEX INDEX GistIndex3a;
+REINDEX TABLE GistTable3;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the coordinate values, not just the area,
+-- are the same.
+SELECT id, property AS "Property" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      Property       
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT id, property AS "Property" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex3a on gisttable3  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes3 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable3(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable3(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to table gisttable3
+-- end_ignore

--- a/src/test/regress/expected/qp_gist_indexes4.out
+++ b/src/test/regress/expected/qp_gist_indexes4.out
@@ -1,0 +1,850 @@
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes4;
+set search_path to qp_gist_indexes4;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01_createConversionFunctions.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     These functions help convert TEXT data to geometric data types (box, 
+--     circle, and polygon).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS TO_CIRCLE(TEXT) CASCADE;
+NOTICE:  function to_circle(text) does not exist, skipping
+DROP FUNCTION IF EXISTS TO_POLY(TEXT) CASCADE;
+NOTICE:  function to_poly(text) does not exist, skipping
+-- end_ignore
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL
+  IMMUTABLE;
+CREATE FUNCTION TO_CIRCLE(TEXT) RETURNS CIRCLE AS
+  $$
+    SELECT circle_in(textout($1))
+  $$ LANGUAGE SQL
+  IMMUTABLE;
+CREATE FUNCTION TO_POLY(TEXT) RETURNS POLYGON AS
+  $$
+    SELECT poly_in(textout($1))
+  $$ LANGUAGE SQL
+  IMMUTABLE;
+-- ----------------------------------------------------------------------
+-- Test: test02_createSeedToMangledIntegerFunctions.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     These functions generate data that "jumps around a lot", i.e. 
+--         is not in ascending or descending order; 
+--         is reasonably, although nowhere near perfectly, dispersed;  
+--         and yet is non-volatile (given a specific input, they will always 
+--             return the same output) 
+--     The results are not very close to random, and in fact are "biased" 
+--     (unintentionally) to increase as the input seed value increases, but 
+--     they jump around enough to give an index operation some real work to 
+--     do, which wouldn't be the case if we simply generated an 
+--     ascending sequence like 1, 2, 3, ...
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP FUNCTION IF EXISTS SeedToMangledInteger(INTEGER, VARCHAR, VARCHAR);
+NOTICE:  function seedtomangledinteger(pg_catalog.int4,pg_catalog.varchar,pg_catalog.varchar) does not exist, skipping
+DROP FUNCTION IF EXISTS f1(INTEGER);
+NOTICE:  function f1(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS f2(INTEGER);
+NOTICE:  function f2(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS f3(INTEGER);
+NOTICE:  function f3(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS f4(INTEGER);
+NOTICE:  function f4(pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE FUNCTION SeedToMangledInteger(seed INTEGER, v1 VARCHAR, v2 VARCHAR) 
+RETURNS INTEGER
+AS
+$$
+-- Compose a number.
+DECLARE 
+    result INTEGER;
+    len1 INTEGER;
+    len2 INTEGER;
+    char1 CHAR(1);
+    char2 CHAR(1);
+    idx INTEGER;
+    firstDigits INTEGER;
+    lastDigits INTEGER;
+    res INTEGER;
+BEGIN
+    len1 = char_length(v1);
+    len2 = char_length(v2);
+    idx = seed % len1;
+    char1 = substring(v1 from idx for 1);
+    idx = seed % len2;
+    char2 = substring(v2 from idx for 1);
+    firstDigits = ascii(char1);
+    lastDigits = ascii(char2);
+    res = (firstDigits - 32) * 100 + (lastDigits - 32);
+    RETURN res;
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+CREATE FUNCTION f1(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'Oh I live in the mid-S.F. Bay, now a suburb of Northern L.A., which extends from the south Baja coast, to the point of the snows northernmost.';
+    string2 = ';lkwjeqroiuoiu2rThe-8Quick90uBrown4-89Fox43yJumpedt-19Over27theLazyt4f[g9yghDoghy3-948yrASDFnvcGHJn,oqKLPwqelBVNCMXZ;foqwfpoqiuwepfhgnvpown;ONZJNI&*(^$*(@#$@##OWEUR';
+    RETURN SeedToMangledInteger(seed, string1, string2);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+CREATE FUNCTION f2(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'And the mountains from which we can see are just piles of debris.';
+    string2 = ';lkwjeqroiuoiu2rThe-8Quick90uBrown4-89Fox43yJumpedt-19Over27theLazyt4f[g9yghDoghy3-948yrASDFnvcGHJn,oqKLPwqelBVNCMXZ;foqwfpoqiuwepfhgnvpown;ONZJNI&*(^$*(@#$@##OWEUR';
+    RETURN SeedToMangledInteger(seed, string1, string2);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- This one always returns a positive number.
+-- Use this one for the radius of a circle.
+CREATE FUNCTION f3(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'Oh I live in the mid-S.F. Bay, now a suburb of Northern L.A., which extends from the south Baja coast, to the point of the snows northernmost.';
+    string2 = 'rewqjL:KJkl;vzxc*)(_uoipnm,.7890fa@#$%sd4321n,m.7403-sdfoxc;,ew8vwer;oiuxcvlkqwer98vkpjn;lkqwer;ADOFIPUQWERLKNASDF [8QUREQFOI JQWRE8PRJ;GOVN;WEJRP98EURJNVM.ipigunvpjsdpry';
+    RETURN ABS(SeedToMangledInteger(seed, string1, string2));
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+CREATE FUNCTION f4(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'The mountains from which we oft preach, are generally far out of reach; the examples we set, we quickly regret; so we hide alone at the beach';
+    string2 = 'ChiangMaiBangkokMoscowPhiledelphiaColoradoFujiIcelandSaskatchwanManitobaVancouverAlbertaAustraliazenoGREECEisTHAWURDBritishColumbiaFrenchQuarter';
+    RETURN SeedToMangledInteger(seed, string1, string2);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- ----------------------------------------------------------------------
+-- Test: test03_createSeedToGeometricDataTypes.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     These functions generate geometric data types given an integer "seed" 
+--     value as a starting point.
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP FUNCTION IF EXISTS SeedToBoxAsText(INTEGER);
+NOTICE:  function seedtoboxastext(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS SeedToBox(INTEGER);
+NOTICE:  function seedtobox(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS SeedToCircle(INTEGER);
+NOTICE:  function seedtocircle(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS SeedToPolygon(INTEGER);
+NOTICE:  function seedtopolygon(pg_catalog.int4) does not exist, skipping
+-- end_ignore
+-- A box is defined by a pair of points.
+-- A box looks like:
+--    ( (x1, y1), (x2, y2) )
+CREATE FUNCTION SeedToBoxAsText(seed INTEGER) RETURNS TEXT
+AS
+$$
+DECLARE 
+    s TEXT;
+    x1 INTEGER;
+    y1 INTEGER;
+    x2 INTEGER;
+    y2 INTEGER;
+BEGIN
+   x1 = f1(seed);
+   y1 = f2(seed);
+   x2 = f3(seed);
+   y2 = f4(seed);
+   s = '((' || x1 || ', ' || y1 || '), (' || x2 || ', ' || y2 || '))';
+   RETURN s;
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- A box is defined by a pair of points.
+-- A box looks like:
+--    ( (x1, y1), (x2, y2) )
+CREATE FUNCTION SeedToBox(seed INTEGER) RETURNS BOX
+AS
+$$
+DECLARE 
+   s TEXT;
+BEGIN
+   s = SeedToBoxAsText(seed);
+   RETURN TO_BOX(s);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- A circle is defined by a center point and a radius.
+-- The radius should be a positive number.
+-- A circle looks like:
+--    ( (x1, y1), r )
+CREATE FUNCTION SeedToCircle(seed INTEGER) RETURNS CIRCLE
+AS
+$$
+DECLARE 
+    s TEXT;
+    x1 INTEGER;
+    y1 INTEGER;
+    r INTEGER;
+BEGIN
+   x1 = f1(seed);
+   y1 = f2(seed);
+   r  = f3(seed);
+   s = '((' || x1 || ', ' || y1 || '), ' || r || ')';
+   RETURN TO_CIRCLE(s);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- A polygon is defined by a sequence of points.
+-- A polygon looks like:
+--    ( (x1, y1), (x2, y2) [, ...] )
+-- To save time, we "cheat" and call the SeedToBoxAsText() function, 
+-- which returns a sequence of 2 points (as TEXT) and then convert that 
+-- to a POLYGON.
+CREATE FUNCTION SeedToPolygon(seed INTEGER) RETURNS POLYGON
+AS
+$$
+DECLARE
+   s TEXT;
+BEGIN
+   s = SeedToBoxAsText(seed);
+   RETURN TO_POLY(s);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- ----------------------------------------------------------------------
+-- Test: test04_createTableAndData.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS geometricTypes;
+NOTICE:  table "geometrictypes" does not exist, skipping
+-- end_ignore
+CREATE TABLE geometricTypes (seed INTEGER, c CIRCLE, b BOX, p POLYGON) 
+ DISTRIBUTED BY (seed);
+INSERT INTO geometricTypes (seed, c, b, p) 
+ SELECT x, 
+   SeedToCircle(x), 
+   SeedToBox(x), 
+   SeedToPolygon(x)
+  FROM generate_series(1, 300000)x
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test05_select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly.  Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = False;
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+ seed  |         c          |            b            |             p             
+-------+--------------------+-------------------------+---------------------------
+ 10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5262.64 rows=1 width=129)
+   ->  Seq Scan on geometrictypes  (cost=0.00..5262.64 rows=1 width=129)
+         Filter: c ~= '<(1255,7955),1227>'::circle
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5262.64 rows=1 width=129)
+   ->  Seq Scan on geometrictypes  (cost=0.00..5262.64 rows=1 width=129)
+         Filter: b ~= '(7352,7352),(7350,-3128)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5262.64 rows=1 width=129)
+   ->  Seq Scan on geometrictypes  (cost=0.00..5262.64 rows=1 width=129)
+         Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test06_createIndexes.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP INDEX IF EXISTS gt_index_c;
+NOTICE:  index "gt_index_c" does not exist, skipping
+DROP INDEX IF EXISTS gt_index_b;
+NOTICE:  index "gt_index_b" does not exist, skipping
+DROP INDEX IF EXISTS gt_index_p;
+NOTICE:  index "gt_index_p" does not exist, skipping
+-- end_ignore
+CREATE INDEX gt_index_c ON geometricTypes USING GIST (c);
+CREATE INDEX gt_index_b ON geometricTypes USING GIST (b);
+CREATE INDEX gt_index_p ON geometricTypes USING GIST (p);
+-- ----------------------------------------------------------------------
+-- Test: test07_select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly.  Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = False;
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+ seed  |         c          |            b            |             p             
+-------+--------------------+-------------------------+---------------------------
+ 10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.56 rows=1 width=129)
+   ->  Index Scan using gt_index_c on geometrictypes  (cost=0.00..200.56 rows=1 width=129)
+         Index Cond: c ~= '<(1255,7955),1227>'::circle
+         Filter: c ~= '<(1255,7955),1227>'::circle
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.56 rows=1 width=129)
+   ->  Index Scan using gt_index_b on geometrictypes  (cost=0.00..200.56 rows=1 width=129)
+         Index Cond: b ~= '(7352,7352),(7350,-3128)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.56 rows=1 width=129)
+   ->  Index Scan using gt_index_p on geometrictypes  (cost=0.00..200.56 rows=1 width=129)
+         Index Cond: p ~= '((4679,8579),(4670,-3232))'::polygon
+         Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test08_reindex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This can be run manually to give the user the option of 
+--     interrupting the REINDEX operation with ctrl-C or another kill method.
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+ALTER INDEX gt_index_c SET (FILLFACTOR = 20);
+ALTER INDEX gt_index_b SET (FILLFACTOR = 20);
+ALTER INDEX gt_index_p SET (FILLFACTOR = 20);
+REINDEX INDEX gt_index_c;
+REINDEX INDEX gt_index_b;
+REINDEX INDEX gt_index_p;
+ALTER INDEX gt_index_c SET (FILLFACTOR = 13);
+ALTER INDEX gt_index_b SET (FILLFACTOR = 13);
+ALTER INDEX gt_index_p SET (FILLFACTOR = 13);
+REINDEX TABLE geometricTypes; 
+-- ----------------------------------------------------------------------
+-- Test: test10_rollback.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This tests ROLLBACK on the following index-related operations
+--     with GiST indexes:
+--         CREATE INDEX
+--         REINDEX
+--         ALTER INDEX
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS gone;
+NOTICE:  table "gone" does not exist, skipping
+-- end_ignore
+CREATE TABLE gone (seed INTEGER, already_gone CIRCLE, too_far_gone BOX, 
+  paragon POLYGON)
+ DISTRIBUTED BY (seed);
+INSERT INTO gone (seed, already_gone, too_far_gone, paragon)
+ SELECT x, SeedToCircle(x), SeedToBox(x), SeedToPolygon(x)
+  FROM generate_series(1, 10000)x
+ ;
+ 
+SET enable_seqscan = False;
+-- Create an index; use the index; then roll back.
+BEGIN WORK;
+CREATE INDEX gone_around_the_bend ON gone USING GiST (already_gone);
+-- This should use the index that we just created.
+SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+ seed |    already_gone     |       too_far_gone       |          paragon           
+------+---------------------+--------------------------+----------------------------
+  857 | <(-3176,7824),3174> | (3174,7824),(-3176,7372) | ((-3176,7824),(3174,7372))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=129)
+   ->  Index Scan using gone_around_the_bend on gone  (cost=0.00..200.28 rows=1 width=129)
+         Index Cond: already_gone ~= '<(-3176,7824),3174>'::circle
+         Filter: already_gone ~= '<(-3176,7824),3174>'::circle
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+ROLLBACK WORK;
+-- Should not use the index, since we rolled back the statement that created 
+-- the index.
+SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+ seed |    already_gone     |       too_far_gone       |          paragon           
+------+---------------------+--------------------------+----------------------------
+  857 | <(-3176,7824),3174> | (3174,7824),(-3176,7372) | ((-3176,7824),(3174,7372))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..176.00 rows=1 width=129)
+   ->  Seq Scan on gone  (cost=0.00..176.00 rows=1 width=129)
+         Filter: already_gone ~= '<(-3176,7824),3174>'::circle
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+CREATE INDEX polly_gone ON gone USING GiST (paragon);
+BEGIN WORK;
+ALTER INDEX polly_gone RENAME TO polly_wanna_cracker;
+-- This should use the index, and the EXPLAIN should use the new name.
+SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  858 | <(7625,8425),7643> | (7643,8425),(7625,7849) | ((7625,8425),(7643,7849))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=129)
+   ->  Index Scan using polly_wanna_cracker on gone  (cost=0.00..200.28 rows=1 width=129)
+         Index Cond: paragon ~= '((7625,8425),(7643,7849))'::polygon
+         Filter: paragon ~= '((7625,8425),(7643,7849))'::polygon
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+ROLLBACK WORK;
+-- Explain should show the original name of the index.
+SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  858 | <(7625,8425),7643> | (7643,8425),(7625,7849) | ((7625,8425),(7643,7849))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=129)
+   ->  Index Scan using polly_gone on gone  (cost=0.00..200.28 rows=1 width=129)
+         Index Cond: paragon ~= '((7625,8425),(7643,7849))'::polygon
+         Filter: paragon ~= '((7625,8425),(7643,7849))'::polygon
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+CREATE INDEX box_of_rain ON gone USING GiST (too_far_gone) 
+ WITH (FILLFACTOR = 100);
+-- I'm not sure what should happen when we roll back a REINDEX operation.
+-- Let's try it and see.  ;-)  
+BEGIN WORK;
+REINDEX INDEX box_of_rain;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..200.28 rows=1 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+ROLLBACK WORK;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..200.28 rows=1 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+BEGIN WORK;
+ALTER INDEX box_of_rain SET (FILLFACTOR = 40);
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..200.28 rows=1 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+ROLLBACK WORK;
+BEGIN WORK;
+ALTER INDEX box_of_rain SET (FILLFACTOR = 40);
+REINDEX TABLE gone;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.29 rows=1 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..200.29 rows=1 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+ROLLBACK WORK;
+BEGIN WORK;
+ALTER INDEX box_of_rain RESET (FILLFACTOR);  -- Sets fillfactor back to 100??
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..200.28 rows=1 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+REINDEX TABLE gone;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..200.28 rows=1 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+ROLLBACK WORK;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.28 rows=1 width=129)
+   ->  Index Scan using box_of_rain on gone  (cost=0.00..200.28 rows=1 width=129)
+         Index Cond: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+DROP TABLE IF EXISTS gone;
+-- ----------------------------------------------------------------------
+-- Test: test09_select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly.  Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = False;
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+ seed  |         c          |            b            |             p             
+-------+--------------------+-------------------------+---------------------------
+ 10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..202.29 rows=1 width=129)
+   ->  Index Scan using gt_index_c on geometrictypes  (cost=0.00..202.29 rows=1 width=129)
+         Index Cond: c ~= '<(1255,7955),1227>'::circle
+         Filter: c ~= '<(1255,7955),1227>'::circle
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..202.21 rows=1 width=129)
+   ->  Index Scan using gt_index_b on geometrictypes  (cost=0.00..202.21 rows=1 width=129)
+         Index Cond: b ~= '(7352,7352),(7350,-3128)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..202.21 rows=1 width=129)
+   ->  Index Scan using gt_index_p on geometrictypes  (cost=0.00..202.21 rows=1 width=129)
+         Index Cond: p ~= '((4679,8579),(4670,-3232))'::polygon
+         Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test99_cleanup.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS geometricTypes;
+DROP FUNCTION IF EXISTS SeedToMangledInteger(INTEGER, VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS f1(INTEGER);
+DROP FUNCTION IF EXISTS f2(INTEGER);
+DROP FUNCTION IF EXISTS f3(INTEGER);
+DROP FUNCTION IF EXISTS f4(INTEGER);
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes4 cascade;
+NOTICE:  drop cascades to function seedtopolygon(integer)
+NOTICE:  drop cascades to function seedtocircle(integer)
+NOTICE:  drop cascades to function seedtobox(integer)
+NOTICE:  drop cascades to function seedtoboxastext(integer)
+NOTICE:  drop cascades to function to_poly(text)
+NOTICE:  drop cascades to function to_circle(text)
+NOTICE:  drop cascades to function to_box(text)
+-- end_ignore

--- a/src/test/regress/expected/qp_gist_indexes4_optimizer.out
+++ b/src/test/regress/expected/qp_gist_indexes4_optimizer.out
@@ -1,0 +1,843 @@
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes4;
+set search_path to qp_gist_indexes4;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01_createConversionFunctions.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     These functions help convert TEXT data to geometric data types (box, 
+--     circle, and polygon).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS TO_CIRCLE(TEXT) CASCADE;
+NOTICE:  function to_circle(text) does not exist, skipping
+DROP FUNCTION IF EXISTS TO_POLY(TEXT) CASCADE;
+NOTICE:  function to_poly(text) does not exist, skipping
+-- end_ignore
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL
+  IMMUTABLE;
+CREATE FUNCTION TO_CIRCLE(TEXT) RETURNS CIRCLE AS
+  $$
+    SELECT circle_in(textout($1))
+  $$ LANGUAGE SQL
+  IMMUTABLE;
+CREATE FUNCTION TO_POLY(TEXT) RETURNS POLYGON AS
+  $$
+    SELECT poly_in(textout($1))
+  $$ LANGUAGE SQL
+  IMMUTABLE;
+-- ----------------------------------------------------------------------
+-- Test: test02_createSeedToMangledIntegerFunctions.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     These functions generate data that "jumps around a lot", i.e. 
+--         is not in ascending or descending order; 
+--         is reasonably, although nowhere near perfectly, dispersed;  
+--         and yet is non-volatile (given a specific input, they will always 
+--             return the same output) 
+--     The results are not very close to random, and in fact are "biased" 
+--     (unintentionally) to increase as the input seed value increases, but 
+--     they jump around enough to give an index operation some real work to 
+--     do, which wouldn't be the case if we simply generated an 
+--     ascending sequence like 1, 2, 3, ...
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP FUNCTION IF EXISTS SeedToMangledInteger(INTEGER, VARCHAR, VARCHAR);
+NOTICE:  function seedtomangledinteger(pg_catalog.int4,pg_catalog.varchar,pg_catalog.varchar) does not exist, skipping
+DROP FUNCTION IF EXISTS f1(INTEGER);
+NOTICE:  function f1(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS f2(INTEGER);
+NOTICE:  function f2(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS f3(INTEGER);
+NOTICE:  function f3(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS f4(INTEGER);
+NOTICE:  function f4(pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE FUNCTION SeedToMangledInteger(seed INTEGER, v1 VARCHAR, v2 VARCHAR) 
+RETURNS INTEGER
+AS
+$$
+-- Compose a number.
+DECLARE 
+    result INTEGER;
+    len1 INTEGER;
+    len2 INTEGER;
+    char1 CHAR(1);
+    char2 CHAR(1);
+    idx INTEGER;
+    firstDigits INTEGER;
+    lastDigits INTEGER;
+    res INTEGER;
+BEGIN
+    len1 = char_length(v1);
+    len2 = char_length(v2);
+    idx = seed % len1;
+    char1 = substring(v1 from idx for 1);
+    idx = seed % len2;
+    char2 = substring(v2 from idx for 1);
+    firstDigits = ascii(char1);
+    lastDigits = ascii(char2);
+    res = (firstDigits - 32) * 100 + (lastDigits - 32);
+    RETURN res;
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+CREATE FUNCTION f1(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'Oh I live in the mid-S.F. Bay, now a suburb of Northern L.A., which extends from the south Baja coast, to the point of the snows northernmost.';
+    string2 = ';lkwjeqroiuoiu2rThe-8Quick90uBrown4-89Fox43yJumpedt-19Over27theLazyt4f[g9yghDoghy3-948yrASDFnvcGHJn,oqKLPwqelBVNCMXZ;foqwfpoqiuwepfhgnvpown;ONZJNI&*(^$*(@#$@##OWEUR';
+    RETURN SeedToMangledInteger(seed, string1, string2);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+CREATE FUNCTION f2(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'And the mountains from which we can see are just piles of debris.';
+    string2 = ';lkwjeqroiuoiu2rThe-8Quick90uBrown4-89Fox43yJumpedt-19Over27theLazyt4f[g9yghDoghy3-948yrASDFnvcGHJn,oqKLPwqelBVNCMXZ;foqwfpoqiuwepfhgnvpown;ONZJNI&*(^$*(@#$@##OWEUR';
+    RETURN SeedToMangledInteger(seed, string1, string2);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- This one always returns a positive number.
+-- Use this one for the radius of a circle.
+CREATE FUNCTION f3(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'Oh I live in the mid-S.F. Bay, now a suburb of Northern L.A., which extends from the south Baja coast, to the point of the snows northernmost.';
+    string2 = 'rewqjL:KJkl;vzxc*)(_uoipnm,.7890fa@#$%sd4321n,m.7403-sdfoxc;,ew8vwer;oiuxcvlkqwer98vkpjn;lkqwer;ADOFIPUQWERLKNASDF [8QUREQFOI JQWRE8PRJ;GOVN;WEJRP98EURJNVM.ipigunvpjsdpry';
+    RETURN ABS(SeedToMangledInteger(seed, string1, string2));
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+CREATE FUNCTION f4(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'The mountains from which we oft preach, are generally far out of reach; the examples we set, we quickly regret; so we hide alone at the beach';
+    string2 = 'ChiangMaiBangkokMoscowPhiledelphiaColoradoFujiIcelandSaskatchwanManitobaVancouverAlbertaAustraliazenoGREECEisTHAWURDBritishColumbiaFrenchQuarter';
+    RETURN SeedToMangledInteger(seed, string1, string2);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- ----------------------------------------------------------------------
+-- Test: test03_createSeedToGeometricDataTypes.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     These functions generate geometric data types given an integer "seed" 
+--     value as a starting point.
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP FUNCTION IF EXISTS SeedToBoxAsText(INTEGER);
+NOTICE:  function seedtoboxastext(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS SeedToBox(INTEGER);
+NOTICE:  function seedtobox(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS SeedToCircle(INTEGER);
+NOTICE:  function seedtocircle(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS SeedToPolygon(INTEGER);
+NOTICE:  function seedtopolygon(pg_catalog.int4) does not exist, skipping
+-- end_ignore
+-- A box is defined by a pair of points.
+-- A box looks like:
+--    ( (x1, y1), (x2, y2) )
+CREATE FUNCTION SeedToBoxAsText(seed INTEGER) RETURNS TEXT
+AS
+$$
+DECLARE 
+    s TEXT;
+    x1 INTEGER;
+    y1 INTEGER;
+    x2 INTEGER;
+    y2 INTEGER;
+BEGIN
+   x1 = f1(seed);
+   y1 = f2(seed);
+   x2 = f3(seed);
+   y2 = f4(seed);
+   s = '((' || x1 || ', ' || y1 || '), (' || x2 || ', ' || y2 || '))';
+   RETURN s;
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- A box is defined by a pair of points.
+-- A box looks like:
+--    ( (x1, y1), (x2, y2) )
+CREATE FUNCTION SeedToBox(seed INTEGER) RETURNS BOX
+AS
+$$
+DECLARE 
+   s TEXT;
+BEGIN
+   s = SeedToBoxAsText(seed);
+   RETURN TO_BOX(s);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- A circle is defined by a center point and a radius.
+-- The radius should be a positive number.
+-- A circle looks like:
+--    ( (x1, y1), r )
+CREATE FUNCTION SeedToCircle(seed INTEGER) RETURNS CIRCLE
+AS
+$$
+DECLARE 
+    s TEXT;
+    x1 INTEGER;
+    y1 INTEGER;
+    r INTEGER;
+BEGIN
+   x1 = f1(seed);
+   y1 = f2(seed);
+   r  = f3(seed);
+   s = '((' || x1 || ', ' || y1 || '), ' || r || ')';
+   RETURN TO_CIRCLE(s);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- A polygon is defined by a sequence of points.
+-- A polygon looks like:
+--    ( (x1, y1), (x2, y2) [, ...] )
+-- To save time, we "cheat" and call the SeedToBoxAsText() function, 
+-- which returns a sequence of 2 points (as TEXT) and then convert that 
+-- to a POLYGON.
+CREATE FUNCTION SeedToPolygon(seed INTEGER) RETURNS POLYGON
+AS
+$$
+DECLARE
+   s TEXT;
+BEGIN
+   s = SeedToBoxAsText(seed);
+   RETURN TO_POLY(s);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+-- ----------------------------------------------------------------------
+-- Test: test04_createTableAndData.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS geometricTypes;
+NOTICE:  table "geometrictypes" does not exist, skipping
+-- end_ignore
+CREATE TABLE geometricTypes (seed INTEGER, c CIRCLE, b BOX, p POLYGON) 
+ DISTRIBUTED BY (seed);
+INSERT INTO geometricTypes (seed, c, b, p) 
+ SELECT x, 
+   SeedToCircle(x), 
+   SeedToBox(x), 
+   SeedToPolygon(x)
+  FROM generate_series(1, 300000)x
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test05_select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly.  Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = False;
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+ seed  |         c          |            b            |             p             
+-------+--------------------+-------------------------+---------------------------
+ 10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+         Filter: c ~= '<(1255,7955),1227>'::circle
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+         Filter: b ~= '(7352,7352),(7350,-3128)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+         Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test06_createIndexes.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP INDEX IF EXISTS gt_index_c;
+NOTICE:  index "gt_index_c" does not exist, skipping
+DROP INDEX IF EXISTS gt_index_b;
+NOTICE:  index "gt_index_b" does not exist, skipping
+DROP INDEX IF EXISTS gt_index_p;
+NOTICE:  index "gt_index_p" does not exist, skipping
+-- end_ignore
+CREATE INDEX gt_index_c ON geometricTypes USING GIST (c);
+CREATE INDEX gt_index_b ON geometricTypes USING GIST (b);
+CREATE INDEX gt_index_p ON geometricTypes USING GIST (p);
+-- ----------------------------------------------------------------------
+-- Test: test07_select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly.  Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = False;
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+ seed  |         c          |            b            |             p             
+-------+--------------------+-------------------------+---------------------------
+ 10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+         Filter: c ~= '<(1255,7955),1227>'::circle
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+         Filter: b ~= '(7352,7352),(7350,-3128)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+         Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test08_reindex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This can be run manually to give the user the option of 
+--     interrupting the REINDEX operation with ctrl-C or another kill method.
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+ALTER INDEX gt_index_c SET (FILLFACTOR = 20);
+ALTER INDEX gt_index_b SET (FILLFACTOR = 20);
+ALTER INDEX gt_index_p SET (FILLFACTOR = 20);
+REINDEX INDEX gt_index_c;
+REINDEX INDEX gt_index_b;
+REINDEX INDEX gt_index_p;
+ALTER INDEX gt_index_c SET (FILLFACTOR = 13);
+ALTER INDEX gt_index_b SET (FILLFACTOR = 13);
+ALTER INDEX gt_index_p SET (FILLFACTOR = 13);
+REINDEX TABLE geometricTypes; 
+-- ----------------------------------------------------------------------
+-- Test: test10_rollback.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This tests ROLLBACK on the following index-related operations
+--     with GiST indexes:
+--         CREATE INDEX
+--         REINDEX
+--         ALTER INDEX
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS gone;
+NOTICE:  table "gone" does not exist, skipping
+-- end_ignore
+CREATE TABLE gone (seed INTEGER, already_gone CIRCLE, too_far_gone BOX, 
+  paragon POLYGON)
+ DISTRIBUTED BY (seed);
+INSERT INTO gone (seed, already_gone, too_far_gone, paragon)
+ SELECT x, SeedToCircle(x), SeedToBox(x), SeedToPolygon(x)
+  FROM generate_series(1, 10000)x
+ ;
+ 
+SET enable_seqscan = False;
+-- Create an index; use the index; then roll back.
+BEGIN WORK;
+CREATE INDEX gone_around_the_bend ON gone USING GiST (already_gone);
+-- This should use the index that we just created.
+SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+ seed |    already_gone     |       too_far_gone       |          paragon           
+------+---------------------+--------------------------+----------------------------
+  857 | <(-3176,7824),3174> | (3174,7824),(-3176,7372) | ((-3176,7824),(3174,7372))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: already_gone ~= '<(-3176,7824),3174>'::circle
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+ROLLBACK WORK;
+-- Should not use the index, since we rolled back the statement that created 
+-- the index.
+SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+ seed |    already_gone     |       too_far_gone       |          paragon           
+------+---------------------+--------------------------+----------------------------
+  857 | <(-3176,7824),3174> | (3174,7824),(-3176,7372) | ((-3176,7824),(3174,7372))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: already_gone ~= '<(-3176,7824),3174>'::circle
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+CREATE INDEX polly_gone ON gone USING GiST (paragon);
+BEGIN WORK;
+ALTER INDEX polly_gone RENAME TO polly_wanna_cracker;
+-- This should use the index, and the EXPLAIN should use the new name.
+SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  858 | <(7625,8425),7643> | (7643,8425),(7625,7849) | ((7625,8425),(7643,7849))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: paragon ~= '((7625,8425),(7643,7849))'::polygon
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+ROLLBACK WORK;
+-- Explain should show the original name of the index.
+SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  858 | <(7625,8425),7643> | (7643,8425),(7625,7849) | ((7625,8425),(7643,7849))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: paragon ~= '((7625,8425),(7643,7849))'::polygon
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+CREATE INDEX box_of_rain ON gone USING GiST (too_far_gone) 
+ WITH (FILLFACTOR = 100);
+-- I'm not sure what should happen when we roll back a REINDEX operation.
+-- Let's try it and see.  ;-)  
+BEGIN WORK;
+REINDEX INDEX box_of_rain;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+ROLLBACK WORK;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+BEGIN WORK;
+ALTER INDEX box_of_rain SET (FILLFACTOR = 40);
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+ROLLBACK WORK;
+BEGIN WORK;
+ALTER INDEX box_of_rain SET (FILLFACTOR = 40);
+REINDEX TABLE gone;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+ROLLBACK WORK;
+BEGIN WORK;
+ALTER INDEX box_of_rain RESET (FILLFACTOR);  -- Sets fillfactor back to 100??
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+REINDEX TABLE gone;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+ROLLBACK WORK;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ seed |    already_gone    |      too_far_gone       |          paragon          
+------+--------------------+-------------------------+---------------------------
+  859 | <(7338,6538),7342> | (7342,8385),(7338,6538) | ((7338,6538),(7342,8385))
+(1 row)
+
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.64 rows=4000 width=129)
+   ->  Table Scan on gone  (cost=0.00..431.72 rows=1334 width=129)
+         Filter: too_far_gone ~= '(7342,8385),(7338,6538)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+DROP TABLE IF EXISTS gone;
+-- ----------------------------------------------------------------------
+-- Test: test09_select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly.  Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = False;
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+ seed  |         c          |            b            |             p             
+-------+--------------------+-------------------------+---------------------------
+ 10001 | <(1255,7955),1227> | (1255,8445),(1227,7955) | ((1255,7955),(1227,8445))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+         Filter: c ~= '<(1255,7955),1227>'::circle
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 1001 | <(7352,7352),7350> | (7352,7352),(7350,-3128) | ((7352,7352),(7350,-3128))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+         Filter: b ~= '(7352,7352),(7350,-3128)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+ seed |         c          |            b             |             p              
+------+--------------------+--------------------------+----------------------------
+ 3456 | <(4679,8579),4670> | (4679,8579),(4670,-3232) | ((4679,8579),(4670,-3232))
+(1 row)
+
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.40 rows=120117 width=129)
+   ->  Table Scan on geometrictypes  (cost=0.00..452.65 rows=40039 width=129)
+         Filter: p ~= '((4679,8579),(4670,-3232))'::polygon
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test99_cleanup.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS geometricTypes;
+DROP FUNCTION IF EXISTS SeedToMangledInteger(INTEGER, VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS f1(INTEGER);
+DROP FUNCTION IF EXISTS f2(INTEGER);
+DROP FUNCTION IF EXISTS f3(INTEGER);
+DROP FUNCTION IF EXISTS f4(INTEGER);
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes4 cascade;
+NOTICE:  drop cascades to function seedtopolygon(integer)
+NOTICE:  drop cascades to function seedtocircle(integer)
+NOTICE:  drop cascades to function seedtobox(integer)
+NOTICE:  drop cascades to function seedtoboxastext(integer)
+NOTICE:  drop cascades to function to_poly(text)
+NOTICE:  drop cascades to function to_circle(text)
+NOTICE:  drop cascades to function to_box(text)
+-- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -89,6 +89,8 @@ test: qp_executor qp_olap_windowerr qp_olap_window qp_derived_table qp_bitmapsca
 
 test: qp_dpe qp_subquery qp_correlated_query qp_function
 
+test: qp_gist_indexes2 qp_gist_indexes3 qp_gist_indexes4
+
 ignore: tpch500GB_orca
 
 # XXX: This test depends on libgpoptudfs library, which includes ORCA helper

--- a/src/test/regress/input/qp_gist_indexes2.source
+++ b/src/test/regress/input/qp_gist_indexes2.source
@@ -1,0 +1,2621 @@
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ DISTRIBUTED BY (id);
+
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+
+
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+-- end_ignore
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+-- end_ignore
+
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+VACUUM GistTable13;
+
+ANALYZE GistTable13;
+
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+TRUNCATE TABLE GistTable13;
+
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+REINDEX INDEX propertyBoxIndex;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+DROP INDEX propertyBoxIndex;
+
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True, COMPRESSTYPE=ZLIB, COMPRESSLEVEL=1)
+ DISTRIBUTED BY (id);
+
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+
+
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+-- end_ignore
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+-- end_ignore
+
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+VACUUM GistTable13;
+
+ANALYZE GistTable13;
+
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+TRUNCATE TABLE GistTable13;
+
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+REINDEX INDEX propertyBoxIndex;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+DROP INDEX propertyBoxIndex;
+
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+-- end_ignore
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True)
+ DISTRIBUTED BY (id);
+
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+
+
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+-- end_ignore
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+-- end_ignore
+
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+VACUUM GistTable13;
+
+ANALYZE GistTable13;
+
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+TRUNCATE TABLE GistTable13;
+
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+REINDEX INDEX propertyBoxIndex;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+DROP INDEX propertyBoxIndex;
+
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+-- end_ignore
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True, ORIENTATION='column', COMPRESSTYPE=ZLIB, COMPRESSLEVEL=1)
+ DISTRIBUTED BY (id);
+
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+
+
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+-- end_ignore
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+-- end_ignore
+
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+VACUUM GistTable13;
+
+ANALYZE GistTable13;
+
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+TRUNCATE TABLE GistTable13;
+
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+REINDEX INDEX propertyBoxIndex;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+DROP INDEX propertyBoxIndex;
+
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+-- end_ignore
+
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True, ORIENTATION='column')
+ DISTRIBUTED BY (id);
+
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+-- end_ignore
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+
+
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+
+SET enable_seqscan = FALSE;
+
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+-- end_ignore
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+-- end_ignore
+
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+VACUUM GistTable13;
+
+ANALYZE GistTable13;
+
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+TRUNCATE TABLE GistTable13;
+
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+
+ANALYZE GistTable13;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+
+SET enable_seqscan = FALSE;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+REINDEX INDEX propertyBoxIndex;
+
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+DROP INDEX propertyBoxIndex;
+
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+-- end_ignore
+
+
+
+

--- a/src/test/regress/output/qp_gist_indexes2.source
+++ b/src/test/regress/output/qp_gist_indexes2.source
@@ -1,0 +1,3557 @@
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=47)
+   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..200.27 rows=1 width=47)
+         Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=47)
+   ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..200.27 rows=1 width=47)
+         Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 212
+ 100
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ A. Gent                     | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+ S. T. "Rip" Sunset          | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
+   Merge Key: "?column3?"
+   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+         Sort Key: id
+         ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..200.27 rows=1 width=51)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
+         Sort Key: id
+         ->  Index Scan using propertyisnullindex on gisttable1  (cost=0.00..200.27 rows=1 width=36)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.28 rows=1 width=4)
+         Sort Key: id
+         ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..200.27 rows=1 width=4)
+               Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.28 rows=1 width=4)
+         Sort Key: id
+         ->  Index Scan using propertyboxindex on gisttable1  (cost=0.00..200.27 rows=1 width=4)
+               Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.23..3.24 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=3.23..3.24 rows=1 width=4)
+         Sort Key: id
+         ->  Seq Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to table gisttable1
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True, COMPRESSTYPE=ZLIB, COMPRESSLEVEL=1)
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
+   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
+   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 100
+ 212
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ S. T. "Rip" Sunset          | 
+ A. Gent                     | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
+   Merge Key: "?column3?"
+   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=36)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.23..3.24 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=3.23..3.24 rows=1 width=4)
+         Sort Key: id
+         ->  Append-only Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only table gisttable1
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True)
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
+   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
+   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 212
+ 100
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ S. T. "Rip" Sunset          | 
+ A. Gent                     | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
+   Merge Key: "?column3?"
+   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=36)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+         Sort Key: id
+         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.23..3.24 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=3.23..3.24 rows=1 width=4)
+         Sort Key: id
+         ->  Append-only Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only table gisttable1
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True, ORIENTATION='column', COMPRESSTYPE=ZLIB, COMPRESSLEVEL=1)
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
+   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
+   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 100
+ 212
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ S. T. "Rip" Sunset          | 
+ A. Gent                     | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
+   Merge Key: "?column3?"
+   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=36)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.23..3.24 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=3.23..3.24 rows=1 width=4)
+         Sort Key: id
+         ->  Append-only Columnar Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only columnar table gisttable1
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True, ORIENTATION='column')
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
+   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
+   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
+         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
+         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+               Index Cond: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(7 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 212
+ 100
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ A. Gent                     | 
+ S. T. "Rip" Sunset          | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=51)
+   Merge Key: "?column3?"
+   ->  Sort  (cost=200.28..200.28 rows=1 width=51)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=36)
+               Recheck Cond: property IS NULL
+               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..200.27 rows=1 width=36)
+   ->  Index Scan using gistindex13 on gisttable13  (cost=0.00..200.27 rows=1 width=36)
+         Index Cond: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.29 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=200.28..200.29 rows=1 width=4)
+         Sort Key: id
+         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=4)
+               Recheck Cond: property ~= '(3,4),(1,2)'::box
+               ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
+                     Index Cond: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.23..3.24 rows=1 width=4)
+   Merge Key: id
+   ->  Sort  (cost=3.23..3.24 rows=1 width=4)
+         Sort Key: id
+         ->  Append-only Columnar Scan on gisttable1  (cost=0.00..3.23 rows=1 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only columnar table gisttable1
+-- end_ignore

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -1,0 +1,3529 @@
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'@abs_srcdir@/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 100
+ 212
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ A. Gent                     | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+ S. T. "Rip" Sunset          | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.00 rows=3 width=47)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+         Merge Key: id
+         ->  Result  (cost=0.00..431.00 rows=3 width=51)
+               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
+                     Sort Key: id
+                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
+                           Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(10 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
+               Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to table gisttable1
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True, COMPRESSTYPE=ZLIB, COMPRESSLEVEL=1)
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'/Users/oarap/gitdev/gpdb/src/test/regress/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 100
+ 212
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ S. T. "Rip" Sunset          | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+ A. Gent                     | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.00 rows=3 width=47)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+         Merge Key: id
+         ->  Result  (cost=0.00..431.00 rows=3 width=51)
+               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
+                     Sort Key: id
+                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
+                           Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(10 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
+               Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only table gisttable1
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True)
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'/Users/oarap/gitdev/gpdb/src/test/regress/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 212
+ 100
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ S. T. "Rip" Sunset          | 
+ A. Gent                     | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.00 rows=3 width=47)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+         Merge Key: id
+         ->  Result  (cost=0.00..431.00 rows=3 width=51)
+               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
+                     Sort Key: id
+                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
+                           Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(10 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
+               Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only table gisttable1
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True, ORIENTATION='column', COMPRESSTYPE=ZLIB, COMPRESSLEVEL=1)
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'/Users/oarap/gitdev/gpdb/src/test/regress/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 100
+ 212
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ S. T. "Rip" Sunset          | 
+ A. Gent                     | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.00 rows=3 width=47)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+         Merge Key: id
+         ->  Result  (cost=0.00..431.00 rows=3 width=51)
+               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
+                     Sort Key: id
+                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
+                           Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(10 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
+               Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only columnar table gisttable1
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_gist_indexes2;
+set search_path to qp_gist_indexes2;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test00DropTable.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable1;
+NOTICE:  table "gisttable1" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01create_table.sql
+-- ----------------------------------------------------------------------
+CREATE TABLE GistTable1 ( id INTEGER, owner VARCHAR, description VARCHAR, property BOX, poli POLYGON, bullseye CIRCLE, v VARCHAR, t TEXT, f FLOAT, p POINT, c CIRCLE, filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?'
+ )
+ WITH (APPENDONLY=True, ORIENTATION='column')
+ DISTRIBUTED BY (id);
+COPY GistTable1 FROM
+'/Users/oarap/gitdev/gpdb/src/test/regress/bugbuster/data/PropertyInfo.txt'
+ CSV
+ ;
+-- ----------------------------------------------------------------------
+-- Test: test03IndexScan.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+CREATE INDEX propertyBoxIndex ON GistTable1 USING Gist (property);
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (66, 'Miller', 'Lubbock or leave it', '((3, 1300), (33, 1330))',
+   '( (66,660), (67, 650), (68, 660) )', '( (66, 66), 66)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= '((7052,250),(6050,20))';
+  owner  |       property       
+---------+----------------------
+ Hypatia | (7052,250),(6050,20)
+  Patty  | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1 
+ WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+  owner  |       property       
+---------+----------------------
+  Patty  | (7052,250),(6050,20)
+ Hypatia | (7052,250),(6050,20)
+(2 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT owner, property FROM GistTable1
+ WHERE property ~= '( (6050, 20), (7052, 250) )';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
+         Filter: property ~= '(7052,250),(6050,20)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- end_ignore
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id;
+ id | property 
+----+----------
+  8 | 
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04Insert.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Insert more data.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- INSERT some more data.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (76, 'James McMurtry', 'Levelland', '((1500, 1500), (1700, 1900))', 
+   '( (76, 77), (76, 75), (75, 77) )', '( (76, 76), 76)' );
+-- ----------------------------------------------------------------------
+-- Test: test05Select.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id, owner, description, property, poli, bullseye FROM GistTable1
+ WHERE property IS NOT NULL
+ ORDER BY id;
+ id |              owner              |               description               |                  property                   |             poli             |   bullseye   
+----+---------------------------------+-----------------------------------------+---------------------------------------------+------------------------------+--------------
+  1 | Snidely Whiplash                |  an empire dreamt of but as yet unbuilt | (1,1),(0,0)                                 | ((0,0),(1,1),(2,2),(3,3))    | <(0,0),0>
+  2 | Theodore Turner                 |  a ranch and reserve                    | (2100,2100),(2000,2000)                     | ((1,1),(2,1),(1,2))          | <(2,2),2>
+  3 | Theodore Roosevelt              |  overlooks Yellowstone River            | (1801,2201),(1800,2200)                     | ((3,3),(3,4),(4,3))          | <(3,3),3>
+  4 | Donald Duck                     |  overlooks Colorado River               | (1001,1001),(1000,1000)                     | ((4,4),(4,5),(5,4),(5,5))    | <(4,4),4>
+  5 | Roger Rabbit                    |  Toon Town, unit 127                    | (-999999,-100000),(-1000000,-999999)        | ((5,-1),(5,-2),(5,-5))       | <(5,5),5>
+  6 | James T. Kirk                   |  Utopia Planetia                        | (123456790,123456790),(123456789,123456789) | ((6,7),(6,5),(5,7))          | <(6,6),6>
+  7 | Albus Dumbledore                |  Hogwarts                               | (-11999990,-11999990),(-12000000,-12000000) | ((7,7),(7,8),(6,7))          | <(7,7),7>
+  9 | Hyquotia P. Cucumber            | Radical Vegan Farms                     | (42,25),(40,20)                             | ((9,9),(9,8),(8,10))         | <(9,9),9>
+ 10 | Junipero Serra                  | California                              | (200,1000),(0,0)                            | ((10,10),(10,9),(8,11))      | <(10,10),10>
+ 18 | K. Serra                        | California                              | (200,1000),(0,0)                            | ((18,18),(18,19),(17,19))    | <(18,18),18>
+ 19 | Kay Serra                       | California                              | (200,1000),(0,0)                            | ((19,19),(19,18),(20,19))    | <(19,19),19>
+ 38 | Que Sera                        | California                              | (200,1000),(0,0)                            | ((38,38),(38,39),(37,38))    | <(38,38),38>
+ 59 | Hypatia                         | Greece                                  | (7052,250),(6050,20)                        | ((59,59),(59,60),(60,59))    | <(59,59),59>
+ 66 | Miller                          | Lubbock or leave it                     | (33,1330),(3,1300)                          | ((66,660),(67,650),(68,660)) | <(66,66),66>
+ 70 |  Patty                          |  Cake                                   | (7052,250),(6050,20)                        | ((70,70),(70,60),(60,70))    | <(70,70),70>
+ 76 | James McMurtry                  | Levelland                               | (1700,1900),(1500,1500)                     | ((76,77),(76,75),(75,77))    | <(76,76),76>
+ 80 |  Leading space man              |  Leading space woman                    | (3,4),(1,2)                                 | ((80,80),(80,79),(79,80))    | <(80,80),80>
+ 81 | Trailing space man              | trailing space woman                    | (3,4),(1,2)                                 | ((81,81),(81,80),(80,81))    | <(81,81),81>
+ 82 |   Leading and trailing spaces   |   leading and trailing spaces           | (3,4),(1,2)                                 | ((82,82),(82,80),(80,82))    | <(82,82),82>
+(19 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08UniqueAndPKey.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test UNIQUE indexes and primary keys on geometric data types.  
+--     It turns out that columns with the geometric data types (at least 
+--     box, polygon, and circle, and probably any others) can't be part of 
+--     a distribution key.  And since Greenplum allows unique indexes only on 
+--     columns that are part of the distribution key, GiST indexes cannot 
+--     be unique.  And of course since primary keys rely on unique indexes, 
+--     if we can't have unique GiST indexes, then we can't have primary 
+--     keys on geometric data types.  So this script is basically a negative 
+--     test that verifies that we get reasonable error messages when we try 
+--     to create unique GiST indexes or pimary keys on gemoetric data types.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- Test whether geometric types can be part of a primary key.
+CREATE TABLE GistTable2 (id INTEGER, property BOX)
+ DISTRIBUTED BY (property);
+ERROR:  type "box" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, poli POLYGON)
+ DISTRIBUTED BY (poli);
+ERROR:  type "polygon" can't be a part of a distribution key
+CREATE TABLE GistTable2 (id INTEGER, bullseye CIRCLE)
+ DISTRIBUTED BY (bullseye);
+ERROR:  type "circle" can't be a part of a distribution key
+-- start_ignore
+DROP TABLE IF EXISTS GistTable2;
+NOTICE:  table "gisttable2" does not exist, skipping
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test09NegativeTests.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     "Negative" tests.  Verify that we get reasonable error messages when 
+--     we try to do unreasonable things, such as create indexes on types that 
+--     do not support GiST (non-geometric types).
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Try to create GiST indexes on non-geometric data types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (id);
+ERROR:  data type integer has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (v);
+ERROR:  data type character varying has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (t);
+ERROR:  data type text has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (p);
+ERROR:  data type point has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- Try to create GiST indexes on a mix of geometric and 
+-- non-geometric types.
+CREATE INDEX ShouldNotExist ON GistTable1 USING GiST (c, f);
+ERROR:  data type double precision has no default operator class for access method "gist"
+HINT:  You must specify an operator class for the index or define a default operator class for the data type.
+-- ----------------------------------------------------------------------
+-- Test: test10MultipleColumns.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: 
+--     Test multi-column indexes.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+-- Insert 2 more records, but insert them with the same value for BULLSEYE.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (212, 'Fahrenheit', 'Slightly north of Hades', '( (212, 212), (32, 32) )', '( (212, 212), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye) 
+ VALUES (100, 'Celsius', 'Barely north of Hades', '( (100, 100), (0, 0) )', '( (100, 100), (600, 600), (70, 70) )', '( (100,100), 212 )' );
+-- This should create an index that has duplicate entries for at least one 
+--  value of bullseye.
+CREATE INDEX i2 ON GistTable1 USING GIST(bullseye);
+CREATE INDEX i3 ON GistTable1 USING GIST(poli, bullseye);
+-- This should return 2 rows.
+SELECT id FROM GistTable1
+ WHERE bullseye ~= '( (100,100), 212 )';
+ id  
+-----
+ 100
+ 212
+(2 rows)
+
+-- This should return 1 row.
+SELECT id FROM GistTable1
+ WHERE property ~= '( (212, 212), (32, 32) )';
+ id  
+-----
+ 212
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test11WherePredicate.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Test GiST indexes with the WHERE predicate in the CREATE INDEX 
+--     statement.  This does some simple queries that should use the index.  
+--     We can't see directly whether the index was used, but for each query 
+--     we can run "EXPLAIN" and see whether the query used the index.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+-- Add another record that has NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (77, 'S. T. "Rip" Sunset', 'Lost Vegas',NULL,
+   '( (77, 77), (76, 78), (78, 76) )', '( (77, 77), 77)' );
+CREATE INDEX propertyIsNullIndex ON GistTable1 USING Gist (property)
+ WHERE property IS NULL;
+-- Add two more records that have NULL in the property field.
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (86, 'A. Gent', 'Washingtoon D.C.',NULL,
+   '( (86, 86), (85, 87), (87, 85) )', '( (86, 86), 86)' );
+INSERT INTO GistTable1 (id, owner, description, property, poli, bullseye)
+ VALUES (99, 'FelDon Adams', 'Washingtoon D.C.',NULL,
+   '( (99, 99), (97, 98), (98, 97) )', '( (99, 99), 99)' );
+SET enable_seqscan = FALSE;
+-- We should be able to search the column that uses a geometric data type, 
+-- and of course we should find the right rows.  We should be able to search 
+-- using different "formats" (e.g. spacing) of the data, and in some cases 
+-- even different "order" of the data (if the data is converted to a 
+-- canonical form, as it is for the BOX data type and perhaps some other 
+-- data types), as long as data in all of those formats should be converted 
+-- to the same internal representation.
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL;
+            owner            | property 
+-----------------------------+----------
+ S. T. "Rip" Sunset          | 
+ A. Gent                     | 
+ Neil, Nell, and Noel Newall | 
+ FelDon Adams                | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN 
+SELECT owner, property FROM GistTable1 
+ WHERE property IS NULL
+ ORDER BY id
+ ;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.00 rows=3 width=47)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
+         Merge Key: id
+         ->  Result  (cost=0.00..431.00 rows=3 width=51)
+               ->  Sort  (cost=0.00..431.00 rows=3 width=51)
+                     Sort Key: id
+                     ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=51)
+                           Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(10 rows)
+
+-- end_ignore
+-- Alter the table and see if we get the same results.
+ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+ id | property 
+----+----------
+  8 | 
+ 77 | 
+ 86 | 
+ 99 | 
+(4 rows)
+
+-- start_ignore
+EXPLAIN
+SELECT id, property FROM GistTable1 
+ WHERE property IS NULL 
+ ORDER BY id
+ ;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
+               Filter: property IS NULL
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test13Vacuum.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+NOTICE:  table "gisttable13" does not exist, skipping
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+NOTICE:  function to_box(text) does not exist, skipping
+DROP FUNCTION IF EXISTS insertIntoGistTable13(INTEGER);
+NOTICE:  function insertintogisttable13(pg_catalog.int4) does not exist, skipping
+DROP FUNCTION IF EXISTS insertManyIntoGistTable13(INTEGER, INTEGER);
+NOTICE:  function insertmanyintogisttable13(pg_catalog.int4,pg_catalog.int4) does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable13 (
+ id INTEGER,
+ property BOX,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+CREATE FUNCTION insertIntoGistTable13 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable13(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+CREATE FUNCTION insertManyIntoGistTable13 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable13(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+-- Create the index.
+CREATE INDEX GistIndex13 ON GistTable13 USING GiST (property);
+SET enable_seqscan = FALSE;
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable13(1001, 2000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values (coordinates), not just the 
+-- AREA, are the same.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+VACUUM GistTable13;
+ANALYZE GistTable13;
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.31 rows=800 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.20 rows=267 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+TRUNCATE TABLE GistTable13;
+-- Add some rows.
+SELECT insertManyIntoGistTable13(1, 1000);
+ insertmanyintogisttable13 
+---------------------------
+ 
+(1 row)
+
+ANALYZE GistTable13;
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the values are the same, not just the 
+-- same AREA.
+SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+ id  |      ProperTee      
+-----+---------------------
+ 999 | (999,999),(998,998)
+(1 row)
+
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable13 
+ WHERE property ~= '( (999,999), (998,998) )';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=400 width=36)
+   ->  Table Scan on gisttable13  (cost=0.00..431.10 rows=134 width=36)
+         Filter: property ~= '(999,999),(998,998)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable13;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test14Hash.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test that you get a reasonable error message when you try to create a 
+--     HASH index (we no longer support those).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+NOTICE:  table "gisttable14" does not exist, skipping
+-- end_ignore
+CREATE TABLE GistTable14 (
+ id INTEGER,
+ property BOX
+ )
+ DISTRIBUTED BY (id);
+-- Try to create a hash index.
+CREATE INDEX GistIndex14a ON GistTable14 USING HASH (id);
+ERROR:  hash indexes are not supported
+CREATE INDEX GistIndex14b ON GistTable14 USING HASH (property);
+ERROR:  hash indexes are not supported
+-- start_ignore
+DROP TABLE IF EXISTS GistTable14;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test15ReindexDropIndex.sql
+-- ----------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Sanity test GiST indexes.
+--     REINDEX
+--     DROP INDEX
+-- AUTHOR: mgilkey
+-- NOTES:
+--     Although we seemingly ignore the output of the EXPLAIN statements, 
+--     elsewhere in this test we look for "Index Scan on propertyBoxIndex" 
+--     or something similar in order to verify that the index was used.
+-- LAST MODIFIED:
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+REINDEX INDEX propertyBoxIndex;
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+DROP INDEX propertyBoxIndex;
+-- Obviously, this shouldn't use the index now that the index is gone.
+SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+ id 
+----
+ 80
+ 81
+ 82
+(3 rows)
+
+-- start_ignore
+EXPLAIN SELECT id FROM GistTable1 
+ WHERE property ~= '( (1,2), (3,4) )'
+ ORDER BY id;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=4)
+   Merge Key: id
+   ->  Sort  (cost=0.00..431.00 rows=3 width=4)
+         Sort Key: id
+         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=4)
+               Filter: property ~= '(3,4),(1,2)'::box
+ Settings:  enable_seqscan=off; optimizer=on
+ Optimizer status: PQO version 1.624
+(8 rows)
+
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_gist_indexes2 cascade;
+NOTICE:  drop cascades to function insertmanyintogisttable13(integer,integer)
+NOTICE:  drop cascades to function insertintogisttable13(integer)
+NOTICE:  drop cascades to function to_box(text)
+NOTICE:  drop cascades to append only columnar table gisttable1
+-- end_ignore

--- a/src/test/regress/sql/qp_gist_indexes3.sql
+++ b/src/test/regress/sql/qp_gist_indexes3.sql
@@ -1,0 +1,195 @@
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_gist_indexes3;
+set search_path to qp_gist_indexes3;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: test01CreateTable.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS GistTable3;
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+DROP FUNCTION IF EXISTS insertIntoGistTable3(INTEGER);
+DROP FUNCTION IF EXISTS insertManyIntoGistTable3(INTEGER, INTEGER);
+-- end_ignore
+
+CREATE TABLE GistTable3 (
+ id INTEGER,
+ property BOX,
+ poli POLYGON,
+ filler VARCHAR DEFAULT 'This is here just to take up space so that we use more pages of data and sequential scans take a lot more time.  Stones tinheads and mixers coming; we did it all on our own; this summer I hear the crunching; 11 dead in Ohio. Got right down to it; we were cutting us down; could have had fun but, no; left them face down dead on the ground.  How can you listen when you know?' 
+ )
+ DISTRIBUTED BY (id);
+
+-- Register a function that converts TEXT to BOX data type.
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL;
+
+CREATE FUNCTION insertIntoGistTable3 (seed INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   str1 VARCHAR;
+   ss VARCHAR;
+   s2 VARCHAR;
+BEGIN
+   ss = CAST(seed AS VARCHAR);
+   s2 = CAST((seed - 1) AS VARCHAR);
+   str1 = '((' || ss || ', ' || ss || '), (' || s2 || ', ' || s2 || '))';
+   INSERT INTO GistTable3(id, property) VALUES (seed, TO_BOX(CAST(str1 AS TEXT)) );
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+CREATE FUNCTION insertManyIntoGistTable3 (startValue INTEGER, endValue INTEGER) RETURNS VOID
+AS
+$$
+DECLARE 
+   i INTEGER;
+BEGIN
+   i = startValue;
+   WHILE i <= endValue LOOP
+       PERFORM insertIntoGistTable3(i);
+       i = i + 1;
+   END LOOP;
+END;
+$$
+LANGUAGE PLPGSQL
+;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test02Insert.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- COPYRIGHT (c) 2010, Greenplum, Inc.  All rights reserved.  
+-- PURPOSE:
+--     Test VACUUM on GiST indexes.
+--     Also test somewhat larger data sets than most of my other GiST index 
+--     tests.
+-- AUTHOR: mgilkey
+-- LAST MODIFIED:
+--     2010-04-20 mgilkey
+--         This test suite is for AO (Append-Only) and CO (Column-Oriented) 
+--         tables as well as heap tables, so I removed statement(s) such as 
+--         DELETE that can't be executed on AO and CO tables.
+-- end_ignore
+------------------------------------------------------------------------------
+
+
+-- Add some rows before we create the index.
+SELECT insertManyIntoGistTable3(1, 2000);
+
+-- Create the index.
+CREATE INDEX GistIndex3a ON GistTable3 USING GiST (property);
+CREATE INDEX GistIndex3b ON GistTable3 USING GiST (poli);
+
+-- Add more rows after we create the index.
+SELECT insertManyIntoGistTable3(2001, 4000);
+
+SELECT id, property AS "ProperTee" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+
+
+-- ----------------------------------------------------------------------
+-- Test: test06VacuumFull.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Help test VACUUM and REINDEX with GiST indexes. 
+-- AUTHOR: mgilkey
+-- NOTES:
+--     1) We use start_ignore and end_ignore around the EXPLAIN plans.  We use 
+--        separate code look at whether the indexes were used by the 
+--        optimizer.
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Encourage the optimizer to use indexes rather than sequential table scans.
+SET enable_seqscan=False;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the coordinate values, not just the area,
+-- are the same.
+SELECT id, property AS "Property" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+-- start_ignore
+EXPLAIN SELECT id, property AS "Property" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+-- end_ignore
+
+VACUUM ANALYZE GistTable3;
+
+SELECT id, property AS "ProperTee" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+-- start_ignore
+EXPLAIN SELECT id, property AS "ProperTee" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: test07Reindex.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE: Help test VACUUM and REINDEX with GiST indexes. 
+-- AUTHOR: mgilkey
+-- NOTES:
+--     1) We use start_ignore and end_ignore around the EXPLAIN plans.  We use 
+--        separate code look at whether the indexes were used by the 
+--        optimizer.
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- Encourage the optimizer to use indexes rather than sequential table scans.
+SET enable_seqscan=False;
+
+REINDEX INDEX GistIndex3a;
+REINDEX TABLE GistTable3;
+
+-- Note that "=" for geometric data types means equal AREA, NOT COORDINATES.
+-- The "~=" operator means that the coordinate values, not just the area,
+-- are the same.
+SELECT id, property AS "Property" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+-- start_ignore
+EXPLAIN SELECT id, property AS "Property" FROM GistTable3
+ WHERE property ~= '( (999,999), (998,998) )';
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_gist_indexes3 cascade;
+-- end_ignore

--- a/src/test/regress/sql/qp_gist_indexes4.sql
+++ b/src/test/regress/sql/qp_gist_indexes4.sql
@@ -1,0 +1,637 @@
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_gist_indexes4;
+set search_path to qp_gist_indexes4;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: test01_createConversionFunctions.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     These functions help convert TEXT data to geometric data types (box, 
+--     circle, and polygon).
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP FUNCTION IF EXISTS TO_BOX(TEXT) CASCADE;
+DROP FUNCTION IF EXISTS TO_CIRCLE(TEXT) CASCADE;
+DROP FUNCTION IF EXISTS TO_POLY(TEXT) CASCADE;
+-- end_ignore
+
+
+CREATE FUNCTION TO_BOX(TEXT) RETURNS BOX AS
+  $$
+    SELECT box_in(textout($1))
+  $$ LANGUAGE SQL
+  IMMUTABLE;
+
+CREATE FUNCTION TO_CIRCLE(TEXT) RETURNS CIRCLE AS
+  $$
+    SELECT circle_in(textout($1))
+  $$ LANGUAGE SQL
+  IMMUTABLE;
+
+CREATE FUNCTION TO_POLY(TEXT) RETURNS POLYGON AS
+  $$
+    SELECT poly_in(textout($1))
+  $$ LANGUAGE SQL
+  IMMUTABLE;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test02_createSeedToMangledIntegerFunctions.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     These functions generate data that "jumps around a lot", i.e. 
+--         is not in ascending or descending order; 
+--         is reasonably, although nowhere near perfectly, dispersed;  
+--         and yet is non-volatile (given a specific input, they will always 
+--             return the same output) 
+--     The results are not very close to random, and in fact are "biased" 
+--     (unintentionally) to increase as the input seed value increases, but 
+--     they jump around enough to give an index operation some real work to 
+--     do, which wouldn't be the case if we simply generated an 
+--     ascending sequence like 1, 2, 3, ...
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP FUNCTION IF EXISTS SeedToMangledInteger(INTEGER, VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS f1(INTEGER);
+DROP FUNCTION IF EXISTS f2(INTEGER);
+DROP FUNCTION IF EXISTS f3(INTEGER);
+DROP FUNCTION IF EXISTS f4(INTEGER);
+-- end_ignore
+
+
+CREATE FUNCTION SeedToMangledInteger(seed INTEGER, v1 VARCHAR, v2 VARCHAR) 
+RETURNS INTEGER
+AS
+$$
+-- Compose a number.
+DECLARE 
+    result INTEGER;
+    len1 INTEGER;
+    len2 INTEGER;
+    char1 CHAR(1);
+    char2 CHAR(1);
+    idx INTEGER;
+    firstDigits INTEGER;
+    lastDigits INTEGER;
+    res INTEGER;
+BEGIN
+    len1 = char_length(v1);
+    len2 = char_length(v2);
+    idx = seed % len1;
+    char1 = substring(v1 from idx for 1);
+    idx = seed % len2;
+    char2 = substring(v2 from idx for 1);
+    firstDigits = ascii(char1);
+    lastDigits = ascii(char2);
+    res = (firstDigits - 32) * 100 + (lastDigits - 32);
+    RETURN res;
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+
+CREATE FUNCTION f1(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'Oh I live in the mid-S.F. Bay, now a suburb of Northern L.A., which extends from the south Baja coast, to the point of the snows northernmost.';
+    string2 = ';lkwjeqroiuoiu2rThe-8Quick90uBrown4-89Fox43yJumpedt-19Over27theLazyt4f[g9yghDoghy3-948yrASDFnvcGHJn,oqKLPwqelBVNCMXZ;foqwfpoqiuwepfhgnvpown;ONZJNI&*(^$*(@#$@##OWEUR';
+    RETURN SeedToMangledInteger(seed, string1, string2);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+
+CREATE FUNCTION f2(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'And the mountains from which we can see are just piles of debris.';
+    string2 = ';lkwjeqroiuoiu2rThe-8Quick90uBrown4-89Fox43yJumpedt-19Over27theLazyt4f[g9yghDoghy3-948yrASDFnvcGHJn,oqKLPwqelBVNCMXZ;foqwfpoqiuwepfhgnvpown;ONZJNI&*(^$*(@#$@##OWEUR';
+    RETURN SeedToMangledInteger(seed, string1, string2);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+
+
+-- This one always returns a positive number.
+-- Use this one for the radius of a circle.
+CREATE FUNCTION f3(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'Oh I live in the mid-S.F. Bay, now a suburb of Northern L.A., which extends from the south Baja coast, to the point of the snows northernmost.';
+    string2 = 'rewqjL:KJkl;vzxc*)(_uoipnm,.7890fa@#$%sd4321n,m.7403-sdfoxc;,ew8vwer;oiuxcvlkqwer98vkpjn;lkqwer;ADOFIPUQWERLKNASDF [8QUREQFOI JQWRE8PRJ;GOVN;WEJRP98EURJNVM.ipigunvpjsdpry';
+    RETURN ABS(SeedToMangledInteger(seed, string1, string2));
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+
+CREATE FUNCTION f4(seed INTEGER) RETURNS INTEGER
+AS
+$$
+DECLARE 
+    string1 VARCHAR;
+    string2 VARCHAR;
+BEGIN
+    string1 = 'The mountains from which we oft preach, are generally far out of reach; the examples we set, we quickly regret; so we hide alone at the beach';
+    string2 = 'ChiangMaiBangkokMoscowPhiledelphiaColoradoFujiIcelandSaskatchwanManitobaVancouverAlbertaAustraliazenoGREECEisTHAWURDBritishColumbiaFrenchQuarter';
+    RETURN SeedToMangledInteger(seed, string1, string2);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test03_createSeedToGeometricDataTypes.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     These functions generate geometric data types given an integer "seed" 
+--     value as a starting point.
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP FUNCTION IF EXISTS SeedToBoxAsText(INTEGER);
+DROP FUNCTION IF EXISTS SeedToBox(INTEGER);
+DROP FUNCTION IF EXISTS SeedToCircle(INTEGER);
+DROP FUNCTION IF EXISTS SeedToPolygon(INTEGER);
+-- end_ignore
+
+
+
+
+
+-- A box is defined by a pair of points.
+-- A box looks like:
+--    ( (x1, y1), (x2, y2) )
+CREATE FUNCTION SeedToBoxAsText(seed INTEGER) RETURNS TEXT
+AS
+$$
+DECLARE 
+    s TEXT;
+    x1 INTEGER;
+    y1 INTEGER;
+    x2 INTEGER;
+    y2 INTEGER;
+BEGIN
+   x1 = f1(seed);
+   y1 = f2(seed);
+   x2 = f3(seed);
+   y2 = f4(seed);
+   s = '((' || x1 || ', ' || y1 || '), (' || x2 || ', ' || y2 || '))';
+   RETURN s;
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+
+-- A box is defined by a pair of points.
+-- A box looks like:
+--    ( (x1, y1), (x2, y2) )
+CREATE FUNCTION SeedToBox(seed INTEGER) RETURNS BOX
+AS
+$$
+DECLARE 
+   s TEXT;
+BEGIN
+   s = SeedToBoxAsText(seed);
+   RETURN TO_BOX(s);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+
+-- A circle is defined by a center point and a radius.
+-- The radius should be a positive number.
+-- A circle looks like:
+--    ( (x1, y1), r )
+CREATE FUNCTION SeedToCircle(seed INTEGER) RETURNS CIRCLE
+AS
+$$
+DECLARE 
+    s TEXT;
+    x1 INTEGER;
+    y1 INTEGER;
+    r INTEGER;
+BEGIN
+   x1 = f1(seed);
+   y1 = f2(seed);
+   r  = f3(seed);
+   s = '((' || x1 || ', ' || y1 || '), ' || r || ')';
+   RETURN TO_CIRCLE(s);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+
+-- A polygon is defined by a sequence of points.
+-- A polygon looks like:
+--    ( (x1, y1), (x2, y2) [, ...] )
+-- To save time, we "cheat" and call the SeedToBoxAsText() function, 
+-- which returns a sequence of 2 points (as TEXT) and then convert that 
+-- to a POLYGON.
+CREATE FUNCTION SeedToPolygon(seed INTEGER) RETURNS POLYGON
+AS
+$$
+DECLARE
+   s TEXT;
+BEGIN
+   s = SeedToBoxAsText(seed);
+   RETURN TO_POLY(s);
+END;
+$$
+LANGUAGE PLPGSQL
+IMMUTABLE
+;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test04_createTableAndData.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS geometricTypes;
+-- end_ignore
+
+CREATE TABLE geometricTypes (seed INTEGER, c CIRCLE, b BOX, p POLYGON) 
+ DISTRIBUTED BY (seed);
+
+INSERT INTO geometricTypes (seed, c, b, p) 
+ SELECT x, 
+   SeedToCircle(x), 
+   SeedToBox(x), 
+   SeedToPolygon(x)
+  FROM generate_series(1, 300000)x
+ ;
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test05_select.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly.  Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = False;
+
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+-- end_ignore
+
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+-- end_ignore
+
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test06_createIndexes.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP INDEX IF EXISTS gt_index_c;
+DROP INDEX IF EXISTS gt_index_b;
+DROP INDEX IF EXISTS gt_index_p;
+-- end_ignore
+
+CREATE INDEX gt_index_c ON geometricTypes USING GIST (c);
+CREATE INDEX gt_index_b ON geometricTypes USING GIST (b);
+CREATE INDEX gt_index_p ON geometricTypes USING GIST (p);
+
+
+-- ----------------------------------------------------------------------
+-- Test: test07_select.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly.  Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = False;
+
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+-- end_ignore
+
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+-- end_ignore
+
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test08_reindex.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This can be run manually to give the user the option of 
+--     interrupting the REINDEX operation with ctrl-C or another kill method.
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+ALTER INDEX gt_index_c SET (FILLFACTOR = 20);
+ALTER INDEX gt_index_b SET (FILLFACTOR = 20);
+ALTER INDEX gt_index_p SET (FILLFACTOR = 20);
+
+REINDEX INDEX gt_index_c;
+REINDEX INDEX gt_index_b;
+REINDEX INDEX gt_index_p;
+
+ALTER INDEX gt_index_c SET (FILLFACTOR = 13);
+ALTER INDEX gt_index_b SET (FILLFACTOR = 13);
+ALTER INDEX gt_index_p SET (FILLFACTOR = 13);
+
+REINDEX TABLE geometricTypes; 
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test10_rollback.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This tests ROLLBACK on the following index-related operations
+--     with GiST indexes:
+--         CREATE INDEX
+--         REINDEX
+--         ALTER INDEX
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS gone;
+-- end_ignore
+
+CREATE TABLE gone (seed INTEGER, already_gone CIRCLE, too_far_gone BOX, 
+  paragon POLYGON)
+ DISTRIBUTED BY (seed);
+
+INSERT INTO gone (seed, already_gone, too_far_gone, paragon)
+ SELECT x, SeedToCircle(x), SeedToBox(x), SeedToPolygon(x)
+  FROM generate_series(1, 10000)x
+ ;
+ 
+
+SET enable_seqscan = False;
+
+-- Create an index; use the index; then roll back.
+BEGIN WORK;
+CREATE INDEX gone_around_the_bend ON gone USING GiST (already_gone);
+-- This should use the index that we just created.
+SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+EXPLAIN SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+ROLLBACK WORK;
+
+-- Should not use the index, since we rolled back the statement that created 
+-- the index.
+SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+EXPLAIN SELECT * FROM gone 
+ WHERE already_gone ~= SeedToCircle(857);
+
+CREATE INDEX polly_gone ON gone USING GiST (paragon);
+
+BEGIN WORK;
+ALTER INDEX polly_gone RENAME TO polly_wanna_cracker;
+-- This should use the index, and the EXPLAIN should use the new name.
+SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+EXPLAIN SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+ROLLBACK WORK;
+
+-- Explain should show the original name of the index.
+SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+EXPLAIN SELECT * FROM gone 
+ WHERE paragon ~= SeedToPolygon(858);
+
+CREATE INDEX box_of_rain ON gone USING GiST (too_far_gone) 
+ WITH (FILLFACTOR = 100);
+
+-- I'm not sure what should happen when we roll back a REINDEX operation.
+-- Let's try it and see.  ;-)  
+BEGIN WORK;
+REINDEX INDEX box_of_rain;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ROLLBACK WORK;
+
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+
+BEGIN WORK;
+ALTER INDEX box_of_rain SET (FILLFACTOR = 40);
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ROLLBACK WORK;
+
+BEGIN WORK;
+ALTER INDEX box_of_rain SET (FILLFACTOR = 40);
+REINDEX TABLE gone;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ROLLBACK WORK;
+
+BEGIN WORK;
+ALTER INDEX box_of_rain RESET (FILLFACTOR);  -- Sets fillfactor back to 100??
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+REINDEX TABLE gone;
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+ROLLBACK WORK;
+
+SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+EXPLAIN SELECT * FROM gone 
+ WHERE too_far_gone ~= SeedToBox(859);
+
+DROP TABLE IF EXISTS gone;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test09_select.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+--     This does a few SELECT statements as a brief sanity check that the 
+--     indexes are working correctly.  Furthermore, we request EXPLAIN info
+--     for each SELECT.  In this script, we ignore the output of the EXPLAIN
+--     commands, but a later part of the test checks that we used an index 
+--     scan rather than a sequential scan when executing the SELECT 
+--     statements.
+-- end_ignore
+------------------------------------------------------------------------------
+SET enable_seqscan = False;
+
+SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE c ~= SeedToCircle(10001);
+-- end_ignore
+
+SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE b ~= SeedToBox(1001);
+-- end_ignore
+
+SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+-- start_ignore
+EXPLAIN SELECT * FROM geometricTypes 
+ WHERE p ~= SeedToPolygon(3456);
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: test99_cleanup.sql
+-- ----------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+-- start_ignore
+-- PURPOSE:
+-- AUTHOR: mgilkey
+-- end_ignore
+------------------------------------------------------------------------------
+
+-- start_ignore
+DROP TABLE IF EXISTS geometricTypes;
+DROP FUNCTION IF EXISTS SeedToMangledInteger(INTEGER, VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS f1(INTEGER);
+DROP FUNCTION IF EXISTS f2(INTEGER);
+DROP FUNCTION IF EXISTS f3(INTEGER);
+DROP FUNCTION IF EXISTS f4(INTEGER);
+-- end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_gist_indexes4 cascade;
+-- end_ignore


### PR DESCRIPTION
There are 4 different test suites for gist_indexes.
First suite is already in bugbuster and there was no need to migrate that suite.
Second suite is run in nested `for` loops for to test different WITH clauses. Therefore, to be able to test every condition, the tables are created differently and appended duplicated tests in the same file. 
Third and forth suite basically runs back to back queries. 