### PR TITLE
Add new guc to speed up optimization time [#116333899]

### DIFF
--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -22,7 +22,7 @@
     </configurations>
 
     <dependencies>
-      <dependency org="emc"             name="optimizer"       rev="1.628"          conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="optimizer"       rev="1.629"          conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="emc"             name="libgpos"         rev="1.136"          conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="OpenSSL"         name="openssl"         rev="0.9.8zg"        conf="osx106_x86->osx105_x86;aix5_ppc_32->aix5_ppc_32;aix5_ppc_64->aix5_ppc_64;hpux_ia64->hpux_ia64;rhel5_x86_32->rhel5_x86_32;rhel5_x86_64->rhel5_x86_64;rhel6_x86_64->rhel6_x86_64;sol10_x86_32->sol10_x86_32;sol10_x86_64->sol10_x86_64;sol10_sparc_32->sol10_sparc_32;sol10_sparc_64->sol10_sparc_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse11_x86_64" />

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -750,6 +750,7 @@ COptTasks::PoconfCreate
 	DOUBLE dDampingFactorGroupBy = (DOUBLE) optimizer_damping_factor_groupby;
 
 	ULONG ulCTEInliningCutoff =  (ULONG) optimizer_cte_inlining_bound;
+	ULONG ulJoinArityForAssociativityCommutativity =  (ULONG) optimizer_join_arity_for_associativity_commutativity;
 
 	return GPOS_NEW(pmp) COptimizerConfig
 						(
@@ -757,7 +758,7 @@ COptTasks::PoconfCreate
 						GPOS_NEW(pmp) CStatisticsConfig(pmp, dDampingFactorFilter, dDampingFactorJoin, dDampingFactorGroupBy),
 						GPOS_NEW(pmp) CCTEConfig(ulCTEInliningCutoff),
 						pcm,
-						CHint::PhintDefault(pmp)
+						GPOS_NEW(pmp) CHint(INT_MAX /* optimizer_parts_to_force_sort_on_insert */, ulJoinArityForAssociativityCommutativity)
 						);
 }
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -553,6 +553,7 @@ double		optimizer_damping_factor_filter;
 double		optimizer_damping_factor_join;
 double		optimizer_damping_factor_groupby;
 int			optimizer_segments;
+int			optimizer_join_arity_for_associativity_commutativity;
 bool		optimizer_analyze_root_partition;
 bool		optimizer_analyze_midlevel_partition;
 bool		optimizer_enable_constant_expression_evaluation;
@@ -4703,6 +4704,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&optimizer_segments,
 		0, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"optimizer_join_arity_for_associativity_commutativity", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Maximum number of children n-ary-join have without disabling commutativity and associativity transform"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_join_arity_for_associativity_commutativity,
+		INT_MAX, 0, INT_MAX, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -430,6 +430,7 @@ extern double optimizer_damping_factor_filter;
 extern double optimizer_damping_factor_join;
 extern double optimizer_damping_factor_groupby;
 extern int optimizer_segments;
+extern int optimizer_join_arity_for_associativity_commutativity;
 extern bool optimizer_analyze_root_partition;
 extern bool optimizer_analyze_midlevel_partition;
 extern bool optimizer_enable_constant_expression_evaluation;


### PR DESCRIPTION
`set optimizer_join_arity_for_associativity_commutativity=7` will hint
at the optimizer to stop exploring join associativity and join
commutativity transformations when an n-ary join operator has more than
7 children during optimization, pruning quite a bit of the search space.

This PR depends on greenplum-db/gporca#38