### PR TITLE
Add qp_query_execution testsuite to greenplum_schedule

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -101,6 +101,8 @@ test: qp_gist_indexes2 qp_gist_indexes3 qp_gist_indexes4
 test: olap_setup
 test: qp_olap_group
 
+test: qp_query_execution
+
 ignore: tpch500GB_orca
 
 # XXX: This test depends on libgpoptudfs library, which includes ORCA helper


### PR DESCRIPTION
I might be missing something but.. The qp_query_execution test was added to the tree in commit 9d19664 and then further updated in 29a0fec but it's not present in any test schedule. Add to the greenplum_schedule to include it when running installcheck-good.

What do you think @foyzur and @gcaragea?