### PR TITLE
Use "outer slot" to hold result of Agg's child node.

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -817,7 +817,7 @@ agg_hash_initial_pass(AggState *aggstate)
 		}
 
 		/* set up for advance_aggregates call */
-		tmpcontext->ecxt_scantuple = outerslot;
+		tmpcontext->ecxt_outertuple = outerslot;
 
 		/* Find or (if there's room) build a hash table entry for the
 		 * input tuple's group. */
@@ -1583,7 +1583,7 @@ agg_hash_reload(AggState *aggstate)
 		has_tuples = true;
 
 		/* set up for advance_aggregates call */
-		tmpcontext->ecxt_scantuple = aggstate->hashslot;
+		tmpcontext->ecxt_outertuple = aggstate->hashslot;
 
 		entry = lookup_agg_hash_entry(aggstate, input, INPUT_RECORD_GROUP_AND_AGGS, input_size,
 									  hashkey, reloaded_hash_bit, &isNew);

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -183,14 +183,7 @@ CMappingColIdVarPlStmt::PvarFromDXLNodeScId
 		// lookup column in the left child translation context
 		const TargetEntry *pte = pdxltrctxLeft->Pte(ulColId);
 
-		if (pdxltrctxLeft->FParentAggNode())
-		{
-			// variable appears in an Agg node: varno must be 0 as expected by GPDB
-			// TODO: Jan 26, 2011; clean this up once MPP-12034 is fixed
-			GPOS_ASSERT(NULL != pte);
-			idxVarno = 0;
-		}
-		else if (NULL != pte)
+		if (NULL != pte)
 		{
 			// identifier comes from left child
 			idxVarno = OUTER;


### PR DESCRIPTION
Long time ago, a hack was put in place in GPDB to use the "scan" slot,
instead of the "outer" slot which is used in the upstream, to hold the
result of an Agg or Window plan node's child. It's not clear to me why
that was done. There was even a comment in fix_upper_expr() saying we
wouldn't need it if we just fixed the executor to not contain that hack,
and there was also a TODO comment in CMappingColIdVarPlStmt.cpp about
that.

Everything seems to work without those hacks, so revert this thing back
to the way it works in the upstream. This is simpler in its own right,
and also reduces our diff vs. upstream, which will make merging easier
in the future.