### PR TITLE
Dumping memory usage during runaway query termination.

### DIFF
--- a/src/backend/utils/mmgr/runaway_cleaner.c
+++ b/src/backend/utils/mmgr/runaway_cleaner.c
@@ -258,6 +258,15 @@ RunawayCleaner_RunawayCleanupDoneForProcess(bool ignoredCleanup)
 		 */
 		RunawayCleaner_RunawayCleanupDoneForSession();
 	}
+
+	/*
+	 * Finally we are done with all critical cleanup, which includes releasing all our memory and
+	 * releasing our cleanup counter so that another session can be marked as runaway, if needed.
+	 * Now, we have some head room to actually record our usage.
+	 */
+	write_stderr("Logging memory usage because of runaway cleanup. Note, this is a post-cleanup logging and may be incomplete.");
+	MemoryAccounting_SaveToLog();
+	MemoryContextStats(TopMemoryContext);
 }
 
 /*

--- a/src/backend/utils/mmgr/test/Makefile
+++ b/src/backend/utils/mmgr/test/Makefile
@@ -39,6 +39,8 @@ memaccounting.t: \
 
 runaway_cleaner.t: \
 	$(MOCK_DIR)/backend/utils/error/elog_mock.o \
+	$(MOCK_DIR)/backend/utils/mmgr/mcxt_mock.o \
+	$(MOCK_DIR)/backend/utils/mmgr/memaccounting_mock.o \
 	$(MOCK_DIR)/backend/utils/misc/faultinjector_mock.o \
 	$(MOCK_DIR)/backend/utils/misc/superuser_mock.o \
 	$(MOCK_DIR)/backend/utils/mmgr/idle_tracker_mock.o

--- a/src/backend/utils/mmgr/test/runaway_cleaner_test.c
+++ b/src/backend/utils/mmgr/test/runaway_cleaner_test.c
@@ -36,6 +36,13 @@
     	will_return_with_sideeffect(errstart, false, &_ExceptionalCondition, NULL);\
     } \
 
+#define CHECK_FOR_RUNAWAY_CLEANUP_MEMORY_LOGGING() \
+	will_be_called(write_stderr); \
+	expect_any(write_stderr, fmt); \
+	will_be_called(MemoryAccounting_SaveToLog); \
+	will_be_called(MemoryContextStats); \
+	expect_any(MemoryContextStats, context); \
+
 /* MySessionState will use the address of this global variable */
 static SessionState fakeSessionState;
 
@@ -203,6 +210,8 @@ test__RunawayCleaner_StartCleanup__IgnoresCleanupInCriticalSection(void **state)
 
 	CritSectionCount = 1;
 	InterruptHoldoffCount = 0;
+
+	CHECK_FOR_RUNAWAY_CLEANUP_MEMORY_LOGGING();
 	RunawayCleaner_StartCleanup();
 
 	assert_true(beginCleanupRunawayVersion == *latestRunawayVersion);
@@ -243,6 +252,8 @@ test__RunawayCleaner_StartCleanup__IgnoresCleanupInHoldoffInterrupt(void **state
 
 	CritSectionCount = 0;
 	InterruptHoldoffCount = 1;
+
+	CHECK_FOR_RUNAWAY_CLEANUP_MEMORY_LOGGING();
 	RunawayCleaner_StartCleanup();
 
 	assert_true(beginCleanupRunawayVersion == *latestRunawayVersion);
@@ -385,6 +396,7 @@ test__RunawayCleaner_RunawayCleanupDoneForProcess__PreventsDuplicateCleanup(void
 	vmemTrackerInited = true;
 	isProcessActive = true;
 
+	CHECK_FOR_RUNAWAY_CLEANUP_MEMORY_LOGGING();
 	RunawayCleaner_RunawayCleanupDoneForProcess(false /* ignoredCleanup */);
 	/* cleanupCountdown should be adjusted */
 	assert_true(MySessionState->cleanupCountdown == CLEANUP_COUNTDOWN - 1);
@@ -433,6 +445,7 @@ test__RunawayCleaner_RunawayCleanupDoneForProcess__UndoDeactivation(void **state
 	/* We must undo the idle state */
 	will_be_called(IdleTracker_ActivateProcess);
 
+	CHECK_FOR_RUNAWAY_CLEANUP_MEMORY_LOGGING();
 	RunawayCleaner_RunawayCleanupDoneForProcess(false /* ignoredCleanup */);
 	/* The cleanupCountdown must be decremented as we cleaned up */
 	assert_true(MySessionState->cleanupCountdown == 1);
@@ -472,6 +485,7 @@ test__RunawayCleaner_RunawayCleanupDoneForProcess__ReactivatesRunawayDetection(v
 	/* Make sure the cleanup goes through */
 	vmemTrackerInited = true;
 
+	CHECK_FOR_RUNAWAY_CLEANUP_MEMORY_LOGGING();
 	RunawayCleaner_RunawayCleanupDoneForProcess(false /* ignoredCleanup */);
 	/* The cleanupCountdown must be decremented as we cleaned up */
 	assert_true(MySessionState->cleanupCountdown == 1);
@@ -487,6 +501,7 @@ test__RunawayCleaner_RunawayCleanupDoneForProcess__ReactivatesRunawayDetection(v
 	 */
 	endCleanupRunawayVersion = 1;
 
+	CHECK_FOR_RUNAWAY_CLEANUP_MEMORY_LOGGING();
 	/*
 	 * cleanupCountdown should reach 0, and immediately afterwards should be set to
 	 * CLEANUP_COUNTDOWN_BEFORE_RUNAWAY


### PR DESCRIPTION
Signed-off-by: Nikos Armenatzoglou <nikos.armenatzoglou@gmail.com>

Previously when we ran out of memory, we logged the memory usage of all the running queries on the segment where OOM happened. However, if runaway termination successfully terminates the biggest offender, before we hit OOM, we did not have any logging mechanism. This left us with insufficient information for root cause analysis of memory leaks.

This PR is introducing logging of memory usage for only the runaway query. Note, we do not log usage for all the other queries, like we do for out of memory. Rather we restrict ourselves to only the biggest violator that is getting terminated. Moreover, because of the sensitive nature of runaway termination, we need to terminate as fast as possible, to prevent hitting an out of memory in other processes. Therefore, we cannot log the full memory context dump at the time of runaway cleanup. Rather, we attempt to dump memory usage after the cleanup. This gives us the details of memory accounting peak usage for all the operators. For memory context, however, we only dump partial memory context tree as most of the memory contexts will have been dropped by then. This is still a valuable piece of information to do root cause analysis as the memory accounting tree represents the execution plan closely and helps us pinpoint the operator where we might have excessive memory consumption.