### PR TITLE
Removing built-in logger from gp_unittest

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
+++ b/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
@@ -1,14 +1,9 @@
-import logging
-import sys
 import unittest2 as unittest
 
 
 class GpTestCase(unittest.TestCase):
     def __init__(self, methodName='runTest'):
         super(GpTestCase, self).__init__(methodName)
-        logging.basicConfig(stream=sys.stderr)
-        self.logger = logging.getLogger()
-        self.logger.setLevel(logging.DEBUG)
         self.patches = []
 
     def apply_patches(self, patches):


### PR DESCRIPTION
This was causing issues on make check where as the logger gets inherited
by other unittests and causes unexpected log outputs.

Authors: Marbin Tan & Stephen Wu