### PR TITLE
Remove leftovers from gpcheckdb

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -62,8 +62,6 @@ endif
 #$(warning BLD_CFLAGS=$(BLD_CFLAGS))
 #$(warning )
 
-# help gpcheckdb, our only C++ binary, find the right copy of libstdc++
-sol10_sparc_32_CXX_LIB_DIR=/usr/sfw/lib
 BLD_CXX_LIB_DIR=$($(BLD_ARCH)_CXX_LIB_DIR)
 
 # help Windows builds find the cross-compiler and a pre-built curl

--- a/src/bin/gpcheckdb/.gitignore
+++ b/src/bin/gpcheckdb/.gitignore
@@ -1,1 +1,0 @@
-gpcheckdb


### PR DESCRIPTION
This seems to be leftovers from when gpcheckdb was in `src/bin` and was written in C++. Nothing references this anymore since gpcheckdb is now in Python and the directory is empty so remove. My guess is it was removed earlier but since the gitignore is a hidden file it was missed.