### PR TITLE
Clean up the way the results array is allocated in cdbdisp_returnResults().

### DIFF
--- a/src/backend/cdb/cdbpersistentcheck.c
+++ b/src/backend/cdb/cdbpersistentcheck.c
@@ -1125,15 +1125,15 @@ Persistent_PostDTMRecv_NonDBSpecificPTCatVerification(void)
 {
 	PGresult  **pgresultSets = NULL;
 	StringInfoData errmsgbuf;
-	PGresult   *rs = NULL;
-	int i;
+	int			nresults;
+	int			i;
 	const char *cmdbuf = "select * from gp_nondbspecific_ptcat_verification()";
 
 	initStringInfo(&errmsgbuf);
 
 	/* call to all QE to perform verifications */
 	pgresultSets = cdbdisp_dispatchRMCommand(cmdbuf, /* withSnapshot */false,
-											 &errmsgbuf, NULL);
+											 &errmsgbuf, &nresults);
 
 	if (errmsgbuf.len > 0)
 	{
@@ -1144,13 +1144,8 @@ Persistent_PostDTMRecv_NonDBSpecificPTCatVerification(void)
 		pfree(errmsgbuf.data);
 	}
 
-	rs = pgresultSets[0];
-	i=0;
-
-	do
-	{
-		PQclear(rs);
-	} while ((rs = pgresultSets[++i]) != NULL);
+	for (i = 0; i < nresults; i++)
+		PQclear(pgresultSets[i]);
 
 	pfree(errmsgbuf.data);
 	free(pgresultSets);
@@ -1165,15 +1160,15 @@ Persistent_PostDTMRecv_DBSpecificPTCatVerification(void)
 {
 	PGresult  **pgresultSets = NULL;
 	StringInfoData errmsgbuf;
-	PGresult   *rs = NULL;
-	int i =0;
+	int			nresults;
+	int			i;
 	const char *cmdbuf = "select * from gp_dbspecific_ptcat_verification()";
 
 	initStringInfo(&errmsgbuf);
 
 	/* call to all QE to perform verifications */
 	pgresultSets = cdbdisp_dispatchRMCommand(cmdbuf, /* withSnapshot */false,
-											 &errmsgbuf, NULL);
+											 &errmsgbuf, &nresults);
 
 	/* display error messages */
 	if (errmsgbuf.len > 0)
@@ -1185,12 +1180,8 @@ Persistent_PostDTMRecv_DBSpecificPTCatVerification(void)
 		pfree(errmsgbuf.data);
 	}
 
-	rs = pgresultSets[0];
-	i=0;
-	do
-	{
-		PQclear(rs);
-	} while ((rs = pgresultSets[++i]) != NULL);
+	for (i = 0; i < nresults; i++)
+		PQclear(pgresultSets[i]);
 
 	pfree(errmsgbuf.data);
 	free(pgresultSets);

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -868,7 +868,7 @@ gp_read_error_log(PG_FUNCTION_ARGS)
 			PQclear(context->segResults[i]);
 
 		/* XXX: better to copy to palloc'ed area */
-		free(context->segResults[i]);
+		free(context->segResults);
 	}
 
 	/*


### PR DESCRIPTION
Plus a fix for a memory leak that was exposed when I removed the NULL terminator from the array returned by cdbdisp_returnResults().