### PR TITLE
Handle the Sentinel case in node creation

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4432,6 +4432,13 @@ CTranslatorDXLToPlStmt::PplanDML
 			aclmode = ACL_INSERT;
 			break;
 		}
+		case gpdxl::EdxldmlSentinel:
+		default:
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion
+				GPOS_WSZ_LIT("Unexpected error during plan generation."));
+			break;
+		}
 	}
 	
 	IMDId *pmdidTargetTable = pdxlop->Pdxltabdesc()->Pmdid();


### PR DESCRIPTION
This might be more of a discussion piece since I might be way off, but I think there might be something worth looking at here. In the node creation, we really shouldn't get a sentinel node but perusing the code it seems at least theoretically possible (if not, hints to where in the code to look is appreciated since I'm not familiar with the Orca code)? If we for some reason do we need/should handle it and stop from propagating it further it seems. Or?