### PR TITLE
Test migration from cdbfast to ICG. Migrated tests: targeted_dispatch, cursor and case

### DIFF
--- a/src/test/regress/data/lu_customer.data
+++ b/src/test/regress/data/lu_customer.data
@@ -1,0 +1,679 @@
+1|Maxwell|Aaronson|7/11/1960|9865 Marion Place Apt.|6||24
+2|Hugh|Abarca|9/17/1933|1660 Park Ave.|3||252
+3|Hazel|Abelson|4/8/1942|1882 St. Johns|3||111
+4|Brooks|Abern|12/5/1936|245 Eastwood|3||135
+5|Ross|Abram|2/28/1938|45 South Deer Creek Drive|3||236
+6|Wylie|Abrams|1/1/1968|5628 Orwenstensia|5||123
+7|Don|Addison|1/3/1950|9433 Burton Ave.|2||160
+8|Merrell|Adess|12/5/1950|310 Marquette Rd.|3||215
+9|Keith|Adler|1/12/1965|150 Harding Ave.|6||112
+10|Daniel|Aguilar|2/24/1966|125 Eastwood|3||227
+11|Deborah|Aguirre|11/13/1949|4259 W. Lake Ave.|7||72
+12|Dean|Ahern|10/15/1948|33 University Ave.|5||235
+13|Elton|Al-Timinu|9/10/1947|22 Ashland Ave.|7||212
+14|Dorthy|Alcaraz|3/7/1967|54 Lakeview Terrace|3||241
+15|Sarah|Aldo|3/29/1970|3901 Chester Ave. Apt. 3C|5||232
+16|Peggy|Alein|7/31/1931|1029 Marvel Way|2||182
+17|Maxwell|Alexander|8/30/1946|175 Lily Court|5||161
+18|Selene|Allen|1/1/1961|152 Clinton Ave.|2||103
+19|Mario|Alonso|4/30/1968|1815 Judson Rd.|9||147
+20|Calbert|Alvarado|2/7/1962|3618 Woodland Rd.|3||251
+21|Xavier|Alyea-Burkell|2/16/1951|1109 Marvel Way|8||74
+22|Belinda|Amsov|3/4/1963|17 Cavell Ave.|7||47
+23|Kent|Angelina|4/24/1964|4530 Oakland Drive|9||117
+24|Brent|Anovitz|5/12/1969|222 Clay Rd.|5||251
+25|Nicholas|Anthony|6/18/1970|1539 Bay Colony Dr.|3||98
+26|Jules|Apert|5/15/1965|1215 Judson Rd.|4||280
+27|Brock|Applebaum|6/13/1966|6228 Orwenstensia|2||56
+28|Laurell|Ardini|1/31/1949|644 Princeton Ln.|6||97
+29|Saul|Arenburg|3/4/1952|171 Clifton Rd.|7||216
+30|Jean|Armstrong|6/8/1959|1365 Hillcrest Circle|7||80
+31|Tess|Aronoff|6/12/1972|551 Madison St.|5||67
+32|Veda|Arrezola|7/3/1973|7261 White Oaks Ave.|6||85
+33|Sue|Artemis|10/3/1979|34 Lynn Terrace|4|suebaby@aol|76
+34|Mara|Ascher|1/8/1942|1750 Lily Court|4||206
+35|Gilbert|Astorino|4/25/1953|1701 W. Mellody Rd.|8||207
+36|Roger|Aufox|8/12/1937|1585 County line Rd.|4||270
+37|Rebecca|Aya|5/17/1954|224 Sherman Rd.|10||12
+38|Stacy|Azzi|10/1/1961|9365 Marion Place Apt.|6||55
+39|Sherwood|Bagleman|6/12/1955|763 Blackhawk Rd.|9||76
+40|Isaiah|Bahr|7/8/1971|1233 Arbor Rd.|4||16
+41|Mario|Baker|1/17/1932|1858 Balsam Way|1||18
+42|Dolly|Bakhitari|6/23/1967|8542 Sumac Rd.|6||129
+43|Wenda|Bales|7/18/1956|202 St.Johns Ave.|6||196
+44|Eli|Ball|10/2/1939|1839 McCraren Rd.|2||65
+45|Wylie|Ballatini|8/14/1937|3255 Golf Rd.|6||237
+46|Stephen|Ballin|8/23/1957|12 Eastwood|3||245
+47|Bridget|Bao|9/14/1958|1714 Clifton Rd.|1||135
+48|Ruby|Barack|8/31/1972|1715 Chicago Ave.|5||190
+49|Luther|Barcani|9/2/1973|8172 Virginia Rd.|5||248
+50|Tabitha|Barker|10/22/1974|922 Twin Oaks Drive|7|tabbycat@yahoo.com|170
+51|Patty|Barlow|10/2/1959|280 Skokie Rd.|4||198
+52|John|Barnett|12/6/1975|191 Old Briar Lane|2||84
+53|Ralph|Baron|7/31/1956|335 University Ave.|3||188
+54|Deborah|Barris|11/13/1975|190 Sunnyside Ave.|6|debbi@aol|69
+55|Jonathon|Barrow|8/22/1957|8122 North Ave.|4||46
+56|Barry|Baruffi|6/24/1968|539 Cordon Terr.|4||102
+57|Nell|Basillos|10/10/1959|456 Groverland Ave.|4||193
+58|Pamela|Bauden|1/31/1950|2644 Princeton Ln.|3||114
+59|Louis|Baum|12/26/1961|25 Oakridge Ave.|1||187
+60|Milton|Baumrick|4/17/1961|594 Cordon Terr.|9||232
+61|Alan|Bayanie|11/7/1960|1787 Balsamic Ave.|7||119
+62|Serge|Bayer|4/19/1965|1752 Clinton Ave.|3||76
+63|Randolph|Bazzoni|2/1/1953|2878 Sheridan Rd.|5||80
+64|Dwight|Bear|12/5/1951|224  Highwood Ave.|7||237
+65|Regan|Becerra|12/5/1961|2148 Oakridge Ave.|3||4
+66|Carrie|Becker|3/29/1942|2378 Sheridan Rd.|6||71
+67|Theo|Bederman|12/5/1965|171 Chicago Ave.|6||11
+68|Carey|Belmonti|4/16/1943|4586 Groverland Ave.|4||271
+69|Pierre|Belster|5/12/1944|550 Sheridan|6||211
+70|Trent|Benbaum|1/29/1962|3970 Vilas Circle|5||57
+71|Nathan|Benberg|6/11/1945|24 Ashland Ave.|4||35
+72|Ben|Benjamin|2/13/1963|2219 Hillcrest Ave|10||260
+73|Mercedes|Berber|8/19/1947|77 Blackhawk Rd|3||92
+74|Marcus|Berhoff|1/16/1966|2188 Oakridge Ave.|5||84
+75|Galvin|Beris|2/9/1959|67 Sheridan Rd.|9||169
+76|Clarinda|Berk|3/14/1936|6626 Lyons Circle|6||14
+77|Christie|Berkenhiemer|9/18/1942|154 Vine|2||270
+78|Reed|Berkson|6/18/1951|5212 Hill|1||50
+79|Max|Berman|9/11/1954|302-A Crestwood Village Rd.|4||32
+80|Fletcher|bernadi|2/13/1967|8599 Harvard Ct|6||128
+81|Jonathon|Berrity|3/26/1964|9187 Fairview Ave.|3||175
+82|Jonathon|Bertam|3/6/1960|872 Virginia Rd.|3||236
+83|Merrell|Bickmore|4/21/1965|7530 Homewood Ave.|4||152
+84|Zabrina|Biley|1/9/1952|267 Anderson Lane|2||271
+85|Geoffery|Birkenstein|2/28/1967|195 First St.|4||173
+86|Abner|Bishop|5/31/1968|22 Vine Ave.|4||74
+87|Elaine|Bishop|5/6/1950|222 Sherman Rd.|5||145
+88|Bartlett|Black|9/14/1960|3513 Grove Ave.|5||228
+89|Craig|Black|11/13/1960|54 Chicago Ave.|3||59
+90|Libby|Black|6/18/1951|629 Kincaid Ave.|6||22
+91|Amber|Blackard|11/12/1942|251 Crain|3||2
+92|Megan|Blair|7/8/1970|1393 Bay Colony Dr.|8||6
+93|Stefan|Blair|3/9/1968|3565 Golf Rd.|2||96
+94|Ted|Blechman|8/13/1951|1126 Hillcrest Ave|4||130
+95|Taylor|Blitstein|12/13/1941|1556 Ridge Rd.|3||270
+96|Jacob|Blondi|4/10/1969|4343 Burton Ave.|6||153
+97|Jed|Bloomberg|10/3/1976|1715 Judson Rd.|9|bloomberg@yahoo.com|123
+98|Jed|Bloomgarden|7/22/1950|442 Valley Rd.|10||13
+99|Darrick|Blum|11/6/1930|899 Harvard Ct|2||109
+100|regan|Bolender|9/24/1964|262 Prarie Ln.|2||103
+101|Selene|Bommario|2/13/1945|3367 Bluebird Terr.|2||3
+102|Eugene|Bonelli|3/15/1958|770 Exmoor Rd.|5||281
+103|Waldo|Borden|11/13/1954|377 Blackhawk Rd|9||28
+104|Cary|Bowden|10/16/1953|2479 Woodridge Drive|8||159
+105|Fernanda|Bowden|9/20/1952|715 Chicago Ave.|3||231
+106|Erwin|Brickstone|5/20/1970|4635 Stratford Rd.|4||167
+107|Moses|Brickstone|5/12/1966|662 Lyons Circle|5||234
+108|Wendy|Brinkman|7/14/1952|169 Judson Ave.|1||77
+109|Daphne|Brooks|2/9/1963|2445 Oakridge Ave.|4||129
+110|Jessica|Brooks|8/29/1953|33976 Forest View Rd.|4||17
+111|Otto|Brown|1/18/1962|1455 Ridgewood Drive|6||199
+112|Rita|Brown|6/27/1955|311 Barkwood Ct.|6||164
+113|Judy|Brugioni|6/12/1971|1957 Huntington Ave.|3||215
+114|Iona|Bruns|5/12/1954|3555 Golf Rd.|5||130
+115|Mercedes|Bush|9/9/1954|600 Winsor Mall|3||107
+116|Clarinda|Butler|4/18/1953|318 Barkwood Ct.|5||62
+117|George|Butler|3/16/1952|614 Green bay Rd.|4||271
+118|Harvey|Campaigni|7/14/1972|475 Roger Williams Ave.|2||57
+119|Dion|Candeni|4/16/1947|124 Eastwood|5||75
+120|Jesse|Canel|8/26/1973|6843 De Temple Rd.|4||69
+121|Judith|Cao|9/11/1958|2870 Skokie Rd.|2||280
+122|Serge|Cao|10/20/1955|8441 Spruce St.|3||90
+123|Nevin|Capian|9/14/1974|795 Lake Cook Rd.|8||53
+124|Leroy|Carani|5/23/1948|8615 Old Tall Tree Lane|3||260
+125|Zabrina|Carmel|11/12/1961|31976 Forest View Rd.|3||178
+126|Blossom|Carper|10/5/1975|632 Prarie Ln.|6||22
+127|Felix|Cawn|2/3/1952|6433 De Temple Rd.|2||74
+128|Frances|Chi-Lin|9/30/1959|292 Twin Oaks Drive|1||39
+129|Julie|Chio|5/2/1967|445 Park Ave.|6||123
+130|Weston|Christopher|6/20/1956|6004 Central Ave.|3||115
+131|Spencer|Chubin|4/17/1954|9065 Marion Place Apt.|4||163
+132|Ira|Churchill|6/19/1949|22 Clay Rd.|6||251
+133|Darcy|Cohen|10/11/1960|486 Old Deerfield Rd.|5||86
+134|Stanley|Coretti|12/9/1955|129 Broadview Lane|1||171
+135|Forrest|Crane|6/21/1961|1375 Beech St.|9||226
+136|Cherry|Cross|8/19/1963|422 Valley Rd.|8||7
+137|Aldora|Dahl|12/13/1941|4335 Burton Ave.|3||66
+138|Lilly|Davis|6/12/1944|2922 Twin Oaks Drive|9||77
+139|Travis|De Bolsky|11/12/1956|120 Linden Ave.|4||214
+140|Nelson|DeFillipos|12/13/1957|1859 Green Bay Rd.|6||38
+141|Perry|Delrahim|8/25/1958|1355 Ridgewood Drive|3||156
+142|Gerald|Denver|6/15/1932|507 S. Prospect Ave.|5||44
+143|Leslie|Deutsch|1/16/1958|45 Oakridge Ave.|3||226
+144|Abner|Devora|2/13/1959|225 Jeffrys Place|4||143
+145|Lynn|Diaz|3/23/1960|2015 Pleasent Ave.|8||81
+146|Aldora|Dim|4/27/1930|5518 Madison St.|2||159
+147|Barrett|DiVenanzo|11/17/1965|175 Roger Williams Ave.|4||151
+148|Margaret|Divinci|5/25/1961|1954 First St.|5||176
+149|Alexandria|Dixon|3/14/1939|3455 Golf Rd.|4||30
+150|Amber|Dixon|4/15/1961|387 Green Bay Rd.|3||281
+151|Lester|Donovan|6/4/1930|4750 Homewood Ave.|5||137
+152|Wenda|Dranove|12/7/1966|4304 Oakland Drive|6||245
+153|Edana|Duenow|9/4/1935|4656 Grossman Ln.|1||59
+154|Alison|Eichner|4/5/1960|263 Prarie Ln.|8||90
+155|Natalie|Ellman|10/13/1965|9167 Fairview Ave.|3||125
+156|Jason|Erwin|9/7/1964|146 Old Deerfield Rd.|3||34
+157|Paul|Evans|8/3/1963|110 Marquette Rd.|5||56
+158|Taylor|Evans|5/27/1962|1704 Ridgelee Rd|3||261
+159|Libby|Ewing|1/3/1967|185 Balsam Way|8||251
+160|James|Extov|3/3/1958|9291 Brittany Ave.|8||281
+161|Marilyn|Fabbi|12/13/1955|564 Lakeview Terrace|7||205
+162|Jules|Feight|11/25/1954|264 Princeton Ln.|4||193
+163|Gladys|Feldman|4/27/1968|158 Balsam Way|9||26
+164|Jules|Ferratti|2/23/1957|406 Trinity Ct.|5||230
+165|Brett|Fieldman|6/14/1963|76 Judson Place|5||247
+166|Emily|Filipowski|7/18/1964|643 De Temple Rd.|1||90
+167|Prior|Finger|4/4/1959|2220 Grant Blvd.|3||63
+168|Cecelia|Fish|3/26/1956|119 Twin Oaks Place|4||25
+169|Tara|Fish|2/22/1955|3575 Golf Rd.|2||87
+170|Travis|Fish|12/7/1953|157 Oakwood Ave.|3||175
+171|Ross|Fisher|11/18/1952|347 Green Bay Rd.|3||80
+172|Stacy|Fleishman|11/12/1940|671 Blackstone Ave.|5||10
+173|Marcus|Fligel|5/27/1946|135 Lakewood place|4||39
+174|Colby|Flinn|8/19/1974|15 Chicago Ave.|2|beast@erols.com|60
+175|Katharine|Flinn|2/14/1968|3644 Princeton Ln.|4||19
+176|Abraham|Flore|10/3/1934|1658 Second St.|5||101
+177|Ara|Foreman|12/3/1967|310-C Crestwood Village Rd.|6||33
+178|Dalton|Foreman|3/18/1969|518 Madison St.|2||189
+179|Ted|Fox|5/3/1969|21 Callan Rd.|4||86
+180|Ward|Fox|4/15/1970|385 University Ave.|4||65
+181|Dustin|Frump|8/7/1965|1619 Judson Ave. Apt #34B|6||192
+182|Henry|Funk|6/27/1959|122 Fort Sheriden Ave.|5||27
+183|Lucy|Furgatch|3/14/1967|2345 Oakridge Ave.|4||145
+184|Tabitha|Furla|5/27/1971|214 Eastview Dr.|6||270
+185|Nelson|Furner|6/14/1972|160 Park Ave.|6||280
+186|Selby|Fyk|9/22/1950|425 Lake Ave.|9||131
+187|Laggie|Galassani|7/23/1973|1550 Ridge Rd.|3|glass@hotmail.com|271
+188|Susan|Gallen|2/13/1969|917 Fairview Ave.  Apt. 982|5||93
+189|Connie|Gant|11/25/1964|1515 Judson Rd.|4||97
+190|Stacy|Gant|10/13/1951|6716 Cobblestone Cir.|5||142
+191|Brandon|Garland|8/14/1961|467 Sheridan Rd.|3||53
+192|Tara|Garland|11/12/1952|310 Summit Ave.|8||182
+193|Morris|Gellar|7/19/1967|3876 Forest View Rd.|4||52
+194|Roxanne|Gelling|8/21/1968|6218 Sheriden Rd.|4||147
+195|Agna|Gerdes|9/23/1969|185 Green Bay Rd.|6||32
+196|Meryl|Gertler|10/28/1970|487 Green Bay Rd.|5||111
+197|Vern|Gill|7/29/1945|886 Yale Lane|9||270
+198|Douglas|Gimelferd|8/11/1974|4536 Grossman Ln.|4||65
+199|Bartlett|Ginnely|9/5/1975|3181 Barkwood Ct.|6||271
+200|Val|Ginrich|10/19/1936|18 Madison St.|5||147
+201|Marilyn|Glantz|5/24/1943|901 Chester Ave. Apt.|6||106
+202|Mario|Glazier|11/13/1959|267 Sheridan Rd.|10||237
+203|Elena|Glenwood|1/7/1951|135 Knollwood Drive|1||281
+204|Rosalie|Glenwood|12/27/1953|6020 Central Ave|6||202
+205|Ray|Gluterman|3/14/1941|8812 North Ave.|7||189
+206|Blair|Goldstein|2/11/1940|1155 Ridgewood Drive|4||280
+207|Jennifer|Gould|1/31/1954|12 Craven Way|3||281
+208|Ira|Graham|1/9/1939|42 Valley Rd.|6||175
+209|Don|Gray|9/11/1962|9270 Vilas Circle|2||99
+210|Laura|Gray|2/28/1955|239 Sheriden Rd.|5||191
+211|Corey|Greco|3/10/1956|660 Park Ave.|6||195
+212|Jonathon|Grey|10/6/1965|175 Lake Cook Rd.|4||179
+213|Charles|Gross|4/18/1969|1575 Oakwood Ave.|3||112
+214|Wane|Guzman|12/10/1938|852 Sumac Rd.|2||53
+215|Timothy|Haines|2/23/1967|268 Sheridan Rd.|2||120
+216|Conroy|Hallsten|1/12/1966|122 Craven Way|5||163
+217|Caesar|Halverson|12/10/1965|432 Valley Rd.|1||113
+218|Quinn|Hambrick|11/29/1964|42 Ashland Ave.|8||204
+219|Yvonne|Happ|11/4/1966|232 Northbrook Ct.|2||120
+220|Claude|Hardy|4/1/1957|8126 North Ave.|2||33
+221|Newton|Harris|5/8/1958|177 Balsamic Ave.|10||202
+222|Barry|Hartman|12/25/1967|12 Broadview Lane|5||60
+223|Moses|Hearn|1/16/1968|24 Briar Ln|6||12
+224|Juliet|Hehner|11/23/1966|170 Linden Ave.|7||92
+225|Deloris|Heller|3/14/1968|6700 Central Ave.|9||82
+226|Harry|Heller|6/16/1959|4836 W. River Oaks Dr.|2||116
+227|Priscilla|Heritage|2/15/1969|139 Bay Colony Dr.|5||66
+228|Kay|Hershenson|8/19/1961|1920 Sunnyside Ave.|5||85
+229|Theo|Heyman|7/7/1960|38 University Ave.|6||155
+230|Wayne|Highlander|5/20/1970|3487 Green Bay Rd.  |3||117
+231|Carla|Hill|3/28/1970|2313 Grove Ave.|5||228
+232|Rebecca|Hill|9/20/1962|168 Second St.|8||280
+233|Wade|Hirsh|7/2/1931|35 University Ave.|6||220
+234|Judy|Hoffmann|7/12/1969|244 Briar Ln|2||72
+235|Dale|Holmes|10/28/1965|8244 Spruce St.|6||143
+236|Perry|Holmes|4/13/1971|1077 Court Ave.|3||62
+237|Homer|Holstein|7/13/1962|316 Summit Ave.|1||231
+238|Bela|Howard|5/12/1972|147 Vine|6||185
+239|Hans|Hurst|10/2/1963|750 Lily Court|6||151
+240|Eunice|Husher|5/12/1960|1912 Old Briar Lane #2|6||116
+241|Tilda|Ingres|2/4/1955|1253 Arbor Rd.|10||140
+242|Shirley|Irvince|9/23/1945|1220 Heather Lane|2||235
+243|Frank|Isacc|7/18/1943|1420 High St.|2||168
+244|Daniel|Isenberg|1/3/1956|4564 Grossman Ln.|3||8
+245|Pedro|Isreal|8/3/1932|232 Clay Rd.|6||154
+246|James|Izotafor|9/14/1933|4633 Burton Ave.|7||86
+247|Cherry|Jackson|11/2/1964|2148 Eastview Dr.|6||70
+248|Douglas|Johnson|12/16/1965|174 Ridgelee Rd|4||1
+249|Peter|Johnson|10/9/1934|812 North Ave.|4||215
+250|Emmanual|Joseph|11/13/1935|10 Crain|2||96
+251|Darnell|Juul|12/18/1936|43 Blackhawk Rd.|6||188
+252|Sloan|kafenshock|6/26/1973|101 W. Mellody Rd.|2||79
+253|Hilary|Kagan|1/9/1944|32 Northbrook Ct.|6||58
+254|Jordan|Kahn|2/13/1931|338 University Ave.|6||91
+255|Irvin|Kallick|10/17/1963|4763 Blackhawk Rd.|9||112
+256|Curt|Kane|2/13/1933|1949 Cloverdale Rd.|5||90
+257|Reuben|Kane|1/16/1932|452 Valley Rd.|3||165
+258|Sophia|Kanter|7/7/1950|107 S. Prospect Ave.|3||281
+259|Diana|Kaplan|12/14/1931|232 Prarie Ln.|4||89
+387|Gregory|Palmero|12/5/1962|1279 McCraren|3||233
+388|Abigail|Paoletti|7/21/1958|146 Oakwood|3||260
+389|Wanda|Pappolone|6/20/1957|154 Knolwood Rd.|2||168
+390|Ella|Parsons|5/17/1956|678 Sheridan Rd.|5||93
+391|Aaron|Paschen|4/4/1955|459 W. Lake Ave.|2||82
+392|Priscilla|Pasieka|3/14/1954|43078 Kennedy Dr.|4||154
+393|Alisa|Passis|1/4/1946|1450 Harding Ave.|5||105
+394|Brad|Patrick|2/3/1947|450 Harding Ave.|9||7
+395|Miles|Paulessian|4/8/1948|616 Cobblestone Cir.|8||111
+396|Bradford|Pauly|1/15/1963|1950 Sunnyside Ave.|2||140
+397|Kent|Pauly|2/13/1964|6500 Central Ave.|2||87
+398|Belinda|Pawkov|5/3/1949|2718 Oakridge Ave.|8||125
+399|May|Pawsquesi|3/1/1950|35 Glenlake Dr.|6||168
+400|Sanders|Pederson|1/7/1940|81 Hill St. Apt.|4||9
+401|Virgil|Pederson|11/23/1969|1639 Bay Colony Dr.|4||39
+402|Emeline|Perkins|7/18/1936|390 Chester Ave. Apt.|8||72
+403|Mary|Perlstein|3/28/1965|310 Walker Ave.|3||66
+404|Vivian|Perlstein|7/15/1952|306 Lindenwood Ln.|5||181
+405|Edward|Perryman|12/8/1970|204 St.Johns Ave.|3||95
+406|Corey|Pestine|12/7/1945|4830 Oakland Drive|7||88
+407|Frances|Peters|1/6/1971|547 Vine|2||138
+408|Jean|Pettorelli|2/19/1972|1185 County line Rd.|5||247
+409|Don|Phillips|10/10/1955|30 Walker Ave.|10||224
+410|Maxwell|Pieracci|11/15/1956|58 Madison St.|5||180
+411|Dora|Pierce|12/1/1957|774 Blackhawk Rd|3||129
+412|Murray|Plathe|1/2/1958|293 Arlington Ave.|9||109
+413|Ellis|Podolony|9/1/1930|1255 Ridgewood Drive|6||227
+414|Rebecca|Pomerantz|8/14/1953|937 Judson Ave.|9||243
+415|Wendell|Porges|3/9/1973|1120 Heather Lane|9||270
+416|Alexis|Powell|10/2/1943|1385 County line Rd.|4||252
+417|Kurt|Pratt|4/22/1974|1420 Sunnyside Ave.|2||58
+418|Anna|Prior|8/14/1941|8512 North Ave.|5||142
+419|Clara|Pristav|3/17/1934|119 Judson Ave.|4||240
+420|Malcolm|Prokos|7/31/1940|1245 Eastwood|3||241
+421|Nina|Pulver|6/30/1939|511 Maple Ave.  Apt. 1B|4||224
+422|Susan|Pyster|4/30/1950|245 Oakridge Ave.|5||208
+423|Jane|Queary|5/21/1938|123 Broadview Lane|9||42
+424|Julie|Quillman|4/9/1937|752 Clinton Ave.|5||49
+425|Sabrina|Quintos|5/11/1975|6100 Central Ave|3|witch@hotmail.com|252
+426|Calvin|Quirk|2/16/1935|807 Old Trail Rd.|3||281
+427|Heather|Rabatinni|1/4/1934|154 First St.|4||98
+428|Kara|Rabin|12/18/1933|545 Lakeview Terrace|2||104
+429|Charis|Rackland|11/6/1932|673 Calais Drive|2||232
+430|Violette|Raden|6/7/1965|788 Tennyson Ave.|2||120
+431|John|Radke|5/20/1951|1485 County line Rd.|2||168
+432|Trent|Rafferty|10/5/1931|210 Crain|5||260
+433|Alisa|Raisman|5/14/1962|227 Anderson Lane|6||106
+434|Megan|Rapaport|2/10/1965|8939 Harvard Ct|7||222
+435|Micah|Rapaport|6/7/1952|1860 Parkside Ln.|6||176
+436|Emmanual|Raupp|7/8/1953|1486 Oakwood|3||251
+437|Tess|Redeemer|7/19/1966|2267 Anderson Lane|5||214
+438|Alanzo|Redman|9/12/1962|3515 Golf Rd.|10||5
+439|Rita|Reed|10/4/1963|3150 Skokie Valley Rd.|5||194
+440|Stewart|Reeder|8/19/1954|4126 Hillcrest Ave|3||149
+441|Charlton|Reese|12/26/1965|619 Judson Ave.|4||210
+442|Cherry|Reese|1/5/1966|785 Highland place|5||244
+443|Louis|Reich|9/22/1955|750 Homewood Ave.|2||70
+444|Ivy|Reidda|12/19/1960|6259 Kincaid Ave.|5||261
+445|Audrey|Reinhold|8/23/1967|4458 Park Ave.|2||68
+446|Bradford|Reinhold|10/11/1956|9470 Vilas Circle|2||150
+447|Hans|Reinhold|6/9/1970|10 Walker Ave.|5||226
+448|Ursula|Rich|8/21/1951|9137 Judson Ave.|4||20
+449|Ula|Richards|11/6/1950|24 Oakridge Ave.|2||168
+450|Nola|Richmond|9/25/1968|47 Vine|6||121
+451|Seth|Rickey|11/15/1957|6345 St. Johns Ave.|3||144
+452|Accalia|Rifkin|10/2/1949|35 Lakewood place|5||221
+453|Pedro|Rifkin|9/10/1948|1270 Linden Ave.|7||251
+454|Samson|Ritter|8/2/1949|3100 Trailer Way|3||114
+455|Willis|Ritter|6/7/1947|4567 Grossman Ln.|4||78
+456|Laurell|Rivi|2/12/1967|1221 Marvel Way|5||207
+457|Allister|Robbins|1/26/1942|57 Chicago Ave.|1||77
+458|Elaine|Rodin|2/26/1943|142 Broadview Lane|5||44
+459|Beth|Roener|12/27/1958|179 Rosemary Way|3||156
+460|Wayne|Roener|3/25/1944|4465 Stratford Rd.|5||18
+461|Isaac|Roenick|4/12/1945|38976 Forest View Rd.|2||130
+462|Faith|Rogalsky|10/31/1969|133 Cavell Ave.|1||195
+463|Rosanna|Rogers|5/16/1958|45 Eastwood|9||240
+464|Dorthy|Rojas|7/19/1948|7815 Highland place|3||87
+465|Lester|Root|1/20/1959|1547 Knolwood Rd.|5||95
+466|Desma|Rosenbrack|9/2/1950|2937 Judson Ave.|3||242
+467|Jean|Rosendo|10/14/1951|150 Lily Court|6||128
+468|Sarah|Rosenzweig|11/12/1970|1320 Heather Lane|5||244
+469|Nell|Rosie|2/3/1960|175 Clinton Ave.|5||147
+470|Nina|Roth|1/18/1954|350 Skokie Valley Rd.|4||280
+471|Darrell|Rothman|3/14/1961|1915 Pleasent Ave.|1||230
+472|Kara|Rowe|12/13/1971|235 Easton Rd.|2||82
+473|Evan|Rozenfeld|4/21/1957|302 Lindenwood Ln.|6||61
+474|Tyson|Rozino|4/25/1962|381 Barkwood Ct.|2||80
+475|Brice|Rozoff|5/5/1963|181 Beverly Place|7||87
+476|Quincy|Rubens|1/3/1972|1577 Balsamic Ave.|6||74
+477|Arthur|Rubenstein|7/13/1946|446 Sheridan Rd.|9||154
+478|Avery|Rubinoff|9/20/1952|1267 Balsamic Ave.|3||57
+479|Brad|Rudman|10/11/1953|296 Arlington Ave.|8||142
+480|Lucy|Ruffer|2/4/1973|79 McCraren|4||204
+481|Darrick|Ruken|6/27/1964|218 Eastview Dr.|2||18
+482|Mac|Runn|1/17/1956|360 Summit Ave.|9||167
+483|Clarinda|Rusnack|12/12/1967|5126 Hill|6||155
+484|Kimberly|Russell|3/17/1974|1415 Judson Rd.|6||178
+485|Ariana|Russian|7/7/1950|2698 Sheridan Rd.|7||151
+486|Neville|Ruth|5/5/1960|2678 Sheridan Rd. |7||95
+487|Priscilla|Rychel|6/6/1961|5131 Hill|5||167
+488|Jason|Rynor|7/7/1962|875 Roger Williams Ave.|3||184
+489|Molly|Saalfield|8/8/1963|5412 Hill|3||98
+490|Jessica|Sachman|9/9/1964|473 Blackhawk Rd.|5||99
+491|page|Sachnoff|10/10/1965|38476 Forest View Rd.|10||60
+492|Henry|Sachs|11/11/1966|1754 Beech St.|5||62
+493|Oakey|Sadowsky|7/18/1965|1065 Hillcrest Circle|9||81
+494|Emerson|Saed|7/22/1962|9117 Fairview Ave.|10||189
+495|Yvonne|Saigh|4/20/1975|169 McCraren|1|yvi@aol|260
+496|Shaw|Salelli|8/3/1950|4516 Grossman Ln.|4||225
+497|Celena|Saliba|9/14/1951|309 Priscilla Court|6||217
+498|Bert|Salomon|11/17/1966|2032 Northbrook Ct.|3||96
+499|Samuel|Saltpeper|8/13/1932|558 Madison St.|3||226
+500|Kirby|Saltzman|1/7/1968|4467 Sheridan Rd.|9||136
+501|Judy|Samson|10/12/1952|52 Clinton Ave.|3||252
+502|Kelsey|Samuelson|3/7/1970|6431 De Temple Rd.|6||176
+503|Stanley|Sanderas|11/17/1953|6136 Cobblestone Cir.|10||153
+504|Pierre|Santucci|11/8/1935|15 Lakewood place|1||173
+505|Shelby|Santucci|5/30/1965|254  Highwood Ave.|4||82
+506|Amber|Sass|1/12/1937|120 Heather Lane|4||163
+507|Peter|Sass|12/22/1954|1201 Deerfield Place|4||67
+508|Cornelius|Savin|1/20/1955|6423 De Temple Rd.|1||154
+509|Alan|Savocci|2/13/1956|18 St. Johns|8||202
+510|Deborah|Scava|5/17/1931|175 Elmwood Circle|5||158
+511|Wayne|Schack|6/27/1966|535 Knollwood Drive|5||251
+512|Gail|Schad|7/31/1933|4233 Burton Ave.|7||167
+513|Jules|Schalfer|8/1/1934|8393 Burton Ave|4||64
+514|Duke|Schalps|4/17/1957|6443 De Temple Rd.|4||25
+515|Alexandria|Schanks|3/31/1946|55 Madison St.|4||189
+516|Jasper|Schecherman|5/15/1958|269 Winsor Mall|4||63
+517|Tabitha|Schectman|8/15/1970|125 Broadview Lane|6||63
+518|Milton|Scheff|6/21/1959|5311 Maple Ave.  Apt.|2||260
+519|Madeline|Schelbas|12/16/1969|50 Sheridan|2||55
+520|Dean|Schelenger|10/31/1967|362 Lindenwood Ln.|4||91
+521|Hector|Schessel|3/18/1966|212 Clay Rd.|4||133
+522|Kerry|Scheurzer|7/17/1967|2183 Oakridge Ave.|4||92
+523|Jason|Schilling|6/22/1963|3267 Bluebird Terr.|3||141
+524|Hal|Schmidt|7/25/1964|179 Lake Cook Rd.|4||158
+525|Duke|Schneider|8/23/1965|63 Blackhawk Rd.|5||164
+526|Lara|Schoenberg|9/28/1966|73 Calais Drive|4||142
+527|Earl|Schoenfeld|2/19/1965|1101 Deerfield Place|10||79
+528|Stacy|Schuman|8/28/1968|545 St. Johns Ave.|8||122
+529|Martin|Schwartz|11/12/1968|1799 Rosemary Way|2||93
+530|Darrell|Scoravacco|9/2/1969|436 Waverly Rd.|9||261
+531|Oakey|Scotten|10/4/1970|120 Sunnyside Ave.|1||49
+532|Leroy|Sedgewick|2/2/1969|3344 Beachwood Ln.|2||115
+533|Patty|Segel |1/3/1964|120 High St.|4||49
+534|Minnie|Seibold|3/8/1953|148 Eastview Dr.|2||199
+535|Robin|Selan|11/1/1950|231 Sheriden Rd.|1||175
+536|Trude|Seligman|5/18/1955|669 Kikaid|6||248
+537|Rodman|Sennett|12/31/1951|157 Vine|3||227
+538|Clifford|Shafer|7/21/1957|131 Beverly Place|9||69
+539|Eve|Shafer|8/23/1968|6008 Central Ave.|7||121
+540|Ruby|Shafer|1/5/1952|547 Knolwood Rd.|6||205
+541|Cecelia|Shah|2/3/1953|194 First St.|3||249
+542|Nicolette|Shallow|3/14/1954|8439 Burton Ave|4||136
+543|Crsby|Shelton|12/14/1962|4256 Grossman Ln.|3||122
+544|Ferris|Sher|1/9/1963|337 Cavell Ave.|4||73
+545|Enos|Shorr|2/17/1964|30 Priscilla Court|3||189
+546|Timothy|Shutan|3/19/1965|9417 Fairview Ave.|1||281
+547|Dwight|Siber|4/18/1966|8139 Burton Ave|8||86
+548|Ivan|Siegal|11/20/1937|1231 Hillcrest Ave|4||221
+549|Wade|Silberman|12/9/1963|6144 Green bay Rd.|5||174
+550|Ward|Silverman|11/8/1962|2518 Oakridge Ave.|4||270
+551|Carla|Simon|11/6/1944|224 St.Johns Ave.|4||77
+552|Dustin|Simon|2/14/1951|8949 Harvard Ct|6||169
+553|Libby|Siskel|9/14/1969|175 Oakwood Ave.|7||188
+554|Betsy|Sizemore|4/16/1955|155 Knollwood Drive|4||28
+555|Byron|Skae|5/13/1956|59 Priscilla Court|6||260
+556|Elijah|Skikelmire|3/14/1966|4730 Oakland Drive|3||108
+557|Sabrina|sklyes|10/22/1970|14 Ridgelee Rd|2||19
+558|Fred|Small|3/14/1964|4777 Balsamic Ave.|3||180
+559|Roger|Small|11/12/1971|186 Parkside Ln.|3||13
+560|Stephen|Small|6/17/1957|234 Devonshire Court|2||101
+561|Adela|Smalls|12/7/1972|161 Judson Ave.|3||180
+562|Gabe|Smiley|11/28/1974|355 Golf Rd.|4||204
+563|Rosanna|Smiley|10/30/1973|3412 Hillcrest Ave|10|smile@erols.com|280
+564|Laurell|Smith|9/29/1972|6 Cobblestone Cir.|6||95
+565|Sarah|Smith|8/13/1971|201-C Frontage Rd.|6||197
+566|Gail|Solomon|7/1/1970|312-A Crestwood Village Rd.|8||76
+567|Johanna|Somner|6/14/1969|172 Clinton Ave.|1||44
+568|Rachel|Soth|7/12/1958|4333 Burton Ave.|2||184
+569|Hubert|Soto|1/18/1973|112 Old Briar Lane|2||251
+570|Ray|Spanier|2/13/1974|43588 Kennedy Dr.|6||69
+571|Chandler|Sporadin|5/19/1968|136 Waverly Rd.|8||218
+572|Cecil|Sproat|4/18/1967|135 Easton Rd.|4||119
+573|Kermit|Sraneck|8/14/1959|145 Eastwood|3||194
+574|Adam|Srungin|1/9/1964|14836 W. River Oaks Dr.|7||54
+575|Elaine|Starr|1/9/1968|278 Sheridan Rd.|6||1
+576|Wendy|Stefani|3/19/1975|425 W. Lake Ave.|2|wstefani@erols.com|224
+577|George|Steibel|4/8/1965|1615 Judson Rd.|4||192
+578|Frederick|Steiger|4/12/1967|6703 Calais Drive|4||250
+579|Felix|Stein|6/4/1969|2844 Princeton Ln.|2||155
+580|Jessica|Stein|2/4/1933|3134 Grove Ave.|4||187
+581|Dara|Steinberg|4/5/1959|6435 De Temple Rd.|5||186
+582|Umma|Stickdale|9/10/1960|227 Clay Rd.|3||152
+583|Moses|Stine|2/7/1957|4 Lakeview Terrace|7||209
+584|Christie|Stirrat|5/6/1966|315 Skokie Valley Rd.|3||93
+585|Lena|Stone|10/3/1961|522 N. Greenview Apt.|10||61
+586|Chenet|Storck|3/8/1932|31876 Forest View Rd.|4||51
+587|Nathan|Stuart|6/27/1967|1315 Judson Rd.|4||251
+588|Charles|Stukkle|11/2/1962|510 Crain|3||18
+589|Sheldon|Sutherland|7/30/1969|9173 Fairview Ave.|5||225
+590|Prescott|Swanson|7/13/1968|62 Lindenwood Ln.|2||60
+591|Stacy|Swanson|4/7/1933|6743 De Temple Rd.|4||84
+592|Carter|Sweig|5/16/1934|12 Walker Ave.|7||96
+593|Susan|Swislow|4/8/1970|3844 Spruce St.|4||163
+594|Brad|Szanto|12/16/1963|839 Burton Ave|6||1
+595|Ted|Szokol|6/19/1935|202 Northbrook Ct.|4||164
+596|Holly|Talman|7/1/1933|1679 McCraren|10||37
+597|Violette|Taubner|8/3/1969|1836 W. River Oaks Dr.|2||187
+598|Katharine|Taxy|1/12/1964|32 Prarie Ln.|4||111
+599|Mara|Teitbaum|9/30/1938|74 Judson Place|4||85
+600|Elbert|Terry|9/24/1970|452 N. Greenview Apt.|8||25
+601|Edward|Thomas|8/17/1970|965 Marion Place Apt. 65C|3||15
+602|Isaac|Thuente|2/13/1965|1287 Glencoe Ave.|3||187
+603|Aaron|Tilmon|10/26/1971|6652 Lyons Circle|2||38
+604|Amber|Timber|1/6/1944|175 Chicago Ave.|3||105
+605|Chloris|Timber|11/23/1972|21 Lakeview Terrace #2312|10||158
+606|Hugh|Tiran|12/16/1973|1040 Marvel Way|4||114
+607|Lucy|Tisch|3/14/1950|6783 Calais Drive|4||21
+608|Brice|Tobiason|1/7/1930|8433 Burton Ave.|6||9
+609|Merrell|Tobin|1/7/1974|1875 Roger Williams Ave.|5|toby@aol|83
+610|Forrest|Tomei|4/17/1951|4522 N. Greenview Apt. 1B |8||176
+611|Connie|Tondi|3/7/1934|4628 Orwenstensia|4||205
+612|Wendell|Towain|4/16/1935|2936 Arlington Ave.|7||1
+613|Harry|Treviarius|5/25/1952|1547 Vine|1||251
+614|Ivan|Triefu|5/17/1936|21 Twin Oaks Place|4||271
+615|Gabrielle|Triffler|6/19/1937|205 St. Johns Ave.|6||85
+616|Murray|Troji|7/22/1938|25 Jeffrys Place|8||94
+617|Joshua|Trudell|8/25/1939|60 Central Ave.|8||84
+618|Charlton|Trull|9/13/1940|183 McCraren Rd.|4||270
+619|Agatha|Trunbar|10/16/1941|8329 Burton Ave|4||112
+620|Jean|Tschudy|6/26/1953|199 Rosemary Way|6||260
+621|Tyler|Tunick|2/4/1975|125 Easton Rd.|1||54
+622|Prescott|Turban|3/8/1965|1383 Cavell Ave.|3||252
+623|Crystal|Turner|7/8/1954|476 Blackhawk Rd.|4||261
+624|Margaret|Turner|4/8/1966|17 Chicago Ave.|6||91
+625|Harris|Uhlman|1/5/1944|241 Callan Rd.|9||226
+626|Lynn|Umbach|12/13/1931|403 Marquette Rd.|6||123
+627|Chloris|Underwood|9/25/1950|87 Old Trail Rd.|9||181
+628|Conroy|Underwood|5/19/1967|201 Callan Rd.|5||157
+629|Bruce|Urban|8/23/1955|1520 Heather Lane|3||216
+630|Grace|Ury|8/24/1949|199 Cloverdale Rd.|1||249
+631|Daphne|Utep|9/10/1956|155 Oakwood Ave.|4||260
+632|Brandon|Utler|7/23/1948|244 Princeton Ln.|4||197
+633|Vern|Vahlcamp|6/22/1947|6118 Sheriden Rd.|8||245
+634|Jordan|Vai|5/21/1946|250 Crain|5||167
+635|Dominico|Valdez|11/17/1957|368 Woodland Rd.|9||149
+636|Malcolm|Vale|1/4/1930|2917 Fairview Ave.|3||239
+637|Sherlock|Vale|12/13/1958|522 Clay Rd.|7||194
+638|Randall|Valia|2/7/1943|334 Lynn Terrace|4||211
+639|Gertrude|Van Ellen|7/3/1956|356 Glenlake Dr.|6||85
+640|Calvin|Van Epps|1/7/1959|204 St. Johns Ave.|4||4
+641|Norris|Vanderflute|2/18/1960|1349 Bay Colony Dr.|8||280
+260|Rosa|Karen|8/14/1951|44 Chantilly Ln.|5||164
+261|Mercedes|Kay|9/26/1952|3059 Priscilla Court|2||250
+262|Alexis|Kellner|7/18/1974|67 Calais Drive|5||24
+263|Claarence|Kelly|11/30/1930|6070 Central Ave.|3||29
+264|Roger|Kelly|10/4/1939|171 W. Mellody Rd.|3||108
+265|Curt|Kern|1/17/1930|2510 Crain|5||224
+266|Dallas|Kern|8/15/1937|541 Callan Rd.|9||270
+267|Eugene|Kern|4/19/1935|391 Chester Ave. Apt.|5||222
+268|Val|Kessler|10/12/1953|1019 Deerfield Rd.|5||190
+269|Colin|Kestin|6/27/1935|426 Valley Rd.|3||196
+270|Edana|Kim|5/14/1934|170 Ridgelee Rd|2||142
+271|Johanna|Kite|11/18/1954|192 Sunnyside Ave.|9||51
+272|Kenneth|Kivi|4/30/1933|954 First St.|8||56
+273|Charles|Klein|8/23/1975|20 Vine Ave.|3||103
+274|Norman|Klein|9/17/1965|1777 Balsamic Ave.|7||70
+275|Alexandria|Klipowiski|10/12/1966|185 Roger Williams Ave.|3||226
+276|Adam|Knaff|11/14/1967|8999 Harvard Ct|8||7
+277|Clara|Koplec|3/26/1932|511 Hill|4||161
+278|Brooks|Kordick|12/18/1955|458 Balsam Way|3||117
+279|Turk|Kowalski|11/4/1942|5161 Maple Ave.  Apt.|8||69
+280|Celena|Kraut|1/15/1956|969 Saxony Drive|5||56
+281|Norma|Kropp|2/13/1957|9710 Vilas Circle|6||210
+282|Franklin|Krunbein|12/18/1968|1975 Elmwood Circle|3||271
+283|Allister|Kurtz|1/1/1969|175 Beech St.|9||213
+284|Elaine|Kurtz|3/17/1958|180 Parkside Ln.|6||51
+285|Elena|Kust|7/2/1936|287 Glencoe Ave.|9||270
+286|Peggy|Kuznowicz|2/14/1970|8352 Sumac Rd.|1||62
+287|Ara|Ladin|9/11/1938|222 Twin Oaks Drive|6||213
+288|Nicolette|Lamer|7/9/1960|75 Elmwood Circle|3||13
+289|Dara|Lang|3/17/1971|632 Florence Dr.|4||56
+290|Jerome|Langer|6/3/1959|5917 Fairview Ave.|3||104
+291|Phillip|Langerman|5/30/1958|301 Chester Ave. Apt.|5||171
+292|Sarah|Lantz|4/17/1959|6741 Blackstone Ave.|6||55
+293|Brenda|Larson|4/27/1957|1433 Arbor Rd.|4||58
+294|Pierre|LaRussa|3/30/1946|132 Fort Sheriden Ave.|8||260
+295|Darnell|Lasky|2/16/1945|4 Kikaid|6||218
+296|Chad|Laurie|4/20/1972|24 St.Johns Ave.|7||260
+297|Richard|Lawerence|5/12/1973|124 Devonshire Court|4||139
+298|Caesar|Leech|5/22/1936|2189 Oakridge Ave.|9||252
+299|Graham|Lencinoni|12/6/1943|7250 Homewood Ave.|2||52
+300|Daryl|Lenzi|5/6/1960|248 Eastview Dr.|3||280
+301|Parker|Leonard|8/9/1961|188 Balsam Way|4||99
+302|Isaiah|Less|10/2/1941|59 Cordon Terr.|3||68
+303|Arthur|Levin|9/29/1940|3900 Chester Ave. Apt.|8||71
+304|Jared|Lewitz|8/21/1939|1831 Beverly Place #9D|2||227
+305|Derrick|Lidholm|6/18/1961|925 Jeffrys Place|2||72
+306|Leroy|Lieber|7/13/1938|505 N. Frances St.|2||149
+307|Veronica|Lieber|6/12/1974|3062 Lindenwood Ln.|1||8
+308|Hal|Lipper|6/28/1937|6218 Oakridge Ave.|4||207
+309|Rosalie|Liska|7/8/1975|701 W. Mellody Rd.|5|rose66@erols.com|252
+310|Fiona|Lissner|8/7/1965|134 Devonshire Court|5||93
+311|Kate|Littleman|1/4/1937|236 Arlington Ave.|3||111
+312|Homer|Lucas|2/9/1938|7450 Homewood Ave.|2||212
+313|June|Ludwig|3/13/1939|4206 Trinity Ct.|8||102
+314|Peter|Luke|9/17/1966|220 Grant Blvd.|4||23
+315|Weston|Lurie|7/26/1962|3618 Sheriden Rd.|2||193
+316|Ida|Lynman|4/19/1940|4345 Park Ave.|4||212
+317|Rex|Magani|5/8/1941|186 Oakwood|3||94
+318|Dion|Mahoney|10/26/1967|920 Sunnyside Ave.|5||237
+319|Dana|Maki|8/31/1963|206-A Frontage Rd.|2||53
+320|Jill|Maletsky|9/3/1964|600 Central Ave|5||202
+321|Jeffrey|Malick|9/6/1964|704 Ridgelee Rd|2||102
+322|Wendy|Malone|10/12/1965|21 Frontage Rd.|10||251
+323|Hilary|Mandel|11/27/1965|844 Spruce St.|7||270
+324|Mario|Manfredini|11/30/1968|313 Grove Ave.|2||113
+325|Christie|Mantle|6/13/1942|2664 Princeton Ln.|2||26
+326|Milton|Margolis|12/13/1950|746 Judson Place|1||261
+327|Shelby|Marko|10/2/1958|574 Chicago Ave.|5||175
+328|Blake|Marks|8/22/1944|2505 Allison ct.|5||136
+329|Cecil|Marshall|6/30/1930|1819 Deerfield Rd.|4||6
+330|Hazel|Mason|1/13/1951|1923 Sunnyside Ave.|3||235
+331|Fred|Matensky|12/31/1969|359 Priscilla Court|3||251
+332|Ben|McCarthy|1/18/1970|1320 High St.|2||23
+333|Dalton|McColley|2/24/1952|1220 High St.|1||190
+334|Sherlock|McMillan|2/18/1971|85 University Ave.|6||21
+335|Daryl|Medici|10/30/1946|3355 Golf Rd.|3||219
+336|Joy|Menaker|11/29/1947|5456 Grossman Ln.|1||108
+337|Lynn|Mendoza|12/30/1948|1633 McGovern place|6||46
+338|Betsy|Merritt|3/4/1972|44 Briar Ln|3||203
+339|Joshua|Meyers|2/26/1950|3478 Bryn Mawr St.|6||100
+340|Christopher|Michaels|4/9/1973|5053 N. Frances St.|3||103
+341|Edwin|Michalek|6/13/1968|127 Glencoe Ave.|4||231
+342|Ferris|Miligori|3/17/1951|255 Allison ct.|4||70
+343|Barry|Miltenberg|4/20/1952|12 Fort Sheriden Ave.|4||281
+344|Conroy|Mintz|5/21/1953|799 Rosemary Way|6||79
+345|Brett|Morales|6/28/1954|19 Judson Ave.|6||32
+346|Faith|Moreno|3/30/1953|1734 Balsamic Ave.|9||271
+347|Lynn|Morin|5/10/1974|1535 Knollwood Drive|7|lynn@yahoo.com|8
+348|Louis|Moss|7/17/1955|463 Blackhawk Rd.|3||43
+349|Cynthia|Muchin|8/12/1956|44 Sheridan Rd.|6||160
+350|Oliver|Mullen|4/25/1954|1436 W. River Oaks Dr.|2||246
+351|Benjamin|Mullick|9/16/1957|2632 Prarie Ln.|2||197
+352|Johanna|Munski|12/12/1967|1575 Oak Ave.  Apt. 2C|10||190
+353|Taylor|Nachenberg|2/3/1969|3385 University Ave.|3||211
+354|Walt|Nastier|5/26/1955|347 Bryn Mawr St.|10||219
+355|Molly|Nathan|6/28/1956|137 Cavell Ave.|4||270
+356|Micah|Navarro|2/4/1931|447 Sheridan Rd.|6||84
+357|Emily|Nedved|6/6/1975|155 Oak Ave.  Apt. 2C|2||217
+358|Dominico|Noonan|7/1/1965|194 Cloverdale Rd.|8||260
+359|Calvin|Nowacku|12/16/1943|8545 Woodbine|3||271
+360|Rosanna|Nyberg|9/4/1956|726 White Oaks Ave.|7||18
+361|Palmer|Nye|8/7/1974|6793 Calais Drive|2|laurap@aol|219
+362|Grace|O' Malley|7/12/1957|226 Anderson Lane|10||260
+363|Jane|O'Campo|11/8/1978|854 Woodbine|2|dickjane@hotmail.com|249
+364|Erin|O'Rourke|12/8/1979|175 Oak Ave.  Apt. 2C|4|roar@yahoo.com|33
+365|Karl|O'Rourke|6/23/1935|581 Hill St. Apt. 234|3||84
+366|Libby|O'Toole|8/21/1958|6516 Cobblestone Cir.|6||233
+367|Hugh|Oakey|11/17/1940|320 Vine Ave.|3||173
+368|Judy|Oakey|8/2/1966|865 Old Tall Tree Lane|3||97
+369|Laura|Oberman|4/20/1945|1486 W. River Oaks Dr.|4||57
+370|Robert|Oberman|10/26/1951|104 Ridgelee Rd|8||261
+371|Grant|Ocampo|11/27/1952|186 Old Deerfield Rd.|2||181
+372|Cathleen|Olderman|9/3/1967|2224 Sherman Rd.|3||183
+373|Leslie|Olderman|9/10/1959|305-D Crestwood Village Rd.|4||124
+374|Rita|Olderman|10/9/1960|144 Chantilly Ln.|5||15
+375|Trude|Olin|12/28/1953|8655 Old Tall Tree Lane|6||173
+376|Jordan|Olson|1/7/1954|262 Clay Rd.|5||234
+377|Newton|Olson|9/14/1967|195 Elmwood Circle|1||60
+378|Nicholas|Olson|2/3/1941|245 St. Johns Ave.|3||166
+379|Phoebe|Olson|9/18/1938|1486 Old Deerfield Rd.|6||280
+380|Tara|Orsini|11/12/1961|3148 cottonwood Ct.|2||98
+381|Kevin|Ortega|12/7/1963|4733 Burton Ave.|5||47
+382|Morgan|Ortega|11/2/1962|430 Oakland Drive|4||80
+383|Sophia|Ortiz|10/28/1968|147 Knolwood Rd.|3||161
+384|Yvonne|Otiri|10/8/1961|4630 Oakland Drive|9||199
+385|Randall|Pagali|9/25/1960|2045 St. Johns Ave.|4||78
+386|Chad|Palmero|8/31/1959|275 Jeffrys Place|6||46
+642|Katharine|Vanni|10/12/1939|5152 Hill|5||179
+643|Julie|Vanonni|7/5/1933|5141 Hill|6||95
+644|Curt|Varon|6/17/1968|45 St. Johns Ave.|4||195
+645|Newton|Velk|3/19/1944|929 Brittany Ave.|9||181
+646|Garrett|Vena|7/12/1969|6281 Orwenstensia|3||99
+647|Avery|Venturi|5/17/1934|220 Vine Ave.|2||114
+648|Natalie|Venturini|4/12/1933|260 Winsor Mall|3||202
+649|Connie|Vickman|3/8/1932|80 Old Trail Rd.|4||55
+650|Leslie|Vignocchi|2/6/1931|1770 First St.|4||21
+651|Sherlock|Vingrad|8/17/1970|7510 Homewood Ave.|6||57
+652|Carrie|Vista|1/12/1970|2872 Virginia Rd.|5||115
+653|Kevin|Vista|1/15/1950|249 Woodridge Drive|4||143
+654|Phillip|Viti|2/13/1951|195 Lake Cook Rd.|5||238
+655|Tara|Vognaroli|3/26/1952|345 Glenlake Dr.|1||260
+656|Garrett|Vole|7/18/1969|1907 S. Prospect Ave.|3||261
+657|Roy|Volpe|1/12/1978|4930 Oakland Drive|5|volpe@erols.com|61
+658|Molly|Vyas|4/29/1953|210 Cresant Rd.|3||73
+659|Calbert|Wade|5/6/1954|465 Stratford Rd.|2||251
+660|Kerry|Wagner|3/6/1980|6146 Cobblestone Cir.|4||270
+661|Jay|Walich|1/1/1977|7828 Tennyson Ave.|4|jms@yahoo.com|148
+662|Charis|Walker|12/9/1977|12 Twin Oaks Place|2||240
+663|Mirian|Waller|6/7/1955|422 Clay Rd.|3||83
+664|Rupert|Waller|11/12/1977|30 Lindenwood Ln.|7||150
+665|Bradford|Walters|7/24/1956|1795 Lake Cook Rd.|3||39
+666|Isaac|Walters|9/12/1975|6600 Central Ave.|3|isaaaaac@yahoo.com|77
+667|Leslie|Walters|8/3/1957|109 Marquette Rd.|4||172
+668|Dustin|Wanger|8/8/1970|395 Lake Cook Rd.|5||98
+669|Hubert|Waxews|9/3/1971|305 Priscilla Court|3||88
+670|Wilson|Wayne|3/5/1971|6328 Orwenstensia|4||250
+671|Kelsey|Weicker|3/9/1956|277 Balsamic Ave.|7||246
+672|Katharine|Weinstein|10/5/1958|1915 Lewis Ln.  Apt 13|4||223
+673|Gabe|Weintraub|10/2/1972|149 Cloverdale Rd.|5||104
+674|Orville|Weisel|3/12/1959|3647 Bluebird Terr.|4||41
+675|Alvin|Wender|11/1/1959|170 Lily Court|2||100
+676|Tyler|Wender|5/19/1958|3160 Summit Ave.|9||162
+677|Crsby|West|4/13/1957|266 Green Bay Rd.|4||88
+678|Miles|Whittenberg|11/5/1973|115 Chicago Ave.|7||281
+679|Jill|Widen|12/3/1974|187 Roger Williams Ave.|6|jill@hotmail.com|78

--- a/src/test/regress/expected/qp_case.out
+++ b/src/test/regress/expected/qp_case.out
@@ -1,0 +1,599 @@
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_case;
+set search_path to qp_case;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: test01_case_noelse.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop table if exists genders;
+NOTICE:  table "genders" does not exist, skipping
+-- end_ignore
+select CASE 'M'
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END;
+ case 
+------
+ Male
+(1 row)
+
+select CASE 'F'
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END;
+  case  
+--------
+ Female
+(1 row)
+
+select CASE ''
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END;
+     case      
+---------------
+ Not Specified
+(1 row)
+
+select CASE null
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END;
+     case      
+---------------
+ Not Specified
+(1 row)
+
+create table genders (gid integer, gender char(1)) distributed by (gid);
+insert into genders(gid, gender) values (1, 'F');
+insert into genders(gid, gender) values (2, 'M');
+insert into genders(gid, gender) values (3, 'Z');
+insert into genders(gid, gender) values (4, '');
+insert into genders(gid, gender) values (5, null);
+insert into genders(gid, gender) values (6, 'G');
+select gender, CASE gender
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END
+from genders
+order by gid;
+ gender |     case      
+--------+---------------
+ F      | Female
+ M      | Male
+ Z      | 
+        | Not Specified
+        | Not Specified
+ G      | 
+(6 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test02_case_withelse.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop table if exists genders;
+-- end_ignore
+select CASE 'M'
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    ELSE 'Other' END;
+ case 
+------
+ Male
+(1 row)
+
+select CASE null
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    ELSE 'Other' END;
+ case  
+-------
+ Other
+(1 row)
+
+create table genders (gid integer, gender char(1)) distributed by (gid);
+insert into genders(gid, gender) values (1, 'F');
+insert into genders(gid, gender) values (2, 'M');
+insert into genders(gid, gender) values (3, 'Z');
+insert into genders(gid, gender) values (4, '');
+insert into genders(gid, gender) values (5, null);
+insert into genders(gid, gender) values (6, 'G');
+select gender, CASE gender
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    ELSE 'Other' END
+from genders
+order by gid;
+ gender |     case      
+--------+---------------
+ F      | Female
+ M      | Male
+ Z      | Other
+        | Not Specified
+        | Not Specified
+ G      | Other
+(6 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test03_case_combined_when_match_found.sql
+-- ----------------------------------------------------------------------
+select 'a' as lhs, CASE 'a'
+       WHEN 'f' THEN 'WHEN: f'
+       WHEN IS NOT DISTINCT FROM 'f' THEN 'WHEN NEW: f'
+       WHEN 'e' THEN 'WHEN: e'
+       WHEN IS NOT DISTINCT FROM 'e' THEN 'WHEN NEW: e'
+       WHEN 'd' THEN 'WHEN: d'
+       WHEN IS NOT DISTINCT FROM 'd' THEN 'WHEN NEW: d'
+       WHEN 'c' THEN 'WHEN: c'
+       WHEN IS NOT DISTINCT FROM 'c' THEN 'WHEN NEW: c'
+       WHEN 'b' THEN 'WHEN: b'
+       WHEN IS NOT DISTINCT FROM 'b' THEN 'WHEN NEW: b'
+       WHEN 'a' THEN 'WHEN: a'
+       WHEN IS NOT DISTINCT FROM 'a' THEN 'WHEN NEW: a'
+    ELSE 'NO MATCH' END as match; 
+ lhs |  match  
+-----+---------
+ a   | WHEN: a
+(1 row)
+
+select 1 as lhs, CASE 1
+       WHEN 4 THEN 'WHEN: 4'
+       WHEN IS NOT DISTINCT FROM 4 THEN 'WHEN NEW: 4'
+       WHEN 3 THEN 'WHEN: 3'
+       WHEN IS NOT DISTINCT FROM 3 THEN 'WHEN NEW: 3'
+       WHEN 2 THEN 'WHEN: 2'
+       WHEN IS NOT DISTINCT FROM 2 THEN 'WHEN NEW: 2'
+       WHEN 11 THEN 'WHEN: 11'
+       WHEN IS NOT DISTINCT FROM 1 THEN 'WHEN NEW: 1'
+    ELSE 'NO MATCH' END as match; 
+ lhs |    match    
+-----+-------------
+   1 | WHEN NEW: 1
+(1 row)
+
+select '2011-05-27'::date as lsh,  CASE '2011-05-27'::date
+       WHEN '2011-07-25'::date THEN 'WHEN: 2011-07-25'
+       WHEN IS NOT DISTINCT FROM '2011-05-27'::date THEN 'WHEN NEW: 2011-05-27'
+    END as match; 
+    lsh     |        match         
+------------+----------------------
+ 05-27-2011 | WHEN NEW: 2011-05-27
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Test: test04_case_combined_when_nomatch_found.sql
+-- ----------------------------------------------------------------------
+-- start_ignore 
+drop table if exists nomatch_case;
+NOTICE:  table "nomatch_case" does not exist, skipping
+-- end_ignore
+create table nomatch_case
+(
+   sid integer, 
+   gender char(1) default 'F',
+   name text,
+   start_dt date
+) distributed by (sid);
+insert into nomatch_case(sid, gender, name, start_dt)
+values(1000, 'F', 'Jane Doe', '2011-01-15'::date);
+insert into nomatch_case(sid, gender, name, start_dt)
+values(2000, 'M', 'Ryan Goesling', '2011-02-01'::date);
+insert into nomatch_case(sid, gender, name, start_dt)
+values(3000, 'M', 'Tim Tebow', '2011-01-15'::date);
+insert into nomatch_case(sid, gender, name, start_dt)
+values(4000, 'F', 'Katy Perry', '2011-03-01'::date);
+insert into nomatch_case(sid, gender, name, start_dt)
+values(5000, 'F', 'Michael Scott', '2011-02-01'::date);
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE upper(gender)
+          WHEN 'MALE' THEN 'M'
+          WHEN IS NOT DISTINCT FROM 'FEMALE' THEN 'F'
+          WHEN trim('MALE ') THEN 'M'
+       ELSE 'NO MATCH' END as case_gender
+from nomatch_case
+order by sid, name; 
+ sid  |     name      | gender |  start_dt  | case_gender 
+------+---------------+--------+------------+-------------
+ 1000 | Jane Doe      | F      | 01-15-2011 | NO MATCH
+ 2000 | Ryan Goesling | M      | 02-01-2011 | NO MATCH
+ 3000 | Tim Tebow     | M      | 01-15-2011 | NO MATCH
+ 4000 | Katy Perry    | F      | 03-01-2011 | NO MATCH
+ 5000 | Michael Scott | F      | 02-01-2011 | NO MATCH
+(5 rows)
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE start_dt
+           WHEN IS NOT DISTINCT FROM '2009-01-01'::date THEN 2009
+           WHEN '2008-01-01'::date THEN 2008
+           WHEN IS NOT DISTINCT FROM '2010-01-01'::date then 2010
+           WHEN 2007 THEN 2007
+           WHEN IS NOT DISTINCT FROM 2007 THEN 2007
+           WHEN '2006-01-01'::date then 2006
+       END as case_start_dt
+from nomatch_case
+order by sid, name;
+ sid  |     name      | gender |  start_dt  | case_start_dt 
+------+---------------+--------+------------+---------------
+ 1000 | Jane Doe      | F      | 01-15-2011 |              
+ 2000 | Ryan Goesling | M      | 02-01-2011 |              
+ 3000 | Tim Tebow     | M      | 01-15-2011 |              
+ 4000 | Katy Perry    | F      | 03-01-2011 |              
+ 5000 | Michael Scott | F      | 02-01-2011 |              
+(5 rows)
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE sid
+           WHEN 100 THEN 'Dept 10' 
+           WHEN 200 THEN 'Dept 20' 
+           WHEN IS NOT DISTINCT FROM 300 then 'Dept 30'
+           WHEN 400 THEN 'Dept 40'
+           WHEN 500 THEN 'Dept 50'
+           WHEN IS NOT DISTINCT FROM 600 then 'Dept 60'
+           WHEN IS NOT DISTINCT FROM 700 then 'Dept 70'
+       END as case_sid
+from nomatch_case
+order by sid, name;
+ sid  |     name      | gender |  start_dt  | case_sid 
+------+---------------+--------+------------+----------
+ 1000 | Jane Doe      | F      | 01-15-2011 | 
+ 2000 | Ryan Goesling | M      | 02-01-2011 | 
+ 3000 | Tim Tebow     | M      | 01-15-2011 | 
+ 4000 | Katy Perry    | F      | 03-01-2011 | 
+ 5000 | Michael Scott | F      | 02-01-2011 | 
+(5 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test05_case_combined_when_in_aggr.sql
+-- ----------------------------------------------------------------------
+-- start_ignore 
+drop table if exists combined_when;
+NOTICE:  table "combined_when" does not exist, skipping
+-- end_ignore
+create table combined_when 
+(
+   sid integer, 
+   gender varchar(10) default 'F',
+   name text,
+   start_dt date
+) distributed by (sid);
+insert into combined_when(sid, gender, name, start_dt)
+values(1000, 'F', 'Jane Doe', '2011-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(2000, 'M', 'Ryan Goesling', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(3000, 'm', 'Tim Tebow', '2007-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(4000, 'F', 'Katy Perry', '2011-03-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(5000, 'f', 'Michael Scott', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(6000, 'Female  ', 'Mila Kunis', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(7000, ' Male ', 'Tom Brady', '2011-03-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(8000,  ' ', 'Lady Gaga', '2008-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(9000,  null, 'George Michael', '2011-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(10000,  'Male   ', 'Michael Jordan', null);
+select case_yr_start_dt, count(sid)
+from (select sid,
+       name,
+       gender,
+       start_dt,
+       CASE extract(year from start_dt)
+           WHEN IS NOT DISTINCT FROM 2009 THEN 2009
+           WHEN abs(2009-1) THEN 2008
+           WHEN IS NOT DISTINCT FROM extract(year from '2010-01-01'::date) then 2010
+           WHEN round(2007.05, 0) THEN 2007
+           WHEN IS NOT DISTINCT FROM 2007 THEN 2007
+           WHEN extract(year from '2006-01-01'::date) then 2006
+           WHEN extract(year from '2011-01-01'::date) then 2011
+       END as case_yr_start_dt
+from combined_when
+order by sid, name) a
+group by case_yr_start_dt
+order by 2 desc, 1;
+ case_yr_start_dt | count 
+------------------+-------
+             2011 |     7
+             2007 |     1
+             2008 |     1
+                  |     1
+(4 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test06_case_combined_when_expr.sql
+-- ----------------------------------------------------------------------
+-- start_ignore 
+drop table if exists case_expr;
+NOTICE:  table "case_expr" does not exist, skipping
+-- end_ignore
+create table case_expr
+(
+   sid integer, 
+   gender char(1) default 'F',
+   name text,
+   start_dt date
+) distributed by (sid);
+insert into case_expr(sid, gender, name, start_dt)
+values(1000, 'F', 'Jane Doe', '2011-01-15'::date);
+insert into case_expr(sid, gender, name, start_dt)
+values(2000, 'M', 'Ryan Goesling', '2011-02-01'::date);
+insert into case_expr(sid, gender, name, start_dt)
+values(3000, 'M', 'Tim Tebow', '2011-01-15'::date);
+insert into case_expr(sid, gender, name, start_dt)
+values(4000, 'F', 'Katy Perry', '2011-03-01'::date);
+insert into case_expr(sid, gender, name, start_dt)
+values(5000, 'F', 'Michael Scott', '2011-02-01'::date);
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE (gender is not null)
+          WHEN (gender = 'MALE') THEN 'M'
+          WHEN IS NOT DISTINCT FROM (gender = 'FEMALE') THEN 'F'
+          WHEN (gender = trim('MALE ')) THEN 'M'
+          WHEN IS NOT DISTINCT FROM (gender = 'M') THEN 'M'
+          WHEN (gender = 'F') THEN 'F'
+       ELSE 'NO MATCH' END as case_gender
+from case_expr
+order by sid, name; 
+ sid  |     name      | gender |  start_dt  | case_gender 
+------+---------------+--------+------------+-------------
+ 1000 | Jane Doe      | F      | 01-15-2011 | F
+ 2000 | Ryan Goesling | M      | 02-01-2011 | M
+ 3000 | Tim Tebow     | M      | 01-15-2011 | M
+ 4000 | Katy Perry    | F      | 03-01-2011 | F
+ 5000 | Michael Scott | F      | 02-01-2011 | F
+(5 rows)
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE (extract(year from start_dt) = 2011)
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 1) THEN 'January'
+           WHEN (extract(month from start_dt) = 2) THEN 'February'
+           WHEN (extract(month from start_dt) = 3) THEN 'March'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 4) THEN 'April'
+           WHEN (extract(month from start_dt) = 5) THEN 'May'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 6) THEN 'June'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 7) THEN 'July'
+           WHEN (extract(month from start_dt) = 8) THEN 'August'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 9) THEN 'September'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 10) THEN 'October'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 11) THEN 'November'
+           WHEN (extract(month from start_dt) = 12) THEN 'December'
+       END as case_start_month
+from case_expr
+order by sid, name;
+ sid  |     name      | gender |  start_dt  | case_start_month 
+------+---------------+--------+------------+------------------
+ 1000 | Jane Doe      | F      | 01-15-2011 | January
+ 2000 | Ryan Goesling | M      | 02-01-2011 | February
+ 3000 | Tim Tebow     | M      | 01-15-2011 | January
+ 4000 | Katy Perry    | F      | 03-01-2011 | March
+ 5000 | Michael Scott | F      | 02-01-2011 | February
+(5 rows)
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE (sid > 100)
+           WHEN (sid = 1000) THEN 'Dept 10' 
+           WHEN (sid > 1000 and sid <= 2000) THEN 'Dept 20' 
+           WHEN IS NOT DISTINCT FROM (sid = 3000) then 'Dept 30'
+           WHEN (sid = 4000) THEN 'Dept 40'
+           WHEN (sid = 5000) THEN 'Dept 50'
+           WHEN IS NOT DISTINCT FROM (sid > 5000 and sid <= 6000) then 'Dept 60'
+           WHEN IS NOT DISTINCT FROM (sid = 7000) then 'Dept 70'
+       END as case_sid
+from case_expr
+order by sid, name;
+ sid  |     name      | gender |  start_dt  | case_sid 
+------+---------------+--------+------------+----------
+ 1000 | Jane Doe      | F      | 01-15-2011 | Dept 10
+ 2000 | Ryan Goesling | M      | 02-01-2011 | Dept 20
+ 3000 | Tim Tebow     | M      | 01-15-2011 | Dept 30
+ 4000 | Katy Perry    | F      | 03-01-2011 | Dept 40
+ 5000 | Michael Scott | F      | 02-01-2011 | Dept 50
+(5 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test07_case_combined_when_functions.sql
+-- ----------------------------------------------------------------------
+-- start_ignore 
+drop table if exists combined_when;
+-- end_ignore
+create table combined_when 
+(
+   sid integer, 
+   gender varchar(10) default 'F',
+   name text,
+   start_dt date
+) distributed by (sid);
+insert into combined_when(sid, gender, name, start_dt)
+values(1000, 'F', 'Jane Doe', '2011-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(2000, 'M', 'Ryan Goesling', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(3000, 'm', 'Tim Tebow', '2007-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(4000, 'F', 'Katy Perry', '2011-03-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(5000, 'f', 'Michael Scott', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(6000, 'Female  ', 'Mila Kunis', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(7000, ' Male ', 'Tom Brady', '2011-03-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(8000,  ' ', 'Lady Gaga', '2008-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(9000,  null, 'George Michael', '2011-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(10000,  'Male   ', 'Michael Jordan', null);
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE upper(trim(gender))
+          WHEN 'MALE' THEN 'M'
+          WHEN IS NOT DISTINCT FROM 'FEMALE' THEN 'F'
+          WHEN trim('MALE ') THEN 'M'
+          WHEN trim(' FEMALE ') THEN 'F'
+          WHEN IS NOT DISTINCT FROM 'M' THEN 'M'
+          WHEN IS NOT DISTINCT FROM 'F' THEN 'F'
+       ELSE 'NO MATCH' END as case_gender
+from combined_when
+order by sid, name; 
+  sid  |      name      |  gender  |  start_dt  | case_gender 
+-------+----------------+----------+------------+-------------
+  1000 | Jane Doe       | F        | 01-15-2011 | F
+  2000 | Ryan Goesling  | M        | 02-01-2011 | M
+  3000 | Tim Tebow      | m        | 01-15-2007 | M
+  4000 | Katy Perry     | F        | 03-01-2011 | F
+  5000 | Michael Scott  | f        | 02-01-2011 | F
+  6000 | Mila Kunis     | Female   | 02-01-2011 | F
+  7000 | Tom Brady      |  Male    | 03-01-2011 | M
+  8000 | Lady Gaga      |          | 01-15-2008 | NO MATCH
+  9000 | George Michael |          | 01-15-2011 | NO MATCH
+ 10000 | Michael Jordan | Male     |            | M
+(10 rows)
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE extract(year from start_dt)
+           WHEN IS NOT DISTINCT FROM 2009 THEN 2009
+           WHEN abs(2009-1) THEN 2008
+           WHEN IS NOT DISTINCT FROM extract(year from '2010-01-01'::date) then 2010
+           WHEN round(2007.05, 0) THEN 2007
+           WHEN IS NOT DISTINCT FROM 2007 THEN 2007
+           WHEN extract(year from '2006-01-01'::date) then 2006
+           WHEN extract(year from '2011-01-01'::date) then 2011
+       END as case_yr_start_dt
+from combined_when
+order by sid, name;
+  sid  |      name      |  gender  |  start_dt  | case_yr_start_dt 
+-------+----------------+----------+------------+------------------
+  1000 | Jane Doe       | F        | 01-15-2011 |             2011
+  2000 | Ryan Goesling  | M        | 02-01-2011 |             2011
+  3000 | Tim Tebow      | m        | 01-15-2007 |             2007
+  4000 | Katy Perry     | F        | 03-01-2011 |             2011
+  5000 | Michael Scott  | f        | 02-01-2011 |             2011
+  6000 | Mila Kunis     | Female   | 02-01-2011 |             2011
+  7000 | Tom Brady      |  Male    | 03-01-2011 |             2011
+  8000 | Lady Gaga      |          | 01-15-2008 |             2008
+  9000 | George Michael |          | 01-15-2011 |             2011
+ 10000 | Michael Jordan | Male     |            |                 
+(10 rows)
+
+select case_yr_start_dt, count(sid)
+from (select sid,
+       name,
+       gender,
+       start_dt,
+       CASE extract(year from start_dt)
+           WHEN IS NOT DISTINCT FROM 2009 THEN 2009
+           WHEN abs(2009-1) THEN 2008
+           WHEN IS NOT DISTINCT FROM extract(year from '2010-01-01'::date) then 2010
+           WHEN round(2007.05, 0) THEN 2007
+           WHEN IS NOT DISTINCT FROM 2007 THEN 2007
+           WHEN extract(year from '2006-01-01'::date) then 2006
+           WHEN extract(year from '2011-01-01'::date) then 2011
+       END as case_yr_start_dt
+from combined_when
+order by sid, name) a
+group by case_yr_start_dt
+order by 2 desc, 1;
+ case_yr_start_dt | count 
+------------------+-------
+             2011 |     7
+             2007 |     1
+             2008 |     1
+                  |     1
+(4 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: test08_case_negative_syntax_err.sql
+-- ----------------------------------------------------------------------
+select CASE 'a'
+       WHEN IS NOT DISTINCT FROM 'b' THEN 'a=b'
+       WHEN NOT DISTINCT FROM 'a' THEN 'a=a'
+END;
+ERROR:  syntax error at or near "DISTINCT"
+LINE 3:        WHEN NOT DISTINCT FROM 'a' THEN 'a=a'
+                        ^
+select CASE 'a'
+       WHEN IS NOT DISTINCT 'b' THEN 'a=b'
+       WHEN IS NOT DISTINCT FROM 'a' THEN 'a=a'
+END;
+ERROR:  syntax error at or near "'b'"
+LINE 2:        WHEN IS NOT DISTINCT 'b' THEN 'a=b'
+                                    ^
+select CASE 'a'
+       WHEN IS NOT DISTINCT FROM 'b' THEN 'a=b'
+       WHEN IS NOT DISTINCT FROM 'a' IS 'a=a'
+END;
+ERROR:  syntax error at or near "'a=a'"
+LINE 3:        WHEN IS NOT DISTINCT FROM 'a' IS 'a=a'
+                                                ^
+select CASE 'a'
+       WHEN IS NOT DISTINCT FROM 'b' IS 'a=b'
+       WHEN IS NOT DISTINCT FROM 'a' THEN 'a=a'
+END;
+ERROR:  syntax error at or near "'a=b'"
+LINE 2:        WHEN IS NOT DISTINCT FROM 'b' IS 'a=b'
+                                                ^
+-- ----------------------------------------------------------------------
+-- Test: test09_case_negative_unsupported.sql
+-- ----------------------------------------------------------------------
+select CASE 1
+       WHEN IS NOT DISTINCT FROM 2 THEN '1=2'
+       WHEN IS DISTINCT FROM 2 THEN '1<>2'
+       WHEN IS NOT DISTINCT FROM 1 THEN '1=1'
+END;
+ERROR:  syntax error at or near "DISTINCT"
+LINE 3:        WHEN IS DISTINCT FROM 2 THEN '1<>2'
+                       ^
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_case cascade;
+NOTICE:  drop cascades to table combined_when
+NOTICE:  drop cascades to table case_expr
+NOTICE:  drop cascades to table nomatch_case
+NOTICE:  drop cascades to table genders
+-- end_ignore

--- a/src/test/regress/expected/qp_targeted_dispatch.out
+++ b/src/test/regress/expected/qp_targeted_dispatch.out
@@ -1,0 +1,1385 @@
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_targeted_dispatch;
+set search_path to qp_targeted_dispatch;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query01.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table direct_test;
+ERROR:  table "direct_test" does not exist
+Drop table direct_test_two_column; 
+ERROR:  table "direct_test_two_column" does not exist
+--end_ignore
+create table direct_test
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key); 
+create table direct_test_two_column
+(
+  key1 int NULL,
+  key2 int NULL,
+  value varchar(50) NULL
+)
+distributed by (key1, key2);
+insert into direct_test values (100, 'cow');
+insert into direct_test_two_column values (100, 101, 'cow');
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+-- Constant single-row insert, one column in distribution
+-- DO direct dispatch
+insert into direct_test values (100, 'cow');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- verify
+select * from direct_test order by key, value;
+INFO:  Dispatch command to ALL contents
+ key | value 
+-----+-------
+ 100 | cow
+ 100 | cow
+(2 rows)
+
+-- Constant single-row update, one column in distribution
+-- DO direct dispatch
+update direct_test set value = 'horse' where key = 100;
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- verify
+select * from direct_test order by key, value;
+INFO:  Dispatch command to ALL contents
+ key | value 
+-----+-------
+ 100 | horse
+ 100 | horse
+(2 rows)
+
+-- Constant single-row delete, one column in distribution
+-- DO direct dispatch
+delete from direct_test where key = 100;
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- verify
+select * from direct_test order by key, value;
+INFO:  Dispatch command to ALL contents
+ key | value 
+-----+-------
+(0 rows)
+
+-- Constant single-row insert, two columns in distribution
+-- DO direct dispatch
+insert into direct_test_two_column values (100, 101, 'cow');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- verify
+select * from direct_test_two_column order by key1, key2, value;
+INFO:  Dispatch command to ALL contents
+ key1 | key2 | value 
+------+------+-------
+  100 |  101 | cow
+  100 |  101 | cow
+(2 rows)
+
+-- Constant single-row update, two columns in distribution
+-- DO direct dispatch
+update direct_test_two_column set value = 'horse' where key1 = 100 and key2 = 101;
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- verify
+select * from direct_test_two_column order by key1, key2, value;
+INFO:  Dispatch command to ALL contents
+ key1 | key2 | value 
+------+------+-------
+  100 |  101 | horse
+  100 |  101 | horse
+(2 rows)
+
+-- Constant single-row delete, two columns in distribution
+-- DO direct dispatch
+delete from direct_test_two_column where key1 = 100 and key2 = 101;
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- verify
+select * from direct_test_two_column order by key1, key2, value;
+INFO:  Dispatch command to ALL contents
+ key1 | key2 | value 
+------+------+-------
+(0 rows)
+
+-- Multiple row update, where clause lists multiple values which hash differently so no direct dispatch
+--
+-- note that if the hash function for values changes then certain segment configurations may actually 
+--                hash all these values to the same content! (and so test would change)
+--
+update direct_test set value = 'pig' where key in (1,2,3,4,5);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+update direct_test_two_column set value = 'pig' where key1 = 100 and key2 in (1,2,3,4);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+update direct_test_two_column set value = 'pig' where key1 in (100,101,102,103,104) and key2 in (1);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+update direct_test_two_column set value = 'pig' where key1 in (100,101) and key2 in (1,2);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--start_ignore
+Drop table direct_test;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+Drop table direct_test_two_column;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query02.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table direct_test1;
+ERROR:  table "direct_test1" does not exist
+--end_ignore
+create table direct_test1
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into direct_test1 values (200, 'horse');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748440"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748440"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.key, Ta.value from qp_targeted_dispatch.direct_test1 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+Begin;
+declare c0 cursor for select * from direct_test1 where value='horse';
+INFO:  Dispatch command to ALL contents
+select * from direct_test1 where value='horse';
+INFO:  Dispatch command to ALL contents
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+select value from direct_test1 where value='horse';
+INFO:  Dispatch command to ALL contents
+ value 
+-------
+ horse
+(1 row)
+
+select * from direct_test1 where key=200;
+INFO:  Dispatch command to SINGLE content
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+declare c1 cursor for select * from direct_test1 where key=200;
+INFO:  Dispatch command to SINGLE content
+fetch c1;
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+fetch c0;
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+fetch c1;
+ key | value 
+-----+-------
+(0 rows)
+
+fetch c0;
+ key | value 
+-----+-------
+(0 rows)
+
+End;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--start_ignore
+Drop table direct_test1;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query03.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table key_value_table cascade;
+ERROR:  table "key_value_table" does not exist
+--end_ignore
+create table key_value_table
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into key_value_table values (200, 'horse');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748466"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748466"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.key, Ta.value from qp_targeted_dispatch.key_value_table as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+Begin;
+SELECT * FROM key_value_table WHERE key = 200 FOR UPDATE;
+INFO:  Dispatch command to SINGLE content
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+update key_value_table set value=300 where key =200;
+INFO:  Dispatch command to SINGLE content
+savepoint s;
+update key_value_table set value=200 where key =300;
+INFO:  Dispatch command to SINGLE content
+update key_value_table set value=300 where key =200;
+INFO:  Dispatch command to SINGLE content
+rollback to s;
+commit;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+Begin;
+SELECT * FROM key_value_table WHERE key = 200 FOR UPDATE;
+INFO:  Dispatch command to SINGLE content
+ key | value 
+-----+-------
+ 200 | 300
+(1 row)
+
+savepoint s;
+update key_value_table set value=200 where key =300;
+INFO:  Dispatch command to SINGLE content
+rollback;
+INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents
+savepoint s;
+ERROR:  SAVEPOINT can only be used in transaction blocks
+abort;
+WARNING:  there is no transaction in progress
+--start_ignore
+Drop table key_value_table cascade;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query05.sql
+-- ----------------------------------------------------------------------
+-- Targeted Dispatch to make sure it works fine for all possible data types. This test case is to check if it works fine for boolean and int data type
+--start_ignore
+DROP TABLE IF EXISTS boolean;
+NOTICE:  table "boolean" does not exist, skipping
+--end_ignore
+create table boolean (boo boolean, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'boo' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into boolean values ('f', 1);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748492"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748492"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.boo, Ta.b from qp_targeted_dispatch."boolean" as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into boolean values ('t', 2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table boolean set distributed by (b);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into boolean values ('t', 1);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table boolean set distributed randomly;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into boolean values ('t', 1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+alter table boolean set distributed by (boo, b);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from boolean where boo='t' and b=2;
+INFO:  Dispatch command to ALL contents
+ boo | b 
+-----+---
+ t   | 2
+(1 row)
+
+--start_ignore
+DROP TABLE if EXISTS boolean;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query06.sql
+-- ----------------------------------------------------------------------
+-- Targeted Dispatch to make sure it works fine for all possible data types. This test case is to check if it works fine for date and double precision data type
+--start_ignore
+Drop table if exists date;
+NOTICE:  table "date" does not exist, skipping
+--end_ignore
+create table date (date1 date, dp1 double precision);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'date1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into date values ('2001-11-11',234.23234);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748603"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748603"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.date1, Ta.dp1 from qp_targeted_dispatch.date as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into date values ('2001-11-12',234.2323);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table date set distributed by (dp1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into date values ('2001-11-13',234.23234);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+insert into date values ('2001-11-14',234.2323);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table date set distributed by (date1, dp1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from date where date1='2001-11-12' and dp1=234.2323;
+INFO:  Dispatch command to SINGLE content
+   date1    |   dp1    
+------------+----------
+ 11-12-2001 | 234.2323
+(1 row)
+
+--start_ignore
+Drop table if exists date;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query07.sql
+-- ----------------------------------------------------------------------
+-- Targeted Dispatch to make sure it works fine for all possible data types. This test case is to check if it works fine for interval and Numeric data type
+--start_ignore
+Drop table if exists interval;
+NOTICE:  table "interval" does not exist, skipping
+--end_ignore
+create table interval (interval1 interval, num numeric);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'interval1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into interval values ('23',2345);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748703"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748703"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.interval1, Ta.num from qp_targeted_dispatch."interval" as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into interval values ('2',234);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table interval set distributed by (num);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into interval values ('24',234);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+insert into interval values ('26',2343);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table interval set distributed by (num,interval1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from interval where interval1='23' and num=2345;
+INFO:  Dispatch command to SINGLE content
+ interval1 | num  
+-----------+------
+ @ 23 secs | 2345
+(1 row)
+
+--start_ignore
+Drop table if exists interval;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query08.sql
+-- ----------------------------------------------------------------------
+-- This test case is to check if it works fine for real and smallint data type
+--start_ignore
+Drop table if exists real;
+NOTICE:  table "real" does not exist, skipping
+--end_ignore
+create table real (real1 real, si1 smallint) distributed by (real1);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into real values (23, 4);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748809"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748809"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.real1, Ta.si1 from qp_targeted_dispatch."real" as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into real values (23, 4);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+Alter table real set distributed by (si1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into real values (21, 3);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+insert into real values (21, 2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from real where real.si1=3;
+INFO:  Dispatch command to SINGLE content
+ real1 | si1 
+-------+-----
+    21 |   3
+(1 row)
+
+Alter table real set distributed by (si1,real1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from real where real1=21 and si1=3;
+INFO:  Dispatch command to ALL contents
+ real1 | si1 
+-------+-----
+    21 |   3
+(1 row)
+
+--start_ignore
+Drop table if exists real;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query09.sql
+-- ----------------------------------------------------------------------
+-- This test case is to check if it works fine for bytea and cidr data type
+--start_ignore
+Drop table if exists bytea;
+NOTICE:  table "bytea" does not exist, skipping
+--end_ignore
+create table bytea (bytea1 bytea, cidr1 cidr) distributed by (bytea1);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bytea values ('d','0.0.0.0');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748909"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748909"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.bytea1, Ta.cidr1 from qp_targeted_dispatch.bytea as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into bytea values ('d','0.0.0.1');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table bytea set distributed by (cidr1,bytea1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bytea values ('e','0.0.1.0');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from bytea where bytea1='d' and cidr1='0.0.0.1';
+INFO:  Dispatch command to SINGLE content
+ bytea1 |   cidr1    
+--------+------------
+ d      | 0.0.0.1/32
+(1 row)
+
+--start_ignore
+Drop table if exists bytea;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query10.sql
+-- ----------------------------------------------------------------------
+-- This test case is to check if it works fine for inet and macaddr data type
+--start_ignore
+Drop table if exists inetmac;
+NOTICE:  table "inetmac" does not exist, skipping
+--end_ignore
+create table inetmac (inet1 inet, macaddr1 macaddr) distributed by (inet1);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into inetmac values ('0.0.0.0','AA:AA:AA:AA:AA:AA');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748976"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1748976"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.inet1, Ta.macaddr1 from qp_targeted_dispatch.inetmac as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into inetmac values ('0.0.0.0','AC:AA:AA:AA:AA:AA');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table inetmac set distributed by (macaddr1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into inetmac values ('0.0.0.2','AA:AA:AA:AA:AA:AC');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table inetmac set distributed by (macaddr1,inet1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into inetmac values ('0.0.0.2','AA:AA:AA:AA:AA:AC');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from inetmac where inet1='0.0.0.0' and macaddr1 ='AA:AA:AA:AA:AA:AA';
+INFO:  Dispatch command to SINGLE content
+  inet1  |     macaddr1      
+---------+-------------------
+ 0.0.0.0 | aa:aa:aa:aa:aa:aa
+(1 row)
+
+--start_ignore
+Drop table if exists inetmac;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query11.sql
+-- ----------------------------------------------------------------------
+-- This test case is to check if it works fine for money and int data type
+--start_ignore
+Drop table if exists money;
+NOTICE:  table "money" does not exist, skipping
+--end_ignore
+create table money (money1 money, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'money1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into money values ('34.23',5);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1749076"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1749076"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.money1, Ta.b from qp_targeted_dispatch.money as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into money values ('34.23',2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table money set distributed by (money1, b);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into money values ('34.13',2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from money where money1='34.13' and b =2;
+INFO:  Dispatch command to SINGLE content
+ money1 | b 
+--------+---
+ $34.13 | 2
+(1 row)
+
+--start_ignore
+Drop table if exists money;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query12.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table if exists time2;
+NOTICE:  table "time2" does not exist, skipping
+--end_ignore
+create table time2 (time2 time with time zone, text1 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'time2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into time2 values ('00:00:00+1359', 'abcg');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1749139"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1749139"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.time2, Ta.text1 from qp_targeted_dispatch.time2 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into time2 values ('00:00:00+1359', 'abcf');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table time2 set distributed by (text1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into time2 values ('00:00:00+1352', 'abce');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table time2 set distributed by (text1,time2);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into time2 values ('00:00:00+1352', 'abcd');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from time2 where time2='00:00:00+1359' and text1='abcg';
+INFO:  Dispatch command to SINGLE content
+     time2      | text1 
+----------------+-------
+ 00:00:00+13:59 | abcg
+(1 row)
+
+--start_ignore
+Drop table if exists time2;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query13.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table if exists timestamp;
+NOTICE:  table "timestamp" does not exist, skipping
+--end_ignore
+create table timestamp (timestamp1 timestamp without time zone, time2 timestamp with time zone);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'timestamp1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1749245"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1749245"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.timestamp1, Ta.time2 from qp_targeted_dispatch."timestamp" as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table timestamp set distributed by (time2);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into timestamp values ('2004-12-13 01:51:25','2004-12-12 01:51:15+1359');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table timestamp set distributed by (time2, timestamp1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into timestamp values ('2004-12-13 01:51:25','2004-12-12 01:51:15+1359');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from timestamp where timestamp1='2004-12-13 01:51:25' and time2 ='2004-12-12 01:51:15+1359';
+INFO:  Dispatch command to SINGLE content
+        timestamp1        |            time2             
+--------------------------+------------------------------
+ Mon Dec 13 01:51:25 2004 | Sat Dec 11 03:52:15 2004 PST
+ Mon Dec 13 01:51:25 2004 | Sat Dec 11 03:52:15 2004 PST
+(2 rows)
+
+--start_ignore
+Drop table if exists timestamp;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query14.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+drop table if exists bit1;
+NOTICE:  table "bit1" does not exist, skipping
+--end_ignore
+create table bit1 (a bit(1), b int) distributed by (a);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bit1 values ('0', 23);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1749345"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1749345"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.a, Ta.b from qp_targeted_dispatch.bit1 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into bit1 values ('1', 23);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table bit1 set distributed by (b);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bit1 values ('0', 24);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table bit1 set distributed by (b,a);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bit1 values ('0', 24);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from bit1 where a='0' and b =24;
+INFO:  Dispatch command to SINGLE content
+ a | b  
+---+----
+ 0 | 24
+ 0 | 24
+(2 rows)
+
+--start_ignore
+drop table if exists bit1;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query18.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table if exists mpp7638;
+NOTICE:  table "mpp7638" does not exist, skipping
+--end_ignore
+create table mpp7638 (a int, b int, c int, d int) partition by range(d) (start(1) end(10) every(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_1" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_2" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_3" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_4" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_5" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_6" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_7" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_8" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_9" for table "mpp7638"
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 2) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 3) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 4) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 5) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 6) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select count(*) from mpp7638 where a =1;
+INFO:  Dispatch command to SINGLE content
+ count 
+-------
+     5
+(1 row)
+
+explain select count(*) from mpp7638 where a =1;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Aggregate  (cost=59.42..59.43 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=59.35..59.40 rows=1 width=8)
+         ->  Aggregate  (cost=59.35..59.36 rows=1 width=8)
+               ->  Append  (cost=0.00..59.33 rows=3 width=0)
+                     ->  Seq Scan on mpp7638_1_prt_1 mpp7638  (cost=0.00..0.00 rows=1 width=0)
+                           Filter: a = 1
+                     ->  Seq Scan on mpp7638_1_prt_2 mpp7638  (cost=0.00..0.00 rows=1 width=0)
+                           Filter: a = 1
+                     ->  Seq Scan on mpp7638_1_prt_3 mpp7638  (cost=0.00..0.00 rows=1 width=0)
+                           Filter: a = 1
+                     ->  Seq Scan on mpp7638_1_prt_4 mpp7638  (cost=0.00..9.89 rows=1 width=0)
+                           Filter: a = 1
+                     ->  Seq Scan on mpp7638_1_prt_5 mpp7638  (cost=0.00..9.89 rows=1 width=0)
+                           Filter: a = 1
+                     ->  Seq Scan on mpp7638_1_prt_6 mpp7638  (cost=0.00..9.89 rows=1 width=0)
+                           Filter: a = 1
+                     ->  Seq Scan on mpp7638_1_prt_7 mpp7638  (cost=0.00..9.89 rows=1 width=0)
+                           Filter: a = 1
+                     ->  Seq Scan on mpp7638_1_prt_8 mpp7638  (cost=0.00..9.89 rows=1 width=0)
+                           Filter: a = 1
+                     ->  Seq Scan on mpp7638_1_prt_9 mpp7638  (cost=0.00..9.89 rows=1 width=0)
+                           Filter: a = 1
+ Optimizer status: legacy query optimizer
+(23 rows)
+
+alter table mpp7638 set distributed by (a, b, c);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from mpp7638 where a=1 and b=2 and c=3;
+INFO:  Dispatch command to SINGLE content
+ a | b | c | d 
+---+---+---+---
+ 1 | 2 | 3 | 4
+ 1 | 2 | 3 | 4
+ 1 | 2 | 3 | 4
+ 1 | 2 | 3 | 4
+ 1 | 2 | 3 | 4
+(5 rows)
+
+--start_ignore
+Drop table if exists mpp7638;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query19.sql
+-- ----------------------------------------------------------------------
+--Partition by range table should use targeted diaptch
+CREATE TABLE range_table (id INTEGER)
+ PARTITION BY RANGE (id)
+(START (0) END (200000) EVERY (100000)) ;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "range_table_1_prt_1" for table "range_table"
+NOTICE:  CREATE TABLE will create partition "range_table_1_prt_2" for table "range_table"
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INSERT INTO range_table(id) VALUES (0);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+CREATE INDEX id3 ON range_table USING BITMAP (id);
+NOTICE:  building index for child partition "range_table_1_prt_1"
+NOTICE:  building index for child partition "range_table_1_prt_2"
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+INSERT INTO range_table(id) VALUES (1);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+DROP INDEX id3;
+WARNING:  Only dropped the index "id3"
+HINT:  To drop other indexes on child partitions, drop each one explicitly.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE INDEX id3 ON range_table USING BITMAP (id);
+NOTICE:  building index for child partition "range_table_1_prt_1"
+NOTICE:  building index for child partition "range_table_1_prt_2"
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INSERT INTO range_table(id) VALUES (2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+INSERT INTO range_table(id) VALUES (3);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+INSERT INTO range_table(id) VALUES (4);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+INSERT INTO range_table(id) VALUES (5);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+INSERT INTO range_table(id) VALUES (5);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from range_table where id =1;
+INFO:  Dispatch command to SINGLE content
+ id 
+----
+  1
+(1 row)
+
+select count(*) from range_table where id=1;
+INFO:  Dispatch command to SINGLE content
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE range_table;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- ----------------------------------------------------------------------
+-- Test: query20.sql
+-- ----------------------------------------------------------------------
+-- Table using inheritance, Rules and Insert-Select is not getting targeted even though Select is targeted.
+create table tblexecutions (date date not null, mykey bigint, "sequence" int not null, firm character varying(4) NOT NULL) distributed by ("sequence");
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+create table tblexecutions_20080102 (CONSTRAINT tblexecutions_20080102_date_check CHECK (((date >= '2008-01-02'::date) AND (date <= '2008-01-02'::date)))) INHERITS (tblexecutions) distributed by ("sequence");
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE TABLE tblexecutions_20080103 (CONSTRAINT tblexecutions_20080103_date_check CHECK (((date >= '2008-01-03'::date) AND (date <= '2008-01-03'::date)))) INHERITS (tblexecutions) distributed by ("sequence");
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE TABLE tblexecutions_20080104 (CONSTRAINT tblexecutions_20080104_date_check CHECK (((date >= '2008-01-04'::date) AND (date <= '2008-01-04'::date)))) INHERITS (tblexecutions) distributed by ("sequence");
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+create index tblexecutions_20080103_idx on tblexecutions_20080103 using bitmap (firm);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE RULE rule_tblexecutions_20080102 AS ON INSERT TO tblexecutions WHERE ((new.date >= '2008-01-02'::date) AND (new.date <= '2008-01-02'::date)) DO INSTEAD INSERT INTO tblexecutions_20080102 (date, mykey, "sequence", firm) VALUES (new.date, new.mykey, new."sequence", new.firm);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE RULE rule_tblexecutions_20080103 AS ON INSERT TO tblexecutions WHERE ((new.date >= '2008-01-03'::date) AND (new.date <= '2008-01-03'::date)) DO INSTEAD INSERT INTO tblexecutions_20080103 (date, mykey, "sequence", firm) VALUES (new.date, new.mykey, new."sequence", new.firm);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE RULE rule_tblexecutions_20080104 AS ON INSERT TO tblexecutions WHERE ((new.date >= '2008-01-04'::date) AND (new.date <= '2008-01-04'::date)) DO INSTEAD INSERT INTO tblexecutions_20080104 (date, mykey, "sequence", firm) VALUES (new.date, new.mykey, new."sequence", new.firm);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into tblexecutions select '2008/01/02'::date + ((i % 3) || ' days')::interval, i*10, i, 'f' || to_char(random()*100, '99') from generate_series(1, 1000000) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1750325"
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1750351"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.date, Ta.mykey, Ta.sequence, Ta.firm from qp_targeted_dispatch.tblexecutions_20080102 as Ta where random() < 0.02244937606155872344970703125000000000 limit 7500 "
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1750378"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.date, Ta.mykey, Ta.sequence, Ta.firm from qp_targeted_dispatch.tblexecutions_20080103 as Ta where random() < 0.02248605899512767791748046875000000000 limit 7500 "
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1750432"
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1750405"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.date, Ta.mykey, Ta.sequence, Ta.firm from qp_targeted_dispatch.tblexecutions_20080104 as Ta where random() < 0.02248605899512767791748046875000000000 limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into tblexecutions select * from tblexecutions where sequence=10;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+select count(*) from tblexecutions where sequence=10;
+INFO:  Dispatch command to SINGLE content
+ count 
+-------
+     2
+(1 row)
+
+DROP index tblexecutions_20080103_idx; 
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+drop rule rule_tblexecutions_20080104 on tblexecutions;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+drop rule rule_tblexecutions_20080103 on tblexecutions;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+drop rule rule_tblexecutions_20080102 on tblexecutions;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+DROP TABLE tblexecutions_20080104; 
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+DROP TABLE tblexecutions_20080103;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+DROP TABLE tblexecutions_20080102;  
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+DRop table tblexecutions;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- ----------------------------------------------------------------------
+-- Test: query21.sql
+-- ----------------------------------------------------------------------
+--targeted dispatch for CTAS and Insert-Select, It doesn't work today still I have been asked to check in test cases and later move o/p to ans when we have this working. MPP_7620
+--start_ignore
+Drop table zoompp7620;
+ERROR:  table "zoompp7620" does not exist
+Drop table mpp7620;
+ERROR:  table "mpp7620" does not exist
+--end_ignore
+create table mpp7620
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7620 values (200, 'horse');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1750456"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1750456"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.key, Ta.value from qp_targeted_dispatch.mpp7620 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+Create table zoompp7620 as select * from mpp7620 where key=200;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'key' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1750482"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.key, Ta.value from qp_targeted_dispatch.zoompp7620 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7620 values (200, 200);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+insert into zoompp7620 select * from mpp7620 where key=200;
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select key from mpp7620 where mpp7620.key=200;
+INFO:  Dispatch command to SINGLE content
+ key 
+-----
+ 200
+ 200
+(2 rows)
+
+select * from (select * from mpp7620 where key=200) ss where key =200;
+INFO:  Dispatch command to SINGLE content
+ key | value 
+-----+-------
+ 200 | horse
+ 200 | 200
+(2 rows)
+
+explain select * from (select * from mpp7620 where key=200) ss where key =200; 
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1.01 rows=1 width=10)
+   ->  Seq Scan on mpp7620  (cost=0.00..1.01 rows=1 width=10)
+         Filter: key = 200
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+explain insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Insert (slice0; segments: 3)  (rows=1 width=4)
+   ->  Seq Scan on mpp7620  (cost=0.00..1.01 rows=1 width=4)
+         Filter: key = 200
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+explain select key from mpp7620 where mpp7620.key=200;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1.01 rows=1 width=4)
+   ->  Seq Scan on mpp7620  (cost=0.00..1.01 rows=1 width=4)
+         Filter: key = 200
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+--start_ignore
+Drop table zoompp7620;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+Drop table mpp7620;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query22.sql
+-- ----------------------------------------------------------------------
+--Test case for Deepslice queries, since this is disabled right now we need to move correct o/p to expected result once feature is made available for Deepslice queries. QA-592
+--start_ignore
+drop table table_a cascade;
+ERROR:  table "table_a" does not exist
+drop sequence s;
+ERROR:  sequence "s" does not exist
+--end_ignore
+CREATE SEQUENCE s;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE TABLE table_a (a0 int, a1 int, a2 int, a3 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a0' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INSERT INTO table_a (a3, a2, a0, a1) VALUES (nextval('s'), nextval('s'), nextval('s'), nextval('s'));
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1750510"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.a0, Ta.a1, Ta.a2, Ta.a3 from qp_targeted_dispatch.table_a as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into table_a (a3,a2,a0,a1) values (1,2,3,4);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+set test_print_direct_dispatch_info=on;
+--Check to see distributed vs distributed randomly
+alter table table_a set distributed randomly;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select max(a0) from table_a where a0=3;
+INFO:  Dispatch command to ALL contents
+ max 
+-----
+   3
+(1 row)
+
+alter table table_a set distributed by (a0);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+explain select * from table_a where a0=3;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1.01 rows=1 width=16)
+   ->  Seq Scan on table_a  (cost=0.00..1.01 rows=1 width=16)
+         Filter: a0 = 3
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+explain select a0 from table_a where a0 in (select max(a1) from table_a);
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=1.13..2.18 rows=4 width=4)
+   ->  Hash EXISTS Join  (cost=1.13..2.18 rows=2 width=4)
+         Hash Cond: qp_targeted_dispatch.table_a.a0 = "IN_subquery".max
+         ->  Seq Scan on table_a  (cost=0.00..1.01 rows=1 width=4)
+         ->  Hash  (cost=1.12..1.12 rows=1 width=4)
+               ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=1.08..1.12 rows=1 width=4)
+                     Hash Key: "IN_subquery".max
+                     ->  Aggregate  (cost=1.08..1.09 rows=1 width=4)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.01..1.06 rows=1 width=4)
+                                 ->  Aggregate  (cost=1.01..1.02 rows=1 width=4)
+                                       ->  Seq Scan on table_a  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer status: legacy query optimizer
+(12 rows)
+
+select a0 from table_a where a0 in (select max(a1) from table_a);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+ a0 
+----
+(0 rows)
+
+select max(a1) from table_a;
+INFO:  Dispatch command to ALL contents
+ max 
+-----
+   4
+(1 row)
+
+select max(a0) from table_a where a0=1;
+INFO:  Dispatch command to SINGLE content
+ max 
+-----
+   1
+(1 row)
+
+explain select a0 from table_a where a0 in (select max(a1) from table_a where a0=1);
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=1.13..2.18 rows=4 width=4)
+   ->  Hash EXISTS Join  (cost=1.13..2.18 rows=2 width=4)
+         Hash Cond: qp_targeted_dispatch.table_a.a0 = "IN_subquery".max
+         ->  Seq Scan on table_a  (cost=0.00..1.01 rows=1 width=4)
+         ->  Hash  (cost=1.12..1.12 rows=1 width=4)
+               ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=1.08..1.12 rows=1 width=4)
+                     Hash Key: "IN_subquery".max
+                     ->  Aggregate  (cost=1.08..1.09 rows=1 width=4)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..1.07 rows=1 width=4)
+                                 ->  Aggregate  (cost=1.02..1.03 rows=1 width=4)
+                                       ->  Seq Scan on table_a  (cost=0.00..1.01 rows=1 width=4)
+                                             Filter: a0 = 1
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+--start_ignore
+drop table table_a cascade;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+drop sequence s;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_targeted_dispatch cascade;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- end_ignore

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -1,0 +1,1381 @@
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_targeted_dispatch;
+set search_path to qp_targeted_dispatch;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query01.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table direct_test;
+ERROR:  table "direct_test" does not exist
+Drop table direct_test_two_column; 
+ERROR:  table "direct_test_two_column" does not exist
+--end_ignore
+create table direct_test
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key); 
+create table direct_test_two_column
+(
+  key1 int NULL,
+  key2 int NULL,
+  value varchar(50) NULL
+)
+distributed by (key1, key2);
+insert into direct_test values (100, 'cow');
+insert into direct_test_two_column values (100, 101, 'cow');
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+-- Constant single-row insert, one column in distribution
+-- DO direct dispatch
+insert into direct_test values (100, 'cow');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+-- verify
+select * from direct_test order by key, value;
+INFO:  Dispatch command to ALL contents
+ key | value 
+-----+-------
+ 100 | cow
+ 100 | cow
+(2 rows)
+
+-- Constant single-row update, one column in distribution
+-- DO direct dispatch
+update direct_test set value = 'horse' where key = 100;
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- verify
+select * from direct_test order by key, value;
+INFO:  Dispatch command to ALL contents
+ key | value 
+-----+-------
+ 100 | horse
+ 100 | horse
+(2 rows)
+
+-- Constant single-row delete, one column in distribution
+-- DO direct dispatch
+delete from direct_test where key = 100;
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- verify
+select * from direct_test order by key, value;
+INFO:  Dispatch command to ALL contents
+ key | value 
+-----+-------
+(0 rows)
+
+-- Constant single-row insert, two columns in distribution
+-- DO direct dispatch
+insert into direct_test_two_column values (100, 101, 'cow');
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- verify
+select * from direct_test_two_column order by key1, key2, value;
+INFO:  Dispatch command to ALL contents
+ key1 | key2 | value 
+------+------+-------
+  100 |  101 | cow
+  100 |  101 | cow
+(2 rows)
+
+-- Constant single-row update, two columns in distribution
+-- DO direct dispatch
+update direct_test_two_column set value = 'horse' where key1 = 100 and key2 = 101;
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- verify
+select * from direct_test_two_column order by key1, key2, value;
+INFO:  Dispatch command to ALL contents
+ key1 | key2 | value 
+------+------+-------
+  100 |  101 | horse
+  100 |  101 | horse
+(2 rows)
+
+-- Constant single-row delete, two columns in distribution
+-- DO direct dispatch
+delete from direct_test_two_column where key1 = 100 and key2 = 101;
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- verify
+select * from direct_test_two_column order by key1, key2, value;
+INFO:  Dispatch command to ALL contents
+ key1 | key2 | value 
+------+------+-------
+(0 rows)
+
+-- Multiple row update, where clause lists multiple values which hash differently so no direct dispatch
+--
+-- note that if the hash function for values changes then certain segment configurations may actually 
+--                hash all these values to the same content! (and so test would change)
+--
+update direct_test set value = 'pig' where key in (1,2,3,4,5);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+update direct_test_two_column set value = 'pig' where key1 = 100 and key2 in (1,2,3,4);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+update direct_test_two_column set value = 'pig' where key1 in (100,101,102,103,104) and key2 in (1);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+update direct_test_two_column set value = 'pig' where key1 in (100,101) and key2 in (1,2);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--start_ignore
+Drop table direct_test;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+Drop table direct_test_two_column;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query02.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table direct_test1;
+ERROR:  table "direct_test1" does not exist
+--end_ignore
+create table direct_test1
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into direct_test1 values (200, 'horse');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753342"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753342"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.key, Ta.value from qp_targeted_dispatch.direct_test1 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+Begin;
+declare c0 cursor for select * from direct_test1 where value='horse';
+INFO:  Dispatch command to ALL contents
+select * from direct_test1 where value='horse';
+INFO:  Dispatch command to ALL contents
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+select value from direct_test1 where value='horse';
+INFO:  Dispatch command to ALL contents
+ value 
+-------
+ horse
+(1 row)
+
+select * from direct_test1 where key=200;
+INFO:  Dispatch command to SINGLE content
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+declare c1 cursor for select * from direct_test1 where key=200;
+INFO:  Dispatch command to SINGLE content
+fetch c1;
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+fetch c0;
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+fetch c1;
+ key | value 
+-----+-------
+(0 rows)
+
+fetch c0;
+ key | value 
+-----+-------
+(0 rows)
+
+End;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--start_ignore
+Drop table direct_test1;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query03.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table key_value_table cascade;
+ERROR:  table "key_value_table" does not exist
+--end_ignore
+create table key_value_table
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into key_value_table values (200, 'horse');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753368"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753368"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.key, Ta.value from qp_targeted_dispatch.key_value_table as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+Begin;
+SELECT * FROM key_value_table WHERE key = 200 FOR UPDATE;
+INFO:  Dispatch command to SINGLE content
+ key | value 
+-----+-------
+ 200 | horse
+(1 row)
+
+update key_value_table set value=300 where key =200;
+INFO:  Dispatch command to ALL contents
+savepoint s;
+update key_value_table set value=200 where key =300;
+INFO:  Dispatch command to ALL contents
+update key_value_table set value=300 where key =200;
+INFO:  Dispatch command to ALL contents
+rollback to s;
+commit;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+Begin;
+SELECT * FROM key_value_table WHERE key = 200 FOR UPDATE;
+INFO:  Dispatch command to SINGLE content
+ key | value 
+-----+-------
+ 200 | 300
+(1 row)
+
+savepoint s;
+update key_value_table set value=200 where key =300;
+INFO:  Dispatch command to ALL contents
+rollback;
+INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents
+savepoint s;
+ERROR:  SAVEPOINT can only be used in transaction blocks
+abort;
+WARNING:  there is no transaction in progress
+--start_ignore
+Drop table key_value_table cascade;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query05.sql
+-- ----------------------------------------------------------------------
+-- Targeted Dispatch to make sure it works fine for all possible data types. This test case is to check if it works fine for boolean and int data type
+--start_ignore
+DROP TABLE IF EXISTS boolean;
+NOTICE:  table "boolean" does not exist, skipping
+--end_ignore
+create table boolean (boo boolean, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'boo' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into boolean values ('f', 1);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753394"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753394"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.boo, Ta.b from qp_targeted_dispatch."boolean" as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into boolean values ('t', 2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table boolean set distributed by (b);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into boolean values ('t', 1);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table boolean set distributed randomly;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into boolean values ('t', 1);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+alter table boolean set distributed by (boo, b);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from boolean where boo='t' and b=2;
+INFO:  Dispatch command to ALL contents
+ boo | b 
+-----+---
+ t   | 2
+(1 row)
+
+--start_ignore
+DROP TABLE if EXISTS boolean;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query06.sql
+-- ----------------------------------------------------------------------
+-- Targeted Dispatch to make sure it works fine for all possible data types. This test case is to check if it works fine for date and double precision data type
+--start_ignore
+Drop table if exists date;
+NOTICE:  table "date" does not exist, skipping
+--end_ignore
+create table date (date1 date, dp1 double precision);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'date1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into date values ('2001-11-11',234.23234);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753505"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753505"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.date1, Ta.dp1 from qp_targeted_dispatch.date as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into date values ('2001-11-12',234.2323);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table date set distributed by (dp1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into date values ('2001-11-13',234.23234);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+insert into date values ('2001-11-14',234.2323);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table date set distributed by (date1, dp1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from date where date1='2001-11-12' and dp1=234.2323;
+INFO:  Dispatch command to SINGLE content
+   date1    |   dp1    
+------------+----------
+ 11-12-2001 | 234.2323
+(1 row)
+
+--start_ignore
+Drop table if exists date;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query07.sql
+-- ----------------------------------------------------------------------
+-- Targeted Dispatch to make sure it works fine for all possible data types. This test case is to check if it works fine for interval and Numeric data type
+--start_ignore
+Drop table if exists interval;
+NOTICE:  table "interval" does not exist, skipping
+--end_ignore
+create table interval (interval1 interval, num numeric);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'interval1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into interval values ('23',2345);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753605"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753605"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.interval1, Ta.num from qp_targeted_dispatch."interval" as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into interval values ('2',234);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table interval set distributed by (num);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into interval values ('24',234);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+insert into interval values ('26',2343);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table interval set distributed by (num,interval1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from interval where interval1='23' and num=2345;
+INFO:  Dispatch command to SINGLE content
+ interval1 | num  
+-----------+------
+ @ 23 secs | 2345
+(1 row)
+
+--start_ignore
+Drop table if exists interval;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query08.sql
+-- ----------------------------------------------------------------------
+-- This test case is to check if it works fine for real and smallint data type
+--start_ignore
+Drop table if exists real;
+NOTICE:  table "real" does not exist, skipping
+--end_ignore
+create table real (real1 real, si1 smallint) distributed by (real1);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into real values (23, 4);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753711"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753711"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.real1, Ta.si1 from qp_targeted_dispatch."real" as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into real values (23, 4);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+Alter table real set distributed by (si1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into real values (21, 3);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+insert into real values (21, 2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from real where real.si1=3;
+INFO:  Dispatch command to SINGLE content
+ real1 | si1 
+-------+-----
+    21 |   3
+(1 row)
+
+Alter table real set distributed by (si1,real1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from real where real1=21 and si1=3;
+INFO:  Dispatch command to ALL contents
+ real1 | si1 
+-------+-----
+    21 |   3
+(1 row)
+
+--start_ignore
+Drop table if exists real;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query09.sql
+-- ----------------------------------------------------------------------
+-- This test case is to check if it works fine for bytea and cidr data type
+--start_ignore
+Drop table if exists bytea;
+NOTICE:  table "bytea" does not exist, skipping
+--end_ignore
+create table bytea (bytea1 bytea, cidr1 cidr) distributed by (bytea1);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bytea values ('d','0.0.0.0');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753811"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753811"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.bytea1, Ta.cidr1 from qp_targeted_dispatch.bytea as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into bytea values ('d','0.0.0.1');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table bytea set distributed by (cidr1,bytea1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bytea values ('e','0.0.1.0');
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from bytea where bytea1='d' and cidr1='0.0.0.1';
+INFO:  Dispatch command to ALL contents
+ bytea1 |   cidr1    
+--------+------------
+ d      | 0.0.0.1/32
+(1 row)
+
+--start_ignore
+Drop table if exists bytea;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query10.sql
+-- ----------------------------------------------------------------------
+-- This test case is to check if it works fine for inet and macaddr data type
+--start_ignore
+Drop table if exists inetmac;
+NOTICE:  table "inetmac" does not exist, skipping
+--end_ignore
+create table inetmac (inet1 inet, macaddr1 macaddr) distributed by (inet1);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into inetmac values ('0.0.0.0','AA:AA:AA:AA:AA:AA');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753878"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753878"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.inet1, Ta.macaddr1 from qp_targeted_dispatch.inetmac as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into inetmac values ('0.0.0.0','AC:AA:AA:AA:AA:AA');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table inetmac set distributed by (macaddr1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into inetmac values ('0.0.0.2','AA:AA:AA:AA:AA:AC');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table inetmac set distributed by (macaddr1,inet1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into inetmac values ('0.0.0.2','AA:AA:AA:AA:AA:AC');
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from inetmac where inet1='0.0.0.0' and macaddr1 ='AA:AA:AA:AA:AA:AA';
+INFO:  Dispatch command to SINGLE content
+  inet1  |     macaddr1      
+---------+-------------------
+ 0.0.0.0 | aa:aa:aa:aa:aa:aa
+(1 row)
+
+--start_ignore
+Drop table if exists inetmac;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query11.sql
+-- ----------------------------------------------------------------------
+-- This test case is to check if it works fine for money and int data type
+--start_ignore
+Drop table if exists money;
+NOTICE:  table "money" does not exist, skipping
+--end_ignore
+create table money (money1 money, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'money1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into money values ('34.23',5);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753978"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1753978"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.money1, Ta.b from qp_targeted_dispatch.money as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into money values ('34.23',2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table money set distributed by (money1, b);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into money values ('34.13',2);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from money where money1='34.13' and b =2;
+INFO:  Dispatch command to SINGLE content
+ money1 | b 
+--------+---
+ $34.13 | 2
+(1 row)
+
+--start_ignore
+Drop table if exists money;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query12.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table if exists time2;
+NOTICE:  table "time2" does not exist, skipping
+--end_ignore
+create table time2 (time2 time with time zone, text1 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'time2' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into time2 values ('00:00:00+1359', 'abcg');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1754041"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1754041"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.time2, Ta.text1 from qp_targeted_dispatch.time2 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into time2 values ('00:00:00+1359', 'abcf');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table time2 set distributed by (text1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into time2 values ('00:00:00+1352', 'abce');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table time2 set distributed by (text1,time2);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into time2 values ('00:00:00+1352', 'abcd');
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from time2 where time2='00:00:00+1359' and text1='abcg';
+INFO:  Dispatch command to SINGLE content
+     time2      | text1 
+----------------+-------
+ 00:00:00+13:59 | abcg
+(1 row)
+
+--start_ignore
+Drop table if exists time2;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query13.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table if exists timestamp;
+NOTICE:  table "timestamp" does not exist, skipping
+--end_ignore
+create table timestamp (timestamp1 timestamp without time zone, time2 timestamp with time zone);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'timestamp1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1754147"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1754147"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.timestamp1, Ta.time2 from qp_targeted_dispatch."timestamp" as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table timestamp set distributed by (time2);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into timestamp values ('2004-12-13 01:51:25','2004-12-12 01:51:15+1359');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table timestamp set distributed by (time2, timestamp1);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into timestamp values ('2004-12-13 01:51:25','2004-12-12 01:51:15+1359');
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from timestamp where timestamp1='2004-12-13 01:51:25' and time2 ='2004-12-12 01:51:15+1359';
+INFO:  Dispatch command to SINGLE content
+        timestamp1        |            time2             
+--------------------------+------------------------------
+ Mon Dec 13 01:51:25 2004 | Sat Dec 11 03:52:15 2004 PST
+ Mon Dec 13 01:51:25 2004 | Sat Dec 11 03:52:15 2004 PST
+(2 rows)
+
+--start_ignore
+Drop table if exists timestamp;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query14.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+drop table if exists bit1;
+NOTICE:  table "bit1" does not exist, skipping
+--end_ignore
+create table bit1 (a bit(1), b int) distributed by (a);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bit1 values ('0', 23);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1754247"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1754247"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.a, Ta.b from qp_targeted_dispatch.bit1 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into bit1 values ('1', 23);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table bit1 set distributed by (b);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bit1 values ('0', 24);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+alter table bit1 set distributed by (b,a);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into bit1 values ('0', 24);
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from bit1 where a='0' and b =24;
+INFO:  Dispatch command to SINGLE content
+ a | b  
+---+----
+ 0 | 24
+ 0 | 24
+(2 rows)
+
+--start_ignore
+drop table if exists bit1;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query18.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+Drop table if exists mpp7638;
+NOTICE:  table "mpp7638" does not exist, skipping
+--end_ignore
+create table mpp7638 (a int, b int, c int, d int) partition by range(d) (start(1) end(10) every(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_1" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_2" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_3" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_4" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_5" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_6" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_7" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_8" for table "mpp7638"
+NOTICE:  CREATE TABLE will create partition "mpp7638_1_prt_9" for table "mpp7638"
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 2) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 3) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 4) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 5) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 6) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select count(*) from mpp7638 where a =1;
+INFO:  Dispatch command to ALL contents
+ count 
+-------
+     5
+(1 row)
+
+explain select count(*) from mpp7638 where a =1;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Partition Selector for mpp7638 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                           Partitions selected:  9 (out of 9)
+                     ->  Dynamic Table Scan on mpp7638 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
+                           Filter: a = 1
+ Settings:  optimizer=on
+ Optimizer status: PQO version 1.624
+(10 rows)
+
+alter table mpp7638 set distributed by (a, b, c);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select * from mpp7638 where a=1 and b=2 and c=3;
+INFO:  Dispatch command to SINGLE content
+ a | b | c | d 
+---+---+---+---
+ 1 | 2 | 3 | 4
+ 1 | 2 | 3 | 4
+ 1 | 2 | 3 | 4
+ 1 | 2 | 3 | 4
+ 1 | 2 | 3 | 4
+(5 rows)
+
+--start_ignore
+Drop table if exists mpp7638;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query19.sql
+-- ----------------------------------------------------------------------
+--Partition by range table should use targeted diaptch
+CREATE TABLE range_table (id INTEGER)
+ PARTITION BY RANGE (id)
+(START (0) END (200000) EVERY (100000)) ;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "range_table_1_prt_1" for table "range_table"
+NOTICE:  CREATE TABLE will create partition "range_table_1_prt_2" for table "range_table"
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INSERT INTO range_table(id) VALUES (0);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+CREATE INDEX id3 ON range_table USING BITMAP (id);
+NOTICE:  building index for child partition "range_table_1_prt_1"
+NOTICE:  building index for child partition "range_table_1_prt_2"
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+INSERT INTO range_table(id) VALUES (1);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+DROP INDEX id3;
+WARNING:  Only dropped the index "id3"
+HINT:  To drop other indexes on child partitions, drop each one explicitly.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE INDEX id3 ON range_table USING BITMAP (id);
+NOTICE:  building index for child partition "range_table_1_prt_1"
+NOTICE:  building index for child partition "range_table_1_prt_2"
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INSERT INTO range_table(id) VALUES (2);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+INSERT INTO range_table(id) VALUES (3);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+INSERT INTO range_table(id) VALUES (4);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+INSERT INTO range_table(id) VALUES (5);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+INSERT INTO range_table(id) VALUES (5);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+select * from range_table where id =1;
+INFO:  Dispatch command to SINGLE content
+ id 
+----
+  1
+(1 row)
+
+select count(*) from range_table where id=1;
+INFO:  Dispatch command to ALL contents
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE range_table;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- ----------------------------------------------------------------------
+-- Test: query20.sql
+-- ----------------------------------------------------------------------
+-- Table using inheritance, Rules and Insert-Select is not getting targeted even though Select is targeted.
+create table tblexecutions (date date not null, mykey bigint, "sequence" int not null, firm character varying(4) NOT NULL) distributed by ("sequence");
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+create table tblexecutions_20080102 (CONSTRAINT tblexecutions_20080102_date_check CHECK (((date >= '2008-01-02'::date) AND (date <= '2008-01-02'::date)))) INHERITS (tblexecutions) distributed by ("sequence");
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE TABLE tblexecutions_20080103 (CONSTRAINT tblexecutions_20080103_date_check CHECK (((date >= '2008-01-03'::date) AND (date <= '2008-01-03'::date)))) INHERITS (tblexecutions) distributed by ("sequence");
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE TABLE tblexecutions_20080104 (CONSTRAINT tblexecutions_20080104_date_check CHECK (((date >= '2008-01-04'::date) AND (date <= '2008-01-04'::date)))) INHERITS (tblexecutions) distributed by ("sequence");
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+create index tblexecutions_20080103_idx on tblexecutions_20080103 using bitmap (firm);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE RULE rule_tblexecutions_20080102 AS ON INSERT TO tblexecutions WHERE ((new.date >= '2008-01-02'::date) AND (new.date <= '2008-01-02'::date)) DO INSTEAD INSERT INTO tblexecutions_20080102 (date, mykey, "sequence", firm) VALUES (new.date, new.mykey, new."sequence", new.firm);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE RULE rule_tblexecutions_20080103 AS ON INSERT TO tblexecutions WHERE ((new.date >= '2008-01-03'::date) AND (new.date <= '2008-01-03'::date)) DO INSTEAD INSERT INTO tblexecutions_20080103 (date, mykey, "sequence", firm) VALUES (new.date, new.mykey, new."sequence", new.firm);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE RULE rule_tblexecutions_20080104 AS ON INSERT TO tblexecutions WHERE ((new.date >= '2008-01-04'::date) AND (new.date <= '2008-01-04'::date)) DO INSTEAD INSERT INTO tblexecutions_20080104 (date, mykey, "sequence", firm) VALUES (new.date, new.mykey, new."sequence", new.firm);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into tblexecutions select '2008/01/02'::date + ((i % 3) || ' days')::interval, i*10, i, 'f' || to_char(random()*100, '99') from generate_series(1, 1000000) i;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1755227"
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1755253"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.date, Ta.mykey, Ta.sequence, Ta.firm from qp_targeted_dispatch.tblexecutions_20080102 as Ta where random() < 0.02244937606155872344970703125000000000 limit 7500 "
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1755280"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.date, Ta.mykey, Ta.sequence, Ta.firm from qp_targeted_dispatch.tblexecutions_20080103 as Ta where random() < 0.02248605899512767791748046875000000000 limit 7500 "
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1755334"
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1755307"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.date, Ta.mykey, Ta.sequence, Ta.firm from qp_targeted_dispatch.tblexecutions_20080104 as Ta where random() < 0.02250697650015354156494140625000000000 limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into tblexecutions select * from tblexecutions where sequence=10;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+set test_print_direct_dispatch_info=on;
+select count(*) from tblexecutions where sequence=10;
+INFO:  Dispatch command to SINGLE content
+ count 
+-------
+     2
+(1 row)
+
+DROP index tblexecutions_20080103_idx; 
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+drop rule rule_tblexecutions_20080104 on tblexecutions;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+drop rule rule_tblexecutions_20080103 on tblexecutions;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+drop rule rule_tblexecutions_20080102 on tblexecutions;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+DROP TABLE tblexecutions_20080104; 
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+DROP TABLE tblexecutions_20080103;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+DROP TABLE tblexecutions_20080102;  
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+DRop table tblexecutions;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- ----------------------------------------------------------------------
+-- Test: query21.sql
+-- ----------------------------------------------------------------------
+--targeted dispatch for CTAS and Insert-Select, It doesn't work today still I have been asked to check in test cases and later move o/p to ans when we have this working. MPP_7620
+--start_ignore
+Drop table zoompp7620;
+ERROR:  table "zoompp7620" does not exist
+Drop table mpp7620;
+ERROR:  table "mpp7620" does not exist
+--end_ignore
+create table mpp7620
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key);
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7620 values (200, 'horse');
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Force Implied Writer' to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1755358"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1755358"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.key, Ta.value from qp_targeted_dispatch.mpp7620 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+Create table zoompp7620 as select * from mpp7620 where key=200;
+NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1755384"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.key, Ta.value from qp_targeted_dispatch.zoompp7620 as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into mpp7620 values (200, 200);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+insert into zoompp7620 select * from mpp7620 where key=200;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select key from mpp7620 where mpp7620.key=200;
+INFO:  Dispatch command to SINGLE content
+ key 
+-----
+ 200
+ 200
+(2 rows)
+
+select * from (select * from mpp7620 where key=200) ss where key =200;
+INFO:  Dispatch command to SINGLE content
+ key | value 
+-----+-------
+ 200 | horse
+ 200 | 200
+(2 rows)
+
+explain select * from (select * from mpp7620 where key=200) ss where key =200; 
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=10)
+   ->  Table Scan on mpp7620  (cost=0.00..431.00 rows=1 width=10)
+         Filter: key = 200
+ Settings:  optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+explain insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Insert  (cost=0.00..431.03 rows=1 width=4)
+   ->  Result  (cost=0.00..431.00 rows=1 width=20)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+               ->  Table Scan on mpp7620  (cost=0.00..431.00 rows=1 width=4)
+                     Filter: key = 200
+ Settings:  optimizer=on
+ Optimizer status: PQO version 1.624
+(7 rows)
+
+explain select key from mpp7620 where mpp7620.key=200;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Table Scan on mpp7620  (cost=0.00..431.00 rows=1 width=4)
+         Filter: key = 200
+ Settings:  optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+--start_ignore
+Drop table zoompp7620;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+Drop table mpp7620;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query22.sql
+-- ----------------------------------------------------------------------
+--Test case for Deepslice queries, since this is disabled right now we need to move correct o/p to expected result once feature is made available for Deepslice queries. QA-592
+--start_ignore
+drop table table_a cascade;
+ERROR:  table "table_a" does not exist
+drop sequence s;
+ERROR:  sequence "s" does not exist
+--end_ignore
+CREATE SEQUENCE s;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+CREATE TABLE table_a (a0 int, a1 int, a2 int, a3 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a0' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INSERT INTO table_a (a3, a2, a0, a1) VALUES (nextval('s'), nextval('s'), nextval('s'), nextval('s'));
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1755412"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select Ta.a0, Ta.a1, Ta.a2, Ta.a3 from qp_targeted_dispatch.table_a as Ta  limit 7500 "
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into table_a (a3,a2,a0,a1) values (1,2,3,4);
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
+set test_print_direct_dispatch_info=on;
+--Check to see distributed vs distributed randomly
+alter table table_a set distributed randomly;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+select max(a0) from table_a where a0=3;
+INFO:  Dispatch command to ALL contents
+ max 
+-----
+   3
+(1 row)
+
+alter table table_a set distributed by (a0);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+explain select * from table_a where a0=3;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=16)
+   ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=16)
+         Filter: a0 = 3
+ Settings:  optimizer=on
+ Optimizer status: PQO version 1.624
+(5 rows)
+
+explain select a0 from table_a where a0 in (select max(a1) from table_a);
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: "outer".max = qp_targeted_dispatch.table_a.a0
+         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
+               Hash Key: max
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 1.624
+(13 rows)
+
+select a0 from table_a where a0 in (select max(a1) from table_a);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+ a0 
+----
+(0 rows)
+
+select max(a1) from table_a;
+INFO:  Dispatch command to ALL contents
+ max 
+-----
+   4
+(1 row)
+
+select max(a0) from table_a where a0=1;
+INFO:  Dispatch command to ALL contents
+ max 
+-----
+   1
+(1 row)
+
+explain select a0 from table_a where a0 in (select max(a1) from table_a where a0=1);
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: "outer".max = qp_targeted_dispatch.table_a.a0
+         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
+               Hash Key: max
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                                       Filter: a0 = 1
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Table Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 1.624
+(14 rows)
+
+--start_ignore
+drop table table_a cascade;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+drop sequence s;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_targeted_dispatch cascade;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -87,7 +87,7 @@ test: bfv_cte bfv_joins bfv_statistic bfv_subquery bfv_planner bfv_legacy
 
 test: qp_executor qp_olap_windowerr qp_olap_window qp_derived_table qp_bitmapscan
 
-test: qp_correlated_query 
+test: qp_correlated_query qp_targeted_dispatch qp_cursor qp_case
 
 test: qp_dpe qp_subquery qp_function qp_regexp
 

--- a/src/test/regress/input/qp_cursor.source
+++ b/src/test/regress/input/qp_cursor.source
@@ -1,0 +1,304 @@
+
+-- ----------------------------------------------------------------------
+-- Test: setup_schema.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_cursor;
+set search_path to qp_cursor;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+DROP TABLE if exists lu_customer;
+CREATE TABLE lu_customer (
+    customer_id numeric(28,0),
+    cust_first_name character varying(50),
+    cust_last_name character varying(50),
+    cust_birthdate date,
+    address character varying(50),
+    income_id numeric(28,0),
+    email character varying(50),
+    cust_city_id numeric(28,0)
+);
+
+-- ----------------------------------------------------------------------
+-- Test: copy.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+\copy lu_customer from '@abs_srcdir@/data/lu_customer.data' delimiter as '|'
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query03.sql
+-- ----------------------------------------------------------------------
+
+begin;
+declare c0 cursor for select count(*) from lu_customer;
+savepoint x;
+update lu_customer set cust_city_id =32 where cust_city_id=24;
+fetch c0;
+declare c1 cursor for select * from lu_customer a13 where (extract(year from a13.cust_birthdate) in (select extract(year from c21.cust_birthdate) from lu_customer c21)) order by customer_id;
+fetch absolute 679 from c1;
+fetch absolute 680 from c1;
+rollback to x;
+fetch c0; 
+commit;
+
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+DROP TABLE if exists lu_customer;
+CREATE TABLE lu_customer (
+    customer_id numeric(28,0),
+    cust_first_name character varying(50),
+    cust_last_name character varying(50),
+    cust_birthdate date,
+    address character varying(50),
+    income_id numeric(28,0),
+    email character varying(50),
+    cust_city_id numeric(28,0)
+);
+
+-- ----------------------------------------------------------------------
+-- Test: copy.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+\copy lu_customer from '@abs_srcdir@/data/lu_customer.data' delimiter as '|'
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query04.sql
+-- ----------------------------------------------------------------------
+
+Begin;
+savepoint x;
+update lu_customer set cust_city_id =24 where cust_city_id=32;
+declare c0 cursor for select cust_city_id from lu_customer where cust_city_id=24;
+fetch c0;
+fetch c0;
+rollback to x;
+declare c1 cursor for select cust_city_id from lu_customer where cust_city_id=32;
+fetch c1;
+fetch c1;
+savepoint y;
+declare c2 cursor for select cust_city_id from lu_customer where cust_city_id =32;
+rollback to x;
+fetch c2;
+fetch c1;
+commit;
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+DROP TABLE if exists lu_customer;
+CREATE TABLE lu_customer (
+    customer_id numeric(28,0),
+    cust_first_name character varying(50),
+    cust_last_name character varying(50),
+    cust_birthdate date,
+    address character varying(50),
+    income_id numeric(28,0),
+    email character varying(50),
+    cust_city_id numeric(28,0)
+);
+
+-- ----------------------------------------------------------------------
+-- Test: copy.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+\copy lu_customer from '@abs_srcdir@/data/lu_customer.data' delimiter as '|'
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query05.sql
+-- ----------------------------------------------------------------------
+
+Begin;
+savepoint x;
+update lu_customer set cust_city_id =24 where cust_city_id=32;
+declare c0 cursor for select cust_city_id from lu_customer where cust_city_id=24;
+fetch c0;
+fetch c0;
+declare c1 cursor for select cust_city_id from lu_customer where cust_city_id=32;
+savepoint y;
+fetch c1;
+rollback to y; 
+fetch c0;
+fetch c0;
+fetch c0;
+fetch c0;
+commit;
+
+
+-- ----------------------------------------------------------------------
+-- Test: query09.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore
+DROP TABLE o_users cascade;
+DROP TABLE o_join1;
+DROP TABLE o_join2;
+DROP TABLE o_direct cascade;
+DROP VIEW o_indirect;
+
+--end_ignore
+CREATE TABLE o_users (username text) distributed randomly;
+INSERT INTO o_users VALUES (current_user);
+INSERT INTO o_users VALUES ('test_user');
+
+CREATE TABLE o_join1 (a int, b int) distributed randomly;
+INSERT INTO o_join1 VALUES (5, 6);
+INSERT INTO o_join1 VALUES (3, 7);
+
+CREATE TABLE o_join2 (a int, b int) distributed randomly;
+INSERT INTO o_join2 VALUES (10, 50);
+INSERT INTO o_join2 VALUES (5, 2);
+
+CREATE TABLE o_direct (a int, b int, c text) distributed randomly;
+INSERT INTO o_direct VALUES (1, 2, 'hello');
+INSERT INTO o_direct VALUES (5, 2, 'goodbye');
+
+CREATE OR REPLACE FUNCTION o_tester() RETURNS boolean
+    AS $$select coalesce((select max(1) from o_users where username=current_user) ,0)::boolean;$$
+LANGUAGE sql IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION o_rev(text) RETURNS text
+    AS $_$
+DECLARE original alias for $1;
+reverse_str text;
+i int4;
+BEGIN reverse_str := '';
+   FOR i IN REVERSE LENGTH(original)..1 LOOP
+     reverse_str := reverse_str || substr(original,i,1);
+   END LOOP;
+   RETURN reverse_str;
+END;$_$ LANGUAGE plpgsql IMMUTABLE; 
+
+CREATE VIEW o_indirect as
+SELECT a, b, CASE WHEN o_tester() THEN o_rev(c) ELSE c END AS tested FROM o_direct;
+--order 1
+SELECT o_indirect.a, o_indirect.tested FROM o_indirect LEFT OUTER JOIN (select o_join1.b FROM o_join1 FULL JOIN o_join2 ON (o_join2.b = o_join1.b)) BLAH ON o_indirect.b = BLAH.b order by 1;
+
+BEGIN;
+CREATE TABLE o_second (a int, b int) distributed randomly;
+INSERT INTO o_second VALUES (1, 1);
+INSERT INTO o_second VALUES (10, 9);
+--order 1
+DECLARE c0 CURSOR FOR SELECT o_indirect.a, o_indirect.tested FROM o_indirect LEFT OUTER JOIN (select o_join1.b FROM o_join1 FULL JOIN o_join2 ON (o_join2.b = o_join1.b)) BLAH ON o_indirect.b = BLAH.b order by 1;
+FETCH c0;
+ABORT;
+--start_ignore
+DROP TABLE o_users cascade;
+DROP TABLE o_join1;
+DROP TABLE o_join2;
+DROP TABLE o_direct Cascade;
+DROP VIEW o_indirect;
+--end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query12.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore
+DROP TABLE test cascade;
+DROP FUNCTION reffunc2();
+--end_ignore
+CREATE TABLE test (col text);
+INSERT INTO test VALUES ('123');
+CREATE FUNCTION reffunc2() RETURNS refcursor AS '
+DECLARE
+    ref refcursor;
+BEGIN
+    OPEN ref FOR SELECT col FROM test;
+    RETURN ref;
+END;
+' LANGUAGE plpgsql;
+BEGIN;
+SELECT reffunc2();
+FETCH ALL IN "<unnamed portal 1>";
+COMMIT;
+--start_ignore
+DROP TABLE test cascade;
+DROP FUNCTION reffunc2();
+--end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: query17.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore 
+DROP INDEX if exists fog_4752_sidx;
+DROP TABLE if exists fog_4752;
+--end_ignore
+
+CREATE TABLE fog_4752 ( description text, gid integer NOT NULL, item_class text, item_id integer, origin_x double precision, origin_y double precision, origin_z double precision) distributed randomly;
+CREATE INDEX fog_4752_sidx ON fog_4752 USING bitmap(gid);
+ALTER TABLE fog_4752 ADD CONSTRAINT fog_4752_pkey PRIMARY KEY (description,gid);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon1', 3, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon2', 2, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon3', 4, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon4', 5, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon6', 6, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon5', 1, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+SET ENABLE_SEQSCAN = On;
+BEGIN;
+--order 1
+DECLARE C63 SCROLL CURSOR FOR select * from fog_4752 order by 1;
+FETCH ABSOLUTE 1 IN C63;
+FETCH FORWARD 3 IN C63;
+FETCH C63;
+COMMIT;
+
+SET ENABLE_SEQSCAN = OFF; 
+BEGIN;
+--order 1
+DECLARE C63 SCROLL CURSOR FOR select * from fog_4752 order by 1;
+FETCH ABSOLUTE 1 IN C63;
+FETCH FORWARD 3 IN C63;
+FETCH C63;
+COMMIT;
+
+ ---- Drop and recreate index using btree and check if using btree fetch returns correct results. 
+
+DROP INDEX if exists fog_4752_sidx;
+CREATE INDEX fog_4752_sidx ON fog_4752 USING btree(gid);
+
+SET ENABLE_SEQSCAN = On;
+BEGIN;
+--order 1
+DECLARE C63 SCROLL CURSOR FOR select * from fog_4752 order by 1;
+FETCH ABSOLUTE 1 IN C63;
+FETCH FORWARD 3 IN C63;
+FETCH C63;
+COMMIT;
+
+SET ENABLE_SEQSCAN = OFF; 
+BEGIN;
+--order 1
+DECLARE C63 SCROLL CURSOR FOR select * from fog_4752 order by 1;
+FETCH ABSOLUTE 1 IN C63;
+FETCH FORWARD 3 IN C63;
+FETCH C63;
+COMMIT;
+--start_ignore 
+DROP INDEX if exists fog_4752_sidx;
+DROP TABLE if exists fog_4752;
+--end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_cursor cascade;
+-- end_ignore

--- a/src/test/regress/output/qp_cursor.source
+++ b/src/test/regress/output/qp_cursor.source
@@ -1,0 +1,446 @@
+-- ----------------------------------------------------------------------
+-- Test: setup_schema.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+create schema qp_cursor;
+set search_path to qp_cursor;
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+DROP TABLE if exists lu_customer;
+NOTICE:  table "lu_customer" does not exist, skipping
+CREATE TABLE lu_customer (
+    customer_id numeric(28,0),
+    cust_first_name character varying(50),
+    cust_last_name character varying(50),
+    cust_birthdate date,
+    address character varying(50),
+    income_id numeric(28,0),
+    email character varying(50),
+    cust_city_id numeric(28,0)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'customer_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- ----------------------------------------------------------------------
+-- Test: copy.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+\copy lu_customer from '@abs_srcdir@/data/lu_customer.data' delimiter as '|'
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query03.sql
+-- ----------------------------------------------------------------------
+begin;
+declare c0 cursor for select count(*) from lu_customer;
+savepoint x;
+update lu_customer set cust_city_id =32 where cust_city_id=24;
+fetch c0;
+ count 
+-------
+   679
+(1 row)
+
+declare c1 cursor for select * from lu_customer a13 where (extract(year from a13.cust_birthdate) in (select extract(year from c21.cust_birthdate) from lu_customer c21)) order by customer_id;
+fetch absolute 679 from c1;
+ customer_id | cust_first_name | cust_last_name | cust_birthdate |         address         | income_id |      email       | cust_city_id 
+-------------+-----------------+----------------+----------------+-------------------------+-----------+------------------+--------------
+         679 | Jill            | Widen          | 12-03-1974     | 187 Roger Williams Ave. |         6 | jill@hotmail.com |           78
+(1 row)
+
+fetch absolute 680 from c1;
+ customer_id | cust_first_name | cust_last_name | cust_birthdate | address | income_id | email | cust_city_id 
+-------------+-----------------+----------------+----------------+---------+-----------+-------+--------------
+(0 rows)
+
+rollback to x;
+fetch c0; 
+ count 
+-------
+(0 rows)
+
+commit;
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+DROP TABLE if exists lu_customer;
+CREATE TABLE lu_customer (
+    customer_id numeric(28,0),
+    cust_first_name character varying(50),
+    cust_last_name character varying(50),
+    cust_birthdate date,
+    address character varying(50),
+    income_id numeric(28,0),
+    email character varying(50),
+    cust_city_id numeric(28,0)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'customer_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- ----------------------------------------------------------------------
+-- Test: copy.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+\copy lu_customer from '@abs_srcdir@/data/lu_customer.data' delimiter as '|'
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query04.sql
+-- ----------------------------------------------------------------------
+Begin;
+savepoint x;
+update lu_customer set cust_city_id =24 where cust_city_id=32;
+declare c0 cursor for select cust_city_id from lu_customer where cust_city_id=24;
+fetch c0;
+ cust_city_id 
+--------------
+           24
+(1 row)
+
+fetch c0;
+ cust_city_id 
+--------------
+           24
+(1 row)
+
+rollback to x;
+declare c1 cursor for select cust_city_id from lu_customer where cust_city_id=32;
+fetch c1;
+ cust_city_id 
+--------------
+           32
+(1 row)
+
+fetch c1;
+ cust_city_id 
+--------------
+           32
+(1 row)
+
+savepoint y;
+declare c2 cursor for select cust_city_id from lu_customer where cust_city_id =32;
+rollback to x;
+fetch c2;
+ERROR:  cursor "c2" does not exist
+fetch c1;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+commit;
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+DROP TABLE if exists lu_customer;
+CREATE TABLE lu_customer (
+    customer_id numeric(28,0),
+    cust_first_name character varying(50),
+    cust_last_name character varying(50),
+    cust_birthdate date,
+    address character varying(50),
+    income_id numeric(28,0),
+    email character varying(50),
+    cust_city_id numeric(28,0)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'customer_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- ----------------------------------------------------------------------
+-- Test: copy.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+\copy lu_customer from '@abs_srcdir@/data/lu_customer.data' delimiter as '|'
+-- end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query05.sql
+-- ----------------------------------------------------------------------
+Begin;
+savepoint x;
+update lu_customer set cust_city_id =24 where cust_city_id=32;
+declare c0 cursor for select cust_city_id from lu_customer where cust_city_id=24;
+fetch c0;
+ cust_city_id 
+--------------
+           24
+(1 row)
+
+fetch c0;
+ cust_city_id 
+--------------
+           24
+(1 row)
+
+declare c1 cursor for select cust_city_id from lu_customer where cust_city_id=32;
+savepoint y;
+fetch c1;
+ cust_city_id 
+--------------
+(0 rows)
+
+rollback to y; 
+fetch c0;
+ cust_city_id 
+--------------
+           24
+(1 row)
+
+fetch c0;
+ cust_city_id 
+--------------
+           24
+(1 row)
+
+fetch c0;
+ cust_city_id 
+--------------
+           24
+(1 row)
+
+fetch c0;
+ cust_city_id 
+--------------
+(0 rows)
+
+commit;
+-- ----------------------------------------------------------------------
+-- Test: query09.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+DROP TABLE o_users cascade;
+ERROR:  table "o_users" does not exist
+DROP TABLE o_join1;
+ERROR:  table "o_join1" does not exist
+DROP TABLE o_join2;
+ERROR:  table "o_join2" does not exist
+DROP TABLE o_direct cascade;
+ERROR:  table "o_direct" does not exist
+DROP VIEW o_indirect;
+ERROR:  view "o_indirect" does not exist
+--end_ignore
+CREATE TABLE o_users (username text) distributed randomly;
+INSERT INTO o_users VALUES (current_user);
+INSERT INTO o_users VALUES ('test_user');
+CREATE TABLE o_join1 (a int, b int) distributed randomly;
+INSERT INTO o_join1 VALUES (5, 6);
+INSERT INTO o_join1 VALUES (3, 7);
+CREATE TABLE o_join2 (a int, b int) distributed randomly;
+INSERT INTO o_join2 VALUES (10, 50);
+INSERT INTO o_join2 VALUES (5, 2);
+CREATE TABLE o_direct (a int, b int, c text) distributed randomly;
+INSERT INTO o_direct VALUES (1, 2, 'hello');
+INSERT INTO o_direct VALUES (5, 2, 'goodbye');
+CREATE OR REPLACE FUNCTION o_tester() RETURNS boolean
+    AS $$select coalesce((select max(1) from o_users where username=current_user) ,0)::boolean;$$
+LANGUAGE sql IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION o_rev(text) RETURNS text
+    AS $_$
+DECLARE original alias for $1;
+reverse_str text;
+i int4;
+BEGIN reverse_str := '';
+   FOR i IN REVERSE LENGTH(original)..1 LOOP
+     reverse_str := reverse_str || substr(original,i,1);
+   END LOOP;
+   RETURN reverse_str;
+END;$_$ LANGUAGE plpgsql IMMUTABLE; 
+CREATE VIEW o_indirect as
+SELECT a, b, CASE WHEN o_tester() THEN o_rev(c) ELSE c END AS tested FROM o_direct;
+--order 1
+SELECT o_indirect.a, o_indirect.tested FROM o_indirect LEFT OUTER JOIN (select o_join1.b FROM o_join1 FULL JOIN o_join2 ON (o_join2.b = o_join1.b)) BLAH ON o_indirect.b = BLAH.b order by 1;
+ a | tested  
+---+---------
+ 1 | olleh
+ 5 | eybdoog
+(2 rows)
+
+BEGIN;
+CREATE TABLE o_second (a int, b int) distributed randomly;
+INSERT INTO o_second VALUES (1, 1);
+INSERT INTO o_second VALUES (10, 9);
+--order 1
+DECLARE c0 CURSOR FOR SELECT o_indirect.a, o_indirect.tested FROM o_indirect LEFT OUTER JOIN (select o_join1.b FROM o_join1 FULL JOIN o_join2 ON (o_join2.b = o_join1.b)) BLAH ON o_indirect.b = BLAH.b order by 1;
+FETCH c0;
+ a | tested 
+---+--------
+ 1 | olleh
+(1 row)
+
+ABORT;
+--start_ignore
+DROP TABLE o_users cascade;
+DROP TABLE o_join1;
+DROP TABLE o_join2;
+DROP TABLE o_direct Cascade;
+NOTICE:  drop cascades to rule _RETURN on view o_indirect
+NOTICE:  drop cascades to view o_indirect
+DROP VIEW o_indirect;
+ERROR:  view "o_indirect" does not exist
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query12.sql
+-- ----------------------------------------------------------------------
+--start_ignore
+DROP TABLE test cascade;
+ERROR:  table "test" does not exist
+DROP FUNCTION reffunc2();
+ERROR:  function reffunc2() does not exist
+--end_ignore
+CREATE TABLE test (col text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO test VALUES ('123');
+CREATE FUNCTION reffunc2() RETURNS refcursor AS '
+DECLARE
+    ref refcursor;
+BEGIN
+    OPEN ref FOR SELECT col FROM test;
+    RETURN ref;
+END;
+' LANGUAGE plpgsql;
+BEGIN;
+SELECT reffunc2();
+      reffunc2      
+--------------------
+ <unnamed portal 1>
+(1 row)
+
+FETCH ALL IN "<unnamed portal 1>";
+ col 
+-----
+ 123
+(1 row)
+
+COMMIT;
+--start_ignore
+DROP TABLE test cascade;
+DROP FUNCTION reffunc2();
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: query17.sql
+-- ----------------------------------------------------------------------
+--start_ignore 
+DROP INDEX if exists fog_4752_sidx;
+NOTICE:  index "fog_4752_sidx" does not exist, skipping
+DROP TABLE if exists fog_4752;
+NOTICE:  table "fog_4752" does not exist, skipping
+--end_ignore
+CREATE TABLE fog_4752 ( description text, gid integer NOT NULL, item_class text, item_id integer, origin_x double precision, origin_y double precision, origin_z double precision) distributed randomly;
+CREATE INDEX fog_4752_sidx ON fog_4752 USING bitmap(gid);
+ALTER TABLE fog_4752 ADD CONSTRAINT fog_4752_pkey PRIMARY KEY (description,gid);
+ERROR:  PRIMARY KEY and DISTRIBUTED RANDOMLY are incompatible
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon1', 3, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon2', 2, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon3', 4, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon4', 5, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon6', 6, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+INSERT INTO fog_4752 (description, gid, item_class, item_id, origin_x, origin_y, origin_z) VALUES ('Polygon5', 1, 'Polygon', 3, 567242.49402979179, 197718.29200272885, 0);
+SET ENABLE_SEQSCAN = On;
+BEGIN;
+--order 1
+DECLARE C63 SCROLL CURSOR FOR select * from fog_4752 order by 1;
+FETCH ABSOLUTE 1 IN C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon1    |   3 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(1 row)
+
+FETCH FORWARD 3 IN C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon2    |   2 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+ Polygon3    |   4 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+ Polygon4    |   5 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(3 rows)
+
+FETCH C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon5    |   1 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(1 row)
+
+COMMIT;
+SET ENABLE_SEQSCAN = OFF; 
+BEGIN;
+--order 1
+DECLARE C63 SCROLL CURSOR FOR select * from fog_4752 order by 1;
+FETCH ABSOLUTE 1 IN C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon1    |   3 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(1 row)
+
+FETCH FORWARD 3 IN C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon2    |   2 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+ Polygon3    |   4 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+ Polygon4    |   5 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(3 rows)
+
+FETCH C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon5    |   1 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(1 row)
+
+COMMIT;
+ ---- Drop and recreate index using btree and check if using btree fetch returns correct results. 
+DROP INDEX if exists fog_4752_sidx;
+CREATE INDEX fog_4752_sidx ON fog_4752 USING btree(gid);
+SET ENABLE_SEQSCAN = On;
+BEGIN;
+--order 1
+DECLARE C63 SCROLL CURSOR FOR select * from fog_4752 order by 1;
+FETCH ABSOLUTE 1 IN C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon1    |   3 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(1 row)
+
+FETCH FORWARD 3 IN C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon2    |   2 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+ Polygon3    |   4 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+ Polygon4    |   5 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(3 rows)
+
+FETCH C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon5    |   1 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(1 row)
+
+COMMIT;
+SET ENABLE_SEQSCAN = OFF; 
+BEGIN;
+--order 1
+DECLARE C63 SCROLL CURSOR FOR select * from fog_4752 order by 1;
+FETCH ABSOLUTE 1 IN C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon1    |   3 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(1 row)
+
+FETCH FORWARD 3 IN C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon2    |   2 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+ Polygon3    |   4 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+ Polygon4    |   5 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(3 rows)
+
+FETCH C63;
+ description | gid | item_class | item_id |     origin_x     |     origin_y     | origin_z 
+-------------+-----+------------+---------+------------------+------------------+----------
+ Polygon5    |   1 | Polygon    |       3 | 567242.494029792 | 197718.292002729 |        0
+(1 row)
+
+COMMIT;
+--start_ignore 
+DROP INDEX if exists fog_4752_sidx;
+DROP TABLE if exists fog_4752;
+--end_ignore
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+-- start_ignore
+drop schema qp_cursor cascade;
+NOTICE:  drop cascades to function o_rev(text)
+NOTICE:  drop cascades to function o_tester()
+NOTICE:  drop cascades to table lu_customer
+-- end_ignore

--- a/src/test/regress/sql/qp_case.sql
+++ b/src/test/regress/sql/qp_case.sql
@@ -1,0 +1,479 @@
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_case;
+set search_path to qp_case;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: test01_case_noelse.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop table if exists genders;
+-- end_ignore
+
+select CASE 'M'
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END;
+select CASE 'F'
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END;
+select CASE ''
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END;
+select CASE null
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END;
+
+create table genders (gid integer, gender char(1)) distributed by (gid);
+
+insert into genders(gid, gender) values (1, 'F');
+insert into genders(gid, gender) values (2, 'M');
+insert into genders(gid, gender) values (3, 'Z');
+insert into genders(gid, gender) values (4, '');
+insert into genders(gid, gender) values (5, null);
+insert into genders(gid, gender) values (6, 'G');
+
+select gender, CASE gender
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    END
+from genders
+order by gid;
+
+-- ----------------------------------------------------------------------
+-- Test: test02_case_withelse.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop table if exists genders;
+-- end_ignore
+
+select CASE 'M'
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    ELSE 'Other' END;
+
+select CASE null
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    ELSE 'Other' END;
+
+create table genders (gid integer, gender char(1)) distributed by (gid);
+
+insert into genders(gid, gender) values (1, 'F');
+insert into genders(gid, gender) values (2, 'M');
+insert into genders(gid, gender) values (3, 'Z');
+insert into genders(gid, gender) values (4, '');
+insert into genders(gid, gender) values (5, null);
+insert into genders(gid, gender) values (6, 'G');
+
+select gender, CASE gender
+    WHEN IS NOT DISTINCT FROM 'M' THEN 'Male'
+    WHEN IS NOT DISTINCT FROM 'F' THEN 'Female'
+    WHEN IS NOT DISTINCT FROM '' THEN 'Not Specified'
+    WHEN IS NOT DISTINCT FROM null THEN 'Not Specified'
+    ELSE 'Other' END
+from genders
+order by gid;
+
+-- ----------------------------------------------------------------------
+-- Test: test03_case_combined_when_match_found.sql
+-- ----------------------------------------------------------------------
+
+select 'a' as lhs, CASE 'a'
+       WHEN 'f' THEN 'WHEN: f'
+       WHEN IS NOT DISTINCT FROM 'f' THEN 'WHEN NEW: f'
+       WHEN 'e' THEN 'WHEN: e'
+       WHEN IS NOT DISTINCT FROM 'e' THEN 'WHEN NEW: e'
+       WHEN 'd' THEN 'WHEN: d'
+       WHEN IS NOT DISTINCT FROM 'd' THEN 'WHEN NEW: d'
+       WHEN 'c' THEN 'WHEN: c'
+       WHEN IS NOT DISTINCT FROM 'c' THEN 'WHEN NEW: c'
+       WHEN 'b' THEN 'WHEN: b'
+       WHEN IS NOT DISTINCT FROM 'b' THEN 'WHEN NEW: b'
+       WHEN 'a' THEN 'WHEN: a'
+       WHEN IS NOT DISTINCT FROM 'a' THEN 'WHEN NEW: a'
+    ELSE 'NO MATCH' END as match; 
+
+
+select 1 as lhs, CASE 1
+       WHEN 4 THEN 'WHEN: 4'
+       WHEN IS NOT DISTINCT FROM 4 THEN 'WHEN NEW: 4'
+       WHEN 3 THEN 'WHEN: 3'
+       WHEN IS NOT DISTINCT FROM 3 THEN 'WHEN NEW: 3'
+       WHEN 2 THEN 'WHEN: 2'
+       WHEN IS NOT DISTINCT FROM 2 THEN 'WHEN NEW: 2'
+       WHEN 11 THEN 'WHEN: 11'
+       WHEN IS NOT DISTINCT FROM 1 THEN 'WHEN NEW: 1'
+    ELSE 'NO MATCH' END as match; 
+
+select '2011-05-27'::date as lsh,  CASE '2011-05-27'::date
+       WHEN '2011-07-25'::date THEN 'WHEN: 2011-07-25'
+       WHEN IS NOT DISTINCT FROM '2011-05-27'::date THEN 'WHEN NEW: 2011-05-27'
+    END as match; 
+
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: test04_case_combined_when_nomatch_found.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore 
+drop table if exists nomatch_case;
+-- end_ignore
+
+create table nomatch_case
+(
+   sid integer, 
+   gender char(1) default 'F',
+   name text,
+   start_dt date
+) distributed by (sid);
+
+insert into nomatch_case(sid, gender, name, start_dt)
+values(1000, 'F', 'Jane Doe', '2011-01-15'::date);
+insert into nomatch_case(sid, gender, name, start_dt)
+values(2000, 'M', 'Ryan Goesling', '2011-02-01'::date);
+insert into nomatch_case(sid, gender, name, start_dt)
+values(3000, 'M', 'Tim Tebow', '2011-01-15'::date);
+insert into nomatch_case(sid, gender, name, start_dt)
+values(4000, 'F', 'Katy Perry', '2011-03-01'::date);
+insert into nomatch_case(sid, gender, name, start_dt)
+values(5000, 'F', 'Michael Scott', '2011-02-01'::date);
+
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE upper(gender)
+          WHEN 'MALE' THEN 'M'
+          WHEN IS NOT DISTINCT FROM 'FEMALE' THEN 'F'
+          WHEN trim('MALE ') THEN 'M'
+       ELSE 'NO MATCH' END as case_gender
+from nomatch_case
+order by sid, name; 
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE start_dt
+           WHEN IS NOT DISTINCT FROM '2009-01-01'::date THEN 2009
+           WHEN '2008-01-01'::date THEN 2008
+           WHEN IS NOT DISTINCT FROM '2010-01-01'::date then 2010
+           WHEN 2007 THEN 2007
+           WHEN IS NOT DISTINCT FROM 2007 THEN 2007
+           WHEN '2006-01-01'::date then 2006
+       END as case_start_dt
+from nomatch_case
+order by sid, name;
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE sid
+           WHEN 100 THEN 'Dept 10' 
+           WHEN 200 THEN 'Dept 20' 
+           WHEN IS NOT DISTINCT FROM 300 then 'Dept 30'
+           WHEN 400 THEN 'Dept 40'
+           WHEN 500 THEN 'Dept 50'
+           WHEN IS NOT DISTINCT FROM 600 then 'Dept 60'
+           WHEN IS NOT DISTINCT FROM 700 then 'Dept 70'
+       END as case_sid
+from nomatch_case
+order by sid, name;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test05_case_combined_when_in_aggr.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore 
+drop table if exists combined_when;
+-- end_ignore
+
+create table combined_when 
+(
+   sid integer, 
+   gender varchar(10) default 'F',
+   name text,
+   start_dt date
+) distributed by (sid);
+
+insert into combined_when(sid, gender, name, start_dt)
+values(1000, 'F', 'Jane Doe', '2011-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(2000, 'M', 'Ryan Goesling', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(3000, 'm', 'Tim Tebow', '2007-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(4000, 'F', 'Katy Perry', '2011-03-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(5000, 'f', 'Michael Scott', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(6000, 'Female  ', 'Mila Kunis', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(7000, ' Male ', 'Tom Brady', '2011-03-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(8000,  ' ', 'Lady Gaga', '2008-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(9000,  null, 'George Michael', '2011-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(10000,  'Male   ', 'Michael Jordan', null);
+
+select case_yr_start_dt, count(sid)
+from (select sid,
+       name,
+       gender,
+       start_dt,
+       CASE extract(year from start_dt)
+           WHEN IS NOT DISTINCT FROM 2009 THEN 2009
+           WHEN abs(2009-1) THEN 2008
+           WHEN IS NOT DISTINCT FROM extract(year from '2010-01-01'::date) then 2010
+           WHEN round(2007.05, 0) THEN 2007
+           WHEN IS NOT DISTINCT FROM 2007 THEN 2007
+           WHEN extract(year from '2006-01-01'::date) then 2006
+           WHEN extract(year from '2011-01-01'::date) then 2011
+       END as case_yr_start_dt
+from combined_when
+order by sid, name) a
+group by case_yr_start_dt
+order by 2 desc, 1;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test06_case_combined_when_expr.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore 
+drop table if exists case_expr;
+-- end_ignore
+
+create table case_expr
+(
+   sid integer, 
+   gender char(1) default 'F',
+   name text,
+   start_dt date
+) distributed by (sid);
+
+insert into case_expr(sid, gender, name, start_dt)
+values(1000, 'F', 'Jane Doe', '2011-01-15'::date);
+insert into case_expr(sid, gender, name, start_dt)
+values(2000, 'M', 'Ryan Goesling', '2011-02-01'::date);
+insert into case_expr(sid, gender, name, start_dt)
+values(3000, 'M', 'Tim Tebow', '2011-01-15'::date);
+insert into case_expr(sid, gender, name, start_dt)
+values(4000, 'F', 'Katy Perry', '2011-03-01'::date);
+insert into case_expr(sid, gender, name, start_dt)
+values(5000, 'F', 'Michael Scott', '2011-02-01'::date);
+
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE (gender is not null)
+          WHEN (gender = 'MALE') THEN 'M'
+          WHEN IS NOT DISTINCT FROM (gender = 'FEMALE') THEN 'F'
+          WHEN (gender = trim('MALE ')) THEN 'M'
+          WHEN IS NOT DISTINCT FROM (gender = 'M') THEN 'M'
+          WHEN (gender = 'F') THEN 'F'
+       ELSE 'NO MATCH' END as case_gender
+from case_expr
+order by sid, name; 
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE (extract(year from start_dt) = 2011)
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 1) THEN 'January'
+           WHEN (extract(month from start_dt) = 2) THEN 'February'
+           WHEN (extract(month from start_dt) = 3) THEN 'March'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 4) THEN 'April'
+           WHEN (extract(month from start_dt) = 5) THEN 'May'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 6) THEN 'June'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 7) THEN 'July'
+           WHEN (extract(month from start_dt) = 8) THEN 'August'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 9) THEN 'September'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 10) THEN 'October'
+           WHEN IS NOT DISTINCT FROM (extract(month from start_dt) = 11) THEN 'November'
+           WHEN (extract(month from start_dt) = 12) THEN 'December'
+       END as case_start_month
+from case_expr
+order by sid, name;
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE (sid > 100)
+           WHEN (sid = 1000) THEN 'Dept 10' 
+           WHEN (sid > 1000 and sid <= 2000) THEN 'Dept 20' 
+           WHEN IS NOT DISTINCT FROM (sid = 3000) then 'Dept 30'
+           WHEN (sid = 4000) THEN 'Dept 40'
+           WHEN (sid = 5000) THEN 'Dept 50'
+           WHEN IS NOT DISTINCT FROM (sid > 5000 and sid <= 6000) then 'Dept 60'
+           WHEN IS NOT DISTINCT FROM (sid = 7000) then 'Dept 70'
+       END as case_sid
+from case_expr
+order by sid, name;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test07_case_combined_when_functions.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore 
+drop table if exists combined_when;
+-- end_ignore
+
+create table combined_when 
+(
+   sid integer, 
+   gender varchar(10) default 'F',
+   name text,
+   start_dt date
+) distributed by (sid);
+
+insert into combined_when(sid, gender, name, start_dt)
+values(1000, 'F', 'Jane Doe', '2011-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(2000, 'M', 'Ryan Goesling', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(3000, 'm', 'Tim Tebow', '2007-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(4000, 'F', 'Katy Perry', '2011-03-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(5000, 'f', 'Michael Scott', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(6000, 'Female  ', 'Mila Kunis', '2011-02-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(7000, ' Male ', 'Tom Brady', '2011-03-01'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(8000,  ' ', 'Lady Gaga', '2008-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(9000,  null, 'George Michael', '2011-01-15'::date);
+insert into combined_when(sid, gender, name, start_dt)
+values(10000,  'Male   ', 'Michael Jordan', null);
+
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE upper(trim(gender))
+          WHEN 'MALE' THEN 'M'
+          WHEN IS NOT DISTINCT FROM 'FEMALE' THEN 'F'
+          WHEN trim('MALE ') THEN 'M'
+          WHEN trim(' FEMALE ') THEN 'F'
+          WHEN IS NOT DISTINCT FROM 'M' THEN 'M'
+          WHEN IS NOT DISTINCT FROM 'F' THEN 'F'
+       ELSE 'NO MATCH' END as case_gender
+from combined_when
+order by sid, name; 
+
+select sid,
+       name,
+       gender,
+       start_dt,
+       CASE extract(year from start_dt)
+           WHEN IS NOT DISTINCT FROM 2009 THEN 2009
+           WHEN abs(2009-1) THEN 2008
+           WHEN IS NOT DISTINCT FROM extract(year from '2010-01-01'::date) then 2010
+           WHEN round(2007.05, 0) THEN 2007
+           WHEN IS NOT DISTINCT FROM 2007 THEN 2007
+           WHEN extract(year from '2006-01-01'::date) then 2006
+           WHEN extract(year from '2011-01-01'::date) then 2011
+       END as case_yr_start_dt
+from combined_when
+order by sid, name;
+
+select case_yr_start_dt, count(sid)
+from (select sid,
+       name,
+       gender,
+       start_dt,
+       CASE extract(year from start_dt)
+           WHEN IS NOT DISTINCT FROM 2009 THEN 2009
+           WHEN abs(2009-1) THEN 2008
+           WHEN IS NOT DISTINCT FROM extract(year from '2010-01-01'::date) then 2010
+           WHEN round(2007.05, 0) THEN 2007
+           WHEN IS NOT DISTINCT FROM 2007 THEN 2007
+           WHEN extract(year from '2006-01-01'::date) then 2006
+           WHEN extract(year from '2011-01-01'::date) then 2011
+       END as case_yr_start_dt
+from combined_when
+order by sid, name) a
+group by case_yr_start_dt
+order by 2 desc, 1;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test08_case_negative_syntax_err.sql
+-- ----------------------------------------------------------------------
+
+select CASE 'a'
+       WHEN IS NOT DISTINCT FROM 'b' THEN 'a=b'
+       WHEN NOT DISTINCT FROM 'a' THEN 'a=a'
+END;
+
+select CASE 'a'
+       WHEN IS NOT DISTINCT 'b' THEN 'a=b'
+       WHEN IS NOT DISTINCT FROM 'a' THEN 'a=a'
+END;
+
+select CASE 'a'
+       WHEN IS NOT DISTINCT FROM 'b' THEN 'a=b'
+       WHEN IS NOT DISTINCT FROM 'a' IS 'a=a'
+END;
+
+select CASE 'a'
+       WHEN IS NOT DISTINCT FROM 'b' IS 'a=b'
+       WHEN IS NOT DISTINCT FROM 'a' THEN 'a=a'
+END;
+
+
+-- ----------------------------------------------------------------------
+-- Test: test09_case_negative_unsupported.sql
+-- ----------------------------------------------------------------------
+
+select CASE 1
+       WHEN IS NOT DISTINCT FROM 2 THEN '1=2'
+       WHEN IS DISTINCT FROM 2 THEN '1<>2'
+       WHEN IS NOT DISTINCT FROM 1 THEN '1=1'
+END;
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_case cascade;
+-- end_ignore

--- a/src/test/regress/sql/qp_targeted_dispatch.sql
+++ b/src/test/regress/sql/qp_targeted_dispatch.sql
@@ -1,0 +1,516 @@
+
+-- ----------------------------------------------------------------------
+-- Test: setup.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+create schema qp_targeted_dispatch;
+set search_path to qp_targeted_dispatch;
+-- end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query01.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore
+Drop table direct_test;
+Drop table direct_test_two_column; 
+--end_ignore
+create table direct_test
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key); 
+create table direct_test_two_column
+(
+  key1 int NULL,
+  key2 int NULL,
+  value varchar(50) NULL
+)
+distributed by (key1, key2);
+insert into direct_test values (100, 'cow');
+insert into direct_test_two_column values (100, 101, 'cow');
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+-- Constant single-row insert, one column in distribution
+-- DO direct dispatch
+insert into direct_test values (100, 'cow');
+-- verify
+select * from direct_test order by key, value;
+
+-- Constant single-row update, one column in distribution
+-- DO direct dispatch
+
+update direct_test set value = 'horse' where key = 100;
+-- verify
+select * from direct_test order by key, value;
+
+-- Constant single-row delete, one column in distribution
+-- DO direct dispatch
+delete from direct_test where key = 100;
+-- verify
+select * from direct_test order by key, value;
+-- Constant single-row insert, two columns in distribution
+-- DO direct dispatch
+insert into direct_test_two_column values (100, 101, 'cow');
+-- verify
+select * from direct_test_two_column order by key1, key2, value;
+-- Constant single-row update, two columns in distribution
+-- DO direct dispatch
+update direct_test_two_column set value = 'horse' where key1 = 100 and key2 = 101;
+-- verify
+select * from direct_test_two_column order by key1, key2, value;
+-- Constant single-row delete, two columns in distribution
+-- DO direct dispatch
+delete from direct_test_two_column where key1 = 100 and key2 = 101;
+-- verify
+select * from direct_test_two_column order by key1, key2, value;
+-- Multiple row update, where clause lists multiple values which hash differently so no direct dispatch
+--
+-- note that if the hash function for values changes then certain segment configurations may actually 
+--                hash all these values to the same content! (and so test would change)
+--
+
+update direct_test set value = 'pig' where key in (1,2,3,4,5);
+
+update direct_test_two_column set value = 'pig' where key1 = 100 and key2 in (1,2,3,4);
+update direct_test_two_column set value = 'pig' where key1 in (100,101,102,103,104) and key2 in (1);
+update direct_test_two_column set value = 'pig' where key1 in (100,101) and key2 in (1,2);
+
+--start_ignore
+Drop table direct_test;
+Drop table direct_test_two_column;
+--end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: query02.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore
+Drop table direct_test1;
+--end_ignore
+create table direct_test1
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key);
+insert into direct_test1 values (200, 'horse');
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+Begin;
+declare c0 cursor for select * from direct_test1 where value='horse';
+select * from direct_test1 where value='horse';
+select value from direct_test1 where value='horse';
+select * from direct_test1 where key=200;
+declare c1 cursor for select * from direct_test1 where key=200;
+fetch c1;
+fetch c0;
+fetch c1;
+fetch c0;
+End;
+--start_ignore
+Drop table direct_test1;
+--end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: query03.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore
+Drop table key_value_table cascade;
+--end_ignore
+create table key_value_table
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key);
+insert into key_value_table values (200, 'horse');
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+Begin;
+SELECT * FROM key_value_table WHERE key = 200 FOR UPDATE;
+update key_value_table set value=300 where key =200;
+savepoint s;
+update key_value_table set value=200 where key =300;
+update key_value_table set value=300 where key =200;
+rollback to s;
+commit;
+Begin;
+SELECT * FROM key_value_table WHERE key = 200 FOR UPDATE;
+savepoint s;
+update key_value_table set value=200 where key =300;
+rollback;
+savepoint s;
+abort;
+--start_ignore
+Drop table key_value_table cascade;
+--end_ignore
+
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: query05.sql
+-- ----------------------------------------------------------------------
+
+-- Targeted Dispatch to make sure it works fine for all possible data types. This test case is to check if it works fine for boolean and int data type
+--start_ignore
+DROP TABLE IF EXISTS boolean;
+--end_ignore
+create table boolean (boo boolean, b int);
+insert into boolean values ('f', 1);
+set test_print_direct_dispatch_info=on;
+insert into boolean values ('t', 2);
+alter table boolean set distributed by (b);
+insert into boolean values ('t', 1);
+alter table boolean set distributed randomly;
+insert into boolean values ('t', 1);
+alter table boolean set distributed by (boo, b);
+select * from boolean where boo='t' and b=2;
+--start_ignore
+DROP TABLE if EXISTS boolean;
+--end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query06.sql
+-- ----------------------------------------------------------------------
+
+-- Targeted Dispatch to make sure it works fine for all possible data types. This test case is to check if it works fine for date and double precision data type
+--start_ignore
+Drop table if exists date;
+--end_ignore
+create table date (date1 date, dp1 double precision);
+insert into date values ('2001-11-11',234.23234);
+set test_print_direct_dispatch_info=on;
+insert into date values ('2001-11-12',234.2323);
+alter table date set distributed by (dp1);
+insert into date values ('2001-11-13',234.23234);
+insert into date values ('2001-11-14',234.2323);
+alter table date set distributed by (date1, dp1);
+select * from date where date1='2001-11-12' and dp1=234.2323;
+--start_ignore
+Drop table if exists date;
+--end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: query07.sql
+-- ----------------------------------------------------------------------
+
+-- Targeted Dispatch to make sure it works fine for all possible data types. This test case is to check if it works fine for interval and Numeric data type
+--start_ignore
+Drop table if exists interval;
+--end_ignore
+create table interval (interval1 interval, num numeric);
+insert into interval values ('23',2345);
+set test_print_direct_dispatch_info=on;
+insert into interval values ('2',234);
+alter table interval set distributed by (num);
+insert into interval values ('24',234);
+insert into interval values ('26',2343);
+alter table interval set distributed by (num,interval1);
+select * from interval where interval1='23' and num=2345;
+--start_ignore
+Drop table if exists interval;
+--end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: query08.sql
+-- ----------------------------------------------------------------------
+
+-- This test case is to check if it works fine for real and smallint data type
+--start_ignore
+Drop table if exists real;
+--end_ignore
+create table real (real1 real, si1 smallint) distributed by (real1);
+insert into real values (23, 4);
+set test_print_direct_dispatch_info=on;
+insert into real values (23, 4);
+Alter table real set distributed by (si1);
+insert into real values (21, 3);
+insert into real values (21, 2);
+select * from real where real.si1=3;
+Alter table real set distributed by (si1,real1);
+select * from real where real1=21 and si1=3;
+--start_ignore
+Drop table if exists real;
+--end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query09.sql
+-- ----------------------------------------------------------------------
+
+-- This test case is to check if it works fine for bytea and cidr data type
+--start_ignore
+Drop table if exists bytea;
+--end_ignore
+create table bytea (bytea1 bytea, cidr1 cidr) distributed by (bytea1);
+insert into bytea values ('d','0.0.0.0');
+set test_print_direct_dispatch_info=on;
+insert into bytea values ('d','0.0.0.1');
+alter table bytea set distributed by (cidr1,bytea1);
+insert into bytea values ('e','0.0.1.0');
+select * from bytea where bytea1='d' and cidr1='0.0.0.1';
+--start_ignore
+Drop table if exists bytea;
+--end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: query10.sql
+-- ----------------------------------------------------------------------
+
+-- This test case is to check if it works fine for inet and macaddr data type
+--start_ignore
+Drop table if exists inetmac;
+--end_ignore
+create table inetmac (inet1 inet, macaddr1 macaddr) distributed by (inet1);
+insert into inetmac values ('0.0.0.0','AA:AA:AA:AA:AA:AA');
+set test_print_direct_dispatch_info=on;
+insert into inetmac values ('0.0.0.0','AC:AA:AA:AA:AA:AA');
+alter table inetmac set distributed by (macaddr1);
+insert into inetmac values ('0.0.0.2','AA:AA:AA:AA:AA:AC');
+alter table inetmac set distributed by (macaddr1,inet1);
+insert into inetmac values ('0.0.0.2','AA:AA:AA:AA:AA:AC');
+select * from inetmac where inet1='0.0.0.0' and macaddr1 ='AA:AA:AA:AA:AA:AA';
+--start_ignore
+Drop table if exists inetmac;
+--end_ignore
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: query11.sql
+-- ----------------------------------------------------------------------
+
+-- This test case is to check if it works fine for money and int data type
+--start_ignore
+Drop table if exists money;
+--end_ignore
+create table money (money1 money, b int);
+insert into money values ('34.23',5);
+set test_print_direct_dispatch_info=on;
+insert into money values ('34.23',2);
+alter table money set distributed by (money1, b);
+insert into money values ('34.13',2);
+select * from money where money1='34.13' and b =2;
+--start_ignore
+Drop table if exists money;
+--end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query12.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore
+Drop table if exists time2;
+--end_ignore
+create table time2 (time2 time with time zone, text1 text);
+insert into time2 values ('00:00:00+1359', 'abcg');
+set test_print_direct_dispatch_info=on;
+insert into time2 values ('00:00:00+1359', 'abcf');
+alter table time2 set distributed by (text1);
+insert into time2 values ('00:00:00+1352', 'abce');
+alter table time2 set distributed by (text1,time2);
+insert into time2 values ('00:00:00+1352', 'abcd');
+select * from time2 where time2='00:00:00+1359' and text1='abcg';
+--start_ignore
+Drop table if exists time2;
+--end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query13.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore
+Drop table if exists timestamp;
+--end_ignore
+create table timestamp (timestamp1 timestamp without time zone, time2 timestamp with time zone);
+insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
+set test_print_direct_dispatch_info=on;
+insert into timestamp values ('2004-12-13 01:51:15','2004-12-13 01:51:15+1359');
+alter table timestamp set distributed by (time2);
+insert into timestamp values ('2004-12-13 01:51:25','2004-12-12 01:51:15+1359');
+alter table timestamp set distributed by (time2, timestamp1);
+insert into timestamp values ('2004-12-13 01:51:25','2004-12-12 01:51:15+1359');
+select * from timestamp where timestamp1='2004-12-13 01:51:25' and time2 ='2004-12-12 01:51:15+1359';
+--start_ignore
+Drop table if exists timestamp;
+--end_ignore
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: query14.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore
+drop table if exists bit1;
+--end_ignore
+create table bit1 (a bit(1), b int) distributed by (a);
+insert into bit1 values ('0', 23);
+set test_print_direct_dispatch_info=on;
+insert into bit1 values ('1', 23);
+alter table bit1 set distributed by (b);
+insert into bit1 values ('0', 24);
+alter table bit1 set distributed by (b,a);
+insert into bit1 values ('0', 24);
+select * from bit1 where a='0' and b =24;
+--start_ignore
+drop table if exists bit1;
+--end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query18.sql
+-- ----------------------------------------------------------------------
+
+--start_ignore
+Drop table if exists mpp7638;
+--end_ignore
+create table mpp7638 (a int, b int, c int, d int) partition by range(d) (start(1) end(10) every(1));
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 2) i;
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 3) i;
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 4) i;
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 5) i;
+set test_print_direct_dispatch_info=on;
+insert into mpp7638 select i, i+1, i+2, i+3 from generate_series(1, 6) i;
+select count(*) from mpp7638 where a =1;
+explain select count(*) from mpp7638 where a =1;
+alter table mpp7638 set distributed by (a, b, c);
+select * from mpp7638 where a=1 and b=2 and c=3;
+--start_ignore
+Drop table if exists mpp7638;
+--end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query19.sql
+-- ----------------------------------------------------------------------
+
+--Partition by range table should use targeted diaptch
+
+CREATE TABLE range_table (id INTEGER)
+ PARTITION BY RANGE (id)
+(START (0) END (200000) EVERY (100000)) ;
+INSERT INTO range_table(id) VALUES (0);
+CREATE INDEX id3 ON range_table USING BITMAP (id);
+set test_print_direct_dispatch_info=on;
+INSERT INTO range_table(id) VALUES (1);
+DROP INDEX id3;
+CREATE INDEX id3 ON range_table USING BITMAP (id);
+INSERT INTO range_table(id) VALUES (2);
+INSERT INTO range_table(id) VALUES (3);
+INSERT INTO range_table(id) VALUES (4);
+INSERT INTO range_table(id) VALUES (5);
+INSERT INTO range_table(id) VALUES (5);
+select * from range_table where id =1;
+select count(*) from range_table where id=1;
+DROP TABLE range_table;
+
+
+-- ----------------------------------------------------------------------
+-- Test: query20.sql
+-- ----------------------------------------------------------------------
+
+-- Table using inheritance, Rules and Insert-Select is not getting targeted even though Select is targeted.
+
+create table tblexecutions (date date not null, mykey bigint, "sequence" int not null, firm character varying(4) NOT NULL) distributed by ("sequence");
+create table tblexecutions_20080102 (CONSTRAINT tblexecutions_20080102_date_check CHECK (((date >= '2008-01-02'::date) AND (date <= '2008-01-02'::date)))) INHERITS (tblexecutions) distributed by ("sequence");
+CREATE TABLE tblexecutions_20080103 (CONSTRAINT tblexecutions_20080103_date_check CHECK (((date >= '2008-01-03'::date) AND (date <= '2008-01-03'::date)))) INHERITS (tblexecutions) distributed by ("sequence");
+CREATE TABLE tblexecutions_20080104 (CONSTRAINT tblexecutions_20080104_date_check CHECK (((date >= '2008-01-04'::date) AND (date <= '2008-01-04'::date)))) INHERITS (tblexecutions) distributed by ("sequence");
+create index tblexecutions_20080103_idx on tblexecutions_20080103 using bitmap (firm);
+CREATE RULE rule_tblexecutions_20080102 AS ON INSERT TO tblexecutions WHERE ((new.date >= '2008-01-02'::date) AND (new.date <= '2008-01-02'::date)) DO INSTEAD INSERT INTO tblexecutions_20080102 (date, mykey, "sequence", firm) VALUES (new.date, new.mykey, new."sequence", new.firm);
+CREATE RULE rule_tblexecutions_20080103 AS ON INSERT TO tblexecutions WHERE ((new.date >= '2008-01-03'::date) AND (new.date <= '2008-01-03'::date)) DO INSTEAD INSERT INTO tblexecutions_20080103 (date, mykey, "sequence", firm) VALUES (new.date, new.mykey, new."sequence", new.firm);
+CREATE RULE rule_tblexecutions_20080104 AS ON INSERT TO tblexecutions WHERE ((new.date >= '2008-01-04'::date) AND (new.date <= '2008-01-04'::date)) DO INSTEAD INSERT INTO tblexecutions_20080104 (date, mykey, "sequence", firm) VALUES (new.date, new.mykey, new."sequence", new.firm);
+insert into tblexecutions select '2008/01/02'::date + ((i % 3) || ' days')::interval, i*10, i, 'f' || to_char(random()*100, '99') from generate_series(1, 1000000) i;
+insert into tblexecutions select * from tblexecutions where sequence=10;
+set test_print_direct_dispatch_info=on;
+select count(*) from tblexecutions where sequence=10;
+DROP index tblexecutions_20080103_idx; 
+drop rule rule_tblexecutions_20080104 on tblexecutions;
+drop rule rule_tblexecutions_20080103 on tblexecutions;
+drop rule rule_tblexecutions_20080102 on tblexecutions;
+DROP TABLE tblexecutions_20080104; 
+DROP TABLE tblexecutions_20080103;
+DROP TABLE tblexecutions_20080102;  
+DRop table tblexecutions;
+
+
+
+-- ----------------------------------------------------------------------
+-- Test: query21.sql
+-- ----------------------------------------------------------------------
+
+--targeted dispatch for CTAS and Insert-Select, It doesn't work today still I have been asked to check in test cases and later move o/p to ans when we have this working. MPP_7620
+
+--start_ignore
+Drop table zoompp7620;
+Drop table mpp7620;
+--end_ignore
+create table mpp7620
+(
+  key int NULL,
+  value varchar(50) NULL
+)
+distributed by (key);
+insert into mpp7620 values (200, 'horse');
+-- enable printing of printing info
+set test_print_direct_dispatch_info=on;
+Create table zoompp7620 as select * from mpp7620 where key=200;
+insert into mpp7620 values (200, 200);
+insert into zoompp7620 select * from mpp7620 where key=200;
+insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
+select key from mpp7620 where mpp7620.key=200;
+select * from (select * from mpp7620 where key=200) ss where key =200;
+explain select * from (select * from mpp7620 where key=200) ss where key =200; 
+explain insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
+explain select key from mpp7620 where mpp7620.key=200;
+--start_ignore
+Drop table zoompp7620;
+Drop table mpp7620;
+--end_ignore
+
+-- ----------------------------------------------------------------------
+-- Test: query22.sql
+-- ----------------------------------------------------------------------
+
+--Test case for Deepslice queries, since this is disabled right now we need to move correct o/p to expected result once feature is made available for Deepslice queries. QA-592
+--start_ignore
+drop table table_a cascade;
+drop sequence s;
+--end_ignore
+
+CREATE SEQUENCE s;
+CREATE TABLE table_a (a0 int, a1 int, a2 int, a3 int);
+INSERT INTO table_a (a3, a2, a0, a1) VALUES (nextval('s'), nextval('s'), nextval('s'), nextval('s'));
+insert into table_a (a3,a2,a0,a1) values (1,2,3,4);
+set test_print_direct_dispatch_info=on;
+
+--Check to see distributed vs distributed randomly
+alter table table_a set distributed randomly;
+select max(a0) from table_a where a0=3;
+alter table table_a set distributed by (a0);
+explain select * from table_a where a0=3;
+explain select a0 from table_a where a0 in (select max(a1) from table_a);
+select a0 from table_a where a0 in (select max(a1) from table_a);
+select max(a1) from table_a;
+select max(a0) from table_a where a0=1;
+explain select a0 from table_a where a0 in (select max(a1) from table_a where a0=1);
+--start_ignore
+drop table table_a cascade;
+drop sequence s;
+--end_ignore
+
+
+-- ----------------------------------------------------------------------
+-- Test: teardown.sql
+-- ----------------------------------------------------------------------
+
+-- start_ignore
+drop schema qp_targeted_dispatch cascade;
+-- end_ignore


### PR DESCRIPTION
 - targeted_dispatch: 
`query4` has a reference to quicklz, and it seems like it is not supported by master. The tests that are using quicklz as a compression type is disabled in the ICG because of the failure. 

- cursor
Only 6 new tests are ported, the rest was part of bugbuster suite.

- case
I could not find any duplicate test in ICG, so ported all the tests. 