### PR TITLE
Remove warning of 'incompatible type' when compiling

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -271,7 +271,10 @@ InitMotionLayerIPC(void)
 	/*activated = false;*/
 	savedSeqServerFd = -1;
 
-	InitMotionUDPIFC(&UDP_listenerFd, (uint16 *) &Gp_listener_port);
+	/* use a local uint16 to remove warning of 'incompatible type' */
+	uint16 port;
+	InitMotionUDPIFC(&UDP_listenerFd, &port);
+	Gp_listener_port = port;
 
 	elog(DEBUG1, "Interconnect listening on udp port %d", Gp_listener_port);
 }

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -271,7 +271,7 @@ InitMotionLayerIPC(void)
 	/*activated = false;*/
 	savedSeqServerFd = -1;
 
-	InitMotionUDPIFC(&UDP_listenerFd, &Gp_listener_port);
+	InitMotionUDPIFC(&UDP_listenerFd, (uint16 *) &Gp_listener_port);
 
 	elog(DEBUG1, "Interconnect listening on udp port %d", Gp_listener_port);
 }

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1666,7 +1666,7 @@ _SPI_execute_plan(_SPI_plan * plan, ParamListInfo paramLI,
 	volatile int res = 0;
 	Snapshot	saveActiveSnapshot;
 	const char *saved_query_string;
-	const char *current_query_string = NULL;
+	char *current_query_string = NULL;
 
 	/* Be sure to restore ActiveSnapshot on error exit */
 	saveActiveSnapshot = ActiveSnapshot;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -404,7 +404,7 @@ _outScanInfo(StringInfo str, Scan *node)
 		 * subquery, but this is serialized elsewhere in outSubqueryScan, no
 		 * need to duplicate it here
 		 */
-		if (rte->type != RTE_SUBQUERY)
+		if (rte->rtekind != RTE_SUBQUERY)
 		{
 			_outNode(str,rte);
 		}

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -70,6 +70,7 @@
 #include "optimizer/cost.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/planmain.h"
+#include "parser/parse_expr.h"
 #include "parser/parsetree.h"
 #include "utils/lsyscache.h"
 #include "utils/selfuncs.h"

--- a/src/backend/storage/file/compress_zlib.c
+++ b/src/backend/storage/file/compress_zlib.c
@@ -59,7 +59,7 @@ bfz_zlib_write_ex(bfz_t *thiz, const char *buffer, int size)
 {
 	struct bfz_zlib_freeable_stuff *fs = (void *) thiz->freeable_stuff;
 
-	ssize_t written = gfile_write(fs->gfile, buffer, size);
+	ssize_t written = gfile_write(fs->gfile, (void *)buffer, size);
 	if (written < 0)
 	{
 		ereport(ERROR,


### PR DESCRIPTION
Files changed:
    modified:   src/backend/cdb/motion/ic_common.c
    modified:   src/backend/executor/spi.c
    modified:   src/backend/nodes/outfuncs.c
    modified:   src/backend/optimizer/path/costsize.c
    modified:   src/backend/storage/file/compress_zlib.c

Note: The warning indicates a potential error in
    function _outScanInfo() of outfuncs.c.