### PR TITLE
Adds support for running gpcheckcat when indexes are defined with opclasses

### DIFF
--- a/gpMgmt/bin/gpcheckcat_modules/unique_index_violation_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/unique_index_violation_check.py
@@ -2,13 +2,19 @@
 
 class UniqueIndexViolationCheck:
     unique_indexes_query = """
-        select table_class.oid as tableoid, index_class.relname as indexname, table_class.relname as tablename, substring(pg_get_indexdef(index_class.oid) from '%#(#"%#"#)%' for '#') as columnnames
-        from pg_index
-        join pg_class table_class on table_class.oid = pg_index.indrelid
-        join pg_class index_class on index_class.oid = pg_index.indexrelid
-        left join pg_namespace on pg_namespace.oid = table_class.relnamespace
-        left join pg_tablespace on pg_tablespace.oid = index_class.reltablespace
-        where table_class.relkind = 'r'::"char" and index_class.relkind = 'i'::"char" and pg_namespace.nspname = 'pg_catalog' and pg_index.indisunique='t';
+        select table_oid, index_name, table_name, array_agg(attname) as column_names
+        from pg_attribute, (
+            select pg_index.indrelid as table_oid, index_class.relname as index_name, table_class.relname as table_name, unnest(pg_index.indkey) as column_index
+            from pg_index, pg_class index_class, pg_class table_class
+            where pg_index.indisunique='t'
+            and index_class.relnamespace = (select oid from pg_namespace where nspname = 'pg_catalog')
+            and index_class.relkind = 'i'
+            and index_class.oid = pg_index.indexrelid
+            and table_class.oid = pg_index.indrelid
+        ) as unique_catalog_index_columns
+        where attnum = column_index
+        and attrelid = table_oid
+        group by table_oid, index_name, table_name;
     """
 
     def __init__(self):
@@ -33,6 +39,7 @@ class UniqueIndexViolationCheck:
         violations = []
 
         for (table_oid, index_name, table_name, column_names) in unique_indexes:
+            column_names = column_names[1:-1]
             sql = self.get_violated_segments_query(table_name, column_names)
             violated_segments = db_connection.query(sql).getresult()
             if violated_segments:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_unique_index_violation_check.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_unique_index_violation_check.py
@@ -10,8 +10,8 @@ class UniqueIndexViolationCheckTestCase(GpTestCase):
 
         self.index_query_result = Mock()
         self.index_query_result.getresult.return_value = [
-            (9001, 'index1', 'table1', 'index1_column1, index1_column2'),
-            (9001, 'index2', 'table1', 'index2_column1, index2_column2')
+            (9001, 'index1', 'table1', '{index1_column1,index1_column2}'),
+            (9001, 'index2', 'table1', '{index2_column1,index2_column2}')
         ]
 
         self.violated_segments_query_result = Mock()
@@ -44,13 +44,13 @@ class UniqueIndexViolationCheckTestCase(GpTestCase):
         self.assertEqual(violations[0]['table_oid'], 9001)
         self.assertEqual(violations[0]['table_name'], 'table1')
         self.assertEqual(violations[0]['index_name'], 'index1')
-        self.assertEqual(violations[0]['column_names'], 'index1_column1, index1_column2')
+        self.assertEqual(violations[0]['column_names'], 'index1_column1,index1_column2')
         self.assertEqual(violations[0]['violated_segments'], [-1, 0, 1])
 
         self.assertEqual(violations[1]['table_oid'], 9001)
         self.assertEqual(violations[1]['table_name'], 'table1')
         self.assertEqual(violations[1]['index_name'], 'index2')
-        self.assertEqual(violations[1]['column_names'], 'index2_column1, index2_column2')
+        self.assertEqual(violations[1]['column_names'], 'index2_column1,index2_column2')
         self.assertEqual(violations[1]['violated_segments'], [-1])
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updates unique index query to find column names by querying pg_attribute instead of string-parsing the index definition.  This allows us to support opclasses as well as special characters in the column name.

Authors: Stephen Wu, Marbin Tan