### PR TITLE
Fix syntax bug - space to tab on makefile

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -1035,7 +1035,7 @@ mkgphdfs:
 	@cd extensions && $(MAKE) mkgphdfs OPT="$(INSTCFLAGS)" INSTLOC=$(INSTLOC)
 
 mkgps3ext:
-    @cd extensions && $(MAKE) mks3ext OPT="$(INSTCFLAGS)" INSTLOC=$(INSTLOC)
+	@cd extensions && $(MAKE) mks3ext OPT="$(INSTCFLAGS)" INSTLOC=$(INSTLOC)
 
 mkpljava:
 	@cd extensions && $(MAKE) mkpljava OPT="$(INSTCFLAGS)" INSTLOC=$(INSTLOC)


### PR DESCRIPTION
This is causing solaris to fail. complaining about syntax issues, while other platforms will just skip this tag.