### PR TITLE
Improve duplicate key value violation reporting on unique indexes.

### DIFF
--- a/src/backend/access/common/indextuple.c
+++ b/src/backend/access/common/indextuple.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/access/common/indextuple.c,v 1.81 2007-02-27 23:48:06 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/access/common/indextuple.c,v 1.89 2009/08/01 19:59:41 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -403,6 +403,27 @@ nocache_index_getattr(IndexTuple tup,
 			off = att_align(off, att[attnum]->attalign);
 
 		return fetchatt(att[attnum], tp + off);
+	}
+}
+
+/*
+ * Convert an index tuple into Datum/isnull arrays.
+ *
+ * The caller must allocate sufficient storage for the output arrays.
+ * (INDEX_MAX_KEYS entries should be enough.)
+ */
+void
+index_deform_tuple(IndexTuple tup, TupleDesc tupleDescriptor,
+				   Datum *values, bool *isnull)
+{
+	int			i;
+
+	/* Assert to protect callers who allocate fixed-size arrays */
+	Assert(tupleDescriptor->natts <= INDEX_MAX_KEYS);
+
+	for (i = 0; i < tupleDescriptor->natts; i++)
+	{
+		values[i] = index_getattr(tup, i + 1, tupleDescriptor, &isnull[i]);
 	}
 }
 

--- a/src/backend/access/index/genam.c
+++ b/src/backend/access/index/genam.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/access/index/genam.c,v 1.61 2007/01/20 18:43:35 neilc Exp $
+ *	  $PostgreSQL: pgsql/src/backend/access/index/genam.c,v 1.76 2009/08/01 20:59:17 tgl Exp $
  *
  * NOTES
  *	  many of the old access method routines have been turned into
@@ -26,6 +26,8 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 #include "storage/bufmgr.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/tqual.h"
 
@@ -128,6 +130,59 @@ IndexScanEnd(IndexScanDesc scan)
 		pfree(scan->keyData);
 
 	pfree(scan);
+}
+
+/*
+ * BuildIndexValueDescription
+ *
+ * Construct a string describing the contents of an index entry, in the
+ * form "(key_name, ...)=(key_value, ...)".  This is currently used
+ * only for building unique-constraint error messages, but we don't want
+ * to hardwire the spelling of the messages here.
+ */
+char *
+BuildIndexValueDescription(Relation indexRelation,
+						   Datum *values, bool *isnull)
+{
+	/*
+	 * XXX for the moment we use the index's tupdesc as a guide to the
+	 * datatypes of the values.  This is okay for btree indexes but is in
+	 * fact the wrong thing in general.  This will have to be fixed if we
+	 * are ever to support non-btree unique indexes.
+	 */
+	TupleDesc	tupdesc = RelationGetDescr(indexRelation);
+	StringInfoData buf;
+	int			i;
+
+	initStringInfo(&buf);
+	appendStringInfo(&buf, "(%s)=(",
+					 pg_get_indexdef_columns(RelationGetRelid(indexRelation),
+											 true));
+
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		char   *val;
+
+		if (isnull[i])
+			val = "null";
+		else
+		{
+			Oid		foutoid;
+			bool	typisvarlena;
+
+			getTypeOutputInfo(tupdesc->attrs[i]->atttypid,
+							  &foutoid, &typisvarlena);
+			val = OidOutputFunctionCall(foutoid, values[i]);
+		}
+
+		if (i > 0)
+			appendStringInfoString(&buf, ", ");
+		appendStringInfoString(&buf, val);
+	}
+
+	appendStringInfoChar(&buf, ')');
+
+	return buf.data;
 }
 
 

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -875,6 +875,7 @@ tuplesort_begin_index_mk(Relation indexRel,
 {
     Tuplesortstate_mk *state = tuplesort_begin_common(NULL, workMem, randomAccess, true);
     MemoryContext oldcontext;
+    TupleDesc tupdesc;
 
     oldcontext = MemoryContextSwitchTo(state->sortcontext);
 
@@ -882,7 +883,7 @@ tuplesort_begin_index_mk(Relation indexRel,
         PG_TRACE3(tuplesort__begin, enforceUnique, workMem, randomAccess);
 
     state->nKeys = RelationGetNumberOfAttributes(indexRel);
-    state->tupDesc = RelationGetDescr(indexRel);
+    tupdesc = RelationGetDescr(indexRel);
 
     state->copytup = copytup_index;
     state->writetup = writetup_index;
@@ -898,7 +899,7 @@ tuplesort_begin_index_mk(Relation indexRel,
 			state->cmpScanKey,
             tupsort_fetch_datum_itup,
             freetup_index,
-            state->tupDesc, 0, 0);
+            tupdesc, 0, 0);
    
     state->mkctxt.enforceUnique = enforceUnique;
     state->mkctxt.indexRel = indexRel;

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -195,7 +195,6 @@ typedef struct TupsortMergeReadCtxt
     int mem_used;
 } TupsortMergeReadCtxt;
 
-
 /*
  * Private state of a Tuplesort operation.
  */
@@ -876,7 +875,6 @@ tuplesort_begin_index_mk(Relation indexRel,
 {
     Tuplesortstate_mk *state = tuplesort_begin_common(NULL, workMem, randomAccess, true);
     MemoryContext oldcontext;
-    TupleDesc tupdesc;
 
     oldcontext = MemoryContextSwitchTo(state->sortcontext);
 
@@ -884,7 +882,7 @@ tuplesort_begin_index_mk(Relation indexRel,
         PG_TRACE3(tuplesort__begin, enforceUnique, workMem, randomAccess);
 
     state->nKeys = RelationGetNumberOfAttributes(indexRel);
-    tupdesc = RelationGetDescr(indexRel);
+    state->tupDesc = RelationGetDescr(indexRel);
 
     state->copytup = copytup_index;
     state->writetup = writetup_index;
@@ -900,9 +898,10 @@ tuplesort_begin_index_mk(Relation indexRel,
 			state->cmpScanKey,
             tupsort_fetch_datum_itup,
             freetup_index,
-            tupdesc, 0, 0);
+            state->tupDesc, 0, 0);
    
     state->mkctxt.enforceUnique = enforceUnique;
+    state->mkctxt.indexRel = indexRel;
     MemoryContextSwitchTo(oldcontext);
 
     return state;

--- a/src/backend/utils/sort/tuplesort_mkqsort.c
+++ b/src/backend/utils/sort/tuplesort_mkqsort.c
@@ -292,7 +292,7 @@ void mk_qsort_impl(MKEntry *a, int left, int right, int lv, bool lvdown, MKConte
 		/*
 		 * [lastInLow+1,firstInHigh-1] defines the pivot region which was all equal at level lv.  So increase the level and compare that region!
 		 */
-        mk_qsort_impl(a, lastInLow+1, firstInHigh-1, lv+1, true, ctxt, seenNull || mke_is_null(a+lastInLow+1)); /* a + lastInLow + 1 points to the pivot */
+		mk_qsort_impl(a, lastInLow+1, firstInHigh-1, lv+1, true, ctxt, seenNull || mke_is_null(a+lastInLow+1)); /* a + lastInLow + 1 points to the pivot */
 	}
 	else
 	{

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -7,7 +7,7 @@
  * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/access/genam.h,v 1.66 2007/01/05 22:19:50 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/access/genam.h,v 1.81 2009/08/01 20:59:17 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -134,6 +134,8 @@ extern FmgrInfo *index_getprocinfo(Relation irel, AttrNumber attnum,
 extern IndexScanDesc RelationGetIndexScan(Relation indexRelation,
 					 int nkeys, ScanKey key);
 extern void IndexScanEnd(IndexScanDesc scan);
+extern char *BuildIndexValueDescription(Relation indexRelation,
+						   Datum *values, bool *isnull);
 
 /*
  * heap-or-index access to system catalogs (in genam.c)

--- a/src/include/access/itup.h
+++ b/src/include/access/itup.h
@@ -7,7 +7,7 @@
  * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/access/itup.h,v 1.48 2007/01/05 22:19:51 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/access/itup.h,v 1.52 2009/08/01 19:59:41 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -143,6 +143,8 @@ extern IndexTuple index_form_tuple(TupleDesc tupleDescriptor,
 				 Datum *values, bool *isnull);
 extern Datum nocache_index_getattr(IndexTuple tup, int attnum,
 					  TupleDesc tupleDesc, bool *isnull);
+extern void index_deform_tuple(IndexTuple tup, TupleDesc tupleDescriptor,
+				 Datum *values, bool *isnull);
 extern IndexTuple CopyIndexTuple(IndexTuple source);
 
 #endif   /* ITUP_H */

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -8,7 +8,7 @@
  * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/utils/builtins.h,v 1.288 2007/02/17 00:55:58 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/utils/builtins.h,v 1.336 2009/08/01 19:59:41 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -573,6 +573,7 @@ extern Datum pg_get_viewdef_name_ext(PG_FUNCTION_ARGS);
 extern Datum pg_get_indexdef(PG_FUNCTION_ARGS);
 extern Datum pg_get_indexdef_ext(PG_FUNCTION_ARGS);
 extern char *pg_get_indexdef_string(Oid indexrelid);
+extern char *pg_get_indexdef_columns(Oid indexrelid, bool pretty);
 extern Datum pg_get_triggerdef(PG_FUNCTION_ARGS);
 extern Datum pg_get_constraintdef(PG_FUNCTION_ARGS);
 extern Datum pg_get_constraintdef_ext(PG_FUNCTION_ARGS);

--- a/src/include/utils/tuplesort_mk.h
+++ b/src/include/utils/tuplesort_mk.h
@@ -271,6 +271,7 @@ typedef struct MKContext {
     int strxfrmConstantFactor;
 
     TupleDesc tupdesc;
+    Relation indexRel;
     MemTupleBinding *mt_bind;
 
     /* Limit the sort?  If 0 then we sort all input values, else we keep only the first limit-many values */
@@ -284,8 +285,6 @@ typedef struct MKContext {
 
     /* enforce Unique, for index build */
     bool enforceUnique;
-
-    Relation indexRel;
 } MKContext;
 
 /**

--- a/src/include/utils/tuplesort_mk.h
+++ b/src/include/utils/tuplesort_mk.h
@@ -284,6 +284,8 @@ typedef struct MKContext {
 
     /* enforce Unique, for index build */
     bool enforceUnique;
+
+    Relation indexRel;
 } MKContext;
 
 /**
@@ -418,16 +420,5 @@ static inline int64 mkheap_cnt(MKHeap *mkheap)
 {
     return mkheap->count;
 }
-
-/**
- * ereport an ERROR indicating that the uniqueness constraint was violated
- */
-#define ERROR_UNIQUENESS_VIOLATED() \
-    do \
-    { \
-        ereport(ERROR, (errcode(ERRCODE_UNIQUE_VIOLATION), \
-                    errmsg("could not create unique index"), \
-                    errdetail("Table contains duplicate values."))); \
-    } while(0)
 
 #endif

--- a/src/interfaces/ecpg/test/expected/compat_informix-test_informix.stderr
+++ b/src/interfaces/ecpg/test/expected/compat_informix-test_informix.stderr
@@ -23,6 +23,7 @@
 [NO_PID]: ecpg_execute on line 31: using PQexec
 [NO_PID]: sqlca: code: 0, state: 00000
 [NO_PID]: ecpg_check_PQresult on line 31: ERROR:  duplicate key value violates unique constraint "test_pkey"
+DETAIL:  Key (i)=(7) already exists.
 [NO_PID]: sqlca: code: 0, state: 00000
 [NO_PID]: raising sqlstate 23505 (sqlcode -239) on line 31: duplicate key value violates unique constraint "test_pkey" on line 31
 [NO_PID]: sqlca: code: -239, state: 23505

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -476,7 +476,8 @@ NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "atacc1_test_key" f
 insert into atacc1 (test) values (2);
 -- should fail
 insert into atacc1 (test) values (2);
-ERROR:  duplicate key violates unique constraint "atacc1_test_key"  (seg0 rh55-qavm63:18506 pid=26645)
+ERROR:  duplicate key value violates unique constraint "atacc1_test_key"
+DETAIL:  Key (test)=(2) already exists.
 -- should succeed
 insert into atacc1 (test) values (4);
 -- try adding a unique oid constraint
@@ -491,8 +492,8 @@ insert into atacc1 (test) values (2);
 -- add a unique constraint (fails)
 alter table atacc1 add constraint atacc_test1 unique (test);
 NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "atacc1_test_key" for table "atacc1"
-ERROR:  could not create unique index  (seg0 rh55-qavm63:18506 pid=26645)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "atacc1_test_key"
+DETAIL:  Key (test)=(2) is duplicated.
 insert into atacc1 (test) values (3);
 drop table atacc1;
 -- let's do one where the unique constraint fails
@@ -511,7 +512,8 @@ NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "atacc1_test_key" f
 insert into atacc1 (test,test2) values (4,4);
 -- should fail
 insert into atacc1 (test,test2) values (4,4);
-ERROR:  duplicate key violates unique constraint "atacc1_test_key"  (seg1 rh55-qavm63:18507 pid=26647)
+ERROR:  duplicate key value violates unique constraint "atacc1_test_key"
+DETAIL:  Key (test, test2)=(4, 4) already exists.
 -- should all succeed
 insert into atacc1 (test,test2) values (4,5);
 insert into atacc1 (test,test2) values (5,4);
@@ -539,7 +541,8 @@ ERROR:  UNIQUE index must contain all columns in the distribution key of relatio
 -- should fail for @@ second one @@
 insert into atacc1 (test2, test) values (3, 3);
 insert into atacc1 (test2, test) values (2, 3);
-ERROR:  duplicate key violates unique constraint "atacc1_test_key"  (seg1 rh55-qavm63:18507 pid=26647)
+ERROR:  duplicate key value violates unique constraint "atacc1_test_key"
+DETAIL:  Key (test)=(3) already exists.
 drop table atacc1;
 -- test primary key constraint adding
 create table atacc1 ( test int ) with oids distributed by (test);
@@ -551,7 +554,8 @@ NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "atacc1_pkey" 
 insert into atacc1 (test) values (2);
 -- should fail
 insert into atacc1 (test) values (2);
-ERROR:  duplicate key violates unique constraint "atacc1_pkey"  (seg0 rh55-qavm63:18506 pid=26645)
+ERROR:  duplicate key value violates unique constraint "atacc1_pkey"
+DETAIL:  Key (test)=(2) already exists.
 -- should succeed
 insert into atacc1 (test) values (4);
 -- inserting NULL should fail
@@ -574,8 +578,8 @@ insert into atacc1 (test) values (2);
 -- add a primary key (fails)
 alter table atacc1 add constraint atacc_test1 primary key (test);
 NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "atacc1_pkey" for table "atacc1"
-ERROR:  could not create unique index  (seg0 rh55-qavm63:18506 pid=26645)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "atacc1_pkey"
+DETAIL:  Key (test)=(2) is duplicated.
 insert into atacc1 (test) values (3);
 drop table atacc1;
 -- let's do another one where the primary key constraint fails when added
@@ -618,7 +622,8 @@ ERROR:  multiple primary keys for table "atacc1" are not allowed
 insert into atacc1 (test,test2) values (4,4);
 -- should fail
 insert into atacc1 (test,test2) values (4,4);
-ERROR:  duplicate key violates unique constraint "atacc1_pkey"  (seg1 rh55-qavm63:18507 pid=26647)
+ERROR:  duplicate key value violates unique constraint "atacc1_pkey"
+DETAIL:  Key (test, test2)=(4, 4) already exists.
 insert into atacc1 (test,test2) values (NULL,3);
 ERROR:  null value in column "test" violates not-null constraint  (seg1 rh55-qavm63:18507 pid=26647)
 insert into atacc1 (test,test2) values (3, NULL);
@@ -636,7 +641,8 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "atacc1_pkey" for
 -- only first should succeed
 insert into atacc1 (test2, test) values (3, 3);
 insert into atacc1 (test2, test) values (2, 3);
-ERROR:  duplicate key violates unique constraint "atacc1_pkey"  (seg1 rh55-qavm63:18507 pid=26647)
+ERROR:  duplicate key value violates unique constraint "atacc1_pkey"
+DETAIL:  Key (test)=(3) already exists.
 insert into atacc1 (test2, test) values (1, NULL);
 ERROR:  null value in column "test" violates not-null constraint  (seg1 rh55-qavm63:18507 pid=26647)
 drop table atacc1;

--- a/src/test/regress/expected/alter_table_optimizer.out
+++ b/src/test/regress/expected/alter_table_optimizer.out
@@ -482,7 +482,8 @@ NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "atacc1_test_key" f
 insert into atacc1 (test) values (2);
 -- should fail
 insert into atacc1 (test) values (2);
-ERROR:  duplicate key violates unique constraint "atacc1_test_key"  (seg1 usxxshenem1.local:40001 pid=85314)
+ERROR:  duplicate key value violates unique constraint "atacc1_test_key"
+DETAIL:  Key (test)=(2) already exists.
 -- should succeed
 insert into atacc1 (test) values (4);
 -- try adding a unique oid constraint
@@ -497,8 +498,8 @@ insert into atacc1 (test) values (2);
 -- add a unique constraint (fails)
 alter table atacc1 add constraint atacc_test1 unique (test);
 NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "atacc1_test_key" for table "atacc1"
-ERROR:  could not create unique index  (seg1 usxxshenem1.local:40001 pid=85314)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "atacc1_test_key"
+DETAIL:  Key (test)=(2) is duplicated.
 insert into atacc1 (test) values (3);
 drop table atacc1;
 -- let's do one where the unique constraint fails
@@ -517,7 +518,8 @@ NOTICE:  ALTER TABLE / ADD UNIQUE will create implicit index "atacc1_test_key" f
 insert into atacc1 (test,test2) values (4,4);
 -- should fail
 insert into atacc1 (test,test2) values (4,4);
-ERROR:  duplicate key violates unique constraint "atacc1_test_key"  (seg1 usxxshenem1.local:40001 pid=85314)
+ERROR:  duplicate key value violates unique constraint "atacc1_test_key"
+DETAIL:  Key (test, test2)=(4, 4) already exists.
 -- should all succeed
 insert into atacc1 (test,test2) values (4,5);
 insert into atacc1 (test,test2) values (5,4);
@@ -545,7 +547,8 @@ ERROR:  UNIQUE index must contain all columns in the distribution key of relatio
 -- should fail for @@ second one @@
 insert into atacc1 (test2, test) values (3, 3);
 insert into atacc1 (test2, test) values (2, 3);
-ERROR:  duplicate key violates unique constraint "atacc1_test_key"  (seg0 usxxshenem1.local:40000 pid=85313)
+ERROR:  duplicate key value violates unique constraint "atacc1_test_key"
+DETAIL:  Key (test)=(3) already exists.
 drop table atacc1;
 -- test primary key constraint adding
 create table atacc1 ( test int ) with oids distributed by (test);
@@ -557,7 +560,8 @@ NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "atacc1_pkey" 
 insert into atacc1 (test) values (2);
 -- should fail
 insert into atacc1 (test) values (2);
-ERROR:  duplicate key violates unique constraint "atacc1_pkey"  (seg1 usxxshenem1.local:40001 pid=85314)
+ERROR:  duplicate key value violates unique constraint "atacc1_pkey"
+DETAIL:  Key (test)=(2) already exists.
 -- should succeed
 insert into atacc1 (test) values (4);
 -- inserting NULL should fail
@@ -581,8 +585,8 @@ insert into atacc1 (test) values (2);
 -- add a primary key (fails)
 alter table atacc1 add constraint atacc_test1 primary key (test);
 NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "atacc1_pkey" for table "atacc1"
-ERROR:  could not create unique index  (seg1 usxxshenem1.local:40001 pid=85314)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "atacc1_pkey"
+DETAIL:  Key (test)=(2) is duplicated.
 insert into atacc1 (test) values (3);
 drop table atacc1;
 -- let's do another one where the primary key constraint fails when added
@@ -625,7 +629,8 @@ ERROR:  multiple primary keys for table "atacc1" are not allowed
 insert into atacc1 (test,test2) values (4,4);
 -- should fail
 insert into atacc1 (test,test2) values (4,4);
-ERROR:  duplicate key violates unique constraint "atacc1_pkey"  (seg1 usxxshenem1.local:40001 pid=85314)
+ERROR:  duplicate key value violates unique constraint "atacc1_pkey"
+DETAIL:  Key (test, test2)=(4, 4) already exists.
 insert into atacc1 (test,test2) values (NULL,3);
 ERROR:  One or more assertions failed  (seg0 antova-mbp.local:40010 pid=87501)
 DETAIL:  Not null constraint for column test of table atacc1 was violated
@@ -648,7 +653,8 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "atacc1_pkey" for
 -- only first should succeed
 insert into atacc1 (test2, test) values (3, 3);
 insert into atacc1 (test2, test) values (2, 3);
-ERROR:  duplicate key violates unique constraint "atacc1_pkey"  (seg0 usxxshenem1.local:40000 pid=85313)
+ERROR:  duplicate key value violates unique constraint "atacc1_pkey"
+DETAIL:  Key (test)=(3) already exists.
 insert into atacc1 (test2, test) values (1, NULL);
 ERROR:  One or more assertions failed  (seg0 antova-mbp.local:40010 pid=87501)
 DETAIL:  Not null constraint for column test of table atacc1 was violated

--- a/src/test/regress/expected/arrays.out
+++ b/src/test/regress/expected/arrays.out
@@ -722,7 +722,8 @@ insert into arr_tbl values ('{1,2,3}');
 insert into arr_tbl values ('{1,2}');
 -- failure expected:
 insert into arr_tbl values ('{1,2,3}');
-ERROR:  duplicate key violates unique constraint "arr_tbl_f1_key"
+ERROR:  duplicate key value violates unique constraint "arr_tbl_f1_key"
+DETAIL:  Key (f1)=({1,2,3}) already exists.
 insert into arr_tbl values ('{2,3,4}');
 insert into arr_tbl values ('{1,5,3}');
 insert into arr_tbl values ('{1,2,10}');

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -393,7 +393,8 @@ INSERT INTO concur_heap VALUES  ('b','b');
 CREATE UNIQUE INDEX CONCURRENTLY concur_index2 ON concur_heap(f1);
 -- check if constraint is set up properly to be enforced
 INSERT INTO concur_heap VALUES ('b','x');
-ERROR:  duplicate key violates unique constraint "concur_index2"  (seg1 jeffsmac:11002 pid=62533)
+ERROR:  duplicate key value violates unique constraint "concur_index2"
+DETAIL:  Key (f1)=(b) already exists.
 -- check if constraint is enforced properly at build time
 --CREATE UNIQUE INDEX CONCURRENTLY concur_index3 ON concur_heap(f2);
 -- test that expression indexes and partial indexes work concurrently
@@ -899,11 +900,11 @@ insert into ijk values (1, NULL, NULL);
 insert into ijk values (1, NULL, NULL);
 -- should fail.
 create unique index ijk_i on ijk(i);
-ERROR:  could not create unique index  (seg0 jeffsmac:11001 pid=62532)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "ijk_i"
+DETAIL:  Key (i)=(1) is duplicated.
 create unique index ijk_ij on ijk(i,j);
-ERROR:  could not create unique index  (seg0 jeffsmac:11001 pid=62532)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "ijk_ij"
+DETAIL:  Key (i, j)=(1, 3) is duplicated.
 -- should OK.
 create unique index ijk_ijk on ijk(i,j,k);
 set gp_enable_mk_sort=on;
@@ -917,11 +918,11 @@ insert into ijk values (1, NULL, NULL);
 insert into ijk values (1, NULL, NULL);
 -- should fail.
 create unique index ijk_i on ijk(i);
-ERROR:  could not create unique index  (seg0 jeffsmac:11001 pid=62532)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "ijk_i"
+DETAIL:  Key (i)=(1) is duplicated.
 create unique index ijk_ij on ijk(i,j);
-ERROR:  could not create unique index  (seg0 jeffsmac:11001 pid=62532)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "ijk_ij"
+DETAIL:  Key (i, j)=(1, 3) is duplicated.
 -- should OK.
 create unique index ijk_ijk on ijk(i,j,k);
 set gp_enable_mk_sort=off;

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -393,7 +393,8 @@ INSERT INTO concur_heap VALUES  ('b','b');
 CREATE UNIQUE INDEX CONCURRENTLY concur_index2 ON concur_heap(f1);
 -- check if constraint is set up properly to be enforced
 INSERT INTO concur_heap VALUES ('b','x');
-ERROR:  duplicate key violates unique constraint "concur_index2"  (seg1 jeffsmac:11002 pid=62533)
+ERROR:  duplicate key value violates unique constraint "concur_index2"
+DETAIL:  Key (f1)=(b) already exists.
 -- check if constraint is enforced properly at build time
 --CREATE UNIQUE INDEX CONCURRENTLY concur_index3 ON concur_heap(f2);
 -- test that expression indexes and partial indexes work concurrently
@@ -899,11 +900,11 @@ insert into ijk values (1, NULL, NULL);
 insert into ijk values (1, NULL, NULL);
 -- should fail.
 create unique index ijk_i on ijk(i);
-ERROR:  could not create unique index  (seg0 jeffsmac:11001 pid=62532)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "ijk_i"
+DETAIL:  Key (i)=(1) is duplicated.
 create unique index ijk_ij on ijk(i,j);
-ERROR:  could not create unique index  (seg0 jeffsmac:11001 pid=62532)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "ijk_ij"
+DETAIL:  Key (i, j)=(1, 3) is duplicated.
 -- should OK.
 create unique index ijk_ijk on ijk(i,j,k);
 set gp_enable_mk_sort=on;
@@ -917,11 +918,11 @@ insert into ijk values (1, NULL, NULL);
 insert into ijk values (1, NULL, NULL);
 -- should fail.
 create unique index ijk_i on ijk(i);
-ERROR:  could not create unique index  (seg0 jeffsmac:11001 pid=62532)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "ijk_i"
+DETAIL:  Key (i)=(1) is duplicated.
 create unique index ijk_ij on ijk(i,j);
-ERROR:  could not create unique index  (seg0 jeffsmac:11001 pid=62532)
-DETAIL:  Table contains duplicate values.
+ERROR:  could not create unique index "ijk_ij"
+DETAIL:  Key (i, j)=(1, 3) is duplicated.
 -- should OK.
 create unique index ijk_ijk on ijk(i,j,k);
 set gp_enable_mk_sort=off;

--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -641,6 +641,7 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "inhg_pkey" for t
 INSERT INTO inhg VALUES (5, 10);
 INSERT INTO inhg VALUES (20, 10); -- should fail
 ERROR:  duplicate key value violates unique constraint "inhg_pkey"
+DETAIL:  Key (xx)=(10) already exists.
 DROP TABLE inhg;
 /* Multiple primary keys creation should fail */
 CREATE TABLE inhg (x text, LIKE inhx INCLUDING INDEXES, PRIMARY KEY(x)); /* fails */
@@ -656,6 +657,7 @@ INSERT INTO inhg (xx, yy, x) VALUES ('test', 5, 10);
 INSERT INTO inhg (xx, yy, x) VALUES ('test', 10, 15);
 INSERT INTO inhg (xx, yy, x) VALUES ('foo', 10, 15); -- should fail
 ERROR:  duplicate key value violates unique constraint "inhg_x_key"
+DETAIL:  Key (x)=(15) already exists.
 DROP TABLE inhg;
 DROP TABLE inhz;
 -- Test changing the type of inherited columns

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -93,7 +93,8 @@ select * from region where r_regionkey = '7';
 -- tables since we cannot enfoce them. But since this insert maps to a 
 -- single definitive partition, we can detect it.
 insert into region values(7, 'abc', 'def');
-ERROR:  duplicate key violates unique constraint "region_pkey_1_prt_p1_2_prt_sp1_3_prt_1"  (seg0 slarimac:40000 pid=97859)
+ERROR: duplicate key value violates unique constraint "region_pkey_1_prt_p1_2_prt_sp1_3_prt_1"  (seg0 slarimac:40000 pid=97859)
+DETAIL: Key (r_regionkey)=(7) already exists.
 drop table region;
 -- exchange
 -- 1) test all sanity checking

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -93,7 +93,8 @@ select * from region where r_regionkey = '7';
 -- tables since we cannot enfoce them. But since this insert maps to a 
 -- single definitive partition, we can detect it.
 insert into region values(7, 'abc', 'def');
-ERROR:  duplicate key violates unique constraint "region_pkey_1_prt_p1_2_prt_sp1_3_prt_1"  (seg0 rahmaf2-mbp:40000 pid=78904)
+ERROR:  duplicate key value violates unique constraint "region_pkey_1_prt_p1_2_prt_sp1_3_prt_1"
+DETAIL:  Key (r_regionkey)=(7) already exists.
 drop table region;
 -- exchange
 -- 1) test all sanity checking

--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -1517,7 +1517,8 @@ select * from PField_v1 where pfname = 'PF0_2' order by slotname;
 -- Finally we want errors
 --
 insert into PField values ('PF1_1', 'should fail due to unique index');
-ERROR:  duplicate key violates unique constraint "pfield_name"
+ERROR:  duplicate key value violates unique constraint "pfield_name"
+DETAIL:  Key (name)=(PF1_1) already exists.
 update PSlot set backlink = 'WS.not.there' where slotname = 'PS.base.a1';
 ERROR:  WS.not.there         does not exist
 CONTEXT:  PL/pgSQL function "tg_backlink_a" line 16 at assignment
@@ -1531,7 +1532,8 @@ update PSlot set slotlink = 'XX.illegal' where slotname = 'PS.base.a1';
 ERROR:  illegal slotlink beginning with XX
 CONTEXT:  PL/pgSQL function "tg_slotlink_a" line 16 at assignment
 insert into HSlot values ('HS', 'base.hub1', 1, '');
-ERROR:  duplicate key violates unique constraint "hslot_name"
+ERROR:  duplicate key value violates unique constraint "hslot_name"
+DETAIL:  Key (slotname)=(HS.base.hub1.1      ) already exists.
 insert into HSlot values ('HS', 'base.hub1', 20, '');
 ERROR:  no manual manipulation of HSlot
 delete from HSlot;

--- a/src/test/regress/expected/transactions.out
+++ b/src/test/regress/expected/transactions.out
@@ -463,13 +463,15 @@ BEGIN;
 NOTICE:  CREATE TABLE / UNIQUE will create implicit index "koju_a_key" for table "koju"
 		INSERT INTO koju VALUES (1);
 		INSERT INTO koju VALUES (1);
-ERROR:  duplicate key violates unique constraint "koju_a_key"
+ERROR:  duplicate key value violates unique constraint "koju_a_key"
+DETAIL:  Key (a)=(1) already exists.
 	rollback to x;
 	CREATE TABLE koju (a INT UNIQUE);
 NOTICE:  CREATE TABLE / UNIQUE will create implicit index "koju_a_key" for table "koju"
 	INSERT INTO koju VALUES (1);
 	INSERT INTO koju VALUES (1);
-ERROR:  duplicate key violates unique constraint "koju_a_key"
+ERROR:  duplicate key value violates unique constraint "koju_a_key"
+DETAIL:  Key (a)=(1) already exists.
 ROLLBACK;
 DROP TABLE foo;
 DROP TABLE baz;

--- a/src/test/regress/expected/uuid.out
+++ b/src/test/regress/expected/uuid.out
@@ -105,7 +105,8 @@ CREATE INDEX guid1_btree ON guid1 USING BTREE (guid_field);
 CREATE UNIQUE INDEX guid1_unique_BTREE ON guid1 USING BTREE (guid_field);
 -- should fail
 INSERT INTO guid1(guid_field) VALUES('11111111-1111-1111-1111-111111111111');
-ERROR:  duplicate key violates unique constraint "guid1_unique_btree"
+ERROR:  duplicate key value violates unique constraint "guid1_unique_btree"
+DETAIL:  Key (guid_field)=(11111111-1111-1111-1111-111111111111) already exists.
 -- check to see whether the new indexes are actually there
 SELECT count(*) FROM pg_class WHERE relkind='i' AND relname LIKE 'guid%';
  count 

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -280,7 +280,8 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "primary_tbl_pkey
 INSERT INTO PRIMARY_TBL VALUES (1, 'one');
 INSERT INTO PRIMARY_TBL VALUES (2, 'two');
 INSERT INTO PRIMARY_TBL VALUES (1, 'three');
-ERROR:  duplicate key violates unique constraint "primary_tbl_pkey"
+ERROR:  duplicate key value violates unique constraint "primary_tbl_pkey"
+DETAIL:  Key (i)=(1) already exists.
 INSERT INTO PRIMARY_TBL VALUES (4, 'three');
 INSERT INTO PRIMARY_TBL VALUES (5, 'one');
 INSERT INTO PRIMARY_TBL (t) VALUES ('six');
@@ -324,7 +325,8 @@ NOTICE:  CREATE TABLE / UNIQUE will create implicit index "unique_tbl_i_key" for
 INSERT INTO UNIQUE_TBL VALUES (1, 'one');
 INSERT INTO UNIQUE_TBL VALUES (2, 'two');
 INSERT INTO UNIQUE_TBL VALUES (1, 'three');
-ERROR:  duplicate key violates unique constraint "unique_tbl_i_key"
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(1) already exists.
 INSERT INTO UNIQUE_TBL VALUES (4, 'four');
 INSERT INTO UNIQUE_TBL VALUES (5, 'one');
 INSERT INTO UNIQUE_TBL (t) VALUES ('six');
@@ -348,7 +350,8 @@ INSERT INTO UNIQUE_TBL VALUES (1, 'one');
 INSERT INTO UNIQUE_TBL VALUES (2, 'two');
 INSERT INTO UNIQUE_TBL VALUES (1, 'three');
 INSERT INTO UNIQUE_TBL VALUES (1, 'one');
-ERROR:  duplicate key violates unique constraint "unique_tbl_i_key"
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i, t)=(1, one) already exists.
 INSERT INTO UNIQUE_TBL VALUES (5, 'one');
 INSERT INTO UNIQUE_TBL (t) VALUES ('six');
 SELECT '' AS five, * FROM UNIQUE_TBL;

--- a/src/test/regress/output/constraints_optimizer.source
+++ b/src/test/regress/output/constraints_optimizer.source
@@ -312,7 +312,8 @@ NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "primary_tbl_pkey
 INSERT INTO PRIMARY_TBL VALUES (1, 'one');
 INSERT INTO PRIMARY_TBL VALUES (2, 'two');
 INSERT INTO PRIMARY_TBL VALUES (1, 'three');
-ERROR:  duplicate key violates unique constraint "primary_tbl_pkey"
+ERROR:  duplicate key value violates unique constraint "primary_tbl_pkey"
+DETAIL:  Key (i)=(1) already exists.
 INSERT INTO PRIMARY_TBL VALUES (4, 'three');
 INSERT INTO PRIMARY_TBL VALUES (5, 'one');
 INSERT INTO PRIMARY_TBL (t) VALUES ('six');
@@ -356,7 +357,8 @@ NOTICE:  CREATE TABLE / UNIQUE will create implicit index "unique_tbl_i_key" for
 INSERT INTO UNIQUE_TBL VALUES (1, 'one');
 INSERT INTO UNIQUE_TBL VALUES (2, 'two');
 INSERT INTO UNIQUE_TBL VALUES (1, 'three');
-ERROR:  duplicate key violates unique constraint "unique_tbl_i_key"
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i)=(1) already exists.
 INSERT INTO UNIQUE_TBL VALUES (4, 'four');
 INSERT INTO UNIQUE_TBL VALUES (5, 'one');
 INSERT INTO UNIQUE_TBL (t) VALUES ('six');
@@ -380,7 +382,8 @@ INSERT INTO UNIQUE_TBL VALUES (1, 'one');
 INSERT INTO UNIQUE_TBL VALUES (2, 'two');
 INSERT INTO UNIQUE_TBL VALUES (1, 'three');
 INSERT INTO UNIQUE_TBL VALUES (1, 'one');
-ERROR:  duplicate key violates unique constraint "unique_tbl_i_key"
+ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
+DETAIL:  Key (i, t)=(1, one) already exists.
 INSERT INTO UNIQUE_TBL VALUES (5, 'one');
 INSERT INTO UNIQUE_TBL (t) VALUES ('six');
 SELECT '' AS five, * FROM UNIQUE_TBL;

--- a/src/test/regress/output/tablespace.source
+++ b/src/test/regress/output/tablespace.source
@@ -48,7 +48,8 @@ ALTER TABLE testschema.atable SET TABLESPACE testspace;
 ALTER INDEX testschema.anindex SET TABLESPACE testspace;
 INSERT INTO testschema.atable VALUES(3);	-- ok
 INSERT INTO testschema.atable VALUES(1);	-- fail (checks index)
-ERROR:  duplicate key violates unique constraint "anindex"
+ERROR:  duplicate key value violates unique constraint "anindex"
+DETAIL:  Key (column1)=(1) already exists.
 SELECT COUNT(*) FROM testschema.atable;		-- checks heap
  count 
 -------


### PR DESCRIPTION
Currently, the error reporting for duplicate key value violation for unique
indexes does not contain useful information for users when debugging. This
commit backports two commits from PostgreSQL (shown below) and updates our
multikey tuplesort to use the same. Now the error will display the first
instance of a duplicate key violation.

Authors: Jimmy Yih and Abhijit Subramanya

commit b680ae4bdbf1c7fd78e6988bbe8f89e1e1b5db86
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Sat Aug 1 19:59:41 2009 +0000

    Improve unique-constraint-violation error messages to include the exact
    values being complained of.

    In passing, also remove the arbitrary length limitation in the similar
    error detail message for foreign key violations.

    Itagaki Takahiro

 Conflicts:
	contrib/citext/expected/citext.out
	contrib/citext/expected/citext_1.out
	src/backend/access/common/indextuple.c
	src/backend/access/index/genam.c
	src/backend/access/nbtree/nbtinsert.c
	src/backend/utils/adt/ri_triggers.c
	src/backend/utils/adt/ruleutils.c
	src/include/access/genam.h
	src/include/access/itup.h
	src/include/utils/builtins.h
	src/test/regress/expected/alter_table.out
	src/test/regress/expected/arrays.out
	src/test/regress/expected/create_index.out
	src/test/regress/expected/plpgsql.out
	src/test/regress/expected/transactions.out
	src/test/regress/expected/uuid.out
	src/test/regress/output/constraints.source
	src/test/regress/output/tablespace.source

commit 527f0ae3fa48c3c3a8ba1bde19039545e88a52b6
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Sat Aug 1 20:59:17 2009 +0000

    Department of second thoughts: let's show the exact key during unique index
    build failures, too.  Refactor a bit more since that error message isn't
    spelled the same.

 Conflicts:
	src/backend/access/nbtree/nbtinsert.c
	src/backend/utils/sort/tuplesort.c
	src/test/regress/expected/alter_table.out
	src/test/regress/expected/create_index.out