### PR TITLE
Make the demo cluster use it's own logfile directory

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -208,7 +208,7 @@ if [ -d $DATADIRS ]; then
 fi
 mkdir $DATADIRS
 mkdir $QDDIR
-mkdir $QDDIR/gpAdminLogs
+mkdir $DATADIRS/gpAdminLogs
 
 for dir in ${DIRVEC[@]} ${DIRVEC_MIRROR[@]}
 do
@@ -348,17 +348,17 @@ fi
 if [ -f "${CLUSTER_CONFIG_POSTGRES_ADDONS}" ]; then
     echo "=========================================================================================="
     echo "executing:"
-    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $QDDIR/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} \"$@\""
+    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} \"$@\""
     echo "=========================================================================================="
     echo ""
-    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $QDDIR/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} "$@"
+    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} "$@"
 else
     echo "=========================================================================================="
     echo "executing:"
-    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $QDDIR/gpAdminLogs \"$@\""
+    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs \"$@\""
     echo "=========================================================================================="
     echo ""
-    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $QDDIR/gpAdminLogs "$@"
+    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs "$@"
 fi
 RETURN=$?
 

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -208,6 +208,7 @@ if [ -d $DATADIRS ]; then
 fi
 mkdir $DATADIRS
 mkdir $QDDIR
+mkdir $QDDIR/gpAdminLogs
 
 for dir in ${DIRVEC[@]} ${DIRVEC_MIRROR[@]}
 do
@@ -347,17 +348,17 @@ fi
 if [ -f "${CLUSTER_CONFIG_POSTGRES_ADDONS}" ]; then
     echo "=========================================================================================="
     echo "executing:"
-    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} \"$@\""
+    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $QDDIR/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} \"$@\""
     echo "=========================================================================================="
     echo ""
-    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} "$@"
+    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $QDDIR/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} "$@"
 else
     echo "=========================================================================================="
     echo "executing:"
-    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG \"$@\""
+    echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $QDDIR/gpAdminLogs \"$@\""
     echo "=========================================================================================="
     echo ""
-    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG "$@"
+    $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $QDDIR/gpAdminLogs "$@"
 fi
 RETURN=$?
 

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1510,7 +1510,7 @@ STOP_QD_PRODUCTION () {
     if [ -f $GPSTOP ]; then
 	GPSTOP_OPTS=$(OUTPUT_LEVEL_OPTS)
 	export MASTER_DATA_DIRECTORY=${MASTER_DIRECTORY}/${SEG_PREFIX}-1
-	$GPSTOP -a -i -m -d $MASTER_DATA_DIRECTORY $GPSTOP_OPTS
+	$GPSTOP -a -l $LOG_DIR -i -m -d $MASTER_DATA_DIRECTORY $GPSTOP_OPTS
 	RETVAL=$?
 	case $RETVAL in
 	    0 ) LOG_MSG "[INFO]:-Successfully shutdown the new Greenplum instance" ;;
@@ -1558,7 +1558,7 @@ START_QD_PRODUCTION () {
     if [ -f $GPSTART ]; then
 	GPSTART_OPTS=$(OUTPUT_LEVEL_OPTS)
 	export MASTER_DATA_DIRECTORY=${MASTER_DIRECTORY}/${SEG_PREFIX}-1
-	$GPSTART -a -d $MASTER_DATA_DIRECTORY $GPSTART_OPTS
+	$GPSTART -a -l $LOG_DIR -d $MASTER_DATA_DIRECTORY $GPSTART_OPTS
 
         if [ $? -eq 0 ];then
             LOG_MSG "[INFO]:-Successfully started new Greenplum instance"
@@ -1576,7 +1576,7 @@ START_QD_PRODUCTION () {
             if [ -f $GPSTOP ]; then
 		GPSTOP_OPTS=$(OUTPUT_LEVEL_OPTS)
                 export MASTER_DATA_DIRECTORY=${MASTER_DIRECTORY}/${SEG_PREFIX}-1
-                $GPSTOP -a -i -d $MASTER_DATA_DIRECTORY $GPSTOP_OPTS
+                $GPSTOP -a -l $LOG_DIR -i -d $MASTER_DATA_DIRECTORY $GPSTOP_OPTS
 
                 RETVAL=$?
                 case $RETVAL in
@@ -1977,17 +1977,17 @@ if [ x"" != x"$PG_CONF_ADD_FILE" ]; then
 	fi
 fi
 if [ x"" != x"$LOG_DIR" ];then
-        CHK_DIR $LOG_DIR
+        CHK_DIR $LOG_DIR "" 1
         if [ $EXISTS -eq 1 ]; then
-                LOG_MSG "[WARN]:-Log directory $LOG_DIR does not exist, using default log directory" 1
-                EXIT_STATUS=1
-                BACKOUT_FILE=$DEFLOGDIR/backout_${PROG_NAME}_${USER_NAME}_${CUR_DATE}_$FILE_TIME
+                ERROR_EXIT "[FATAL]:-Log directory $LOG_DIR does not exist!" 2
         else
                 LOG_FILE=$LOG_DIR/${PROG_NAME}_${CUR_DATE}.log
                 BACKOUT_FILE=$LOG_DIR/backout_${PROG_NAME}_${USER_NAME}_${CUR_DATE}_$FILE_TIME
         fi
 else
         BACKOUT_FILE=$DEFLOGDIR/backout_${PROG_NAME}_${USER_NAME}_${CUR_DATE}_$FILE_TIME
+        # set $LOG_DIR to $DEFLOGDIR, so $LOG_DIR can be used everywhere
+        LOG_DIR=$DEFLOGDIR
 fi
 
 LOG_MSG "[INFO]:-Start Main"

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -773,7 +773,8 @@ class GpSegStartCmd(Command):
                  mirrormode, numContentsInCluster, era,
                  timeout=SEGMENT_TIMEOUT_DEFAULT, verbose=False, 
                  ctxt=LOCAL, remoteHost=None, pickledTransitionData=None,
-                 specialMode=None, wrapper=None, wrapper_args=None):
+                 specialMode=None, wrapper=None, wrapper_args=None,
+                 logfileDirectory=False):
 
         # Referenced by calling code (in operations/startSegments.py), create a clone
         self.dblist = [x for x in segments]
@@ -789,6 +790,8 @@ class GpSegStartCmd(Command):
         cmdStr = str(c)
         logger.debug(cmdStr)
 
+        if (logfileDirectory):
+            cmdStr = cmdStr + " -l '" + logfileDirectory + "'"
         Command.__init__(self,name,cmdStr,ctxt,remoteHost)
 
 
@@ -817,7 +820,7 @@ class GpSegChangeMirrorModeCmd(Command):
 #-----------------------------------------------
 class GpSegStopCmd(Command):
     def __init__(self, name, gphome, version,mode,dbs,timeout=SEGMENT_STOP_TIMEOUT_DEFAULT,
-                 verbose=False, ctxt=LOCAL, remoteHost=None):
+                 verbose=False, ctxt=LOCAL, remoteHost=None, logfileDirectory=False):
         self.gphome=gphome
         self.dblist=dbs
         self.dirportlist=[]
@@ -837,6 +840,8 @@ class GpSegStopCmd(Command):
         self.cmdStr="$GPHOME/sbin/gpsegstop.py %s -D %s -m %s -t %s -V '%s'"  %\
                         (setverbose,dirstr,mode,timeout,version)
 
+        if (logfileDirectory):
+            self.cmdStr = self.cmdStr + " -l '" + logfileDirectory + "'"
         Command.__init__(self,name,self.cmdStr,ctxt,remoteHost)
 
 
@@ -967,7 +972,7 @@ class NewGpStop(Command):
 
 #-----------------------------------------------
 class GpStop(Command):
-    def __init__(self, name, masterOnly=False, verbose=False, quiet=False, restart=False, fast=False, force=False, datadir=None,ctxt=LOCAL, remoteHost=None):
+    def __init__(self, name, masterOnly=False, verbose=False, quiet=False, restart=False, fast=False, force=False, datadir=None, ctxt=LOCAL, remoteHost=None, logfileDirectory=False):
         self.cmdStr="$GPHOME/bin/gpstop -a"
         if masterOnly:
             self.cmdStr += " -m"
@@ -983,6 +988,8 @@ class GpStop(Command):
             self.cmdStr += " -v"
         if quiet:
             self.cmdStr += " -q"
+        if logfileDirectory:
+            self.cmdStr += " -l '" + logfileDirectory + "'"
         Command.__init__(self,name,self.cmdStr,ctxt,remoteHost)
 
     @staticmethod

--- a/gpMgmt/bin/gppylib/operations/startSegments.py
+++ b/gpMgmt/bin/gppylib/operations/startSegments.py
@@ -73,7 +73,8 @@ class StartSegmentsOperation:
 
     def __init__(self, workerPool, quiet, localeData, gpVersion, 
                  gpHome, masterDataDirectory, timeout=SEGMENT_TIMEOUT_DEFAULT,
-                 specialMode=None, wrapper=None, wrapper_args=None):
+                 specialMode=None, wrapper=None, wrapper_args=None,
+                 logfileDirectory=False):
         checkNotNone("workerPool", workerPool)
         self.__workerPool = workerPool
         self.__quiet = quiet
@@ -86,6 +87,7 @@ class StartSegmentsOperation:
         self.__specialMode = specialMode
         self.__wrapper = wrapper
         self.__wrapper_args = wrapper_args
+        self.logfileDirectory = logfileDirectory
 
     def startSegments(self, gpArray, segments, startMethod, era):
         """
@@ -210,7 +212,8 @@ class StartSegmentsOperation:
                                    pickledTransitionData=pickledTransitionData,
                                    specialMode=self.__specialMode,
                                    wrapper=self.__wrapper,
-                                   wrapper_args=self.__wrapper_args)
+                                   wrapper_args=self.__wrapper_args,
+                                   logfileDirectory=self.logfileDirectory)
             self.__workerPool.addCommand(cmd)
             dispatchCount+=1
 

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -55,7 +55,8 @@ class GpStart:
                  quiet=False,
                  masteronly=False,
                  interactive=False,
-                 timeout=SEGMENT_TIMEOUT_DEFAULT
+                 timeout=SEGMENT_TIMEOUT_DEFAULT,
+                 logfileDirectory=False
                  ):
         assert(specialMode in [None, 'upgrade', 'maintenance'])
         self.specialMode=specialMode
@@ -70,8 +71,9 @@ class GpStart:
         self.interactive=interactive
         self.timeout=timeout
         self.wrapper=wrapper;
-        self.wrapper_args=wrapper_args;
-        self.skip_standby_check=skip_standby_check;
+        self.wrapper_args=wrapper_args
+        self.skip_standby_check=skip_standby_check
+        self.logfileDirectory=logfileDirectory
         
         #
         # Some variables that are set during execution
@@ -146,7 +148,8 @@ class GpStart:
             cmd=gp.GpStop("Shutting down master", masterOnly=True,
                           fast=True, quiet=logging_is_quiet(),
                           verbose=logging_is_verbose(),
-                          datadir=self.master_datadir)
+                          datadir=self.master_datadir,
+                          logfileDirectory=self.logfileDirectory)
             cmd.run()
             logger.debug("results of forcing master shutdown: %s" % cmd)
             #TODO: check results of command.
@@ -450,9 +453,11 @@ class GpStart:
             startMode = START_AS_MIRRORLESS
 
         localeData = ":".join([self.lc_collate,self.lc_monetary,self.lc_numeric])
+        # this will eventually start gpsegstart.py
         segmentStartOp = StartSegmentsOperation(self.pool,self.quiet, localeData, self.gpversion,
                                                 self.gphome, self.master_datadir, self.timeout, 
-                                                self.specialMode, self.wrapper, self.wrapper_args)
+                                                self.specialMode, self.wrapper, self.wrapper_args,
+                                                logfileDirectory=self.logfileDirectory)
         segmentStartResult = segmentStartOp.startSegments(self.gparray, segmentsToStart, startMode, self.era)
 
         # see if we have at least one segment per content
@@ -857,6 +862,7 @@ class GpStart:
 
     @staticmethod
     def createProgram(options, args):
+        logfileDirectory = options.ensure_value("logfileDirectory", False)
         proccount=os.environ.get('GP_MGMT_PROCESS_COUNT')
         if options.parallel == 64 and proccount is not None:
             options.parallel = int(proccount)
@@ -878,7 +884,8 @@ class GpStart:
                           timeout=options.timeout,
                           wrapper=options.wrapper,
                           wrapper_args=options.wrapper_args,
-                          skip_standby_check=options.skip_standby_check)
+                          skip_standby_check=options.skip_standby_check,
+                          logfileDirectory=logfileDirectory)
 
 if __name__ == '__main__':
     simple_main( GpStart.createParser, GpStart.createProgram)

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -71,8 +71,8 @@ class GpStart:
         self.interactive=interactive
         self.timeout=timeout
         self.wrapper=wrapper;
-        self.wrapper_args=wrapper_args
-        self.skip_standby_check=skip_standby_check
+        self.wrapper_args=wrapper_args;
+        self.skip_standby_check=skip_standby_check;
         self.logfileDirectory=logfileDirectory
         
         #

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -63,7 +63,7 @@ class GpStop:
     def __init__(self,mode,master_datadir=None,
                  parallel=DEFAULT_NUM_WORKERS,quiet=False,masteronly=False,sighup=False,
                  interactive=False,stopstandby=False,restart=False,
-                 timeout=SEGMENT_STOP_TIMEOUT_DEFAULT):
+                 timeout=SEGMENT_STOP_TIMEOUT_DEFAULT,logfileDirectory=False):
         self.mode=mode
         self.master_datadir=master_datadir
         self.pool = None
@@ -77,6 +77,7 @@ class GpStop:
         self.restart=restart
         self.hadFailures = False
         self.timeout=timeout
+        self.logfileDirectory=logfileDirectory
 
         # some variables that will be assigned during run() 
         self.gphome = None
@@ -118,7 +119,7 @@ class GpStop:
                     self._stop_segments()                                
                     self._stop_gpmmon()
                     self._stop_gpsmon()
-                    self._remove_shared_memory()
+                    self._remove_shared_memory() # this creates a new logfile - why?
                 finally:
                     # Reenable Ctrl-C
                     self.cleanup()
@@ -497,7 +498,8 @@ class GpStop:
             logger.debug("Dispatching command to shutdown %d segments on host: %s" % (len(dbs), hostname))
             cmd=gp.GpSegStopCmd("remote segment starts on host '%s'" % hostname, self.gphome,self.gpversion,
                                 mode=self.mode, dbs=dbs, timeout=self.timeout,
-                                verbose=logging_is_verbose(),ctxt=base.REMOTE, remoteHost=hostname)
+                                verbose=logging_is_verbose(),ctxt=base.REMOTE, remoteHost=hostname,
+                                logfileDirectory=self.logfileDirectory)
             self.pool.addCommand(cmd)
             dispatch_count+=1
         
@@ -748,6 +750,7 @@ class GpStop:
 
     @staticmethod
     def createProgram(options, args):
+        logfileDirectory = options.ensure_value("logfileDirectory", False)
         if options.mode != 'smart':
             if options.fast or options.immediate:
                 raise ProgramArgumentValidationException("Can not mix --mode options with older deprecated '-f,-i,-s'")
@@ -788,7 +791,8 @@ class GpStop:
                         interactive=options.interactive,
                         stopstandby=options.stop_standby,
                         restart=options.restart,
-                        timeout=options.timeout)
+                        timeout=options.timeout,
+                        logfileDirectory=logfileDirectory)
 
 if __name__ == '__main__':
     simple_main( GpStop.createParser, GpStop.createProgram)

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1030,9 +1030,12 @@ CHK_FILE () {
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 CHK_DIR () {
-		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-		DIR_NAME=$1;shift
-		DIR_HOST=$1
+		# this function might be called very early, before logfiles are initialized
+		if [ x"" == x"$3" ];then
+			LOG_MSG "[INFO]:-Start Function $FUNCNAME"
+		fi
+		DIR_NAME=$1
+		DIR_HOST=$2
 		if [ x"" == x"$DIR_HOST" ];then
 			EXISTS=`if [ -d $DIR_NAME ];then $ECHO 0;else $ECHO 1;fi`
 		else
@@ -1044,7 +1047,9 @@ CHK_DIR () {
 			EXISTS=1
 			fi
 		fi
-		LOG_MSG "[INFO]:-End Function $FUNCNAME"
+		if [ x"" == x"$3" ];then
+			LOG_MSG "[INFO]:-End Function $FUNCNAME"
+		fi
 }
 
 CHK_WRITE_DIR () {

--- a/gpMgmt/sbin/gpsegstart.py
+++ b/gpMgmt/sbin/gpsegstart.py
@@ -130,7 +130,8 @@ class GpSegStart:
     """
 
     def __init__(self, dblist, gpversion, collation, mirroringMode, num_cids, era, 
-                 timeout, pickledTransitionData, specialMode, wrapper, wrapper_args):
+                 timeout, pickledTransitionData, specialMode, wrapper, wrapper_args,
+                 logfileDirectory=False):
 
         # validate/store arguments
         #
@@ -166,6 +167,8 @@ class GpSegStart:
         self.pool                  = base.WorkerPool(numWorkers=len(dblist))
         self.logger                = logger
         self.overall_status        = None
+
+        self.logfileDirectory      = logfileDirectory
 
     def getOverallStatusKeys(self):
         return self.overall_status.dirmap.keys()
@@ -545,6 +548,7 @@ class GpSegStart:
         """
         Create program expected by simple_main
         """
+        logfileDirectory = options.ensure_value("logfileDirectory", False)
         return GpSegStart(options.dblist,
                           options.gpversion,
                           options.collation,
@@ -555,7 +559,8 @@ class GpSegStart:
                           options.pickledTransitionData,
                           options.specialMode,
                           options.wrapper,
-                          options.wrapper_args)
+                          options.wrapper_args,
+                          logfileDirectory=logfileDirectory)
 
 #------------------------------------------------------------------------- 
 if __name__ == '__main__':

--- a/gpMgmt/sbin/gpsegstop.py
+++ b/gpMgmt/sbin/gpsegstop.py
@@ -132,7 +132,7 @@ class SegStop(base.Command):
 #-------------------------------------------------------------------------    
 class GpSegStop:
     ######
-    def __init__(self,dblist,mode,gpversion,timeout=SEGMENT_STOP_TIMEOUT_DEFAULT):
+    def __init__(self,dblist,mode,gpversion,timeout=SEGMENT_STOP_TIMEOUT_DEFAULT,logfileDirectory=False):
         self.dblist=dblist
         self.mode=mode
         self.expected_gpversion=gpversion
@@ -146,6 +146,7 @@ class GpSegStop:
                             "Please review and correct" % (self.actual_gpversion,self.expected_gpversion))                
         self.logger = logger
         self.pool = None
+        self.logfileDirectory = logfileDirectory
         
     ######
     def run(self):
@@ -199,7 +200,8 @@ class GpSegStop:
 
     @staticmethod
     def createProgram(options, args):
-        return GpSegStop(options.dblist,options.mode,options.gpversion,options.timeout)
+        logfileDirectory = options.ensure_value("logfileDirectory", False)
+        return GpSegStop(options.dblist,options.mode,options.gpversion,options.timeout,logfileDirectory=logfileDirectory)
 
 #-------------------------------------------------------------------------
 if __name__ == '__main__':


### PR DESCRIPTION
This will no longer spill logfiles from the demo cluster into
the users ~/gpAdminLogs directory. Also it makes it easier to
identify which logfile was created by the last regression test run,

Addresses #523