### PR TITLE
Remove redundant tests between bfv_legacy and qp_misc_rio

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -817,7 +817,7 @@ agg_hash_initial_pass(AggState *aggstate)
 		}
 
 		/* set up for advance_aggregates call */
-		tmpcontext->ecxt_scantuple = outerslot;
+		tmpcontext->ecxt_outertuple = outerslot;
 
 		/* Find or (if there's room) build a hash table entry for the
 		 * input tuple's group. */
@@ -1583,7 +1583,7 @@ agg_hash_reload(AggState *aggstate)
 		has_tuples = true;
 
 		/* set up for advance_aggregates call */
-		tmpcontext->ecxt_scantuple = aggstate->hashslot;
+		tmpcontext->ecxt_outertuple = aggstate->hashslot;
 
 		entry = lookup_agg_hash_entry(aggstate, input, INPUT_RECORD_GROUP_AND_AGGS, input_size,
 									  hashkey, reloaded_hash_bit, &isNew);

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -183,14 +183,7 @@ CMappingColIdVarPlStmt::PvarFromDXLNodeScId
 		// lookup column in the left child translation context
 		const TargetEntry *pte = pdxltrctxLeft->Pte(ulColId);
 
-		if (pdxltrctxLeft->FParentAggNode())
-		{
-			// variable appears in an Agg node: varno must be 0 as expected by GPDB
-			// TODO: Jan 26, 2011; clean this up once MPP-12034 is fixed
-			GPOS_ASSERT(NULL != pte);
-			idxVarno = 0;
-		}
-		else if (NULL != pte)
+		if (NULL != pte)
 		{
 			// identifier comes from left child
 			idxVarno = OUTER;


### PR DESCRIPTION
Most of the test cases in bfv_legacy and qp_misc_rio test files are identical. @karthijrk, @xinzweb, you added these tests about one month apart from each other. Did we accidentally port the same test twice? Can you have a look at this PR, please?

This greatly reduces the time spent on these tests. In addition to removing duplicates, I changed the auto-ANALYZE tests to load fewer rows into the test table (was 10 million, now only half a million).
