### PR TITLE
Fixes to qp_misc_jiras test

### DIFF
--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -2403,6 +2403,7 @@ set statement_timeout = 1000; -- 1 sec
 execute prestmt; -- should get cancelled automatically
 ERROR:  canceling statement due to statement timeout
 drop table statement_timeout_test;
+reset statement_timeout;
 set gp_autostats_mode=none;
 drop table qp_misc_jiras.tbl_6934;
 ERROR:  table "tbl_6934" does not exist
@@ -2410,7 +2411,6 @@ create table qp_misc_jiras.tbl_6934(x inet);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into qp_misc_jiras.tbl_6934 select (i%200 || '.' || i%11 || '.' || i%11 || '.' || i%100)::inet from generate_series(1,4000000) i;
-ERROR:  canceling statement due to statement timeout
 analyze qp_misc_jiras.tbl_6934; 
 drop table qp_misc_jiras.tbl_6934;
 drop table if exists qp_misc_jiras.tbl7286_test;

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -1477,6 +1477,7 @@ prepare prestmt as select * from statement_timeout_test s1, statement_timeout_te
 set statement_timeout = 1000; -- 1 sec
 execute prestmt; -- should get cancelled automatically
 drop table statement_timeout_test;
+reset statement_timeout;
 set gp_autostats_mode=none;
 drop table qp_misc_jiras.tbl_6934;
 create table qp_misc_jiras.tbl_6934(x inet);


### PR DESCRIPTION
Regression tests failed on **suse10_x86_64** platform indicating that qp_misc_jiras test failed. Upon investigation it was found that **statement_timeout** value (1 sec) was overrunning to tbl6934 and tbl7286 tests.  This is attributed to the ICG porting process of the original misc_jiras test suite.
In order to fix the problem we added a **reset statement_timeout** to sql file and updated the expected output file accordingly.  Additionally, we removed an incorrect **ERROR** statement which again resulted from the **statement_timeout** value (1 sec). This fix was tested on 10.103.218.101 a SuSE Linux build machine and builds and tests succeeded.

Reviewer (original ICG porting committer): @armenatzoglou @kuien @edespino 