### PR TITLE
Remove warning when compiling aosegfiles.c

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -24,6 +24,7 @@
 #include "cdb/cdbvars.h"
 #include "executor/spi.h"
 #include "nodes/makefuncs.h"
+#include "port.h"
 #include "utils/acl.h"
 #include "utils/syscache.h"
 #include "utils/numeric.h"
@@ -1843,8 +1844,12 @@ PrintPgaocssegAndGprelationNodeEntries(AOCSFileSegInfo **allseginfo, int totalse
 			break;
 		}
 
-		strncat(segnumArray, tmp, sizeof(tmp));
-		strncat(segnumArray, delimiter, sizeof(delimiter));
+		/*
+		 * The original code "strncat(segnumArray, tmp, sizeof(tmp))" is simple
+		 * and safe, but the compiler complains much by law of [-Wstrncat-size].
+		 */
+		strlcat(segnumArray, tmp, sizeof(segnumArray));
+		strlcat(segnumArray, delimiter, sizeof(segnumArray));
 	}
 	elog(LOG, "pg_aocsseg segno entries: %s", segnumArray);
 
@@ -1861,8 +1866,9 @@ PrintPgaocssegAndGprelationNodeEntries(AOCSFileSegInfo **allseginfo, int totalse
 				break;
 			}
 
-			strncat(segnumArray, tmp, sizeof(tmp));
-			strncat(segnumArray, delimiter, sizeof(delimiter));
+			/* Use strlcat instead of strncat to stop compiler complaining. */
+			strlcat(segnumArray, tmp, sizeof(segnumArray));
+			strlcat(segnumArray, delimiter, sizeof(segnumArray));
 		}
 	}
 	elog(LOG, "gp_relation_node segno entries: %s", segnumArray);

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -28,6 +28,7 @@
 #include "cdb/cdbvars.h"
 #include "executor/spi.h"
 #include "nodes/makefuncs.h"
+#include "port.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/syscache.h"
@@ -2164,8 +2165,12 @@ PrintPgaosegAndGprelationNodeEntries(FileSegInfo **allseginfo, int totalsegs, bo
 			break;
 		}
 
-		strncat(segnumArray, tmp, sizeof(tmp));
-		strncat(segnumArray, delimiter, sizeof(delimiter));
+		/*
+		 * The original code "strncat(segnumArray, tmp, sizeof(tmp))" is simple
+		 * and safe, but the compiler complains much by law of [-Wstrncat-size].
+		 */
+		strlcat(segnumArray, tmp, sizeof(segnumArray));
+		strlcat(segnumArray, delimiter, sizeof(segnumArray));
 	}
 	elog(LOG, "pg_aoseg segno:eof entries: %s", segnumArray);
 
@@ -2182,8 +2187,9 @@ PrintPgaosegAndGprelationNodeEntries(FileSegInfo **allseginfo, int totalsegs, bo
 				break;
 			}
 
-			strncat(segnumArray, tmp, sizeof(tmp));
-			strncat(segnumArray, delimiter, sizeof(delimiter));
+			/* Use strlcat instead of strncat to stop compiler complaining. */
+			strlcat(segnumArray, tmp, sizeof(segnumArray));
+			strlcat(segnumArray, delimiter, sizeof(segnumArray));
 		}
 	}
 	elog(LOG, "gp_relation_node segno entries: %s", segnumArray);


### PR DESCRIPTION
Use strlcat instead of strncat to stop compiler complaining. The
original case "strncat(segnumArray, tmp, sizeof(tmp))" is simple
and safe, but the compiler complains much by law [-Wstrncat-size].
So we fix it by "strlcat(segnumArray, tmp, sizeof(segnumArray))".

Changes to be committed:
	modified:   src/backend/access/aocs/aocssegfiles.c
	modified:   src/backend/access/appendonly/aosegfiles.c