### PR TITLE
Fixing memory leak during partition initialization in Window operator

### DIFF
--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -3017,7 +3017,7 @@ makeWindowState(Window * window, EState *estate)
 	if (numlevels > 0)
 	{
 		wstate->level_state = (WindowStatePerLevel)
-			palloc0(numlevels * sizeof(WindowStatePerLevelData));
+			palloc0(wstate->numlevels * sizeof(WindowStatePerLevelData));
 
 		for (int level = 0; level < wstate->numlevels; level++)
 		{

--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -3012,12 +3012,22 @@ makeWindowState(Window * window, EState *estate)
 	wstate->level_state = NULL;
 
 	numlevels = list_length(window->windowKeys);
+	wstate->numlevels = numlevels;
+
 	if (numlevels > 0)
+	{
 		wstate->level_state = (WindowStatePerLevel)
 			palloc0(numlevels * sizeof(WindowStatePerLevelData));
+
+		for (int level = 0; level < wstate->numlevels; level++)
+		{
+			WindowStatePerLevel level_state = &wstate->level_state[level];
+			level_state->serial_array = palloc0(FRAMEBUFFER_ENTRY_SIZE);
+			level_state->max_size = FRAMEBUFFER_ENTRY_SIZE;
+		}
+	}
 	else
 		wstate->level_state = NULL;
-	wstate->numlevels = numlevels;
 
 	wstate->transcontext = AllocSetContextCreate(CurrentMemoryContext,
 												 "TransContext",
@@ -3061,9 +3071,6 @@ initializePartition(WindowState * wstate)
 		level_state->dense_rank = 1;
 		level_state->prior_rank = 1;
 		level_state->prior_dense_rank = 1;
-
-		level_state->serial_array = palloc0(FRAMEBUFFER_ENTRY_SIZE);
-		level_state->max_size = FRAMEBUFFER_ENTRY_SIZE;
 	}
 
 	/* Per-partition input buffer management reinitialzation. */


### PR DESCRIPTION
In Window operator we currently allocate all the level_state->serial_array once per partition. Unfortunately, we don't free these memory until the end of the window operator (in ExecEndWindow). Therefore, we leak all the level_state->serial_array, once per-partition. This drives the system out of memory if we have large number of partitions. This PR fixes these leaks by relocating the allocations in makeWindowState, only once per window operator.

The following repro will consume gigabytes of memory and should run out of memory, given appropriate VMEM configuration:

```
drop table if exists wtest;
create table wtest
(
	id integer,
	dt date,
	name character varying(100),
	created_dt date
);

insert into wtest select a, current_date + a, 'xyz' || a, current_date + (a % 10) from (select a from generate_series(1, 10000000) as a) as temp;

select row_number() over (w) as row_num,
id,
dt,
name
from wtest
window w as (partition by dt,
name,
id
order by created_dt desc
);
```
After the fix the same repro should consume very little memory.