### PR TITLE
Remove traceflag that allows ORCA to run in multiple threads 

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -111,13 +111,6 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elem[] =
 		},
 
 		{
-		EopttraceParallel,
-		&optimizer_parallel,
-		false, // m_fNegate
-		GPOS_WSZ_LIT("Enable using threads in optimization engine.")
-		},
-
-		{
 		EopttraceMinidump,
 		&optimizer_minidump,
 		false, // m_fNegate

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -113,7 +113,7 @@ using namespace gpdbcost;
 #define GPOPT_ERROR_BUFFER_SIZE 10 * 1024 * 1024
 
 // definition of default AutoMemoryPool
-#define AUTO_MEM_POOL(amp) CAutoMemoryPool amp(CAutoMemoryPool::ElcExc, CMemoryPoolManager::EatTracker, optimizer_parallel)
+#define AUTO_MEM_POOL(amp) CAutoMemoryPool amp(CAutoMemoryPool::ElcExc, CMemoryPoolManager::EatTracker, false /* fThreadSafe */)
 
 // default id for the source system
 const CSystemId sysidDefault(IMDId::EmdidGPDB, GPOS_WSZ_STR_LENGTH("GPDB"));
@@ -516,23 +516,12 @@ COptTasks::Execute
 {
 	Assert(pfunc);
 
-	if (optimizer_parallel)
-	{
-		// be-aware that parallel optimizer mode may conflict with GPDB signal handlers,
-		// this mode should be avoided unless optimizer is spawned in a different process
-		if (gpos_set_threads(4, 4))
-		{
-			elog(ERROR, "unable to set number of threads in gpos");
-			return;
-		}
-	}
-
 	// initialize DXL support
 	InitDXL();
 
 	bool abort_flag = false;
 
-	CAutoMemoryPool amp(CAutoMemoryPool::ElcNone, CMemoryPoolManager::EatTracker, optimizer_parallel);
+	CAutoMemoryPool amp(CAutoMemoryPool::ElcNone, CMemoryPoolManager::EatTracker, false /* fThreadSafe */);
 	IMemoryPool *pmp = amp.Pmp();
 	CHAR *err_buf = SzAllocate(pmp, GPOPT_ERROR_BUFFER_SIZE);
 
@@ -1009,16 +998,6 @@ COptTasks::PvOptimizeTask
 			CConstExprEvaluatorProxy ceevalproxy(pmp, &mda);
 			IConstExprEvaluator *pceeval =
 					GPOS_NEW(pmp) CConstExprEvaluatorDXL(pmp, &mda, &ceevalproxy);
-
-			// preload metadata if optimizer uses multiple threads
-			if (optimizer_parallel)
-			{
-				// install opt context in TLS
-				pocconf->AddRef();
-				pceeval->AddRef();
-				CAutoOptCtxt aoc(pmp, &mda, pceeval, pocconf);
-				CTranslatorUtils::PreloadMD(pmp, &mda, sysidDefault, (Query*) poctx->m_pquery);
-			}
 
 			CDXLNode *pdxlnQuery = ptrquerytodxl->PdxlnFromQuery();
 			DrgPdxln *pdrgpdxlnQueryOutput = ptrquerytodxl->PdrgpdxlnQueryOutput();

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -507,7 +507,6 @@ bool		optimizer_print_expression_properties;
 bool		optimizer_print_group_properties;
 bool		optimizer_print_optimization_context;
 bool		optimizer_print_optimization_stats;
-bool		optimizer_parallel;
 bool		optimizer_local;
 int			optimizer_retries;
 /* array of xforms disable flags */
@@ -2888,15 +2887,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false, NULL, NULL
 	},
 
-	{
-		{"optimizer_parallel", PGC_USERSET, LOGGING_WHAT,
-			gettext_noop("Enable using threads in optimization engine."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&optimizer_parallel,
-		false, NULL, NULL
-	},
 	{
 		{"optimizer_extract_dxl_stats", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Extract plan stats in dxl."),

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -386,7 +386,6 @@ extern bool	optimizer_print_expression_properties;
 extern bool	optimizer_print_group_properties;
 extern bool	optimizer_print_optimization_context;
 extern bool optimizer_print_optimization_stats;
-extern bool	optimizer_parallel;
 extern bool	optimizer_local;
 extern int  optimizer_retries;
 extern bool  optimizer_xforms[OPTIMIZER_XFORMS_COUNT];


### PR DESCRIPTION
Story: #118416535

Our team is integrating VEM with GPOS memory allocator. VMEM is not thread safe. So, ORCA/GPOS also need to be single threaded. Currently, customers are using only the single threaded Orca.

In this PR, we are removing the traceflag that allows ORCA to run in multiple threads so that our customers do not accidentally run ORCA in multiple threads. 

Refer to #117374177 for more context. Eventually we would GPDB to use Orca in a multi-threaded fashion to reduce query optimization time.

@foyzur @xinzweb @d @oarap @hsyuan please take a look.
