### PR TITLE
Release locks heldby filerep resync worker on exit

### DIFF
--- a/src/backend/cdb/cdbfilerepservice.c
+++ b/src/backend/cdb/cdbfilerepservice.c
@@ -153,6 +153,10 @@ FileRepSubProcess_ShutdownHandler(SIGNAL_ARGS)
 				{
 					FileRepResync_Cleanup();
 				}
+				else
+				{
+					LockReleaseAll(DEFAULT_LOCKMETHOD, false);
+				}
 				
 				/*
 				 * We remove ourself from LW waiter list (if applicable).
@@ -745,7 +749,7 @@ FileRepSubProcess_Main()
 		
 		LWLockReleaseAll();
 
-		if (fileRepProcessType == FileRepProcessTypeResyncManager)
+		if (FileRepPrimary_IsResyncManagerOrWorker())
 		{
 			LockReleaseAll(DEFAULT_LOCKMETHOD, false);
 		}


### PR DESCRIPTION
Resync worker process queries to get the changes from change tracking
mode, which gets lock on relations. Worker process later when terminated
on SIGUSR2 from postmaster to shutdown, the
FileRepSubProcess_ShutdownHandler() missed releasing locks, plus also in
case any error happens in resync worker its exits, but missed releasing
some lock. hence later if the PGPROC pointer of this exited worker process
is allocated to other processes, that process would find itself holding
locks it doesn't know. This was detected when message's log level was
elevated from LOG to ERROR in locking code which detected local lock
table corruption.

Thank You Kenan and Xiong for the root-cause.