### PR TITLE
Fix broken CREATE RULE test in appendonly and aocs regression tests.

### DIFF
--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -409,8 +409,13 @@ commit;
 select count(*) from tenk_aocs5_temp_pres_rows;
 
 -- RULES
-create rule aocs_rule_update as on insert to tenk_aocs5 do instead update foo_aocs set two=2;
-create rule aocs_rule_delete as on insert to tenk_aocs5 do instead delete from foo_aocs where unique1=1;
+insert into tenk_aocs5(unique1, unique2) values (1, 99998889);
+create rule ao_rule_update as on insert to tenk_aocs5 do instead update tenk_aocs5 set two=2;
+insert into tenk_aocs5(unique1, unique2) values (2, 99998889);
+select distinct two from tenk_aocs5;
+create rule ao_rule_delete as on update to tenk_aocs5 do instead delete from tenk_aocs5 where unique1=1;
+insert into tenk_aocs5(unique1, unique2) values (3, 99998889); -- should go through both rules
+select * from tenk_aocs5 where unique1=1;
 
 ---------------------
 -- UAO

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -370,8 +370,13 @@ commit;
 select count(*) from tenk_ao5_temp_pres_rows;
 
 -- RULES
-create rule ao_rule_update as on insert to tenk_ao5 do instead update foo_ao set two=2;
-create rule ao_rule_delete as on insert to tenk_ao5 do instead delete from foo_ao where unique1=1;
+insert into tenk_ao5(unique1, unique2) values (1, 99998889);
+create rule ao_rule_update as on insert to tenk_ao5 do instead update tenk_ao5 set two=2;
+insert into tenk_ao5(unique1, unique2) values (2, 99998889);
+select distinct two from tenk_ao5;
+create rule ao_rule_delete as on update to tenk_ao5 do instead delete from tenk_ao5 where unique1=1;
+insert into tenk_ao5(unique1, unique2) values (3, 99998889); -- should go through both rules
+select * from tenk_ao5 where unique1=1;
 
 ---------------------
 -- UAO

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -869,10 +869,22 @@ select count(*) from tenk_aocs5_temp_pres_rows;
 (1 row)
 
 -- RULES
-create rule aocs_rule_update as on insert to tenk_aocs5 do instead update foo_aocs set two=2;
-ERROR:  relation "foo_aocs" does not exist
-create rule aocs_rule_delete as on insert to tenk_aocs5 do instead delete from foo_aocs where unique1=1;
-ERROR:  relation "foo_aocs" does not exist
+insert into tenk_aocs5(unique1, unique2) values (1, 99998889);
+create rule ao_rule_update as on insert to tenk_aocs5 do instead update tenk_aocs5 set two=2;
+insert into tenk_aocs5(unique1, unique2) values (2, 99998889);
+select distinct two from tenk_aocs5;
+ two 
+-----
+   2
+(1 row)
+
+create rule ao_rule_delete as on update to tenk_aocs5 do instead delete from tenk_aocs5 where unique1=1;
+insert into tenk_aocs5(unique1, unique2) values (3, 99998889); -- should go through both rules
+select * from tenk_aocs5 where unique1=1;
+ unique1 | unique2 | two | four | ten | twenty | hundred | thousand | twothousand | fivethous | tenthous | odd | even | stringu1 | stringu2 | string4 
+---------+---------+-----+------+-----+--------+---------+----------+-------------+-----------+----------+-----+------+----------+----------+---------
+(0 rows)
+
 ---------------------
 -- UAO
 ---------------------

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -816,10 +816,22 @@ select count(*) from tenk_ao5_temp_pres_rows;
 (1 row)
 
 -- RULES
-create rule ao_rule_update as on insert to tenk_ao5 do instead update foo_ao set two=2;
-ERROR:  relation "foo_ao" does not exist
-create rule ao_rule_delete as on insert to tenk_ao5 do instead delete from foo_ao where unique1=1;
-ERROR:  relation "foo_ao" does not exist
+insert into tenk_ao5(unique1, unique2) values (1, 99998889);
+create rule ao_rule_update as on insert to tenk_ao5 do instead update tenk_ao5 set two=2;
+insert into tenk_ao5(unique1, unique2) values (2, 99998889);
+select distinct two from tenk_ao5;
+ two 
+-----
+   2
+(1 row)
+
+create rule ao_rule_delete as on update to tenk_ao5 do instead delete from tenk_ao5 where unique1=1;
+insert into tenk_ao5(unique1, unique2) values (3, 99998889); -- should go through both rules
+select * from tenk_ao5 where unique1=1;
+ unique1 | unique2 | two | four | ten | twenty | hundred | thousand | twothousand | fivethous | tenthous | odd | even | stringu1 | stringu2 | string4 
+---------+---------+-----+------+-----+--------+---------+----------+-------------+-----------+----------+-----+------+----------+----------+---------
+(0 rows)
+
 ---------------------
 -- UAO
 ---------------------


### PR DESCRIPTION
The tests were added in commit 7d0325e417bd2054ad9140b5ddb20f757b811cd5
and were not properly translated from Pivotal's internal tests to the
pg_regress tests. They now properly test CREATE RULE on AO/CO tables.

Thanks to Heikki Linnakangas for catching this issue.