### PR TITLE
Remove warning of 'unused variables' when compiling

### DIFF
--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -2484,7 +2484,6 @@ url_fflush(URL_FILE *file, CopyState pstate)
 void
 url_rewind(URL_FILE *file, const char *relname)
 {
-	char *url = file->url;
     switch(file->type)
     {
 		case CFTYPE_FILE:

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -227,7 +227,6 @@ hashDatum(Datum datum, Oid type, datumHashFunction hashFn, void *clientData)
 	Complex		complex_buf;
 	double		complex_real;
 	double		complex_imag;
-	AclItem		*aclitem_ptr;
 	
 	Cash		cash_buf;
 	pg_uuid_t  *uuid_buf;

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -271,7 +271,6 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 			{
 				List   *hashExpr;
 				ListCell *exp1;
-				int			maxattrs = MaxPolicyAttributeNumber;
 				
 				if (query->intoPolicy != NULL)
 				{

--- a/src/pl/plpgsql/src/pl_funcs.c
+++ b/src/pl/plpgsql/src/pl_funcs.c
@@ -697,8 +697,6 @@ free_return_next(PLpgSQL_stmt_return_next *stmt)
 static void
 free_return_query(PLpgSQL_stmt_return_query *stmt)
 {
-	ListCell   *lc;
-
 	free_expr(stmt->query);
 }
 


### PR DESCRIPTION
Files changed:
    modified:   src/backend/access/external/url.c
    modified:   src/backend/cdb/cdbhash.c
    modified:   src/backend/cdb/cdbmutate.c
    modified:   src/pl/plpgsql/src/pl_funcs.c

Skipped:
    catcoretable.c:104:26:CatCoreType_int4_array
    because it is an enumerated constant to ensure integrity