### PR TITLE
Avoid deadlock on catchup interrupt.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -90,7 +90,7 @@
 #include "parser/parser.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/backendid.h"
-#include "storage/procsignal.h"
+#include "storage/sinval.h"
 #include "storage/smgr.h"
 #include "tcop/utility.h"
 #include "utils/acl.h"
@@ -17157,7 +17157,7 @@ PreCommit_on_commit_actions(void)
 	 * is not visible yet.  Skipping this under the catchup handler
 	 * should be ok in known cases.
 	 */
-	if (AmIInSIGUSR1Handler())
+	if (in_process_catchup_event)
 		return;
 
 	foreach(l, on_commits)

--- a/src/backend/storage/ipc/sinval.c
+++ b/src/backend/storage/ipc/sinval.c
@@ -45,6 +45,9 @@ uint64		SharedInvalidMessageCounter;
 static volatile int catchupInterruptEnabled = 0;
 static volatile int catchupInterruptOccurred = 0;
 
+/* Are we currently processing a catchup event? */
+volatile int in_process_catchup_event = 0;
+
 static void ProcessCatchupEvent(void);
 
 
@@ -306,6 +309,15 @@ ProcessCatchupEvent(void)
 	bool		notify_enabled;
 	DtxContext  saveDistributedTransactionContext;
 
+	/*
+	 * Funny indentation to keep the code inside identical to upstream
+	 * while at the same time supporting CMockery which has problems with
+	 * multiple bracing on column 1.
+	 */
+	PG_TRY();
+	{
+	in_process_catchup_event = 1;
+
 	/* Must prevent notify interrupt while I am running */
 	notify_enabled = DisableNotifyInterrupt();
 
@@ -345,4 +357,14 @@ ProcessCatchupEvent(void)
 
 	if (notify_enabled)
 		EnableNotifyInterrupt();
+
+	in_process_catchup_event = 0;
+
+	}
+	PG_CATCH();
+	{
+		in_process_catchup_event = 0;
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 }

--- a/src/include/storage/sinval.h
+++ b/src/include/storage/sinval.h
@@ -104,4 +104,6 @@ extern void HandleCatchupInterrupt(void);
 extern void EnableCatchupInterrupt(void);
 extern bool DisableCatchupInterrupt(void);
 
+extern volatile int in_process_catchup_event;
+
 #endif   /* SINVAL_H */


### PR DESCRIPTION
An earlier attempt at this checked AmIInSIGUSR1Handler() to see if we
are currently processing a catchup event. But that's not good enough:
we also process catchup interrupts outside the signal handler, in
EnableCatchupInterrupt(). I saw lockups during "make installcheck-good"
with a stack trace that shows a backend waiting for lock on a temporary
relation, while trying to truncate it when committing the transaction
opened for processing a catchup event.

For reference, the commit message for the commit that introduced the
AmIInSIGUSR1Handler check said:

    Recent parallel installcheck-good revealed we have a chance to process
    catchup interrupt while waiting for commit-prepare, and if the prepared
    transaction has created a temporary table with on commit option, the
    newly opened transaction for the sake of AcceptInvalidationMessages()
    cannot see and fails before the commit-prepare.  It's even not clear if
    we are safe to open and commit another transaction between prepare and
    commit-prepare, but for now just skip the oncommit operation as it
    doesn't have any effect anyway.