### PR TITLE
Backport AggCheckCallContext()

### DIFF
--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -570,5 +570,18 @@ extern PGFunction lookup_external_function(void *filehandle, char *funcname);
 extern void load_file(const char *filename, bool restricted);
 extern void **find_rendezvous_variable(const char *varName);
 
+/*
+ * Support for aggregate functions
+ *
+ * This is actually in executor/nodeAgg.c, but we declare it here since the
+ * whole point is for callers of it to not be overly friendly with nodeAgg.
+ */
+
+/* AggCheckCallContext can return one of the following codes, or 0: */
+#define AGG_CONTEXT_AGGREGATE   1       /* regular aggregate */
+#define AGG_CONTEXT_WINDOW      2       /* window function */
+
+extern int AggCheckCallContext(FunctionCallInfo fcinfo,
+                    MemoryContext *aggcontext);
 
 #endif   /* FMGR_H */


### PR DESCRIPTION
To better support geospatial component in 5.0,  especially for postgis/raster, we add function AggCheckCallContext() to keep compiler quiet.

Backport below commit from upstream:

    commit d5768dce10576c2fb1254c03fb29475d4fac6bb4
    Author: Tom Lane <tgl@sss.pgh.pa.us>
    Date:   Mon Feb 8 20:39:52 2010 +0000

        Create an official API function for C functions to use to check if they are
        being called as aggregates, and to get the aggregate transition state memory
        context if needed.  Use it instead of poking directly into AggState and
        WindowAggState in places that shouldn't know so much.

        We should have done this in 8.4, probably, but better late than never.

        Revised version of a patch by Hitoshi Harada.

modified:   src/backend/executor/nodeAgg.c
modified:   src/include/fmgr.h