### PR TITLE
Remove ignored error message when building demo cluster

### DIFF
--- a/gpAux/gpdemo/Makefile
+++ b/gpAux/gpdemo/Makefile
@@ -18,7 +18,7 @@ all:
 	$(MAKE) probe
 
 cluster:	
-	@- MASTER_DEMO_PORT=$(MASTER_PORT) DEMO_PORT_BASE=$(PORT_BASE) ./demo_cluster.sh 
+	@ MASTER_DEMO_PORT=$(MASTER_PORT) DEMO_PORT_BASE=$(PORT_BASE) ./demo_cluster.sh 
 	@ echo ""
 
 probe:

--- a/gpAux/gpdemo/Makefile
+++ b/gpAux/gpdemo/Makefile
@@ -18,7 +18,7 @@ all:
 	$(MAKE) probe
 
 cluster:	
-	@ MASTER_DEMO_PORT=$(MASTER_PORT) DEMO_PORT_BASE=$(PORT_BASE) ./demo_cluster.sh 
+	@ MASTER_DEMO_PORT=$(MASTER_PORT) DEMO_PORT_BASE=$(PORT_BASE) ./demo_cluster.sh
 	@ echo ""
 
 probe:

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -401,4 +401,10 @@ cat > gpdemo-env.sh <<-EOF
 	export MASTER_DATA_DIRECTORY=$QDDIR/${SEG_PREFIX}-1
 EOF
 
-exit ${RETURN}
+if [ "${RETURN}" -gt 1 ];
+then
+    # gpinitsystem will return warnings as exit code 1
+    exit ${RETURN}
+else
+    exit 0
+fi


### PR DESCRIPTION
This patch slightly changes the way the demo cluster is built.
A gpinitdbsystem return code of 1 (warning) is ignored, and the script
exits with return code 0. Any error code greather than that is returned.
The Makefile is no longer ignoring errors.

This will fix #456.