### PR TITLE
Fixes to keep OIDs across segments in sync

### DIFF
--- a/contrib/isn/isn.sql.in
+++ b/contrib/isn/isn.sql.in
@@ -28,7 +28,10 @@ CREATE OR REPLACE FUNCTION ean13_out(ean13)
 CREATE TYPE ean13 (
 	INPUT = ean13_in,
 	OUTPUT = ean13_out,
-	LIKE = pg_catalog.int8
+	PASSEDBYVALUE,
+	INTERNALLENGTH = 8,
+	ALIGNMENT = double,
+	STORAGE = PLAIN
 );
 COMMENT ON TYPE ean13
 	IS 'International European Article Number (EAN13)';
@@ -46,7 +49,10 @@ CREATE OR REPLACE FUNCTION ean13_out(isbn13)
 CREATE TYPE isbn13 (
 	INPUT = isbn13_in,
 	OUTPUT = ean13_out,
-	LIKE = pg_catalog.int8
+	PASSEDBYVALUE,
+	INTERNALLENGTH = 8,
+	ALIGNMENT = double,
+	STORAGE = PLAIN
 );
 COMMENT ON TYPE isbn13
 	IS 'International Standard Book Number 13 (ISBN13)';
@@ -64,7 +70,10 @@ CREATE OR REPLACE FUNCTION ean13_out(ismn13)
 CREATE TYPE ismn13 (
 	INPUT = ismn13_in,
 	OUTPUT = ean13_out,
-	LIKE = pg_catalog.int8
+	PASSEDBYVALUE,
+	INTERNALLENGTH = 8,
+	ALIGNMENT = double,
+	STORAGE = PLAIN
 );
 COMMENT ON TYPE ismn13
 	IS 'International Standard Music Number 13 (ISMN13)';
@@ -82,7 +91,10 @@ CREATE OR REPLACE FUNCTION ean13_out(issn13)
 CREATE TYPE issn13 (
 	INPUT = issn13_in,
 	OUTPUT = ean13_out,
-	LIKE = pg_catalog.int8
+	PASSEDBYVALUE,
+	INTERNALLENGTH = 8,
+	ALIGNMENT = double,
+	STORAGE = PLAIN
 );
 COMMENT ON TYPE issn13
 	IS 'International Standard Serial Number 13 (ISSN13)';
@@ -102,7 +114,10 @@ CREATE OR REPLACE FUNCTION isn_out(isbn)
 CREATE TYPE isbn (
 	INPUT = isbn_in,
 	OUTPUT = isn_out,
-	LIKE = pg_catalog.int8
+	PASSEDBYVALUE,
+	INTERNALLENGTH = 8,
+	ALIGNMENT = double,
+	STORAGE = PLAIN
 );
 COMMENT ON TYPE isbn
 	IS 'International Standard Book Number (ISBN)';
@@ -120,7 +135,10 @@ CREATE OR REPLACE FUNCTION isn_out(ismn)
 CREATE TYPE ismn (
 	INPUT = ismn_in,
 	OUTPUT = isn_out,
-	LIKE = pg_catalog.int8
+	PASSEDBYVALUE,
+	INTERNALLENGTH = 8,
+	ALIGNMENT = double,
+	STORAGE = PLAIN
 );
 COMMENT ON TYPE ismn
 	IS 'International Standard Music Number (ISMN)';
@@ -138,7 +156,10 @@ CREATE OR REPLACE FUNCTION isn_out(issn)
 CREATE TYPE issn (
 	INPUT = issn_in,
 	OUTPUT = isn_out,
-	LIKE = pg_catalog.int8
+	PASSEDBYVALUE,
+	INTERNALLENGTH = 8,
+	ALIGNMENT = double,
+	STORAGE = PLAIN
 );
 COMMENT ON TYPE issn
 	IS 'International Standard Serial Number (ISSN)';
@@ -156,7 +177,10 @@ CREATE OR REPLACE FUNCTION isn_out(upc)
 CREATE TYPE upc (
 	INPUT = upc_in,
 	OUTPUT = isn_out,
-	LIKE = pg_catalog.int8
+	PASSEDBYVALUE,
+	INTERNALLENGTH = 8,
+	ALIGNMENT = double,
+	STORAGE = PLAIN
 );
 COMMENT ON TYPE upc
 	IS 'Universal Product Code (UPC)';

--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -24,10 +24,13 @@
 #include "access/transam.h"
 #include "catalog/catalog.h"
 #include "catalog/indexing.h"
+#include "catalog/pg_amop.h"
+#include "catalog/pg_amproc.h"
 #include "catalog/pg_auth_members.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_database.h"
 #include "catalog/pg_exttable.h"
+#include "catalog/pg_largeobject.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_pltemplate.h"
 #include "catalog/pg_resqueue.h"
@@ -37,8 +40,10 @@
 #include "catalog/pg_filespace_entry.h"
 #include "catalog/pg_tablespace.h"
 #include "catalog/pg_resqueue.h"
+#include "catalog/pg_rewrite.h"
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_tidycat.h"
+#include "catalog/pg_trigger.h"
 
 #include "catalog/gp_configuration.h"
 #include "catalog/gp_configuration.h"
@@ -847,6 +852,41 @@ relationId == PgFileSpaceEntryToastIndex ||
 	return false;
 }
 
+/*
+ * OIDs for catalog object are normally allocated in the master, and
+ * executor nodes should just use the OIDs passed by the master. But
+ * there are some exceptions.
+ */
+static bool
+RelationNeedsSynchronizedOIDs(Relation relation)
+{
+	if (IsSystemNamespace(RelationGetNamespace(relation)))
+	{
+		switch(RelationGetRelid(relation))
+		{
+			/*
+			 * pg_largeobject is more like a user table, and has
+			 * different contents in each segment and master.
+			 */
+			case LargeObjectRelationId:
+				return false;
+
+			/* We don't currently synchronize the OIDs of these catalogs. */
+			case RewriteRelationId:
+			case TriggerRelationId:
+			case AccessMethodOperatorRelationId:
+			case AccessMethodProcedureRelationId:
+				return false;
+		}
+
+		/*
+		 * All other system catalogs are assumed to need synchronized
+		 * OIDs.
+		 */
+		return true;
+	}
+	return false;
+}
 
 /*
  * GetNewOid
@@ -889,7 +929,6 @@ GetNewOid(Relation relation)
 	/* If no OID index, just hand back the next OID counter value */
 	if (!OidIsValid(oidIndex))
 	{
-		Oid result;
 		/*
 		 * System catalogs that have OIDs should *always* have a unique OID
 		 * index; we should only take this path for user tables. Give a
@@ -899,26 +938,25 @@ GetNewOid(Relation relation)
 			elog(WARNING, "generating possibly-non-unique OID for \"%s\"",
 				 RelationGetRelationName(relation));
 
-		result=  GetNewObjectId();
-		
-		if (IsSystemNamespace(RelationGetNamespace(relation)))
-		{
-			if (Gp_role == GP_ROLE_EXECUTE)
-			{
-				elog(DEBUG1,"Allocating Oid %u on relid %u %s in EXECUTE mode",result,relation->rd_id,RelationGetRelationName(relation));
-			}
-			if (Gp_role == GP_ROLE_DISPATCH)
-			{
-				elog(DEBUG5,"Allocating Oid %u on relid %u %s in DISPATCH mode",result,relation->rd_id,RelationGetRelationName(relation));
-			}
-		}
-		return result;
+		return GetNewObjectId();
 	}
 
 	/* Otherwise, use the index to find a nonconflicting OID */
 	indexrel = index_open(oidIndex, AccessShareLock);
 	newOid = GetNewOidWithIndex(relation, indexrel);
 	index_close(indexrel, AccessShareLock);
+
+	/*
+	 * Most catalog objects need to have the same OID in the master and all
+	 * segments. When creating a new object, the master should allocate the
+	 * OID and tell the segments to use the same, so segments should have no
+	 * need to ever allocate OIDs on their own. Therefore, give a WARNING if
+	 * GetNewOid() is called in a segment. (There are a few exceptions, see
+	 * RelationNeedsSynchronizedOIDs()).
+	 */
+	if (Gp_role == GP_ROLE_EXECUTE && RelationNeedsSynchronizedOIDs(relation))
+		elog(WARNING, "allocated OID %u for relation \"%s\" in segment",
+			 newOid, RelationGetRelationName(relation));
 
 	return newOid;
 }
@@ -963,21 +1001,6 @@ GetNewOidWithIndex(Relation relation, Relation indexrel)
 
 		index_endscan(scan);
 	} while (collides);
-	
-	if (IsSystemNamespace(RelationGetNamespace(relation)))
-	{
-		if (Gp_role == GP_ROLE_EXECUTE)
-		{
-			if (relation->rd_id != 2604 /* pg_attrdef */ && relation->rd_id != 2606 /* pg_constraint */ && relation->rd_id != 2615 /* pg_namespace */) 
-				elog(DEBUG1,"Allocating Oid %u with index on relid %u %s in EXECUTE mode",newOid,relation->rd_id, RelationGetRelationName(relation));
-			else
-				elog(DEBUG4,"Allocating Oid %u with index on relid %u %s in EXECUTE mode",newOid,relation->rd_id, RelationGetRelationName(relation));
-		}
-		if (Gp_role == GP_ROLE_DISPATCH)
-		{
-			elog(DEBUG5,"Allocating Oid %u with index on relid %u %s in DISPATCH mode",newOid,relation->rd_id,  RelationGetRelationName(relation));
-		}
-	}
 
 	return newOid;
 }

--- a/src/backend/commands/aggregatecmds.c
+++ b/src/backend/commands/aggregatecmds.c
@@ -234,7 +234,7 @@ DefineAggregate(List *name, List *args, bool oldstyle, List *parameters,
 		stmt->args = args;
 		stmt->definition = parameters;
 		stmt->newOid = aggOid;
-		stmt->shadowOid = 0;
+		stmt->arrayOid = stmt->commutatorOid = stmt->negatorOid = InvalidOid;
 		stmt->ordered = ordered;
 		CdbDispatchUtilityStatement((Node *) stmt, "DefineAggregate");
 	}

--- a/src/backend/commands/extprotocolcmds.c
+++ b/src/backend/commands/extprotocolcmds.c
@@ -94,7 +94,7 @@ DefineExtProtocol(List *name, List *parameters, Oid newOid, bool trusted)
 		stmt->args = NIL;
 		stmt->definition = parameters;
 		stmt->newOid = protOid;
-		stmt->shadowOid = 0;
+		stmt->arrayOid = stmt->commutatorOid = stmt->negatorOid = InvalidOid;
 		stmt->ordered = false;
 		stmt->trusted = trusted;
 		CdbDispatchUtilityStatement((Node *) stmt, "DefineExtprotocol");

--- a/src/backend/commands/opclasscmds.c
+++ b/src/backend/commands/opclasscmds.c
@@ -170,7 +170,7 @@ OpClassCacheLookup(Oid amID, List *opclassname)
  * Caller must have done permissions checks etc. already.
  */
 static Oid
-CreateOpFamily(char *amname, char *opfname, Oid namespaceoid, Oid amoid)
+CreateOpFamily(char *amname, char *opfname, Oid namespaceoid, Oid amoid, Oid newOid)
 {
 	Oid			opfamilyoid;
 	Relation	rel;
@@ -212,6 +212,9 @@ CreateOpFamily(char *amname, char *opfname, Oid namespaceoid, Oid amoid)
 	values[Anum_pg_opfamily_opfowner - 1] = ObjectIdGetDatum(GetUserId());
 
 	tup = heap_form_tuple(rel->rd_att, values, nulls);
+
+	if (newOid != InvalidOid)
+		HeapTupleSetOid(tup, newOid);
 
 	opfamilyoid = simple_heap_insert(rel, tup);
 
@@ -392,9 +395,14 @@ DefineOpClass(CreateOpClassStmt *stmt)
 			 * Create it ... again no need for more permissions ...
 			 */
 			opfamilyoid = CreateOpFamily(stmt->amname, opcname,
-										 namespaceoid, amoid);
+										 namespaceoid, amoid, stmt->opfamilyOid);
 		}
 	}
+
+	/* cross-check that the QD had the same OID for this op family */
+	if (Gp_role == GP_ROLE_EXECUTE && stmt->opfamilyOid != opfamilyoid)
+		elog(ERROR, "operator family \"%s\" has different OID in segment (%u) and in master (%u)",
+			 NameListToString(stmt->opfamilyname), opfamilyoid, stmt->opfamilyOid);
 
 	operators = NIL;
 	procedures = NIL;
@@ -607,8 +615,6 @@ DefineOpClass(CreateOpClassStmt *stmt)
 
 	CatalogUpdateIndexes(rel, tup);
 
-	stmt->opclassOid = opclassoid;
-
 	heap_freetuple(tup);
 
 	/*
@@ -664,6 +670,8 @@ DefineOpClass(CreateOpClassStmt *stmt)
 	
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		stmt->opclassOid = opclassoid;
+		stmt->opfamilyOid = opfamilyoid;
 		CdbDispatchUtilityStatement((Node *) stmt, "DefineOpClass");
 	}
 }
@@ -758,6 +766,9 @@ DefineOpFamily(CreateOpFamilyStmt *stmt)
 
 	tup = heap_form_tuple(rel->rd_att, values, nulls);
 
+	if (stmt->newOid != InvalidOid)
+		HeapTupleSetOid(tup, stmt->newOid);
+
 	opfamilyoid = simple_heap_insert(rel, tup);
 
 	CatalogUpdateIndexes(rel, tup);
@@ -783,6 +794,12 @@ DefineOpFamily(CreateOpFamilyStmt *stmt)
 	recordDependencyOnOwner(OperatorFamilyRelationId, opfamilyoid, GetUserId());
 
 	heap_close(rel, RowExclusiveLock);
+
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		stmt->newOid = opfamilyoid;
+		CdbDispatchUtilityStatement((Node *) stmt, "DefineOpFamily");
+	}
 }
 
 
@@ -857,6 +874,9 @@ AlterOpFamily(AlterOpFamilyStmt *stmt)
 		AlterOpFamilyAdd(stmt->opfamilyname, amoid, opfamilyoid,
 						 maxOpNumber, maxProcNumber,
 						 stmt->items);
+
+	if (Gp_role == GP_ROLE_DISPATCH)
+		CdbDispatchUtilityStatement((Node *) stmt, "AlterOpFamilyStmt");
 }
 
 /*
@@ -1660,6 +1680,9 @@ RemoveOpFamily(RemoveOpFamilyStmt *stmt)
 	object.objectSubId = 0;
 
 	performDeletion(&object, stmt->behavior);
+
+	if (Gp_role == GP_ROLE_DISPATCH)
+		CdbDispatchUtilityStatement((Node *) stmt, "RemoveOpFamily");
 }
 
 

--- a/src/backend/commands/operatorcmds.c
+++ b/src/backend/commands/operatorcmds.c
@@ -63,7 +63,8 @@ static void AlterOperatorOwner_internal(Relation rel, Oid operOid, Oid newOwnerI
  * 'parameters' is a list of DefElem
  */
 void
-DefineOperator(List *names, List *parameters, Oid newOid)
+DefineOperator(List *names, List *parameters,
+			   Oid newOid, Oid newCommutatorOid, Oid newNegatorOid)
 {
 	char	   *oprName;
 	Oid			oprNamespace;
@@ -172,7 +173,9 @@ DefineOperator(List *names, List *parameters, Oid newOid)
 				   joinName,	/* optional join sel. procedure name */
 				   canMerge,	/* operator merges */
 				   canHash,	/* operator hashes */
-				   newOid);
+				   newOid,
+				   &newCommutatorOid,
+				   &newNegatorOid);
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
@@ -183,7 +186,9 @@ DefineOperator(List *names, List *parameters, Oid newOid)
 		stmt->args = NIL;
 		stmt->definition = parameters;
 		stmt->newOid = opOid;
-		stmt->shadowOid = 0;
+		stmt->commutatorOid = newCommutatorOid;
+		stmt->negatorOid = newNegatorOid;
+		stmt->arrayOid = InvalidOid;
 		CdbDispatchUtilityStatement((Node *) stmt, "DefineOperator");
 	}
 }

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3634,6 +3634,9 @@ _copyCreateOpClassStmt(CreateOpClassStmt *from)
 	COPY_NODE_FIELD(items);
 	COPY_SCALAR_FIELD(isDefault);
 
+	COPY_SCALAR_FIELD(opclassOid);
+	COPY_SCALAR_FIELD(opfamilyOid);
+
 	return newnode;
 }
 
@@ -3660,6 +3663,7 @@ _copyCreateOpFamilyStmt(CreateOpFamilyStmt *from)
 
 	COPY_NODE_FIELD(opfamilyname);
 	COPY_STRING_FIELD(amname);
+	COPY_SCALAR_FIELD(newOid);
 
 	return newnode;
 }

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3286,10 +3286,12 @@ _copyDefineStmt(DefineStmt *from)
 	COPY_NODE_FIELD(defnames);
 	COPY_NODE_FIELD(args);
 	COPY_NODE_FIELD(definition);
-	COPY_SCALAR_FIELD(newOid);
-	COPY_SCALAR_FIELD(shadowOid);
 	COPY_SCALAR_FIELD(ordered);  /* CDB */
 	COPY_SCALAR_FIELD(trusted);  /* CDB */
+	COPY_SCALAR_FIELD(newOid);
+	COPY_SCALAR_FIELD(arrayOid);
+	COPY_SCALAR_FIELD(commutatorOid);
+	COPY_SCALAR_FIELD(negatorOid);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1531,6 +1531,8 @@ _equalCreateOpClassStmt(CreateOpClassStmt *a, CreateOpClassStmt *b)
 	COMPARE_NODE_FIELD(datatype);
 	COMPARE_NODE_FIELD(items);
 	COMPARE_SCALAR_FIELD(isDefault);
+	COMPARE_SCALAR_FIELD(opclassOid);
+	COMPARE_SCALAR_FIELD(opfamilyOid);
 
 	return true;
 }
@@ -1554,6 +1556,8 @@ _equalCreateOpFamilyStmt(CreateOpFamilyStmt *a, CreateOpFamilyStmt *b)
 {
 	COMPARE_NODE_FIELD(opfamilyname);
 	COMPARE_STRING_FIELD(amname);
+
+	COMPARE_SCALAR_FIELD(newOid);
 
 	return true;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1660,8 +1660,17 @@ _outNode(StringInfo str, void *obj)
 			case T_CreateOpClassItem:
 				_outCreateOpClassItem(str,obj);
 				break;
+			case T_CreateOpFamilyStmt:
+				_outCreateOpFamilyStmt(str,obj);
+				break;
+			case T_AlterOpFamilyStmt:
+				_outAlterOpFamilyStmt(str,obj);
+				break;
 			case T_RemoveOpClassStmt:
 				_outRemoveOpClassStmt(str,obj);
+				break;
+			case T_RemoveOpFamilyStmt:
+				_outRemoveOpFamilyStmt(str,obj);
 				break;
 			case T_CreateConversionStmt:
 				_outCreateConversionStmt(str,obj);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2525,6 +2525,7 @@ _outAlterTableStmt(StringInfo str, AlterTableStmt *node)
 	{
 		WRITE_OID_FIELD(oidInfo[m].relOid);
 		WRITE_OID_FIELD(oidInfo[m].comptypeOid);
+		WRITE_OID_FIELD(oidInfo[m].comptypeArrayOid);
 		WRITE_OID_FIELD(oidInfo[m].toastOid);
 		WRITE_OID_FIELD(oidInfo[m].toastIndexOid);
 		WRITE_OID_FIELD(oidInfo[m].toastComptypeOid);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3042,11 +3042,13 @@ _outCreateOpClassStmt(StringInfo str, CreateOpClassStmt *node)
 {
 	WRITE_NODE_TYPE("CREATEOPCLASS");
 	WRITE_NODE_FIELD(opclassname);
+	WRITE_NODE_FIELD(opfamilyname);
 	WRITE_STRING_FIELD(amname);
 	WRITE_NODE_FIELD(datatype);
 	WRITE_NODE_FIELD(items);
 	WRITE_BOOL_FIELD(isDefault);
 	WRITE_OID_FIELD(opclassOid);
+	WRITE_OID_FIELD(opfamilyOid);
 }
 
 static void
@@ -3062,10 +3064,39 @@ _outCreateOpClassItem(StringInfo str, CreateOpClassItem *node)
 }
 
 static void
+_outCreateOpFamilyStmt(StringInfo str, CreateOpFamilyStmt *node)
+{
+	WRITE_NODE_TYPE("CREATEOPFAMILY");
+	WRITE_NODE_FIELD(opfamilyname);
+	WRITE_STRING_FIELD(amname);
+	WRITE_OID_FIELD(newOid);
+}
+
+static void
+_outAlterOpFamilyStmt(StringInfo str, AlterOpFamilyStmt *node)
+{
+	WRITE_NODE_TYPE("ALTEROPFAMILY");
+	WRITE_NODE_FIELD(opfamilyname);
+	WRITE_STRING_FIELD(amname);
+	WRITE_BOOL_FIELD(isDrop);
+	WRITE_NODE_FIELD(items);
+}
+
+static void
 _outRemoveOpClassStmt(StringInfo str, RemoveOpClassStmt *node)
 {
 	WRITE_NODE_TYPE("REMOVEOPCLASS");
 	WRITE_NODE_FIELD(opclassname);
+	WRITE_STRING_FIELD(amname);
+	WRITE_ENUM_FIELD(behavior, DropBehavior);
+	WRITE_BOOL_FIELD(missing_ok);
+}
+
+static void
+_outRemoveOpFamilyStmt(StringInfo str, RemoveOpFamilyStmt *node)
+{
+	WRITE_NODE_TYPE("REMOVEOPFAMILY");
+	WRITE_NODE_FIELD(opfamilyname);
 	WRITE_STRING_FIELD(amname);
 	WRITE_ENUM_FIELD(behavior, DropBehavior);
 	WRITE_BOOL_FIELD(missing_ok);
@@ -4754,8 +4785,17 @@ _outNode(StringInfo str, void *obj)
 			case T_CreateOpClassItem:
 				_outCreateOpClassItem(str,obj);
 				break;
+			case T_CreateOpFamilyStmt:
+				_outCreateOpFamilyStmt(str,obj);
+				break;
+			case T_AlterOpFamilyStmt:
+				_outAlterOpFamilyStmt(str,obj);
+				break;
 			case T_RemoveOpClassStmt:
 				_outRemoveOpClassStmt(str,obj);
+				break;
+			case T_RemoveOpFamilyStmt:
+				_outRemoveOpFamilyStmt(str,obj);
 				break;
 			case T_CreateConversionStmt:
 				_outCreateConversionStmt(str,obj);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2997,10 +2997,12 @@ _outDefineStmt(StringInfo str, DefineStmt *node)
 	WRITE_NODE_FIELD(defnames);
 	WRITE_NODE_FIELD(args);
 	WRITE_NODE_FIELD(definition);
-	WRITE_OID_FIELD(newOid);
-	WRITE_OID_FIELD(shadowOid);
 	WRITE_BOOL_FIELD(ordered);  /* CDB */
 	WRITE_BOOL_FIELD(trusted);  /* CDB */
+	WRITE_OID_FIELD(newOid);
+	WRITE_OID_FIELD(arrayOid);
+	WRITE_OID_FIELD(commutatorOid);
+	WRITE_OID_FIELD(negatorOid);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1376,30 +1376,6 @@ _readDefineStmt(void)
 
 }
 
-static DropCastStmt *
-_readDropCastStmt(void)
-{
-	READ_LOCALS(DropCastStmt);
-	READ_NODE_FIELD(sourcetype);
-	READ_NODE_FIELD(targettype);
-	READ_ENUM_FIELD(behavior, DropBehavior); Assert(local_node->behavior <= DROP_CASCADE);
-	READ_BOOL_FIELD(missing_ok);
-
-	READ_DONE();
-}
-
-static RemoveOpClassStmt *
-_readRemoveOpClassStmt(void)
-{
-	READ_LOCALS(RemoveOpClassStmt);
-	READ_NODE_FIELD(opclassname);
-	READ_STRING_FIELD(amname);
-	READ_ENUM_FIELD(behavior, DropBehavior); Assert(local_node->behavior <= DROP_CASCADE);
-	READ_BOOL_FIELD(missing_ok);
-
-	READ_DONE();
-}
-
 static CopyStmt *
 _readCopyStmt(void)
 {
@@ -3040,8 +3016,17 @@ readNodeBinary(void)
 			case T_CreateOpClassItem:
 				return_value = _readCreateOpClassItem();
 				break;
+			case T_CreateOpFamilyStmt:
+				return_value = _readCreateOpFamilyStmt();
+				break;
+			case T_AlterOpFamilyStmt:
+				return_value = _readAlterOpFamilyStmt();
+				break;
 			case T_RemoveOpClassStmt:
 				return_value = _readRemoveOpClassStmt();
+				break;
+			case T_RemoveOpFamilyStmt:
+				return_value = _readRemoveOpFamilyStmt();
 				break;
 			case T_CreateConversionStmt:
 				return_value = _readCreateConversionStmt();

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -568,6 +568,7 @@ _readAlterTableStmt(void)
 		{
 			READ_OID_FIELD(oidInfo[m].relOid);
 			READ_OID_FIELD(oidInfo[m].comptypeOid);
+			READ_OID_FIELD(oidInfo[m].comptypeArrayOid);
 			READ_OID_FIELD(oidInfo[m].toastOid);
 			READ_OID_FIELD(oidInfo[m].toastIndexOid);
 			READ_OID_FIELD(oidInfo[m].toastComptypeOid);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1365,10 +1365,12 @@ _readDefineStmt(void)
 	READ_NODE_FIELD(defnames);
 	READ_NODE_FIELD(args);
 	READ_NODE_FIELD(definition);
-	READ_OID_FIELD(newOid);
-	READ_OID_FIELD(shadowOid);
 	READ_BOOL_FIELD(ordered);   /* CDB */
 	READ_BOOL_FIELD(trusted);   /* CDB */
+	READ_OID_FIELD(newOid);
+	READ_OID_FIELD(arrayOid);
+	READ_OID_FIELD(commutatorOid);
+	READ_OID_FIELD(negatorOid);
 
 	READ_DONE();
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1077,6 +1077,7 @@ _readAlterTableStmt(void)
 		{
 			READ_OID_FIELD(oidInfo[m].relOid);
 			READ_OID_FIELD(oidInfo[m].comptypeOid);
+			READ_OID_FIELD(oidInfo[m].comptypeArrayOid);
 			READ_OID_FIELD(oidInfo[m].toastOid);
 			READ_OID_FIELD(oidInfo[m].toastIndexOid);
 			READ_OID_FIELD(oidInfo[m].toastComptypeOid);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2754,7 +2754,6 @@ _readCreateCastStmt(void)
 	READ_DONE();
 }
 
-#ifndef COMPILING_BINARY_FUNCS
 static DropCastStmt *
 _readDropCastStmt(void)
 {
@@ -2767,7 +2766,6 @@ _readDropCastStmt(void)
 
 	READ_DONE();
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
 static CreateOpClassStmt *
 _readCreateOpClassStmt(void)
@@ -2775,11 +2773,13 @@ _readCreateOpClassStmt(void)
 	READ_LOCALS(CreateOpClassStmt);
 
 	READ_NODE_FIELD(opclassname);
+	READ_NODE_FIELD(opfamilyname);
 	READ_STRING_FIELD(amname);
 	READ_NODE_FIELD(datatype);
 	READ_NODE_FIELD(items);
 	READ_BOOL_FIELD(isDefault);
 	READ_OID_FIELD(opclassOid);
+	READ_OID_FIELD(opfamilyOid);
 
 	READ_DONE();
 }
@@ -2798,7 +2798,29 @@ _readCreateOpClassItem(void)
 	READ_DONE();
 }
 
-#ifndef COMPILING_BINARY_FUNCS
+static CreateOpFamilyStmt *
+_readCreateOpFamilyStmt(void)
+{
+	READ_LOCALS(CreateOpFamilyStmt);
+	READ_NODE_FIELD(opfamilyname);
+	READ_STRING_FIELD(amname);
+	READ_OID_FIELD(newOid);
+
+	READ_DONE();
+}
+
+static AlterOpFamilyStmt *
+_readAlterOpFamilyStmt(void)
+{
+	READ_LOCALS(AlterOpFamilyStmt);
+	READ_NODE_FIELD(opfamilyname);
+	READ_STRING_FIELD(amname);
+	READ_BOOL_FIELD(isDrop);
+	READ_NODE_FIELD(items);
+
+	READ_DONE();
+}
+
 static RemoveOpClassStmt *
 _readRemoveOpClassStmt(void)
 {
@@ -2810,7 +2832,18 @@ _readRemoveOpClassStmt(void)
 
 	READ_DONE();
 }
-#endif /* COMPILING_BINARY_FUNCS */
+
+static RemoveOpFamilyStmt *
+_readRemoveOpFamilyStmt(void)
+{
+	READ_LOCALS(RemoveOpFamilyStmt);
+	READ_NODE_FIELD(opfamilyname);
+	READ_STRING_FIELD(amname);
+	READ_ENUM_FIELD(behavior, DropBehavior);
+	READ_BOOL_FIELD(missing_ok);
+
+	READ_DONE();
+}
 
 static CreateConversionStmt *
 _readCreateConversionStmt(void)
@@ -3107,6 +3140,7 @@ static ParseNodeInfo infoAr[] =
 	{"ALTERFUNCTIONSTMT", (ReadFn)_readAlterFunctionStmt},
 	{"ALTEROBJECTSCHEMASTMT", (ReadFn)_readAlterObjectSchemaStmt},
 	{"ALTEROWNERSTMT", (ReadFn)_readAlterOwnerStmt},
+	{"ALTEROPFAMILYSTMT", (ReadFn)_readAlterOpFamilyStmt},
 	{"ALTERPARTITIONCMD", (ReadFn)_readAlterPartitionCmd},
 	{"ALTERPARTITIONID", (ReadFn)_readAlterPartitionId},
 	{"ALTERROLESETSTMT", (ReadFn)_readAlterRoleSetStmt},
@@ -3145,6 +3179,7 @@ static ParseNodeInfo infoAr[] =
 	{"CREATEFUNCSTMT", (ReadFn)_readCreateFunctionStmt},
 	{"CREATEOPCLASS", (ReadFn)_readCreateOpClassStmt},
 	{"CREATEOPCLASSITEM", (ReadFn)_readCreateOpClassItem},
+	{"CREATEOPFAMILYSTMT", (ReadFn)_readCreateOpFamilyStmt},
 	{"CREATEPLANGSTMT", (ReadFn)_readCreatePLangStmt},
 	{"CREATEROLESTMT", (ReadFn)_readCreateRoleStmt},
 	{"CREATESCHEMASTMT", (ReadFn)_readCreateSchemaStmt},
@@ -3205,6 +3240,7 @@ static ParseNodeInfo infoAr[] =
 	{"RELABELTYPE", (ReadFn)_readRelabelType},
 	{"REMOVEFUNCSTMT", (ReadFn)_readRemoveFuncStmt},
 	{"REMOVEOPCLASS", (ReadFn)_readRemoveOpClassStmt},
+	{"REMOVEOPFAMILY", (ReadFn)_readRemoveOpFamilyStmt},
 	{"RENAMESTMT", (ReadFn)_readRenameStmt},
 	{"ROW", (ReadFn)_readRowExpr},
 	{"ROWCOMPAREEXPR", (ReadFn)_readRowCompareExpr},

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2717,10 +2717,12 @@ _readDefineStmt(void)
 	READ_NODE_FIELD(defnames);
 	READ_NODE_FIELD(args);
 	READ_NODE_FIELD(definition);
-	READ_OID_FIELD(newOid);
-	READ_OID_FIELD(shadowOid);
 	READ_BOOL_FIELD(ordered);   /* CDB */
 	READ_BOOL_FIELD(trusted);   /* CDB */
+	READ_OID_FIELD(newOid);
+	READ_OID_FIELD(arrayOid);
+	READ_OID_FIELD(commutatorOid);
+	READ_OID_FIELD(negatorOid);
 
 	READ_DONE();
 }

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1180,11 +1180,12 @@ ProcessUtility(Node *parsetree,
 						break;
 					case OBJECT_OPERATOR:
 						Assert(stmt->args == NIL);
-						DefineOperator(stmt->defnames, stmt->definition, stmt->newOid);
+						DefineOperator(stmt->defnames, stmt->definition,
+									   stmt->newOid, stmt->commutatorOid, stmt->negatorOid);
 						break;
 					case OBJECT_TYPE:
 						Assert(stmt->args == NIL);
-						DefineType(stmt->defnames, stmt->definition, stmt->newOid, stmt->shadowOid);
+						DefineType(stmt->defnames, stmt->definition, stmt->newOid, stmt->arrayOid);
 						break;
 					case OBJECT_EXTPROTOCOL:
 						Assert(stmt->args == NIL);

--- a/src/include/catalog/pg_operator.h
+++ b/src/include/catalog/pg_operator.h
@@ -1005,18 +1005,6 @@ DATA(insert OID = 7096 (  "%"    PGNSP PGUID b f f 1186  1186 1186         0  0 
 /*
  * function prototypes
  */
-extern Oid OperatorCreate(const char *operatorName,
-			   Oid operatorNamespace,
-			   Oid leftTypeId,
-			   Oid rightTypeId,
-			   List *procedureName,
-			   List *commutatorName,
-			   List *negatorName,
-			   List *restrictionName,
-			   List *joinName,
-			   bool canMerge,
-			   bool canHash);
-
 extern Oid OperatorCreateWithOid(const char *operatorName,
 			   Oid operatorNamespace,
 			   Oid leftTypeId,
@@ -1028,6 +1016,8 @@ extern Oid OperatorCreateWithOid(const char *operatorName,
 			   List *joinName,
 			   bool canMerge,
 			   bool canHash,
-			   Oid newOid);
+			   Oid newOid,
+			   Oid *newCommutatorOid,
+			   Oid *newNegatorId);
 
 #endif   /* PG_OPERATOR_H */

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -69,7 +69,8 @@ extern void AlterFunctionNamespace(List *name, List *argtypes, bool isagg,
 					   const char *newschema);
 
 /* commands/operatorcmds.c */
-extern void DefineOperator(List *names, List *parameters, Oid newOid);
+extern void DefineOperator(List *names, List *parameters,
+			   Oid newOid, Oid newCommutatorOid, Oid newNegatorOid);
 extern void RemoveOperator(RemoveFuncStmt *stmt);
 extern void RemoveOperatorById(Oid operOid);
 extern void AlterOperatorOwner(List *name, TypeName *typeName1,

--- a/src/include/commands/typecmds.h
+++ b/src/include/commands/typecmds.h
@@ -19,7 +19,7 @@
 
 #define DEFAULT_TYPDELIM		','
 
-extern void DefineType(List *names, List *parameters, Oid newOid, Oid shadowOid);
+extern void DefineType(List *names, List *parameters, Oid newOid, Oid newArrayOid);
 extern void RemoveType(List *names, DropBehavior behavior, bool missing_ok);
 extern void RemoveTypeById(Oid typeOid);
 extern void DefineDomain(CreateDomainStmt *stmt);

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1907,10 +1907,18 @@ typedef struct DefineStmt
 	List	   *defnames;		/* qualified name (list of Value strings) */
 	List	   *args;			/* a list of TypeName (if needed) */
 	List	   *definition;		/* a list of DefElem */
-	Oid			newOid;			/* for MPP only, the new Oid of the object */
-	Oid			shadowOid;
 	bool        ordered;        /* signals ordered aggregates */
 	bool		trusted;		/* used only for PROTOCOL as this point */
+
+	/*
+	 * These are filled in by the dispatcher, when sending the command
+	 * to segments.
+	 */
+	Oid			newOid;			/* the new Oid of the object */
+	Oid			arrayOid;		/* for CREATE TYPE, array type's OID */
+	Oid			commutatorOid;	/* for CREATE OPERATOR, commutator's OID */
+	Oid			negatorOid;		/* for CREATE OPERATOR, negator's OID */
+
 } DefineStmt;
 
 /* ----------------------

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1947,7 +1947,15 @@ typedef struct CreateOpClassStmt
 	TypeName   *datatype;		/* datatype of indexed column */
 	List	   *items;			/* List of CreateOpClassItem nodes */
 	bool		isDefault;		/* Should be marked as default for type? */
+
+	/*
+	 * When dispatched from QD to QEs, opclassOid is the OID to use for
+	 * the opclass, and opfamilyOid is the OID of the operator family
+	 * to associate it with.
+	 */
 	Oid			opclassOid;
+	Oid			opfamilyOid;
+	bool		createOpFamily;
 } CreateOpClassStmt;
 
 #define OPCLASS_ITEM_OPERATOR		1
@@ -1977,6 +1985,9 @@ typedef struct CreateOpFamilyStmt
 	NodeTag		type;
 	List	   *opfamilyname;	/* qualified name (list of Value strings) */
 	char	   *amname;			/* name of index AM opfamily is for */
+
+	Oid			newOid;			/* Created opfamily's OID, when dispatched
+								 * from QD to QEs */
 } CreateOpFamilyStmt;
 
 /* ----------------------

--- a/src/test/regress/expected/opclass_ddl.out
+++ b/src/test/regress/expected/opclass_ddl.out
@@ -1,0 +1,52 @@
+-- The following is a cut-down version of PostgreSQL 9.3's "alter_generic"
+-- test, containing the opclass and opfamily parts of that test. Backported
+-- to GPDB, because we have no other tests for the opclass and opfamily DDL
+-- commands. These can be removed once we merge with 9.3 (the DROP+CREATE
+-- with same name tests are not in the upstream version though!)
+-- Clean up in case a prior regression run failed
+SET client_min_messages TO 'warning';
+DROP ROLE IF EXISTS regtest_alter_user1;
+DROP ROLE IF EXISTS regtest_alter_user2;
+DROP ROLE IF EXISTS regtest_alter_user3;
+RESET client_min_messages;
+CREATE USER regtest_alter_user3;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE USER regtest_alter_user2;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE USER regtest_alter_user1 IN ROLE regtest_alter_user3;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE SCHEMA alt_nsp1;
+GRANT ALL ON SCHEMA alt_nsp1 TO public;
+SET search_path = alt_nsp1, public;
+--
+-- OpFamily and OpClass
+--
+CREATE OPERATOR FAMILY alt_opf1 USING hash;
+CREATE OPERATOR FAMILY alt_opf2 USING hash;
+-- Drop, and create another opfamily with same name. Should work, unless
+-- we forgot to dispatch the DROP to a segment.
+DROP OPERATOR FAMILY alt_opf1 USING hash;
+CREATE OPERATOR FAMILY alt_opf1 USING hash;
+ALTER OPERATOR FAMILY alt_opf1 USING hash OWNER TO regtest_alter_user1;
+ALTER OPERATOR FAMILY alt_opf2 USING hash OWNER TO regtest_alter_user1;
+CREATE OPERATOR CLASS alt_opc1 FOR TYPE uuid USING hash AS STORAGE uuid;
+CREATE OPERATOR CLASS alt_opc2 FOR TYPE uuid USING hash AS STORAGE uuid;
+-- Also test DROP+CREATE for opclasses
+DROP OPERATOR CLASS alt_opc1 USING hash;
+CREATE OPERATOR CLASS alt_opc1 FOR TYPE uuid USING hash AS STORAGE uuid;
+ALTER OPERATOR CLASS alt_opc1 USING hash OWNER TO regtest_alter_user1;
+ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user1;
+SET SESSION AUTHORIZATION regtest_alter_user1;
+ALTER OPERATOR FAMILY alt_opf1 USING hash RENAME TO alt_opf2;  -- failed (name conflict)
+ERROR:  operator family "alt_opf2" for access method "hash" already exists in schema "alt_nsp1"
+ALTER OPERATOR FAMILY alt_opf1 USING hash RENAME TO alt_opf3;  -- OK
+ALTER OPERATOR FAMILY alt_opf2 USING hash OWNER TO regtest_alter_user2;  -- failed (no role membership)
+ERROR:  must be member of role "regtest_alter_user2"
+ALTER OPERATOR FAMILY alt_opf2 USING hash OWNER TO regtest_alter_user3;  -- OK
+ALTER OPERATOR CLASS alt_opc1 USING hash RENAME TO alt_opc2;  -- failed (name conflict)
+ERROR:  operator class "alt_opc2" for access method "hash" already exists in schema "alt_nsp1"
+ALTER OPERATOR CLASS alt_opc1 USING hash RENAME TO alt_opc3;  -- OK
+ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user2;  -- failed (no role membership)
+ERROR:  must be member of role "regtest_alter_user2"
+ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user3;  -- OK
+RESET SESSION AUTHORIZATION;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -17,7 +17,7 @@
 
 ignore: leastsquares
 test: opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy
-test: filter gpctas gpdist matrix toast sublink sirv_functions table_functions olap_setup complex
+test: filter gpctas gpdist matrix toast sublink sirv_functions table_functions olap_setup complex opclass_ddl
 
 test: dispatch
 

--- a/src/test/regress/sql/opclass_ddl.sql
+++ b/src/test/regress/sql/opclass_ddl.sql
@@ -1,0 +1,62 @@
+-- The following is a cut-down version of PostgreSQL 9.3's "alter_generic"
+-- test, containing the opclass and opfamily parts of that test. Backported
+-- to GPDB, because we have no other tests for the opclass and opfamily DDL
+-- commands. These can be removed once we merge with 9.3 (the DROP+CREATE
+-- with same name tests are not in the upstream version though!)
+
+-- Clean up in case a prior regression run failed
+SET client_min_messages TO 'warning';
+
+DROP ROLE IF EXISTS regtest_alter_user1;
+DROP ROLE IF EXISTS regtest_alter_user2;
+DROP ROLE IF EXISTS regtest_alter_user3;
+
+RESET client_min_messages;
+
+CREATE USER regtest_alter_user3;
+CREATE USER regtest_alter_user2;
+CREATE USER regtest_alter_user1 IN ROLE regtest_alter_user3;
+
+CREATE SCHEMA alt_nsp1;
+
+GRANT ALL ON SCHEMA alt_nsp1 TO public;
+
+SET search_path = alt_nsp1, public;
+
+--
+-- OpFamily and OpClass
+--
+CREATE OPERATOR FAMILY alt_opf1 USING hash;
+CREATE OPERATOR FAMILY alt_opf2 USING hash;
+
+-- Drop, and create another opfamily with same name. Should work, unless
+-- we forgot to dispatch the DROP to a segment.
+DROP OPERATOR FAMILY alt_opf1 USING hash;
+CREATE OPERATOR FAMILY alt_opf1 USING hash;
+
+ALTER OPERATOR FAMILY alt_opf1 USING hash OWNER TO regtest_alter_user1;
+ALTER OPERATOR FAMILY alt_opf2 USING hash OWNER TO regtest_alter_user1;
+
+CREATE OPERATOR CLASS alt_opc1 FOR TYPE uuid USING hash AS STORAGE uuid;
+CREATE OPERATOR CLASS alt_opc2 FOR TYPE uuid USING hash AS STORAGE uuid;
+
+-- Also test DROP+CREATE for opclasses
+DROP OPERATOR CLASS alt_opc1 USING hash;
+CREATE OPERATOR CLASS alt_opc1 FOR TYPE uuid USING hash AS STORAGE uuid;
+
+ALTER OPERATOR CLASS alt_opc1 USING hash OWNER TO regtest_alter_user1;
+ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user1;
+
+SET SESSION AUTHORIZATION regtest_alter_user1;
+
+ALTER OPERATOR FAMILY alt_opf1 USING hash RENAME TO alt_opf2;  -- failed (name conflict)
+ALTER OPERATOR FAMILY alt_opf1 USING hash RENAME TO alt_opf3;  -- OK
+ALTER OPERATOR FAMILY alt_opf2 USING hash OWNER TO regtest_alter_user2;  -- failed (no role membership)
+ALTER OPERATOR FAMILY alt_opf2 USING hash OWNER TO regtest_alter_user3;  -- OK
+
+ALTER OPERATOR CLASS alt_opc1 USING hash RENAME TO alt_opc2;  -- failed (name conflict)
+ALTER OPERATOR CLASS alt_opc1 USING hash RENAME TO alt_opc3;  -- OK
+ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user2;  -- failed (no role membership)
+ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user3;  -- OK
+
+RESET SESSION AUTHORIZATION;


### PR DESCRIPTION
To debug issues stemming from objects having different OIDs in segments and master, I added code to print a WARNING whenever an OID is assigned to system object in segments. That should never happen, because the master should assign the OID and pass it to all the segments (although there are some exceptions where the OIDs are not kept in sync). That's the fourth patch in this series.

That WARNING revealed a few cases where OIDs are not kept in sync. ALTER TABLE didn't synchronize the OID of the type's array type (1st patch). That was missed when the patch to support array types of composite types was merged from PostgreSQL 8.3. Also, the new operator family -related DDL commands, also merged from PostgreSQL 8.3 some time ago, didn't make any effort to dispatch the commands to segments, so the segments were missing opfamily information altogether (3rd patch). Also, if CREATE OPERATOR needs to create a shell negator or commutator operator, the shell operator's OID was not synchronized (2nd patch).

Finally, this fixes the install script of the "isn" extension (5th patch). The reason it's included in this PR is that I used the isn extension to test CREATE OPERATOR FAMILY/CLASS support, because there were almost no regression tests for those. This PR adds some regression tests, but might as well fix the isn module while we're at it.