### PR TITLE
Allow gpcheckcat to determine default batch size at runtime

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -33,6 +33,7 @@ try:
     from gppylib.gplog import *
     from gppylib.gpcatalog import *
     from gppylib.commands.unix import *
+    from gppylib.system.info import *
     from pygresql.pgdb import DatabaseError
     from pygresql import pg
     from gpcheckcat_modules.unique_index_violation_check import UniqueIndexViolationCheck
@@ -40,7 +41,6 @@ try:
 except ImportError, e:
     sys.exit('Error: unable to import module: ' + str(e))
 
-parallelism = 8
 # cache OID -> object name cache
 oidmap = {}
 
@@ -50,8 +50,10 @@ setup_tool_logging(EXECNAME, getLocalHostname(), getUserName())
 very_quiet_stdout_logging()
 logger = get_default_logger()
 
+sysinfo = SystemInfo(logger)
 
-# -------------------------------------------------------------------------------
+parallelism = get_max_available_thread_count()
+#-------------------------------------------------------------------------------
 
 ################
 def parse_int(val):
@@ -4830,9 +4832,13 @@ def generateVerifyFile(catname, fields, results, checkname):
     except Exception as e:
         logger.warning('Unable to generate verify file for %s (%s)' % (catname, str(e)))
 
-#############
-if __name__ == '__main__':
+def truncate_batch_size(primaries):
+    if GV.opt['-B'] > primaries:
+        GV.opt['-B'] = primaries
+        myprint("Truncated batch size to number of primaries: %d" % primaries)
 
+
+def main():
     parseCommandLine()
     if GV.opt['-l']:
         listAllChecks()
@@ -4844,6 +4850,8 @@ if __name__ == '__main__':
         sys.exit(GV.retcode)
 
     GV.cfg = getGPConfiguration()
+    truncate_batch_size(len(GV.cfg.keys()))
+
     GV.report_cfg = getReportConfiguration()
     GV.max_content = max([GV.cfg[dbid]['content'] for dbid in GV.cfg])
     GV.catalog = getCatalog()
@@ -4860,6 +4868,7 @@ if __name__ == '__main__':
         myprint("Connected as user \'%s\' to database '%s', port '%d', gpdb version '%s'" \
                 % (GV.opt['-U'], GV.dbname, GV.report_cfg[-1]['port'], GV.version))
         myprint('-------------------------------------------------------------------')
+        myprint('Batch size: %s' % GV.opt['-B'])
 
         drop_leaked_schemas(leaked_schema_dropper, dbname)
 
@@ -4889,3 +4898,7 @@ if __name__ == '__main__':
             GV.opt['-S'] = "none"
 
     sys.exit(GV.retcode)
+
+#############
+if __name__ == '__main__':
+    main()

--- a/gpMgmt/bin/gppylib/system/info.py
+++ b/gpMgmt/bin/gppylib/system/info.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python
+import psutil
+import os
+import resource
+
+PERCENTAGE_OF_AVAIL_MEM_USED_FOR_THREADS = 0.8  # allow 20% of memory to remain for parent process
+
+MB = 1024 * 1024
+
+class SystemInfo():
+    def __init__(self, logger=None):
+        self.logger = logger
+        self.pid = os.getpid()
+        self.process = psutil.Process(self.pid)
+
+    def print_mem_usage(self):
+        mem = psutil.virtual_memory()
+        print "available: %sMB percent: %s" % (mem.available >> 20, mem.percent)
+        print "process memory usage %s" % (self.process.memory_info().vms >> 20)
+
+    def debug_log_mem_usage(self):
+        mem = psutil.virtual_memory()
+        if self.logger:
+            self.logger.debug('available: %sMB percent: %s' % (mem.available >> 20, mem.percent))
+            self.logger.debug('process memory usage: %sMB' % (self.process.memory_info().vms >> 20))
+
+def get_max_available_thread_count():
+    stack_size, _ = resource.getrlimit(resource.RLIMIT_STACK)
+    # assuming a generous 10K bytes per line of error output,
+    # 20 MB allows 2000 errors in a single run; if user has more,
+    # we will explain in the manual
+    # the the user can always set batch (number of threads) manually
+    thread_size = 20 * MB + stack_size
+
+    mem = psutil.virtual_memory()
+    available_mem = mem.available
+    num_threads = int(available_mem / thread_size * PERCENTAGE_OF_AVAIL_MEM_USED_FOR_THREADS)
+    return max(1, num_threads)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_info.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_info.py
@@ -1,0 +1,27 @@
+from mock import *
+
+from gp_unittest import *
+from gppylib.system.info import *
+
+
+class InfoTestCase(GpTestCase):
+
+    def setUp(self):
+        self.vmem = Mock()
+        self.vmem.available = 123 * MB
+        STACK_SIZE = 8 * MB
+        self.apply_patches([
+            patch("psutil.virtual_memory", return_value=self.vmem),
+            patch("resource.getrlimit", return_value=[STACK_SIZE, 0])
+        ])
+
+    def test_automatic_thread_count(self):
+        self.assertEquals(get_max_available_thread_count(), 3)
+
+    def test_automatic_thread_minimum(self):
+        self.vmem.available = 123
+        self.assertEquals(get_max_available_thread_count(), 1)
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
When gpcheckcat runs certain tests, it can fan out queries to each segment simultaneously. The number of such simultaneous queries is determined by the "batch size", which previously defaulted to 8 (user can override via -B option).  However, 8 is too low for large clusters, and it seems best to try to determine how many simultaneous threads the master system can support in order to optimize.  

This commit does that, measuring RAM availability and making a conservative estimate of the maximum number of simultaneous threads.

In a cluster with 100 primaries, this automatic batch sizing resulted in approximately 37x reduction in duration for the tests that use fan-out, compared with the default of 8 maximum threads.  Of course, this reduction in duration depends on the how long the queries take, so improvements may vary.