### PR TITLE
gpcheckcat refactoring

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -163,9 +163,9 @@ class Global():
 
         # the following variables used for reporting purposes
         self.elapsedTime = 0
-        self.totalTestRun = 0
-        self.testStatus = True
-        self.failedTest = []
+        self.totalCheckRun = 0
+        self.checkStatus = True
+        self.failedChecks = []
 
 
 GV = Global()
@@ -466,7 +466,7 @@ def checkDistribPolicy():
         if not err:
             logger.info('[OK] randomly distributed tables')
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_REMOVE)
             logger.info('[FAIL] randomly distributed tables')
             logger.error('pg_constraint has %d issue(s)' % len(err))
@@ -508,7 +508,7 @@ def checkDistribPolicy():
         if not err:
             logger.info('[OK] unique constraints')
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_REMOVE)
             logger.info('[FAIL] unique constraints')
             logger.error('pg_constraint has %d issue(s)' % len(err))
@@ -557,7 +557,7 @@ def checkPartitionIntegrity():
         if not err:
             logger.info('[OK] pg_partition branch integrity')
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
             logger.info('[FAIL] pg_partition branch integrity')
             logger.error('pg_partition has %d issue(s)' % len(err))
@@ -589,7 +589,7 @@ def checkPartitionIntegrity():
         if not err:
             logger.info('[OK] partition with oids check')
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
             logger.info('[FAIL] partition with oids check')
             logger.error('partition with oids check found %d issue(s)' % len(err))
@@ -682,7 +682,7 @@ def checkPartitionIntegrity():
         if not err:
             logger.info('[OK] partition distribution policy check')
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_REMOVE)
             logger.info('[FAIL] partition distribution policy check')
             logger.error('partition distribution policy check found %d issue(s)' % len(err))
@@ -1690,7 +1690,7 @@ def checkPartitionRegularity():
 
     db = connect()
 
-    testname = 'user-defined constraint regularity on partitioned tables'
+    checkname = 'user-defined constraint regularity on partitioned tables'
 
     qry = partitionRegularityChecks['irreg_user_constraint']
     err = []
@@ -1702,23 +1702,23 @@ def checkPartitionRegularity():
             err.append((row['tableconname'], row['tableid'], row['numactual'], row['numexpected']))
 
         if not err:
-            logger.info('[OK]  %s' % testname)
+            logger.info('[OK]  %s' % checkname)
         else:
             irregular = True
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
-            logger.info('[FAIL]  %s' % testname)
-            logger.error(' %s test has %d issue(s)' % (testname, len(err)))
+            logger.info('[FAIL]  %s' % checkname)
+            logger.error(' %s test has %d issue(s)' % (checkname, len(err)) )
             efmt = '  Constraint "%s" of partitioned table "%s" occurs %d times, %d expected.'
             for e in err:
                 logger.error(efmt % e)
 
     except Exception, e:
         setError(ERROR_NOREPAIR)
-        myprint('[ERROR] executing test: %s' % testname)
+        myprint('[ERROR] executing test: %s' % checkname)
         myprint('  Execution error: ' + str(e))
 
-    testname = 'system-defined partition constraint regularity on partitioned tables'
+    checkname = 'system-defined partition constraint regularity on partitioned tables'
 
     # Determine maximum number of partitioning levels in this database
     try:
@@ -1735,28 +1735,28 @@ def checkPartitionRegularity():
                 err.append((row['partid'], row['tableid'], row['actual'], row['expected']))
 
         if not err:
-            logger.info('[OK]  %s' % testname)
+            logger.info('[OK]  %s' % checkname)
         else:
             irregular = True
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
-            logger.info('[FAIL]  %s' % testname)
-            logger.error(' %s test has %d issue(s)' % (testname, len(err)))
+            logger.info('[FAIL]  %s' % checkname)
+            logger.error(' %s test has %d issue(s)' % ( checkname, len(err)) )
             efmt = '  Part table "%s" of partitioned table "%s" has %d system-defined constraints, %d expected.'
             for e in err:
                 logger.error(efmt % e)
 
     except Exception, e:
         setError(ERROR_NOREPAIR)
-        myprint('[ERROR] executing test: %s' % testname)
+        myprint('[ERROR] executing test: %s' % checkname)
         myprint('  Execution error: ' + str(e))
 
-    testname = 'unenforced unique constraints on partitioned tables'
+    checkname = 'unenforced unique constraints on partitioned tables'
 
     if irregular:
-        logger.warn('skipping test %s due to constraint irregularities' % testname)
+        logger.warn('skipping check %s due to constraint irregularities' % checkname)
     elif GV.Remove:
-        logger.warn('skipping test %s due to required removals' % testname)
+        logger.warn('skipping check %s due to required removals' % checkname)
     else:
         qry = partitionRegularityChecks['unenforced_constraint_info']
         err = []
@@ -1769,12 +1769,12 @@ def checkPartitionRegularity():
                 err.append(row)
 
             if not err:
-                logger.info('[OK]  %s' % testname)
+                logger.info('[OK]  %s' % checkname)
             else:
-                GV.testStatus = False
+                GV.checkStatus = False
                 setError(ERROR_REMOVE)
-                logger.info('[FAIL]  %s' % testname)
-                logger.error(' %s test has %d issue(s)' % (testname, len(err)))
+                logger.info('[FAIL]  %s' % checkname)
+                logger.error(' %s test has %d issue(s)' % ( checkname, len(err) ) )
                 efmt = '  partitioned table "{tableid}" has unenforced {con_type_phrase} constraint: "{partid}"'
                 repair_fmt = partitionRegularityChecks['unenforced_constraint_repairs']
                 n = 0
@@ -1790,17 +1790,17 @@ def checkPartitionRegularity():
 
         except Exception, e:
             setError(ERROR_NOREPAIR)
-            myprint('[ERROR] executing test: %s' % testname)
+            myprint('[ERROR] executing test: %s' % checkname)
             myprint('  Execution error: ' + str(e))
 
-    testname = 'inconsistently named constraint in partitioned table'
+    checkname = 'inconsistently named constraint in partitioned table'
 
     if irregular:
-        logger.warn('skipping test %s due to constraint irregularities' % testname)
+        logger.warn('skipping check %s due to constraint irregularities' % checkname)
     elif GV.Remove:
-        logger.warn('skipping test %s due to required removals' % testname)
+        logger.warn('skipping check %s due to required removals' % checkname)
     elif GV.DemoteConstraint:
-        logger.warn('skipping test %s due to unenforced constraint removals' % testname)
+        logger.warn('skipping check %s due to unenforced constraint removals' % checkname)
     else:
         qry = partitionRegularityChecks['fix_ill_named_constraint']
         err = []
@@ -1810,12 +1810,12 @@ def checkPartitionRegularity():
                 err.append(row)
 
             if not err:
-                logger.info('[OK]  %s' % testname)
+                logger.info('[OK]  %s' % checkname)
             else:
-                GV.testStatus = False
+                GV.checkStatus = False
                 setError(ERROR_REMOVE)
-                logger.info('[FAIL]  %s' % testname)
-                logger.error(' %s test has %d issue(s)' % (testname, len(err)))
+                logger.info('[FAIL]  %s' % checkname)
+                logger.error(' %s test has %d issue(s)' % ( checkname, len(err) ) )
                 efmt = '  part table "%s" has constraint named "%s"; should be "%s"'
                 n = 0
                 for e in err:
@@ -1833,7 +1833,7 @@ def checkPartitionRegularity():
 
         except Exception, e:
             setError(ERROR_NOREPAIR)
-            myprint('[ERROR] executing test: %s' % testname)
+            myprint('[ERROR] executing test: %s' % checkname)
             myprint('  Execution error: ' + str(e))
 
     db.close()
@@ -1854,7 +1854,7 @@ def checkPGClass():
     if not err:
         logger.info('[OK] pg_class')
     else:
-        GV.testStatus = False
+        GV.checkStatus = False
         setError(ERROR_NOREPAIR)
         logger.info('[FAIL] pg_class')
         logger.error('pg_class has %d issue(s)' % len(err))
@@ -1900,7 +1900,7 @@ def getLeakedSchemas():
         if curs.ntuples() == 0:
             logger.info('[OK] temporary schemas')
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_REMOVE)
             logger.info('[FAIL] temporary schemas')
             logger.error('found %d unbound temporary schemas' % curs.ntuples())
@@ -1937,7 +1937,7 @@ def checkPGNamespace():
     if not err:
         logger.info('[OK] missing schema definitions')
     else:
-        GV.testStatus = False
+        GV.checkStatus = False
         setError(ERROR_NOREPAIR)
         logger.info('[FAIL] missing schema definitons')
         logger.error('found %d references to non-existent schemas' % len(err))
@@ -2104,7 +2104,7 @@ def checkDepend():
         if not err:
             logger.info('[OK] basic object dependencies')
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
             logger.info('[FAIL] basic object dependencies')
             logger.error('  found %d dependencies on dropped objects' % len(err))
@@ -2178,7 +2178,7 @@ def checkOwners():
         if len(rows) == 0:
             logger.info('[OK] table ownership')
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_REMOVE)
             logger.info('[FAIL] table ownership')
             logger.error('found %d table ownership issue(s)' % len(rows))
@@ -2226,7 +2226,7 @@ def checkOwners():
         if len(rows) == 0:
             logger.info('[OK] type ownership')
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
             logger.info('[FAIL] type ownership')
             logger.error('found %d type ownership issue(s)' % len(rows))
@@ -2246,7 +2246,7 @@ def checkOwners():
 
         # FIXME: add repair script
         # NOTE: types with typrelid probably will be repaired by the
-        # script generated by the table ownership test above.
+        # script generated by the table ownership check above.
 
         # TODO:
         # Check owners in pg_proc
@@ -2669,7 +2669,7 @@ def checkPersistentTables():
         if not err:
             logger.info('[OK] ' + qname)
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
             logger.info('[FAIL] ' + qname)
             logger.error('%s found %d issue(s)' % (qname, len(err)))
@@ -2793,7 +2793,7 @@ def checkTableACL(cat):
         if nrows == 0:
             logger.info('[OK] Cross consistency acl check for ' + catname)
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
             GV.aclStatus = False
             logger.info('[FAIL] Cross consistency acl check for ' + catname)
@@ -2886,7 +2886,7 @@ def checkTableForeignKey(cat):
                 logger.info('[OK] Foreign key check for %s(%s) referencing %s(%s)' %
                             (catname, fkeystr, pkcatname, pkeystr))
             else:
-                GV.testStatus = False
+                GV.checkStatus = False
                 setError(ERROR_NOREPAIR)
                 GV.foreignKeyStatus = False
                 logger.info('[FAIL] Foreign key check for %s(%s) referencing %s(%s)' %
@@ -3010,7 +3010,7 @@ def checkTableMissingEntry(cat):
                 logger_with_level = logger.warning
                 log_level = logging.WARNING
             else:
-                GV.testStatus = False
+                GV.checkStatus = False
                 setError(ERROR_NOREPAIR)
                 GV.missingEntryStatus = False
                 logger_with_level = logger.error
@@ -3164,7 +3164,7 @@ def checkTableInconsistentEntry(cat):
         if nrows == 0:
             logger.info('[OK] Checking for inconsistent entries for ' + catname)
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
             GV.inconsistentEntryStatus = False
             logger.info('[FAIL] Checking for inconsistent entries for ' + catname)
@@ -3301,7 +3301,7 @@ def checkTableDuplicateEntry(cat):
         if nrows == 0:
             logger.info('[OK] Checking for duplicate entries for ' + catname)
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
             logger.error('[FAIL] Checking for duplicate entries for ' + catname)
             logger.error('  %s has %d issue(s)' % (catname, nrows))
@@ -3376,7 +3376,7 @@ def checkDuplicatePersistentEntry():
         if nrows == 0:
             logger.info('[OK] Checking for duplicate persistent entries for ' + catname)
         else:
-            GV.testStatus = False
+            GV.checkStatus = False
             setError(ERROR_NOREPAIR)
             logger.error('[FAIL] Checking for duplicate persistent entries for ' + catname)
             logger.error('  %s has %d issue(s)' % (catname, nrows))
@@ -3430,7 +3430,7 @@ def duplicatePersistentEntryQuery(catname, pkey, excol, state):
 
 
 ############################################################################
-# Help populating repair part for all tested types
+# Help populating repair part for all checked types
 # All functions dependent on results stored in global variable GV
 ############################################################################
 name_repair = {
@@ -3462,13 +3462,13 @@ name_repair = {
 }
 
 ############################################################################
-# version = X.X : run this test as part of running all tests on gpdb <= X.X  
-#                 individually, any test should be ok run on any version
+# version = X.X : run this check as part of running all checks on gpdb <= X.X
+#                 individually, any check should be ok run on any version
 #  online = True: okie to run gpcheckcat online
-#   order = X   : the order test should be run when running all tests
+#   order = X   : the order check should be run when running all checks
 ############################################################################
 
-name_test = {
+all_checks = {
     "duplicate":
         {
             "description": "Check for duplicate entries",
@@ -3584,66 +3584,70 @@ name_test = {
 }
 
 
-# -------------------------------------------------------------------------------
-def listAllTests():
+#-------------------------------------------------------------------------------
+def listAllChecks():
+
     myprint('\nList of gpcheckcat tests:\n')
-    for name in sorted(name_test, key=lambda x: name_test[x]["order"]):
+    for name in sorted(all_checks, key=lambda x: all_checks[x]["order"]):
         myprint(" %24s: %s" % \
-                (name, name_test[name]["description"]))
+                (name, all_checks[name]["description"]))
     myprint('')
 
 
-# -------------------------------------------------------------------------------
-def runTestCatname(cat):
-    tests = {'missing_extraneous': lambda: checkTableMissingEntry(cat),
+#-------------------------------------------------------------------------------
+def runCheckCatname(cat):
+
+    checks = {'missing_extraneous': lambda: checkTableMissingEntry(cat),
              'inconsistent': lambda: checkTableInconsistentEntry(cat),
              'foreign_key': lambda: checkTableForeignKey(cat),
              'duplicate': lambda: checkTableDuplicateEntry(cat),
              'acl': lambda: checkTableACL(cat)}
 
-    for test in sorted(tests):
-        myprint("Performing test '%s' for %s" % (test, cat.getTableName()))
+    for check in sorted(checks):
+        myprint("Performing test '%s' for %s" % (check,cat.getTableName()))
         stime = time.time()
-        tests[test]()
+        checks[check]()
         etime = time.time()
         elapsed = etime - stime
         GV.elapsedTime += elapsed
         elapsed = str(datetime.timedelta(seconds=elapsed))[:-4]
-        GV.totalTestRun += 1
-        myprint("Total runtime for test '%s': %s" % (test, elapsed))
+        GV.totalCheckRun += 1
+        myprint("Total runtime for test '%s': %s" % (check, elapsed))
 
 
-# -------------------------------------------------------------------------------
-def runOneTest(name):
-    if not name_test.has_key(name):
+#-------------------------------------------------------------------------------
+def runOneCheck(name):
+
+    if not all_checks.has_key(name):
         logger.info("'%s' is not a valid test" % (name))
         raise LookupError
-    if GV.opt['-O'] and not name_test[name]["online"]:
+    if GV.opt['-O'] and not all_checks[name]["online"]:
         logger.info("%s: Skip this test in online mode" % (name))
         return
     else:
         myprint("Performing test '%s'" % name)
-        GV.totalTestRun += 1
-        GV.testStatus = True
+        GV.totalCheckRun += 1
+        GV.checkStatus = True
         stime = time.time()
-        name_test[name]["fn"]()
+        all_checks[name]["fn"]()
         etime = time.time()
         elapsed = etime - stime
         GV.elapsedTime += elapsed
         elapsed = str(datetime.timedelta(seconds=elapsed))[:-4]
         myprint("Total runtime for test '%s': %s" % (name, elapsed))
-        if GV.testStatus == False:
-            GV.failedTest.append(name)
+        if GV.checkStatus == False:
+            GV.failedChecks.append(name)
 
 
-# -------------------------------------------------------------------------------
-def runAllTests():
+
+#-------------------------------------------------------------------------------
+def runAllChecks():
     '''
     perform catalog check for specified database
     '''
-    for name in sorted(name_test, key=lambda x: name_test[x]["order"]):
-        if name_test[name]["version"] >= GV.version:
-            runOneTest(name)
+    for name in sorted(all_checks, key=lambda x: all_checks[x]["order"]):
+        if all_checks[name]["version"] >= GV.version:
+            runOneCheck(name)
 
     closeDbs()
     logger.info("------------------------------------")
@@ -4040,8 +4044,8 @@ def getResourceTypeOid(oid):
         myprint('  Execution error: ' + str(e))
 
 
-# -------------------------------------------------------------------------------
-# Process results of tests (CC and FK) for a particular catalog:
+#-------------------------------------------------------------------------------
+# Process results of checks (CC and FK) for a particular catalog:
 #   - Categorize entry into GPObject
 #   - Instantiate GPObject if needed
 # -------------------------------------------------------------------------------
@@ -4686,16 +4690,16 @@ def checkcatReport():
             reportAllIssuesRecursive(child, graph)
 
     buildGraph()
-    reportedTest = ['duplicate', 'missing_extraneous', 'inconsistent', 'foreign_key', 'acl', 'duplicate_persistent']
+    reportedCheck = ['duplicate','missing_extraneous','inconsistent','foreign_key','acl', 'duplicate_persistent']
     myprint('')
     myprint('SUMMARY REPORT')
     myprint('===================================================================')
     elapsed = datetime.timedelta(seconds=int(GV.elapsedTime))
     endTime = datetime.datetime.now().strftime('%Y-%m-%d %H:%I:%S')
     myprint('Completed %d test(s) on database \'%s\' at %s with elapsed time %s' \
-            % (GV.totalTestRun, GV.dbname, endTime, elapsed))
+            % (GV.totalCheckRun, GV.dbname, endTime, elapsed))
 
-    if len(GPObjectGraph) == 0 and len(GV.failedTest) == 0:
+    if len(GPObjectGraph) == 0 and len(GV.failedChecks) == 0:
         myprint('Found no catalog issue\n')
         return
 
@@ -4715,7 +4719,7 @@ def checkcatReport():
                 reportAllIssuesRecursive(par, GPObjectGraph)
         myprint('')
 
-    notReported = set(GV.failedTest).difference(reportedTest)
+    notReported = set(GV.failedChecks).difference(reportedCheck)
     if len(notReported) > 0:
         myprint('Failed test(s) that are not reported here: %s' % (', '.join(notReported)))
         myprint('See %s for detail\n' % get_logfile())
@@ -4727,8 +4731,7 @@ def _myprint(str, level=logging.CRITICAL):
 
 myprint = _myprint
 
-
-def generateVerifyFile(catname, fields, results, testname):
+def generateVerifyFile(catname, fields, results, checkname):
     in_clause = reduce(lambda x, y: x + ('' if not x else ',') + str(y[fields.index('oid')]), results, '')
     verify_sql = '''
           SELECT *
@@ -4739,7 +4742,7 @@ def generateVerifyFile(catname, fields, results, testname):
           ) alltyprelids
           GROUP BY relname, oid ORDER BY count(*) desc
     '''.format(in_clause=in_clause)
-    filename = 'gpcheckcat.verify.%s.%s.%s.%s.sql' % (GV.dbname, catname, testname, TIMESTAMP)
+    filename = 'gpcheckcat.verify.%s.%s.%s.%s.sql' % (GV.dbname, catname, checkname, TIMESTAMP)
     try:
         with open(filename, 'w') as fp:
             fp.write(verify_sql + '\n')
@@ -4752,7 +4755,7 @@ if __name__ == '__main__':
 
     parseCommandLine()
     if GV.opt['-l']:
-        listAllTests()
+        listAllChecks()
         sys.exit(GV.retcode)
 
     GV.version = getversion()
@@ -4781,7 +4784,7 @@ if __name__ == '__main__':
         if GV.opt['-R']:
             name = GV.opt['-R']
             try:
-                runOneTest(name)
+                runOneCheck(name)
             except LookupError, e:
                 myprint("'%s' is not a valid test\n\n" % (name))
                 setError(ERROR_NOREPAIR)
@@ -4790,12 +4793,12 @@ if __name__ == '__main__':
             namestr = GV.opt['-C']
             try:
                 cat = getCatObj(namestr)
-                runTestCatname(cat)
+                runCheckCatname(cat)
             except Exception, e:
                 setError(ERROR_NOREPAIR)
                 sys.exit(GV.retcode)
         else:
-            runAllTests()
+            runAllChecks()
 
         checkcatReport()
 

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -17,15 +17,15 @@ Usage: gpcheckcat [<option>] [dbname]
     -C catname : run cross consistency, FK and ACL tests for this catalog table
 
 '''
-import sys, os, subprocess, tempfile, stat, re
-from threading import Thread
+import getopt
+import re
+import stat
+import sys
 from datetime import datetime
 from time import localtime, strftime
-import time
-import getopt
 
 TIMESTAMP = datetime.now().strftime("%Y%m%d%H%M%S")
-REPAIR_SCRIPT='runsql_%s.sh' % TIMESTAMP
+REPAIR_SCRIPT = 'runsql_%s.sh' % TIMESTAMP
 
 try:
     from gppylib.db import dbconn
@@ -41,30 +41,37 @@ parallelism = 8
 # cache OID -> object name cache
 oidmap = {}
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 EXECNAME = os.path.split(__file__)[-1]
-setup_tool_logging(EXECNAME,getLocalHostname(),getUserName())
+setup_tool_logging(EXECNAME, getLocalHostname(), getUserName())
 very_quiet_stdout_logging()
 logger = get_default_logger()
-#-------------------------------------------------------------------------------
+
+
+# -------------------------------------------------------------------------------
 
 ################
 def parse_int(val):
-    try: val = int(val)
-    except ValueError: val = 0
+    try:
+        val = int(val)
+    except ValueError:
+        val = 0
     return val
+
 
 ###############################
 def quote_value(name):
     """Add surrounding single quote, double interior single quote."""
-    assert isinstance(name,str)
+    assert isinstance(name, str)
     return "'" + "''".join(name.split("'")) + "'"
 
 
-SUCCESS=0
-ERROR_REMOVE=1
-ERROR_RESYNC=2
-ERROR_NOREPAIR=3
+SUCCESS = 0
+ERROR_REMOVE = 1
+ERROR_RESYNC = 2
+ERROR_NOREPAIR = 3
+
+
 def setError(level):
     '''
     Increases the error level to the specified level, if specified level is
@@ -80,10 +87,9 @@ def setError(level):
 
 ###############################
 class Global():
-
     def __init__(self):
-        self.retcode   = SUCCESS
-        self.opt       = {}
+        self.retcode = SUCCESS
+        self.opt = {}
         self.opt['-h'] = None
         self.opt['-p'] = None
         self.opt['-P'] = None
@@ -91,70 +97,69 @@ class Global():
         self.opt['-v'] = False
         self.opt['-V'] = False
         self.opt['-t'] = False
-    
+
         self.opt['-g'] = 'gpcheckcat.repair.' + strftime('%Y-%m-%d.%H.%M.%S', localtime())
         self.opt['-B'] = parallelism
         self.opt['-T'] = None
-    
+
         self.opt['-A'] = False
         self.opt['-S'] = None
         self.opt['-O'] = False
-    
+
         self.opt['-R'] = None
         self.opt['-C'] = None
         self.opt['-l'] = False
-    
-        self.cfg       = None
-        self.dbname    = None
-        self.firstdb   = None
-        self.alldb     = []
-        self.db        = {}
-        self.tmpdir    = None
-    
+
+        self.cfg = None
+        self.dbname = None
+        self.firstdb = None
+        self.alldb = []
+        self.db = {}
+        self.tmpdir = None
+
         self.reset_stmt_queues()
-        
+
         self.home = os.environ.get('HOME')
         if self.home == None:
             usage('Error: $HOME must be set')
         self.user = os.environ.get('USER') or os.environ.get('LOGNAME')
         if self.user == None:
             usage('Error: either $USER or $LOGNAME must be set')
-    
+
         self.catalog = None
         self.max_content = 0
         self.report_cfg = {}
-        
+
     def reset_stmt_queues(self):
 
         # dictionary of SQL statements. Key is dbid
         self.Remove = {}
-    
+
         # dictionary of SQL statements. Key is dbid
         self.AdjustConname = {}
-    
+
         # dictionary of SQL statements. Key is dbid
         self.DemoteConstraint = {}
-    
+
         # array of SQL statements. Key is dbid
         self.ReSync = {}
-    
+
         # Indexes to rebuild
         self.Reindex = []
-    
+
         # constraints which are actually unenforcable
         self.Constraints = []
-    
+
         # ownership fixups
         self.Owners = []
-    
+
         # fix distribution policies
         self.Policies = []
-        
+
         self.missingEntryStatus = None
         self.inconsistentEntryStatus = None
         self.foreignKeyStatus = None
         self.aclStatus = None
-
 
         # the following variables used for reporting purposes
         self.elapsedTime = 0
@@ -162,12 +167,12 @@ class Global():
         self.testStatus = True
         self.failedTest = []
 
+
 GV = Global()
 
 
-
 ###############################
-def usage(exitarg = None):
+def usage(exitarg=None):
     print __doc__
     sys.exit(exitarg)
 
@@ -188,6 +193,7 @@ def getversion():
     logger.debug('got version %s' % version)
     return version
 
+
 ###############################
 def getalldbs():
     """
@@ -199,6 +205,7 @@ def getalldbs():
     row = curs.getresult()
     return row
 
+
 ###############################
 def parseCommandLine():
     try:
@@ -207,17 +214,20 @@ def parseCommandLine():
         usage('Error: ' + str(e))
 
     for (switch, val) in options:
-        if switch == '-?':      usage(0)
-        elif switch[1] in 'pBPUgSRC': GV.opt[switch] = val
-        elif switch[1] in 'vtAOl':   GV.opt[switch] = True
+        if switch == '-?':
+            usage(0)
+        elif switch[1] in 'pBPUgSRC':
+            GV.opt[switch] = val
+        elif switch[1] in 'vtAOl':
+            GV.opt[switch] = True
 
     def setdef(x, v):
         if not GV.opt[x]:
             t = os.environ.get(v)
             GV.opt[x] = t
             if t:
-                logger.debug('%s not specified; default to %s (from %s)' % 
-                        (x, t, v))
+                logger.debug('%s not specified; default to %s (from %s)' %
+                             (x, t, v))
 
     if GV.opt['-l']: return
 
@@ -234,7 +244,7 @@ def parseCommandLine():
 
     GV.opt['-h'] = 'localhost'
     logger.debug('Set default hostname to %s' % GV.opt['-h'])
-    
+
     if GV.opt['-R']:
         logger.debug('Run this test: %s' % GV.opt['-R'])
 
@@ -246,13 +256,13 @@ def parseCommandLine():
         usage('Too many arguments')
 
     if len(args) == 0:
-        GV.dbname = os.environ.get('PGDATABASE') 
+        GV.dbname = os.environ.get('PGDATABASE')
         if GV.dbname is None:
             GV.dbname = 'template1'
         logger.debug('database is %s' % GV.dbname)
     else:
         GV.dbname = args[0]
-    
+
     GV.firstdb = GV.dbname
     GV.alldb.append(GV.firstdb)
 
@@ -265,11 +275,11 @@ def parseCommandLine():
 
     if GV.opt['-S']:
         if not re.match("none|only", GV.opt['-S'], re.I):
-            usage('Error: invalid value \'%s\' for shared table option. Legal values are (none, only)'% GV.opt['-S']);
+            usage('Error: invalid value \'%s\' for shared table option. Legal values are (none, only)' % GV.opt['-S'])
         GV.opt['-S'] = GV.opt['-S'].lower()
 
-    logger.debug('master at host %s, port %s, user %s, database %s' % 
-           (GV.opt['-h'], GV.opt['-p'], GV.opt['-U'], GV.dbname))
+    logger.debug('master at host %s, port %s, user %s, database %s' %
+                 (GV.opt['-h'], GV.opt['-p'], GV.opt['-U'], GV.dbname))
 
     try:
         GV.opt['-B'] = int(GV.opt['-B'])
@@ -280,9 +290,10 @@ def parseCommandLine():
         usage('Error: parallelism must be 1 or greater')
 
     logger.debug('degree of parallelism: %s' % GV.opt['-B'])
-    
+
+
 #############
-def connect(user=None, password=None, host=None, port=None, 
+def connect(user=None, password=None, host=None, port=None,
             database=None, utilityMode=False):
     '''Connect to DB using parameters in GV'''
     options = utilityMode and '-c gp_session_role=utility' or None
@@ -296,12 +307,13 @@ def connect(user=None, password=None, host=None, port=None,
         db = pg.connect(host=host, port=port, user=user,
                         passwd=password, dbname=database, opt=options)
     except pg.InternalError, ex:
-        logger.fatal('could not connect to %s: "%s"' % 
-            (database, str(ex).strip()))
+        logger.fatal('could not connect to %s: "%s"' %
+                     (database, str(ex).strip()))
         exit(1)
-    
-    logger.debug('connected with %s:%s %s' % (host, port, database))     
+
+    logger.debug('connected with %s:%s %s' % (host, port, database))
     return db
+
 
 #############
 def connect2(cfgrec, user=None, password=None, database=None, utilityMode=True):
@@ -314,17 +326,18 @@ def connect2(cfgrec, user=None, password=None, database=None, utilityMode=True):
         utilityMode = False
 
     key = "%s.%s.%s.%s.%s.%s.%s" % (host, port, datadir, user, password, database,
-                                 str(utilityMode))
+                                    str(utilityMode))
     conns = GV.db.get(key)
     if conns:
         return conns[0]
 
-    conn = connect(host=host, port=port, user=user, password=password, 
+    conn = connect(host=host, port=port, user=user, password=password,
                    database=database, utilityMode=utilityMode)
     if conn:
         GV.db[key] = [conn, cfgrec]
-    
+
     return conn
+
 
 class execThread(Thread):
     def __init__(self, cfg, db, qry):
@@ -340,7 +353,7 @@ class execThread(Thread):
             self.curs = self.db.query(self.qry)
         except BaseException, e:
             self.error = e
-    
+
 
 def processThread(threads):
     batch = []
@@ -349,11 +362,11 @@ def processThread(threads):
         th.join()
         if th.error:
             setError(ERROR_NOREPAIR)
-            myprint("%s:%d:%s : %s" % 
-                     (th.cfg['hostname'],
-                      th.cfg['port'],
-                      th.cfg['datadir'],
-                      str(th.error)))
+            myprint("%s:%d:%s : %s" %
+                    (th.cfg['hostname'],
+                     th.cfg['port'],
+                     th.cfg['datadir'],
+                     str(th.error)))
         else:
             batch.append([th.cfg, th.curs])
     return batch
@@ -362,7 +375,7 @@ def processThread(threads):
 #############
 def connect2run(qry, col=None):
     logger.debug('%s' % qry)
-        
+
     batch = []
     threads = []
     i = 1
@@ -374,8 +387,8 @@ def connect2run(qry, col=None):
 
         thread = execThread(c, db, qry)
         thread.start()
-        logger.debug('launching query thread %s for dbid %i' % 
-                (thread.getName(), dbid))
+        logger.debug('launching query thread %s for dbid %i' %
+                     (thread.getName(), dbid))
         threads.append(thread)
 
         # we don't want too much going on at once
@@ -398,13 +411,15 @@ def connect2run(qry, col=None):
 
     return err
 
+
 def formatErr(c, col, row):
-    s = ('%s:%s:%s, content %s, dbid %s' % 
-        (c['hostname'], c['port'], c['datadir'],
-         c['content'], c['dbid']))
+    s = ('%s:%s:%s, content %s, dbid %s' %
+         (c['hostname'], c['port'], c['datadir'],
+          c['content'], c['dbid']))
     for i in col:
         s = '%s, %s %s' % (s, i, row[i])
     return s
+
 
 #############
 def getGPConfiguration():
@@ -423,10 +438,11 @@ def getGPConfiguration():
     curs = db.query(qry)
     for row in curs.dictresult():
         if row['content'] == -1 and row['isprimary'] != 't':
-            continue    # skip standby master
+            continue  # skip standby master
         cfg[row['dbid']] = row
     db.close()
     return cfg
+
 
 def checkDistribPolicy():
     logger.info('-----------------------------------')
@@ -455,17 +471,16 @@ def checkDistribPolicy():
             logger.info('[FAIL] randomly distributed tables')
             logger.error('pg_constraint has %d issue(s)' % len(err))
             logger.error(qry)
-            for e in err: 
+            for e in err:
                 logger.error(formatErr(e[0], e[1], e[2]))
             for e in err:
                 cons = e[2]
                 removeIndexConstraint(cons['nspname'], cons['relname'],
-                                  cons['constraint'])
+                                      cons['constraint'])
     except Exception, e:
         setError(ERROR_NOREPAIR)
         myprint('[ERROR] executing test: checkDistribPolicy')
         myprint('  Execution error: ' + str(e))
-
 
     logger.info('-----------------------------------')
     logger.info('Checking that unique constraints are only on distribution columns')
@@ -502,7 +517,7 @@ def checkDistribPolicy():
             for e in err:
                 cons = e[2]
                 removeIndexConstraint(cons['nspname'], cons['relname'],
-                                  cons['constraint'])
+                                      cons['constraint'])
     except Exception, e:
         setError(ERROR_NOREPAIR)
         myprint('[ERROR] executing test: checkDistribPolicy')
@@ -533,10 +548,9 @@ def checkPartitionIntegrity():
             qy2 = ('select count(*) as cc from (select 1 from only %s limit(2)) q'
                    % (row['parname']))
 
-            # logger.info(qy2)
             curs2 = db.query(qy2)
             for row2 in curs2.dictresult():
-                if row2['cc'] == 0 :
+                if row2['cc'] == 0:
                     continue
                 err.append([row['parname']])
 
@@ -548,8 +562,8 @@ def checkPartitionIntegrity():
             logger.info('[FAIL] pg_partition branch integrity')
             logger.error('pg_partition has %d issue(s)' % len(err))
             logger.error('Discovered row data in branch partitions')
-            for e in err: 
-               logger.error('  partition table name:  %s' % (e[0]))
+            for e in err:
+                logger.error('  partition table name:  %s' % (e[0]))
 
     except Exception, e:
         setError(ERROR_NOREPAIR)
@@ -580,10 +594,10 @@ def checkPartitionIntegrity():
             logger.info('[FAIL] partition with oids check')
             logger.error('partition with oids check found %d issue(s)' % len(err))
             logger.error(qry)
-            for e in err[0:100]: 
+            for e in err[0:100]:
                 row = e[2]
-                logger.error(" table %s.%s oid %s" % 
-                         (row['nspname'], row['relname'], row['oid']))
+                logger.error(" table %s.%s oid %s" %
+                             (row['nspname'], row['relname'], row['oid']))
             if len(err) > 100:
                 logger.error("...")
     except Exception, e:
@@ -592,7 +606,6 @@ def checkPartitionIntegrity():
         myprint('  Execution error: ' + str(e))
 
         # TODO: add repair script
-
 
     # MPP-11120: check for child partitions with different
     # distribution policies The complexity of this query is due to
@@ -695,9 +708,8 @@ def checkPartitionIntegrity():
                 if count == 0:
                     logger.error("--------")
                     logger.error("  " + " | ".join(map(str, col)))
-                    logger.error("  " + "-+-".join(['-'*len(x) for x in col]))
+                    logger.error("  " + "-+-".join(['-' * len(x) for x in col]))
 
-            
                 logger.error("  " + " | ".join([str(row[x]) for x in col]))
                 count += 1
 
@@ -706,8 +718,8 @@ def checkPartitionIntegrity():
         myprint('[ERROR] executing test: checkPartitionIntegrity')
         myprint('  Execution error: ' + str(e))
 
-
     db.close()
+
 
 #############
 # A dictionary of SQL statements for checkPartitionRegularity()
@@ -733,180 +745,180 @@ partitionRegularityChecks = {
     # condef:  specification of constraint (same on part and table)
     # numexpected:  number of constraint occurrences expected (incl table)
     # numactual:  number of constraint occurrences observed (incl table)
-    'irreg_user_constraint' :
-    """select 
-	    tableid,
-	    tableconname,
-	    contype,
-	    condef,
-	    numexpected,
-	    numactual
-	from
-	    (
-			select 
-				c.tableid, 
-				c.tableconname, 
-				c.contype, 
-				c.condef, 
-				i.tableparts + 1, 
-				count(c.partid), 
-				count(distinct c.partconname) 
-			from 
-				(
-					select
-						u.tableid,
-						u.conname, 
-						u.contype,
-						u.condef, 
-						p.partid, 
-						p.conid,
-						coalesce(p.conname) 
-					from
-						(
-							select
-								p.tableid,
-								c.conname,
-								c.contype,
-								pg_get_constraintdef(c.oid) as condef
-							from 
-								(
-									select 
-										parrelid::regclass,
-										max(parlevel)+1
-									from
-										pg_partition
-									group by parrelid
-								) as p(tableid, tabledepth) ,
-								pg_constraint c
-							where
-								p.tableid = c.conrelid
-						) as u(tableid, conname, contype, condef) 
-							join
-						(
-							select 
-								x.tableid::regclass as tableid,
-								c.conrelid::regclass as partid,
-								c.oid as conid,
-								c.conname,
-								c.contype,
-								pg_get_constraintdef(c.oid) as condef
-							from 
-								pg_constraint c,
-								(
-									select 
-										tableid,  
-										tabledepth,
-										tableid::regclass partid, 
-										0 as partdepth, 
-										0 as partordinal,
-										'r'::char as partstatus
-									from 
-										(
-											select 
-												parrelid::regclass,
-												max(parlevel)+1
-											from
-												pg_partition
-											group by parrelid
-										) as ptable(tableid, tabledepth) 
-									union all
-									select 
-										parrelid::regclass as tableid,  
-										t.tabledepth as tabledepth,
-										r.parchildrelid::regclass partid, 
-										p.parlevel + 1 as partdepth, 
-										r.parruleord as partordinal,
-										case
-											when t.tabledepth = p.parlevel + 1 then 'l'::char
-											else 'i'::char
-										end as partstatus
-									from 
-										pg_partition p, 
-										pg_partition_rule r,
-										 (
-											select 
-												parrelid::regclass,
-												max(parlevel)+1
-											from
-												pg_partition
-											group by parrelid
-										) as t(tableid, tabledepth) 
-									where 
-										p.oid = r.paroid
-										and not p.paristemplate
-										and p.parrelid = t.tableid
-								) as x(tableid, tabledepth, partid, partdepth, partordinal, partstatus) 
-							where
-								x.partid = c.conrelid
-						) as p(tableid, partid, conid, conname, contype, condef) 
-							on (
-								u.tableid = p.tableid and
-								u.contype = p.contype and
-								u.condef = p.condef
-								)
-				) as c(tableid, tableconname, contype, condef, partid, partconid, partconname) ,
-				(
-					select
-						t.tableid,
-						t.tabledepth,
-						n.nparts as tableparts,
-						r.nspname,
-						r.relname
-					from
-						(
-							select 
-								parrelid::regclass,
-								max(parlevel)+1
-							from
-								pg_partition
-							group by parrelid
-						) as t(tableid, tabledepth) ,
-						(
-							select 
-								c.oid::regclass as relid,
-								n.nspname,
-								c.relname, 
-								c.relkind
-							from
-								pg_class c,
-								pg_namespace n
-							where
-								c.relnamespace = n.oid
-						) as r(relid, nspname, relname, relkind) ,
-						(
-							select tableid, count(*) 
-							from (
-									select 
-										t.tableid::regclass,
-										p.parchildrelid::regclass as partid
-									from 
-										( 
-											select pg_partition.parrelid, pg_partition.oid
-											from pg_partition
-											where not pg_partition.paristemplate
-										) t(tableid, partid), 
-										pg_partition_rule p
-									where p.paroid = t.partid
-								) as contains_part(tableid, partid)  
-							group by tableid
-						) n(tableid, nparts)
-					where 
-						t.tableid = r.relid and
-						t.tableid = n.tableid 
-				) as i(tableid, tabledepth, tableparts, nspname, relname) 
-			where
-				c.tableid = i.tableid
-			group by 
-				c.tableid, 
-				c.tableconname, 
-				c.contype, 
-				c.condef,
-				i.tableparts
-		) as ptable_user_con_info(tableid, tableconname, contype, condef, numexpected, numactual, numnames) 
-	where
-	    contype != 'f' and -- no FK consistency in Rio
-	    numexpected != numactual""",
-    
+    'irreg_user_constraint':
+        """select
+            tableid,
+            tableconname,
+            contype,
+            condef,
+            numexpected,
+            numactual
+        from
+            (
+                select
+                    c.tableid,
+                    c.tableconname,
+                    c.contype,
+                    c.condef,
+                    i.tableparts + 1,
+                    count(c.partid),
+                    count(distinct c.partconname)
+                from
+                    (
+                        select
+                            u.tableid,
+                            u.conname,
+                            u.contype,
+                            u.condef,
+                            p.partid,
+                            p.conid,
+                            coalesce(p.conname)
+                        from
+                            (
+                                select
+                                    p.tableid,
+                                    c.conname,
+                                    c.contype,
+                                    pg_get_constraintdef(c.oid) as condef
+                                from
+                                    (
+                                        select
+                                            parrelid::regclass,
+                                            max(parlevel)+1
+                                        from
+                                            pg_partition
+                                        group by parrelid
+                                    ) as p(tableid, tabledepth) ,
+                                    pg_constraint c
+                                where
+                                    p.tableid = c.conrelid
+                            ) as u(tableid, conname, contype, condef)
+                                join
+                            (
+                                select
+                                    x.tableid::regclass as tableid,
+                                    c.conrelid::regclass as partid,
+                                    c.oid as conid,
+                                    c.conname,
+                                    c.contype,
+                                    pg_get_constraintdef(c.oid) as condef
+                                from
+                                    pg_constraint c,
+                                    (
+                                        select
+                                            tableid,
+                                            tabledepth,
+                                            tableid::regclass partid,
+                                            0 as partdepth,
+                                            0 as partordinal,
+                                            'r'::char as partstatus
+                                        from
+                                            (
+                                                select
+                                                    parrelid::regclass,
+                                                    max(parlevel)+1
+                                                from
+                                                    pg_partition
+                                                group by parrelid
+                                            ) as ptable(tableid, tabledepth)
+                                        union all
+                                        select
+                                            parrelid::regclass as tableid,
+                                            t.tabledepth as tabledepth,
+                                            r.parchildrelid::regclass partid,
+                                            p.parlevel + 1 as partdepth,
+                                            r.parruleord as partordinal,
+                                            case
+                                                when t.tabledepth = p.parlevel + 1 then 'l'::char
+                                                else 'i'::char
+                                            end as partstatus
+                                        from
+                                            pg_partition p,
+                                            pg_partition_rule r,
+                                             (
+                                                select
+                                                    parrelid::regclass,
+                                                    max(parlevel)+1
+                                                from
+                                                    pg_partition
+                                                group by parrelid
+                                            ) as t(tableid, tabledepth)
+                                        where
+                                            p.oid = r.paroid
+                                            and not p.paristemplate
+                                            and p.parrelid = t.tableid
+                                    ) as x(tableid, tabledepth, partid, partdepth, partordinal, partstatus)
+                                where
+                                    x.partid = c.conrelid
+                            ) as p(tableid, partid, conid, conname, contype, condef)
+                                on (
+                                    u.tableid = p.tableid and
+                                    u.contype = p.contype and
+                                    u.condef = p.condef
+                                    )
+                    ) as c(tableid, tableconname, contype, condef, partid, partconid, partconname) ,
+                    (
+                        select
+                            t.tableid,
+                            t.tabledepth,
+                            n.nparts as tableparts,
+                            r.nspname,
+                            r.relname
+                        from
+                            (
+                                select
+                                    parrelid::regclass,
+                                    max(parlevel)+1
+                                from
+                                    pg_partition
+                                group by parrelid
+                            ) as t(tableid, tabledepth) ,
+                            (
+                                select
+                                    c.oid::regclass as relid,
+                                    n.nspname,
+                                    c.relname,
+                                    c.relkind
+                                from
+                                    pg_class c,
+                                    pg_namespace n
+                                where
+                                    c.relnamespace = n.oid
+                            ) as r(relid, nspname, relname, relkind) ,
+                            (
+                                select tableid, count(*)
+                                from (
+                                        select
+                                            t.tableid::regclass,
+                                            p.parchildrelid::regclass as partid
+                                        from
+                                            (
+                                                select pg_partition.parrelid, pg_partition.oid
+                                                from pg_partition
+                                                where not pg_partition.paristemplate
+                                            ) t(tableid, partid),
+                                            pg_partition_rule p
+                                        where p.paroid = t.partid
+                                    ) as contains_part(tableid, partid)
+                                group by tableid
+                            ) n(tableid, nparts)
+                        where
+                            t.tableid = r.relid and
+                            t.tableid = n.tableid
+                    ) as i(tableid, tabledepth, tableparts, nspname, relname)
+                where
+                    c.tableid = i.tableid
+                group by
+                    c.tableid,
+                    c.tableconname,
+                    c.contype,
+                    c.condef,
+                    i.tableparts
+            ) as ptable_user_con_info(tableid, tableconname, contype, condef, numexpected, numactual, numnames)
+        where
+            contype != 'f' and -- no FK consistency in Rio
+            numexpected != numactual""",
+
     # Query: irreg_sys_constraint
     # 
     #     A row represents an irregular system-defined constraint.
@@ -926,27 +938,26 @@ partitionRegularityChecks = {
     # partid:  pg_class.oid of the (constrained) part table
     # expected:  number of constraint occurrences expected
     # actual:  number of constraint occurrences observed
-    'irreg_sys_constraint' :
-    """select 
-		coalesce(x.partid, a.partid) as partid,
-		x.tableid, 
-		x.expected, 
-		coalesce(a.actual, 0) as actual                                                                                                                                                                                                                                                                                                                                             
-	from
-		(
-		{expected}
-		) x
-		  full join 
-		(
-		{actual}
-		) a                                                                                                                                                                                                                                                                                                                                      
-		  on (x.partid = a.partid) 
-	where 
-		x.expected != a.actual or 
-		x.expected is null or
-		x.expected != coalesce(a.actual,0);""",
-        
-    
+    'irreg_sys_constraint':
+        """select
+            coalesce(x.partid, a.partid) as partid,
+            x.tableid,
+            x.expected,
+            coalesce(a.actual, 0) as actual
+        from
+            (
+            {expected}
+            ) x
+              full join
+            (
+            {actual}
+            ) a
+              on (x.partid = a.partid)
+        where
+            x.expected != a.actual or
+            x.expected is null or
+            x.expected != coalesce(a.actual,0);""",
+
     # Query based on view: unenforced_constraint_info
     # 
     #     a row represents an unenforced unique constraint to be fixed.
@@ -959,230 +970,230 @@ partitionRegularityChecks = {
     # contype
     # conname
     # refobjid
-    
-    'unenforced_constraint_info' :
-    """select
-        c.tableid,
-        c.partid,
-        b.indexid,
-        c.partid::int as partoid,
-        b.indexid::int as indexoid,
-        b.contype,
-        b.conname,
-        b.refobjid
-    from 
-        (
-            select
-                k.tableid,
-                k.distkey,
-                k.partkey,
-                c.conid,
-                c.conname,
-                c.contype,
-                i.indrelid::regclass,
-                i.indkey::smallint[]
-            from 
-                pg_index i, 
-                (
-                    select 
-                        k.tableid, 
-                        d.attrcnt,
-                        d.attrnums,
-                        sum(k.partkeylen),
-                        array_agg(k.partkey[g.g])  
-                    from 
-                        (
-                            select
-                                p.parrelid::regclass,
-                                t.tabledepth,
-                                p.parlevel,
-                                p.parnatts,
-                                p.paratts
-                            from 
-                                pg_partition p,
-                                (
-                                    select 
-                                        parrelid::regclass,
-                                        max(parlevel)+1
-                                    from
-                                        pg_partition
-                                    group by parrelid
-                                ) as t(tableid, tabledepth) 
-                            where 
-                                p.parrelid = t.tableid and
-                                p.paristemplate is false
-                        ) as k(tableid, tabledepth, partdepth, partkeylen, partkey) , 
-                        generate_series(0, (select max(partkeylen) from (
-                            select
-                                p.parrelid::regclass,
-                                t.tabledepth,
-                                p.parlevel,
-                                p.parnatts,
-                                p.paratts
-                            from 
-                                pg_partition p,
-                                (
-                                    select 
-                                        parrelid::regclass,
-                                        max(parlevel)+1
-                                    from
-                                        pg_partition
-                                    group by parrelid
-                                ) as t(tableid, tabledepth) 
-                            where 
-                                p.parrelid = t.tableid and
-                                p.paristemplate is false
-                        ) as partition_level(tableid, tabledepth, partdepth, partkeylen, partkey) )-1) g(g),
-                        (
-                            select 
-                                localoid::regclass, 
-                                attrnums,
-                                coalesce(1+array_upper(attrnums,1)-array_lower(attrnums,1),0)
-                            from 
-                                gp_distribution_policy
-                        ) as d(relid, attrnums, attrcnt) 
-                    where 
-                        g.g < k.partkeylen and
-                        k.tableid = d.relid
-                    group by 
-                        k.tableid,
-                        d.attrcnt,
-                        d.attrnums 
-                ) as k(tableid, distkeylen, distkey, partkeylen, partkey) ,
-                (
-                    select
-                        relid,
-                        conid,
-                        conname,
-                        contype,
-                        indexid        
-                    from 
-                        (
-                            select  
-                                r.oid::regclass as relid, 
-                                c.oid as conid,
-                                c.conname,
-                                c.contype,
-                                c.consrc,
-                                pg_get_constraintdef(c.oid) as condef,
-                                d.objid::regclass as indexid
-                            from 
-                                (
-                                    pg_class r
-                                        join
-                                        pg_constraint c
-                                        on 
-                                            r.oid = c.conrelid
-                                            and r.relkind = 'r'
-                                )
-                                    left join
-                                    pg_depend d
-                                    on 
-                                        d.refobjid = c.oid
-                                        and d.classid = 'pg_class'::regclass
-                                        and d.refclassid = 'pg_constraint'::regclass
-                                        and d.deptype = 'i'
-                            ) as relconstraint(relid, conid, conname, contype, consrc, condef, indexid) 
-                    where 
-                        indexid is not null
-                        or contype in ('p', 'u') 
-                ) as c(relid, conid, conname, contype, indexid) 
-            where 
-                c.relid = k.tableid and
-                i.indrelid = k.tableid and
-                i.indexrelid = c.indexid and 
-                not i.indkey::smallint[] @> array_cat(k.distkey, k.partkey)
-        ) as x(tableid, distkey, partkey, conid, conname, contype, indrelid, indkey) , 
-        (
-            select 
-                tableid,  
-                tabledepth,
-                tableid::regclass partid, 
-                0 as partdepth, 
-                0 as partordinal,
-                'r'::char as partstatus
-            from 
-                (
-                    select 
-                        parrelid::regclass,
-                        max(parlevel)+1
-                    from
-                        pg_partition
-                    group by parrelid
-                ) as ptable(tableid, tabledepth) 
-            union all
-            select 
-                parrelid::regclass as tableid,  
-                t.tabledepth as tabledepth,
-                r.parchildrelid::regclass partid, 
-                p.parlevel + 1 as partdepth, 
-                r.parruleord as partordinal,
-                case
-                    when t.tabledepth = p.parlevel + 1 then 'l'::char
-                    else 'i'::char
-                end as partstatus
-            from 
-                pg_partition p, 
-                pg_partition_rule r,
-                 (
-                    select 
-                        parrelid::regclass,
-                        max(parlevel)+1
-                    from
-                        pg_partition
-                    group by parrelid
-                ) as t(tableid, tabledepth) 
-            where 
-                p.oid = r.paroid
-                and not p.paristemplate
-                and p.parrelid = t.tableid
-        ) as c(tableid, tabledepth, partid, partdepth, partordinal, partstatus) ,
-        (
-            select
-                r.oid::regclass as relid,
-                i.oid::regclass as indexid,
-                c.oid as conid,
-                c.contype,
-                c.conname,
-                pg_get_constraintdef(c.oid) as condef,
-                d.classid,
-                d.objid,
-                d.objsubid,
-                d.refclassid,
-                d.refobjid,
-                d.refobjsubid,
-                d.deptype
-            from 
-                pg_constraint c,
-                pg_class i, 
-                pg_depend d,
-                pg_index x, 
-                pg_class r
-            where
-                d.classid = 'pg_class'::regclass and
-                d.objid = i.oid and
-                d.objsubid = 0 and
-                d.refclassid = 'pg_constraint'::regclass and
-                d.refobjid = c.oid and
-                d.refobjsubid = 0 and
-                d.deptype = 'i' and
-                i.relkind = 'i' and
-                i.oid = x.indexrelid and
-                r.oid = x.indrelid
-        ) as b(relid, indexid, conid, contype, conname, condef, classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)  
-    where 
-        x.tableid = c.tableid and
-        c.partid = b.relid and
-        b.classid = 'pg_class'::regclass and
-        b.objsubid = 0 and
-        b.refclassid = 'pg_constraint'::regclass and
-        b.refobjsubid = 0 and
-        b.deptype = 'i'""",
-        
-        # Repair sequence for issues identified by unenforced_constraint_info.
-        # Must substitute values from a row of that query, before running.
-        
-        'unenforced_constraint_repairs' :
+
+    'unenforced_constraint_info':
+        """select
+            c.tableid,
+            c.partid,
+            b.indexid,
+            c.partid::int as partoid,
+            b.indexid::int as indexoid,
+            b.contype,
+            b.conname,
+            b.refobjid
+        from
+            (
+                select
+                    k.tableid,
+                    k.distkey,
+                    k.partkey,
+                    c.conid,
+                    c.conname,
+                    c.contype,
+                    i.indrelid::regclass,
+                    i.indkey::smallint[]
+                from
+                    pg_index i,
+                    (
+                        select
+                            k.tableid,
+                            d.attrcnt,
+                            d.attrnums,
+                            sum(k.partkeylen),
+                            array_agg(k.partkey[g.g])
+                        from
+                            (
+                                select
+                                    p.parrelid::regclass,
+                                    t.tabledepth,
+                                    p.parlevel,
+                                    p.parnatts,
+                                    p.paratts
+                                from
+                                    pg_partition p,
+                                    (
+                                        select
+                                            parrelid::regclass,
+                                            max(parlevel)+1
+                                        from
+                                            pg_partition
+                                        group by parrelid
+                                    ) as t(tableid, tabledepth)
+                                where
+                                    p.parrelid = t.tableid and
+                                    p.paristemplate is false
+                            ) as k(tableid, tabledepth, partdepth, partkeylen, partkey) ,
+                            generate_series(0, (select max(partkeylen) from (
+                                select
+                                    p.parrelid::regclass,
+                                    t.tabledepth,
+                                    p.parlevel,
+                                    p.parnatts,
+                                    p.paratts
+                                from
+                                    pg_partition p,
+                                    (
+                                        select
+                                            parrelid::regclass,
+                                            max(parlevel)+1
+                                        from
+                                            pg_partition
+                                        group by parrelid
+                                    ) as t(tableid, tabledepth)
+                                where
+                                    p.parrelid = t.tableid and
+                                    p.paristemplate is false
+                            ) as partition_level(tableid, tabledepth, partdepth, partkeylen, partkey) )-1) g(g),
+                            (
+                                select
+                                    localoid::regclass,
+                                    attrnums,
+                                    coalesce(1+array_upper(attrnums,1)-array_lower(attrnums,1),0)
+                                from
+                                    gp_distribution_policy
+                            ) as d(relid, attrnums, attrcnt)
+                        where
+                            g.g < k.partkeylen and
+                            k.tableid = d.relid
+                        group by
+                            k.tableid,
+                            d.attrcnt,
+                            d.attrnums
+                    ) as k(tableid, distkeylen, distkey, partkeylen, partkey) ,
+                    (
+                        select
+                            relid,
+                            conid,
+                            conname,
+                            contype,
+                            indexid
+                        from
+                            (
+                                select
+                                    r.oid::regclass as relid,
+                                    c.oid as conid,
+                                    c.conname,
+                                    c.contype,
+                                    c.consrc,
+                                    pg_get_constraintdef(c.oid) as condef,
+                                    d.objid::regclass as indexid
+                                from
+                                    (
+                                        pg_class r
+                                            join
+                                            pg_constraint c
+                                            on
+                                                r.oid = c.conrelid
+                                                and r.relkind = 'r'
+                                    )
+                                        left join
+                                        pg_depend d
+                                        on
+                                            d.refobjid = c.oid
+                                            and d.classid = 'pg_class'::regclass
+                                            and d.refclassid = 'pg_constraint'::regclass
+                                            and d.deptype = 'i'
+                                ) as relconstraint(relid, conid, conname, contype, consrc, condef, indexid)
+                        where
+                            indexid is not null
+                            or contype in ('p', 'u')
+                    ) as c(relid, conid, conname, contype, indexid)
+                where
+                    c.relid = k.tableid and
+                    i.indrelid = k.tableid and
+                    i.indexrelid = c.indexid and
+                    not i.indkey::smallint[] @> array_cat(k.distkey, k.partkey)
+            ) as x(tableid, distkey, partkey, conid, conname, contype, indrelid, indkey) ,
+            (
+                select
+                    tableid,
+                    tabledepth,
+                    tableid::regclass partid,
+                    0 as partdepth,
+                    0 as partordinal,
+                    'r'::char as partstatus
+                from
+                    (
+                        select
+                            parrelid::regclass,
+                            max(parlevel)+1
+                        from
+                            pg_partition
+                        group by parrelid
+                    ) as ptable(tableid, tabledepth)
+                union all
+                select
+                    parrelid::regclass as tableid,
+                    t.tabledepth as tabledepth,
+                    r.parchildrelid::regclass partid,
+                    p.parlevel + 1 as partdepth,
+                    r.parruleord as partordinal,
+                    case
+                        when t.tabledepth = p.parlevel + 1 then 'l'::char
+                        else 'i'::char
+                    end as partstatus
+                from
+                    pg_partition p,
+                    pg_partition_rule r,
+                     (
+                        select
+                            parrelid::regclass,
+                            max(parlevel)+1
+                        from
+                            pg_partition
+                        group by parrelid
+                    ) as t(tableid, tabledepth)
+                where
+                    p.oid = r.paroid
+                    and not p.paristemplate
+                    and p.parrelid = t.tableid
+            ) as c(tableid, tabledepth, partid, partdepth, partordinal, partstatus) ,
+            (
+                select
+                    r.oid::regclass as relid,
+                    i.oid::regclass as indexid,
+                    c.oid as conid,
+                    c.contype,
+                    c.conname,
+                    pg_get_constraintdef(c.oid) as condef,
+                    d.classid,
+                    d.objid,
+                    d.objsubid,
+                    d.refclassid,
+                    d.refobjid,
+                    d.refobjsubid,
+                    d.deptype
+                from
+                    pg_constraint c,
+                    pg_class i,
+                    pg_depend d,
+                    pg_index x,
+                    pg_class r
+                where
+                    d.classid = 'pg_class'::regclass and
+                    d.objid = i.oid and
+                    d.objsubid = 0 and
+                    d.refclassid = 'pg_constraint'::regclass and
+                    d.refobjid = c.oid and
+                    d.refobjsubid = 0 and
+                    d.deptype = 'i' and
+                    i.relkind = 'i' and
+                    i.oid = x.indexrelid and
+                    r.oid = x.indrelid
+            ) as b(relid, indexid, conid, contype, conname, condef, classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+        where
+            x.tableid = c.tableid and
+            c.partid = b.relid and
+            b.classid = 'pg_class'::regclass and
+            b.objsubid = 0 and
+            b.refclassid = 'pg_constraint'::regclass and
+            b.refobjsubid = 0 and
+            b.deptype = 'i'""",
+
+    # Repair sequence for issues identified by unenforced_constraint_info.
+    # Must substitute values from a row of that query, before running.
+
+    'unenforced_constraint_repairs':
         """--Demote type-{contype} constraint {conname} on part {partid}
 --of partitioned table {tableid} to simple unique index.
 
@@ -1254,7 +1265,7 @@ where
     conname = {quoted_conname} and
     contypid = 0 and
     contype = {quoted_contype};""",
-    
+
     # Query: fix_ill_named_constraint
     # 
     #     a row represents the data for a fixup of an ill-named constraint
@@ -1265,348 +1276,349 @@ where
     # partrelid:  pg_class.oid of the part table as int
     # partconname:  pg_constraint.conname on the part or partitioned table
 
-    'fix_ill_named_constraint' :
-    """select 
-        tableid, 
-        tableconname, 
-        partid, 
-        partid::int as partrelid, 
-        partconname
-    from (
-			select
-				u.tableid,
-				u.conname, 
-				u.contype,
-				u.condef, 
-				p.partid, 
-				p.conid,
-				coalesce(p.conname) 
-			from
-				(
-					select
-						p.tableid,
-						c.conname,
-						c.contype,
-						pg_get_constraintdef(c.oid) as condef
-					from 
-						(
-							select 
-								parrelid::regclass,
-								max(parlevel)+1
-							from
-								pg_partition
-							group by parrelid
-						) as p(tableid, tabledepth) ,
-						pg_constraint c
-					where
-						p.tableid = c.conrelid
-				) as u(tableid, conname, contype, condef) 
-					join
-				(
-					select 
-						x.tableid::regclass as tableid,
-						c.conrelid::regclass as partid,
-						c.oid as conid,
-						c.conname,
-						c.contype,
-						pg_get_constraintdef(c.oid) as condef
-					from 
-						pg_constraint c,
-						(
-							select 
-								tableid,  
-								tabledepth,
-								tableid::regclass partid, 
-								0 as partdepth, 
-								0 as partordinal,
-								'r'::char as partstatus
-							from 
-								(
-									select 
-										parrelid::regclass,
-										max(parlevel)+1
-									from
-										pg_partition
-									group by parrelid
-								) as ptable(tableid, tabledepth) 
-							union all
-							select 
-								parrelid::regclass as tableid,  
-								t.tabledepth as tabledepth,
-								r.parchildrelid::regclass partid, 
-								p.parlevel + 1 as partdepth, 
-								r.parruleord as partordinal,
-								case
-									when t.tabledepth = p.parlevel + 1 then 'l'::char
-									else 'i'::char
-								end as partstatus
-							from 
-								pg_partition p, 
-								pg_partition_rule r,
-								 (
-									select 
-										parrelid::regclass,
-										max(parlevel)+1
-									from
-										pg_partition
-									group by parrelid
-								) as t(tableid, tabledepth) 
-							where 
-								p.oid = r.paroid
-								and not p.paristemplate
-								and p.parrelid = t.tableid
-						) as x(tableid, tabledepth, partid, partdepth, partordinal, partstatus) 
-					where
-						x.partid = c.conrelid
-				) as p(tableid, partid, conid, conname, contype, condef) 
-					on (
-						u.tableid = p.tableid and
-						u.contype = p.contype and
-						u.condef = p.condef
-						)
-		) as part_user_constraint(tableid, tableconname, contype, condef, partid, partconid, partconname) 
-    where partconname != tableconname""",
-    
+    'fix_ill_named_constraint':
+        """select
+            tableid,
+            tableconname,
+            partid,
+            partid::int as partrelid,
+            partconname
+        from (
+                select
+                    u.tableid,
+                    u.conname,
+                    u.contype,
+                    u.condef,
+                    p.partid,
+                    p.conid,
+                    coalesce(p.conname)
+                from
+                    (
+                        select
+                            p.tableid,
+                            c.conname,
+                            c.contype,
+                            pg_get_constraintdef(c.oid) as condef
+                        from
+                            (
+                                select
+                                    parrelid::regclass,
+                                    max(parlevel)+1
+                                from
+                                    pg_partition
+                                group by parrelid
+                            ) as p(tableid, tabledepth) ,
+                            pg_constraint c
+                        where
+                            p.tableid = c.conrelid
+                    ) as u(tableid, conname, contype, condef)
+                        join
+                    (
+                        select
+                            x.tableid::regclass as tableid,
+                            c.conrelid::regclass as partid,
+                            c.oid as conid,
+                            c.conname,
+                            c.contype,
+                            pg_get_constraintdef(c.oid) as condef
+                        from
+                            pg_constraint c,
+                            (
+                                select
+                                    tableid,
+                                    tabledepth,
+                                    tableid::regclass partid,
+                                    0 as partdepth,
+                                    0 as partordinal,
+                                    'r'::char as partstatus
+                                from
+                                    (
+                                        select
+                                            parrelid::regclass,
+                                            max(parlevel)+1
+                                        from
+                                            pg_partition
+                                        group by parrelid
+                                    ) as ptable(tableid, tabledepth)
+                                union all
+                                select
+                                    parrelid::regclass as tableid,
+                                    t.tabledepth as tabledepth,
+                                    r.parchildrelid::regclass partid,
+                                    p.parlevel + 1 as partdepth,
+                                    r.parruleord as partordinal,
+                                    case
+                                        when t.tabledepth = p.parlevel + 1 then 'l'::char
+                                        else 'i'::char
+                                    end as partstatus
+                                from
+                                    pg_partition p,
+                                    pg_partition_rule r,
+                                     (
+                                        select
+                                            parrelid::regclass,
+                                            max(parlevel)+1
+                                        from
+                                            pg_partition
+                                        group by parrelid
+                                    ) as t(tableid, tabledepth)
+                                where
+                                    p.oid = r.paroid
+                                    and not p.paristemplate
+                                    and p.parrelid = t.tableid
+                            ) as x(tableid, tabledepth, partid, partdepth, partordinal, partstatus)
+                        where
+                            x.partid = c.conrelid
+                    ) as p(tableid, partid, conid, conname, contype, condef)
+                        on (
+                            u.tableid = p.tableid and
+                            u.contype = p.contype and
+                            u.condef = p.condef
+                            )
+            ) as part_user_constraint(tableid, tableconname, contype, condef, partid, partconid, partconname)
+        where partconname != tableconname""",
+
     # Query based on view: part_sys_actual
-	# tableid
-	# partid
-	# actual observed number of system-constraints
+    # tableid
+    # partid
+    # actual observed number of system-constraints
 
-    "actual_part_con_query" :
-    """select 
-		tableid, 
-		partid, 
-		count(*) as actual  
-	from (
-			select 
-				tableid,
-				partid,
-				conid,
-				conname,
-				contype,
-				condef 
-			from (
-					select 
-						x.tableid::regclass as tableid,
-						c.conrelid::regclass as partid,
-						c.oid as conid,
-						c.conname,
-						c.contype,
-						pg_get_constraintdef(c.oid) as condef
-					from 
-						pg_constraint c,
-						(
-							select 
-								tableid,  
-								tabledepth,
-								tableid::regclass partid, 
-								0 as partdepth, 
-								0 as partordinal,
-								'r'::char as partstatus
-							from 
-								(
-									select 
-										parrelid::regclass,
-										max(parlevel)+1
-									from
-										pg_partition
-									group by parrelid
-								) as ptable(tableid, tabledepth) 
-							union all
-							select 
-								parrelid::regclass as tableid,  
-								t.tabledepth as tabledepth,
-								r.parchildrelid::regclass partid, 
-								p.parlevel + 1 as partdepth, 
-								r.parruleord as partordinal,
-								case
-									when t.tabledepth = p.parlevel + 1 then 'l'::char
-									else 'i'::char
-								end as partstatus
-							from 
-								pg_partition p, 
-								pg_partition_rule r,
-								 (
-									select 
-										parrelid::regclass,
-										max(parlevel)+1
-									from
-										pg_partition
-									group by parrelid
-								) as t(tableid, tabledepth) 
-							where 
-								p.oid = r.paroid
-								and not p.paristemplate
-								and p.parrelid = t.tableid
-						) as x(tableid, tabledepth, partid, partdepth, partordinal, partstatus) 
-					where
-						x.partid = c.conrelid
-				) as part_constraint(tableid, partid, conid, conname, contype, condef)  
-			where 
-				(partid, condef) not in 
-					(
-						select partid, condef 
-						from (
-							select
-								u.tableid,
-								u.conname, 
-								u.contype,
-								u.condef, 
-								p.partid, 
-								p.conid,
-								coalesce(p.conname) 
-							from
-								(
-									select
-										p.tableid,
-										c.conname,
-										c.contype,
-										pg_get_constraintdef(c.oid) as condef
-									from 
-										(
-											select 
-												parrelid::regclass,
-												max(parlevel)+1
-											from
-												pg_partition
-											group by parrelid
-										) as p(tableid, tabledepth) ,
-										pg_constraint c
-									where
-										p.tableid = c.conrelid
-								) as u(tableid, conname, contype, condef) 
-									join
-								(
-									select 
-										x.tableid::regclass as tableid,
-										c.conrelid::regclass as partid,
-										c.oid as conid,
-										c.conname,
-										c.contype,
-										pg_get_constraintdef(c.oid) as condef
-									from 
-										pg_constraint c,
-										(
-											select 
-												tableid,  
-												tabledepth,
-												tableid::regclass partid, 
-												0 as partdepth, 
-												0 as partordinal,
-												'r'::char as partstatus
-											from 
-												(
-													select 
-														parrelid::regclass,
-														max(parlevel)+1
-													from
-														pg_partition
-													group by parrelid
-												) as ptable(tableid, tabledepth) 
-											union all
-											select 
-												parrelid::regclass as tableid,  
-												t.tabledepth as tabledepth,
-												r.parchildrelid::regclass partid, 
-												p.parlevel + 1 as partdepth, 
-												r.parruleord as partordinal,
-												case
-													when t.tabledepth = p.parlevel + 1 then 'l'::char
-													else 'i'::char
-												end as partstatus
-											from 
-												pg_partition p, 
-												pg_partition_rule r,
-												 (
-													select 
-														parrelid::regclass,
-														max(parlevel)+1
-													from
-														pg_partition
-													group by parrelid
-												) as t(tableid, tabledepth) 
-											where 
-												p.oid = r.paroid
-												and not p.paristemplate
-												and p.parrelid = t.tableid
-										) as x(tableid, tabledepth, partid, partdepth, partordinal, partstatus) 
-									where
-										x.partid = c.conrelid
-								) as p(tableid, partid, conid, conname, contype, condef) 
-									on (
-										u.tableid = p.tableid and
-										u.contype = p.contype and
-										u.condef = p.condef
-										)
-						) as part_user_constraint(tableid, tableconname, contype, condef, partid, partconid, partconname) 
-					)  
-		) as part_sys_constraint(tableid, partid, conid, conname, contype, condef)  
-	group by tableid, partid""",
-	
-	# Query contains_directly has a row per step along a path from
-	# root to leaf.  The columns are
-	# tableid - pg_class.oid of the partitioned table.
-	# parentid - pg_class.oid of the "from" table.
-	# childid - pg_class.oid of the "to" table, the target of the step.
-	# npcon - constraint count for this step: 0 if "to" is default, else 1.
-	#    
-	 
-	'contains_directly' :
-	"""(
-		select
-			r.parrelid::regclass as tableid,
-			coalesce(p.parchildrelid, r.parrelid)::regclass as parentid,
-			c.parchildrelid::regclass as childid,
-			case when c.parisdefault then 0 else 1 end as npcon
-		from
-			pg_partition r,
-			pg_partition_rule c
-				left join pg_partition_rule p on (c.parparentrule = p.oid)
-		where
-			not r.paristemplate and
-			not c.parchildrelid = 0 and
-			c.paroid = r.oid 
-		) {alias}""",
-	
-	# The base case is the length 1 path from root or branch to branch 
-	# or leaf. This is always the first union term.
-	
-	'base_query' :
-	"""select
-		start.tableid,
-		start.parentid,
-		start.childid,
-		start.npcon
-	from 
-		{contains_directly_start}""",
-	
-	# A union term is an N-way self join of contains_directly and
-	# identifies paths of length N.  Note that the length of a path
-	# to a part at depth N+1 is N. 
-	 
-	'union_term' :
-	"""select
-		start.tableid,
-		start.parentid,
-		stop.childid,
-		start.npcon -- stop.npcon
-	from
-		{contains_directly_start},
-		{contains_directly_stop}{intermediate_path_from}
-	where
-		start.childid {intermediate_path_where}
-		= stop.parentid""",
-	
-	#
-	
-	'union_query' :
-	"""select tableid, childid as partid, sum(npcon) as expected
-	from (
-		{open_union}
-		) r
-	group by tableid, childid"""
+    "actual_part_con_query":
+        """select
+            tableid,
+            partid,
+            count(*) as actual
+        from (
+                select
+                    tableid,
+                    partid,
+                    conid,
+                    conname,
+                    contype,
+                    condef
+                from (
+                        select
+                            x.tableid::regclass as tableid,
+                            c.conrelid::regclass as partid,
+                            c.oid as conid,
+                            c.conname,
+                            c.contype,
+                            pg_get_constraintdef(c.oid) as condef
+                        from
+                            pg_constraint c,
+                            (
+                                select
+                                    tableid,
+                                    tabledepth,
+                                    tableid::regclass partid,
+                                    0 as partdepth,
+                                    0 as partordinal,
+                                    'r'::char as partstatus
+                                from
+                                    (
+                                        select
+                                            parrelid::regclass,
+                                            max(parlevel)+1
+                                        from
+                                            pg_partition
+                                        group by parrelid
+                                    ) as ptable(tableid, tabledepth)
+                                union all
+                                select
+                                    parrelid::regclass as tableid,
+                                    t.tabledepth as tabledepth,
+                                    r.parchildrelid::regclass partid,
+                                    p.parlevel + 1 as partdepth,
+                                    r.parruleord as partordinal,
+                                    case
+                                        when t.tabledepth = p.parlevel + 1 then 'l'::char
+                                        else 'i'::char
+                                    end as partstatus
+                                from
+                                    pg_partition p,
+                                    pg_partition_rule r,
+                                     (
+                                        select
+                                            parrelid::regclass,
+                                            max(parlevel)+1
+                                        from
+                                            pg_partition
+                                        group by parrelid
+                                    ) as t(tableid, tabledepth)
+                                where
+                                    p.oid = r.paroid
+                                    and not p.paristemplate
+                                    and p.parrelid = t.tableid
+                            ) as x(tableid, tabledepth, partid, partdepth, partordinal, partstatus)
+                        where
+                            x.partid = c.conrelid
+                    ) as part_constraint(tableid, partid, conid, conname, contype, condef)
+                where
+                    (partid, condef) not in
+                        (
+                            select partid, condef
+                            from (
+                                select
+                                    u.tableid,
+                                    u.conname,
+                                    u.contype,
+                                    u.condef,
+                                    p.partid,
+                                    p.conid,
+                                    coalesce(p.conname)
+                                from
+                                    (
+                                        select
+                                            p.tableid,
+                                            c.conname,
+                                            c.contype,
+                                            pg_get_constraintdef(c.oid) as condef
+                                        from
+                                            (
+                                                select
+                                                    parrelid::regclass,
+                                                    max(parlevel)+1
+                                                from
+                                                    pg_partition
+                                                group by parrelid
+                                            ) as p(tableid, tabledepth) ,
+                                            pg_constraint c
+                                        where
+                                            p.tableid = c.conrelid
+                                    ) as u(tableid, conname, contype, condef)
+                                        join
+                                    (
+                                        select
+                                            x.tableid::regclass as tableid,
+                                            c.conrelid::regclass as partid,
+                                            c.oid as conid,
+                                            c.conname,
+                                            c.contype,
+                                            pg_get_constraintdef(c.oid) as condef
+                                        from
+                                            pg_constraint c,
+                                            (
+                                                select
+                                                    tableid,
+                                                    tabledepth,
+                                                    tableid::regclass partid,
+                                                    0 as partdepth,
+                                                    0 as partordinal,
+                                                    'r'::char as partstatus
+                                                from
+                                                    (
+                                                        select
+                                                            parrelid::regclass,
+                                                            max(parlevel)+1
+                                                        from
+                                                            pg_partition
+                                                        group by parrelid
+                                                    ) as ptable(tableid, tabledepth)
+                                                union all
+                                                select
+                                                    parrelid::regclass as tableid,
+                                                    t.tabledepth as tabledepth,
+                                                    r.parchildrelid::regclass partid,
+                                                    p.parlevel + 1 as partdepth,
+                                                    r.parruleord as partordinal,
+                                                    case
+                                                        when t.tabledepth = p.parlevel + 1 then 'l'::char
+                                                        else 'i'::char
+                                                    end as partstatus
+                                                from
+                                                    pg_partition p,
+                                                    pg_partition_rule r,
+                                                     (
+                                                        select
+                                                            parrelid::regclass,
+                                                            max(parlevel)+1
+                                                        from
+                                                            pg_partition
+                                                        group by parrelid
+                                                    ) as t(tableid, tabledepth)
+                                                where
+                                                    p.oid = r.paroid
+                                                    and not p.paristemplate
+                                                    and p.parrelid = t.tableid
+                                            ) as x(tableid, tabledepth, partid, partdepth, partordinal, partstatus)
+                                        where
+                                            x.partid = c.conrelid
+                                    ) as p(tableid, partid, conid, conname, contype, condef)
+                                        on (
+                                            u.tableid = p.tableid and
+                                            u.contype = p.contype and
+                                            u.condef = p.condef
+                                            )
+                            ) as part_user_constraint(tableid, tableconname, contype, condef, partid, partconid, partconname)
+                        )
+            ) as part_sys_constraint(tableid, partid, conid, conname, contype, condef)
+        group by tableid, partid""",
 
-    }
+    # Query contains_directly has a row per step along a path from
+    # root to leaf.  The columns are
+    # tableid - pg_class.oid of the partitioned table.
+    # parentid - pg_class.oid of the "from" table.
+    # childid - pg_class.oid of the "to" table, the target of the step.
+    # npcon - constraint count for this step: 0 if "to" is default, else 1.
+    #
+
+    'contains_directly':
+        """(
+            select
+                r.parrelid::regclass as tableid,
+                coalesce(p.parchildrelid, r.parrelid)::regclass as parentid,
+                c.parchildrelid::regclass as childid,
+                case when c.parisdefault then 0 else 1 end as npcon
+            from
+                pg_partition r,
+                pg_partition_rule c
+                    left join pg_partition_rule p on (c.parparentrule = p.oid)
+            where
+                not r.paristemplate and
+                not c.parchildrelid = 0 and
+                c.paroid = r.oid
+            ) {alias}""",
+
+    # The base case is the length 1 path from root or branch to branch
+    # or leaf. This is always the first union term.
+
+    'base_query':
+        """select
+            start.tableid,
+            start.parentid,
+            start.childid,
+            start.npcon
+        from
+            {contains_directly_start}""",
+
+    # A union term is an N-way self join of contains_directly and
+    # identifies paths of length N.  Note that the length of a path
+    # to a part at depth N+1 is N.
+
+    'union_term':
+        """select
+            start.tableid,
+            start.parentid,
+            stop.childid,
+            start.npcon -- stop.npcon
+        from
+            {contains_directly_start},
+            {contains_directly_stop}{intermediate_path_from}
+        where
+            start.childid {intermediate_path_where}
+            = stop.parentid""",
+
+    #
+
+    'union_query':
+        """select tableid, childid as partid, sum(npcon) as expected
+        from (
+            {open_union}
+            ) r
+        group by tableid, childid"""
+
+}
+
 
 #############
 
@@ -1616,45 +1628,47 @@ def make_union_term(depth):
 
     union_term = partitionRegularityChecks['union_term']
     contains_directly = partitionRegularityChecks['contains_directly']
-    
+
     path_from = []
     path_where = []
-    
-    if depth > 1: # for later .join()
+
+    if depth > 1:  # for later .join()
         path_from.append('')
         path_where.append('')
-    
+
     for i in range(1, depth):
         path_alias = "path%d" % i
-        path_from.append(contains_directly.format(alias = path_alias))
-        path_where.append("    = %s.parentid and %s.childid" 
-            % (path_alias, path_alias) )
-    
+        path_from.append(contains_directly.format(alias=path_alias))
+        path_where.append("    = %s.parentid and %s.childid"
+                          % (path_alias, path_alias))
+
     return union_term.format(
-        contains_directly_start = contains_directly.format(alias = 'start'),
-        contains_directly_stop = contains_directly.format(alias = 'stop'),
-        intermediate_path_from = ",\n    ".join(path_from),
-        intermediate_path_where = "\n".join(path_where)
-        )
-    
+        contains_directly_start=contains_directly.format(alias='start'),
+        contains_directly_stop=contains_directly.format(alias='stop'),
+        intermediate_path_from=",\n    ".join(path_from),
+        intermediate_path_where="\n".join(path_where)
+    )
+
+
 # For partitionRegularityChecks.
 def expected_part_con_query(maxdepth):
-    cds = partitionRegularityChecks['contains_directly'].format(alias = 'start')
+    cds = partitionRegularityChecks['contains_directly'].format(alias='start')
     base_query = partitionRegularityChecks['base_query']
     terms = [base_query.format(contains_directly_start=cds)]
-    
-    for depth in range(1, maxdepth+1):
+
+    for depth in range(1, maxdepth + 1):
         terms.append(make_union_term(depth))
-    
+
     return partitionRegularityChecks['union_query'].format(
-        open_union = '\n\nunion all\n\n'.join(terms))
+        open_union='\n\nunion all\n\n'.join(terms))
+
 
 # For partitionRegularityChecks.
 def make_irregular_sys_con_query(maxdepth):
     expected = expected_part_con_query(maxdepth)
     actual = partitionRegularityChecks['actual_part_con_query']
     qry = partitionRegularityChecks['irreg_sys_constraint']
-    return qry.format(expected = expected, actual = actual)
+    return qry.format(expected=expected, actual=actual)
 
 
 #############
@@ -1668,24 +1682,24 @@ def checkPartitionRegularity():
 
     logger.info('-----------------------------------')
     logger.info('Checking pg_partition/pg_constraint regularity ...')
-    
+
     if not okayToRun:
         logger.warn('unable to run pg_partition/pg_constraint regularity checks')
         logger.warn('prerequisite tests failed or not run')
         return
-    
+
     db = connect()
 
     testname = 'user-defined constraint regularity on partitioned tables'
-    
-    qry = partitionRegularityChecks['irreg_user_constraint']    
+
+    qry = partitionRegularityChecks['irreg_user_constraint']
     err = []
 
     try:
         curs = db.query(qry)
-    
+
         for row in curs.dictresult():
-            err.append( (row['tableconname'], row['tableid'], row['numactual'], row['numexpected']) )
+            err.append((row['tableconname'], row['tableid'], row['numactual'], row['numexpected']))
 
         if not err:
             logger.info('[OK]  %s' % testname)
@@ -1694,9 +1708,9 @@ def checkPartitionRegularity():
             GV.testStatus = False
             setError(ERROR_NOREPAIR)
             logger.info('[FAIL]  %s' % testname)
-            logger.error(' %s test has %d issue(s)' % (testname, len(err)) )
+            logger.error(' %s test has %d issue(s)' % (testname, len(err)))
             efmt = '  Constraint "%s" of partitioned table "%s" occurs %d times, %d expected.'
-            for e in err: 
+            for e in err:
                 logger.error(efmt % e)
 
     except Exception, e:
@@ -1705,20 +1719,20 @@ def checkPartitionRegularity():
         myprint('  Execution error: ' + str(e))
 
     testname = 'system-defined partition constraint regularity on partitioned tables'
-    
+
     # Determine maximum number of partitioning levels in this database
     try:
         qry = """select max(parlevel)+1 as maxdepth from pg_partition;"""
         curs = db.query(qry)
-        assert len(curs.dictresult()) == 1 # scalar aggregation!
+        assert len(curs.dictresult()) == 1  # scalar aggregation!
         maxdepth = curs.dictresult()[0]['maxdepth']
-        
+
         err = []
         if isinstance(maxdepth, int):
             qry = make_irregular_sys_con_query(maxdepth)
             curs = db.query(qry)
             for row in curs.dictresult():
-                err.append( (row['partid'], row['tableid'], row['actual'], row['expected']) )
+                err.append((row['partid'], row['tableid'], row['actual'], row['expected']))
 
         if not err:
             logger.info('[OK]  %s' % testname)
@@ -1727,7 +1741,7 @@ def checkPartitionRegularity():
             GV.testStatus = False
             setError(ERROR_NOREPAIR)
             logger.info('[FAIL]  %s' % testname)
-            logger.error(' %s test has %d issue(s)' % ( testname, len(err)) )
+            logger.error(' %s test has %d issue(s)' % (testname, len(err)))
             efmt = '  Part table "%s" of partitioned table "%s" has %d system-defined constraints, %d expected.'
             for e in err:
                 logger.error(efmt % e)
@@ -1738,14 +1752,12 @@ def checkPartitionRegularity():
         myprint('  Execution error: ' + str(e))
 
     testname = 'unenforced unique constraints on partitioned tables'
-    
+
     if irregular:
         logger.warn('skipping test %s due to constraint irregularities' % testname)
     elif GV.Remove:
         logger.warn('skipping test %s due to required removals' % testname)
     else:
-        # logger.info('Checking %s ...' % testname)
-
         qry = partitionRegularityChecks['unenforced_constraint_info']
         err = []
         try:
@@ -1755,19 +1767,19 @@ def checkPartitionRegularity():
                 row['quoted_conname'] = quote_value(row['conname'])
                 row['quoted_contype'] = quote_value(row['contype'])
                 err.append(row)
-   
+
             if not err:
                 logger.info('[OK]  %s' % testname)
             else:
                 GV.testStatus = False
                 setError(ERROR_REMOVE)
                 logger.info('[FAIL]  %s' % testname)
-                logger.error(' %s test has %d issue(s)' % ( testname, len(err) ) )
+                logger.error(' %s test has %d issue(s)' % (testname, len(err)))
                 efmt = '  partitioned table "{tableid}" has unenforced {con_type_phrase} constraint: "{partid}"'
                 repair_fmt = partitionRegularityChecks['unenforced_constraint_repairs']
                 n = 0
                 for e in err:
-                    n = n+1
+                    n = n + 1
                     if n <= 100:
                         logger.error(efmt.format(**e))
                     repair_sequence = repair_fmt.format(**e)
@@ -1780,10 +1792,9 @@ def checkPartitionRegularity():
             setError(ERROR_NOREPAIR)
             myprint('[ERROR] executing test: %s' % testname)
             myprint('  Execution error: ' + str(e))
-          
 
     testname = 'inconsistently named constraint in partitioned table'
-    
+
     if irregular:
         logger.warn('skipping test %s due to constraint irregularities' % testname)
     elif GV.Remove:
@@ -1791,34 +1802,32 @@ def checkPartitionRegularity():
     elif GV.DemoteConstraint:
         logger.warn('skipping test %s due to unenforced constraint removals' % testname)
     else:
-        # logger.info('Checking %s ...' % testname)
-        
-        qry = partitionRegularityChecks['fix_ill_named_constraint']    
+        qry = partitionRegularityChecks['fix_ill_named_constraint']
         err = []
         try:
             curs = db.query(qry)
             for row in curs.dictresult():
-                err.append( row ) 
-    
+                err.append(row)
+
             if not err:
                 logger.info('[OK]  %s' % testname)
             else:
                 GV.testStatus = False
                 setError(ERROR_REMOVE)
                 logger.info('[FAIL]  %s' % testname)
-                logger.error(' %s test has %d issue(s)' % ( testname, len(err) ) )
+                logger.error(' %s test has %d issue(s)' % (testname, len(err)))
                 efmt = '  part table "%s" has constraint named "%s"; should be "%s"'
                 n = 0
                 for e in err:
-                    n = n+1
+                    n = n + 1
                     if n <= 100:
                         # part name, wrong constraint name, right constraint name
-                       logger.error(efmt % (e['partid'], e['partconname'], e['tableconname']))
+                        logger.error(efmt % (e['partid'], e['partconname'], e['tableconname']))
                     for dbid in GV.cfg:
                         buildAdjustConname(
-					     	dbid, e['tableid'], int(e['partrelid']), 
-		    				quote_value(e['partconname']), 
-			    			quote_value(e['tableconname']) )
+                            dbid, e['tableid'], int(e['partrelid']),
+                            quote_value(e['partconname']),
+                            quote_value(e['tableconname']))
                 if len(err) > 100:
                     logger.error("...")
 
@@ -1828,6 +1837,7 @@ def checkPartitionRegularity():
             myprint('  Execution error: ' + str(e))
 
     db.close()
+
 
 #############
 def checkPGClass():
@@ -1849,10 +1859,11 @@ def checkPGClass():
         logger.info('[FAIL] pg_class')
         logger.error('pg_class has %d issue(s)' % len(err))
         logger.error(qry)
-        for e in err[0:100]: 
+        for e in err[0:100]:
             logger.error(formatErr(e[0], e[1], e[2]))
         if len(err) > 100:
             logger.error("...")
+
 
 def getLeakedSchemas():
     logger.info('-----------------------------------')
@@ -1888,7 +1899,7 @@ def getLeakedSchemas():
         curs = db.query(qry)
         if curs.ntuples() == 0:
             logger.info('[OK] temporary schemas')
-        else: 
+        else:
             GV.testStatus = False
             setError(ERROR_REMOVE)
             logger.info('[FAIL] temporary schemas')
@@ -1902,6 +1913,7 @@ def getLeakedSchemas():
         myprint('  Execution error: ' + str(e))
 
     return leaked_schemas
+
 
 #############
 def checkPGNamespace():
@@ -1930,8 +1942,9 @@ def checkPGNamespace():
         logger.info('[FAIL] missing schema definitons')
         logger.error('found %d references to non-existent schemas' % len(err))
         logger.error(qry)
-        for e in err: 
+        for e in err:
             logger.error(formatErr(e[0], e[1], e[2]))
+
 
 #############
 '''
@@ -1939,6 +1952,8 @@ Produce repair scripts to remove dangling entries of gp_fastsequence:
 	- one file per segment dbid
 	- contains DELETE statements to remove catalog entry
 '''
+
+
 def removeFastSequence(db):
     '''
     MPP-14758: gp_fastsequence does not get cleanup after a failed transaction (AO/CO)
@@ -1966,11 +1981,11 @@ def removeFastSequence(db):
               """
         curs = db.query(qry)
         for row in curs.dictresult():
-            seg     = row['dbid']				# dbid of targetted segment
-            name    = 'gp_fastsequence tuple'	# for comment purposes 
-            table   = 'gp_fastsequence' 		# table name
-            cols    = {'objid': row['objid']} 	# column name and value
-            objname = 'gp_fastsequence'			# for comment purposes 
+            seg = row['dbid']  # dbid of targetted segment
+            name = 'gp_fastsequence tuple'  # for comment purposes
+            table = 'gp_fastsequence'  # table name
+            cols = {'objid': row['objid']}  # column name and value
+            objname = 'gp_fastsequence'  # for comment purposes
             buildRemove(seg, name, table, cols, objname)
     except Exception, e:
         logger.error('removeFastSequence: ' + str(e))
@@ -1980,10 +1995,12 @@ def removeFastSequence(db):
 
 def removeIndexConstraint(nspname, relname, constraint):
     GV.Constraints.append('ALTER TABLE "%s"."%s" DROP CONSTRAINT "%s" CASCADE;' % \
-            (nspname, relname, constraint))
+                          (nspname, relname, constraint))
+
 
 def distributeRandomly(rel):
     GV.Policies.append('ALTER TABLE %s SET DISTRIBUTED RANDOMLY;' % rel)
+
 
 def buildRemove(seg, name, table, cols, objname):
     first = False
@@ -1991,39 +2008,43 @@ def buildRemove(seg, name, table, cols, objname):
     str = ''
     for col in cols:
         if not first:
-            fullstr = '--Object Name: %s\n--Remove %s for %i\n' %  \
-                (objname, name, cols[col])
+            fullstr = '--Object Name: %s\n--Remove %s for %i\n' % \
+                      (objname, name, cols[col])
         if len(str) > 0:
             str += ' or '
         str += '%s = \'%s\'' % (col, cols[col])
     fullstr += 'DELETE FROM %s WHERE %s;' % (table, str)
     addRemove(seg, fullstr)
 
+
 def addRemove(seg, line):
     if not GV.Remove.has_key(seg):
         GV.Remove[seg] = []
     GV.Remove[seg].append(line)
+
 
 def buildAdjustConname(seg, relname, relid, oldconname, newconname):
     # relname text
     # relid oid as int
     # old/newconname text
     stmt = '--Constraint Name: %s on %s becomes %s\n' % \
-        (oldconname, relname, newconname)
+           (oldconname, relname, newconname)
     stmt += 'UPDATE pg_constraint\n'
     stmt += 'SET conname = %s\n' % newconname
     stmt += 'WHERE conrelid = %d and conname = %s;' % (relid, oldconname)
     addAdjustConname(seg, stmt)
+
 
 def addAdjustConname(seg, stmt):
     if not GV.AdjustConname.has_key(seg):
         GV.AdjustConname[seg] = []
     GV.AdjustConname[seg].append(stmt)
 
+
 def addDemoteConstraint(seg, repair_sequence):
     if not GV.DemoteConstraint.has_key(seg):
         GV.DemoteConstraint[seg] = []
-    GV.DemoteConstraint[seg].append(repair_sequence)    
+    GV.DemoteConstraint[seg].append(repair_sequence)
 
 
 #############
@@ -2082,22 +2103,20 @@ def checkDepend():
         err = connect2run(qry)
         if not err:
             logger.info('[OK] basic object dependencies')
-        else:   
+        else:
             GV.testStatus = False
             setError(ERROR_NOREPAIR)
             logger.info('[FAIL] basic object dependencies')
             logger.error('  found %d dependencies on dropped objects' % len(err))
-            # logger.info(qry)
 
     except Exception, e:
         setError(ERROR_NOREPAIR)
         myprint("[ERROR] executing test: basic object dependencies")
         myprint("  Execution error: " + str(e))
         myprint(qry)
-        
+
 
 def fixupowners(nspname, relname, oldrole, newrole):
-    
     # Must first alter the table to the wrong owner, then back to the right
     # owner.  The purpose of this is that AT doesn't dispatch the change unless
     # it think the table actually changed owner.
@@ -2105,10 +2124,10 @@ def fixupowners(nspname, relname, oldrole, newrole):
     # Note: this means that the Owners list must be run in the order given.
     #
     GV.Owners.append('-- owner for "%s"."%s"' % (nspname, relname))
-    GV.Owners.append('ALTER TABLE "%s"."%s" OWNER TO "%s";' % 
-                  (nspname, relname, oldrole))
-    GV.Owners.append('ALTER TABLE "%s"."%s" OWNER TO "%s";' % 
-                  (nspname, relname, newrole))
+    GV.Owners.append('ALTER TABLE "%s"."%s" OWNER TO "%s";' %
+                     (nspname, relname, oldrole))
+    GV.Owners.append('ALTER TABLE "%s"."%s" OWNER TO "%s";' %
+                     (nspname, relname, newrole))
 
 
 def checkOwners():
@@ -2158,7 +2177,7 @@ def checkOwners():
 
         if len(rows) == 0:
             logger.info('[OK] table ownership')
-        else: 
+        else:
             GV.testStatus = False
             setError(ERROR_REMOVE)
             logger.info('[FAIL] table ownership')
@@ -2166,8 +2185,8 @@ def checkOwners():
             logger.error('%s' % qry)
             for row in rows[0:100]:
                 logger.error('  %s.%s relowner %s != %s'
-                    % (row['nspname'], row['relname'], row['rolname'],
-                       row['master_rolname']))
+                             % (row['nspname'], row['relname'], row['rolname'],
+                                row['master_rolname']))
             if len(rows) > 100:
                 logger.error("...")
             for row in rows:
@@ -2214,8 +2233,8 @@ def checkOwners():
             logger.error('%s' % qry)
             for row in rows[0:100]:
                 logger.error('  %s.%s typeowner %s != %s'
-                    % (row['nspname'], row['typname'], row['rolname'],
-                       row['master_rolname']))
+                             % (row['nspname'], row['typname'], row['rolname'],
+                                row['master_rolname']))
             if len(rows) > 100:
                 logger.error("...")
 
@@ -2229,21 +2248,20 @@ def checkOwners():
         # NOTE: types with typrelid probably will be repaired by the
         # script generated by the table ownership test above.
 
-    # TODO:
-    # Check owners in pg_proc
-    # Check owners in pg_database
-    # Check owners in pg_tablespace
-    # Check owners in pg_filespace
-    # Check owners in pg_namespace
-    # Check owners in pg_operator
-    # Check owners in pg_opclass
-    # ...
+        # TODO:
+        # Check owners in pg_proc
+        # Check owners in pg_database
+        # Check owners in pg_tablespace
+        # Check owners in pg_filespace
+        # Check owners in pg_namespace
+        # Check owners in pg_operator
+        # Check owners in pg_opclass
+        # ...
 
 
 def checkPersistentTables():
     logger.info('-----------------------------------')
     logger.info('Checking persistent tables')
-
 
     # Some of the persistency checks modified depending on if we are in
     # change tracking or not.  For instance when we are in-sync we 
@@ -2351,7 +2369,7 @@ def checkPersistentTables():
     """
     if in_sync:
         queries.append([qname, qry])
-    
+
     qname = "gp_persistent_database_node   <=> pg_database"
     qry = """
     SELECT coalesce(d.oid, p.database_oid) as database_oid,
@@ -2363,7 +2381,7 @@ def checkPersistentTables():
     WHERE (d.datname is null or p.database_oid is null)
     """
     queries.append([qname, qry])
- 
+
     qname = "gp_persistent_database_node   <=> pg_tablespace"
     qry = """
     SELECT  coalesce(t.oid, p.database_oid) as database_oid, 
@@ -2376,7 +2394,6 @@ def checkPersistentTables():
     WHERE  t.spcname is null
     """
     queries.append([qname, qry])
-
 
     qname = "gp_persistent_database_node   <=> gp_global_sequence"
     qry = """
@@ -2502,7 +2519,6 @@ def checkPersistentTables():
     """
     if in_sync:
         queries.append([qname, qry])
-
 
     qname = "gp_persistent_relation_node   <=> pg_tablespace"
     qry = """
@@ -2646,7 +2662,6 @@ def checkPersistentTables():
     """
     queries.append([qname, qry])
 
-
     # Phew, that was a lot of queries, eh?
     # now execute them on every segment.
     for (qname, qry) in queries:
@@ -2659,15 +2674,15 @@ def checkPersistentTables():
             logger.info('[FAIL] ' + qname)
             logger.error('%s found %d issue(s)' % (qname, len(err)))
             logger.error(qry)
-            
+
             # Report at most 100 rows per segment, for brevity
-            last    = None
-            count   = 0
+            last = None
+            count = 0
             for e in err:
                 cfg = e[0]
                 col = e[1]
                 row = e[2]
-                
+
                 # If this is a new host start again
                 if last != cfg:
                     count = 0
@@ -2682,8 +2697,8 @@ def checkPersistentTables():
                 # Actual formatting could be prettied up more
                 if count == 0:
                     logger.error("--------")
-                    logger.error("%s:%s:%s" % (cfg['hostname'], 
-                                               cfg['port'], 
+                    logger.error("%s:%s:%s" % (cfg['hostname'],
+                                               cfg['port'],
                                                cfg['datadir']))
                     logger.error("  " + " | ".join(map(str, col)))
                 logger.error("  " + " | ".join([str(row[x]) for x in col]))
@@ -2696,12 +2711,11 @@ def closeDbs():
     for key, conns in GV.db.iteritems():
         db = conns[0]
         db.close()
-    GV.db = {} # remove everything
+    GV.db = {}  # remove everything
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def getCatObj(namestr):
-
     db = connect2(GV.cfg[1], utilityMode=False)
     try:
         cat = GV.catalog.getCatalogTable(namestr)
@@ -2711,7 +2725,7 @@ def getCatObj(namestr):
     return cat
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def checkACL():
     logger.info('-----------------------------------')
     logger.info('Performing cross database ACL tests')
@@ -2722,18 +2736,18 @@ def checkACL():
     for cat in sorted(tables):
         checkTableACL(cat)
 
-#-------------------------------------------------------------------------------
-def checkTableACL(cat):
 
-    catname  = cat.getTableName()
-    pkey     = cat.getPrimaryKey()
-    master   = cat.isMasterOnly()
+# -------------------------------------------------------------------------------
+def checkTableACL(cat):
+    catname = cat.getTableName()
+    pkey = cat.getPrimaryKey()
+    master = cat.isMasterOnly()
     isShared = cat.isShared()
-    acl      = cat.getTableAcl()
+    acl = cat.getTableAcl()
 
     if GV.aclStatus == None:
         GV.aclStatus = True
-        
+
     # Skip:
     #   - master only tables
     #   - tables without a primary key
@@ -2752,7 +2766,7 @@ def checkTableACL(cat):
     # since it is valid for the ACLs to have different order.  Instead
     # we compare that both acls are subsets of each other => equality.
 
-    mPkey = ['m.'+i for i in pkey]
+    mPkey = ['m.' + i for i in pkey]
     if cat.tableHasConsistentOids():
         mPkey = ['m.oid']
 
@@ -2765,15 +2779,15 @@ def checkTableACL(cat):
            (m.{acl} is null and s.{acl} is not null) or
            (s.{acl} is null and m.{acl} is not null)
     ORDER BY {primary_key}, s.gp_segment_id
-    """.format(catalog     = catname,
-               primary_key = ', '.join(pkey),
-               mPkey       = ', '.join(mPkey),
-               acl         = acl)
+    """.format(catalog=catname,
+               primary_key=', '.join(pkey),
+               mPkey=', '.join(mPkey),
+               acl=acl)
 
     # Execute the query
     try:
         db = connect2(GV.cfg[1], utilityMode=False)
-        curs  = db.query(qry)
+        curs = db.query(qry)
         nrows = curs.ntuples()
 
         if nrows == 0:
@@ -2784,12 +2798,11 @@ def checkTableACL(cat):
             GV.aclStatus = False
             logger.info('[FAIL] Cross consistency acl check for ' + catname)
             logger.error('  %s acl check has %d issue(s)' % (catname, nrows))
-            # logger.error(qry)
 
             fields = curs.listfields()
-            log_literal(logger,logging.ERROR,"    " + " | ".join(fields))
+            log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
             for row in curs.getresult():
-                log_literal(logger,logging.ERROR,"    " + " | ".join(map(str, row)))
+                log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
             processACLResult(catname, fields, curs.getresult())
 
     except Exception, e:
@@ -2800,25 +2813,24 @@ def checkTableACL(cat):
         myprint(qry)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def checkForeignKey():
-
     logger.info('-----------------------------------')
     logger.info('Performing foreign key tests')
 
     if GV.foreignKeyStatus == None:
         GV.foreignKeyStatus = True
-    
+
     # looks up information in the catalog:
     tables = GV.catalog.getCatalogTables()
 
     for cat in sorted(tables):
         checkTableForeignKey(cat)
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 def checkTableForeignKey(cat):
-    
-    catname  = cat.getTableName()
+    catname = cat.getTableName()
     fkeylist = cat.getForeignKeys()
     isShared = cat.isShared()
     pkeylist = cat.getPrimaryKey()
@@ -2831,7 +2843,7 @@ def checkTableForeignKey(cat):
         return
 
     # skip these master-only tables
-    skipped_masteronly = ['gp_relation_node', 'pg_description', 'pg_shdescription', 
+    skipped_masteronly = ['gp_relation_node', 'pg_description', 'pg_shdescription',
                           'pg_stat_last_operation', 'pg_stat_last_shoperation', 'pg_statistic']
 
     if catname in skipped_masteronly:
@@ -2843,49 +2855,49 @@ def checkTableForeignKey(cat):
             return
         if re.match("only", GV.opt['-S'], re.I) and not isShared:
             return
- 
+
     # primary key lists
     cat1pkeys = []
-    pkeys     = []
+    pkeys = []
 
     # build array of catalog primary keys (with aliases) and
     # primary key alias list
     for pk in pkeylist:
-        cat1pkeys.append('cat1.' + pk + ' as %s_%s' % (catname,pk))
-        pkeys.append('%s_%s' % (catname,pk))
+        cat1pkeys.append('cat1.' + pk + ' as %s_%s' % (catname, pk))
+        pkeys.append('%s_%s' % (catname, pk))
 
-    logger.info('Building %d queries to check FK constraint on table %s' % (len(fkeylist),catname))
+    logger.info('Building %d queries to check FK constraint on table %s' % (len(fkeylist), catname))
     for fkeydef in fkeylist:
-        castedFkey  = [c+autoCast.get(coltypes[c],'') for c in fkeydef.getColumns()]
-        fkeystr     = ', '.join(castedFkey)
+        castedFkey = [c + autoCast.get(coltypes[c], '') for c in fkeydef.getColumns()]
+        fkeystr = ', '.join(castedFkey)
         cat1fkeystr = 'cat1.' + ', cat1.'.join(fkeydef.getColumns())
-        pkeystr     = ', '.join(fkeydef.getPKey())
-        pkcatname   = fkeydef.getPkeyTableName()
+        pkeystr = ', '.join(fkeydef.getPKey())
+        pkcatname = fkeydef.getPkeyTableName()
 
         qry = fkQuery(catname, pkcatname, fkeystr, pkeystr, pkeys, cat1pkeys)
-       
+
         # Execute the query
         try:
             db = connect2(GV.cfg[1], utilityMode=False)
-            curs  = db.query(qry)
+            curs = db.query(qry)
             nrows = curs.ntuples()
 
             if nrows == 0:
-                logger.info('[OK] Foreign key check for %s(%s) referencing %s(%s)'%
+                logger.info('[OK] Foreign key check for %s(%s) referencing %s(%s)' %
                             (catname, fkeystr, pkcatname, pkeystr))
             else:
                 GV.testStatus = False
                 setError(ERROR_NOREPAIR)
                 GV.foreignKeyStatus = False
-                logger.info('[FAIL] Foreign key check for %s(%s) referencing %s(%s)'%
+                logger.info('[FAIL] Foreign key check for %s(%s) referencing %s(%s)' %
                             (catname, fkeystr, pkcatname, pkeystr))
-                logger.error('  %s has %d issue(s): entry has NULL reference of %s(%s)'% 
-                            (catname, nrows, pkcatname, pkeystr))
+                logger.error('  %s has %d issue(s): entry has NULL reference of %s(%s)' %
+                             (catname, nrows, pkcatname, pkeystr))
 
                 fields = curs.listfields()
-                log_literal(logger,logging.ERROR,"    " + " | ".join(fields))
+                log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
                 for row in curs.getresult():
-                    log_literal(logger,logging.ERROR,"    " + " | ".join(map(str, row)))
+                    log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
                 processForeignKeyResult(catname, pkcatname, fields, curs.getresult())
 
                 if catname == 'gp_fastsequence' and pkcatname == 'pg_class':
@@ -2900,9 +2912,8 @@ def checkTableForeignKey(cat):
             myprint(qry)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def fkQuery(catname, pkcatname, fkeystr, pkeystr, pkeys, cat1pkeys):
-
     qry = """
           SELECT {primary_key_alias}, {cat2_dot_pk},
                  array_agg(gp_segment_id order by gp_segment_id) as segids
@@ -2927,23 +2938,22 @@ def fkQuery(catname, pkcatname, fkeystr, pkeystr, pkeys, cat1pkeys):
                 ORDER BY {primary_key_alias}, gp_segment_id
           ) allresults
           GROUP BY {primary_key_alias}, {cat2_dot_pk}
-          """.format(FK1      = fkeystr,
-                     PK2      = pkeystr,
-                     CATALOG1 = catname,
-                     CATALOG2 = pkcatname,
-                     cat1_dot_pk = ', '.join(cat1pkeys) ,
-                     cat2_dot_pk = '%s_%s' % (pkcatname,pkeystr),
-                     primary_key_alias    = ', '.join(pkeys))
+          """.format(FK1=fkeystr,
+                     PK2=pkeystr,
+                     CATALOG1=catname,
+                     CATALOG2=pkcatname,
+                     cat1_dot_pk=', '.join(cat1pkeys),
+                     cat2_dot_pk='%s_%s' % (pkcatname, pkeystr),
+                     primary_key_alias=', '.join(pkeys))
 
     return qry
 
 
-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def checkMissingEntry():
     logger.info('-----------------------------------')
     logger.info('Performing cross consistency tests: check for missing or extraneous entries')
-    
+
     if GV.missingEntryStatus == None:
         GV.missingEntryStatus = True
 
@@ -2954,12 +2964,11 @@ def checkMissingEntry():
         checkTableMissingEntry(cat)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def checkTableMissingEntry(cat):
-   
-    catname  = cat.getTableName()
-    pkey     = cat.getPrimaryKey()
-    master   = cat.isMasterOnly()
+    catname = cat.getTableName()
+    pkey = cat.getPrimaryKey()
+    master = cat.isMasterOnly()
     isShared = cat.isShared()
     coltypes = cat.getTableColtypes()
 
@@ -2981,8 +2990,8 @@ def checkTableMissingEntry(cat):
         return
 
     castedPkey = cat.getPrimaryKey()
-    castedPkey = [ c+autoCast.get(coltypes[c],'') for c in castedPkey ]
- 
+    castedPkey = [c + autoCast.get(coltypes[c], '') for c in castedPkey]
+
     if cat.tableHasConsistentOids():
         qry = missingEntryQuery(GV.max_content, catname, ['oid'], ['oid'])
     else:
@@ -2991,7 +3000,7 @@ def checkTableMissingEntry(cat):
     # Execute the query
     try:
         db = connect2(GV.cfg[1], utilityMode=False)
-        curs  = db.query(qry)
+        curs = db.query(qry)
         nrows = curs.ntuples()
 
         if nrows == 0:
@@ -3007,17 +3016,17 @@ def checkTableMissingEntry(cat):
                 logger_with_level = logger.error
                 log_level = logging.ERROR
 
-            logger.info(('[%s] Checking for missing or extraneous entries for ' + catname) % 
+            logger.info(('[%s] Checking for missing or extraneous entries for ' + catname) %
                         ('WARNING' if log_level == logging.WARNING else 'FAIL'))
             logger_with_level('  %s has %d issue(s)' % (catname, nrows))
             fields = curs.listfields()
-            log_literal(logger,log_level,"    " + " | ".join(fields))
+            log_literal(logger, log_level, "    " + " | ".join(fields))
             for row in curs.getresult():
-                log_literal(logger,log_level,"    " + " | ".join(map(str, row)))
+                log_literal(logger, log_level, "    " + " | ".join(map(str, row)))
             results = curs.getresult()
             processMissingDuplicateEntryResult(catname, fields, results, "missing")
             if catname == 'pg_type':
-            	generateVerifyFile(catname, fields, results, 'missing_extraneous')
+                generateVerifyFile(catname, fields, results, 'missing_extraneous')
     except Exception, e:
         setError(ERROR_NOREPAIR)
         GV.missingEntryStatus = False
@@ -3026,10 +3035,8 @@ def checkTableMissingEntry(cat):
         myprint(qry)
 
 
-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def missingEntryQuery(max_content, catname, pkey, castedPkey):
-
     # =================
     #  Missing / Extra
     # =================
@@ -3070,12 +3077,13 @@ def missingEntryQuery(max_content, catname, pkey, castedPkey):
           ) missing_extra
           WHERE subcount <= ({max_content}+2)/2.0
           GROUP BY {oidcasted_pk}, exists;
-          """.format(oidcasted_pk = ','.join(castedPkey),
-                     primary_key = ','.join(pkey),
-                     catalog = catname,
-                     max_content = max_content)
+          """.format(oidcasted_pk=','.join(castedPkey),
+                     primary_key=','.join(pkey),
+                     catalog=catname,
+                     max_content=max_content)
 
     return qry
+
 
 def transformTextArrayCols(catname, columns, colnames, coltypes):
     # Distributing by hash(text[]) is potentially dangerous,
@@ -3093,11 +3101,12 @@ def transformTextArrayCols(catname, columns, colnames, coltypes):
 
     return transformed
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 def checkInconsistentEntry():
     logger.info('-----------------------------------')
     logger.info('Performing cross consistency test: check for inconsistent entries')
-    
+
     if GV.inconsistentEntryStatus == None:
         GV.inconsistentEntryStatus = True
 
@@ -3108,16 +3117,15 @@ def checkInconsistentEntry():
         checkTableInconsistentEntry(cat)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def checkTableInconsistentEntry(cat):
-   
-    catname  = cat.getTableName()
-    pkey     = cat.getPrimaryKey()
-    master   = cat.isMasterOnly()
+    catname = cat.getTableName()
+    pkey = cat.getPrimaryKey()
+    master = cat.isMasterOnly()
     isShared = cat.isShared()
-    columns  = cat.getTableColumns(with_acl=False)
+    columns = cat.getTableColumns(with_acl=False)
     coltypes = cat.getTableColtypes()
-   
+
     # Skip master only tables
     if master:
         return
@@ -3136,8 +3144,8 @@ def checkTableInconsistentEntry(cat):
         return
 
     castedPkey = cat.getPrimaryKey()
-    castedPkey = [ c+autoCast.get(coltypes[c],'') for c in castedPkey ]
-    castcols = [ c+autoCast.get(coltypes[c],'') for c in columns ]
+    castedPkey = [c + autoCast.get(coltypes[c], '') for c in castedPkey]
+    castcols = [c + autoCast.get(coltypes[c], '') for c in columns]
 
     # transform text[] cols for sure. See comments on transformTextArrayCols
     castcols = transformTextArrayCols(catname, castcols, columns, cat.getTableColtypes())
@@ -3150,7 +3158,7 @@ def checkTableInconsistentEntry(cat):
     # Execute the query
     try:
         db = connect2(GV.cfg[1], utilityMode=False)
-        curs  = db.query(qry)
+        curs = db.query(qry)
         nrows = curs.ntuples()
 
         if nrows == 0:
@@ -3163,9 +3171,9 @@ def checkTableInconsistentEntry(cat):
             logger.error('  %s has %d issue(s)' % (catname, nrows))
 
             fields = curs.listfields()
-            log_literal(logger,logging.ERROR,"    " + " | ".join(fields))
+            log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
             for row in curs.getresult():
-                log_literal(logger,logging.ERROR,"    " + " | ".join(map(str, row)))
+                log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
             results = curs.getresult()
             processInconsistentEntryResult(catname, pkey, fields, results)
             if catname == 'pg_type':
@@ -3179,29 +3187,29 @@ def checkTableInconsistentEntry(cat):
         myprint('  Execution error: ' + str(e))
         myprint(qry)
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 def inconsistentEntryQuery(max_content, catname, pkey, columns, castcols):
+    # -- ==============
+    # --  Inconsistent
+    # -- ==============
+    # --   Build set of all values in the instance
+    # --
+    # --   Count number of unique values for the primary key
+    # --     - Ignore rows where this does not equal number of segments
+    # --       (These are the missing/extra rows and are covered by other checks)
+    # --
+    # --   Count number of unique values for all columns
+    # --     - Ignore rows where this equals number of segments
+    # --
+    # --   Group the majority opinion into one bucket and report everyone who disagrees with
+    # --   the majority individually.
+    # --
+    # --   Majority gets reported with gp_segment_id == null
+    # --
+    # -- SET GUC due to MPP-14531:
 
-        #-- ==============
-        #--  Inconsistent
-        #-- ==============
-        #--   Build set of all values in the instance
-        #--
-        #--   Count number of unique values for the primary key
-        #--     - Ignore rows where this does not equal number of segments
-        #--       (These are the missing/extra rows and are covered by other checks)
-        #--
-        #--   Count number of unique values for all columns
-        #--     - Ignore rows where this equals number of segments
-        #--  
-        #--   Group the majority opinion into one bucket and report everyone who disagrees with
-        #--   the majority individually. 
-        #-- 
-        #--   Majority gets reported with gp_segment_id == null
-        #--
-        #-- SET GUC due to MPP-14531:
-
-        qry = """
+    qry = """
               SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
               
               SET gp_enable_mk_sort=off; 
@@ -3231,16 +3239,16 @@ def inconsistentEntryQuery(max_content, catname, pkey, columns, castcols):
               ) rowresult
               GROUP BY {columns}
               ORDER BY {pkey}, segids;
-              """.format(pkey = ','.join(pkey),
-                         catalog = catname,
-                         columns = ','.join(columns),
-                         castcols = ','.join(castcols),
-                         max_content = max_content)
+              """.format(pkey=','.join(pkey),
+                         catalog=catname,
+                         columns=','.join(columns),
+                         castcols=','.join(castcols),
+                         max_content=max_content)
 
-        return qry
+    return qry
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def checkDuplicateEntry():
     logger.info('-----------------------------------')
     logger.info('Performing test: checking for duplicate entries')
@@ -3252,14 +3260,13 @@ def checkDuplicateEntry():
         checkTableDuplicateEntry(cat)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def checkTableDuplicateEntry(cat):
-
-    catname  = cat.getTableName()
-    pkey     = cat.getPrimaryKey()
-    master   = cat.isMasterOnly()
+    catname = cat.getTableName()
+    pkey = cat.getPrimaryKey()
+    master = cat.isMasterOnly()
     isShared = cat.isShared()
-    columns  = cat.getTableColumns(with_acl=False)
+    columns = cat.getTableColumns(with_acl=False)
     coltypes = cat.getTableColtypes()
 
     # Skip master only tables
@@ -3279,7 +3286,7 @@ def checkTableDuplicateEntry(cat):
                     catname)
         return
 
-    pkey = [ c+autoCast.get(coltypes[c],'') for c in pkey ]
+    pkey = [c + autoCast.get(coltypes[c], '') for c in pkey]
     if cat.tableHasConsistentOids():
         qry = duplicateEntryQuery(catname, ['oid'])
     else:
@@ -3288,7 +3295,7 @@ def checkTableDuplicateEntry(cat):
     # Execute the query
     try:
         db = connect2(GV.cfg[1], utilityMode=False)
-        curs  = db.query(qry)
+        curs = db.query(qry)
         nrows = curs.ntuples()
 
         if nrows == 0:
@@ -3300,9 +3307,9 @@ def checkTableDuplicateEntry(cat):
             logger.error('  %s has %d issue(s)' % (catname, nrows))
 
             fields = curs.listfields()
-            log_literal(logger,logging.ERROR,"    " + " | ".join(fields))
+            log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
             for row in curs.getresult():
-                log_literal(logger,logging.ERROR,"    " + " | ".join(map(str, row)))
+                log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
             results = curs.getresult()
             processMissingDuplicateEntryResult(catname, fields, results, "duplicate")
             if catname == 'pg_type':
@@ -3314,14 +3321,13 @@ def checkTableDuplicateEntry(cat):
         myprint(qry)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def duplicateEntryQuery(catname, pkey):
-
-    #-- ===========
-    #--  Duplicate
-    #-- ===========
-    #--   Return any rows having count > 1 for a given segid, {unique_key} pair
-    #--
+    # -- ===========
+    # --  Duplicate
+    # -- ===========
+    # --   Return any rows having count > 1 for a given segid, {unique_key} pair
+    # --
 
     qry = """
           SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -3341,15 +3347,14 @@ def duplicateEntryQuery(catname, pkey):
               HAVING count(*) > 1
           ) rowresult
           GROUP BY {pkey}, total
-          """.format(catalog = catname,
-                     pkey = ','.join(pkey))
+          """.format(catalog=catname,
+                     pkey=','.join(pkey))
 
     return qry
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def checkDuplicatePersistentEntry():
-
     """
     MPP-18178: check duplicate entries in gp_persistent_relation_node
     	have the same: tablespace_oid, database_oid, relfilenode_oid, segment_file_num
@@ -3359,13 +3364,13 @@ def checkDuplicatePersistentEntry():
     catname = 'gp_persistent_relation_node'
     fields = ['tablespace_oid', 'database_oid', 'relfilenode_oid', 'segment_file_num']
     excol = 'mirror_existence_state'
-    state = 6 
+    state = 6
 
     qry = duplicatePersistentEntryQuery(catname, fields, excol, state)
 
     try:
         db = connect2(GV.cfg[1], utilityMode=False)
-        curs  = db.query(qry)
+        curs = db.query(qry)
         nrows = curs.ntuples()
 
         if nrows == 0:
@@ -3383,7 +3388,7 @@ def checkDuplicatePersistentEntry():
             results = curs.getresult()
             processMissingDuplicateEntryResult(catname, fields, results, "duplicate")
             if catname == 'pg_type':
-            	generateVerifyFile(catname, fields, results, 'duplicate_persistent')
+                generateVerifyFile(catname, fields, results, 'duplicate_persistent')
     except Exception, e:
         setError(ERROR_NOREPAIR)
         myprint('[ERROR] Executing: duplicate persistent entries check for ' + catname)
@@ -3392,13 +3397,12 @@ def checkDuplicatePersistentEntry():
 
 
 def duplicatePersistentEntryQuery(catname, pkey, excol, state):
-    
     """
     Check for duplicate persistent table entries:
     	the query is similar to the duplicate catalog entries query, except an extra condition 
     	and the check is limited to the connected database for reporting purposes
     """
-    
+
     qry = """
           SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
           
@@ -3424,36 +3428,37 @@ def duplicatePersistentEntryQuery(catname, pkey, excol, state):
           """.format(catalog=catname, pkey=','.join(pkey), excol=excol, state=state, dbname=GV.dbname)
     return qry
 
+
 ############################################################################
 # Help populating repair part for all tested types
 # All functions dependent on results stored in global variable GV
 ############################################################################
 name_repair = {
     "segment":
-    {
-         "description": "Check if needs repairing segment",
-         "fn": lambda maybeRemove, catmod_guc, seg: checkSegmentRepair(maybeRemove, catmod_guc, seg)
-    },
+        {
+            "description": "Check if needs repairing segment",
+            "fn": lambda maybeRemove, catmod_guc, seg: checkSegmentRepair(maybeRemove, catmod_guc, seg)
+        },
     "reindex":
-    {
-         "description": "Check if needs repair file for reindex",
-         "fn": lambda: checkReindexRepair()
-    },
+        {
+            "description": "Check if needs repair file for reindex",
+            "fn": lambda: checkReindexRepair()
+        },
     "constraints":
-    {
-         "description": "Check if needs repair file to fix constraints",
-         "fn": lambda: checkConstraintsRepair()
-    },
+        {
+            "description": "Check if needs repair file to fix constraints",
+            "fn": lambda: checkConstraintsRepair()
+        },
     "owners":
-    {
-         "description": "Check if needs repair file to fix messed up ownership",
-         "fn": lambda: checkOwnersRepair()
-    },
+        {
+            "description": "Check if needs repair file to fix messed up ownership",
+            "fn": lambda: checkOwnersRepair()
+        },
     "policies":
-    {
-         "description": "Check if needs repair file to fix distribution policy",
-         "fn": lambda: checkPoliciesRepair()
-    }
+        {
+            "description": "Check if needs repair file to fix distribution policy",
+            "fn": lambda: checkPoliciesRepair()
+        }
 }
 
 ############################################################################
@@ -3465,133 +3470,131 @@ name_repair = {
 
 name_test = {
     "duplicate":
-    {
-         "description": "Check for duplicate entries",
-         "fn": lambda: checkDuplicateEntry(),
-         "version": 'main',
-         "order": 1,
-         "online": True
-    },
+        {
+            "description": "Check for duplicate entries",
+            "fn": lambda: checkDuplicateEntry(),
+            "version": 'main',
+            "order": 1,
+            "online": True
+        },
     "missing_extraneous":
-    {
-         "description": "Cross consistency check for missing or extraneous entries",
-         "fn": lambda: checkMissingEntry(),
-         "version": 'main',
-         "order": 2,
-         "online": True
-    },
+        {
+            "description": "Cross consistency check for missing or extraneous entries",
+            "fn": lambda: checkMissingEntry(),
+            "version": 'main',
+            "order": 2,
+            "online": True
+        },
     "inconsistent":
-    {
-         "description": "Cross consistency check for master segment inconsistency",
-         "fn": lambda: checkInconsistentEntry(),
-         "version": 'main',
-         "order": 3,
-         "online": True
-    },
+        {
+            "description": "Cross consistency check for master segment inconsistency",
+            "fn": lambda: checkInconsistentEntry(),
+            "version": 'main',
+            "order": 3,
+            "online": True
+        },
     "foreign_key":
-    {
-         "description": "Check foreign keys",
-         "fn": lambda: checkForeignKey(),
-         "version": 'main',
-         "order": 4,
-         "online": True
-    },
+        {
+            "description": "Check foreign keys",
+            "fn": lambda: checkForeignKey(),
+            "version": 'main',
+            "order": 4,
+            "online": True
+        },
     "acl":
-    {
-         "description": "Cross consistency check for access control privileges",
-         "fn": lambda: checkACL(),
-         "version": 'main',
-         "order": 5,
-         "online": True
-    },
+        {
+            "description": "Cross consistency check for access control privileges",
+            "fn": lambda: checkACL(),
+            "version": 'main',
+            "order": 5,
+            "online": True
+        },
     "persistent":
-    {
-         "description": "Check persistent tables",
-         "fn": lambda: checkPersistentTables(),
-         "version": 'main',
-         "order": 6,
-         "online": False
-    },
+        {
+            "description": "Check persistent tables",
+            "fn": lambda: checkPersistentTables(),
+            "version": 'main',
+            "order": 6,
+            "online": False
+        },
     "pgclass":
-    {
-         "description": "Check pg_class entry that does not have any correspond pg_attribute entry",
-         "fn": lambda: checkPGClass(),
-         "version": 'main',
-         "order": 7,
-         "online": False
-    },
+        {
+            "description": "Check pg_class entry that does not have any correspond pg_attribute entry",
+            "fn": lambda: checkPGClass(),
+            "version": 'main',
+            "order": 7,
+            "online": False
+        },
     "namespace":
-    {
-         "description": "Check for leaked temporary schema and missing schema definition",
-         "fn": lambda: checkPGNamespace(),
-         "version": 'main',
-         "order": 8,
-         "online": False
-    },
+        {
+            "description": "Check for leaked temporary schema and missing schema definition",
+            "fn": lambda: checkPGNamespace(),
+            "version": 'main',
+            "order": 8,
+            "online": False
+        },
     "distribution_policy":
-    {
-         "description": "Check constraints on randomly distributed tables",
-         "fn": lambda: checkDistribPolicy(),
-         "version": 'main',
-         "order": 9,
-         "online": False
-    },
+        {
+            "description": "Check constraints on randomly distributed tables",
+            "fn": lambda: checkDistribPolicy(),
+            "version": 'main',
+            "order": 9,
+            "online": False
+        },
     "dependency":
-    {
-         "description": "Check for dependency on non-existent objects",
-         "fn": lambda: checkDepend(),
-         "version": 'main',
-         "order": 10,
-         "online": False
-    },
+        {
+            "description": "Check for dependency on non-existent objects",
+            "fn": lambda: checkDepend(),
+            "version": 'main',
+            "order": 10,
+            "online": False
+        },
     "owner":
-    {
-         "description": "Check table ownership that is inconsistent with the master database",
-         "fn": lambda: checkOwners(),
-         "version": 'main',
-         "order": 11,
-         "online": True
-    },
+        {
+            "description": "Check table ownership that is inconsistent with the master database",
+            "fn": lambda: checkOwners(),
+            "version": 'main',
+            "order": 11,
+            "online": True
+        },
     "part_integrity":
-    {
-         "description": "Check pg_partition branch integrity, partition with oids, partition distribution policy",
-         "fn": lambda: checkPartitionIntegrity(),
-         "version": 'main',
-         "order": 13,
-         "online": True
-    },
+        {
+            "description": "Check pg_partition branch integrity, partition with oids, partition distribution policy",
+            "fn": lambda: checkPartitionIntegrity(),
+            "version": 'main',
+            "order": 13,
+            "online": True
+        },
     "part_constraint":
-    {
-         "description": "Check constraints on partitioned tables",
-         "fn": lambda: checkPartitionRegularity(),
-         "version": 'main',
-         "order": 14,
-         "online": True
-    },
+        {
+            "description": "Check constraints on partitioned tables",
+            "fn": lambda: checkPartitionRegularity(),
+            "version": 'main',
+            "order": 14,
+            "online": True
+        },
     "duplicate_persistent":
-    {
-        "description": "Check for duplicate gp_persistent_relation_node entries",
-        "fn": lambda: checkDuplicatePersistentEntry(),
-        "version": 'main',
-        "order": 16,
-        "online": True
-    }
+        {
+            "description": "Check for duplicate gp_persistent_relation_node entries",
+            "fn": lambda: checkDuplicatePersistentEntry(),
+            "version": 'main',
+            "order": 16,
+            "online": True
+        }
 }
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def listAllTests():
-
     myprint('\nList of gpcheckcat tests:\n')
     for name in sorted(name_test, key=lambda x: name_test[x]["order"]):
         myprint(" %24s: %s" % \
-              (name, name_test[name]["description"]))
+                (name, name_test[name]["description"]))
     myprint('')
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def runTestCatname(cat):
-
     tests = {'missing_extraneous': lambda: checkTableMissingEntry(cat),
              'inconsistent': lambda: checkTableInconsistentEntry(cat),
              'foreign_key': lambda: checkTableForeignKey(cat),
@@ -3599,7 +3602,7 @@ def runTestCatname(cat):
              'acl': lambda: checkTableACL(cat)}
 
     for test in sorted(tests):
-        myprint("Performing test '%s' for %s" % (test,cat.getTableName()))
+        myprint("Performing test '%s' for %s" % (test, cat.getTableName()))
         stime = time.time()
         tests[test]()
         etime = time.time()
@@ -3610,9 +3613,8 @@ def runTestCatname(cat):
         myprint("Total runtime for test '%s': %s" % (test, elapsed))
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def runOneTest(name):
-
     if not name_test.has_key(name):
         logger.info("'%s' is not a valid test" % (name))
         raise LookupError
@@ -3629,13 +3631,12 @@ def runOneTest(name):
         elapsed = etime - stime
         GV.elapsedTime += elapsed
         elapsed = str(datetime.timedelta(seconds=elapsed))[:-4]
-        myprint("Total runtime for test '%s': %s" % (name, elapsed)) 
+        myprint("Total runtime for test '%s': %s" % (name, elapsed))
         if GV.testStatus == False:
             GV.failedTest.append(name)
 
 
-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def runAllTests():
     '''
     perform catalog check for specified database
@@ -3646,13 +3647,13 @@ def runAllTests():
 
     closeDbs()
     logger.info("------------------------------------")
-    fixes = (len(GV.Remove) > 0 or 
+    fixes = (len(GV.Remove) > 0 or
              len(GV.AdjustConname) > 0 or
              len(GV.DemoteConstraint) > 0 or
-             len(GV.ReSync) > 0 or 
-             len(GV.Reindex) > 0 or 
+             len(GV.ReSync) > 0 or
+             len(GV.Reindex) > 0 or
              len(GV.Constraints) > 0 or
-             len(GV.Owners) > 0 or 
+             len(GV.Owners) > 0 or
              len(GV.Policies) > 0)
     if GV.opt['-g'] != None and fixes:
         try:
@@ -3661,7 +3662,7 @@ def runAllTests():
         except Exception, e:
             logger.fatal('Unable to create directory "%s": %s' % (GV.opt['-g'], str(e)))
             sys.exit(1)
-                   
+
         logger.debug('Building catalog repair scripts')
         # build a script to run these files
         script = ''
@@ -3675,13 +3676,13 @@ def runAllTests():
 
         # don't remove anything if ReSync possible --
         # comment out the delete statements from the repair scripts
-        maybeRemove = "";
+        maybeRemove = ""
         if len(GV.ReSync):
-            maybeRemove="# "
-        
+            maybeRemove = "# "
+
         # use the per-dbid loop for removal and for contraint
         # name adjustments
-        
+
         dbids = set(GV.Remove.keys())
         dbids = dbids.union(GV.AdjustConname.keys())
         dbids = dbids.union(GV.DemoteConstraint.keys())
@@ -3698,15 +3699,16 @@ def runAllTests():
                 continue
             description, repair_filename = name_repair[name]["fn"]()
             if repair_filename != None:
-                    script += description
-                    script += 'psql -X -a -h %s -p %i -f %s "%s" > %s.out 2>&1\n' % \
-                              (c['hostname'], c['port'], repair_filename, GV.dbname, repair_filename)
+                script += description
+                script += 'psql -X -a -h %s -p %i -f %s "%s" > %s.out 2>&1\n' % \
+                          (c['hostname'], c['port'], repair_filename, GV.dbname, repair_filename)
 
         generate_repair_script(script)
 
     if GV.retcode >= ERROR_NOREPAIR:
         logger.warn('[WARN]: unable to generate repairs for some issues')
     logger.info("Check complete")
+
 
 def generate_repair_script(script):
     try:
@@ -3721,6 +3723,7 @@ def generate_repair_script(script):
 
     myprint('')
     myprint('[INFO]: repair scripts generated: %s' % path)
+
 
 def checkReindexRepair():
     if len(GV.Reindex) > 0:
@@ -3741,6 +3744,7 @@ def checkReindexRepair():
     else:
         return None, None
 
+
 def checkConstraintsRepair():
     if len(GV.Constraints) > 0:
         # dbname.type.timestamp.sql
@@ -3760,6 +3764,7 @@ def checkConstraintsRepair():
         return description, filename
     else:
         return None, None
+
 
 def checkOwnersRepair():
     if len(GV.Owners) > 0:
@@ -3784,6 +3789,7 @@ def checkOwnersRepair():
     else:
         return None, None
 
+
 def dropLeakedSchemas(dbname):
     leaked_schemas = getLeakedSchemas()
 
@@ -3807,6 +3813,7 @@ def dropLeakedSchemas(dbname):
         if db is not None:
             db.close()
 
+
 def checkPoliciesRepair():
     # changes to distribution policies
     if len(GV.Policies) > 0:
@@ -3827,6 +3834,7 @@ def checkPoliciesRepair():
     else:
         return None, None
 
+
 def checkSegmentRepair(maybeRemove, catmod_guc, seg):
     # dbid.host.port.dbname.timestamp.sql
     c = GV.cfg[seg]
@@ -3839,7 +3847,7 @@ def checkSegmentRepair(maybeRemove, catmod_guc, seg):
         logger.fatal('Unable to create file "%s": %s' % (fullpath, str(e)))
         sys.exit(1)
 
-    #unique
+    # unique
     lines = set()
     if GV.Remove.has_key(seg):
         lines = lines.union(GV.Remove[seg])
@@ -3851,80 +3859,83 @@ def checkSegmentRepair(maybeRemove, catmod_guc, seg):
     # make sure it is sorted
     li = list(lines)
     li.sort()
-    file.write('BEGIN;\n');
+    file.write('BEGIN;\n')
     for line in li:
         file.write(line + '\n')
-    file.write('COMMIT;\n');
+    file.write('COMMIT;\n')
     file.close()
 
-    run_psql_script= '''{maybe}env PGOPTIONS="-c gp_session_role=utility {guc}" psql -X -a -h {hostname} -p {port} -f {fname} "{dbname}" > {fname}.out'''.format(
-                        maybe = maybeRemove, guc = catmod_guc,
-                        hostname = c['hostname'],
-                        port = c['port'],
-                        fname = filename,
-                        dbname = GV.dbname)
+    run_psql_script = '''{maybe}env PGOPTIONS="-c gp_session_role=utility {guc}" psql -X -a -h {hostname} -p {port} -f {fname} "{dbname}" > {fname}.out'''.format(
+        maybe=maybeRemove, guc=catmod_guc,
+        hostname=c['hostname'],
+        port=c['port'],
+        fname=filename,
+        dbname=GV.dbname)
 
     return run_psql_script
-#-------------------------------------------------------------------------------
+
+
+# -------------------------------------------------------------------------------
 def getCatalog():
     # Establish a connection to the master & looks up info in the catalog
     db = connect2(GV.cfg[1], utilityMode=False)
     return GPCatalog(db)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def getReportConfiguration():
     cfg = {}
     for dbid, each in GV.cfg.iteritems():
-        if each['content'] == -1: 
+        if each['content'] == -1:
             segname = 'master'
-        else: 
-            segname = 'seg'+str(each['content']+1)
-        cfg[each['content']] = {'segname': segname, 
-                                'hostname': each['hostname'], 
+        else:
+            segname = 'seg' + str(each['content'] + 1)
+        cfg[each['content']] = {'segname': segname,
+                                'hostname': each['hostname'],
                                 'port': each['port']}
     return cfg
 
-#===============================================================================
-# GPCHECKCAT REPORT
-#===============================================================================
 
-GPObjects = {}     # key = (catname, oid), value = GPObject
-GPObjectGraph = {} # key = GPObject, value=[GPObject]
-#-------------------------------------------------------------------------------
+# ===============================================================================
+# GPCHECKCAT REPORT
+# ===============================================================================
+
+GPObjects = {}  # key = (catname, oid), value = GPObject
+GPObjectGraph = {}  # key = GPObject, value=[GPObject]
+# -------------------------------------------------------------------------------
 
 
 # TableMainColumn[catname] = [colname, catname2]
 #    - report this catname's issues as part of catname2
 #    - catname.colname references catname2.oid
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 TableMainColumn = {}
 # Table with no OID
-TableMainColumn['gp_verification_history']      = ['vertoken','gp_verification_history']
-TableMainColumn['gp_version_at_initdb']         = ['schemaversion', 'gp_version_at_initdb']
-TableMainColumn['pg_aggregate'] 				= ['aggfnoid','pg_proc']
-TableMainColumn['pg_amop'] 						= ['amopclaid','pg_opclass']
-TableMainColumn['pg_amproc']      				= ['amopclaid','pg_opclass']
-TableMainColumn['pg_appendonly']  				= ['relid','pg_class']
-TableMainColumn['pg_attribute']   				= ['attrelid','pg_class']
-TableMainColumn['pg_attribute_encoding']        = ['attrelid', 'pg_class']
-TableMainColumn['pg_auth_member'] 				= ['roleid','pg_authid']
-TableMainColumn['pg_autovacuum']      		    = ['vacrelid','pg_class']
-TableMainColumn['pg_exttable']                  = ['reloid','pg_class']
-TableMainColumn['pg_foreign_table']    		    = ['reloid','pg_class']
-TableMainColumn['pg_index']                     = ['indexrelid','pg_class']
-TableMainColumn['pg_inherits']    				= ['inhrelid','pg_class']
-TableMainColumn['pg_largeobject']      		    = ['loid','pg_largeobject']
-TableMainColumn['pg_pltemplate']                = ['tmplname', 'pg_pltemplate']
-TableMainColumn['pg_proc_callback']             = ['profnoid', 'pg_proc']
-TableMainColumn['pg_type_encoding']             = ['typid', 'pg_type']
-TableMainColumn['pg_window']      				= ['winfnoid','pg_proc']
+TableMainColumn['gp_verification_history'] = ['vertoken', 'gp_verification_history']
+TableMainColumn['gp_version_at_initdb'] = ['schemaversion', 'gp_version_at_initdb']
+TableMainColumn['pg_aggregate'] = ['aggfnoid', 'pg_proc']
+TableMainColumn['pg_amop'] = ['amopclaid', 'pg_opclass']
+TableMainColumn['pg_amproc'] = ['amopclaid', 'pg_opclass']
+TableMainColumn['pg_appendonly'] = ['relid', 'pg_class']
+TableMainColumn['pg_attribute'] = ['attrelid', 'pg_class']
+TableMainColumn['pg_attribute_encoding'] = ['attrelid', 'pg_class']
+TableMainColumn['pg_auth_member'] = ['roleid', 'pg_authid']
+TableMainColumn['pg_autovacuum'] = ['vacrelid', 'pg_class']
+TableMainColumn['pg_exttable'] = ['reloid', 'pg_class']
+TableMainColumn['pg_foreign_table'] = ['reloid', 'pg_class']
+TableMainColumn['pg_index'] = ['indexrelid', 'pg_class']
+TableMainColumn['pg_inherits'] = ['inhrelid', 'pg_class']
+TableMainColumn['pg_largeobject'] = ['loid', 'pg_largeobject']
+TableMainColumn['pg_pltemplate'] = ['tmplname', 'pg_pltemplate']
+TableMainColumn['pg_proc_callback'] = ['profnoid', 'pg_proc']
+TableMainColumn['pg_type_encoding'] = ['typid', 'pg_type']
+TableMainColumn['pg_window'] = ['winfnoid', 'pg_proc']
 
 # Table with OID (special case), these OIDs are known to be inconsistent
-TableMainColumn['pg_attrdef']     = ['adrelid','pg_class']
-TableMainColumn['pg_constraint']  = ['conrelid','pg_class']
-TableMainColumn['pg_trigger']     = ['tgrelid','pg_class']
-TableMainColumn['pg_rewrite']     = ['ev_class','pg_class']
+TableMainColumn['pg_attrdef'] = ['adrelid', 'pg_class']
+TableMainColumn['pg_constraint'] = ['conrelid', 'pg_class']
+TableMainColumn['pg_trigger'] = ['tgrelid', 'pg_class']
+TableMainColumn['pg_rewrite'] = ['ev_class', 'pg_class']
 
 # Persistent table
 TableMainColumn['gp_persistent_relation_node'] = ['relfilenode_oid', 'pg_class']
@@ -3932,40 +3943,38 @@ TableMainColumn['gp_persistent_relation_node'] = ['relfilenode_oid', 'pg_class']
 # Cast OID alias type to OID since our graph of objects is based on OID
 # int2vector is also casted to int2[] due to the lack of an <(int2vector, int2vector) operator
 autoCast = {
-  'regproc':      '::oid',
-  'regprocedure': '::oid',
-  'regoper':      '::oid',
-  'regoperator':  '::oid',
-  'regclass':     '::oid',
-  'regtype':      '::oid',
-  'int2vector':   '::int2[]'
+    'regproc': '::oid',
+    'regprocedure': '::oid',
+    'regoper': '::oid',
+    'regoperator': '::oid',
+    'regclass': '::oid',
+    'regtype': '::oid',
+    'int2vector': '::int2[]'
 }
 
-#-------------------------------------------------------------------------------
-class QueryException(Exception): pass
-    
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
+class QueryException(Exception): pass
+
+
+# -------------------------------------------------------------------------------
 # Get gpObj from GPObjects, instantiate a new one & add to GPObjects if not found
 def getGPObject(oid, catname):
-
-    gpObj = GPObjects.get((oid, catname),None)
+    gpObj = GPObjects.get((oid, catname), None)
     if gpObj is None:
         if catname == 'pg_class':
             gpObj = RelationObject(oid, catname)
         else:
             gpObj = GPObject(oid, catname)
-        GPObjects[(oid,catname)] = gpObj
+        GPObjects[(oid, catname)] = gpObj
     return gpObj
 
 
-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def getOidFromPK(catname, pkeys):
-
     # pkeys: name-value pair
-    pkeystrList = ["%s='%s'" % (key,value) for key, value in pkeys.iteritems()]
-    pkeystr     = ' and '.join(pkeystrList)
+    pkeystrList = ["%s='%s'" % (key, value) for key, value in pkeys.iteritems()]
+    pkeystr = ' and '.join(pkeystrList)
 
     qry = """
           SELECT oid 
@@ -3978,14 +3987,14 @@ def getOidFromPK(catname, pkeys):
           ) alloids
           GROUP BY oid
           ORDER BY count(*) desc, oid
-          """ .format(catname = catname,
-                      pkeystr = pkeystr)
+          """.format(catname=catname,
+                     pkeystr=pkeystr)
 
     try:
         db = connect2(GV.cfg[1], utilityMode=False)
         curs = db.query(qry)
         if (len(curs.dictresult()) == 0):
-            raise QueryException("No such entry '%s' in %s" % (pkeystr,catname))
+            raise QueryException("No such entry '%s' in %s" % (pkeystr, catname))
 
         return curs.dictresult().pop()['oid']
 
@@ -3995,7 +4004,7 @@ def getOidFromPK(catname, pkeys):
         myprint(qry)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def getClassOidForRelfilenode(relfilenode):
     qry = "SELECT oid FROM pg_class WHERE relfilenode = %d;" % (relfilenode)
     try:
@@ -4008,7 +4017,7 @@ def getClassOidForRelfilenode(relfilenode):
         myprint('  Execution error: ' + str(e))
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def getResourceTypeOid(oid):
     qry = """ 
           SELECT oid
@@ -4030,14 +4039,13 @@ def getResourceTypeOid(oid):
         setError(ERROR_NOREPAIR)
         myprint('  Execution error: ' + str(e))
 
-  
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 # Process results of tests (CC and FK) for a particular catalog:
 #   - Categorize entry into GPObject
 #   - Instantiate GPObject if needed
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def processMissingDuplicateEntryResult(catname, colname, allValues, type):
-
     # type = {"missing" | "duplicate"}
     '''
     colname:       proname | pronamespace | proargtypes | exists | segids
@@ -4051,7 +4059,7 @@ def processMissingDuplicateEntryResult(catname, colname, allValues, type):
     '''
     gpObjName = catname
     gpColName = None
-    pknames = [i for i in colname[:-2]] # Everything except the last two columns
+    pknames = [i for i in colname[:-2]]  # Everything except the last two columns
 
     # This catname may not be a GPObject (e.g. pg_attribute)
     # If these catnames have oids, they are known to be inconsistent
@@ -4064,13 +4072,13 @@ def processMissingDuplicateEntryResult(catname, colname, allValues, type):
     # Process entries
     for row in allValues:
         rowObjName = gpObjName
-        segids = row[-1]                    
+        segids = row[-1]
         pkeys = dict((pk, row[colname.index(pk)]) for pk in pknames)
 
         if gpColName != None:
             oid = row[colname.index(gpColName)]
         else:
-            oid = getOidFromPK(catname, pkeys)    
+            oid = getOidFromPK(catname, pkeys)
             pkeys = {'oid': oid}
 
         # Special case: constraint for domain, report pg_type.contypid
@@ -4080,7 +4088,7 @@ def processMissingDuplicateEntryResult(catname, colname, allValues, type):
         # Special case: persistent table
         if catname == 'gp_persistent_relation_node':
             relfilenode = oid
-            oid = getClassOidForRelfilenode(relfilenode) 
+            oid = getClassOidForRelfilenode(relfilenode)
 
         gpObj = getGPObject(oid, rowObjName)
 
@@ -4093,8 +4101,7 @@ def processMissingDuplicateEntryResult(catname, colname, allValues, type):
             gpObj.setDuplicateIssue(issue)
 
 
-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def processInconsistentEntryResult(catname, pknames, colname, allValues):
     # If tableHasInconsistentOid, columns does not have oid
     '''
@@ -4118,7 +4125,6 @@ def processInconsistentEntryResult(catname, pknames, colname, allValues):
         else:
             groupedValues[keys] = [row]
 
-    
     gpObjName = catname
     gpColName = None
 
@@ -4128,11 +4134,11 @@ def processInconsistentEntryResult(catname, pknames, colname, allValues):
         gpColName = TableMainColumn[catname][0]
         gpObjName = TableMainColumn[catname][1]
     elif 'oid' in colname:
-         gpColName = 'oid'
+        gpColName = 'oid'
 
-    for keys,values in groupedValues.iteritems():
+    for keys, values in groupedValues.iteritems():
         rowObjName = gpObjName
-        pkeys = dict((n,values[0][colname.index(n)]) for n in pknames)
+        pkeys = dict((n, values[0][colname.index(n)]) for n in pknames)
 
         if gpColName != None:
             oid = values[0][colname.index(gpColName)]
@@ -4149,9 +4155,8 @@ def processInconsistentEntryResult(catname, pknames, colname, allValues):
         gpObj.setInconsistentIssue(issue)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def processForeignKeyResult(catname, pkcatname, colname, allValues):
-    
     '''
     colname:    pg_class_relname | pg_class_relnamespace | pg_type_oid | segids
     allValues:            test11 | 2200 | 17389 | {-1,0,1,2,3}
@@ -4159,9 +4164,9 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
     '''
 
     gpObjName = pkcatname
-    gpColName = colname[-2].rsplit('_',1)[1]
-    fkeytab  = catname
-    fkeylist = [name.rsplit('_',1)[1] for name in colname[:-2]]
+    gpColName = colname[-2].rsplit('_', 1)[1]
+    fkeytab = catname
+    fkeylist = [name.rsplit('_', 1)[1] for name in colname[:-2]]
 
     # This catname may not be a GPObject (e.g. pg_attribute)
     #    1. pg_attrdef(adrelid) referencing pg_attribute(attrelid)
@@ -4174,9 +4179,9 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
     for row in allValues:
         rowObjName = gpObjName
         segids = row[-1]
-        oid = row[len(colname)-2]
+        oid = row[len(colname) - 2]
         # Build fkeys dict: used to find oid of pg_class
-        fkeys = dict((n,row[colname.index(fkeytab+'_'+n)]) for n in fkeylist)
+        fkeys = dict((n, row[colname.index(fkeytab + '_' + n)]) for n in fkeylist)
         issue = CatForeignKeyIssue(pkcatname, {gpColName: oid}, segids, catname, fkeys)
 
         # Special cases:
@@ -4191,15 +4196,14 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
         gpObj.setForeignKeyIssue(issue)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def processACLResult(catname, colname, allValues):
-
     '''
     colname:	segid | datname | master_acl | segment_acl
     allValues:		2 | acldb | {=Tc/nmiller,nmiller=CTc/nmiller,person1=C/nmiller} | {=Tc/nmiller,nmiller=CTc/nmiller}
     				1 | gptest | None | {=Tc/nmiller,nmiller=CTc/nmiller,person2=CTc/nmiller}
     '''
- 
+
     gpObjName = catname
     gpColName = None
     pknames = [i for i in colname[1:-2]]
@@ -4213,34 +4217,33 @@ def processACLResult(catname, colname, allValues):
 
     # Process entries
     for row in allValues:
-        segid = row[0]                    
+        segid = row[0]
         pkeys = dict((pk, row[colname.index(pk)]) for pk in pknames)
 
         if gpColName != None:
             oid = row[colname.index(gpColName)]
         else:
-            oid = getOidFromPK(catname, pkeys)    
+            oid = getOidFromPK(catname, pkeys)
             pkeys = {'oid': oid}
 
         macl = row[-2][1:-1].split(',') if row[-2] != None else []
         sacl = row[-1][1:-1].split(',') if row[-1] != None else []
         macl_only = list(set(macl).difference(sacl))
         sacl_only = list(set(sacl).difference(macl))
-        
+
         issue = CatACLIssue(catname, pkeys, segid, macl_only, sacl_only)
         gpObj = getGPObject(oid, gpObjName)
         gpObj.setACLIssue(issue)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 class CatInconsistentIssue:
-
     def __init__(self, catname, columns, rows):
 
         self.catname = catname
         self.columns = columns
         self.rows = rows
-   
+
     def report(self):
 
         def format_segids(segids):
@@ -4251,27 +4254,26 @@ class CatInconsistentIssue:
                 idstr = ''
                 for i in ids:
                     idstr += '%s (%s:%d) ' % \
-                       (GV.report_cfg[i]['segname'], GV.report_cfg[i]['hostname'],
-                        GV.report_cfg[i]['port'])
+                             (GV.report_cfg[i]['segname'], GV.report_cfg[i]['hostname'],
+                              GV.report_cfg[i]['port'])
             return idstr
-            
-        for i in range(0,len(self.columns)-1):
+
+        for i in range(0, len(self.columns) - 1):
             colset = set(j[i] for j in self.rows)
             if len(colset) > 1:
                 for row in self.rows:
-                    myprint("%20s is '%s' on %s" % (self.columns[i],row[i],format_segids(row[-1])))
+                    myprint("%20s is '%s' on %s" % (self.columns[i], row[i], format_segids(row[-1])))
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 class CatForeignKeyIssue:
-
     def __init__(self, catname, pkeys, segids, fcatname, fkeys):
 
-        self.catname  = catname
-        self.pkeys    = pkeys     # string of pkey=xxxx or oid=xxxx 
-        self.segids   = segids    # list of affected segids
+        self.catname = catname
+        self.pkeys = pkeys  # string of pkey=xxxx or oid=xxxx
+        self.segids = segids  # list of affected segids
         self.fcatname = fcatname  # checked object catname
-        self.fkeys    = fkeys     # string of fkeys=xxxx
+        self.fkeys = fkeys  # string of fkeys=xxxx
 
     def report(self):
 
@@ -4287,22 +4289,22 @@ class CatForeignKeyIssue:
 
         if self.fcatname == 'pg_attribute':
             myprint("        No %s entry for %s column '%s' on %s" \
-                     % (self.catname, self.fcatname,self.fkeys['attname'],idstr))
+                    % (self.catname, self.fcatname, self.fkeys['attname'], idstr))
         else:
             myprint("        No %s entry for %s %s on %s" \
-                     % (self.catname, self.fcatname,self.fkeys,idstr))
+                    % (self.catname, self.fcatname, self.fkeys, idstr))
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 class CatMissingIssue:
-
-    def __init__(self, catname, pkeys, segids, type ):
+    def __init__(self, catname, pkeys, segids, type):
 
         self.catname = catname
-        self.pkeys   = pkeys     # string of pkey=xxxx or oid=xxxx 
-        self.segids  = segids    # list of affected segids
-        self.type    = type      # missing or extra
-        assert(self.type in ['missing','extra'])
-       
+        self.pkeys = pkeys  # string of pkey=xxxx or oid=xxxx
+        self.segids = segids  # list of affected segids
+        self.type = type  # missing or extra
+        assert (self.type in ['missing', 'extra'])
+
     def report(self):
 
         ids = [int(i) for i in self.segids[1:-1].split(',')]
@@ -4317,48 +4319,45 @@ class CatMissingIssue:
 
         if self.catname == 'pg_attribute':
             myprint("        %s column '%s' on %s" \
-                     % (self.type.capitalize(), self.pkeys['attname'],idstr))
+                    % (self.type.capitalize(), self.pkeys['attname'], idstr))
         elif self.catname == 'pg_class':
             myprint('        %s relation metadata for %s on %s' \
-                   % (self.type.capitalize(), str(self.pkeys), idstr))
+                    % (self.type.capitalize(), str(self.pkeys), idstr))
         else:
             myprint('        %s %s metadata of %s on %s' \
-                   % (self.type.capitalize(), self.catname[3:], str(self.pkeys), idstr))
+                    % (self.type.capitalize(), self.catname[3:], str(self.pkeys), idstr))
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 class CatDuplicateIssue:
-
-    def __init__(self, catname, pkeys, segids, enum ):
-
+    def __init__(self, catname, pkeys, segids, enum):
         self.catname = catname
-        self.pkeys   = pkeys     # string of pkey=xxxx or oid=xxxx 
-        self.segids  = segids    # list of affected segids
-        self.enum    = enum      # number of entries
+        self.pkeys = pkeys  # string of pkey=xxxx or oid=xxxx
+        self.segids = segids  # list of affected segids
+        self.enum = enum  # number of entries
 
     def report(self):
         """ Found # catname entries of "oid=XXXXX" on segment {Y,Z} """
         myprint('       Found %d %s entries of %s on segment %s' \
-                 % (self.enum, self.catname, str(self.pkeys), str(self.segids)))
+                % (self.enum, self.catname, str(self.pkeys), str(self.segids)))
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 class CatACLIssue:
+    def __init__(self, catname, pkeys, segid, macl_only, sacl_only):
 
-    def __init__(self, catname, pkeys, segid, macl_only, sacl_only ):
-
-        self.catname    = catname
-        self.pkeys      = pkeys       # string of pkey=xxxx or oid=xxxx 
-        self.segid      = segid       # the affected segid
-        self.macl_only  = macl_only   # acl appears only on master
-        self.sacl_only  = sacl_only   # acl appears only on segment
+        self.catname = catname
+        self.pkeys = pkeys  # string of pkey=xxxx or oid=xxxx
+        self.segid = segid  # the affected segid
+        self.macl_only = macl_only  # acl appears only on master
+        self.sacl_only = sacl_only  # acl appears only on segment
 
     def report(self):
         """ Master (host:port) and seg# (host:port) have different ACL:
                 Exist(s) on master only: [...........]
                 Exist(s) on   seg# only: [...........]
         """
-        mstr = 'Master (%s:%s)' % (GV.report_cfg[-1]['hostname'],GV.report_cfg[-1]['port'])
+        mstr = 'Master (%s:%s)' % (GV.report_cfg[-1]['hostname'], GV.report_cfg[-1]['port'])
         sstr = '%s (%s:%s)' % (GV.report_cfg[self.segid]['segname'],
                                GV.report_cfg[self.segid]['hostname'],
                                GV.report_cfg[self.segid]['port'])
@@ -4367,20 +4366,19 @@ class CatACLIssue:
             myprint('            Exist(s) on master only: %s' % (self.macl_only))
         if len(self.sacl_only) > 0:
             myprint('            Exist(s) on %s only: %s ' % \
-                      (GV.report_cfg[self.segid]['segname'], self.sacl_only))
-   
+                    (GV.report_cfg[self.segid]['segname'], self.sacl_only))
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 class GPObject:
-
     def __init__(self, oid, catname):
-        self.oid          = oid
-        self.catname      = catname
-        self.missingIssues      = {} # key=issue.catname, value=list of catMissingIssue
-        self.inconsistentIssues = {} # key=issue.catname, value=list of catInconsistentIssue
-        self.duplicateIssues    = {} # key=issue.catname, value=list of catDuplicateIssue
-        self.aclIssues          = {} # key=issue.catname, value=list of catACLIssue
-        self.foreignkeyIssues   = {} # key=issue.catname, value=list of catForeignKeyIssue
+        self.oid = oid
+        self.catname = catname
+        self.missingIssues = {}  # key=issue.catname, value=list of catMissingIssue
+        self.inconsistentIssues = {}  # key=issue.catname, value=list of catInconsistentIssue
+        self.duplicateIssues = {}  # key=issue.catname, value=list of catDuplicateIssue
+        self.aclIssues = {}  # key=issue.catname, value=list of catACLIssue
+        self.foreignkeyIssues = {}  # key=issue.catname, value=list of catForeignKeyIssue
 
     def setMissingIssue(self, issue):
         if issue.catname in self.missingIssues:
@@ -4422,6 +4420,7 @@ class GPObject:
         will log all the oid inconsistencies as WARNING instead of
         CRITICAL in order to log it in the log file.
         """
+
         def __myprint(string):
             if self.catname in ['pg_constraint']:
                 _myprint(string, logging.WARNING)
@@ -4440,7 +4439,7 @@ class GPObject:
 
         # Report inconsistent issues
         if len(self.inconsistentIssues):
-            for catname,issues in self.inconsistentIssues.iteritems():
+            for catname, issues in self.inconsistentIssues.iteritems():
                 myprint('    Name of test which found this issue: inconsistent_%s' % catname)
                 for each in issues:
                     each.report()
@@ -4448,7 +4447,7 @@ class GPObject:
 
         # Report missing issues
         if len(self.missingIssues):
-            omitlist = ['pg_attribute','pg_attribute_encoding','pg_type','pg_appendonly','pg_index']
+            omitlist = ['pg_attribute', 'pg_attribute_encoding', 'pg_type', 'pg_appendonly', 'pg_index']
             if 'pg_class' in self.missingIssues:
                 myprint('    Name of test which found this issue: missing_extraneous_pg_class')
                 for name in omitlist:
@@ -4463,7 +4462,7 @@ class GPObject:
                         for each in issues:
                             each.report()
             else:
-                for catname,issues in self.missingIssues.iteritems():
+                for catname, issues in self.missingIssues.iteritems():
                     myprint('    Name of test which found this issue: missing_extraneous_%s' % catname)
                     for each in issues:
                         each.report()
@@ -4471,14 +4470,14 @@ class GPObject:
 
         # Report foreign key issues
         if len(self.foreignkeyIssues):
-            for catname,issues in self.foreignkeyIssues.iteritems():
+            for catname, issues in self.foreignkeyIssues.iteritems():
                 myprint('    Name of test which found this issue: foreign_key_%s' % catname)
                 for each in issues:
                     each.report()
             myprint('')
 
         if len(self.duplicateIssues):
-            for catname,issues in self.duplicateIssues.iteritems():
+            for catname, issues in self.duplicateIssues.iteritems():
                 myprint('    Name of test which found this issue: duplicate_%s' % catname)
                 for each in issues:
                     each.report()
@@ -4486,7 +4485,7 @@ class GPObject:
 
         # Report ACL issues
         if len(self.aclIssues):
-            for catname,issues in self.aclIssues.iteritems():
+            for catname, issues in self.aclIssues.iteritems():
                 myprint('    Name of test which found this issue: acl_%s' % catname)
                 for each in issues:
                     each.report()
@@ -4502,11 +4501,10 @@ class GPObject:
 
     def __hash__(self):
         return hash((self.oid, self.catname))
-   
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 class RelationObject(GPObject):
-
     def __init__(self, oid, catname):
         GPObject.__init__(self, oid, catname)
         self.relname = None
@@ -4536,7 +4534,7 @@ class RelationObject(GPObject):
         self.relname = relname
         self.nspname = nspname
         self.relkind = relkind
-        self.paroid  = paroid
+        self.paroid = paroid
 
     def isTopLevel(self):
         if self.relkind == 'i' or self.relkind == 't' or self.relkind == 'o':
@@ -4544,9 +4542,8 @@ class RelationObject(GPObject):
         return True
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def getRelInfo(objects):
-
     # Get relinfo: relname, relkind, par oid for all oids
     #   get relname, relkind
     #   left outer join with union of
@@ -4557,7 +4554,7 @@ def getRelInfo(objects):
 
     if objects == {}: return
 
-    oids = [oid for (oid, catname) in objects if catname=='pg_class']
+    oids = [oid for (oid, catname) in objects if catname == 'pg_class']
     if oids == []: return
 
     qry = """
@@ -4634,29 +4631,28 @@ def getRelInfo(objects):
             ) par_index
             WHERE rank=1
           ) par ON childoid = oid
-          """.format( oids = ','.join(map(str,oids)))
+          """.format(oids=','.join(map(str, oids)))
 
     try:
         db = connect2(GV.cfg[1], utilityMode=False)
         curs = db.query(qry)
         for row in curs.getresult():
             (oid, relname, nspname, relkind, paroid) = row
-            objects[oid,'pg_class'].setRelInfo(relname, nspname, relkind, paroid)
-            
+            objects[oid, 'pg_class'].setRelInfo(relname, nspname, relkind, paroid)
+
     except Exception, e:
         setError(ERROR_NOREPAIR)
         myprint('  Execution error: ' + str(e))
         myprint(qry)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def buildGraph():
-
     def buildGraphRecursive(objects, graph):
         if objects == {}: return
-        getRelInfo (objects)
+        getRelInfo(objects)
         localObjects = {}
-        for (oid, catname),obj in objects.iteritems():
+        for (oid, catname), obj in objects.iteritems():
             # Top level object, add to graph
             if obj.isTopLevel():
                 if obj not in graph:
@@ -4680,19 +4676,17 @@ def buildGraph():
     buildGraphRecursive(GPObjects, GPObjectGraph)
 
 
-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 def checkcatReport():
-
     def reportAllIssuesRecursive(par, graph):
         par.reportAllIssues()
-        if par not in graph: 
+        if par not in graph:
             return
         for child in sorted(graph[par]):
             reportAllIssuesRecursive(child, graph)
 
     buildGraph()
-    reportedTest = ['duplicate','missing_extraneous','inconsistent','foreign_key','acl', 'duplicate_persistent'] 
+    reportedTest = ['duplicate', 'missing_extraneous', 'inconsistent', 'foreign_key', 'acl', 'duplicate_persistent']
     myprint('')
     myprint('SUMMARY REPORT')
     myprint('===================================================================')
@@ -4704,7 +4698,7 @@ def checkcatReport():
     if len(GPObjectGraph) == 0 and len(GV.failedTest) == 0:
         myprint('Found no catalog issue\n')
         return
-  
+
     if len(GPObjectGraph) > 0:
         total = 0
         for par in GPObjectGraph:
@@ -4715,7 +4709,7 @@ def checkcatReport():
                 myprint('Warnings were generated, see %s for detail\n' % get_logfile())
         else:
             myprint('Found a total of %d issue(s)' % total)
-    
+
         for par in sorted(GPObjectGraph):
             if par.isTopLevel():
                 reportAllIssuesRecursive(par, GPObjectGraph)
@@ -4726,10 +4720,13 @@ def checkcatReport():
         myprint('Failed test(s) that are not reported here: %s' % (', '.join(notReported)))
         myprint('See %s for detail\n' % get_logfile())
 
+
 def _myprint(str, level=logging.CRITICAL):
-    log_literal(logger,level,str)
+    log_literal(logger, level, str)
+
 
 myprint = _myprint
+
 
 def generateVerifyFile(catname, fields, results, testname):
     in_clause = reduce(lambda x, y: x + ('' if not x else ',') + str(y[fields.index('oid')]), results, '')
@@ -4748,6 +4745,7 @@ def generateVerifyFile(catname, fields, results, testname):
             fp.write(verify_sql + '\n')
     except Exception as e:
         logger.warning('Unable to generate verify file for %s (%s)' % (catname, str(e)))
+
 
 #############
 if __name__ == '__main__':
@@ -4772,13 +4770,13 @@ if __name__ == '__main__':
         # Reset global variables
         GV.reset_stmt_queues()
         GPObjects = {}
-        GPObjectGraph = {} 
-        GV.dbname  = dbname
+        GPObjectGraph = {}
+        GV.dbname = dbname
         myprint('')
         myprint("Connected as user \'%s\' to database '%s', port '%d', gpdb version '%s'" \
-                   % (GV.opt['-U'], GV.dbname, GV.report_cfg[-1]['port'], GV.version))
+                % (GV.opt['-U'], GV.dbname, GV.report_cfg[-1]['port'], GV.version))
         myprint('-------------------------------------------------------------------')
-           
+
         dropLeakedSchemas(dbname)
         if GV.opt['-R']:
             name = GV.opt['-R']


### PR DESCRIPTION
This PR is identical to #591:

Update nomenclature in gpcheckcat - rename 'test' to 'check'

This is is to be more consistent and to avoid confusion with unit/integration tests in the future.

We purposely did not change 'test' in stdout because integration tests for other parts of the system that call gpcheckcat will fail if our output changes. A future commit may change 'test' to 'check' in stdout in addition to fixing the aforementioned integration tests.

Authors: Chumki Roy, Stephen Wu