### PR TITLE
Change the default value of standard_conforming_strings to on.

### DIFF
--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -24,7 +24,7 @@
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/parser/scan.l,v 1.153 2009/05/05 21:09:23 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/parser/scan.l,v 1.168 2010/07/20 00:34:44 rhaas Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -76,7 +76,7 @@ static uint32	utf16_top_part;
  */
 int				backslash_quote = BACKSLASH_QUOTE_SAFE_ENCODING;
 bool			escape_string_warning = true;
-bool			standard_conforming_strings = false;
+bool			standard_conforming_strings = true;
 
 static bool		warn_on_first_escape;
 static bool		saw_non_ascii = false;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -11,7 +11,7 @@
  * Written by Peter Eisentraut <peter_e@gmx.net>.
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/utils/misc/guc.c,v 1.385 2007/04/16 18:29:55 alvherre Exp $
+ *	  $PostgreSQL: pgsql/src/backend/utils/misc/guc.c,v 1.563 2010/07/20 00:34:44 rhaas Exp $
  *
  *--------------------------------------------------------------------
  */
@@ -1053,7 +1053,7 @@ static struct config_bool ConfigureNamesBool[] =
 			GUC_REPORT
 		},
 		&standard_conforming_strings,
-		false, NULL, NULL
+		true, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -495,7 +495,7 @@ max_appendonly_tables = 10000 # Maximum number of append only tables that can
 #backslash_quote = safe_encoding	# on, off, or safe_encoding
 #escape_string_warning = on
 #regex_flavor = advanced		# advanced, extended, or basic
-#standard_conforming_strings = off
+#standard_conforming_strings = on
 
 
 # - Other Platforms and Clients -

--- a/src/test/regress/bugbuster/expected/xpath.out
+++ b/src/test/regress/bugbuster/expected/xpath.out
@@ -284,11 +284,7 @@ DETAIL:  Entity: line 1: parser error : Premature end of data in tag a line 1
 Entity: line 1: parser error : Premature end of data in tag a line 1
 <a>hello<a>
            ^
-select xmlcomment('<a>hello<\a>');
-WARNING:  nonstandard use of escape in a string literal
-LINE 1: select xmlcomment('<a>hello<\a>');
-                          ^
-HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
+select xmlcomment(E'<a>hello<\a>');
      xmlcomment     
 --------------------
  <!--<a>hello<a>-->
@@ -300,11 +296,7 @@ select xmlcomment('adsfasdfasdfsadf');
  <!--adsfasdfasdfsadf-->
 (1 row)
 
-select xmlcomment('\n');
-WARNING:  nonstandard use of escape in a string literal
-LINE 1: select xmlcomment('\n');
-                          ^
-HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
+select xmlcomment(E'\n');
  xmlcomment 
 ------------
  <!--       

--- a/src/test/regress/bugbuster/sql/xpath.sql
+++ b/src/test/regress/bugbuster/sql/xpath.sql
@@ -21,9 +21,9 @@ select xml_out((select * from readxml));
 
 select xml_out((select xml_in('<a>hello<a>')));
 
-select xmlcomment('<a>hello<\a>');
+select xmlcomment(E'<a>hello<\a>');
 select xmlcomment('adsfasdfasdfsadf');
-select xmlcomment('\n');
+select xmlcomment(E'\n');
 select xml('<hello></hello>');
 select xml('<a><say>speak</say><hello>say hello</hello></a>');
 select xml('hello');

--- a/src/test/regress/expected/gpcopy.out
+++ b/src/test/regress/expected/gpcopy.out
@@ -632,11 +632,7 @@ SELECT gp_truncate_error_log('errcopy');
  t
 (1 row)
 
-COPY errcopy from stdin delimiter '\t' log errors segment reject limit 3 rows;
-WARNING:  nonstandard use of escape in a string literal
-LINE 1: COPY errcopy from stdin delimiter '\t' log errors segment re...
-                                          ^
-HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
+COPY errcopy from stdin delimiter E'\t' log errors segment reject limit 3 rows;
 ERROR:  Segment reject limit reached. Aborting operation. Last error was: missing data for column "b"
 CONTEXT:  COPY errcopy, line 3: "1       4"
 SELECT * FROM errcopy;

--- a/src/test/regress/sql/gpcopy.sql
+++ b/src/test/regress/sql/gpcopy.sql
@@ -628,7 +628,7 @@ SELECT * FROM errcopy;
 TRUNCATE errcopy;
 SELECT gp_truncate_error_log('errcopy');
 
-COPY errcopy from stdin delimiter '\t' log errors segment reject limit 3 rows;
+COPY errcopy from stdin delimiter E'\t' log errors segment reject limit 3 rows;
 1       2       0
 1       3       4
 1       4


### PR DESCRIPTION
This change should be publicized to driver maintainers at once and
release-noted as an incompatibility with previous releases.

(cherry picked from commit 0839f312e92c7ab0aecb2c4133197a7da7c5fc39)

Author:             Álvaro Hernández Tortosa <aht@8kdata.com>
Date:               Sat Mar 12 21:20:19 UTC 2016

Changes to doc/src/sgml/{config,syntax}.sgml ignored as they are not
present in gpdb.