### PR TITLE
Fix gpfdist  makefile to override CPPFLAGS and incorrect output for ssl enabled

### DIFF
--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -26,11 +26,11 @@ else
   APR_LIB=$(shell $(with_apr_config) --link-ld --libs)
 endif
 
-ifneq ($(PORTNAME),win32)
-  CPPFLAGS += -DGPFXDIST
-else
+ifeq ($(PORTNAME),win32)
   override CPPFLAGS := -I$(top_builddir)/src/port $(CPPFLAGS)
   OBJS += $(top_builddir)/src/port/glob.o
+else
+  override CPPFLAGS := -DGPFXDIST $(CPPFLAGS)
 endif
 
 LDLIBS += $(LIBS) $(GPFDIST_LIBS) $(APR_LIB)

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3472,8 +3472,9 @@ int gpfdist_init(int argc, const char* const argv[])
 	if (opt.ssl)
 		printf("Serving HTTPS on port %d, directory %s\n", opt.p, opt.d);
 	else
-#else
 		printf("Serving HTTP on port %d, directory %s\n", opt.p, opt.d);
+#else
+	printf("Serving HTTP on port %d, directory %s\n", opt.p, opt.d);
 #endif
 
 	fflush(stdout);


### PR DESCRIPTION
This fixes the issue:
* Error: -m max row length must be between 32KB and 1MB
* "Serving HTTP on port ..." message was not being printed