### PR TITLE
Fix backup behave test for user defined types

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/check_metadata.ans
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/check_metadata.ans
@@ -34,10 +34,10 @@ Distributed by: (a)
  before_heap_ins_trig |      7
 (1 row)
 
-       List of data types
- Schema |  Name   | Description 
---------+---------+-------------
- public | complex | 
+            List of data types
+ Schema |       Name        | Description 
+--------+-------------------+-------------
+ public | user_defined_type | 
 (1 row)
 
                              List of operators

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/create_metadata.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/create_metadata.sql
@@ -18,7 +18,7 @@ CREATE TRIGGER before_heap_ins_trig BEFORE INSERT ON heap_table
 FOR EACH ROW EXECUTE PROCEDURE trigger_func();
 
 -- Create a user-defined type
-CREATE TYPE complex AS (r real, i real);
+CREATE TYPE user_defined_type AS (r real, i real);
 
 -- Create aggregate functions
 CREATE AGGREGATE newcnt ("any") (


### PR DESCRIPTION
We were using "complex" as a user defined type, which is no longer the
case once #605 was checked in.