### PR TITLE
Replace extended ASCII in the docs with printable characters

### DIFF
--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -28,7 +28,7 @@ CREATE [[GLOBAL | LOCAL] {TEMPORARY | TEMP}] TABLE table_name (
    | LIKE other_table [{INCLUDING | EXCLUDING} 
                       {DEFAULTS | CONSTRAINTS}] ...}
    [, ... ] ]
-   [column_reference_storage_directive [, …] ]
+   [column_reference_storage_directive [, ... ]
    )
    [ INHERITS ( parent_table [, ... ] ) ]
    [ WITH ( storage_parameter=value [, ... ] )

--- a/doc/src/sgml/ref/grant.sgml
+++ b/doc/src/sgml/ref/grant.sgml
@@ -53,8 +53,8 @@ GRANT { CREATE | ALL [ PRIVILEGES ] }
 GRANT <replaceable class="PARAMETER">role</replaceable> [, ...] TO <replaceable class="PARAMETER">username</replaceable> [, ...] [ WITH ADMIN OPTION ]
 
 GRANT { SELECT | INSERT | ALL [PRIVILEGES] } 
-    ON PROTOCOL <replaceable>protocolname</replaceable> 
-    TO <replaceable class="PARAMETER">username</replaceable>
+    ON PROTOCOL <replaceable>protocolname</replaceable>
+    TO <replaceable class="PARAMETER">username</replaceable>
 
 </synopsis>
  </refsynopsisdiv>


### PR DESCRIPTION
The use of non-breaking space (0xA0) and horizontal ellipsis (0x85) in the docs cause problems for the generated docs in psql, replace with counterparts in the printable characters set. This fixes the output to in psql `\h CREATE TABLE` in non-special configured terminals from this:
```
[, ... ] ]
[column_reference_storage_directive [, <85>] ]
)
```
.. and `\h GRANT` from this :
```
GRANT { SELECT | INSERT | ALL [PRIVILEGES] }
<A0><A0><A0><A0>ON PROTOCOL protocolname
<A0><A0><A0><A0>TO username
```
(output abbreviated to just the problematic area)

This also fixes the `illegal character encoding in string literal` warning from clang.