### PR TITLE
Index validation for pg_class, pg_type and gp_relation_node

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -10872,7 +10872,9 @@ ATExecSetTableSpace_BufferPool(
 	int64 newPersistentSerialNum;
 	SMgrRelation dstrel;
 	bool useWal;
-	
+	ItemPointerData oldPersistentTid;
+	int64 oldPersistentSerialNum;
+
 	PersistentFileSysRelStorageMgr localRelStorageMgr;
 	PersistentFileSysRelBufpoolKind relBufpoolKind;
 	
@@ -10900,10 +10902,12 @@ ATExecSetTableSpace_BufferPool(
 			 (!useWal ? "true" : "false"));
 	
 	/* Fetch relation's gp_relation_node row */
-	nodeTuple = ScanGpRelationNodeTuple(
-							gp_relation_node,
-							rel->rd_rel->relfilenode,
-							/* segmentFileNum */ 0);
+	nodeTuple = FetchGpRelationNodeTuple(
+					gp_relation_node,
+					rel->rd_rel->relfilenode,
+					/* segmentFileNum */ 0,
+					&oldPersistentTid,
+					&oldPersistentSerialNum);
 	if (!HeapTupleIsValid(nodeTuple))
 		elog(ERROR, "cache lookup failed for relation %u, tablespace %u, relation file node %u", 
 		     tableOid,

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -539,7 +539,6 @@ DeleteGpRelationNodeTuple(
 	ItemPointerData     persistentTid;
 	int64               persistentSerialNum;
 
-	/* Grab an appropriate lock on the gp_relation_node relation */
 	gp_relation_node = heap_open(GpRelationNodeRelationId, RowExclusiveLock);
 
 	tuple = FetchGpRelationNodeTuple(gp_relation_node,

--- a/src/include/utils/relationnode.h
+++ b/src/include/utils/relationnode.h
@@ -44,10 +44,6 @@ extern void
 GpRelationNodeEndScan(
 	GpRelationNodeScan 	*gpRelationNodeScan);
 
-extern HeapTuple ScanGpRelationNodeTuple(
-	Relation 	gp_relation_node,
-	Oid 		relationNode,
-	int32		segmentFileNum);
 extern HeapTuple FetchGpRelationNodeTuple(
 	Relation 	gp_relation_node,
 	Oid 		relationNode,


### PR DESCRIPTION
Patch has couple of commits to add validation of tuple fetched from pg_class, pg_type and gp_relation_node using index. There were instances seen, where index lookup was returning incorrect tuple for these tables. Cause for the index going out of sync is yet to be found (maybe reset_xlog or some bug in system somewhere), but better to protect the system and detect earlier than causing further damage by blindly using the incorrect tuple. Hence as protective measure adding validation for these system tables.