### PR TITLE
Validations for btree index

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -592,6 +592,9 @@ char	   *gp_default_storage_options = NULL;
 
 int			writable_external_table_bufsize = 64;
 
+IndexCheckType gp_indexcheck_insert = INDEX_CHECK_NONE;
+IndexCheckType gp_indexcheck_vacuum = INDEX_CHECK_NONE;
+
 struct config_bool ConfigureNamesBool_gp[] =
 {
 	{
@@ -4779,6 +4782,26 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&log_count_recovered_files_batch,
 		1000, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"gp_indexcheck_insert", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Validate that a unique index does not already have the new tid during insert."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		(int *) &gp_indexcheck_insert,
+		INDEX_CHECK_NONE, 0, INDEX_CHECK_ALL, NULL, NULL
+	},
+
+	{
+		{"gp_indexcheck_vacuum", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Validate index after lazy vacuum."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		(int *) &gp_indexcheck_vacuum,
+		INDEX_CHECK_NONE, 0, INDEX_CHECK_ALL, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/access/nbtree.h
+++ b/src/include/access/nbtree.h
@@ -607,6 +607,7 @@ extern BTCycleId _bt_vacuum_cycleid(Relation rel);
 extern BTCycleId _bt_start_vacuum(Relation rel);
 extern void _bt_end_vacuum(Relation rel);
 extern void _bt_end_vacuum_callback(int code, Datum arg);
+extern void _bt_validate_vacuum(Relation irel, Relation hrel, TransactionId oldest_xmin);
 extern Size BTreeShmemSize(void);
 extern void BTreeShmemInit(void);
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -509,6 +509,16 @@ extern int log_count_recovered_files_batch;
 
 extern int writable_external_table_bufsize;
 
+typedef enum
+{
+	INDEX_CHECK_NONE,
+	INDEX_CHECK_SYSTEM,
+	INDEX_CHECK_ALL
+} IndexCheckType;
+
+extern IndexCheckType gp_indexcheck_insert;
+extern IndexCheckType gp_indexcheck_vacuum;
+
 /* Storage option names */
 #define SOPT_FILLFACTOR    "fillfactor"
 #define SOPT_APPENDONLY    "appendonly"


### PR DESCRIPTION
This patch adds two GUC controlled validations to ensure index is sane after index and after vacuum. It is an effort towards finding root cause of duplicate entries found in index. Enabling validations would incur significant performance overhead, so they are turned off by default. We hope that they may be helpful in debugging discrepancies seen in production between a system table and its index.