### PR TITLE
External rescan and subplan fix

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -299,15 +299,10 @@ void
 external_rescan(FileScanDesc scan)
 {
 
-	if (!scan->fs_noop)
-	{
-		/* may need to open file since beginscan doens't do it for us */
-		if (!scan->fs_file)
-			open_external_readable_source(scan);
+	/* Close previous scan if it was already open */
+	external_stopscan(scan);
 
-		/* seek to beginning of data source so we can start over */
-		url_rewind((URL_FILE*)scan->fs_file, RelationGetRelationName(scan->fs_rd));
-	}
+	/* The first call to external_getnext will re-open the scan */
 
 	/* reset some parse state variables */
 	scan->fs_pstate->fe_eof = false;

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -2481,65 +2481,6 @@ url_fflush(URL_FILE *file, CopyState pstate)
     }
 }
 
-void
-url_rewind(URL_FILE *file, const char *relname)
-{
-	char *url = file->url;
-    switch(file->type)
-    {
-		case CFTYPE_FILE:
-			fstream_rewind(file->u.file.fp);
-			break;
-
-		case CFTYPE_EXEC:
-			{
-				elog(ERROR, "Rescan is not supported for web external table: %s. "
-						"Please use 'set optimizer=on' as a work around "
-						"and 'set optimizer_enable_master_only_queries=on' if accessing catalog tables.", relname);
-			}
-			break;
-
-#ifdef USE_CURL
-		case CFTYPE_CURL:
-			/* halt transaction */
-			{
-				CURLMcode e;
-				if (!file->u.curl.for_write)
-				{
-					// TODO: Is this for reading only?
-					e = curl_multi_remove_handle(multi_handle, file->u.curl.handle);
-					if (CURLM_OK != e)
-						elog(ERROR, "internal error curl_multi_remove_handle (%d - %s)", e, curl_easy_strerror(e));
-
-					/* restart */
-					e = curl_multi_add_handle(multi_handle, file->u.curl.handle);
-					if (CURLM_OK != e)
-						elog(ERROR, "internal error curl_multi_add_handle (%d - %s)", e, curl_easy_strerror(e));
-				}
-
-				/* ditch buffer - write will recreate - resets stream pos*/
-				if (file->u.curl.in.ptr)
-					free(file->u.curl.in.ptr);
-
-				file->u.curl.gp_proto = 0;
-				file->u.curl.error = file->u.curl.eof = 0;
-				memset(&file->u.curl.in, 0, sizeof(file->u.curl.in));
-				memset(&file->u.curl.block, 0, sizeof(file->u.curl.block));
-			}
-			break;
-#endif
-
-		case CFTYPE_CUSTOM:
-			elog(ERROR, "rewind support not yet implemented in custom protocol");
-			break;
-			
-		default: /* unknown or supported type - oh dear */
-			break;
-
-    }
-}
-
-
 /*
  * interpretError - formats a brief message and/or the exit code from pclose()
  * 		(or wait4()).

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2073,7 +2073,6 @@ _outRelOptInfo(StringInfo str, RelOptInfo *node)
 	WRITE_CHAR_FIELD(rejectlimittype);
 	WRITE_OID_FIELD(fmterrtbl);
 	WRITE_INT_FIELD(ext_encoding);
-	WRITE_BOOL_FIELD(isrescannable);
 	WRITE_BOOL_FIELD(writable);
 	WRITE_NODE_FIELD(baserestrictinfo);
 	WRITE_NODE_FIELD(joininfo);

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1111,7 +1111,13 @@ create_external_path(PlannerInfo *root, RelOptInfo *rel)
 	
     pathnode->path.locus = cdbpathlocus_from_baserel(root, rel); 
     pathnode->path.motionHazard = false;
-	pathnode->path.rescannable = rel->isrescannable;
+
+	/*
+	 * Mark external tables as non-rescannable. While rescan is possible,
+	 * it can lead to surprising results if the external table produces
+	 * different results when invoked twice.
+	 */
+	pathnode->path.rescannable = false;
 
 	cost_externalscan(pathnode, root, rel);
 	

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -358,9 +358,6 @@ get_external_relation_info(Oid relationObjectId, RelOptInfo *rel)
 	rel->ext_encoding = extentry->encoding;
 	rel->writable = extentry->iswritable;
 
-	/* any external tables are non-rescannable. */
-	rel->isrescannable = false;
-
 }
 
 /*

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -99,7 +99,6 @@ build_simple_rel(PlannerInfo *root, int relid, RelOptKind reloptkind)
 	rel->rejectlimittype = '\0';
 	rel->fmterrtbl = InvalidOid;
 	rel->ext_encoding = -1;
-	rel->isrescannable = true;
 	rel->writable = false;
 	rel->baserestrictinfo = NIL;
 	rel->baserestrictcost.startup = 0;

--- a/src/backend/utils/misc/fstream/fstream.c
+++ b/src/backend/utils/misc/fstream/fstream.c
@@ -998,39 +998,6 @@ int64_t fstream_get_compressed_position(fstream_t *fs)
 	return p;
 }
 
-/*
- * fstream_rewind
- *
- * close the currently open file. open the first file in the file stream
- * chain, reset state and start from scratch.
- */
-int fstream_rewind(fstream_t *fs)
-{
-	int 		response_code;
-	const char*	response_string;
-	struct gpfxdist_t* transform = fs->options.transform;
-
-	fs->fidx = 0;
-	fs->foff = 0;
-	fs->line_number = 1;
-	fs->ferror = 0;
-	fs->skip_header_line = fs->options.header;
-	fs->buffer_cur_size = 0;
-	fs->compressed_position = 0;
-
-	gfile_close(&fs->fd);
-
-	if (gfile_open(&fs->fd, fs->glob.gl_pathv[0], GFILE_OPEN_FOR_READ,
-				   &response_code, &response_string, transform))
-	{
-		gfile_printf_then_putc_newline("fstream unable to open file %s",
-				fs->glob.gl_pathv[0]);
-		fs->ferror = "unable to open file";
-		return -1;
-	}
-	return 0;
-}
-
 bool_t fstream_is_win_pipe(fstream_t *fs)
 {
 	return fs->fd.is_win_pipe;

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -159,7 +159,6 @@ extern bool url_feof(URL_FILE *file, int bytesread);
 extern bool url_ferror(URL_FILE *file, int bytesread, char *ebuf, int ebuflen);
 extern size_t url_fread(void *ptr, size_t size, size_t nmemb, URL_FILE *file, CopyState pstate);
 extern size_t url_fwrite(void *ptr, size_t size, size_t nmemb, URL_FILE *file, CopyState pstate);
-extern void url_rewind(URL_FILE *file, const char *relname);
 extern void url_fflush(URL_FILE *file, CopyState pstate);
 
 extern URL_FILE *url_execute_fopen(char* url, char *cmd, bool forwrite, extvar_t *ev);

--- a/src/include/fstream/fstream.h
+++ b/src/include/fstream/fstream.h
@@ -46,7 +46,6 @@ int fstream_write(fstream_t *fs,
 int fstream_eof(fstream_t* fs);
 int64_t fstream_get_compressed_size(fstream_t* fs);
 int64_t fstream_get_compressed_position(fstream_t* fs);
-int fstream_rewind(fstream_t* fs);
 const char* fstream_get_error(fstream_t* fs);
 fstream_t* fstream_open(const char* path, const struct fstream_options* options,
 						int* response_code, const char** response_string);

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -456,7 +456,6 @@ typedef struct RelOptInfo
 	char		rejectlimittype;
 	Oid			fmterrtbl;
 	int32		ext_encoding;
-	bool		isrescannable; /* false for ext web tables */
 	bool		writable;	   /* true for writable, false for readable ext tables*/
 
 	/* used by various scans and joins: */

--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -1,0 +1,32 @@
+-- Test using an external table in a subquery.
+--
+-- We used to have a bug where the scan on the external table was not
+-- broadcast to all nodes, so each segment scanned only its own portion
+-- of the external table, when the scan was in a subquery. In that case,
+-- the count(*) calculated for each value below was 1, but it should be
+-- equal to the number of segments, because this external table produces
+-- the same rows on every segment.
+CREATE EXTERNAL WEB TABLE echotable (c1 int, c2 int, c3 int) EXECUTE
+'echo "1,2,3"; echo "4,5,6";' FORMAT 'TEXT' (DELIMITER ',');
+create table test_ext_foo (c1 int, c2 int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into test_ext_foo select g, g from generate_series(1, 20) g;
+-- This should return 2 and 5, as the two rows are duplicated in
+-- every segment (assuming you have at least two segments in your
+-- cluster).
+select c2 from echotable group by c2 having count(*) >= 2;
+ c2 
+----
+  2
+  5
+(2 rows)
+
+select * from test_ext_foo as o
+where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
+ c1 | c2 
+----+----
+  5 |  5
+  2 |  2
+(2 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -31,7 +31,7 @@ test: sort_finish_pending
 
 test: gpdiffcheck gptokencheck information_schema gp_hashagg sequence_gp tidscan
 
-test: rangefuncs_cdb gp_dqa external_table subselect_gp indexjoin distributed_transactions olap_group olap_window_seq with_clause as_alias regex_gp partition1
+test: rangefuncs_cdb gp_dqa external_table subselect_gp subselect_gp2 indexjoin distributed_transactions olap_group olap_window_seq with_clause as_alias regex_gp partition1
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests. Unfortunately, 'partition' also assumes that there

--- a/src/test/regress/sql/subselect_gp2.sql
+++ b/src/test/regress/sql/subselect_gp2.sql
@@ -1,0 +1,22 @@
+-- Test using an external table in a subquery.
+--
+-- We used to have a bug where the scan on the external table was not
+-- broadcast to all nodes, so each segment scanned only its own portion
+-- of the external table, when the scan was in a subquery. In that case,
+-- the count(*) calculated for each value below was 1, but it should be
+-- equal to the number of segments, because this external table produces
+-- the same rows on every segment.
+
+CREATE EXTERNAL WEB TABLE echotable (c1 int, c2 int, c3 int) EXECUTE
+'echo "1,2,3"; echo "4,5,6";' FORMAT 'TEXT' (DELIMITER ',');
+
+create table test_ext_foo (c1 int, c2 int4);
+insert into test_ext_foo select g, g from generate_series(1, 20) g;
+
+-- This should return 2 and 5, as the two rows are duplicated in
+-- every segment (assuming you have at least two segments in your
+-- cluster).
+select c2 from echotable group by c2 having count(*) >= 2;
+
+select * from test_ext_foo as o
+where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;


### PR DESCRIPTION
This is a follow-up to PR #490. The changes to support rescans for ExternalScan nodes was made and discussed there. But when I ran the PR through in the buildfarm, I got a different result for the regression test it added with ORCA than without ORCA. The ORCA result was correct, while the Postgres planner produced incorrect result. The problem is that the planner did not parallelize a subquery that contains ExternalScan nodes correctly. An ExternalScan needs to be executed on all segments and the results broadcast to all other segments, like we do for all scans of regular tables. An external table should be treated like a randomly-distributed table, i.e. each segment holds on to a different piece of the external data. After fixing that, you also get a Materialize node on top of the broadcast node, which fixes the original problem, without needing the rescan support. (The way we do add those broadcast nodes is quite cheesy: we really ought to be able to do IndexScans in subplans too, for example. But that's a different story.)

This PR still includes the patch to add rescan support for external scans, because it makes the code simpler and more robust anyway. But it's not needed for the original query that started this thread anymore, once the other patch is committed.
