### PR TITLE
Make lc_numeric guc to have GUC_GPDB_ADDOPT.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2157,7 +2157,8 @@ static struct config_string ConfigureNamesString[] =
 	{
 		{"lc_numeric", PGC_USERSET, CLIENT_CONN_LOCALE,
 			gettext_noop("Sets the locale for formatting numbers."),
-			NULL
+			NULL,
+			GUC_GPDB_ADDOPT
 		},
 		&locale_numeric,
 		"C", locale_numeric_assign, NULL

--- a/src/test/regress/expected/lc_numeric_check.out
+++ b/src/test/regress/expected/lc_numeric_check.out
@@ -1,0 +1,76 @@
+---
+--- Set idle gang time to 1ms (minimum)
+--- Want to verify if new segment process get lc_numeric values always
+---
+set gp_vmem_idle_resource_timeout = 1;
+---
+--- Drop existing table
+---
+DROP TABLE IF EXISTS lc_numeric_table;
+NOTICE:  table "lc_numeric_table" does not exist, skipping
+---
+--- Create new table lc_numeric_table
+---
+CREATE TABLE lc_numeric_table(a text, b varchar(50));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+---
+--- Insert some values
+---
+INSERT INTO lc_numeric_table VALUES
+  ('1,1', 'bla'),
+  (2, 'blabla'),
+  (3, 'blablabla');
+---
+--- Select query with default lc_numeric
+--- expect first col value for '1,1' is '11'
+---
+select to_number(a,'999999D99999')::numeric(10,5), b from lc_numeric_table order by to_number;
+ to_number |     b     
+-----------+-----------
+   2.00000 | blabla
+   3.00000 | blablabla
+  11.00000 | bla
+(3 rows)
+
+---
+--- Change lc_numeric
+---
+set lc_numeric='de_DE';
+---
+--- Select query with default lc_numeric
+--- expect first col value for '1,1' is '1.1'
+---
+select to_number(a,'999999D99999')::numeric(10,5), b from lc_numeric_table order by to_number;
+ to_number |     b     
+-----------+-----------
+   1.10000 | bla
+   2.00000 | blabla
+   3.00000 | blablabla
+(3 rows)
+
+-- start_ignore
+\echo `date`
+Thu Apr 28 13:48:54 PDT 2016
+-- end_ignore
+-- start_ignore
+\echo `date`
+Thu Apr 28 13:48:54 PDT 2016
+-- end_ignore
+---
+--- Select query with default lc_numeric
+--- expect first col value for '1,1' is '1.1'
+---
+select to_number(a,'999999D99999')::numeric(10,5), b from lc_numeric_table order by to_number;
+ to_number |     b     
+-----------+-----------
+   1.10000 | bla
+   2.00000 | blabla
+   3.00000 | blablabla
+(3 rows)
+
+---
+--- reset all gucs
+---
+reset lc_numeric;
+reset gp_vmem_idle_resource_timeout;

--- a/src/test/regress/sql/lc_numeric_check.sql
+++ b/src/test/regress/sql/lc_numeric_check.sql
@@ -1,0 +1,62 @@
+---
+--- Set idle gang time to 1ms (minimum)
+--- Want to verify if new segment process get lc_numeric values always
+---
+set gp_vmem_idle_resource_timeout = 1;
+
+
+---
+--- Drop existing table
+---
+DROP TABLE IF EXISTS lc_numeric_table;
+
+---
+--- Create new table lc_numeric_table
+---
+CREATE TABLE lc_numeric_table(a text, b varchar(50));
+
+---
+--- Insert some values
+---
+INSERT INTO lc_numeric_table VALUES
+  ('1,1', 'bla'),
+  (2, 'blabla'),
+  (3, 'blablabla');
+
+---
+--- Select query with default lc_numeric
+--- expect first col value for '1,1' is '11'
+---
+select to_number(a,'999999D99999')::numeric(10,5), b from lc_numeric_table order by to_number;
+
+---
+--- Change lc_numeric
+---
+set lc_numeric='de_DE';
+
+---
+--- Select query with default lc_numeric
+--- expect first col value for '1,1' is '1.1'
+---
+select to_number(a,'999999D99999')::numeric(10,5), b from lc_numeric_table order by to_number;
+
+-- start_ignore
+\echo `date`
+-- end_ignore
+
+-- start_ignore
+\echo `date`
+-- end_ignore
+
+---
+--- Select query with default lc_numeric
+--- expect first col value for '1,1' is '1.1'
+---
+select to_number(a,'999999D99999')::numeric(10,5), b from lc_numeric_table order by to_number;
+
+
+---
+--- reset all gucs
+---
+reset lc_numeric;
+reset gp_vmem_idle_resource_timeout;


### PR DESCRIPTION
Without GUC_GPDB_ADOPT, the values for guc 'lc_numeric' is not dispatched
to the QE processes.

@gcaragea @hardikar @armenatzoglou @vraghavan78  Please take a look when get chance.