### PR TITLE
s3ext: fix memleaks and a forwarding null bug

### DIFF
--- a/gpAux/extensions/gps3ext/src/S3Common_test.cpp
+++ b/gpAux/extensions/gps3ext/src/S3Common_test.cpp
@@ -66,114 +66,132 @@ TEST(S3Common, HeaderContent) {
 }
 
 TEST(S3Common, UrlOptions) {
+    char *option = NULL;
     EXPECT_STREQ("secret_test",
-                 get_opt_s3("s3://neverland.amazonaws.com secret=secret_test",
+                 option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test",
                             "secret"));
+    free(option);
 
     EXPECT_STREQ(
         "\".\\!@#$%^&*()DFGHJK\"",
-        get_opt_s3(
+        option = get_opt_s3(
             "s3://neverland.amazonaws.com accessid=\".\\!@#$%^&*()DFGHJK\"",
             "accessid"));
+    free(option);
 
     EXPECT_STREQ("3456789",
-                 get_opt_s3("s3://neverland.amazonaws.com chunksize=3456789",
+                 option = get_opt_s3("s3://neverland.amazonaws.com chunksize=3456789",
                             "chunksize"));
+    free(option);
 
     EXPECT_STREQ(
         "secret_test",
-        get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+        option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                    "accessid=\".\\!@#$%^&*()DFGHJK\" chunksize=3456789",
                    "secret"));
+    free(option);
 
     EXPECT_STREQ(
         "\".\\!@#$%^&*()DFGHJK\"",
-        get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+        option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                    "accessid=\".\\!@#$%^&*()DFGHJK\" chunksize=3456789",
                    "accessid"));
+    free(option);
 
     EXPECT_STREQ(
         "3456789",
-        get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+        option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                    "accessid=\".\\!@#$%^&*()DFGHJK\" chunksize=3456789",
                    "chunksize"));
+    free(option);
 
     EXPECT_STREQ("secret_test",
-                 get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+                 option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                             "blah=whatever accessid=\".\\!@#$%^&*()DFGHJK\" "
                             "chunksize=3456789 KingOfTheWorld=sanpang",
                             "secret"));
+    free(option);
 
     EXPECT_STREQ("secret_test",
-                 get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+                 option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                             "blah= accessid=\".\\!@#$%^&*()DFGHJK\" "
                             "chunksize=3456789 KingOfTheWorld=sanpang",
                             "secret"));
+    free(option);
 
     EXPECT_STREQ("3456789",
-                 get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+                 option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                             "chunksize=3456789 KingOfTheWorld=sanpang ",
                             "chunksize"));
+    free(option);
 
     EXPECT_STREQ("3456789",
-                 get_opt_s3("s3://neverland.amazonaws.com   secret=secret_test "
+                 option = get_opt_s3("s3://neverland.amazonaws.com   secret=secret_test "
                             "chunksize=3456789  KingOfTheWorld=sanpang ",
                             "chunksize"));
+    free(option);
 
     EXPECT_STREQ("=sanpang",
-                 get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+                 option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                             "chunksize=3456789 KingOfTheWorld==sanpang ",
                             "KingOfTheWorld"));
+    free(option);
 
-    EXPECT_EQ((char *)NULL, get_opt_s3("", "accessid"));
+    EXPECT_EQ((char *)NULL, option = get_opt_s3("", "accessid"));
 
-    EXPECT_EQ((char *)NULL, get_opt_s3(NULL, "accessid"));
-
-    EXPECT_EQ((char *)NULL,
-              get_opt_s3("s3://neverland.amazonaws.com", "secret"));
+    EXPECT_EQ((char *)NULL, option = get_opt_s3(NULL, "accessid"));
 
     EXPECT_EQ((char *)NULL,
-              get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+              option = get_opt_s3("s3://neverland.amazonaws.com", "secret"));
+
+    EXPECT_EQ((char *)NULL,
+              option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                          "blah=whatever accessid= chunksize=3456789 "
                          "KingOfTheWorld=sanpang",
                          "accessid"));
 
     EXPECT_EQ(
         (char *)NULL,
-        get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+        option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                    "blah=whatever chunksize=3456789 KingOfTheWorld=sanpang",
                    ""));
 
     EXPECT_EQ(
         (char *)NULL,
-        get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+        option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                    "blah=whatever chunksize=3456789 KingOfTheWorld=sanpang",
                    NULL));
 
     EXPECT_EQ((char *)NULL,
-              get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
+              option = get_opt_s3("s3://neverland.amazonaws.com secret=secret_test "
                          "chunksize=3456789 KingOfTheWorld=sanpang ",
                          "chunk size"));
 }
 
 TEST(S3Common, TruncateOptions) {
-    EXPECT_STREQ(
-        "s3://neverland.amazonaws.com",
-        truncate_options("s3://neverland.amazonaws.com secret=secret_test"));
+    char *truncated = NULL;
 
     EXPECT_STREQ(
         "s3://neverland.amazonaws.com",
-        truncate_options(
+        truncated = truncate_options("s3://neverland.amazonaws.com secret=secret_test"));
+    free(truncated);
+
+    EXPECT_STREQ(
+        "s3://neverland.amazonaws.com",
+        truncated = truncate_options(
             "s3://neverland.amazonaws.com accessid=\".\\!@#$%^&*()DFGHJK\""));
+    free(truncated);
 
     EXPECT_STREQ(
         "s3://neverland.amazonaws.com",
-        truncate_options("s3://neverland.amazonaws.com secret=secret_test "
+        truncated = truncate_options("s3://neverland.amazonaws.com secret=secret_test "
                          "accessid=\".\\!@#$%^&*()DFGHJK\" chunksize=3456789"));
+    free(truncated);
 
     EXPECT_STREQ(
         "s3://neverland.amazonaws.com",
-        truncate_options("s3://neverland.amazonaws.com secret=secret_test "
+        truncated = truncate_options("s3://neverland.amazonaws.com secret=secret_test "
                          "blah= accessid=\".\\!@#$%^&*()DFGHJK\" "
                          "chunksize=3456789 KingOfTheWorld=sanpang"));
+    free(truncated);
 }

--- a/gpAux/extensions/gps3ext/src/S3Downloader.cpp
+++ b/gpAux/extensions/gps3ext/src/S3Downloader.cpp
@@ -611,15 +611,17 @@ static bool extractContent(ListBucketResult *result, xmlNode *root_element,
                 contNode = contNode->next;
             }
 
-            if (key && (size > 0)) {  // skip empty item
-                BucketContent *item = CreateBucketContentItem(key, size);
-                if (item) {
-                    result->contents.push_back(item);
+            if (key) {
+                if (size > 0) {  // skip empty item
+                    BucketContent *item = CreateBucketContentItem(key, size);
+                    if (item) {
+                        result->contents.push_back(item);
+                    } else {
+                        S3ERROR("Faild to create item for %s", key);
+                    }
                 } else {
-                    S3ERROR("Faild to create item for %s", key);
+                    S3INFO("Size of %s is " PRIu64 ", skip it", key, size);
                 }
-            } else {
-                S3INFO("Size of %s is %llu, skip", key, size);
             }
 
             if (key_size) {

--- a/gpAux/extensions/gps3ext/src/S3Downloader.cpp
+++ b/gpAux/extensions/gps3ext/src/S3Downloader.cpp
@@ -601,12 +601,14 @@ static bool extractContent(ListBucketResult *result, xmlNode *root_element,
             uint64_t size = 0;
 
             while (contNode != NULL) {
+                // no memleak here, every content has only one Key/Size node
                 if (!xmlStrcmp(contNode->name, (const xmlChar *)"Key")) {
                     key = (char *)xmlNodeGetContent(contNode);
                 }
                 if (!xmlStrcmp(contNode->name, (const xmlChar *)"Size")) {
                     key_size = (char *)xmlNodeGetContent(contNode);
-                    size = atoll((const char *)key_size);
+                    // Size of S3 file is a natural number, don't worry
+                    size = (uint64_t)atoll((const char *)key_size);
                 }
                 contNode = contNode->next;
             }

--- a/gpAux/extensions/gps3ext/src/S3Downloader.h
+++ b/gpAux/extensions/gps3ext/src/S3Downloader.h
@@ -142,6 +142,8 @@ struct ListBucketResult {
     string Prefix;
     unsigned int MaxKeys;
     vector<BucketContent*> contents;
+
+    ~ListBucketResult();
 };
 
 BucketContent* CreateBucketContentItem(string key, uint64_t size);

--- a/gpAux/extensions/gps3ext/src/S3Downloader_test.cpp
+++ b/gpAux/extensions/gps3ext/src/S3Downloader_test.cpp
@@ -160,6 +160,8 @@ void DownloadTest(const char *url, const char *region, uint64_t file_size,
     }
 
     ASSERT_STREQ(md5_str, m.Get());
+
+    d->destroy();
     delete d;
     free(buf);
 }

--- a/gpAux/extensions/gps3ext/src/S3Uploader.cpp
+++ b/gpAux/extensions/gps3ext/src/S3Uploader.cpp
@@ -238,7 +238,7 @@ const char *GetUploadId(const char *host, const char *bucket,
     xmlNodePtr cur = root_element->xmlChildrenNode;
     while (cur != NULL) {
         if (!xmlStrcmp(cur->name, (const xmlChar *)"UploadId")) {
-            upload_id = strdup((const char *)xmlNodeGetContent(cur));
+            upload_id = (char *)xmlNodeGetContent(cur);
             break;
         }
 
@@ -246,7 +246,9 @@ const char *GetUploadId(const char *host, const char *bucket,
     }
 
     /* always cleanup */
+    xmlDocPtr doc = xml.ctxt->myDoc;
     xmlFreeParserCtxt(xml.ctxt);
+    xmlFreeDoc(doc);
 
     return upload_id;
 }
@@ -402,7 +404,10 @@ const char *PartPutS3Object(const char *host, const char *bucket,
         std::cout << "Error: " << response_code << std::endl;
     }
 
+    xmlDocPtr doc = xml.ctxt->myDoc;
     xmlFreeParserCtxt(xml.ctxt);
+    xmlFreeDoc(doc);
+    xmlFree(response_code);
 
     curl_slist_free_all(chunk);
     curl_easy_cleanup(curl);
@@ -575,7 +580,10 @@ bool CompleteMultiPutS3(const char *host, const char *bucket,
         return false;
     }
 
+    xmlDocPtr doc = xml.ctxt->myDoc;
     xmlFreeParserCtxt(xml.ctxt);
+    xmlFreeDoc(doc);
+    xmlFree(response_code);
 
     return true;
 }

--- a/gpAux/extensions/gps3ext/src/S3Uploader.cpp
+++ b/gpAux/extensions/gps3ext/src/S3Uploader.cpp
@@ -402,12 +402,12 @@ const char *PartPutS3Object(const char *host, const char *bucket,
 
     if (response_code) {
         std::cout << "Error: " << response_code << std::endl;
+        xmlFree(response_code);
     }
 
     xmlDocPtr doc = xml.ctxt->myDoc;
     xmlFreeParserCtxt(xml.ctxt);
     xmlFreeDoc(doc);
-    xmlFree(response_code);
 
     curl_slist_free_all(chunk);
     curl_easy_cleanup(curl);
@@ -577,13 +577,13 @@ bool CompleteMultiPutS3(const char *host, const char *bucket,
     free(body_data);
 
     if (response_code) {
+        xmlFree(response_code);
         return false;
     }
 
     xmlDocPtr doc = xml.ctxt->myDoc;
     xmlFreeParserCtxt(xml.ctxt);
     xmlFreeDoc(doc);
-    xmlFree(response_code);
 
     return true;
 }

--- a/gpAux/extensions/gps3ext/src/gps3ext.cpp
+++ b/gpAux/extensions/gps3ext/src/gps3ext.cpp
@@ -106,6 +106,12 @@ Datum s3_import(PG_FUNCTION_ARGS) {
             }
             delete myData;
         }
+
+        /*
+         * Cleanup function for the XML library.
+         */
+        xmlCleanupParser();
+
         PG_RETURN_INT32(0);
     }
 

--- a/gpAux/extensions/gps3ext/src/utils_test.cpp
+++ b/gpAux/extensions/gps3ext/src/utils_test.cpp
@@ -54,8 +54,10 @@ TEST(utils, md5) {
 
 #define TEST_STRING "The quick brown fox jumps over the lazy dog"
 TEST(utils, base64) {
+    char *encoded = NULL;
     EXPECT_STREQ("VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==",
-                 Base64Encode(TEST_STRING, strlen(TEST_STRING)));
+                 encoded = Base64Encode(TEST_STRING, strlen(TEST_STRING)));
+    free(encoded);
 }
 
 TEST(utils, sha256) {


### PR DESCRIPTION
This commit fixes issues below:

extractContent() might forward NULL to marker.
ListBucket() fogets to delete keylist when errors happen.
contents in ListBucketResult are not cleared.
downloader is not destroyed in unit tests.
get_opt_s3() and truncate_options() in unit tests need to be freed.
xmlNodeGetContent() needs to be freed.
xml.ctxt->myDoc needs to be freed.
function for the XML library needs to be cleared.

Thanks to Kuien and Valgrind.