### PR TITLE
Fix gpfdist build failing when not configured with yaml

### DIFF
--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -18,6 +18,9 @@ GPFDIST_LIBS =-levent
 ifeq ($(have_yaml),yes)
   GPFDIST_LIBS += -lyaml
   OBJS += transform.o
+  ifneq ($(PORTNAME),win32)
+    override CPPFLAGS := -DGPFXDIST $(CPPFLAGS)
+  endif
 endif
 
 ifeq ($(with_apr_config),yes)
@@ -29,8 +32,6 @@ endif
 ifeq ($(PORTNAME),win32)
   override CPPFLAGS := -I$(top_builddir)/src/port $(CPPFLAGS)
   OBJS += $(top_builddir)/src/port/glob.o
-else
-  override CPPFLAGS := -DGPFXDIST $(CPPFLAGS)
 endif
 
 LDLIBS += $(LIBS) $(GPFDIST_LIBS) $(APR_LIB)


### PR DESCRIPTION
GPDB build fails because gpfdist build fails when configure without any options, with the following error.
```
gcc -L../../../src/port -L../../../src/port -Wl,--as-needed -Wl,-rpath,'/usr/local/gpdb/lib',--enable-new-dtags gpfdist.o gpfdist_helper.o fstream.o gfile.o -lpgport -lbz2 -lrt -
lz -lreadline -lcrypt -ldl -lm  -L/usr/lib/x86_64-linux-gnu -lcurl -levent  -L/usr/lib/x86_64-linux-gnu -lapr-1  -o gpfdist
gpfdist.o: In function `request_set_transform':
gpfdist.c:(.text+0x2728): undefined reference to `transform_lookup'
gpfdist.c:(.text+0x2752): undefined reference to `transform_command'
gpfdist.c:(.text+0x2761): undefined reference to `transform_content_paths'
gpfdist.c:(.text+0x276f): undefined reference to `transform_safe'
gpfdist.c:(.text+0x277f): undefined reference to `transform_saferegex'
gpfdist.c:(.text+0x27c4): undefined reference to `transform_stderr_server'
gpfdist.o: In function `parse_command_line':
gpfdist.c:(.text+0x3612): undefined reference to `transform_config'
```
Installing libyaml-dev fixes the error.  On speaking with @Chibin, this part of the makefile should be moved in have_yaml block.

With that both ```./configure && make``` and ```./configure --enable-yaml && make``` succeed.