### PR TITLE
add test for a drop table scenario when the schema name is the same a…

### DIFF
--- a/src/test/regress/expected/drop_if_exists.out
+++ b/src/test/regress/expected/drop_if_exists.out
@@ -89,3 +89,22 @@ DROP GROUP IF EXISTS tg1, tg2;
 NOTICE:  role "tg2" does not exist, skipping
 DROP GROUP tg1;
 ERROR:  role "tg1" does not exist
+--create a schema with the same name as the logged in user name and try to drop and recreate a table
+drop database if exists drop_table_test;
+NOTICE:  database "drop_table_test" does not exist, skipping
+create database drop_table_test;
+\c drop_table_test
+--get the username and set it to a variable
+\set cur_user `echo $USER`
+CREATE SCHEMA :cur_user;
+CREATE TABLE tbl_to_drop(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+DROP TABLE tbl_to_drop;
+CREATE TABLE tbl_to_drop(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+DROP SCHEMA :cur_user CASCADE;
+NOTICE:  drop cascades to table tbl_to_drop
+\c regression
+drop database drop_table_test;

--- a/src/test/regress/expected/drop_if_exists.out
+++ b/src/test/regress/expected/drop_if_exists.out
@@ -97,6 +97,8 @@ create database drop_table_test;
 --get the username and set it to a variable
 \set cur_user `echo $USER`
 CREATE SCHEMA :cur_user;
+--the following table will be created in the ":cur_user" schema because
+-- the search_path is '"$user",public'
 CREATE TABLE tbl_to_drop(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/sql/drop_if_exists.sql
+++ b/src/test/regress/sql/drop_if_exists.sql
@@ -116,3 +116,25 @@ DROP GROUP IF EXISTS tg1, tg2;
 
 DROP GROUP tg1;
 
+--create a schema with the same name as the logged in user name and try to drop and recreate a table
+drop database if exists drop_table_test;
+create database drop_table_test;
+
+\c drop_table_test
+--get the username and set it to a variable
+\set cur_user `echo $USER`
+
+CREATE SCHEMA :cur_user;
+
+
+CREATE TABLE tbl_to_drop(i int);
+
+
+DROP TABLE tbl_to_drop;
+
+
+CREATE TABLE tbl_to_drop(i int);
+
+DROP SCHEMA :cur_user CASCADE;
+\c regression
+drop database drop_table_test;

--- a/src/test/regress/sql/drop_if_exists.sql
+++ b/src/test/regress/sql/drop_if_exists.sql
@@ -127,6 +127,8 @@ create database drop_table_test;
 CREATE SCHEMA :cur_user;
 
 
+--the following table will be created in the ":cur_user" schema because
+-- the search_path is '"$user",public'
 CREATE TABLE tbl_to_drop(i int);
 
 


### PR DESCRIPTION
…s the user name

There was a bug about when we create a schema with the same name as the user , drop table didn't work properly. Although we fixed the bug a while ago , we never had a test for this scenario . Adding a check will make sure that we don't miss this scenario. 

Authors:-
Nikhil Kak & Pengcheng Tang