### PR TITLE
Remove gpfdist library dependencies on the top level configure.

### DIFF
--- a/configure
+++ b/configure
@@ -697,6 +697,7 @@ LDFLAGS_EX
 ELF_SYS
 EGREP
 GREP
+with_apr_config
 APR_CONFIG
 with_libcurl
 with_rt
@@ -6309,6 +6310,7 @@ else
   APR_CONFIG=$with_apr_config
 fi
 
+
 #
 # Elf
 #
@@ -8824,7 +8826,6 @@ if test -n "$APR_CONFIG"; then
   apr_cppflags=`"$APR_CONFIG" --cppflags`
   CPPFLAGS="$CPPFLAGS $apr_includes $apr_cppflags"
   CFLAGS="$CFLAGS $apr_cflags"
-  LIBS="$LIBS $apr_link_ld_libs"
 fi
 
 if test "$enable_gpfdist" = yes ; then
@@ -8832,6 +8833,8 @@ if test "$enable_gpfdist" = yes ; then
   # in LIBS, hence AC_SEARCH_LIBS rather than AC_CHECK_LIB. (and the autoconf
   # manual recommends always using AC_SEARCH_LIBS rather than AC_CHECK_LIB
   # anyway)
+  _LIBS="$LIBS"
+  LIBS="$LIBS $apr_link_ld_libs"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing apr_getopt_long" >&5
 $as_echo_n "checking for library containing apr_getopt_long... " >&6; }
 if ${ac_cv_search_apr_getopt_long+:} false; then :
@@ -9008,6 +9011,7 @@ else
 $as_echo "$as_me: WARNING: libyaml is not found. disabling transformations for gpfdist." >&2;}
 fi
 
+  LIBS="$_LIBS"
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -921,6 +921,7 @@ if test "$with_apr_config" = yes; then
 else
   APR_CONFIG=$with_apr_config
 fi
+AC_SUBST(with_apr_config)
 
 #
 # Elf
@@ -1129,7 +1130,6 @@ if test -n "$APR_CONFIG"; then
   apr_cppflags=`"$APR_CONFIG" --cppflags`
   CPPFLAGS="$CPPFLAGS $apr_includes $apr_cppflags"
   CFLAGS="$CFLAGS $apr_cflags"
-  LIBS="$LIBS $apr_link_ld_libs"
 fi
 
 if test "$enable_gpfdist" = yes ; then
@@ -1137,10 +1137,13 @@ if test "$enable_gpfdist" = yes ; then
   # in LIBS, hence AC_SEARCH_LIBS rather than AC_CHECK_LIB. (and the autoconf
   # manual recommends always using AC_SEARCH_LIBS rather than AC_CHECK_LIB
   # anyway)
+  _LIBS="$LIBS"
+  LIBS="$LIBS $apr_link_ld_libs"
   AC_SEARCH_LIBS(apr_getopt_long, [apr-1], [], [AC_MSG_ERROR([libapr-1 is required for gpfdist])])
   AC_SEARCH_LIBS(event_add, [event], [], [AC_MSG_ERROR([libevent is required for gpfdist])])
 
   AC_SEARCH_LIBS(yaml_parser_initialize, [yaml], [have_yaml=yes], [AC_MSG_WARN([libyaml is not found. disabling transformations for gpfdist.])])
+  LIBS="$_LIBS"
   AC_SUBST(have_yaml)
 fi
 

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -9,9 +9,21 @@ endif
 override CPPFLAGS := -I. $(CPPFLAGS)
 
 OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o
+# configure should have been run by this point.
+# we are adding the gpfdist libraries here instead
+# of the top level, so that the backend does not
+# need to link with unnecessary libraries.
+GPFDIST_LIBS =-levent
 
 ifeq ($(have_yaml),yes)
+  GPFDIST_LIBS += -lyaml
   OBJS += transform.o
+endif
+
+ifeq ($(with_apr_config),yes)
+  APR_LIB=$(shell apr-1-config --link-ld --libs)
+else
+  APR_LIB=$(shell $(with_apr_config) --link-ld --libs)
 endif
 
 ifneq ($(PORTNAME),win32)
@@ -21,7 +33,7 @@ else
   OBJS += $(top_builddir)/src/port/glob.o
 endif
 
-LDLIBS += $(LIBS)
+LDLIBS += $(LIBS) $(GPFDIST_LIBS) $(APR_LIB)
 
 all: gpfdist$(EXE_EXT)
 


### PR DESCRIPTION
We don't need to link all of the gpfdist libraries to
the backend. Make sure that gpfdist is the only one who uses
libyaml, libevent, and libapr-1 for now.