### PR TITLE
Ability rebuild persistent table free TID list

### DIFF
--- a/contrib/gp_internal_tools/Makefile
+++ b/contrib/gp_internal_tools/Makefile
@@ -1,5 +1,4 @@
-MODULE_big = gp_ao_co_diagnostics
-OBJS       = gp_ao_co_diagnostics.o
+MODULES    = gp_persistent_util gp_ao_co_diagnostics
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
 

--- a/contrib/gp_internal_tools/README
+++ b/contrib/gp_internal_tools/README
@@ -1,3 +1,29 @@
+===========================
+Persistent tables utilities
+===========================
+
+ Function to rebuild free TID list
+
+ The function gp_persistent_freelist_rebuild(OID) may be used to
+ reconstruct free TID list in a persistent table.  Persistent table's
+ OID is the input parameter.  The function must be invoked in utility
+ mode on the affected segment.  To create the function:
+
+   create function gp_persistent_freelist_rebuild(oid) returns int as
+      '$libdir/gp_persistent_util', 'gp_persistent_freelist_rebuild'
+      language C strict;
+
+ To rebuild the free TID list in gp_persistent_relation_node, connect
+ in utility mode to the affected segment and run:
+
+   select gp_persistent_freelist_rebuild(
+      'gp_persistent_relation_node'::regclass);
+
+ The number of free tuples is returned.
+
+================================================
+Diagnostic functions for Append-optimized tables
+================================================
 
  The procedure described in this utility will allow a user to retrieve 
  internal information about an AO or CO table.

--- a/contrib/gp_internal_tools/gp_persistent_util.c
+++ b/contrib/gp_internal_tools/gp_persistent_util.c
@@ -1,0 +1,43 @@
+#include "postgres.h"
+#include "miscadmin.h"
+#include "fmgr.h"
+#include "funcapi.h"
+#include "catalog/gp_persistent.h"
+#include "cdb/cdbpersistentfilesysobj.h"
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
+Datum gp_persistent_freelist_rebuild(PG_FUNCTION_ARGS);
+
+Datum
+gp_persistent_freelist_rebuild(PG_FUNCTION_ARGS)
+{
+	/* Must be super user */
+	if (!superuser())
+		elog(ERROR, "permission denied");
+	Oid pt_oid = PG_GETARG_OID(0);
+	uint64 numFree = 0;
+	switch(pt_oid)
+	{
+		case GpPersistentRelationNodeRelationId:
+			numFree = PersistentFileSysObj_RebuildFreeList(PersistentFsObjType_RelationFile);
+			break;
+		case GpPersistentDatabaseNodeRelationId:
+			numFree = PersistentFileSysObj_RebuildFreeList(PersistentFsObjType_DatabaseDir);
+			break;
+		case GpPersistentFilespaceNodeRelationId:
+			numFree = PersistentFileSysObj_RebuildFreeList(PersistentFsObjType_FilespaceDir);
+			break;
+		case GpPersistentTablespaceNodeRelationId:
+			numFree = PersistentFileSysObj_RebuildFreeList(PersistentFsObjType_TablespaceDir);
+			break;
+		default:
+			elog(ERROR, "invalid persistent table OID specified");
+			break;
+	}
+	PG_RETURN_INT64(numFree);
+}
+PG_FUNCTION_INFO_V1(gp_persistent_freelist_rebuild);
+

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7020,6 +7020,22 @@ StartupXLOG(void)
 		XLogInitRelationCache();
 
 		/*
+		 * Setup syscache so that PT tuples may be updated using usual
+		 * heap access methods.  This is safe because:
+		 *
+		 *   1. Catalog cache is backend local.
+		 *
+		 *   2. The backend handling this pass (pass 1) of recovery is
+		 *   about to exit.  Rebuilding PT is the last operation
+		 *   performed by this backend.
+		 *
+		 *   3. At the beginning of pass 2, we are initializing
+		 *   catlaog cache, see StartupProcessMain()
+		 */
+		if (IsUnderPostmaster)
+			InitCatalogCache();
+
+		/*
 		 * During startup after we have performed recovery is the only place we
 		 * scan in the persistent meta-data into memory on already initdb database.
 		 */

--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -907,6 +907,22 @@ void PersistentFileSysObj_ReadTuple(
 						tupleCopy);
 }
 
+uint64
+PersistentFileSysObj_RebuildFreeList(PersistentFsObjType fsObjType)
+{
+	Assert(fsObjType >= PersistentFsObjType_First);
+	Assert(fsObjType <= PersistentFsObjType_Last);
+
+	uint64 numFree;
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
+	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
+	numFree = PersistentStore_RebuildFreeList(
+			&(fileSysObjDataArray[fsObjType]->storeData),
+			&(fileSysObjSharedDataArray[fsObjType]->storeSharedData));
+	WRITE_PERSISTENT_STATE_ORDERED_UNLOCK;
+	return numFree;
+}
+
 void PersistentFileSysObj_AddTuple(
 	PersistentFsObjType			fsObjType,
 

--- a/src/backend/cdb/cdbpersistentstore.c
+++ b/src/backend/cdb/cdbpersistentstore.c
@@ -18,7 +18,9 @@
 #include "access/genam.h"
 #include "access/heapam.h"
 #include "access/transam.h"
+#include "utils/faultinjector.h"
 #include "utils/guc.h"
+#include "utils/syscache.h"
 #include "storage/smgr.h"
 #include "storage/ipc.h"
 #include "cdb/cdbglobalsequence.h"
@@ -176,6 +178,13 @@ PersistentStore_FreeEntryHashTableInit(void)
 	freeEntryHashTable = hash_create("Persistent Free Entry", 10, &info, hash_flags);
 }
 
+static void
+PersistentStore_FreeEntryHashTableDestroy(void)
+{
+	hash_destroy(freeEntryHashTable);
+	freeEntryHashTable = NULL;
+}
+
 static void PersistentStore_DiagnoseDumpTable(
 	PersistentStoreData 		*storeData,
 	PersistentStoreSharedData 	*storeSharedData)
@@ -317,45 +326,58 @@ static void PersistentStore_InitScanAddFreeEntry(
 	entry->freeOrderNum = freeOrderNum;
 }
 
-static void PersistentStore_InitScanVerifyFreeEntries(
+/*
+ * Try to walk the free TID chain using free TIDs recorded in
+ * freeEntryHashTable.  Return true if the chain is valid, false
+ * otherwise.
+ *
+ * Note: we have already validated that number of free entries is
+ * equal to max free order number.
+ */
+static bool PersistentStore_InitScanVerifyFreeEntries(
 	PersistentStoreData 		*storeData,
 
 	PersistentStoreSharedData 	*storeSharedData)
 {
 	int64 freeOrderNum;
 	ItemPointerData freeTid;
+	PersistentFreeEntryKey key;
 	PersistentFreeEntry *entry;
-	HASH_SEQ_STATUS iterateStatus;
 
 	freeOrderNum = storeSharedData->maxFreeOrderNum;
 	freeTid = storeSharedData->freeTid;
 
+	elog(LOG, "beginning free list validation for %s, maxFreeOrderNum = "
+		 INT64_FORMAT, storeData->tableName, freeOrderNum);
 	if (freeOrderNum == 0)
 	{
 		if (!PersistentStore_IsZeroTid(&freeTid))
 		{
 			PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-			elog(ERROR,
-				 "expected free TID to be (0,0) when free order number is 0 in '%s'",
-				 storeData->tableName);
+			ereport(WARNING,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("free list validation failed"),
+					 errdetail("expected free TID to be (0,0) when "
+							   "free order number is 0 in '%s'",
+							   storeData->tableName)));
+			return false;
 		}
 	}
 	else
 	{
-		PersistentFreeEntryKey key;
-		PersistentFreeEntry *removeEntry;
-
 		if (freeEntryHashTable == NULL)
 		{
 			PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-			elog(ERROR,
-				 "looking for free order number " INT64_FORMAT " and the"
-				 " free entry hash table is empty for '%s'",
-				 freeOrderNum,
-				 storeData->tableName);
+			ereport(WARNING,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("free list validation failed"),
+					 errdetail("looking for free order number " INT64_FORMAT
+							   " and the free entry hash table is empty for '%s'",
+							   freeOrderNum,
+							   storeData->tableName)));
+			return false;
 		}
-
-		while (true)
+		while (freeOrderNum > 0)
 		{
 			MemSet(&key, 0, sizeof(key));
 			key.persistentTid = freeTid;
@@ -369,38 +391,52 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 			if (entry == NULL)
 			{
 				PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-				elog(ERROR,
-					 "did not find free entry for free TID %s (free order number "
-					 INT64_FORMAT ") for '%s'",
-					 ItemPointerToString(&freeTid),
-					 freeOrderNum,
-					 storeData->tableName);
+				ereport(WARNING,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						 errmsg("free list validation failed"),
+						 errdetail(
+								 "did not find free entry for free TID %s ("
+								 "free order number " INT64_FORMAT ") for '%s'",
+								 ItemPointerToString(&freeTid),
+								 freeOrderNum,
+								 storeData->tableName)));
+				return false;
 			}
 
 			if (PersistentStore_IsZeroTid(&entry->previousFreeTid))
 			{
 				PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-				elog(ERROR,
-					 "previous free TID not expected to be (0,0) -- persistent "
-					 "Free Entry hashtable corrupted for '%s' (expected free "
-					 "order number " INT64_FORMAT ", entry free order number "
-					 INT64_FORMAT ")",
-				     storeData->tableName,
-				     freeOrderNum,
-				     entry->freeOrderNum);
+				ereport(WARNING,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						 errmsg("free list validation failed"),
+						 errdetail(
+								 "previous free TID not expected to be (0,0) -- "
+								 "persistent Free Entry hashtable corrupted for "
+								 "'%s' (expected free order number " INT64_FORMAT
+								 ", entry free order number "
+								 INT64_FORMAT ")",
+								 storeData->tableName,
+								 freeOrderNum,
+								 entry->freeOrderNum)));
+				return false;
 			}
 
 			if (freeOrderNum != entry->freeOrderNum)
 			{
 				PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-				elog(ERROR,
-					 "free entry for free TID %s has wrong free order number "
-					 "(expected free order number " INT64_FORMAT ", found free "
-					 "order number " INT64_FORMAT ") for '%s'",
-					 ItemPointerToString(&freeTid),
-					 freeOrderNum,
-					 entry->freeOrderNum,
-					 storeData->tableName);
+				ereport(WARNING,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						 errmsg("free list validation failed"),
+						 errdetail(
+								 "free entry for free TID %s has wrong free "
+								 "order number (expected free order number "
+								 INT64_FORMAT ", found free order number "
+								 INT64_FORMAT ") for '%s'",
+								 ItemPointerToString(&freeTid),
+								 freeOrderNum,
+								 entry->freeOrderNum,
+								 storeData->tableName)));
+				return false;
 			}
 
 			if (Debug_persistent_recovery_print)
@@ -424,58 +460,23 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 									&freeTid) != 0)
 				{
 					PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-					elog(ERROR,
-						 "expected previous_free_tid %s to match the persistent TID"
-						 " %s for the last free entry (free order number 1) for '%s'",
-						 ItemPointerToString(&freeTid),
-						 ItemPointerToString2(&entry->key.persistentTid),
-						 storeData->tableName);
+					ereport(WARNING,
+							(errcode(ERRCODE_INTERNAL_ERROR),
+							 errmsg("free list validation failed"),
+							 errdetail(
+									 "expected previous_free_tid %s to match the"
+									 " persistent TID %s for the last free entry"
+									 " (free order number 1) for '%s'",
+									 ItemPointerToString(&freeTid),
+									 ItemPointerToString2(&entry->key.persistentTid),
+									 storeData->tableName)));
+					return false;
 				}
 			}
 
-			removeEntry = hash_search(
-								freeEntryHashTable,
-								(void *) &entry->key,
-								HASH_REMOVE,
-								NULL);
-			if (removeEntry == NULL)
-			{
-				PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-				elog(ERROR, "persistent Free Entry hashtable corrupted for '%s'",
-				     storeData->tableName);
-			}
 			entry = NULL;
-
 			freeOrderNum--;
-
-			if (freeOrderNum == 0)
-				break;
 		}
-	}
-
-	if (freeEntryHashTable != NULL)
-	{
-		hash_seq_init(
-				&iterateStatus,
-				freeEntryHashTable);
-
-		/*
-		 * Verify the hash table has no free entries left.
-		 */
-		while ((entry = hash_seq_search(&iterateStatus)) != NULL)
-		{
-			PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-			elog(ERROR,
-				 "found at least one unaccounted for free entry for '%s'.  "
-				 "Example: free order number " INT64_FORMAT ", free TID %s, "
-				 "previous free TID %s",
-				 storeData->tableName,
-				 entry->freeOrderNum,
-				 ItemPointerToString(&entry->key.persistentTid),
-				 ItemPointerToString2(&entry->previousFreeTid));
-		}
-		hash_destroy(freeEntryHashTable);
-		freeEntryHashTable = NULL;
 	}
 
 	if (Debug_persistent_recovery_print)
@@ -484,6 +485,112 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 			 "verified " INT64_FORMAT " free entries",
 			 storeData->tableName,
 			 storeSharedData->maxFreeOrderNum);
+	return true;
+}
+
+/*
+ * Rebuild free TID list based on freeEntryHashTable.  Returns number
+ * of free tuples in the rebuilt free list.
+ */
+uint64
+PersistentStore_RebuildFreeList(
+	PersistentStoreData 		*storeData,
+	PersistentStoreSharedData 	*storeSharedData)
+{
+	Datum				*values;
+	PersistentStoreScan storeScan;
+	ItemPointerData		persistentTid;
+	ItemPointerData		previousFreeTid;
+	ItemPointerData		previousTid;
+	uint64				persistentSerialNum;
+	uint64				freeOrderNum;
+
+
+	values = (Datum*)palloc(storeData->numAttributes * sizeof(Datum));
+
+	/*
+	 * PT shared data must be already initialized, even when we are
+	 * called during recovery.
+	 */
+	Assert(!PersistentStore_IsZeroTid(&storeSharedData->maxTid));
+
+	if (storeSharedData->maxFreeOrderNum < 1)
+	{
+		elog(LOG, "no free tuples in %s, not building any free list",
+			 storeData->tableName);
+		return 0;
+	}
+	elog(LOG, "rebuilding free list in %s with " INT64_FORMAT " free tuples",
+		 storeData->tableName, storeSharedData->maxFreeOrderNum);
+
+	/*
+	 * Scan PT for free entries (in TID order) and establish links
+	 * with previous free entry as we go on.
+	 */
+	previousTid.ip_posid = 0;
+	freeOrderNum = 0;
+	PersistentStore_BeginScan(storeData, storeSharedData, &storeScan);
+	while (PersistentStore_GetNext(
+				   &storeScan,
+				   values,
+				   &persistentTid,
+				   (int64 *)&persistentSerialNum))
+	{
+		/*
+		 * We are scanning from low to high TID.  All TIDs we
+		 * encounter should be smaller or equal to the known
+		 * maxTid.
+		 */
+		Assert(ItemPointerCompare(
+					   &storeSharedData->maxTid,
+					   &persistentTid) >= 0);
+
+		PersistentStore_ExtractOurTupleData(
+				storeData,
+				values,
+				(int64 *)&persistentSerialNum,
+				&previousFreeTid);
+
+		if (!PersistentStore_IsZeroTid(&previousFreeTid))
+		{
+			values[storeData->attNumPersistentSerialNum - 1] =
+					Int64GetDatum(++freeOrderNum);
+			values[storeData->attNumPreviousFreeTid - 1] =
+					ItemPointerIsValid(&previousTid) ?
+					PointerGetDatum(&previousTid) :
+					PointerGetDatum(&persistentTid);
+#ifdef FAULT_INJECTOR
+			/*
+			 * Inject fault after free list is partially built - a few
+			 * tuples are updated but at least one is yet to be
+			 * updated.
+			 */
+			if (freeOrderNum > 3)
+			{
+				FaultInjector_InjectFaultIfSet(
+						RebuildPTDB,
+						DDLNotSpecified,
+						"",	// databaseName
+						""); // tableName
+			}
+#endif
+			PersistentStore_UpdateTuple(
+					storeData, storeSharedData,	&persistentTid, values, true);
+			ItemPointerCopy(&persistentTid, &previousTid);
+		}
+	}
+	PersistentStore_EndScan(&storeScan);
+	pfree(values);
+	if (ItemPointerIsValid(&previousTid))
+	{
+		Assert(freeOrderNum > 0);
+		ItemPointerCopy(&previousTid, &storeSharedData->freeTid);
+		storeSharedData->maxFreeOrderNum = freeOrderNum;
+		elog(LOG, "rebuilt free list in %s:  maxFreeOrderNum = " INT64_FORMAT
+			 " freeTid = %s", storeData->tableName, freeOrderNum,
+			 ItemPointerToString(&persistentTid));
+	}
+	return freeOrderNum;
 }
 
 static void PersistentStore_DoInitScan(
@@ -640,16 +747,24 @@ static void PersistentStore_DoInitScan(
 		if (numFreeEntries != storeSharedData->maxFreeOrderNum)
 		{
 			PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-			elog(ERROR,
-				 "number of freeTIDs " INT64_FORMAT ", does not match "
-				 "maximum free order number " INT64_FORMAT ", for '%s'",
-				 numFreeEntries,
-				 storeSharedData->maxFreeOrderNum,
-				 storeData->tableName);
+			ereport(WARNING,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("free list validation failed"),
+					 errdetail(
+							 "number of freeTIDs " INT64_FORMAT ", does not "
+							 "match maximum free order number " INT64_FORMAT
+							 ", for '%s'",
+							 numFreeEntries,
+							 storeSharedData->maxFreeOrderNum,
+							 storeData->tableName)));
+			PersistentStore_RebuildFreeList(storeData, storeSharedData);
 		}
-		PersistentStore_InitScanVerifyFreeEntries(
-											storeData,
-											storeSharedData);
+		else if (!PersistentStore_InitScanVerifyFreeEntries(
+						 storeData, storeSharedData))
+		{
+			PersistentStore_RebuildFreeList(storeData, storeSharedData);
+		}
+		PersistentStore_FreeEntryHashTableDestroy();
 	}
 	else
 	{

--- a/src/backend/cdb/cdbpersistentstore.c
+++ b/src/backend/cdb/cdbpersistentstore.c
@@ -335,7 +335,8 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 		if (!PersistentStore_IsZeroTid(&freeTid))
 		{
 			PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-			elog(ERROR, "Expected free TID to be (0,0) when free order number is 0 in '%s'",
+			elog(ERROR,
+				 "expected free TID to be (0,0) when free order number is 0 in '%s'",
 				 storeData->tableName);
 		}
 	}
@@ -343,22 +344,24 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 	{
 		PersistentFreeEntryKey key;
 		PersistentFreeEntry *removeEntry;
-		
+
 		if (freeEntryHashTable == NULL)
 		{
 			PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-			elog(ERROR, "Looking for free order number " INT64_FORMAT " and the free entry hash table is empty for '%s'",
+			elog(ERROR,
+				 "looking for free order number " INT64_FORMAT " and the"
+				 " free entry hash table is empty for '%s'",
 				 freeOrderNum,
 				 storeData->tableName);
 		}
-		
+
 		while (true)
 		{
 			MemSet(&key, 0, sizeof(key));
 			key.persistentTid = freeTid;
-			
-			entry = 
-				(PersistentFreeEntry*) 
+
+			entry =
+				(PersistentFreeEntry*)
 								hash_search(freeEntryHashTable,
 											(void *) &key,
 											HASH_FIND,
@@ -366,8 +369,9 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 			if (entry == NULL)
 			{
 				PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-				elog(ERROR, 
-					 "Did not find free entry for free TID %s (free order number " INT64_FORMAT ") for '%s'",
+				elog(ERROR,
+					 "did not find free entry for free TID %s (free order number "
+					 INT64_FORMAT ") for '%s'",
 					 ItemPointerToString(&freeTid),
 					 freeOrderNum,
 					 storeData->tableName);
@@ -376,9 +380,11 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 			if (PersistentStore_IsZeroTid(&entry->previousFreeTid))
 			{
 				PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-				elog(ERROR, 
-					 "Previous free TID not expected to be (0,0) -- persistent Free Entry hashtable corrupted for '%s' "
-					 "(expected free order number " INT64_FORMAT ", entry free order number " INT64_FORMAT ")",
+				elog(ERROR,
+					 "previous free TID not expected to be (0,0) -- persistent "
+					 "Free Entry hashtable corrupted for '%s' (expected free "
+					 "order number " INT64_FORMAT ", entry free order number "
+					 INT64_FORMAT ")",
 				     storeData->tableName,
 				     freeOrderNum,
 				     entry->freeOrderNum);
@@ -387,17 +393,20 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 			if (freeOrderNum != entry->freeOrderNum)
 			{
 				PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-				elog(ERROR, 
-					 "Free entry for free TID %s has wrong free order number (expected free order number " INT64_FORMAT ", found free order number " INT64_FORMAT ") for '%s'",
+				elog(ERROR,
+					 "free entry for free TID %s has wrong free order number "
+					 "(expected free order number " INT64_FORMAT ", found free "
+					 "order number " INT64_FORMAT ") for '%s'",
 					 ItemPointerToString(&freeTid),
 					 freeOrderNum,
 					 entry->freeOrderNum,
 					 storeData->tableName);
 			}
-			
+
 			if (Debug_persistent_recovery_print)
-				elog(PersistentRecovery_DebugPrintLevel(), 
-					 "PersistentStore_InitScanVerifyFreeEntries ('%s'): Free order number " INT64_FORMAT ", free TID %s, previous free TID %s",
+				elog(PersistentRecovery_DebugPrintLevel(),
+					 "PersistentStore_InitScanVerifyFreeEntries ('%s'): Free order"
+					 " number " INT64_FORMAT ", free TID %s, previous free TID %s",
 					 storeData->tableName,
 					 freeOrderNum,
 					 ItemPointerToString(&freeTid),
@@ -415,23 +424,24 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 									&freeTid) != 0)
 				{
 					PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-					elog(ERROR, "Expected previous_free_tid %s to match the persistent TID %s for the last free entry (free order number 1) for '%s'",
+					elog(ERROR,
+						 "expected previous_free_tid %s to match the persistent TID"
+						 " %s for the last free entry (free order number 1) for '%s'",
 						 ItemPointerToString(&freeTid),
 						 ItemPointerToString2(&entry->key.persistentTid),
 						 storeData->tableName);
-						 
 				}
 			}
 
 			removeEntry = hash_search(
-								freeEntryHashTable, 
-								(void *) &entry->key, 
-								HASH_REMOVE, 
+								freeEntryHashTable,
+								(void *) &entry->key,
+								HASH_REMOVE,
 								NULL);
 			if (removeEntry == NULL)
 			{
 				PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-				elog(ERROR, "Persistent Free Entry hashtable corrupted for '%s'",
+				elog(ERROR, "persistent Free Entry hashtable corrupted for '%s'",
 				     storeData->tableName);
 			}
 			entry = NULL;
@@ -440,14 +450,13 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 
 			if (freeOrderNum == 0)
 				break;
-		
 		}
 	}
 
 	if (freeEntryHashTable != NULL)
 	{
 		hash_seq_init(
-				&iterateStatus, 
+				&iterateStatus,
 				freeEntryHashTable);
 
 		/*
@@ -456,20 +465,23 @@ static void PersistentStore_InitScanVerifyFreeEntries(
 		while ((entry = hash_seq_search(&iterateStatus)) != NULL)
 		{
 			PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-			elog(ERROR, "Found at least one unaccounted for free entry for '%s'.  Example: free order number " INT64_FORMAT ", free TID %s, previous free TID %s",
-				storeData->tableName,
-				entry->freeOrderNum,
-				ItemPointerToString(&entry->key.persistentTid),
-				ItemPointerToString2(&entry->previousFreeTid));
+			elog(ERROR,
+				 "found at least one unaccounted for free entry for '%s'.  "
+				 "Example: free order number " INT64_FORMAT ", free TID %s, "
+				 "previous free TID %s",
+				 storeData->tableName,
+				 entry->freeOrderNum,
+				 ItemPointerToString(&entry->key.persistentTid),
+				 ItemPointerToString2(&entry->previousFreeTid));
 		}
-
 		hash_destroy(freeEntryHashTable);
 		freeEntryHashTable = NULL;
 	}
-	
+
 	if (Debug_persistent_recovery_print)
-		elog(PersistentRecovery_DebugPrintLevel(), 
-			 "PersistentStore_InitScanVerifyFreeEntries ('%s'): Successfully verified " INT64_FORMAT " free entries",
+		elog(PersistentRecovery_DebugPrintLevel(),
+			 "PersistentStore_InitScanVerifyFreeEntries ('%s'): successfully "
+			 "verified " INT64_FORMAT " free entries",
 			 storeData->tableName,
 			 storeSharedData->maxFreeOrderNum);
 }
@@ -510,7 +522,7 @@ static void PersistentStore_DoInitScan(
 			ItemPointerCompare(
 							&storeSharedData->maxTid,
 							&persistentTid) == -1);	// Less-Than.
-							
+
 		storeSharedData->maxTid = persistentTid;
 
 		PersistentStore_ExtractOurTupleData(
@@ -518,14 +530,14 @@ static void PersistentStore_DoInitScan(
 									values,
 									&persistentSerialNum,
 									&previousFreeTid);
-		
+
 		if (Debug_persistent_recovery_print)
 			(*storeData->printTupleCallback)(
 										PersistentRecovery_DebugPrintLevel(),
 										"SCAN",
 										&persistentTid,
 										values);
-		
+
 		if (!PersistentStore_IsZeroTid(&previousFreeTid))
 		{
 			/*
@@ -545,10 +557,11 @@ static void PersistentStore_DoInitScan(
 												storeSharedData,
 												&persistentTid,
 												&previousFreeTid,
-												/* freeOrderNum */ persistentSerialNum);
+												/* freeOrderNum */
+												persistentSerialNum);
 			}
 		}
-		else 
+		else
 		{
 			storeSharedData->inUseCount++;
 
@@ -579,30 +592,32 @@ static void PersistentStore_DoInitScan(
 	 * not consistent...
 	 */
 	Assert(!InRecovery);
-	
+
 	if (globalSequenceNum < storeSharedData->maxInUseSerialNum)
 	{
 		/*
 		 * We seem to have a corruption problem.
 		 *
-		 * Use the gp_persistent_repair_global_sequence GUC to get the system up.
+		 * Use the gp_persistent_repair_global_sequence GUC to get the
+		 * system up.
 		 */
 
 		if (gp_persistent_repair_global_sequence)
 		{
-			elog(LOG, "Need to Repair global sequence number " INT64_FORMAT " so use scanned maximum value " INT64_FORMAT " ('%s')",
+			elog(LOG, "need to repair global sequence number " INT64_FORMAT
+				 " so use scanned maximum value " INT64_FORMAT " ('%s')",
 				 globalSequenceNum,
 				 storeSharedData->maxInUseSerialNum,
 				 storeData->tableName);
 		}
 		else
 		{
-			elog(ERROR, "Global sequence number " INT64_FORMAT " less than maximum value " INT64_FORMAT " found in scan ('%s')",
+			elog(ERROR, "global sequence number " INT64_FORMAT " less than "
+				 "maximum value " INT64_FORMAT " found in scan ('%s')",
 				 globalSequenceNum,
 				 storeSharedData->maxInUseSerialNum,
 				 storeData->tableName);
 		}
-		
 	}
 	else
 	{
@@ -611,10 +626,12 @@ static void PersistentStore_DoInitScan(
 
 	if (Debug_persistent_recovery_print)
 		elog(PersistentRecovery_DebugPrintLevel(),
-			 "PersistentStore_DoInitScan ('%s'): maximum in-use serial number " INT64_FORMAT ", maximum free order number " INT64_FORMAT ", free TID %s, maximum known TID %s",
+			 "PersistentStore_DoInitScan ('%s'): maximum in-use serial number "
+			 INT64_FORMAT ", maximum free order number " INT64_FORMAT
+			 ", free TID %s, maximum known TID %s",
 			 storeData->tableName,
-			 storeSharedData->maxInUseSerialNum, 
-			 storeSharedData->maxFreeOrderNum, 
+			 storeSharedData->maxInUseSerialNum,
+			 storeSharedData->maxFreeOrderNum,
 			 ItemPointerToString(&storeSharedData->freeTid),
 			 ItemPointerToString2(&storeSharedData->maxTid));
 
@@ -623,13 +640,13 @@ static void PersistentStore_DoInitScan(
 		if (numFreeEntries != storeSharedData->maxFreeOrderNum)
 		{
 			PersistentStore_DiagnoseDumpTable(storeData, storeSharedData);
-			elog(ERROR, 
-					 "Number of freeTIDs " INT64_FORMAT ", do not match maximum free order number " INT64_FORMAT ", for '%s'",
-					 numFreeEntries,
-					 storeSharedData->maxFreeOrderNum,
-					 storeData->tableName);
+			elog(ERROR,
+				 "number of freeTIDs " INT64_FORMAT ", does not match "
+				 "maximum free order number " INT64_FORMAT ", for '%s'",
+				 numFreeEntries,
+				 storeSharedData->maxFreeOrderNum,
+				 storeData->tableName);
 		}
-		
 		PersistentStore_InitScanVerifyFreeEntries(
 											storeData,
 											storeSharedData);
@@ -637,8 +654,9 @@ static void PersistentStore_DoInitScan(
 	else
 	{
 		if (Debug_persistent_recovery_print)
-			elog(PersistentRecovery_DebugPrintLevel(), 
-				 "PersistentStore_DoInitScan ('%s'): Skipping verification because gp_persistent_skip_free_list GUC is ON",
+			elog(PersistentRecovery_DebugPrintLevel(),
+				 "PersistentStore_DoInitScan ('%s'): skipping verification "
+				 "because gp_persistent_skip_free_list GUC is ON",
 				 storeData->tableName);
 	}
 }

--- a/src/include/cdb/cdbpersistentfilesysobj.h
+++ b/src/include/cdb/cdbpersistentfilesysobj.h
@@ -111,6 +111,9 @@ extern void PersistentFileSysObj_AddTuple(
 				/* TID of the stored tuple. */
 	int64						*persistentSerialNum);
 
+extern uint64 PersistentFileSysObj_RebuildFreeList(
+	PersistentFsObjType fsObjType);
+
 extern void PersistentFileSysObj_FreeTuple(
 	PersistentFileSysObjData		*fileSysObjData,
 	PersistentFileSysObjSharedData	*fileSysObjSharedData,

--- a/src/include/cdb/cdbpersistentstore.h
+++ b/src/include/cdb/cdbpersistentstore.h
@@ -523,6 +523,10 @@ extern void PersistentStore_ResetFreeList(
 	PersistentStoreData 		*storeData,
 	PersistentStoreSharedData 	*storeSharedData);
 
+extern uint64 PersistentStore_RebuildFreeList(
+	PersistentStoreData 		*storeData,
+	PersistentStoreSharedData 	*storeSharedData);
+
 extern void PersistentStore_InitScanUnderLock(
 	PersistentStoreData 		*storeData,
 	PersistentStoreSharedData 	*storeSharedData);

--- a/src/test/regress/bugbuster/expected/gp_persistent_table.out
+++ b/src/test/regress/bugbuster/expected/gp_persistent_table.out
@@ -164,3 +164,100 @@ drop table gp_persistent_all_types;
 drop table gp_persistent_supplier_hybrid_part;
 drop table gp_persistent_supplier_hybrid_subpart;
 drop table gp_persistent_supplier_hybrid_subpart1;
+--
+-- Test rebuilding free tid list
+--
+-- Input is PT OID and output is number of tuples in the rebuilt list.
+create function gp_persistent_freelist_rebuild(oid) returns int as
+	   '$libdir/gp_persistent_util', 'gp_persistent_freelist_rebuild' language C strict;
+-- Verifying sanity of free list before rebuilding is not exactly
+-- necessary, because rebuilding should make it sane.  But we check it
+-- anyway, as we don't expect ICG tests to break freelist.
+select count(*) = max(persistent_serial_num) as freelist_valid
+	   from gp_persistent_relation_node where previous_free_tid > '(0,0)';
+ freelist_valid 
+----------------
+ t
+(1 row)
+
+select gp_persistent_freelist_rebuild('gp_persistent_relation_node'::regclass) > 0
+	   as freelist_rebuilt;
+ freelist_rebuilt 
+------------------
+ t
+(1 row)
+
+select count(*) = max(persistent_serial_num) as freelist_valid
+	   from gp_persistent_relation_node where previous_free_tid > '(0,0)';
+ freelist_valid 
+----------------
+ t
+(1 row)
+
+select count(*) = max(persistent_serial_num) as freelist_valid
+	   from gp_persistent_database_node where previous_free_tid > '(0,0)';
+ freelist_valid 
+----------------
+ t
+(1 row)
+
+select gp_persistent_freelist_rebuild('gp_persistent_database_node'::regclass) > 0
+	   as freelist_rebuilt;
+ freelist_rebuilt 
+------------------
+ t
+(1 row)
+
+select count(*) = max(persistent_serial_num) as freelist_valid
+	   from gp_persistent_database_node where previous_free_tid > '(0,0)';
+ freelist_valid 
+----------------
+ t
+(1 row)
+
+-- TODO: Validate that max(ctid) and max(persistent_serial_num) yield
+-- the same tuple in the free list.
+SET allow_system_table_mods = 'DML';
+SET gp_permit_persistent_metadata_update = true;
+-- Break free list by updating persistent_serial_num = 2, so there are
+-- two free list entries with same free order number.  This should be
+-- fixed by rebuild.  Assume at least three entries in the free list,
+-- because we have dropped very many objects earlier in this test.
+UPDATE gp_persistent_relation_node SET persistent_serial_num = 2
+	   WHERE persistent_serial_num = 3 AND previous_free_tid > '(0, 0)';
+SET allow_system_table_mods = 'NONE';
+SET gp_permit_persistent_metadata_update = false;
+select count(*) = count(distinct(persistent_serial_num)) as freelist_valid
+	   from gp_persistent_relation_node where previous_free_tid > '(0,0)';
+ freelist_valid 
+----------------
+ f
+(1 row)
+
+select gp_persistent_freelist_rebuild('gp_persistent_relation_node'::regclass) > 0
+	   as freelist_rebuilt;
+ freelist_rebuilt 
+------------------
+ t
+(1 row)
+
+select count(*) = count(distinct(persistent_serial_num)) as freelist_valid
+	   from gp_persistent_relation_node where previous_free_tid > '(0,0)';
+ freelist_valid 
+----------------
+ t
+(1 row)
+
+-- DDL after rebuilding free list
+create table gp_persistent_ao(a int, b int) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index gp_persistent_ao_idx on gp_persistent_ao(a);
+insert into gp_persistent_ao select i,i from generate_series(1,10)i;
+select count(*) from gp_persistent_ao;
+ count 
+-------
+    10
+(1 row)
+
+drop table gp_persistent_ao;


### PR DESCRIPTION
Each persistent table maintains a list of free tuples.  A tuple is free if and only if `previous_free_tid` is valid (greater than `(0,0)`).  If a tuple is free, the column `persistent_serial_num` indicates its position in the free list.  During normal operation, we maintain the TID and `persistent_serial_num` of the top of the free list in shared memory.  The `previous_free_tid` is used to link free tuples such that it contains the previous free tuple's TID.

If the free list becomes inconsistent (yes, we have seen this happen), this commit introduces one way of reconstructing it.