### PR TITLE
Use finegrained .out ignoring in the output directory .gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,5 @@ build.sh
 
 # Added
 *.swp
-*.out
 
 VERSION

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -23,3 +23,9 @@ table_functions.out
 tidycat2.out
 tpch500GB.out
 partindex_test.out
+external_table.out
+table_functions_optimizer.out
+largeobject.out
+qp_gist_indexes2.out
+qp_gist_indexes2_optimizer.out
+qp_regexp.out

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -17,7 +17,6 @@ aocs.sql
 appendonly.sql
 bkup_bkupdb.sql
 mapred.sql
-ereport.sql
 tidycat.sql
 filespace.sql
 upgrade.sql
@@ -29,3 +28,6 @@ tidycat2.sql
 tpch500GB.sql
 partindex_test.sql
 external_table.sql
+largeobject.sql
+qp_gist_indexes2.sql
+qp_regexp.sql


### PR DESCRIPTION
We already had a mostly up to date list in the directory specific `.gitignore` files but the toplevel `.gitignore` contained a `*.out` which took precedence (lower level files override higher level files so removing `*.out` will allow for the `src/test/regress/*` files to override the now removed `.out` file blocking). The reason for not ignoring `*.out` is that we have quite a few tracked `.out` files in the repository which we don't want to ignore changes to.

Also update the files to match the current set of tests since there were a few missing.

Sorting the files in alphabetical order would be nice for readability but I refrained from doing so in this PR since it would make the end-result patch less readable and it can IMHO be committed without a full PR once this is in since it's just cosmetic.