### PR TITLE
Support the aggregation transition datatype to be "internal"

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -542,7 +542,19 @@ count_agg_clauses_walker(Node *node, AggClauseCounts *counts)
 
 			counts->transitionSpace += avgwidth + 2 * sizeof(void *);
 		}
-		
+		else if (aggtranstype == INTERNALOID)
+		{
+			/*
+			 * INTERNAL transition type is a special case: although INTERNAL
+			 * is pass-by-value, it's almost certainly being used as a pointer
+			 * to some large data structure.  We assume usage of
+			 * ALLOCSET_DEFAULT_INITSIZE, which is a good guess if the data is
+			 * being kept in a private memory context, as is done by
+			 * array_agg() for instance.
+			 */
+			counts->transitionSpace += ALLOCSET_DEFAULT_INITSIZE;
+		}
+
 		if ( inputTypes != NULL )
 			pfree(inputTypes);
 

--- a/src/test/regress/expected/arrays.out
+++ b/src/test/regress/expected/arrays.out
@@ -1176,3 +1176,64 @@ select unnest(array[1,2,3,null,4,null,null,5,6]::text[]);
  6
 (9 rows)
 
+-- Internal function for the aggregate
+-- Is called for each item in an aggregation
+CREATE FUNCTION int_agg_state (internal, int4)
+RETURNS internal
+AS 'array_agg_transfn'
+LANGUAGE INTERNAL;
+-- Internal function for the aggregate
+-- Is called at the end of the aggregation, and returns an array.
+CREATE FUNCTION int_agg_final_array (internal)
+RETURNS int4[]
+AS 'array_agg_finalfn'
+LANGUAGE INTERNAL;
+-- The aggregate function itself
+-- uses the above functions to create an array of integers from an aggregation.
+CREATE ORDERED AGGREGATE int_array_aggregate (
+	BASETYPE = int4,
+	SFUNC = int_agg_state,
+	STYPE = internal,
+	FINALFUNC = int_agg_final_array
+);
+-- Tests
+select int_array_aggregate(i) from generate_series(1,10,2) i;
+ int_array_aggregate
+---------------------
+ {1,3,5,7,9}
+(1 row)
+
+CREATE TEMP TABLE int_test_tbl1 AS (
+	SELECT id FROM generate_series(11, 1000, 11) as id
+) DISTRIBUTED BY ( id );
+CREATE TEMP TABLE int_test_tbl2 AS (
+	SELECT id FROM generate_series(7, 1000, 7) as id
+) DISTRIBUTED BY ( id );
+SELECT l.id as "number % 11 in left",
+	int_array_aggregate(r.id ORDER BY r.id) "array of those % 7 too in right"
+FROM int_test_tbl1 l, int_test_tbl2 r
+WHERE l.id % r.id = 0
+GROUP BY l.id
+ORDER BY l.id;
+ number % 11 in left |      array of those % 7 too in right
+---------------------+-------------------------------------------
+                  77 | {7,77}
+                 154 | {7,14,77,154}
+                 231 | {7,21,77,231}
+                 308 | {7,14,28,77,154,308}
+                 385 | {7,35,77,385}
+                 462 | {7,14,21,42,77,154,231,462}
+                 539 | {7,49,77,539}
+                 616 | {7,14,28,56,77,154,308,616}
+                 693 | {7,21,63,77,231,693}
+                 770 | {7,14,35,70,77,154,385,770}
+                 847 | {7,77,847}
+                 924 | {7,14,21,28,42,77,84,154,231,308,462,924}
+(12 rows)
+
+-- Drop above three functions
+DROP AGGREGATE int_array_aggregate (int4);
+DROP FUNCTION int_agg_final_array (internal);
+NOTICE:  removing built-in function "int_agg_final_array"
+DROP FUNCTION int_agg_state (internal, int4);
+NOTICE:  removing built-in function "int_agg_state"

--- a/src/test/regress/expected/arrays.out
+++ b/src/test/regress/expected/arrays.out
@@ -1176,6 +1176,40 @@ select unnest(array[1,2,3,null,4,null,null,5,6]::text[]);
  6
 (9 rows)
 
+-- Suppress NOTICE messages when users/groups don't exist
+SET client_min_messages TO 'error';
+-- create a non-superuser
+DROP ROLE IF EXISTS user_internal_stype;
+CREATE USER user_internal_stype;
+SET SESSION AUTHORIZATION user_internal_stype;
+RESET client_min_messages;
+-- Internal function for the aggregate
+-- Is called for each item in an aggregation
+CREATE FUNCTION int_agg_state (internal, int4)
+RETURNS internal
+AS 'array_agg_transfn'
+LANGUAGE INTERNAL;
+ERROR:  permission denied for language internal
+-- Internal function for the aggregate
+-- Is called at the end of the aggregation, and returns an array.
+CREATE FUNCTION int_agg_final_array (internal)
+RETURNS int4[]
+AS 'array_agg_finalfn'
+LANGUAGE INTERNAL;
+ERROR:  permission denied for language internal
+-- The aggregate function itself
+-- uses the above functions to create an array of integers from an aggregation.
+CREATE ORDERED AGGREGATE int_array_aggregate (
+	BASETYPE = int4,
+	SFUNC = int_agg_state,
+	STYPE = internal,
+	FINALFUNC = int_agg_final_array
+);
+ERROR:  aggregate transition data type cannot be internal
+-- change to superuser
+-- start_ignore
+\c -
+-- end_ignore
 -- Internal function for the aggregate
 -- Is called for each item in an aggregation
 CREATE FUNCTION int_agg_state (internal, int4)
@@ -1231,9 +1265,16 @@ ORDER BY l.id;
                  924 | {7,14,21,28,42,77,84,154,231,308,462,924}
 (12 rows)
 
+-- clean up
+-- start_ignore
 -- Drop above three functions
 DROP AGGREGATE int_array_aggregate (int4);
 DROP FUNCTION int_agg_final_array (internal);
 NOTICE:  removing built-in function "int_agg_final_array"
 DROP FUNCTION int_agg_state (internal, int4);
 NOTICE:  removing built-in function "int_agg_state"
+-- Drop user and group
+--DROP ROLE IF EXISTS user_group;
+RESET SESSION AUTHORIZATION;
+DROP USER IF EXISTS user_internal_stype;
+-- end_ignore

--- a/src/test/regress/sql/arrays.sql
+++ b/src/test/regress/sql/arrays.sql
@@ -386,3 +386,50 @@ select unnest(array[1,2,3,4.5]::float8[]);
 select unnest(array[1,2,3,4.5]::numeric[]);
 select unnest(array[1,2,3,null,4,null,null,5,6]);
 select unnest(array[1,2,3,null,4,null,null,5,6]::text[]);
+
+-- Internal function for the aggregate
+-- Is called for each item in an aggregation
+CREATE FUNCTION int_agg_state (internal, int4)
+RETURNS internal
+AS 'array_agg_transfn'
+LANGUAGE INTERNAL;
+
+-- Internal function for the aggregate
+-- Is called at the end of the aggregation, and returns an array.
+CREATE FUNCTION int_agg_final_array (internal)
+RETURNS int4[]
+AS 'array_agg_finalfn'
+LANGUAGE INTERNAL;
+
+-- The aggregate function itself
+-- uses the above functions to create an array of integers from an aggregation.
+CREATE ORDERED AGGREGATE int_array_aggregate (
+	BASETYPE = int4,
+	SFUNC = int_agg_state,
+	STYPE = internal,
+	FINALFUNC = int_agg_final_array
+);
+
+-- Tests
+select int_array_aggregate(i) from generate_series(1,10,2) i;
+
+CREATE TEMP TABLE int_test_tbl1 AS (
+	SELECT id FROM generate_series(11, 1000, 11) as id
+) DISTRIBUTED BY ( id );
+
+CREATE TEMP TABLE int_test_tbl2 AS (
+	SELECT id FROM generate_series(7, 1000, 7) as id
+) DISTRIBUTED BY ( id );
+
+
+SELECT l.id as "number % 11 in left",
+	int_array_aggregate(r.id ORDER BY r.id) "array of those % 7 too in right"
+FROM int_test_tbl1 l, int_test_tbl2 r
+WHERE l.id % r.id = 0
+GROUP BY l.id
+ORDER BY l.id;
+
+-- Drop above three functions
+DROP AGGREGATE int_array_aggregate (int4);
+DROP FUNCTION int_agg_final_array (internal);
+DROP FUNCTION int_agg_state (internal, int4);

--- a/src/test/regress/sql/arrays.sql
+++ b/src/test/regress/sql/arrays.sql
@@ -387,6 +387,44 @@ select unnest(array[1,2,3,4.5]::numeric[]);
 select unnest(array[1,2,3,null,4,null,null,5,6]);
 select unnest(array[1,2,3,null,4,null,null,5,6]::text[]);
 
+-- Suppress NOTICE messages when users/groups don't exist
+SET client_min_messages TO 'error';
+
+-- create a non-superuser
+DROP ROLE IF EXISTS user_internal_stype;
+CREATE USER user_internal_stype;
+SET SESSION AUTHORIZATION user_internal_stype;
+
+RESET client_min_messages;
+
+-- Internal function for the aggregate
+-- Is called for each item in an aggregation
+CREATE FUNCTION int_agg_state (internal, int4)
+RETURNS internal
+AS 'array_agg_transfn'
+LANGUAGE INTERNAL;
+
+-- Internal function for the aggregate
+-- Is called at the end of the aggregation, and returns an array.
+CREATE FUNCTION int_agg_final_array (internal)
+RETURNS int4[]
+AS 'array_agg_finalfn'
+LANGUAGE INTERNAL;
+
+-- The aggregate function itself
+-- uses the above functions to create an array of integers from an aggregation.
+CREATE ORDERED AGGREGATE int_array_aggregate (
+	BASETYPE = int4,
+	SFUNC = int_agg_state,
+	STYPE = internal,
+	FINALFUNC = int_agg_final_array
+);
+
+-- change to superuser
+-- start_ignore
+\c -
+-- end_ignore
+
 -- Internal function for the aggregate
 -- Is called for each item in an aggregation
 CREATE FUNCTION int_agg_state (internal, int4)
@@ -429,7 +467,14 @@ WHERE l.id % r.id = 0
 GROUP BY l.id
 ORDER BY l.id;
 
+-- clean up
+-- start_ignore
 -- Drop above three functions
 DROP AGGREGATE int_array_aggregate (int4);
 DROP FUNCTION int_agg_final_array (internal);
 DROP FUNCTION int_agg_state (internal, int4);
+-- Drop user and group
+--DROP ROLE IF EXISTS user_group;
+RESET SESSION AUTHORIZATION;
+DROP USER IF EXISTS user_internal_stype;
+-- end_ignore


### PR DESCRIPTION
Backport below commits from upstream:

    commit 22d9ddbb35f5d316312a2220041ff17744a72330
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Sat Aug 14 15:47:13 2010 +0000

        Fix planner to make a reasonable assumption about the amount of memory space
        used by array_agg(), string_agg(), and similar aggregate functions that use
        "internal" as their transition datatype.  The previous coding thought this
        took *no* extra space, since "internal" is pass-by-value; but actually these
        aggregates typically consume a great deal of space.  Per bug #5608 from
        Itagaki Takahiro, and fix suggestion from Hitoshi Harada.

        Back-patch to 8.4, where array_agg was introduced.

    commit 9e0247aba5e2cac1542823a194d4dc2ea1c3abb6
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Fri Nov 14 19:47:50 2008 +0000

        In CREATE AGGREGATE, allow the transition datatype to be "internal", but only
        if the user is superuser.  This makes available to extension modules the same
        sort of trick being practiced by array_agg().  The reason for the superuser
        restriction is that you could crash the system by connecting up an
        incompatible pair of internal-using functions as an aggregate.  It shouldn't
        interfere with any legitimate use, since you'd have to be superuser to create
        the internal-using transition and final functions anyway.

Besides, we cannot find regression tests in above commits, so we
add a set of tests for this feature, a part of them come from
legacy extension "intagg" regression tests.

Conflicts:
	src/test/regress/expected/arrays.out
	src/test/regress/sql/arrays.sql