### PR TITLE
Support explicit cast for ARRAY[] constructor

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2410,6 +2410,15 @@ _copyA_Indirection(A_Indirection *from)
 	return newnode;
 }
 
+static A_ArrayExpr *
+_copyA_ArrayExpr(A_ArrayExpr *from)
+{
+	A_ArrayExpr *newnode = makeNode(A_ArrayExpr);
+	COPY_NODE_FIELD(elements);
+
+	return newnode;
+}
+
 static ResTarget *
 _copyResTarget(ResTarget *from)
 {
@@ -4985,6 +4994,9 @@ copyObject(void *from)
 			break;
 		case T_A_Indirection:
 			retval = _copyA_Indirection(from);
+			break;
+		case T_A_ArrayExpr:
+			retval = _copyA_ArrayExpr(from);
 			break;
 		case T_ResTarget:
 			retval = _copyResTarget(from);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1648,6 +1648,7 @@ _copyArrayExpr(ArrayExpr *from)
 	COPY_SCALAR_FIELD(element_typeid);
 	COPY_NODE_FIELD(elements);
 	COPY_SCALAR_FIELD(multidims);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }
@@ -2415,6 +2416,7 @@ _copyA_ArrayExpr(A_ArrayExpr *from)
 {
 	A_ArrayExpr *newnode = makeNode(A_ArrayExpr);
 	COPY_NODE_FIELD(elements);
+	COPY_LOCATION_FIELD(location);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -484,6 +484,7 @@ _equalArrayExpr(ArrayExpr *a, ArrayExpr *b)
 	COMPARE_SCALAR_FIELD(element_typeid);
 	COMPARE_NODE_FIELD(elements);
 	COMPARE_SCALAR_FIELD(multidims);
+	COMPARE_LOCATION_FIELD(location);
 
 	return true;
 }
@@ -2017,6 +2018,7 @@ static bool
 _equalA_ArrayExpr(A_ArrayExpr *a, A_ArrayExpr *b)
 {
 	COMPARE_NODE_FIELD(elements);
+	COMPARE_LOCATION_FIELD(location);
 
 	return true;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2014,6 +2014,14 @@ _equalA_Indirection(A_Indirection *a, A_Indirection *b)
 }
 
 static bool
+_equalA_ArrayExpr(A_ArrayExpr *a, A_ArrayExpr *b)
+{
+	COMPARE_NODE_FIELD(elements);
+
+	return true;
+}
+
+static bool
 _equalResTarget(ResTarget *a, ResTarget *b)
 {
 	COMPARE_STRING_FIELD(name);
@@ -2937,6 +2945,9 @@ equal(void *a, void *b)
 			break;
 		case T_A_Indirection:
 			retval = _equalA_Indirection(a, b);
+			break;
+		case T_A_ArrayExpr:
+			retval = _equalA_ArrayExpr(a, b);
 			break;
 		case T_ResTarget:
 			retval = _equalResTarget(a, b);

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -270,6 +270,10 @@ exprLocation(Node *expr)
 								  exprLocation((Node *) fc->args));
 			}
 			break;
+		case T_A_ArrayExpr:
+			/* the location points at ARRAY or [, which must be leftmost */
+			loc = ((A_ArrayExpr *) expr)->location;
+			break;
 		case T_ResTarget:
 			/* we need not examine the contained expression (if any) */
 			loc = ((ResTarget *) expr)->location;

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1847,6 +1847,9 @@ _outNode(StringInfo str, void *obj)
 			case T_A_Indirection:
 				_outA_Indirection(str, obj);
 				break;
+			case T_A_ArrayExpr:
+				_outA_ArrayExpr(str,obj);
+				break;
 			case T_ResTarget:
 				_outResTarget(str, obj);
 				break;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3896,6 +3896,14 @@ _outA_Indirection(StringInfo str, A_Indirection *node)
 }
 
 static void
+_outA_ArrayExpr(StringInfo str, A_ArrayExpr *node)
+{
+	WRITE_NODE_TYPE("A_ARRAY");
+
+	WRITE_NODE_FIELD(elements);
+}
+
+static void
 _outResTarget(StringInfo str, ResTarget *node)
 {
 	WRITE_NODE_TYPE("RESTARGET");
@@ -4912,6 +4920,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_A_Indirection:
 				_outA_Indirection(str, obj);
+				break;
+			case T_A_ArrayExpr:
+				_outA_ArrayExpr(str, obj);
 				break;
 			case T_ResTarget:
 				_outResTarget(str, obj);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -110,6 +110,10 @@
 	(appendStringInfo(str, " :" CppAsString(fldname) " "), \
 	 _outToken(str, node->fldname))
 
+/* Write a parse location field (actually same as INT case) */
+#define WRITE_LOCATION_FIELD(fldname) \
+	appendStringInfo(str, " :" CppAsString(fldname) " %d", node->fldname)
+
 /* Write a Node field */
 #define WRITE_NODE_FIELD(fldname) \
 	(appendStringInfo(str, " :" CppAsString(fldname) " "), \
@@ -1498,6 +1502,7 @@ _outArrayExpr(StringInfo str, ArrayExpr *node)
 	WRITE_OID_FIELD(element_typeid);
 	WRITE_NODE_FIELD(elements);
 	WRITE_BOOL_FIELD(multidims);
+/*	WRITE_LOCATION_FIELD(location); */
 }
 
 static void
@@ -3898,9 +3903,10 @@ _outA_Indirection(StringInfo str, A_Indirection *node)
 static void
 _outA_ArrayExpr(StringInfo str, A_ArrayExpr *node)
 {
-	WRITE_NODE_TYPE("A_ARRAY");
+	WRITE_NODE_TYPE("A_ARRAYEXPR");
 
 	WRITE_NODE_FIELD(elements);
+/*	WRITE_LOCATION_FIELD(location); */
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2873,6 +2873,9 @@ readNodeBinary(void)
 			case T_ArrayExpr:
 				return_value = _readArrayExpr();
 				break;
+			case T_A_ArrayExpr:
+				return_value = _readA_ArrayExpr();
+				break;
 			case T_RowExpr:
 				return_value = _readRowExpr();
 				break;

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -135,6 +135,9 @@ inline static char extended_char(char* token, size_t length)
 /* Read a character-string field */
 #define READ_STRING_FIELD(fldname)  READ_SCALAR_FIELD(fldname, nullable_string(token, length))
 
+/* Read a parse location field (and throw away the value, per notes above) */
+#define READ_LOCATION_FIELD(fldname) READ_SCALAR_FIELD(fldname, -1)
+
 /* Read a Node field */
 #define READ_NODE_FIELD(fldname) \
     do { \
@@ -1851,6 +1854,7 @@ _readArrayExpr(void)
 	READ_OID_FIELD(element_typeid);
 	READ_NODE_FIELD(elements);
 	READ_BOOL_FIELD(multidims);
+/*	READ_LOCATION_FIELD(location); */
 
 	READ_DONE();
 }
@@ -1864,6 +1868,7 @@ _readA_ArrayExpr(void)
 	READ_LOCALS(A_ArrayExpr);
 
 	READ_NODE_FIELD(elements);
+/*	READ_LOCATION_FIELD(location); */
 
 	READ_DONE();
 }
@@ -3197,7 +3202,7 @@ static ParseNodeInfo infoAr[] =
 	{"WINDOWSPECPARSE", (ReadFn)_readWindowSpecParse},
 	{"WITHCLAUSE", (ReadFn)_readWithClause},
 	{"XMLEXPR", (ReadFn)_readXmlExpr},
-	{"A_ARRAY", (ReadFn)_readA_ArrayExpr},
+	{"A_ARRAYEXPR", (ReadFn)_readA_ArrayExpr},
 };
 
 /*

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1856,6 +1856,21 @@ _readArrayExpr(void)
 }
 
 /*
+ * _readA_ArrayExpr
+ */
+static A_ArrayExpr *
+_readA_ArrayExpr(void)
+{
+	READ_LOCALS(A_ArrayExpr);
+
+	READ_NODE_FIELD(elements);
+
+	READ_DONE();
+}
+
+
+
+/*
  * _readRowExpr
  */
 static RowExpr *
@@ -3182,6 +3197,7 @@ static ParseNodeInfo infoAr[] =
 	{"WINDOWSPECPARSE", (ReadFn)_readWindowSpecParse},
 	{"WITHCLAUSE", (ReadFn)_readWithClause},
 	{"XMLEXPR", (ReadFn)_readXmlExpr},
+	{"A_ARRAY", (ReadFn)_readA_ArrayExpr},
 };
 
 /*

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -115,6 +115,7 @@ static Node *makeIntConst(int val, int location);
 static Node *makeFloatConst(char *str, int location);
 static Node *makeNullAConst(int location);
 static Node *makeAConst(Value *v, int location);
+static Node *makeAArrayExpr(List *elements);
 static A_Const *makeBoolAConst(bool state, int location);
 static FuncCall *makeOverlaps(List *largs, List *rargs, int location);
 static void check_qualified_name(List *names);
@@ -11607,6 +11608,28 @@ expr_list:	a_expr
 				}
 		;
 
+type_list:	Typename								{ $$ = list_make1($1); }
+			| type_list ',' Typename				{ $$ = lappend($1, $3); }
+		;
+
+array_expr: '[' expr_list ']'
+				{
+					$$ = makeAArrayExpr($2);
+				}
+			| '[' array_expr_list ']'
+				{
+					$$ = makeAArrayExpr($2);
+				}
+            | '[' ']'
+                {
+                    $$ = makeAArrayExpr(NIL);
+                }
+        ;
+
+array_expr_list: array_expr							{ $$ = list_make1($1); }
+			| array_expr_list ',' array_expr		{ $$ = lappend($1, $3); }
+		;
+
 extract_list:
 			extract_arg FROM a_expr
 				{
@@ -11616,30 +11639,6 @@ extract_list:
 					$$ = list_make2((Node *) n, $3);
 				}
 			| /*EMPTY*/								{ $$ = NIL; }
-		;
-
-type_list:	Typename								{ $$ = list_make1($1); }
-			| type_list ',' Typename				{ $$ = lappend($1, $3); }
-		;
-
-array_expr_list: array_expr
-				{	$$ = list_make1($1);		}
-			| array_expr_list ',' array_expr
-				{	$$ = lappend($1, $3);	}
-		;
-
-array_expr: '[' expr_list ']'
-				{
-					ArrayExpr *n = makeNode(ArrayExpr);
-					n->elements = $2;
-					$$ = (Node *)n;
-				}
-			| '[' array_expr_list ']'
-				{
-					ArrayExpr *n = makeNode(ArrayExpr);
-					n->elements = $2;
-					$$ = (Node *)n;
-				}
 		;
 
 /* Allow delimited string SCONST in extract_arg as an SQL extension.
@@ -13200,13 +13199,6 @@ makeColumnRef(char *colname, List *indirection, int location)
 static Node *
 makeTypeCast(Node *arg, TypeName *typename, int location)
 {
-	/*
-	 * Simply generate a TypeCast node.
-	 *
-	 * Earlier we would determine whether an A_Const would
-	 * be acceptable, however Domains require coerce_type()
-	 * to process them -- applying constraints as required.
-	 */
 	TypeCast *n = makeNode(TypeCast);
 	n->arg = arg;
 	n->typname = typename;
@@ -13295,7 +13287,7 @@ makeBoolAConst(bool state, int location)
 {
 	A_Const *n = makeNode(A_Const);
 	n->val.type = T_String;
-	n->val.val.str = (state? "t": "f");
+	n->val.val.str = (state ? "t" : "f");
 	n->typname = SystemTypeName("bool");
 	n->location = location;
 	return n;
@@ -13500,15 +13492,6 @@ SystemTypeName(char *name)
 											   makeString(name)));
 }
 
-/* parser_init()
- * Initialize to parse one query string
- */
-void
-parser_init(void)
-{
-	QueryIsRule = FALSE;
-}
-
 /* exprIsNullConstant()
  * Test whether an a_expr is a plain NULL constant or not.
  */
@@ -13584,6 +13567,15 @@ doNegateFloat(Value *v)
 	}
 }
 
+static Node*
+makeAArrayExpr(List *elements)
+{
+	A_ArrayExpr *n = makeNode(A_ArrayExpr);
+
+	n->elements = elements;
+	return (Node *) n;
+}
+
 static Node *
 makeXmlExpr(XmlExprOp op, char *name, List *named_args, List *args,
 			int location)
@@ -13604,6 +13596,15 @@ makeXmlExpr(XmlExprOp op, char *name, List *named_args, List *args,
 	x->type = InvalidOid;			/* marks the node as not analyzed */
 	x->location = location;
 	return (Node *) x;
+}
+
+/* parser_init()
+ * Initialize to parse one query string
+ */
+void
+parser_init(void)
+{
+    QueryIsRule = FALSE;
 }
 
 /*

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -115,7 +115,7 @@ static Node *makeIntConst(int val, int location);
 static Node *makeFloatConst(char *str, int location);
 static Node *makeNullAConst(int location);
 static Node *makeAConst(Value *v, int location);
-static Node *makeAArrayExpr(List *elements);
+static Node *makeAArrayExpr(List *elements, int location);
 static A_Const *makeBoolAConst(bool state, int location);
 static FuncCall *makeOverlaps(List *largs, List *rargs, int location);
 static void check_qualified_name(List *names);
@@ -11614,15 +11614,15 @@ type_list:	Typename								{ $$ = list_make1($1); }
 
 array_expr: '[' expr_list ']'
 				{
-					$$ = makeAArrayExpr($2);
+					$$ = makeAArrayExpr($2, @1);
 				}
 			| '[' array_expr_list ']'
 				{
-					$$ = makeAArrayExpr($2);
+					$$ = makeAArrayExpr($2, @1);
 				}
             | '[' ']'
                 {
-                    $$ = makeAArrayExpr(NIL);
+                    $$ = makeAArrayExpr(NIL, @1);
                 }
         ;
 
@@ -11636,6 +11636,8 @@ extract_list:
 					A_Const *n = makeNode(A_Const);
 					n->val.type = T_String;
 					n->val.val.str = $1;
+					n->location = @1;
+
 					$$ = list_make2((Node *) n, $3);
 				}
 			| /*EMPTY*/								{ $$ = NIL; }
@@ -13568,11 +13570,12 @@ doNegateFloat(Value *v)
 }
 
 static Node*
-makeAArrayExpr(List *elements)
+makeAArrayExpr(List *elements, int location)
 {
 	A_ArrayExpr *n = makeNode(A_ArrayExpr);
 
 	n->elements = elements;
+	n->location = location;
 	return (Node *) n;
 }
 

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -56,7 +56,8 @@ static Node *transformAExprOf(ParseState *pstate, A_Expr *a);
 static Node *transformAExprIn(ParseState *pstate, A_Expr *a);
 static Node *transformFuncCall(ParseState *pstate, FuncCall *fn);
 static Node *transformSubLink(ParseState *pstate, SubLink *sublink);
-static Node *transformArrayExpr(ParseState *pstate, ArrayExpr *a);
+static Node *transformArrayExpr(ParseState *pstate, A_ArrayExpr *a,
+                                  Oid array_type, Oid element_type, int32 typmod);
 static Node *transformRowExpr(ParseState *pstate, RowExpr *r);
 static Node *transformTableValueExpr(ParseState *pstate, TableValueExpr *t);
 static Node *transformCoalesceExpr(ParseState *pstate, CoalesceExpr *c);
@@ -164,11 +165,55 @@ transformExpr(ParseState *pstate, Node *expr)
 				break;
 			}
 
+        case T_A_ArrayExpr:
+            result = transformArrayExpr(pstate, (A_ArrayExpr *) expr,
+                                        InvalidOid, InvalidOid, -1);
+            break;
+
 		case T_TypeCast:
 			{
 				TypeCast   *tc = (TypeCast *) expr;
-				Node	   *arg = transformExpr(pstate, tc->arg);
+				Node	   *arg = NULL;
 
+				/*
+				* If the subject of the typecast is an ARRAY[] construct
+				* and the target type is an array type, we invoke
+				* transformArrayExpr() directly so that we can pass down
+				* the type information. This avoids some cases where
+				* transformArrayExpr() might not infer the correct type
+				*/
+				if (IsA(tc->arg, A_ArrayExpr))
+				{
+					Oid	targetType;
+					Oid	elementType;
+					int32	targetTypmod;
+
+					targetType = typenameTypeId(pstate, tc->typname);
+					targetTypmod = typenameTypeMod(pstate, tc->typname, targetType);
+
+					elementType = get_element_type(targetType);
+					if (OidIsValid(elementType))
+					{
+                        /*
+                         * tranformArrayExpr doesn't know how to check domain
+                         * constraints, so ask it to return the base type
+                         * instead. transformTypeCast below will cast it to
+                         * the domain. In the usual case that the target is
+                         * not a domain, transformTypeCast is a no-op.
+                         */
+                        targetType = getBaseTypeAndTypmod(targetType,
+                                                         &targetTypmod);
+
+                        tc = copyObject(tc);
+                        tc->arg = transformArrayExpr(pstate,
+                                                     (A_ArrayExpr *) tc->arg,
+                                                     targetType,
+                                                     elementType,
+                                                     targetTypmod);
+					}
+				}
+
+				arg = transformExpr(pstate, tc->arg);
 				result = typecast_expression(pstate, arg, tc->typname);
 				break;
 			}
@@ -226,10 +271,6 @@ transformExpr(ParseState *pstate, Node *expr)
 
 		case T_CaseExpr:
 			result = transformCaseExpr(pstate, (CaseExpr *) expr);
-			break;
-
-		case T_ArrayExpr:
-			result = transformArrayExpr(pstate, (ArrayExpr *) expr);
 			break;
 
 		case T_RowExpr:
@@ -392,6 +433,7 @@ transformExpr(ParseState *pstate, Node *expr)
 		case T_RelabelType:
 		case T_ConvertRowtypeExpr:
 		case T_CaseTestExpr:
+		case T_ArrayExpr:
 		case T_CoerceToDomain:
 		case T_CoerceToDomainValue:
 		case T_SetToDefault:
@@ -1622,64 +1664,152 @@ transformSubLink(ParseState *pstate, SubLink *sublink)
 }
 
 static Node *
-transformArrayExpr(ParseState *pstate, ArrayExpr *a)
+transformArrayExpr(ParseState *pstate, A_ArrayExpr *a,
+                   Oid array_type, Oid element_type, int32 typmod)
 {
 	ArrayExpr  *newa = makeNode(ArrayExpr);
 	List	   *newelems = NIL;
 	List	   *newcoercedelems = NIL;
 	List	   *typeids = NIL;
 	ListCell   *element;
-	Oid			array_type;
-	Oid			element_type;
+	Oid			coerce_type;
+	bool		coerce_hard;
 
-	/* Transform the element expressions */
+	/*
+	 * Transform the element expressions
+	 *
+	 * Assume that the array is one-dimensional unless we find an array-type
+	 * element expression.
+	 */
+    newa->multidims = false;
 	foreach(element, a->elements)
 	{
 		Node	   *e = (Node *) lfirst(element);
 		Node	   *newe;
+		Oid			newe_type;
 
-		newe = transformExpr(pstate, e);
+		/*
+		* If an element is itself an A_ArrayExpr, resurse directly so that
+		* we can pass down any target type we were given.
+		*/
+		if (IsA(e, A_ArrayExpr))
+		{
+			newe = transformArrayExpr(pstate,
+									(A_ArrayExpr *) e,
+									array_type,
+									element_type,
+									typmod);
+			newe_type = exprType(newe);
+			/* we certainly have an array here */
+			Assert(array_type == InvalidOid || array_type == newe_type);
+			newa->multidims = true;
+		}
+		else
+		{
+			newe = transformExpr(pstate, e);
+			newe_type = exprType(newe);
+			/*
+			* Check for sub-array expressions, if we haven't already
+			* found one.
+			*/
+			if (!newa->multidims && is_array_type(newe_type))
+				newa->multidims = true;
+		}
+
 		newelems = lappend(newelems, newe);
-		typeids = lappend_oid(typeids, exprType(newe));
+		typeids = lappend_oid(typeids, newe_type);
 	}
 
 	/* CDB: Drop a breadcrumb in case of error. */
 	pstate->p_breadcrumb.node = (Node *)a;
 
-	/* Select a common type for the elements */
-	element_type = select_common_type(typeids, "ARRAY");
+	/*
+	* Select a target type for the elements.
+	*
+	* If we haven't been given a target array type, we must try to deduce a
+	* common type based on the types of the individual elements present.
+	*/
+	if (OidIsValid(array_type))
+	{
+		/* Caller must ensure array_type matches element_type */
+		Assert(OidIsValid(element_type));
+		coerce_type = (newa->multidims ? array_type : element_type);
+		coerce_hard = true;
+	}
+	else
+	{
+		/* Can't handle an empty array without a target type */
+		if (typeids == NIL)
+			ereport(ERROR,
+					(errcode(ERRCODE_INDETERMINATE_DATATYPE),
+					 errmsg("cannot determine type of empty array"),
+					 errhint("Explicitly cast to the desired type, "
+							"for example ARRAY[]::interger[].")));
+		/* Select a common type for the elements */
+		coerce_type = select_common_type(typeids, "ARRAY");
 
-	/* Coerce arguments to common type if necessary */
+		if (newa->multidims)
+		{
+			array_type = coerce_type;
+			element_type = get_element_type(array_type);
+			if (!OidIsValid(element_type))
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_OBJECT),
+						 errmsg("could not find element type for data type %s",
+								format_type_be(array_type))));
+		}
+		else
+		{
+			element_type = coerce_type;
+			array_type = get_array_type(element_type);
+			if (!OidIsValid(array_type))
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_OBJECT),
+						 errmsg("could not find array type for data type %s",
+								format_type_be(element_type))));
+
+		}
+		coerce_hard = false;
+	}
+
+	/*
+	* Coerce elements to target type
+	*
+	* If the array has been explicitly cast, then the elements are in turn
+	* explicitly coerced.
+	*
+	* If the array's type was merely derived from the common type of its
+	* elements, then the elements are implicitly coerced to the common type.
+	* This is consistent with other uses of select_common_type().
+	*/
+
 	foreach(element, newelems)
 	{
 		Node	   *e = (Node *) lfirst(element);
 		Node	   *newe;
 
-		newe = coerce_to_common_type(pstate, e,
-									 element_type,
-									 "ARRAY");
+        if (coerce_hard)
+        {
+            newe = coerce_to_target_type(pstate, e,
+                                         exprType(e),
+                                         coerce_type,
+                                         typmod,
+                                         COERCION_EXPLICIT,
+                                         COERCE_EXPLICIT_CAST,-1);
+
+            if (newe == NULL)
+                ereport(ERROR,
+                        (errcode(ERRCODE_CANNOT_COERCE),
+                         errmsg("cannot cast type %s to %s",
+                                format_type_be(exprType(e)),
+                                format_type_be(coerce_type)),
+                         parser_errposition(pstate, exprLocation(e))));
+        }
+        else
+            newe = coerce_to_common_type(pstate, e,
+                                         coerce_type,
+                                         "ARRAY");
 		newcoercedelems = lappend(newcoercedelems, newe);
-	}
-
-	/* Do we have an array type to use? */
-	array_type = get_array_type(element_type);
-	if (array_type != InvalidOid)
-	{
-		/* Elements are presumably of scalar type */
-		newa->multidims = false;
-	}
-	else
-	{
-		/* Must be nested array expressions */
-		newa->multidims = true;
-
-		array_type = element_type;
-		element_type = get_element_type(array_type);
-		if (!OidIsValid(element_type))
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("could not find array type for data type %s",
-							format_type_be(array_type))));
 	}
 
 	newa->array_typeid = array_type;

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1278,6 +1278,7 @@ transformAExprIn(ParseState *pstate, A_Expr *a)
 			newa->element_typeid = scalar_type;
 			newa->elements = aexprs;
 			newa->multidims = false;
+			newa->location = -1;
 
 			return (Node *) make_scalar_array_op(pstate,
 												 a->name,

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -1385,7 +1385,7 @@ FigureColnameInternal(Node *node, char **name)
 				return 1;
 			}
 			break;
-		case T_ArrayExpr:
+		case T_A_ArrayExpr:
 			/* make ARRAY[] act like a function */
 			*name = "array";
 			return 2;

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -4338,6 +4338,15 @@ get_rule_expr(Node *node, deparse_context *context,
 				appendStringInfo(buf, "ARRAY[");
 				get_rule_expr((Node *) arrayexpr->elements, context, true);
 				appendStringInfoChar(buf, ']');
+
+				/*
+				 * If the array isn't empty, we assume its elements are
+				 * coerced to the desired type.  If it's empty, though, we
+				 * need an explicit coercion to the array type.
+				 */
+				if (arrayexpr->elements == NIL)
+					appendStringInfo(buf, "::%s",
+						format_type_with_typemod(arrayexpr->array_typeid, -1));
 			}
 			break;
 

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -443,6 +443,7 @@ typedef enum NodeTag
 	T_FuncCall,
 	T_A_Indices,
 	T_A_Indirection,
+	T_A_ArrayExpr,
 	T_ResTarget,
 	T_TypeCast,
 	T_SortBy,

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -376,7 +376,7 @@ typedef struct A_ArrayExpr
 {
 	NodeTag		type;
 	List	   *elements;		/* array element expressions */
-//	int			location;		/* token location, or -1 if unknown */
+	int			location;		/* token location, or -1 if unknown */
 } A_ArrayExpr;
 
 /*

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -301,9 +301,9 @@ typedef struct A_Const
  * TypeCast - a CAST expression
  *
  * NOTE: for mostly historical reasons, A_Const parsenodes contain
- * room for a TypeName; we only generate a separate TypeCast node if the
- * argument to be casted is not a constant.  In theory either representation
- * would work, but the combined representation saves a bit of code in many
+ * room for a TypeName, allowing a constant to be marked as being of a given
+ * type without a separate TypeCast node.  Either representation will work,
+ * but the combined representation saves a bit of code in many
  * productions in gram.y.
  */
 typedef struct TypeCast
@@ -376,7 +376,7 @@ typedef struct A_ArrayExpr
 {
 	NodeTag		type;
 	List	   *elements;		/* array element expressions */
-	int			location;		/* token location, or -1 if unknown */
+//	int			location;		/* token location, or -1 if unknown */
 } A_ArrayExpr;
 
 /*

--- a/src/test/regress/expected/arrays.out
+++ b/src/test/regress/expected/arrays.out
@@ -812,7 +812,9 @@ select '{ }}'::text[];
 ERROR:  malformed array literal: "{ }}"
 LINE 1: select '{ }}'::text[];
                ^
--- select array[];  -- MPP-11851
+select array[];
+ERROR:  cannot determine type of empty array
+HINT:  Explicitly cast to the desired type, for example ARRAY[]::integer[].
 -- none of the above should be accepted
 -- all of the following should be accepted
 select '{}'::text[];
@@ -854,7 +856,12 @@ select '{
  {"@ 0","@ 1 hour 42 mins 20 secs"}
 (1 row)
 
--- select array[]::text[];  -- MPP-11851
+select array[]::text[];
+ array
+-------
+ {}
+(1 row)
+
 select '[0:1]={1.1,2.2}'::float8[];
      float8      
 -----------------

--- a/src/test/regress/expected/variadic_parameters.out
+++ b/src/test/regress/expected/variadic_parameters.out
@@ -47,9 +47,11 @@ select myleast(variadic array[1.1, -5.5]);
 
 --test with empty variadic call parameter
 select myleast(variadic array[]::int[]);
-ERROR:  syntax error at or near "]"
-LINE 1: select myleast(variadic array[]::int[]);
-                                      ^
+ myleast
+---------
+
+(1 row)
+
 -- an example with some ordinary arguments too
 create or replace function concat(text, variadic anyarray) returns text as $$
   select array_to_string($2, $1);

--- a/src/test/regress/sql/arrays.sql
+++ b/src/test/regress/sql/arrays.sql
@@ -287,7 +287,7 @@ select E'{{1,2},\\{2,3}}'::text[];
 select '{{"1 2" x},{3}}'::text[];
 select '{}}'::text[];
 select '{ }}'::text[];
--- select array[];  -- MPP-11851
+select array[];
 -- none of the above should be accepted
 
 -- all of the following should be accepted
@@ -300,7 +300,7 @@ select '{
            0 second,
            @ 1 hour @ 42 minutes @ 20 seconds
          }'::interval[];
--- select array[]::text[];  -- MPP-11851
+select array[]::text[];
 select '[0:1]={1.1,2.2}'::float8[];
 -- all of the above should be accepted
 


### PR DESCRIPTION
Backport below commits from upstream:

    commit adac22bf8a451eef87ff5693cde021e738191c24
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Fri Dec 19 05:04:35 2008 +0000

        When we added the ability to have zero-element ARRAY[] constructs by adding an
        explicit cast to show the intended array type, we forgot to teach ruleutils.c
        to print out such constructs properly.  Found by noting bogus output from
        recent changes in polymorphism regression test.

    commit 30137bde6db48a8b8c1ffc736eb239bd7381f04d
    Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
    Date:   Fri Nov 13 19:48:26 2009 +0000

        A better fix for the "ARRAY[...]::domain" problem. The previous patch worked,
        but the transformed ArrayExpr claimed to have a return type of "domain",
        even though the domain constraint was only checked by the enclosing
        CoerceToDomain node. With this fix, the ArrayExpr is correctly labeled with
        the base type of the domain. Per gripe by Tom Lane.

    commit 6b0706ac33ab5da815980c642a9cde9a4cd86b6b
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Thu Mar 20 21:42:48 2008 +0000

        Arrange for an explicit cast applied to an ARRAY[] constructor to be applied
        directly to all the member expressions, instead of the previous implementation
        where the ARRAY[] constructor would infer a common element type and then we'd
        coerce the finished array after the fact.  This has a number of benefits,
        one being that we can allow an empty ARRAY[] construct so long as its
        element type is specified by such a cast.