### PR TITLE
Simplify the parsed-representation of ALTER TABLE ADD PARTITION.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -5877,51 +5877,6 @@ transformAlterTable_all_PartitionStmt(
 	{
 		case AT_PartAdd:				/* Add */
 		case AT_PartSetTemplate:		/* Set Subpartn Template */
-
-			if (pci->arg2) /* could be null for settemplate... */
-			{
-				AlterPartitionCmd 	*pc2 = (AlterPartitionCmd *) pci->arg2;
-				CreateStmt 			*ct;
-				InhRelation			*inh = makeNode(InhRelation);
-				List				*cl  = NIL;
-
-				Assert(IsA(pc2->arg2, List));
-				ct = (CreateStmt *)linitial((List *)pc2->arg2);
-
-				inh->relation = copyObject(rv);
-				inh->options = list_make3_int(
-						CREATE_TABLE_LIKE_INCLUDING_DEFAULTS,
-						CREATE_TABLE_LIKE_INCLUDING_CONSTRAINTS,
-						CREATE_TABLE_LIKE_INCLUDING_INDEXES);
-				/*
-				 * fill in remaining fields from parse time (gram.y):
-				 * the new partition is LIKE the parent and it
-				 * inherits from it
-				 */
-				ct->tableElts = lappend(ct->tableElts, inh);
-
-				/*
-				 * If this is an AOCO ADD PARTITION, add in the
-				 * DEFAULT ENCODING provided in the ADD PARTITION WITH clause.
-				 */
-				if (is_aocs(ct->options))
-				{
-					List *stenc = form_default_storage_directive(ct->options);
-					ColumnReferenceStorageDirective *deflt =
-						makeNode(ColumnReferenceStorageDirective);
-
-					stenc = transformStorageEncodingClause(stenc);
-
-					deflt->deflt = true;
-					deflt->encoding = stenc;
-
-					ct->attr_encodings = list_make1(deflt);
-				}
-
-				cl = list_make1(ct);
-
-				pc2->arg2 = (Node *)cl;
-			}
 		case AT_PartCoalesce:			/* Coalesce */
 		case AT_PartDrop:				/* Drop */
 		case AT_PartExchange:			/* Exchange */

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -166,9 +166,9 @@ extern Oid selectPartition(PartitionNode *partnode, Datum *values,
 						   PartitionAccessMethods *accessMethods);
 
 extern Node *atpxPartAddList(Relation rel, 
-							 AlterPartitionCmd *pc,
+							 bool is_split,
+							 List *colencs,
 							 PartitionNode *pNode, 
-							 Node *pUtl,
 							 char *partName,
 							 bool isDefault,
 							 PartitionElem *pelem,

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1184,6 +1184,7 @@ typedef enum AlterTableType
 	AT_SetDistributedBy,		/* SET DISTRIBUTED BY */
 	/* CDB: Partitioned Tables */
 	AT_PartAdd,					/* Add */
+	AT_PartAddForSplit,			/* Add, as subcommand of a split */
 	AT_PartAlter,				/* Alter */
 	AT_PartCoalesce,			/* Coalesce */
 	AT_PartDrop,				/* Drop */


### PR DESCRIPTION
atpxPartAddList() needs a CreateStmt that represents the parent table,
but instead of creating it already in the parser, and adding more details
to it in analyze.c, it's simpler to create it later, in atpxPartAddList(),
where it's actaully needed.