### PR TITLE
Fix case when a PREPARE statement is run with an underlying relation …

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -938,7 +938,7 @@ pg_plan_queries(List *querytrees, ParamListInfo boundParams,
 
 		foreach(rtable_list, query->rtable)
 		{
-			RangeTableEntry *rte = (RangeTableEntry *) lfirst(rtable_list);
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(rtable_list);
 			/* Check if underlying relation is still valid. */
 			prep_underlying_relation = relation_open(rte->relid, AccessShareLock);
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -45,6 +45,7 @@
 #include "access/printtup.h"
 #include "access/xact.h"
 #include "catalog/pg_type.h"
+#include "catalog/heap.h"
 #include "commands/async.h"
 #include "commands/prepare.h"
 #include "libpq/libpq.h"
@@ -927,11 +928,22 @@ pg_plan_queries(List *querytrees, ParamListInfo boundParams,
 {
 	List	   *stmt_list = NIL;
 	ListCell   *query_list;
+	ListCell   *rtable_list;
+	Relation   prep_underlying_relation;
 
 	foreach(query_list, querytrees)
 	{
 		Query	   *query = (Query *) lfirst(query_list);
 		Node *stmt;
+
+		foreach(rtable_list, query->rtable)
+		{
+			RangeTableEntry *rte = (RangeTableEntry *) lfirst(rtable_list);
+			/* Check if underlying relation is still valid. */
+			prep_underlying_relation = relation_open(rte->relid, AccessShareLock);
+
+			relation_close(prep_underlying_relation, AccessShareLock);
+		}
 
 		if (query->commandType == CMD_UTILITY)
 		{


### PR DESCRIPTION
…like prepare p1(text) as select * from t1 and the relation is dropped. PREPARE statement does not see that stored query is invalidated and directly goes to plan the stored statement.

Ideally we should not store rewritten queries in PREPARE statements but that is a larger fix which should happen as part of upstream PG merge anyways.

Reported by Pengzhou Tang