### PR TITLE
Make relation open error message user friendly.

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -882,7 +882,12 @@ relation_open(Oid relationId, LOCKMODE lockmode)
 	r = RelationIdGetRelation(relationId);
 
 	if (!RelationIsValid(r))
-		elog(ERROR, "could not open relation with OID %u", relationId);
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("relation not found (OID %u)", relationId),
+				 errdetail("This can be validly caused by a concurrent delete operation on this object.")));
+	}
 
 	pgstat_initstats(r);
 	
@@ -959,7 +964,12 @@ try_relation_open(Oid relationId, LOCKMODE lockmode, bool noWait)
 	r = RelationIdGetRelation(relationId);
 
 	if (!RelationIsValid(r))
-		elog(ERROR, "could not open relation with OID %u", relationId);
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("relation not found (OID %u)", relationId),
+				 errdetail("This can be validly caused by a concurrent delete operation on this object.")));
+	}
 
 	pgstat_initstats(r);
 
@@ -1052,7 +1062,12 @@ CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 	rel = CdbTryOpenRelation(relid, reqmode, noWait, lockUpgraded);
 
 	if (!RelationIsValid(rel))
-		elog(ERROR, "could not open relation with OID %u", relid);
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("relation not found (OID %u)", relid),
+				 errdetail("This can be validly caused by a concurrent delete operation on this object.")));
+	}
 
 	return rel;
 
@@ -1138,7 +1153,12 @@ relation_open_nowait(Oid relationId, LOCKMODE lockmode)
 	r = RelationIdGetRelation(relationId);
 
 	if (!RelationIsValid(r))
-		elog(ERROR, "could not open relation with OID %u", relationId);
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("relation not found (OID %u)", relationId),
+				 errdetail("This can be validly caused by a concurrent delete operation on this object.")));
+	}
 
 	return r;
 }


### PR DESCRIPTION
Currently, when relation open fails it emits error message which is very
dev centric plus stack trace gets printed. The message and behavior is
confusing as more hints towards some catastrophic problem. While its
more legitimate due to concurrency so best to communicate the same,
plus avoid printing stacktrace.

Simple example is "LOCK TABLE foo", fetches OID and before performs relation_open "DROP TABLE foo".