### PR TITLE
Adds support for running gpcheckcat when indexes are defined with opclass

### DIFF
--- a/gpMgmt/bin/gpcheckcat_modules/unique_index_violation_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/unique_index_violation_check.py
@@ -33,6 +33,7 @@ class UniqueIndexViolationCheck:
         violations = []
 
         for (table_oid, index_name, table_name, column_names) in unique_indexes:
+            column_names = self.__strip_opclass(column_names)
             sql = self.get_violated_segments_query(table_name, column_names)
             violated_segments = db_connection.query(sql).getresult()
             if violated_segments:
@@ -48,3 +49,8 @@ class UniqueIndexViolationCheck:
         return self.violated_segments_query % (
             column_names, table_name, column_names, column_names, column_names, table_name, column_names, column_names
         )
+
+    def __strip_opclass(self, index_arguments):
+        column_names_with_opclass = index_arguments.split(', ')
+        column_names = [string.split(' ')[0] for string in column_names_with_opclass]
+        return ', '.join(column_names)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_unique_index_violation_check.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_unique_index_violation_check.py
@@ -15,6 +15,7 @@ class UniqueIndexViolationCheckTestCase(GpTestCase):
         ]
 
         self.violated_segments_query_result = Mock()
+        self.violated_segments_query_result.getresult.return_value = []
 
         self.db_connection = Mock(spec=['query'])
         self.db_connection.query.side_effect = self.mock_query_return_value
@@ -26,13 +27,37 @@ class UniqueIndexViolationCheckTestCase(GpTestCase):
             return self.violated_segments_query_result
 
     def test_run_check__when_there_are_no_issues(self):
-        self.violated_segments_query_result.getresult.return_value = []
-
         violations = self.subject.runCheck(self.db_connection)
 
         self.assertEqual(len(violations), 0)
 
     def test_run_check__when_index_is_violated(self):
+        self.violated_segments_query_result.getresult.side_effect = [
+            [(-1,), (0,), (1,)],
+            [(-1,)]
+        ]
+
+        violations = self.subject.runCheck(self.db_connection)
+
+        self.assertEqual(len(violations), 2)
+        self.assertEqual(violations[0]['table_oid'], 9001)
+        self.assertEqual(violations[0]['table_name'], 'table1')
+        self.assertEqual(violations[0]['index_name'], 'index1')
+        self.assertEqual(violations[0]['column_names'], 'index1_column1, index1_column2')
+        self.assertEqual(violations[0]['violated_segments'], [-1, 0, 1])
+
+        self.assertEqual(violations[1]['table_oid'], 9001)
+        self.assertEqual(violations[1]['table_name'], 'table1')
+        self.assertEqual(violations[1]['index_name'], 'index2')
+        self.assertEqual(violations[1]['column_names'], 'index2_column1, index2_column2')
+        self.assertEqual(violations[1]['violated_segments'], [-1])
+
+    def test_run_check__when_index_is_defined_with_opclass(self):
+        self.index_query_result.getresult.return_value = [
+            (9001, 'index1', 'table1', 'index1_column1 oid_ops, index1_column2 oid_ops'),
+            (9001, 'index2', 'table1', 'index2_column1 oid_ops, index2_column2 oid_ops')
+        ]
+
         self.violated_segments_query_result.getresult.side_effect = [
             [(-1,), (0,), (1,)],
             [(-1,)]


### PR DESCRIPTION
Some unique indexes in the catalog may be defined with an opclass,
causing the column name parsing to fail (specifically, GPDB 4 had this
problem). This commit fixes this particular issue so that gpcheckcat
can run if indexes are defined with an opclass on one or more columns.

This is a port of a simple/quick fix for the issues on 4.3-stable; we have plans
to add a better way of grabbing the column names instead of parsing the index
definition.  Currently, applying this change will allow gpcheckcat to work
if indexes are defined with opclasses, but will break gpcheckcat if indexes
are defined on columns with names containing spaces (without this fix, 5.x
is fine but 4.3-stable is broken).  Currently, neither v5 nor v4 have column
names containing spaces.  We're looking for feedback as to whether this should
go in or if we should just wait for the more robust fix.

Authors: Stephen Wu, Marbin Tan