### PR TITLE
Removing non-deterministic query from qp_misc_rio

### DIFF
--- a/src/test/regress/expected/qp_misc_rio.out
+++ b/src/test/regress/expected/qp_misc_rio.out
@@ -1116,12 +1116,6 @@ FROM pg_class WHERE oid='tbl_truncate_load'::regclass;
  reltuples and number of records for table tbl_truncate_load are consistent
 (1 row)
 
-SELECT reltuples FROM pg_class WHERE oid='tbl_truncate_load'::regclass;
-  reltuples  
--------------
- 1.00026e+07
-(1 row)
-
 SELECT count(*) FROM tbl_truncate_load;
   count   
 ----------

--- a/src/test/regress/sql/qp_misc_rio.sql
+++ b/src/test/regress/sql/qp_misc_rio.sql
@@ -801,7 +801,6 @@ SELECT CASE WHEN abs(reltuples-10000000)/10000000 < 0.05 THEN 'reltuples and num
             ELSE 'reltuples and number of records for table tbl_truncate_load are inconsistent'
        END AS remark
 FROM pg_class WHERE oid='tbl_truncate_load'::regclass;
-SELECT reltuples FROM pg_class WHERE oid='tbl_truncate_load'::regclass;
 SELECT count(*) FROM tbl_truncate_load;
 
 


### PR DESCRIPTION
SELECT reltuples FROM pg_class WHERE oid='tbl_truncate_load'::regclass; query refer to reltuple which is a statistics used by planner. This might change if other test ran vaccum or analyze or test order change. To make qp_misc_rio more deterministic, this query is removed. Moreover this is ported from tinc test and don't see a need for this in this test.

@armenatzoglou @hardikar @gcaragea @foyzur  Please take a look when you get chance