### PR TITLE
Enhance partition_locking test case to also check locks in segments.

### DIFF
--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -1,19 +1,31 @@
 -- Test locking behaviour. When creating, dropping, querying or adding indexes
 -- partitioned tables, we want to lock only the master, not the children.
--- start_ignore
-create view locktest as
+-- Show locks in master and in segments. Because the number of segments
+-- in the cluster depends on configuration, we print only summary information
+-- of the locks in segments. If a relation is locked only on one segment,
+-- we print that as a special case, but otherwise we just print "n segments",
+-- meaning the relation is locked on more than one segment.
+create or replace view locktest as
 select coalesce(
   case when relname like 'pg_toast%index' then 'toast index'
-  	   when relname like 'pg_toast%' then 'toast table'
-	   else relname end, 'dropped table'), 
-mode,
-locktype from 
-pg_locks l left outer join pg_class c on (l.relation = c.oid),
-pg_database d where relation is not null and l.database = d.oid and 
-l.gp_segment_id = -1 and
-l.relation != 5039 and     -- XXX XXX: ignore gp_fault_strategy
-d.datname = current_database() order by 1, 3, 2;
--- end_ignore
+       when relname like 'pg_toast%' then 'toast table'
+       when relname like 'pg_aoseg%index' then 'aoseg index'
+       when relname like 'pg_aoseg%' then 'aoseg table'
+       else relname end, 'dropped table'),
+  mode,
+  locktype,
+  case when l.gp_segment_id = -1 then 'master'
+       when COUNT(*) = 1 then '1 segment'
+       else 'n segments' end AS node
+from pg_locks l
+left outer join pg_class c on (l.relation = c.oid),
+pg_database d
+where relation is not null
+and l.database = d.oid
+and (relname <> 'gp_fault_strategy' or relname IS NULL)
+and d.datname = current_database()
+group by l.gp_segment_id = -1, relation, relname, locktype, mode
+order by 1, 3, 2;
 -- Partitioned table with toast table
 begin;
 -- creation
@@ -30,54 +42,56 @@ NOTICE:  CREATE TABLE will create partition "g_1_prt_6" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_7" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_8" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_9" for table "g"
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- g                          | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
- toast index                | AccessExclusiveLock | relation
- toast table                | ShareLock           | relation
-(15 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ g                          | AccessExclusiveLock | relation | master
+ g                          | AccessExclusiveLock | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | n segments
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+ toast index                | AccessExclusiveLock | relation | n segments
+ toast index                | AccessExclusiveLock | relation | master
+ toast table                | ShareLock           | relation | n segments
+ toast table                | ShareLock           | relation | master
+(19 rows)
 
 commit;
 -- drop
 begin;
 drop table g;
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
-(14 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+(18 rows)
 
 commit;
 -- AO table (ao segments, block directory won't exist after create)
@@ -92,29 +106,31 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 NOTICE:  CREATE TABLE will create partition "g_1_prt_1" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_2" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_3" for table "g"
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- g                          | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_appendonly              | RowExclusiveLock    | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
- toast index                | AccessExclusiveLock | relation
- toast table                | ShareLock           | relation
-(16 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ g                          | AccessExclusiveLock | relation | n segments
+ g                          | AccessExclusiveLock | relation | master
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_appendonly              | RowExclusiveLock    | relation | n segments
+ pg_appendonly              | RowExclusiveLock    | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | n segments
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+ toast index                | AccessExclusiveLock | relation | n segments
+ toast index                | AccessExclusiveLock | relation | master
+ toast table                | ShareLock           | relation | n segments
+ toast table                | ShareLock           | relation | master
+(21 rows)
 
 commit;
 begin;
@@ -124,56 +140,71 @@ insert into g values(1), (2), (3);
 insert into g values(1), (2), (3);
 insert into g values(1), (2), (3);
 insert into g values(1), (2), (3);
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         |         locktype         
-----------------------------+---------------------+--------------------------
- g                          | RowExclusiveLock    | relation
- g_1_prt_1                  | AccessExclusiveLock | append-only segment file
- g_1_prt_1                  | AccessShareLock     | relation
- g_1_prt_2                  | AccessExclusiveLock | append-only segment file
- g_1_prt_2                  | AccessShareLock     | relation
- g_1_prt_3                  | AccessExclusiveLock | append-only segment file
- g_1_prt_3                  | AccessShareLock     | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_locks                   | AccessShareLock     | relation
-(12 rows)
+          coalesce          |        mode         |         locktype         |    node    
+----------------------------+---------------------+--------------------------+------------
+ aoseg index                | AccessShareLock     | relation                 | n segments
+ aoseg table                | AccessShareLock     | relation                 | n segments
+ aoseg table                | AccessShareLock     | relation                 | n segments
+ aoseg table                | AccessShareLock     | relation                 | n segments
+ aoseg table                | AccessShareLock     | relation                 | n segments
+ g                          | RowExclusiveLock    | relation                 | n segments
+ g                          | RowExclusiveLock    | relation                 | master
+ g_1_prt_1                  | AccessExclusiveLock | append-only segment file | master
+ g_1_prt_1                  | AccessExclusiveLock | append-only segment file | 1 segment
+ g_1_prt_1                  | AccessShareLock     | relation                 | master
+ g_1_prt_1                  | RowExclusiveLock    | relation                 | 1 segment
+ g_1_prt_2                  | AccessExclusiveLock | append-only segment file | 1 segment
+ g_1_prt_2                  | AccessExclusiveLock | append-only segment file | master
+ g_1_prt_2                  | AccessShareLock     | relation                 | master
+ g_1_prt_2                  | RowExclusiveLock    | relation                 | 1 segment
+ g_1_prt_3                  | AccessExclusiveLock | append-only segment file | master
+ g_1_prt_3                  | AccessExclusiveLock | append-only segment file | 1 segment
+ g_1_prt_3                  | AccessShareLock     | relation                 | master
+ g_1_prt_3                  | RowExclusiveLock    | relation                 | 1 segment
+ locktest                   | AccessShareLock     | relation                 | master
+ pg_class                   | AccessShareLock     | relation                 | master
+ pg_class_oid_index         | AccessShareLock     | relation                 | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
+ pg_locks                   | AccessShareLock     | relation                 | master
+(24 rows)
 
 commit;
 -- drop
 begin;
 drop table g;
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_appendonly              | RowExclusiveLock    | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
-(19 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_appendonly              | RowExclusiveLock    | relation | master
+ pg_appendonly              | RowExclusiveLock    | relation | n segments
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+(28 rows)
 
 commit;
 -- Indexing
@@ -201,26 +232,30 @@ NOTICE:  building index for child partition "g_1_prt_6"
 NOTICE:  building index for child partition "g_1_prt_7"
 NOTICE:  building index for child partition "g_1_prt_8"
 NOTICE:  building index for child partition "g_1_prt_9"
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- g                          | ShareLock           | relation
- g_idx                      | AccessExclusiveLock | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | AccessShareLock     | relation
- pg_partition_rule          | AccessShareLock     | relation
- pg_type                    | RowExclusiveLock    | relation
-(11 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ g                          | ShareLock           | relation | n segments
+ g                          | ShareLock           | relation | master
+ g_idx                      | AccessExclusiveLock | relation | n segments
+ g_idx                      | AccessExclusiveLock | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | AccessShareLock     | relation | master
+ pg_partition_rule          | AccessShareLock     | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+(13 rows)
 
 commit;
+-- Force use of the index in the select and delete below. We're not interested
+-- in the plan we get, but a seqscan will not lock the index while an index
+-- scan will, and we want to avoid the plan-dependent difference in the
+-- expected output of this test.
+set enable_seqscan=off;
 -- test select locking
 begin;
 select * from g where i = 1;
@@ -228,83 +263,84 @@ select * from g where i = 1;
 ---+---
 (0 rows)
 
--- start_ignore
 -- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |      mode       | locktype 
-----------------------------+-----------------+----------
- g                          | AccessShareLock | relation
- g_1_prt_1                  | AccessShareLock | relation
- locktest                   | AccessShareLock | relation
- pg_class                   | AccessShareLock | relation
- pg_class_oid_index         | AccessShareLock | relation
- pg_class_relname_nsp_index | AccessShareLock | relation
- pg_locks                   | AccessShareLock | relation
-(7 rows)
+          coalesce          |      mode       | locktype |   node    
+----------------------------+-----------------+----------+-----------
+ g                          | AccessShareLock | relation | master
+ g_1_prt_1                  | AccessShareLock | relation | master
+ g_1_prt_1                  | AccessShareLock | relation | 1 segment
+ g_idx_1_prt_1              | AccessShareLock | relation | 1 segment
+ g_idx_1_prt_1              | AccessShareLock | relation | master
+ locktest                   | AccessShareLock | relation | master
+ pg_class                   | AccessShareLock | relation | master
+ pg_class_oid_index         | AccessShareLock | relation | master
+ pg_class_relname_nsp_index | AccessShareLock | relation | master
+ pg_locks                   | AccessShareLock | relation | master
+(10 rows)
 
 commit;
 begin;
 -- insert locking
 insert into g values(3, 'f');
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |       mode       | locktype 
-----------------------------+------------------+----------
- g                          | RowExclusiveLock | relation
- locktest                   | AccessShareLock  | relation
- pg_class                   | AccessShareLock  | relation
- pg_class_oid_index         | AccessShareLock  | relation
- pg_class_relname_nsp_index | AccessShareLock  | relation
- pg_locks                   | AccessShareLock  | relation
-(6 rows)
+          coalesce          |       mode       | locktype |   node    
+----------------------------+------------------+----------+-----------
+ g                          | RowExclusiveLock | relation | master
+ g                          | RowExclusiveLock | relation | 1 segment
+ g_1_prt_3                  | RowExclusiveLock | relation | 1 segment
+ locktest                   | AccessShareLock  | relation | master
+ pg_class                   | AccessShareLock  | relation | master
+ pg_class_oid_index         | AccessShareLock  | relation | master
+ pg_class_relname_nsp_index | AccessShareLock  | relation | master
+ pg_locks                   | AccessShareLock  | relation | master
+(8 rows)
 
 commit;
 -- delete locking
 begin;
 delete from g where i = 4;
--- start_ignore
 -- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |      mode       | locktype 
-----------------------------+-----------------+----------
- g                          | ExclusiveLock   | relation
- g_1_prt_4                  | ExclusiveLock   | relation
- locktest                   | AccessShareLock | relation
- pg_class                   | AccessShareLock | relation
- pg_class_oid_index         | AccessShareLock | relation
- pg_class_relname_nsp_index | AccessShareLock | relation
- pg_locks                   | AccessShareLock | relation
-(7 rows)
+          coalesce          |       mode       | locktype |   node    
+----------------------------+------------------+----------+-----------
+ g                          | ExclusiveLock    | relation | master
+ g_1_prt_4                  | ExclusiveLock    | relation | master
+ g_1_prt_4                  | RowExclusiveLock | relation | 1 segment
+ locktest                   | AccessShareLock  | relation | master
+ pg_class                   | AccessShareLock  | relation | master
+ pg_class_oid_index         | AccessShareLock  | relation | master
+ pg_class_relname_nsp_index | AccessShareLock  | relation | master
+ pg_locks                   | AccessShareLock  | relation | master
+(8 rows)
 
 commit;
 -- drop index
 begin;
 drop table g;
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
-(15 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ gp_distribution_policy     | RowExclusiveLock    | relation | n segments
+ locktest                   | AccessShareLock     | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+(20 rows)
 
 commit;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -1,19 +1,31 @@
 -- Test locking behaviour. When creating, dropping, querying or adding indexes
 -- partitioned tables, we want to lock only the master, not the children.
--- start_ignore
-create view locktest as
+-- Show locks in master and in segments. Because the number of segments
+-- in the cluster depends on configuration, we print only summary information
+-- of the locks in segments. If a relation is locked only on one segment,
+-- we print that as a special case, but otherwise we just print "n segments",
+-- meaning the relation is locked on more than one segment.
+create or replace view locktest as
 select coalesce(
   case when relname like 'pg_toast%index' then 'toast index'
-  	   when relname like 'pg_toast%' then 'toast table'
-	   else relname end, 'dropped table'), 
-mode,
-locktype from 
-pg_locks l left outer join pg_class c on (l.relation = c.oid),
-pg_database d where relation is not null and l.database = d.oid and 
-l.gp_segment_id = -1 and
-l.relation != 5039 and     -- XXX XXX: ignore gp_fault_strategy
-d.datname = current_database() order by 1, 3, 2;
--- end_ignore
+       when relname like 'pg_toast%' then 'toast table'
+       when relname like 'pg_aoseg%index' then 'aoseg index'
+       when relname like 'pg_aoseg%' then 'aoseg table'
+       else relname end, 'dropped table'),
+  mode,
+  locktype,
+  case when l.gp_segment_id = -1 then 'master'
+       when COUNT(*) = 1 then '1 segment'
+       else 'n segments' end AS node
+from pg_locks l
+left outer join pg_class c on (l.relation = c.oid),
+pg_database d
+where relation is not null
+and l.database = d.oid
+and (relname <> 'gp_fault_strategy' or relname IS NULL)
+and d.datname = current_database()
+group by l.gp_segment_id = -1, relation, relname, locktype, mode
+order by 1, 3, 2;
 -- Partitioned table with toast table
 begin;
 -- creation
@@ -30,54 +42,56 @@ NOTICE:  CREATE TABLE will create partition "g_1_prt_6" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_7" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_8" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_9" for table "g"
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- g                          | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
- toast index                | AccessExclusiveLock | relation
- toast table                | ShareLock           | relation
-(15 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ g                          | AccessExclusiveLock | relation | master
+ g                          | AccessExclusiveLock | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | n segments
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+ toast index                | AccessExclusiveLock | relation | n segments
+ toast index                | AccessExclusiveLock | relation | master
+ toast table                | ShareLock           | relation | n segments
+ toast table                | ShareLock           | relation | master
+(19 rows)
 
 commit;
 -- drop
 begin;
 drop table g;
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
-(14 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+(18 rows)
 
 commit;
 -- AO table (ao segments, block directory won't exist after create)
@@ -92,29 +106,31 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 NOTICE:  CREATE TABLE will create partition "g_1_prt_1" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_2" for table "g"
 NOTICE:  CREATE TABLE will create partition "g_1_prt_3" for table "g"
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- g                          | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_appendonly              | RowExclusiveLock    | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
- toast index                | AccessExclusiveLock | relation
- toast table                | ShareLock           | relation
-(16 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ g                          | AccessExclusiveLock | relation | n segments
+ g                          | AccessExclusiveLock | relation | master
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_appendonly              | RowExclusiveLock    | relation | n segments
+ pg_appendonly              | RowExclusiveLock    | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | n segments
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+ toast index                | AccessExclusiveLock | relation | n segments
+ toast index                | AccessExclusiveLock | relation | master
+ toast table                | ShareLock           | relation | n segments
+ toast table                | ShareLock           | relation | master
+(21 rows)
 
 commit;
 begin;
@@ -124,56 +140,71 @@ insert into g values(1), (2), (3);
 insert into g values(1), (2), (3);
 insert into g values(1), (2), (3);
 insert into g values(1), (2), (3);
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         |         locktype         
-----------------------------+---------------------+--------------------------
- g                          | RowExclusiveLock    | relation
- g_1_prt_1                  | AccessExclusiveLock | append-only segment file
- g_1_prt_1                  | AccessShareLock     | relation
- g_1_prt_2                  | AccessExclusiveLock | append-only segment file
- g_1_prt_2                  | AccessShareLock     | relation
- g_1_prt_3                  | AccessExclusiveLock | append-only segment file
- g_1_prt_3                  | AccessShareLock     | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_locks                   | AccessShareLock     | relation
-(12 rows)
+          coalesce          |        mode         |         locktype         |    node    
+----------------------------+---------------------+--------------------------+------------
+ aoseg index                | AccessShareLock     | relation                 | n segments
+ aoseg table                | AccessShareLock     | relation                 | n segments
+ aoseg table                | AccessShareLock     | relation                 | n segments
+ aoseg table                | AccessShareLock     | relation                 | n segments
+ aoseg table                | AccessShareLock     | relation                 | n segments
+ g                          | RowExclusiveLock    | relation                 | n segments
+ g                          | RowExclusiveLock    | relation                 | master
+ g_1_prt_1                  | AccessExclusiveLock | append-only segment file | master
+ g_1_prt_1                  | AccessExclusiveLock | append-only segment file | 1 segment
+ g_1_prt_1                  | AccessShareLock     | relation                 | master
+ g_1_prt_1                  | RowExclusiveLock    | relation                 | 1 segment
+ g_1_prt_2                  | AccessExclusiveLock | append-only segment file | 1 segment
+ g_1_prt_2                  | AccessExclusiveLock | append-only segment file | master
+ g_1_prt_2                  | AccessShareLock     | relation                 | master
+ g_1_prt_2                  | RowExclusiveLock    | relation                 | 1 segment
+ g_1_prt_3                  | AccessExclusiveLock | append-only segment file | master
+ g_1_prt_3                  | AccessExclusiveLock | append-only segment file | 1 segment
+ g_1_prt_3                  | AccessShareLock     | relation                 | master
+ g_1_prt_3                  | RowExclusiveLock    | relation                 | 1 segment
+ locktest                   | AccessShareLock     | relation                 | master
+ pg_class                   | AccessShareLock     | relation                 | master
+ pg_class_oid_index         | AccessShareLock     | relation                 | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
+ pg_locks                   | AccessShareLock     | relation                 | master
+(24 rows)
 
 commit;
 -- drop
 begin;
 drop table g;
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_appendonly              | RowExclusiveLock    | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
-(19 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | n segments
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_appendonly              | RowExclusiveLock    | relation | master
+ pg_appendonly              | RowExclusiveLock    | relation | n segments
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+(28 rows)
 
 commit;
 -- Indexing
@@ -201,26 +232,30 @@ NOTICE:  building index for child partition "g_1_prt_6"
 NOTICE:  building index for child partition "g_1_prt_7"
 NOTICE:  building index for child partition "g_1_prt_8"
 NOTICE:  building index for child partition "g_1_prt_9"
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- g                          | ShareLock           | relation
- g_idx                      | AccessExclusiveLock | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | AccessShareLock     | relation
- pg_partition_rule          | AccessShareLock     | relation
- pg_type                    | RowExclusiveLock    | relation
-(11 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ g                          | ShareLock           | relation | n segments
+ g                          | ShareLock           | relation | master
+ g_idx                      | AccessExclusiveLock | relation | n segments
+ g_idx                      | AccessExclusiveLock | relation | master
+ locktest                   | AccessShareLock     | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | AccessShareLock     | relation | master
+ pg_partition_rule          | AccessShareLock     | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+(13 rows)
 
 commit;
+-- Force use of the index in the select and delete below. We're not interested
+-- in the plan we get, but a seqscan will not lock the index while an index
+-- scan will, and we want to avoid the plan-dependent difference in the
+-- expected output of this test.
+set enable_seqscan=off;
 -- test select locking
 begin;
 select * from g where i = 1;
@@ -228,81 +263,83 @@ select * from g where i = 1;
 ---+---
 (0 rows)
 
--- start_ignore
 -- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |      mode       | locktype 
-----------------------------+-----------------+----------
- g                          | AccessShareLock | relation
- locktest                   | AccessShareLock | relation
- pg_class                   | AccessShareLock | relation
- pg_class_oid_index         | AccessShareLock | relation
- pg_class_relname_nsp_index | AccessShareLock | relation
- pg_locks                   | AccessShareLock | relation
-(6 rows)
+          coalesce          |      mode       | locktype |   node    
+----------------------------+-----------------+----------+-----------
+ g                          | AccessShareLock | relation | master
+ g_1_prt_1                  | AccessShareLock | relation | 1 segment
+ g_idx_1_prt_1              | AccessShareLock | relation | 1 segment
+ locktest                   | AccessShareLock | relation | master
+ pg_class                   | AccessShareLock | relation | master
+ pg_class_oid_index         | AccessShareLock | relation | master
+ pg_class_relname_nsp_index | AccessShareLock | relation | master
+ pg_locks                   | AccessShareLock | relation | master
+(8 rows)
 
 commit;
 begin;
 -- insert locking
 insert into g values(3, 'f');
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |       mode       | locktype 
-----------------------------+------------------+----------
- g                          | RowExclusiveLock | relation
- locktest                   | AccessShareLock  | relation
- pg_class                   | AccessShareLock  | relation
- pg_class_oid_index         | AccessShareLock  | relation
- pg_class_relname_nsp_index | AccessShareLock  | relation
- pg_locks                   | AccessShareLock  | relation
-(6 rows)
+          coalesce          |       mode       | locktype |   node    
+----------------------------+------------------+----------+-----------
+ g                          | RowExclusiveLock | relation | master
+ g                          | RowExclusiveLock | relation | 1 segment
+ g_1_prt_3                  | RowExclusiveLock | relation | 1 segment
+ locktest                   | AccessShareLock  | relation | master
+ pg_class                   | AccessShareLock  | relation | master
+ pg_class_oid_index         | AccessShareLock  | relation | master
+ pg_class_relname_nsp_index | AccessShareLock  | relation | master
+ pg_locks                   | AccessShareLock  | relation | master
+(8 rows)
 
 commit;
 -- delete locking
 begin;
 delete from g where i = 4;
--- start_ignore
 -- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |      mode       | locktype 
-----------------------------+-----------------+----------
- g                          | ExclusiveLock   | relation
- locktest                   | AccessShareLock | relation
- pg_class                   | AccessShareLock | relation
- pg_class_oid_index         | AccessShareLock | relation
- pg_class_relname_nsp_index | AccessShareLock | relation
- pg_locks                   | AccessShareLock | relation
-(6 rows)
+          coalesce          |       mode       | locktype |    node    
+----------------------------+------------------+----------+------------
+ g                          | ExclusiveLock    | relation | master
+ g                          | RowExclusiveLock | relation | n segments
+ g_1_prt_4                  | AccessShareLock  | relation | n segments
+ g_idx_1_prt_4              | AccessShareLock  | relation | n segments
+ locktest                   | AccessShareLock  | relation | master
+ pg_class                   | AccessShareLock  | relation | master
+ pg_class_oid_index         | AccessShareLock  | relation | master
+ pg_class_relname_nsp_index | AccessShareLock  | relation | master
+ pg_locks                   | AccessShareLock  | relation | master
+(9 rows)
 
 commit;
 -- drop index
 begin;
 drop table g;
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
-          coalesce          |        mode         | locktype 
-----------------------------+---------------------+----------
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- dropped table              | AccessExclusiveLock | relation
- gp_distribution_policy     | RowExclusiveLock    | relation
- locktest                   | AccessShareLock     | relation
- pg_class                   | AccessShareLock     | relation
- pg_class                   | RowExclusiveLock    | relation
- pg_class_oid_index         | AccessShareLock     | relation
- pg_class_relname_nsp_index | AccessShareLock     | relation
- pg_depend                  | RowExclusiveLock    | relation
- pg_locks                   | AccessShareLock     | relation
- pg_partition               | RowExclusiveLock    | relation
- pg_partition_rule          | RowExclusiveLock    | relation
- pg_type                    | RowExclusiveLock    | relation
-(15 rows)
+          coalesce          |        mode         | locktype |    node    
+----------------------------+---------------------+----------+------------
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ dropped table              | AccessExclusiveLock | relation | n segments
+ dropped table              | AccessExclusiveLock | relation | master
+ gp_distribution_policy     | RowExclusiveLock    | relation | master
+ gp_distribution_policy     | RowExclusiveLock    | relation | n segments
+ locktest                   | AccessShareLock     | relation | master
+ pg_class                   | AccessShareLock     | relation | master
+ pg_class                   | RowExclusiveLock    | relation | master
+ pg_class_oid_index         | AccessShareLock     | relation | master
+ pg_class_relname_nsp_index | AccessShareLock     | relation | master
+ pg_depend                  | RowExclusiveLock    | relation | master
+ pg_locks                   | AccessShareLock     | relation | master
+ pg_partition               | RowExclusiveLock    | relation | master
+ pg_partition_rule          | RowExclusiveLock    | relation | master
+ pg_type                    | RowExclusiveLock    | relation | master
+(20 rows)
 
 commit;

--- a/src/test/regress/sql/partition_locking.sql
+++ b/src/test/regress/sql/partition_locking.sql
@@ -1,20 +1,32 @@
 -- Test locking behaviour. When creating, dropping, querying or adding indexes
 -- partitioned tables, we want to lock only the master, not the children.
 
--- start_ignore
-create view locktest as
+-- Show locks in master and in segments. Because the number of segments
+-- in the cluster depends on configuration, we print only summary information
+-- of the locks in segments. If a relation is locked only on one segment,
+-- we print that as a special case, but otherwise we just print "n segments",
+-- meaning the relation is locked on more than one segment.
+create or replace view locktest as
 select coalesce(
   case when relname like 'pg_toast%index' then 'toast index'
-  	   when relname like 'pg_toast%' then 'toast table'
-	   else relname end, 'dropped table'), 
-mode,
-locktype from 
-pg_locks l left outer join pg_class c on (l.relation = c.oid),
-pg_database d where relation is not null and l.database = d.oid and 
-l.gp_segment_id = -1 and
-l.relation != 5039 and     -- XXX XXX: ignore gp_fault_strategy
-d.datname = current_database() order by 1, 3, 2;
--- end_ignore
+       when relname like 'pg_toast%' then 'toast table'
+       when relname like 'pg_aoseg%index' then 'aoseg index'
+       when relname like 'pg_aoseg%' then 'aoseg table'
+       else relname end, 'dropped table'),
+  mode,
+  locktype,
+  case when l.gp_segment_id = -1 then 'master'
+       when COUNT(*) = 1 then '1 segment'
+       else 'n segments' end AS node
+from pg_locks l
+left outer join pg_class c on (l.relation = c.oid),
+pg_database d
+where relation is not null
+and l.database = d.oid
+and (relname <> 'gp_fault_strategy' or relname IS NULL)
+and d.datname = current_database()
+group by l.gp_segment_id = -1, relation, relname, locktype, mode
+order by 1, 3, 2;
 
 -- Partitioned table with toast table
 begin;
@@ -23,18 +35,12 @@ begin;
 create table g (i int, t text) partition by range(i)
 (start(1) end(10) every(1));
 
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 commit;
 
 -- drop
 begin;
 drop table g;
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 commit;
 
@@ -45,9 +51,6 @@ create table g (i int, t text, n numeric)
 with (appendonly = true)
 partition by list(i)
 (values(1), values(2), values(3));
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 commit;
 begin;
@@ -58,18 +61,12 @@ insert into g values(1), (2), (3);
 insert into g values(1), (2), (3);
 insert into g values(1), (2), (3);
 insert into g values(1), (2), (3);
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 
 commit;
 -- drop
 begin;
 drop table g;
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 commit;
 
@@ -79,44 +76,37 @@ create table g (i int, t text) partition by range(i)
 
 begin;
 create index g_idx on g(i);
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 commit;
+
+-- Force use of the index in the select and delete below. We're not interested
+-- in the plan we get, but a seqscan will not lock the index while an index
+-- scan will, and we want to avoid the plan-dependent difference in the
+-- expected output of this test.
+set enable_seqscan=off;
 
 -- test select locking
 begin;
 select * from g where i = 1;
--- start_ignore
 -- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 commit;
 
 begin;
 -- insert locking
 insert into g values(3, 'f');
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 commit;
 
 -- delete locking
 begin;
 delete from g where i = 4;
--- start_ignore
 -- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 commit;
 
 -- drop index
 begin;
 drop table g;
--- start_ignore
--- Known_opt_diff: MPP-20936
--- end_ignore
 select * from locktest;
 commit;


### PR DESCRIPTION
While hacking in this area, at one point I broke the code so that a
partition was not correctly in a segment as it should've been, even though
it was locked in the master. Fortunately, I noticed that in manual testing
before committing, but to prevent such bugs from slipping in in the future,
enhance the 'partition_locking' test to catch that kind of bugs.