### PR TITLE
Truncate test

### DIFF
--- a/src/backend/cdb/cdbmirroredbufferpool.c
+++ b/src/backend/cdb/cdbmirroredbufferpool.c
@@ -1508,7 +1508,7 @@ bool MirroredBufferPool_Truncate(
 		{
 			if (Debug_filerep_print)
 				ereport(LOG,
-					(errmsg("could not sent file truncate request to mirror "), 
+					(errmsg("could not send file truncate request to mirror "),
 							FileRep_ReportRelationPath(
 													   open->mirrorFilespaceLocation,
 													   open->relFileNode,

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -1740,7 +1740,7 @@ mdtruncate(SMgrRelation reln, BlockNumber nblocks, bool isTemp, bool allowNotFou
 			 */
 			BlockNumber lastsegblocks = nblocks - priorblocks;
 
-			if (!MirroredBufferPool_Truncate(&v->mdmir_open, lastsegblocks * BLCKSZ) < 0)
+			if (!MirroredBufferPool_Truncate(&v->mdmir_open, lastsegblocks * BLCKSZ))
 				ereport(ERROR,
 						(errcode_for_file_access(),
 						 errmsg("could not truncate relation %u/%u/%u to %u blocks: %m",
@@ -1764,7 +1764,7 @@ mdtruncate(SMgrRelation reln, BlockNumber nblocks, bool isTemp, bool allowNotFou
 		priorblocks += RELSEG_SIZE;
 	}
 #else
-	if (!MirroredBufferPool_Truncate(&v->mdmir_open, nblocks * BLCKSZ) < 0)
+	if (!MirroredBufferPool_Truncate(&v->mdmir_open, nblocks * BLCKSZ))
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not truncate relation %u/%u/%u to %u blocks: %m",


### PR DESCRIPTION
`MirroredBufferedPool_Truncate()` returns a boolean so testing for `(!boolean < 0)` will always return false and not what we expect it to test. Reported by @fengttt in #687. Also fixed a minor type in the error logging while in there.

Survives ICG but is currently building on Pulse to see if that shakes out any errors that have been masked by this.
