### PR TITLE
Fix incorrect version test for flex and perl in autoconf

### DIFF
--- a/config/perl.m4
+++ b/config/perl.m4
@@ -13,7 +13,7 @@ if test "$PERL"; then
   pgac_perl_version=`$PERL -v 2>/dev/null | sed -n ['s/This is perl.*v[a-z ]*\([0-9]\.[0-9][0-9.]*\).*$/\1/p']`
   AC_MSG_NOTICE([using perl $pgac_perl_version])
   if echo "$pgac_perl_version" | sed ['s/[.a-z_]/ /g'] | \
-    $AWK '{ if ([$]1 = 5 && [$]2 >= 6) exit 1; else exit 0;}'
+    $AWK '{ if ([$]1 == 5 && [$]2 >= 6) exit 1; else exit 0;}'
   then
     AC_MSG_WARN([
 *** The installed version of Perl, $PERL, is too old to use with PostgreSQL.

--- a/config/programs.m4
+++ b/config/programs.m4
@@ -69,7 +69,7 @@ else
         echo '%%'  > conftest.l
         if $pgac_candidate -t conftest.l 2>/dev/null | grep FLEX_SCANNER >/dev/null 2>&1; then
           pgac_flex_version=`$pgac_candidate --version 2>/dev/null`
-          if echo "$pgac_flex_version" | sed ['s/[^0-9]/ /g'] | $AWK '{ if ([$]1 = 2 && [$]2 = 5 && [$]3 >= 4) exit 0; else exit 1;}'
+          if echo "$pgac_flex_version" | sed ['s/[^0-9]/ /g'] | $AWK '{ if ([$]1 == 2 && ([$]2 > 5 || ([$]2 == 5 && [$]3 >= 4))) exit 0; else exit 1;}'
           then
             pgac_cv_path_flex=$pgac_candidate
             break 2

--- a/configure
+++ b/configure
@@ -7579,7 +7579,7 @@ else
         echo '%%'  > conftest.l
         if $pgac_candidate -t conftest.l 2>/dev/null | grep FLEX_SCANNER >/dev/null 2>&1; then
           pgac_flex_version=`$pgac_candidate --version 2>/dev/null`
-          if echo "$pgac_flex_version" | sed 's/[^0-9]/ /g' | $AWK '{ if ($1 = 2 && $2 = 5 && $3 >= 4) exit 0; else exit 1;}'
+          if echo "$pgac_flex_version" | sed 's/[^0-9]/ /g' | $AWK '{ if ($1 == 2 && ($2 > 5 || ($2 == 5 && $3 >= 4))) exit 0; else exit 1;}'
           then
             pgac_cv_path_flex=$pgac_candidate
             break 2
@@ -7677,7 +7677,7 @@ if test "$PERL"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: using perl $pgac_perl_version" >&5
 $as_echo "$as_me: using perl $pgac_perl_version" >&6;}
   if echo "$pgac_perl_version" | sed 's/[.a-z_]/ /g' | \
-    $AWK '{ if ($1 = 5 && $2 >= 6) exit 1; else exit 0;}'
+    $AWK '{ if ($1 == 5 && $2 >= 6) exit 1; else exit 0;}'
   then
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING:
 *** The installed version of Perl, $PERL, is too old to use with PostgreSQL.


### PR DESCRIPTION
The tests for flex and perl are using assignment rather than equality which break when there is a difference in major/minor version. This was raised in #691 and was identified as a bug in upstream as well. The patch has now been committed to upstream, this is a backport with Greenplum versions of Flex/Perl maintained. See below for upstream commit message.

>     commit 7d7b129277eb545286aecf29ec22b5bb7fdf46bd
>     Author: Tom Lane <tgl@sss.pgh.pa.us>
>     Date:   Mon May 2 11:18:10 2016 -0400
> 
>     Fix configure's incorrect version tests for flex and perl.
> 
>     awk's equality-comparison operator is "==" not "=".  We got this right
>     in many places, but not in configure's checks for supported version
>     numbers of flex and perl.  It hadn't been noticed because unsupported
>     versions are so old as to be basically extinct in the wild, and because
>     the only consequence is whether or not a WARNING flies by during
>     configure.
> 
>     Daniel Gustafsson noted the problem with respect to the test for flex,
>     I found the other by reviewing other awk calls.