### PR TITLE
Fix "record type not registered" error, when a subquery returns a row…

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -52,6 +52,7 @@
 #include "parser/parsetree.h"
 #include "utils/memutils.h"
 #include "utils/relcache.h"
+#include "utils/typcache.h"
 #include "utils/workfile_mgr.h"
 
 #include "cdb/cdbvars.h"
@@ -644,6 +645,17 @@ void
 ExecAssignResultType(PlanState *planstate, TupleDesc tupDesc)
 {
 	TupleTableSlot *slot = planstate->ps_ResultTupleSlot;
+
+	/*
+	 * In PostgreSQL, we rely on ExecEvalWholeRowVar() to do this, at
+	 * execution time. In Greenplum, however, the typmods assigned to
+	 * rowtypes must be the same between the master and all segments,
+	 * so we must assign typmods at executor startup, before the plan
+	 * gets dispatched to segments.
+	 */
+	if (tupDesc->tdtypeid == RECORDOID &&
+		tupDesc->tdtypmod < 0)
+		assign_record_type_typmod(tupDesc);
 
 	ExecSetSlotDescriptor(slot, tupDesc);
 }


### PR DESCRIPTION
… var.

PostgreSQL relies on ExecEvalWholeRowVar() to assign a typmod for record
types, but that's too late in GPDB.  This was revealed by this regression
test that was added to upstream in version 8.3:

select q from (select max(f1) from int4_tbl group by f1 order by f1) q;

That test's purpose was to test something else, but it happened to trigger
this GPDB-specific bug. No test case included in this patch, because we'll
get that query later, as part of the 8.3 merge.