### PR TITLE
Eliminate one round-trip when establising QD-QE connection.

### DIFF
--- a/src/backend/cdb/cdbconn.c
+++ b/src/backend/cdb/cdbconn.c
@@ -430,7 +430,7 @@ cdbconn_doConnect(SegmentDatabaseDescriptor *segdbDesc,
          * Wait for it to respond giving us the TCP port number
          * where it listens for connections from the gang below.
          */
-        segdbDesc->motionListener = PQgetQEdetail(segdbDesc->conn, false);
+        segdbDesc->motionListener = PQgetQEdetail(segdbDesc->conn);
         
         segdbDesc->backendPid = PQbackendPID(segdbDesc->conn);
 

--- a/src/backend/gp_libpq_fe/fe-connect.c
+++ b/src/backend/gp_libpq_fe/fe-connect.c
@@ -4368,41 +4368,12 @@ PQoptions(const PGconn *conn)
 }
 
 /* GPDB function to retrieve QE-backend details (motion listener) */
-int	PQgetQEdetail(PGconn *conn, bool alwaysFetch)
+int
+PQgetQEdetail(PGconn *conn)
 {
 	if (!conn || (PQstatus(conn) == CONNECTION_BAD))
 		return -1;
-	
-	/* return it immediately if we've already fetched it. */
-	if (!alwaysFetch && conn->motion_listener != 0)
-		return conn->motion_listener;
 
-	/* reset to 0 */
-	conn->motion_listener = 0;
-	
-	/* send a request to fetch the motion listener port. */
-	pqPacketSend(conn, 'W', NULL, 0 );
-
-	conn->asyncStatus = PGASYNC_BUSY;	
-	
-	/* wait for a response. */
-	if (PG_PROTOCOL_MAJOR(conn->pversion) >= 3)
-		pqParseInput3(conn);
-	else
-		return -1;
-	
-	while (conn->motion_listener == 0)
-	{
-		pqWait(TRUE, FALSE, conn);
-		if (pqReadData(conn) < 0)
-			return -1;
-		
-		if (PG_PROTOCOL_MAJOR(conn->pversion) >= 3)
-			pqParseInput3(conn);
-		else
-			return -1;
-	}
-	
 	return conn->motion_listener;
 }
 

--- a/src/backend/gp_libpq_fe/gp-libpq-fe.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-fe.h
@@ -316,7 +316,7 @@ extern char *PQhost(const PGconn *conn);
 extern char *PQport(const PGconn *conn);
 extern char *PQtty(const PGconn *conn);
 extern char *PQoptions(const PGconn *conn);
-extern int	PQgetQEdetail(PGconn *conn, bool alwaysFetch); /* GPDB -- retrieve QE-backend details. */
+extern int	PQgetQEdetail(PGconn *conn); /* GPDB -- retrieve QE-backend details. */
 extern ConnStatusType PQstatus(const PGconn *conn);
 extern PGTransactionStatusType PQtransactionStatus(const PGconn *conn);
 extern const char *PQparameterStatus(const PGconn *conn,

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4420,6 +4420,10 @@ PostgresMain(int argc, char *argv[],
 		/* Need not flush since ReadyForQuery will do it. */
 	}
 
+	/* Also send GPDB QE-backend startup info (motion listener, version). */
+	if (Gp_role == GP_ROLE_EXECUTE)
+		sendQEDetails();
+
 	/* Welcome banner for standalone case */
 	if (whereToSendOutput == DestDebug)
 		printf("\nPostgreSQL stand-alone backend %s\n", PG_VERSION);
@@ -5012,12 +5016,6 @@ PostgresMain(int argc, char *argv[],
 					
 					exec_parse_message(query_string, stmt_name,
 									   paramTypes, numParams);
-				}
-				break;
-			case 'W':    /* GPDB QE-backend startup info (motion listener, version). */
-				{
-					sendQEDetails();
-					pq_flush();
 				}
 				break;
 


### PR DESCRIPTION
Arrange for the "QEdetails" to be sent automatically from the QE at backend
startup, so that the QD doesn't need to request it and wait for the
response.