### PR TITLE
Ensure that filespace hostname is duplicated before freed

### DIFF
--- a/src/backend/commands/filespace.c
+++ b/src/backend/commands/filespace.c
@@ -30,7 +30,6 @@
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
-#include "utils/memutils.h"
 
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbmirroredfilesysobj.h"
@@ -169,7 +168,6 @@ CreateFileSpace(CreateFileSpaceStmt *stmt)
 		segHashElem				*segElem;
 		HASH_SEQ_STATUS          status;
 		bool					 found;
-		MemoryContext			 oldcontext;
 
 		/* Get the segment information */
 		segments = getCdbComponentDatabases();
@@ -200,13 +198,6 @@ CreateFileSpace(CreateFileSpaceStmt *stmt)
 		segHash = hash_create("filespace segHash", 
 							  numsegs, &segInfo, segFlags);
 		
-		/*
-		 * Ensure that the hostname which is copied out of the CdbComponentDatabase
-		 * struct survives serialization down to the QE's when the struct is freed
-		 * at the end of this processing.
-		 */
-		oldcontext = MemoryContextSwitchTo(CurTransactionContext);
-
 		/* 
 		 * Pass 1 - Loop through all locations specified in the statement:
 		 *   - segHash[dbid] => { _, FileSpaceEntry} 
@@ -304,8 +295,6 @@ CreateFileSpace(CreateFileSpaceStmt *stmt)
 
 		/* Done with the hash, cleanup */
 		hash_destroy(segHash);
-
-		MemoryContextSwitchTo(oldcontext);
 
 		/* Cleanup component info */
 		freeCdbComponentDatabases(segments);


### PR DESCRIPTION
Before freeing the CdbComponentDatabase struct we need to copy the hostname member since we are passing that to the QE's. Should the memory be reclaimed before the command is serialized to be passed down the hostname part will contain rubbish and either not work or crash the backend.

This addresses errors in the filespace test suite which intermittently has failed due to rubbish in the hostname being passed to QE's (or NULL pointer derefs).