### PR TITLE
Add missing install target for gpmapreduce

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -43,6 +43,7 @@ install:
 	$(MAKE) -C contrib/gp_cancel_query $@
 	$(MAKE) -C contrib/indexscan $@ 
 	$(MAKE) -C gpMgmt $@
+	$(MAKE) -C gpAux/extensions $@
 
 	@echo "Greenplum Database installation complete."
 


### PR DESCRIPTION
It seems that the rebase of `--enable-mapreduce` was a brick shy of it's load. The install target for `gpAux/extensions` which in turn invoke gpmapreduce installation fell away in the rebase and didn't make it in the final commit. Re-adding it such that `make install` also handles gpmapreduce.

Thanks to Xin Zhang for reporting.