### PR TITLE
Remove dead code in outfuncs.c

### DIFF
--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -198,13 +198,8 @@ bool WorkfileQueryspace_AddWorkfile(void);
 void WorkfileQueryspace_SubtractWorkfile(int32 nFiles);
 
 /* Serialization functions */
-void outfuncs_workfile_mgr_init(List *rtable);
-void outfuncs_workfile_mgr_end(void);
 void outfast_workfile_mgr_init(List *rtable);
 void outfast_workfile_mgr_end(void);
-
-/* Debugging functions */
-void workfile_mgr_print_set(workfile_set *work_set);
 
 /* Workfile error reporting */
 typedef enum WorkfileError


### PR DESCRIPTION
The reason to remove them is because: print_variable_fields is initialized
to true, and only set to false in outfuncs_workfile_mgr_init() function.
But outfuncs_workfile_mgr_init() is never called. So we can remove all of:
print_variable_fields, outfuncs_workfile_mgr_init(), outfuncs_workfile_mgr_end(),
and all the if() tests depending on print_variable_fields.

Co-authored-by: Kuien Liu and Heikki Linnakangas