### PR TITLE
Allow system to start up, even if pg_auth_time_constraint is corrupt.

### DIFF
--- a/src/backend/utils/init/flatfiles.c
+++ b/src/backend/utils/init/flatfiles.c
@@ -835,6 +835,22 @@ write_auth_time_file(Relation rel_authid, Relation rel_authtime)
 							(errmsg("time constraints are being added against superuser")));
 				authtime_info[curr_constraint].rolname = found_role->rolname;
 			}
+			else
+			{
+				/*
+				 * pg_auth_time_constraint or pg_authid is corrupt: a role mentioned in
+				 * pg_auth_time_constraint was not found in pg_authid. Remove the entry
+				 * from the array so that we can start up the system.
+				 */
+				ereport(WARNING,
+						(errmsg("role with OID %u mentioned in pg_auth_time_constraint does not exist",
+								authtime_info[curr_constraint].roleid)));
+				total_constraints--;
+				memmove(&authtime_info[curr_constraint],
+						&authtime_info[curr_constraint + 1],
+						total_constraints - curr_constraint);
+				curr_constraint--;
+			}
 		}
 	}
 


### PR DESCRIPTION
If pg_auth_time_constraint contains a role OID that doesn't exist in
pg_authid, we used to crash at system startup. A corrupt catalog table
is not good, but refusing to start up is even worse. Make
write_auth_time_file() function more resilient, and throw a warning
in that situation, and avoid the crash. The crash happened in the
pq_qsort() after this loop, because time_name_compar expects every
authtime_entry being sorted to have a valid non-NULL role name.