### PR TITLE
Mapred musings

### DIFF
--- a/gpAux/extensions/gpmapreduce/include/mapred.h
+++ b/gpAux/extensions/gpmapreduce/include/mapred.h
@@ -201,11 +201,11 @@ typedef struct {
 
 	mapred_plist_t     *parameters;     /* points into input plist */
 	mapred_plist_t     *grouping;
-	mapred_plist_t     *returns;	
+	mapred_plist_t     *returns;
 } mapred_task_t;
 
 
-/* 
+/*
  * Whenever a function returns more than a single column an abstract
  * data type will be transparently created.
  */
@@ -213,7 +213,7 @@ typedef struct {
 	mapred_plist_t     *returns;
 } mapred_adt_t;
 
-typedef struct 
+typedef struct
 {
 	char   *buffer;
 	size_t  bufsize;

--- a/gpAux/extensions/gpmapreduce/src/main.c
+++ b/gpAux/extensions/gpmapreduce/src/main.c
@@ -13,10 +13,10 @@
 
 ALLOW_EXCEPTIONS;
 
-static char  VERSION[] = 
+static char  VERSION[] =
 	"Greenplum Map/Reduce Driver 1.00b2";
 
-static char *wordchars = 
+static char *wordchars =
 	"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
 
 /* Initialize global variables */
@@ -121,7 +121,7 @@ int main (int argc, char *argv[])
 	while (1)
 	{
 		int option_index = 0;
-		c = getopt_long(argc, argv, short_options, long_options, 
+		c = getopt_long(argc, argv, short_options, long_options,
 						&option_index);
 		if (c == -1)
 			break; /* done processing options */
@@ -130,7 +130,7 @@ int main (int argc, char *argv[])
 			case '?':  /* --help */
 				
 				/* Actual help option given */
-				if (strcmp(argv[optind - 1], "-?") == 0 || 
+				if (strcmp(argv[optind - 1], "-?") == 0 ||
 					strcmp(argv[optind - 1], "--help") == 0)
 				{
 					usage(procname, true);
@@ -171,15 +171,15 @@ int main (int argc, char *argv[])
 			case 'W':  /* --password */
 				forceprompt = true;
 				break;
-     
+
 			case 'U':  /* --username */
 				username = optarg;
 				break;
-     
+
 			case 'h':  /* --host */
 				hostname = optarg;
 				break;
-     
+
 			case 'p':  /* --port */
 				port = optarg;
 				break;
@@ -187,7 +187,7 @@ int main (int argc, char *argv[])
 			case 'f':  /* --file */
 				filename = optarg;
 				break;
-     
+
 			case 'k':  /* --key */
 			{
 				mapred_plist_t *newitem;
@@ -195,7 +195,7 @@ int main (int argc, char *argv[])
 				char *value = NULL;
 				char *eq = strchr(name, '=');
 
-				/* 
+				/*
 				 * either --key value      : sets parameter named "key"
 				 * or     --key name=value : sets parameter named "name"
 				 */
@@ -240,7 +240,7 @@ int main (int argc, char *argv[])
 	}
 
 	file = fopen(filename, "rb");
-	if (!file) 
+	if (!file)
 	{
 		fprintf(stderr, "Error: Could not open file '%s'\n", filename);
 		exit(1);
@@ -267,7 +267,7 @@ int main (int argc, char *argv[])
 		mapred_plist_t *param = global_plist;
 		while (param)
 		{
-			fprintf(stderr, "- Parameter: %s=%s\n", 
+			fprintf(stderr, "- Parameter: %s=%s\n",
 					param->name, param->type);
 			param = param->next;
 		}
@@ -291,7 +291,7 @@ int main (int argc, char *argv[])
 		if (xframe.exception)
 			fprintf(stderr, "Error: %s\n", (char *) xframe.exception);
 		else
-			fprintf(stderr, "Unknown Error (%d) at %s:%d\n", 
+			fprintf(stderr, "Unknown Error (%d) at %s:%d\n",
 					xframe.errcode, xframe.file, xframe.lineno);
 		exit(1);
 	}
@@ -374,7 +374,7 @@ int main (int argc, char *argv[])
 				if (global_verbose_flag)
 				{
 					fprintf(stderr, "  - Connected Established:\n");
-					fprintf(stderr, "    HOST: %s\n", 
+					fprintf(stderr, "    HOST: %s\n",
 							PQhost(conn) ? PQhost(conn) : "localhost");
 					fprintf(stderr, "    PORT: %s\n", PQport(conn));
 					fprintf(stderr, "    USER: %s/%s\n", PQuser(conn), PQdb(conn));
@@ -415,7 +415,7 @@ int main (int argc, char *argv[])
 			if (xframe.exception)
 				fprintf(stderr, "Error: %s\n", (char *) xframe.exception);
 			else
-				fprintf(stderr, "Unknown Error (%d) at %s:%d\n", 
+				fprintf(stderr, "Unknown Error (%d) at %s:%d\n",
 						xframe.errcode, xframe.file, xframe.lineno);
 			errcode = 1;
 		}
@@ -450,7 +450,7 @@ void read_password(char *p, size_t len)
 
     termin  = fopen("/dev/tty", "r");
     termout = fopen("/dev/tty", "w");
-    if (!termin || !termout) 
+    if (!termin || !termout)
     {
         if (termin)
 			fclose(termin);
@@ -470,7 +470,7 @@ void read_password(char *p, size_t len)
 
     if (fgets(p, len, termin) == NULL)
         p[0] = '\0';
-    
+
     /* If that didn't get the whole input suck the rest off */
     len = strlen(p);
     if (len > 0)
@@ -524,7 +524,7 @@ void check_version(PGconn *conn)
 			if (major < 3 || (major == 3 && minor < 2))
 			{
 				char buf[100];
-				snprintf(buf, sizeof(buf), 
+				snprintf(buf, sizeof(buf),
 						 "Unsupported backend version: %s", version);
 				XRAISE(VERSION_ERROR, strdup(buf));
 			}
@@ -540,8 +540,8 @@ void check_version(PGconn *conn)
 }
 
 
-/* 
- * sigint_handler() -  Interupt handler to cancel active queries 
+/*
+ * sigint_handler() -  Interupt handler to cancel active queries
  */
 static void sigint_handler(SIGNAL_ARGS)
 {

--- a/gpAux/extensions/gpmapreduce/src/mapred.c
+++ b/gpAux/extensions/gpmapreduce/src/mapred.c
@@ -466,10 +466,10 @@ void lookup_function_in_catalog(PGconn *conn, mapred_document_t *doc,
 			rettype = value;
 			value = PQgetvalue(result, 0, 2);   /* Column 2: pronargs */
 			nargs = (int) strtol(value, (char **) NULL, 10);
-			
-			/* 
-			 * Arrays are formated as:  "{value,value,...}" 
-			 * of which we only want "value,value, ..." 
+
+			/*
+			 * Arrays are formatted as:  "{value,value,...}"
+			 * of which we only want "value,value, ..."
 			 * so find the part of the string between the braces
 			 */
 			if (!PQgetisnull(result, 0, 3))   /* Column 3: proargnames */
@@ -2467,10 +2467,10 @@ void mapred_run_queries(PGconn *conn, mapred_document_t *doc)
 							PQprintOpt options;
 							memset(&options, 0, sizeof(options));
 
-							/* 
-							 * Formating:
-							 *   STDOUT = fancy formating
-							 *   FILE   = plain formating
+							/*
+							 * Formatting:
+							 *   STDOUT = fancy formatting
+							 *   FILE   = plain formatting
 							 */
 							if (outfile == stdout)
 							{
@@ -2935,9 +2935,9 @@ boolean mapred_create_object(PGconn *conn, mapred_document_t *doc,
 						 !strncasecmp("python",   obj->u.function.language, 6))
 				{
 					/*
-					 * Python very stuborn about not letting you manually 
+					 * Python very stubborn about not letting you manually
 					 * adjust line number.  So instead we take the stupid route
-					 * and just insert N newlines. 
+					 * and just insert N newlines.
 					*/
 					int i;
 					bufcat(&buffer, "$$\n");
@@ -2976,9 +2976,9 @@ boolean mapred_create_object(PGconn *conn, mapred_document_t *doc,
 				XASSERT(obj->name);
 				XASSERT(transition);
 				XASSERT(transition->name);
-			
-				/* 
-				 * If the reducer depends on an object that hasn't be created
+
+				/*
+				 * If the reducer depends on an object that hasn't been created
 				 * then return false, it will be resolved during a second pass
 				 */
 				if ((transition && !transition->created) ||
@@ -2986,7 +2986,7 @@ boolean mapred_create_object(PGconn *conn, mapred_document_t *doc,
 					(finalizer  && !finalizer->created))
 				{
 					if (global_print_flag && global_debug_flag)
-						printf("-- defering REDUCE %s\n", obj->name);
+						printf("-- deferring REDUCE %s\n", obj->name);
 					break;
 				}
 				if (global_print_flag || global_debug_flag)
@@ -3078,9 +3078,9 @@ boolean mapred_create_object(PGconn *conn, mapred_document_t *doc,
 					qbuffer = makebuffer(1024, 1024);
 				else
 					bufreset(qbuffer);
-				
-				/* 
-				 * If the task depends on an object that hasn't be created then
+
+				/*
+				 * If the task depends on an object that hasn't been created then
 				 * return false, it will be resolved during a second pass
 				 */
 				if ((input   && !input->created)  ||
@@ -3090,9 +3090,9 @@ boolean mapred_create_object(PGconn *conn, mapred_document_t *doc,
 					if (global_print_flag && global_debug_flag)
 					{
 						if (obj->u.task.execute)
-							printf("-- defering EXECUTION\n");
+							printf("-- deferring EXECUTION\n");
 						else
-							printf("-- defering TASK %s\n", obj->name);
+							printf("-- deferring TASK %s\n", obj->name);
 					}
 					break;
 				}

--- a/gpAux/extensions/gpmapreduce/src/parse.c
+++ b/gpAux/extensions/gpmapreduce/src/parse.c
@@ -52,7 +52,7 @@ mapred_olist_t* mapred_parse_string(unsigned char *yaml)
 	
 	XASSERT(yaml);
 	if (!yaml_parser_initialize(&parser))
-		XRAISE(MAPRED_PARSE_INTERNAL, 
+		XRAISE(MAPRED_PARSE_INTERNAL,
 			   "YAML parser initialization failed");
 
 	yaml_parser_set_input_string(&parser, yaml, strlen((char*) yaml));
@@ -68,7 +68,7 @@ mapred_olist_t* mapred_parse_file(FILE *file)
 
 	XASSERT(file);
 	if (!yaml_parser_initialize(&parser))
-		XRAISE(MAPRED_PARSE_INTERNAL, 
+		XRAISE(MAPRED_PARSE_INTERNAL,
 			   "YAML parser initialization failed");
 
 	yaml_parser_set_input_file(&parser, file);
@@ -109,8 +109,8 @@ mapred_olist_t* mapred_parse_yaml(yaml_parser_t *yparser)
 #endif
 
 	/* Check for errors within documents */
-	for (doc_item = parser.doclist; 
-		 doc_item && !error; 
+	for (doc_item = parser.doclist;
+		 doc_item && !error;
 		 doc_item = doc_item->next)
 	{
 		if (doc_item->object->u.document.flags & mapred_document_error)
@@ -180,7 +180,7 @@ void parser_begin_define(mapred_parser_t *parser)
 {
 	XASSERT(parser->current_doc);
 
-	/* 
+	/*
 	 * The only thing we have to do is ensure that this isn't a duplicate
 	 * define list.
 	 */
@@ -189,7 +189,7 @@ void parser_begin_define(mapred_parser_t *parser)
 		mapred_parse_error(parser, "Duplicate DEFINE list in DOCUMENT");
 		return;
 	}
-			   
+
 	parser->current_doc->u.document.flags |= mapred_document_defines;
 }
 
@@ -197,7 +197,7 @@ void parser_begin_execute(mapred_parser_t *parser)
 {
 	XASSERT(parser->current_doc);
 
-	/* 
+	/*
 	 * The only thing we have to do is ensure that this isn't a duplicate
 	 * execution list.
 	 */
@@ -220,7 +220,7 @@ void parser_set_version(mapred_parser_t *parser, char *value)
 		return;
 	}
 
-	/* 
+	/*
 	 * We have already assured that the value matches a good regex,
 	 * but we must still validate that the version itself is supported.
 	 */
@@ -274,9 +274,9 @@ void parser_set_port(mapred_parser_t *parser, char *value)
 		return;
 	}
 
-	/* 
+	/*
 	 * The parse has already assured that the value consists of a sequence
-	 * of digits, so strtol should convert successfully. 
+	 * of digits, so strtol should convert successfully.
 	 */
 	parser->current_doc->u.document.port = (int) strtol(value, NULL, 10);
 }
@@ -291,9 +291,9 @@ void parser_add_object(mapred_parser_t *parser, mapred_kind_t kind)
 
 	XASSERT(parser->current_doc);
 
-	/* 
+	/*
 	 * If we have a current object then verify it and add it into the
-	 * document's object list. 
+	 * document's object list.
 	 */
 	if (parser->current_obj)
 	{
@@ -305,7 +305,7 @@ void parser_add_object(mapred_parser_t *parser, mapred_kind_t kind)
 		if (error != NO_ERROR)
 		{
 			mapred_destroy_object(&parser->current_obj);
-			parser->current_doc->u.document.flags |= 
+			parser->current_doc->u.document.flags |=
 				mapred_document_error;
 		}
 		else
@@ -328,12 +328,12 @@ void parser_add_object(mapred_parser_t *parser, mapred_kind_t kind)
 			if (global_verbose_flag)
 			{
 				const char *type, *name;
-				XASSERT (newitem->object->kind > 0 && 
+				XASSERT (newitem->object->kind > 0 &&
 						 newitem->object->kind <= MAPRED_MAXKIND);
 
 
 				type = mapred_kind_name[newitem->object->kind];
-				name = newitem->object->name; 
+				name = newitem->object->name;
 				if (name)
 					fprintf(stderr, "    - %s: %s\n", type, name);
 				else
@@ -342,7 +342,7 @@ void parser_add_object(mapred_parser_t *parser, mapred_kind_t kind)
 		}
 	}
 
-	/* 
+	/*
 	 * If 'kind' is 'NO_KIND' then we just add in the current object
 	 * (above) and do not create a new one.  We call it this way once
 	 * at the end to add the last object into the current document.
@@ -434,23 +434,23 @@ void parser_set_table(mapred_parser_t *parser, char *value)
 			switch (parser->current_obj->u.input.type)
 			{
 				case MAPRED_INPUT_TABLE:
-					mapred_parse_error(parser, 
+					mapred_parse_error(parser,
 									   "Duplicate TABLE");
 					return;
 				case MAPRED_INPUT_FILE:
-					mapred_parse_error(parser, 
+					mapred_parse_error(parser,
 									   "FILE is incompatible with TABLE");
 					return;
 				case MAPRED_INPUT_GPFDIST:
-					mapred_parse_error(parser, 
+					mapred_parse_error(parser,
 									   "GPFDIST is incompatible with TABLE");
 					return;
 				case MAPRED_INPUT_QUERY:
-					mapred_parse_error(parser, 
+					mapred_parse_error(parser,
 									   "QUERY is incompatible with TABLE");
 					return;
 				case MAPRED_INPUT_EXEC:
-					mapred_parse_error(parser, 
+					mapred_parse_error(parser,
 									   "GPFDIST is incompatible with TABLE");
 					return;
 				default:
@@ -475,11 +475,11 @@ void parser_set_table(mapred_parser_t *parser, char *value)
 			switch (parser->current_obj->u.output.type)
 			{
 				case MAPRED_OUTPUT_TABLE:
-					mapred_parse_error(parser, 
+					mapred_parse_error(parser,
 									   "Duplicate TABLE");
 					return;
 				case MAPRED_OUTPUT_FILE:
-					mapred_parse_error(parser, 
+					mapred_parse_error(parser,
 									   "FILE is incompatible with TABLE");
 					return;
 				default:
@@ -728,9 +728,9 @@ void parser_set_error_limit(mapred_parser_t *parser, char *value)
 		return;
 	}
 
-	/* 
+	/*
 	 * The parse has already assured that the value consists of a sequence
-	 * of digits, so strtol should convert successfully. 
+	 * of digits, so strtol should convert successfully.
 	 */
 	parser->current_obj->u.input.error_limit = (int) strtol(value, NULL, 10);
 }
@@ -817,7 +817,7 @@ void parser_set_mode(mapred_parser_t *parser, char *value)
 
 void parser_set_file(mapred_parser_t *parser, char *value)
 {
-	/* 
+	/*
 	 * Only applies to OUTPUTS which have a single file.
 	 * INPUTS use parser_begin_files, parser_add_file ...
 	 */
@@ -955,8 +955,8 @@ void parser_set_function(mapred_parser_t *parser, char *value)
 	parser->current_obj->u.function.body = copyscalar(value);
 
 
-	/* 
-	 * The "start_mark" of function body has a line number, but what that line 
+	/*
+	 * The "start_mark" of function body has a line number, but what that line
 	 * number refers to is a bit finicky depending on the nature of the YAML.
 	 * So we take it and adjust it accordingly.
 	 */
@@ -979,8 +979,8 @@ void parser_set_function(mapred_parser_t *parser, char *value)
 }
 
 /*
- * parser_set_library was added to support the "LIBRARY" option in mapreduce 
- * yaml schema version 1.0.0.2.  This is used by C language functions to 
+ * parser_set_library was added to support the "LIBRARY" option in mapreduce
+ * yaml schema version 1.0.0.2.  This is used by C language functions to
  * specify which code library the C function is defined in.
  *
  * - MAP:
@@ -1009,7 +1009,7 @@ void parser_set_library(mapred_parser_t *parser, char *value)
 	}
 	parser->current_obj->u.function.library = copyscalar(value);
 
-	/* 
+	/*
 	 * We will validate that the document version is >= 1.0.0.2
 	 * durring object verification.
 	 */
@@ -1131,7 +1131,7 @@ void parser_begin_ordering(mapred_parser_t *parser)
 	XASSERT(parser->current_obj);
 	XASSERT(parser->current_obj->kind == MAPRED_REDUCER);
 
-	/* 
+	/*
 	 * We will validate that the document version is >= 1.0.0.3
 	 * durring object verification.
 	 */
@@ -1151,7 +1151,7 @@ void parser_add_ordering(mapred_parser_t *parser, char *value)
 	XASSERT(parser->current_obj);
 	XASSERT(parser->current_obj->kind == MAPRED_REDUCER);
 
-	/* 
+	/*
 	 * Validate ordering:
 	 *   In general ordering can be an arbitrary expression so it is
 	 *   difficult to verify easily.  If we need more verification it
@@ -1393,7 +1393,7 @@ void parser_add_column(mapred_parser_t *parser, char *value)
 	XASSERT(parser->current_obj);
 	XASSERT(parser->current_obj->kind == MAPRED_INPUT);
 
-	/* 
+	/*
 	 * Verify the new column
 	 * It should be in one of two forms:
 	 *    1)   <name>
@@ -1445,7 +1445,7 @@ void parser_add_parameter(mapred_parser_t *parser, char *value)
 			parser->current_obj->kind == MAPRED_COMBINER   ||
 			parser->current_obj->kind == MAPRED_FINALIZER);
 
-	/* 
+	/*
 	 * Verify the new parameter
 	 * It should be in one of two forms:
 	 *    1)   <name>
@@ -1497,7 +1497,7 @@ void parser_add_return(mapred_parser_t *parser, char *value)
 			parser->current_obj->kind == MAPRED_COMBINER   ||
 			parser->current_obj->kind == MAPRED_FINALIZER);
 
-	/* 
+	/*
 	 * Verify the new return
 	 * It should be in one of two forms:
 	 *    1)   <name>
@@ -1730,7 +1730,7 @@ void mapred_dump_yaml(mapred_object_t *obj)
 			{
 				mapred_plist_t *plist;
 				printf("      PARAMETERS:\n");
-				for (plist = obj->u.function.parameters; plist; 
+				for (plist = obj->u.function.parameters; plist;
 					 plist = plist->next)
 					printf("        - %s %s\n", plist->name, plist->type);
 			}
@@ -1738,7 +1738,7 @@ void mapred_dump_yaml(mapred_object_t *obj)
 			{
 				mapred_plist_t *plist;
 				printf("      RETURNS:\n");
-				for (plist = obj->u.function.returns; plist; 
+				for (plist = obj->u.function.returns; plist;
 					 plist = plist->next)
 					printf("        - %s %s\n", plist->name, plist->type);
 			}
@@ -1787,16 +1787,16 @@ void mapred_dump_yaml(mapred_object_t *obj)
 			if (obj->name)
 				printf("      NAME:       %s\n", obj->name);
 			if (obj->u.reducer.transition.name)
-				printf("      TRANSITION: %s\n", 
+				printf("      TRANSITION: %s\n",
 					   obj->u.reducer.transition.name);
 			if (obj->u.reducer.combiner.name)
-				printf("      CONSOLIDATE:   %s\n", 
+				printf("      CONSOLIDATE:   %s\n",
 					   obj->u.reducer.combiner.name);
 			if (obj->u.reducer.finalizer.name)
-				printf("      FINALIZE:  %s\n", 
+				printf("      FINALIZE:  %s\n",
 					   obj->u.reducer.finalizer.name);
 			if (obj->u.reducer.initialize)
-				printf("      INITIALIZE: %s\n", 
+				printf("      INITIALIZE: %s\n",
 					   obj->u.reducer.initialize);
 			if (obj->u.reducer.keys)
 			{
@@ -1834,7 +1834,7 @@ void mapred_dump_yaml(mapred_object_t *obj)
 
 		case MAPRED_NO_KIND:
 		default:
-			XRAISE(MAPRED_PARSE_INTERNAL, 
+			XRAISE(MAPRED_PARSE_INTERNAL,
 				   "Unknown object type");
 	}
 }
@@ -1854,13 +1854,13 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 	{
 		case MAPRED_DOCUMENT:
 			
-			/* 
+			/*
 			 * If there is a version on the document then it should have
 			 * been validated by parser_set_version()
 			 */
 			if (!obj->u.document.version)
 			{
-				error = mapred_obj_error(obj, "Missing VERSION", 
+				error = mapred_obj_error(obj, "Missing VERSION",
 										 parser->doc_number);
 			}
 
@@ -1872,13 +1872,13 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 			if (!obj->name)
 				error = mapred_obj_error(obj, "Missing NAME");
 			if (obj->u.input.type == MAPRED_INPUT_NONE)
-				error = mapred_obj_error(obj, 
+				error = mapred_obj_error(obj,
 						  "Missing FILE, GPFDIST, TABLE, QUERY, or EXEC");
 
 			/* set default values */
 			if (error == NO_ERROR)
 			{
-				if (!obj->u.input.columns) 
+				if (!obj->u.input.columns)
 				{
 					obj->u.input.columns = malloc(sizeof(mapred_plist_t));
 					obj->u.input.columns->name = copyscalar("value");
@@ -1921,7 +1921,7 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 			if (obj->u.function.language && !obj->u.function.body)
 				error = mapred_obj_error(obj, "Missing FUNCTION");
 
-			/* 
+			/*
 			 * LIBRARY is required for "C" language functions.
 			 * LIBRARY is invalid for any other language.
 			 *
@@ -1932,20 +1932,20 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 			if (obj->u.function.language)
 			{
 				if (obj->u.function.library)
-				{ 
+				{
 					if (strcasecmp("C", obj->u.function.language))
 					{
 						error = mapred_obj_error(obj, "LIBRARY is invalid for "
 												 "%s LANGUAGE functions",
 												 obj->u.function.language);
 					}
-				} 
+				}
 				else if (!strcasecmp("C", obj->u.function.language))
 				{
 					error = mapred_obj_error(obj, "Missing LIBRARY");
 				}
 
-				/* 
+				/*
 				 * Don't bother filling in default arguments if we already have
 				 * an error.
 				 */
@@ -1983,7 +1983,7 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 							if (!obj->u.function.parameters->next)
 							{
 								error = mapred_obj_error(
-									obj, 
+									obj,
 									"requires at least 2 input parameters [state, arg1, ...]"
 									);
 							}
@@ -1994,7 +1994,7 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 								obj->u.function.parameters->next->next)
 							{
 								error = mapred_obj_error(
-									obj, 
+									obj,
 									"requires exactly 2 input parameters [state1, state2]"
 									);
 							}
@@ -2004,7 +2004,7 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 							if (obj->u.function.parameters->next)
 							{
 								error = mapred_obj_error(
-									obj, 
+									obj,
 									"requires exactly 1 input parameter [state]"
 									);
 							}
@@ -2048,7 +2048,7 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 				/* Set default mode: depends on type of function */
 				if (obj->u.function.mode == MAPRED_MODE_NONE)
 				{
-					if (obj->kind == MAPRED_TRANSITION || 
+					if (obj->kind == MAPRED_TRANSITION ||
 						obj->kind == MAPRED_COMBINER)
 					{
 						obj->u.function.mode = MAPRED_MODE_SINGLE;
@@ -2067,7 +2067,7 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 				error = mapred_obj_error(obj, "Missing NAME");
 			if (!obj->u.reducer.transition.name)
 				error = mapred_obj_error(obj, "Missing TRANSITION");
-			/* 
+			/*
 			 * Will verify that functions are valid for reducer input after we
 			 * have resolved the pointers.
 			 */
@@ -2079,12 +2079,12 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 			 */
 
 			/*
-			 * ORDERING and COMBINER are incompatible 
+			 * ORDERING and COMBINER are incompatible
 			 */
 			if (obj->u.reducer.ordering != NULL &&
 				obj->u.reducer.combiner.name)
 			{
-				error = mapred_obj_error(obj, 
+				error = mapred_obj_error(obj,
 										 "REDUCERS cannot specify both a COMBINER "
 										 "function and an ORDERING specification");
 			}
@@ -2113,13 +2113,13 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 				error = mapred_obj_error(obj, "Missing SOURCE");
 			
 			/* IDENTITY Mappers and Reducers */
-			if (obj->u.task.mapper.name && 
+			if (obj->u.task.mapper.name &&
 				!strcasecmp("IDENTITY", obj->u.task.mapper.name))
 			{
 				free(obj->u.task.mapper.name);
 				obj->u.task.mapper.name = NULL;
 			}
-			if (obj->u.task.reducer.name && 
+			if (obj->u.task.reducer.name &&
 				!strcasecmp("IDENTITY", obj->u.task.reducer.name))
 			{
 				free(obj->u.task.reducer.name);
@@ -2127,7 +2127,7 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj)
 			}
 
 			/* STDOUT Output */
-			if (obj->u.task.output.name && 
+			if (obj->u.task.output.name &&
 				!strcasecmp("STDOUT", obj->u.task.output.name))
 			{
 				free(obj->u.task.output.name);

--- a/src/test/regress/input/mapred.source
+++ b/src/test/regress/input/mapred.source
@@ -203,9 +203,10 @@ SELECT mapreduce('@abs_srcdir@/yml/grep.yml', 'key=an') ORDER BY 1;
 SELECT mapreduce('@abs_srcdir@/yml/grep2.yml', 'key=an') ORDER BY 1;
 
 --
--- Test 5) Tests a basic reduce function
+-- Test 5) Tests a basic reduce function and the builtin counterpart
 --
 SELECT mapreduce('@abs_srcdir@/yml/agebracket.yml') ORDER BY 1;
+SELECT mapreduce('@abs_srcdir@/yml/agebracket_builtin.yml') ORDER BY 1;
 
 --
 -- Test 6) File Output tests

--- a/src/test/regress/mapred/agebracket.source
+++ b/src/test/regress/mapred/agebracket.source
@@ -27,6 +27,8 @@ DEFINE:
   - TRANSITION:
       NAME:     myAdd
       LANGUAGE: perlu
+      PARAMETERS: [state integer, value integer]
+      RETURNS: value integer
       FUNCTION: |
         my ($state, $value) = @_;
         return $state + $value;

--- a/src/test/regress/mapred/agebracket_builtin.source
+++ b/src/test/regress/mapred/agebracket_builtin.source
@@ -1,0 +1,32 @@
+%YAML 1.1
+---
+VERSION:         1.0.0.1
+
+DEFINE:
+  - INPUT:
+      NAME:      access_logs
+      FILE:      @hostname@:@abs_srcdir@/data/person.data
+      COLUMNS:
+        - name text
+        - age integer
+        - location point
+
+  - MAP:
+      NAME:       bracketize
+      LANGUAGE:   perlu
+      PARAMETERS: age integer
+      RETURNS:    [key text, value integer]
+      FUNCTION:  |
+        use POSIX qw(ceil floor);
+        my ($age) = @_;
+        my ($lower, $upper) = (floor($age/10.0)*10, ceil($age/10.0)*10);
+        $upper += 10 if ($lower == $upper);
+        my ($bracket) = "$lower => age < $upper";
+        return [{"key" => $bracket, "value" => 1}] ;
+
+EXECUTE:
+  - RUN:
+      SOURCE:    access_logs
+      MAP:       bracketize
+      REDUCE:    SUM
+

--- a/src/test/regress/output/mapred.source
+++ b/src/test/regress/output/mapred.source
@@ -366,9 +366,31 @@ susan  | 78|(6.579,3)
 
 (3 rows)
 --
--- Test 5) Tests a basic reduce function
+-- Test 5) Tests a basic reduce function and the builtin counterpart
 --
 SELECT mapreduce('@abs_srcdir@/yml/agebracket.yml') ORDER BY 1;
+mapreduce
+---------------------
+STDERR> mapreduce_73703_run_1
+STDERR> 
+STDOUT>
+key            |value
+---------------+-----
+0 => age < 10  |    2
+10 => age < 20 |    6
+20 => age < 30 |    6
+30 => age < 40 |    8
+40 => age < 50 |    4
+50 => age < 60 |    5
+60 => age < 70 |    4
+70 => age < 80 |    6
+80 => age < 90 |    6
+90 => age < 100|    3
+(10 rows)
+
+
+(3 rows)
+SELECT mapreduce('@abs_srcdir@/yml/agebracket_builtin.yml') ORDER BY 1;
 mapreduce
 ---------------------
 STDERR> mapreduce_73703_run_1


### PR DESCRIPTION
Handle implicit casting between text and integer in the mapred test suite. The mapred code assumes text datatype for everything unless the parameter types are explicitly stated so mark the parameters to the sum function as integer. This is a test that started failing in the merge branch due to the removal of implicit casts but since the fix applies to master just as well we can fix it here and reduce the merge footprint. Further, the agebracket.yml mapred test case is testing the reduction with a simple reducer summing the values. GPMapred has a builtin SUM reducer however which will yield the same result, extend the test with a copy of the agebracket.yml test using the builtin ensuring that the output is identical.

While I was reading the code I also fixed lots and lots of trailing whitespace issues and a few spelling errors which are included in this PR. Reading the PR commit by commit is recommended.