### PR TITLE
Move test for gpcheckcat (table ownership) from tinc to behave

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2215,7 +2215,7 @@ def checkOwners():
       join pg_namespace n on (n.oid = t.typnamespace)
       join pg_authid a on (a.oid = r.typowner)
       join pg_authid m on (m.oid = t.typowner)
-    where r.typowner <> t.typowner and r.typrelid = 0
+    where r.typowner <> t.typowner
     '''
     try:
         curs = db.query(qry)

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
@@ -21,7 +21,7 @@ Feature: gpcheckcat tests
         And verify that the schema "good_schema" exists in "leak"
         And the user runs "dropdb leak"
 
-  Scenario: gpcheckcat should report unique index violations
+    Scenario: gpcheckcat should report unique index violations
         Given database "test_index" is dropped and recreated
         And the user runs "psql test_index -f 'gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_unique_index_violation.sql'"
         Then psql should return a return code of 0
@@ -135,3 +135,24 @@ Feature: gpcheckcat tests
         And gpcheckcat should print Table miss_attr.public.heap_table.-1 to stdout
         And gpcheckcat should print Table miss_attr.public.ao_table.0 to stdout
         And gpcheckcat should print Table miss_attr.public.ao_table.1 to stdout
+
+    Scenario: gpcheckcat should find owner error and produce timestamped repair scripts from -A (all databases) option
+        Given database "db1" is dropped and recreated
+        And database "db2" is dropped and recreated
+        And the path "gpcheckcat.repair.*" is removed from current working directory
+        And there is a "heap" table "gpadmin_tbl" in "db1" with data
+        And there is a "heap" table "gpadmin_tbl" in "db2" with data
+        And the user runs "psql db1 -f gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_user_wolf.sql"
+        Then psql should return a return code of 0
+        Given the user runs sql "alter table gpadmin_tbl OWNER TO wolf" in "db1" on first primary segment
+        When the user runs "gpcheckcat -A"
+        Then gpcheckcat should return a return code of 3
+        Then gpcheckcat should print reported here: owner to stdout
+        Then the path "gpcheckcat.repair.*" is found in cwd "1" times
+        When the user runs "gpcheckcat -A"
+        Then gpcheckcat should return a return code of 3
+        Then gpcheckcat should print reported here: owner to stdout
+        Then the path "gpcheckcat.repair.*" is found in cwd "2" times
+        And the user runs "dropdb db1"
+        And the user runs "dropdb db2"
+        And the path "gpcheckcat.repair.*" is removed from current working directory

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_user_wolf.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_user_wolf.sql
@@ -1,0 +1,2 @@
+-- sql for gpcheckcat -A
+create user wolf login password 'foo';

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3795,3 +3795,25 @@ def impl(context, table, dbname, segid):
 ssh %s "source %s; export PGUSER=%s; export PGPORT=%s; export PGOPTIONS=\\\"-c gp_session_role=utility\\\"; psql -d %s -c \\\"SET allow_system_table_mods=\'dml\'; DELETE FROM pg_attribute where attrelid=\'%s\'::regclass::oid;\\\""
 """ % (host, source_file, user, port, dbname, table)
     run_command(context, remote_cmd.strip())
+
+@then('The user runs sql "{query}" in "{dbname}" on first primary segment')
+@when('The user runs sql "{query}" in "{dbname}" on first primary segment')
+@given('The user runs sql "{query}" in "{dbname}" on first primary segment')
+def impl(context, query, dbname):
+    host, port = get_primary_segment_host_port()
+    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \'%s\'; " % (dbname, host, port, query)
+    Command(name='Running Remote command: %s' % psql_cmd, cmdStr = psql_cmd).run(validateAfter=True)
+
+@then( 'The path "{path}" is removed from current working directory')
+@when( 'The path "{path}" is removed from current working directory')
+@given('The path "{path}" is removed from current working directory')
+def impl(context, path):
+    remove_local_path(path)
+
+@given('the path "{path}" is found in cwd "{num}" times')
+@then('the path "{path}" is found in cwd "{num}" times')
+@when('the path "{path}" is found in cwd "{num}" times')
+def impl(context, path, num):
+    result = validate_local_path(path)
+    if result != int(num):
+        raise Exception("expected %s items but found %s items in path %s" % (num, result, path) )


### PR DESCRIPTION
Move the gpcheckcat test for mismatched table ownership from tinc to behave. In particular, the test included validation of how repair files were written to timestamped directories such that the -A option and multiple gpcheckcat invocations would still preserve all previous repair files in their timestamped directories.

- add behave steps for removing and also validating directories that are relative to the current working directory (allows * globbing)
- criteria for determining that repair file was not overwritten:  run gpcheckcat twice, and expect 1 and then 2 repair scripts.
- verify that stdout reports "owner" error