### PR TITLE
ORCA - GPDB exception handling

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -21,6 +21,8 @@
 #include "gpopt/init.h"
 #include "gpos/_api.h"
 
+#include "naucrates/exception.h"
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CGPOptimizer::TouchLibraryInitializers
@@ -53,7 +55,19 @@ CGPOptimizer::PplstmtOptimize
 	bool *pfUnexpectedFailure // output : set to true if optimizer unexpectedly failed to produce plan
 	)
 {
-	return COptTasks::PplstmtOptimize(pquery, pfUnexpectedFailure);
+	GPOS_TRY
+	{
+		return COptTasks::PplstmtOptimize(pquery, pfUnexpectedFailure);
+	}
+	GPOS_CATCH_EX(ex)
+	{
+		if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
+		{
+		  elog(ERROR, "GPDB exception. Aborting GPORCA plan generation.");
+		}
+	}
+	GPOS_CATCH_END;
+	return NULL;
 }
 
 

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -216,6 +216,8 @@
 #define GP_WRAP_END	\
 		}	\
 	}	\
+	EmitErrorReport(); \
+	FlushErrorState(); \
 	GPOS_RAISE(gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError)
 
 using namespace gpos;

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -714,9 +714,11 @@ COptTasks::PdrgPssLoad
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		GPOS_RESET_EX;
-
+		if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError)) {
+			GPOS_RETHROW(ex);
+		}
 		elog(DEBUG2, "\n[OPT]: Using default search strategy");
+		GPOS_RESET_EX;
 	}
 	GPOS_CATCH_END;
 
@@ -1673,13 +1675,6 @@ COptTasks::PvEvalExprFromDXLTask
 		if (fReleaseCache)
 		{
 			CMDCache::Shutdown();
-		}
-		// Catch GPDB exceptions
-		if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
-		{
-			elog(NOTICE, "Found non const expression. Please check log for more information.");
-			GPOS_RESET_EX;
-			return NULL;
 		}
 		if (FErrorOut(ex))
 		{

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -10132,3 +10132,37 @@ NOTICE:  drop cascades to table orca.r
 NOTICE:  drop cascades to table orca.bar2
 NOTICE:  drop cascades to table orca.bar1
 reset optimizer_segments;
+-- Check if ORCA can handle GPDB's error properly
+drop table if exists orca_exc_handle;
+NOTICE:  table "orca_exc_handle" does not exist, skipping
+create table orca_exc_handle(
+	a int primary key,
+	b char
+);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "orca_exc_handle_pkey" for table "orca_exc_handle"
+insert into orca_exc_handle select i, i from generate_Series(1,4) as i; 
+-- enable the fault injector
+--start_ignore
+\! gpfaultinjector -f opt_relcache_translator_catalog_access -y error --seg_dbid 1
+20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f opt_relcache_translator_catalog_access -y error --seg_dbid 1
+20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
+20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
+20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
+20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/qddir/demoDataDir-1:content=-1:dbid=1:mode=s:status=u
+20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
+--end_ignore
+select a from orca_exc_handle;
+ERROR:  fault triggered, fault name:'opt_relcache_translator_catalog_access' fault type:'error' (faultinjector.c:671)
+ERROR:  GPDB exception. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
+-- reset the fault injector
+--start_ignore
+\! gpfaultinjector -f opt_relcache_translator_catalog_access -y reset --seg_dbid 1
+20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f opt_relcache_translator_catalog_access -y reset --seg_dbid 1
+20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
+20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
+20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
+20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/qddir/demoDataDir-1:content=-1:dbid=1:mode=s:status=u
+20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
+--end_ignore
+drop table orca_exc_handle;
+-- End of Check if ORCA can handle GPDB's error properly

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -1280,3 +1280,26 @@ explain select * from orca.index_test where a = 5 and c = 5;
 -- clean up
 drop schema orca cascade;
 reset optimizer_segments;
+
+-- Check if ORCA can handle GPDB's error properly
+drop table if exists orca_exc_handle;
+create table orca_exc_handle(
+	a int primary key,
+	b char
+);
+
+insert into orca_exc_handle select i, i from generate_Series(1,4) as i; 
+
+-- enable the fault injector
+--start_ignore
+\! gpfaultinjector -f opt_relcache_translator_catalog_access -y error --seg_dbid 1
+--end_ignore
+
+select a from orca_exc_handle;
+-- reset the fault injector
+--start_ignore
+\! gpfaultinjector -f opt_relcache_translator_catalog_access -y reset --seg_dbid 1
+--end_ignore
+
+drop table orca_exc_handle;
+-- End of Check if ORCA can handle GPDB's error properly


### PR DESCRIPTION
In this pull request, we make sure that whenever gpdb function throw exception / elog::ERROR, we properly emit & clear the error state and then rethrow the c++ exception (as GPDB exception) all the way back to CGPOptimizer::PplstmtOptimize (Entry point to GPORCA from gpdb). We then elog::ERROR to abort the transaction.

We need this PR in GPOS https://github.com/greenplum-db/gpos/pull/21 to rethrow exception all the way back to caller in GPORCA.

Without this fix, GPORCA was falling back to planner and errorstate was not cleared. Eventually maximum ERRORDATA_STACK_SIZE is reached and we promote any elog message to PANIC from then. 


