### PR TITLE
drop leaked/orphan schemas before running gpcheckcat catalog checks

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -83,7 +83,7 @@ install: generate_greenplum_path_file
 	mkdir -p $(prefix)/sbin
 
 	#symlink gpcheckcat from bin to bin/lib to mainitain backward compatibility
-	if [ -f ../gpcheckcat  ]; then \
+	if [ -f bin/gpcheckcat  ]; then \
 		ln -sf ../gpcheckcat bin/lib/gpcheckcat; \
 	fi
 

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -35,7 +35,7 @@ SET_VERSION_SCRIPTS = \
 	bin/gpstate \
 	bin/gpstop \
 	bin/gpsys1 \
-	bin/lib/gpcheckcat \
+	bin/gpcheckcat \
 	sbin/gpaddconfig.py \
 	sbin/gpchangeuserpassword \
 	sbin/gpcheck_hostdump \
@@ -86,6 +86,11 @@ install: generate_greenplum_path_file
 	cp -rp bin/gppylib $(prefix)/lib/python
 	cp -rp bin/ext/* $(prefix)/lib/python
 	cp -rp bin $(prefix)
+	
+	#symlink gpcheckcat from bin to bin/lib to mainitain backward compatibility
+	if [ -f $(prefix)/bin/gpcheckcat  ]; then \
+		ln -sf ../gpcheckcat bin/lib/gpcheckcat; \
+	fi
 
 #ifeq "$(findstring $(BLD_ARCH),$(GPPKG_PLATFORMS))" ""
 #	@echo "Removing gppkg from distribution"

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -82,15 +82,16 @@ install: generate_greenplum_path_file
 	mkdir -p $(prefix)/lib/python	
 	mkdir -p $(prefix)/sbin
 
+	#symlink gpcheckcat from bin to bin/lib to mainitain backward compatibility
+	if [ -f ../gpcheckcat  ]; then \
+		ln -sf ../gpcheckcat bin/lib/gpcheckcat; \
+	fi
+
 	#Setup /lib/python contents
 	cp -rp bin/gppylib $(prefix)/lib/python
 	cp -rp bin/ext/* $(prefix)/lib/python
 	cp -rp bin $(prefix)
 	
-	#symlink gpcheckcat from bin to bin/lib to mainitain backward compatibility
-	if [ -f $(prefix)/bin/gpcheckcat  ]; then \
-		ln -sf ../gpcheckcat bin/lib/gpcheckcat; \
-	fi
 
 #ifeq "$(findstring $(BLD_ARCH),$(GPPKG_PLATFORMS))" ""
 #	@echo "Removing gppkg from distribution"

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -147,9 +147,6 @@ class Global():
         # ownership fixups
         self.Owners = []
     
-        # drop leaked temporary schemas
-        self.Schemas = []
-    
         # fix distribution policies
         self.Policies = []
         
@@ -1857,13 +1854,17 @@ def checkPGClass():
         if len(err) > 100:
             logger.error("...")
 
-
-#############
-def checkPGNamespace():
+def getLeakedSchemas():
     logger.info('-----------------------------------')
     logger.info('Checking for leaked temporary schemas')
     db = connect2(GV.cfg[1], utilityMode=False)
-    
+
+    leaked_schemas = []
+    # This query does a union of all the leaked temp schemas on the master as well as all the segments.
+    # The first part of the query uses gp_dist_random which gets the leaked schemas from only the segments
+    # The second part of the query gets the leaked temp schemas from just the master
+
+
     # The simpler form of this query that pushed the union into the
     # inner select does not run correctly on 3.2.x
     qry = '''
@@ -1894,12 +1895,16 @@ def checkPGNamespace():
             logger.error('found %d unbound temporary schemas' % curs.ntuples())
             for row in curs.getresult():
                 logger.error("  ... %s" % row[0])
-                GV.Schemas.append(row[0])
+                leaked_schemas.append(row[0])
     except Exception, e:
         setError(ERROR_NOREPAIR)
         myprint('[ERROR] executing test: checkPGNamespace')
         myprint('  Execution error: ' + str(e))
 
+    return leaked_schemas
+
+#############
+def checkPGNamespace():
     # Check for objects in various catalogs that are in a schema that has
     # been dropped.
     logger.info('Checking missing schema definitions ...')
@@ -3444,11 +3449,6 @@ name_repair = {
          "description": "Check if needs repair file to fix messed up ownership",
          "fn": lambda: checkOwnersRepair()
     },
-    "schemas":
-    {
-         "description": "Check if needs repair file to fix schema related issues",
-         "fn": lambda: checkSchemaRepair()
-    },
     "policies":
     {
          "description": "Check if needs repair file to fix distribution policy",
@@ -3653,7 +3653,6 @@ def runAllTests():
              len(GV.Reindex) > 0 or 
              len(GV.Constraints) > 0 or
              len(GV.Owners) > 0 or 
-             len(GV.Schemas) > 0 or
              len(GV.Policies) > 0)
     if GV.opt['-g'] != None and fixes:
         try:
@@ -3785,25 +3784,28 @@ def checkOwnersRepair():
     else:
         return None, None
 
-def checkSchemaRepair():
-    # Remove leaked temporary schemas
-    if len(GV.Schemas) > 0:
-        # dbname.type.timestamp.sql
-        filename = '%s.%s.%s.sql' % (GV.dbname, "fixnamespace", TIMESTAMP)
-        fullpath = '%s/%s' % (GV.opt['-g'], filename)
-        try:
-            file = open(fullpath, 'w')
-        except Exception, e:
-            logger.fatal('Unable to create file "%s": %s' % (fullpath, str(e)))
-            sys.exit(1)
+def dropLeakedSchemas(dbname):
+    leaked_schemas = getLeakedSchemas()
 
-        description = '\necho "Dropping temporary schemas"\n'
-        for s in GV.Schemas:
-            file.write('DROP SCHEMA IF EXISTS "%s" CASCADE;\n' % s)
-        file.close()
-        return description, filename
-    else:
-        return None, None
+    if len(leaked_schemas) <= 0:
+        return
+
+    myprint("Dropping leaked schemas '%s' in the database '%s' " % (leaked_schemas, dbname))
+    db = connect(database=dbname)
+    try:
+        for schema in leaked_schemas:
+            # the query will return unquoted schema names
+            # but we only search for schemas with name like pg_temp_[0-9](see the method getLeakedSchemas),
+            # so we don't really need to quote the sql statement
+            logger.debug('DROP SCHEMA IF EXISTS "%s" CASCADE;\n' % schema)
+            qry = 'DROP SCHEMA IF EXISTS "%s" CASCADE;\n' % schema
+            curs = db.query(qry)
+    except Exception, e:
+        setError(ERROR_NOREPAIR)
+        myprint('  Execution error: ' + str(e))
+    finally:
+        if db is not None:
+            db.close()
 
 def checkPoliciesRepair():
     # changes to distribution policies
@@ -4772,12 +4774,12 @@ if __name__ == '__main__':
         GPObjects = {}
         GPObjectGraph = {} 
         GV.dbname  = dbname
-
         myprint('')
         myprint("Connected as user \'%s\' to database '%s', port '%d', gpdb version '%s'" \
                    % (GV.opt['-U'], GV.dbname, GV.report_cfg[-1]['port'], GV.version))
         myprint('-------------------------------------------------------------------')
            
+        dropLeakedSchemas(dbname)
         if GV.opt['-R']:
             name = GV.opt['-R']
             try:

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
@@ -19,4 +19,4 @@ Feature: gpcheckcat tests
         Then psql should return a return code of 0
         And psql should print (0 rows) to stdout
         And verify that the schema "good_schema" exists in "leak"
-
+        And the user runs "dropdb leak"

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
@@ -1,0 +1,22 @@
+@gpcheckcat
+Feature: gpcheckcat tests
+
+  Scenario: gpcheckcat should drop leaked schemas
+        Given database "leak" is dropped and recreated
+        And the user runs the command "psql leak -f 'gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_temp_schema_leak.sql'" in the background without sleep
+        And waiting "1" seconds
+        Then read pid from file "gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/pid_leak" and kill the process
+        And the temporary file "gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/pid_leak" is removed
+        And waiting "2" seconds
+        When the user runs "gpstop -ar"
+        Then gpstart should return a return code of 0
+        When the user runs "psql leak -f gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/leaked_schema.sql"
+        Then psql should return a return code of 0
+        And psql should print pg_temp_ to stdout
+        And psql should print (1 row) to stdout
+        When the user runs "gpcheckcat leak"
+        And the user runs "psql leak -f gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/leaked_schema.sql"
+        Then psql should return a return code of 0
+        And psql should print (0 rows) to stdout
+        And verify that the schema "good_schema" exists in "leak"
+

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_temp_schema_leak.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_temp_schema_leak.sql
@@ -1,0 +1,8 @@
+\t
+create temp table temp_table(i int);
+create schema good_schema;
+create table good_schema.good_table(i int);
+\o gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/pid_leak
+select pg_backend_pid();
+-- sleep for 5 seconds so as to be able to kill the process while the session is still running
+select pg_sleep(5)

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/leaked_schema.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/leaked_schema.sql
@@ -1,0 +1,15 @@
+SELECT distinct nspname as schema
+    FROM (
+      SELECT nspname, replace(nspname, 'pg_temp_','')::int as sess_id
+      FROM   gp_dist_random('pg_namespace')
+      WHERE  nspname ~ '^pg_temp_[0-9]+'
+    ) n LEFT OUTER JOIN pg_stat_activity x using (sess_id)
+    WHERE x.sess_id is null
+    UNION
+    SELECT nspname as schema
+    FROM (
+      SELECT nspname, replace(nspname, 'pg_temp_','')::int as sess_id
+      FROM   pg_namespace
+      WHERE  nspname ~ '^pg_temp_[0-9]+'
+    ) n LEFT OUTER JOIN pg_stat_activity x using (sess_id)
+    WHERE x.sess_id is null;

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -1,0 +1,52 @@
+from pygresql import pg
+import os
+import imp
+import glob
+gpcheckcat_path = os.path.abspath('gpcheckcat')
+gpcheckcat = imp.load_source('gpcheckcat', gpcheckcat_path)
+import mock
+import gpcheckcat
+import unittest2 as unittest
+from mock import call
+from mock import patch
+
+class MockGlobal(object):
+    
+    def __init__(self):
+        pass
+
+
+def start_patches(patchers):
+    for p in patchers:
+        p.start()
+
+def stop_patches(patchers):
+    for p in patchers:
+        p.stop()
+
+
+class GpCheckCatTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.patches = []
+        self.mock_connect = mock.Mock()
+        self.patches.append(mock.patch("gpcheckcat.connect", new = mock.Mock(return_value=self.mock_connect)))
+        self.patches.append(mock.patch("gpcheckcat.GV", MockGlobal()))
+        start_patches(self.patches)
+
+    def tearDown(self):
+        stop_patches(self.patches)
+
+    @patch('gpcheckcat.checkPGNamespace')
+    @patch('gpcheckcat.getLeakedSchemas', new = mock.Mock(return_value=["fake_leak_1" ,"fake_leak_2"]))
+    def test_dropLeakedSchemas(self, mock1):
+        '''testing method dropLeakedSchemas which is supposed to drop any leaked/orphan schemas'''
+
+        gpcheckcat.dropLeakedSchemas(dbname="fake_db") 
+        drop_query_expected_list = [call('DROP SCHEMA IF EXISTS \"fake_leak_1\" CASCADE;\n'),
+                                    call('DROP SCHEMA IF EXISTS \"fake_leak_2\" CASCADE;\n')]
+        self.assertEquals(self.mock_connect.query.call_args_list , drop_query_expected_list)
+
+
+if __name__ == '__main__':
+    (unittest.main(verbosity=2, buffer=True))


### PR DESCRIPTION
  1. drop any leaked/orphaned schemas before running any of the gpcheckcat tests
  2. add unit and behave tests
  3. move gpcheckcat from gpMgmt/bin/lib to gpMgmt/bin
  4. misc refactoring

orphan/leaked schemas are temp schemas that are not associated with any session id.
There used to be a check for leaked temp schemas in gpcheckcat
which ended up creating a repair script.