### PR TITLE
gpcheckcat leakedschema refactoring

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -82,7 +82,7 @@ install: generate_greenplum_path_file
 	mkdir -p $(prefix)/lib/python	
 	mkdir -p $(prefix)/sbin
 
-	#symlink gpcheckcat from bin to bin/lib to mainitain backward compatibility
+	#symlink gpcheckcat from bin to bin/lib to maintain backward compatibility
 	if [ -f bin/gpcheckcat  ]; then \
 		ln -sf ../gpcheckcat bin/lib/gpcheckcat; \
 	fi

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -24,6 +24,7 @@ import sys
 from datetime import datetime
 from time import localtime, strftime
 
+
 TIMESTAMP = datetime.now().strftime("%Y%m%d%H%M%S")
 REPAIR_SCRIPT = 'runsql_%s.sh' % TIMESTAMP
 
@@ -35,6 +36,7 @@ try:
     from pygresql.pgdb import DatabaseError
     from pygresql import pg
     from gpcheckcat_modules.unique_index_violation_check import UniqueIndexViolationCheck
+    from gpcheckcat_modules.leaked_schema_dropper import LeakedSchemaDropper
 except ImportError, e:
     sys.exit('Error: unable to import module: ' + str(e))
 
@@ -1866,56 +1868,6 @@ def checkPGClass():
             logger.error("...")
 
 
-def getLeakedSchemas():
-    logger.info('-----------------------------------')
-    logger.info('Checking for leaked temporary schemas')
-    db = connect2(GV.cfg[1], utilityMode=False)
-
-    leaked_schemas = []
-    # This query does a union of all the leaked temp schemas on the master as well as all the segments.
-    # The first part of the query uses gp_dist_random which gets the leaked schemas from only the segments
-    # The second part of the query gets the leaked temp schemas from just the master
-
-
-    # The simpler form of this query that pushed the union into the
-    # inner select does not run correctly on 3.2.x
-    qry = '''
-    SELECT distinct nspname as schema
-    FROM (
-      SELECT nspname, replace(nspname, 'pg_temp_','')::int as sess_id
-      FROM   gp_dist_random('pg_namespace')
-      WHERE  nspname ~ '^pg_temp_[0-9]+'
-    ) n LEFT OUTER JOIN pg_stat_activity x using (sess_id)
-    WHERE x.sess_id is null
-    UNION
-    SELECT nspname as schema
-    FROM (
-      SELECT nspname, replace(nspname, 'pg_temp_','')::int as sess_id
-      FROM   pg_namespace
-      WHERE  nspname ~ '^pg_temp_[0-9]+'
-    ) n LEFT OUTER JOIN pg_stat_activity x using (sess_id)
-    WHERE x.sess_id is null
-    '''
-    try:
-        curs = db.query(qry)
-        if curs.ntuples() == 0:
-            logger.info('[OK] temporary schemas')
-        else:
-            GV.checkStatus = False
-            setError(ERROR_REMOVE)
-            logger.info('[FAIL] temporary schemas')
-            logger.error('found %d unbound temporary schemas' % curs.ntuples())
-            for row in curs.getresult():
-                logger.error("  ... %s" % row[0])
-                leaked_schemas.append(row[0])
-    except Exception, e:
-        setError(ERROR_NOREPAIR)
-        myprint('[ERROR] executing test: checkPGNamespace')
-        myprint('  Execution error: ' + str(e))
-
-    return leaked_schemas
-
-
 #############
 def checkPGNamespace():
     # Check for objects in various catalogs that are in a schema that has
@@ -2049,6 +2001,26 @@ def addDemoteConstraint(seg, repair_sequence):
 
 
 #############
+def drop_leaked_schemas(leaked_schema_dropper, dbname):
+    logger.info('-----------------------------------')
+    logger.info('Checking for leaked temporary schemas')
+
+    db_connection = connect(database=dbname)
+    try:
+        dropped_schemas = leaked_schema_dropper.drop_leaked_schemas(db_connection)
+        if not dropped_schemas:
+            logger.info('[OK] temporary schemas')
+        else:
+            logger.info('[FAIL] temporary schemas')
+            myprint("Found and dropped %d unbound temporary schemas" % len(dropped_schemas))
+            logger.error('Dropped leaked schemas \'%s\' in the database \'%s\'' % (dropped_schemas, dbname))
+    except Exception, e:
+        setError(ERROR_NOREPAIR)
+        myprint('  Execution error: ' + str(e))
+    finally:
+        db_connection.close()
+
+
 def checkDepend():
     # Check for dependencies on non-existent objects
     logger.info('-----------------------------------')
@@ -3839,31 +3811,6 @@ def checkOwnersRepair():
     else:
         return None, None
 
-
-def dropLeakedSchemas(dbname):
-    leaked_schemas = getLeakedSchemas()
-
-    if len(leaked_schemas) <= 0:
-        return
-
-    myprint("Dropping leaked schemas '%s' in the database '%s' " % (leaked_schemas, dbname))
-    db = connect(database=dbname)
-    try:
-        for schema in leaked_schemas:
-            # the query will return unquoted schema names
-            # but we only search for schemas with name like pg_temp_[0-9](see the method getLeakedSchemas),
-            # so we don't really need to quote the sql statement
-            qry = 'DROP SCHEMA IF EXISTS "%s" CASCADE;\n' % schema
-            logger.info(qry)
-            db.query(qry)
-    except Exception, e:
-        setError(ERROR_NOREPAIR)
-        myprint('  Execution error: ' + str(e))
-    finally:
-        if db is not None:
-            db.close()
-
-
 def checkPoliciesRepair():
     # changes to distribution policies
     if len(GV.Policies) > 0:
@@ -4879,6 +4826,7 @@ if __name__ == '__main__':
     GV.report_cfg = getReportConfiguration()
     GV.max_content = max([GV.cfg[dbid]['content'] for dbid in GV.cfg])
     GV.catalog = getCatalog()
+    leaked_schema_dropper = LeakedSchemaDropper()
 
     for dbname in GV.alldb:
 
@@ -4892,7 +4840,8 @@ if __name__ == '__main__':
                 % (GV.opt['-U'], GV.dbname, GV.report_cfg[-1]['port'], GV.version))
         myprint('-------------------------------------------------------------------')
 
-        dropLeakedSchemas(dbname)
+        drop_leaked_schemas(leaked_schema_dropper, dbname)
+
         if GV.opt['-R']:
             name = GV.opt['-R']
             try:

--- a/gpMgmt/bin/gpcheckcat_modules/leaked_schema_dropper.py
+++ b/gpMgmt/bin/gpcheckcat_modules/leaked_schema_dropper.py
@@ -1,0 +1,41 @@
+from gppylib.operations.backup_utils import escapeDoubleQuoteInSQLString
+
+class LeakedSchemaDropper:
+
+    # This query does a union of all the leaked temp schemas on the master as well as all the segments.
+    # The first part of the query uses gp_dist_random which gets the leaked schemas from only the segments
+    # The second part of the query gets the leaked temp schemas from just the master
+    # The simpler form of this query that pushed the union into the
+    # inner select does not run correctly on 3.2.x
+    leaked_schema_query = """
+        SELECT distinct nspname as schema
+        FROM (
+          SELECT nspname, replace(nspname, 'pg_temp_','')::int as sess_id
+          FROM   gp_dist_random('pg_namespace')
+          WHERE  nspname ~ '^pg_temp_[0-9]+'
+        ) n LEFT OUTER JOIN pg_stat_activity x using (sess_id)
+        WHERE x.sess_id is null
+        UNION
+        SELECT nspname as schema
+        FROM (
+          SELECT nspname, replace(nspname, 'pg_temp_','')::int as sess_id
+          FROM   pg_namespace
+          WHERE  nspname ~ '^pg_temp_[0-9]+'
+        ) n LEFT OUTER JOIN pg_stat_activity x using (sess_id)
+        WHERE x.sess_id is null
+    """
+
+    def __get_leaked_schemas(self, db_connection):
+        leaked_schemas = db_connection.query(self.leaked_schema_query)
+
+        if not leaked_schemas:
+            return []
+
+        return [row[0] for row in leaked_schemas.getresult() if row[0]]
+
+    def drop_leaked_schemas(self, db_connection):
+        leaked_schemas = self.__get_leaked_schemas(db_connection)
+        for leaked_schema in leaked_schemas:
+            escaped_schema_name = escapeDoubleQuoteInSQLString(leaked_schema)
+            db_connection.query('DROP SCHEMA IF EXISTS %s CASCADE;' % (escaped_schema_name))
+        return leaked_schemas

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
@@ -15,11 +15,13 @@ Feature: gpcheckcat tests
         And psql should print pg_temp_ to stdout
         And psql should print (1 row) to stdout
         When the user runs "gpcheckcat leak"
+        Then gpchekcat should return a return code of 0
         And the user runs "psql leak -f gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/leaked_schema.sql"
         Then psql should return a return code of 0
         And psql should print (0 rows) to stdout
         And verify that the schema "good_schema" exists in "leak"
         And the user runs "dropdb leak"
+        And verify that a log was created by gpcheckcat in the user's "gpAdminLogs" directory
 
     Scenario: gpcheckcat should report unique index violations
         Given database "test_index" is dropped and recreated

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_leaked_schema_dropper.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_leaked_schema_dropper.py
@@ -1,0 +1,51 @@
+from mock import *
+
+from gp_unittest import *
+from gpcheckcat_modules.leaked_schema_dropper import LeakedSchemaDropper
+
+
+class LeakedSchemaDropperTestCase(GpTestCase):
+    def setUp(self):
+        self.db_connection = Mock(spec=['query'])
+
+        two_leaked_schemas = Mock()
+        two_leaked_schemas.getresult.return_value = [
+            ('fake_leak_1', 'something_else'),
+            ('some"test"special_#;character--schema', 'something_else')
+        ]
+        self.db_connection.query.return_value = two_leaked_schemas
+
+        self.subject = LeakedSchemaDropper()
+
+    def test_drop_leaked_schemas__returns_a_list_of_leaked_schemas(self):
+        self.assertEqual(self.subject.drop_leaked_schemas(self.db_connection), ['fake_leak_1', 'some"test"special_#;character--schema'])
+
+    def test_drop_leaked_schemas__when_there_are_no_leaked_schemas__returns_an_empty_list(self):
+        no_leaked_schemas = Mock()
+        no_leaked_schemas.getresult.return_value = []
+        self.db_connection.query.return_value = no_leaked_schemas
+
+        self.assertEqual(self.subject.drop_leaked_schemas(self.db_connection), [])
+
+    def test_drop_leaked_schemas__when_query_returns_null_schema__returns_an_empty_list(self):
+        null_leaked_schema = Mock()
+        null_leaked_schema.getresult.return_value = [(None, 'something_else')]
+        self.db_connection.query.return_value = null_leaked_schema
+
+        self.assertEqual(self.subject.drop_leaked_schemas(self.db_connection), [])
+
+    def test_drop_leaked_schemas__when_query_returns_null__returns_an_empty_list(self):
+        self.db_connection.query.return_value = None
+
+        self.assertEqual(self.subject.drop_leaked_schemas(self.db_connection), [])
+
+    def test_drop_leaked_schemas__drops_orphaned_and_leaked_schemas(self):
+        self.subject.drop_leaked_schemas(self.db_connection)
+
+        drop_query_expected_list = [call("DROP SCHEMA IF EXISTS \"fake_leak_1\" CASCADE;"),
+                                    call("DROP SCHEMA IF EXISTS \"some\"\"test\"\"special_#;character--schema\" CASCADE;")]
+        self.db_connection.query.assert_has_calls(drop_query_expected_list)
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
Refactor leaked schema query into it's own module with its own set of unit tests . 

1. create a class for leaked schema handler 
2. refactor leaked schema unit tests 
3. address @danielgustafsson comments from PR #595 
