### PR TITLE
Move gpcheckcat installation to install dir from the source tree

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -76,22 +76,22 @@ install: generate_greenplum_path_file
 	# Generate some python libraries
 	$(MAKE) -C bin all prefix=$(prefix)
 
-#	#Copy the management utilities
+	# Copy the management utilities
 	mkdir -p $(prefix)/bin
 	mkdir -p $(prefix)/lib
 	mkdir -p $(prefix)/lib/python	
 	mkdir -p $(prefix)/sbin
 
-	#symlink gpcheckcat from bin to bin/lib to mainitain backward compatibility
-	if [ -f bin/gpcheckcat  ]; then \
-		ln -sf ../gpcheckcat bin/lib/gpcheckcat; \
-	fi
-
-	#Setup /lib/python contents
+	# Setup /lib/python contents
 	cp -rp bin/gppylib $(prefix)/lib/python
 	cp -rp bin/ext/* $(prefix)/lib/python
+
+	# Setup /bin contents
 	cp -rp bin $(prefix)
-	
+	# Symlink gpcheckcat from bin to bin/lib to maintain backward compatibility
+	if [ -f $(prefix)/bin/gpcheckcat  ]; then \
+		ln -sf ../gpcheckcat $(prefix)/bin/lib/gpcheckcat; \
+	fi
 
 #ifeq "$(findstring $(BLD_ARCH),$(GPPKG_PLATFORMS))" ""
 #	@echo "Removing gppkg from distribution"


### PR DESCRIPTION
Commit 41dfd82 moved `gpcheckcat` from `bin/lib` to `bin/` and installed a symlink to maintain backwards compatibility. However, installing and copying the symlink in the source tree makes Git complain that it's an untracked file. Rather than adding it to `.gitignore` we might as well do this in the installation directory since that's where we want to maintain backwards compatibility anyways. This fixes errors like this when switching from an installed master to an existing branch based off an older master:
```
$ git checkout enable_orca
error: The following untracked working tree files would be overwritten by checkout:
	gpMgmt/bin/lib/gpcheckcat
Please move or remove them before you can switch branches.
Aborting
```
Arguably this is something that will go away with time but it still seems cleaner to keep the symlink out of the source tree.

Cleaned up a few comments around the installation as well while in there.