### PR TITLE
Orca Translator changes due to removal of UlSystemColumns api in IMDRelation

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1089,7 +1089,7 @@ CTranslatorDXLToPlStmt::PtsFromDXLTblScan
 	const CDXLTableDescr *pdxltabdesc = pdxlopTS->Pdxltabdesc();
 	
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	const ULONG ulRelCols = pmdrel->UlColumns() - pmdrel->UlSystemColumns();
+	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
 	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= ACL_SELECT;
@@ -1289,7 +1289,7 @@ CTranslatorDXLToPlStmt::PisFromDXLIndexScan
 	}
 
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlopIndexScan->Pdxltabdesc()->Pmdid());
-	const ULONG ulRelCols = pmdrel->UlColumns() - pmdrel->UlSystemColumns();
+	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
 	RangeTblEntry *prte = PrteFromTblDescr(pdxlopIndexScan->Pdxltabdesc(), pdxlid, ulRelCols, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= ACL_SELECT;
@@ -4217,8 +4217,7 @@ CTranslatorDXLToPlStmt::PplanDTS
 	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
 
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
-	const ULONG ulRelCols = pmdrel->UlColumns() - pmdrel->UlSystemColumns();
-	
+	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
 	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= ACL_SELECT;
@@ -4295,8 +4294,7 @@ CTranslatorDXLToPlStmt::PplanDIS
 	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
 
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
-	const ULONG ulRelCols = pmdrel->UlColumns() - pmdrel->UlSystemColumns();
-
+	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
 	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= ACL_SELECT;
@@ -4457,7 +4455,7 @@ CTranslatorDXLToPlStmt::PplanDML
 	m_plResultRelations = gpdb::PlAppendInt(m_plResultRelations, iRel);
 
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
-	const ULONG ulRelCols = pmdrel->UlColumns() - pmdrel->UlSystemColumns();
+	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
 
 	CDXLTableDescr *pdxltabdesc = pdxlop->Pdxltabdesc();
 	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
@@ -5972,7 +5970,7 @@ CTranslatorDXLToPlStmt::PplanBitmapTableScan
 	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
 
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	const ULONG ulRelCols = pmdrel->UlColumns() - pmdrel->UlSystemColumns();
+	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
 
 	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1087,10 +1087,8 @@ CTranslatorDXLToPlStmt::PtsFromDXLTblScan
 	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
 
 	const CDXLTableDescr *pdxltabdesc = pdxlopTS->Pdxltabdesc();
-	
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
-	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
+	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= ACL_SELECT;
 	m_pctxdxltoplstmt->AddRTE(prte);
@@ -1289,8 +1287,8 @@ CTranslatorDXLToPlStmt::PisFromDXLIndexScan
 	}
 
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlopIndexScan->Pdxltabdesc()->Pmdid());
-	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
-	RangeTblEntry *prte = PrteFromTblDescr(pdxlopIndexScan->Pdxltabdesc(), pdxlid, ulRelCols, iRel, &dxltrctxbt);
+
+	RangeTblEntry *prte = PrteFromTblDescr(pdxlopIndexScan->Pdxltabdesc(), pdxlid, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= ACL_SELECT;
 	m_pctxdxltoplstmt->AddRTE(prte);
@@ -4216,9 +4214,7 @@ CTranslatorDXLToPlStmt::PplanDTS
 	// add the new range table entry as the last element of the range table
 	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
 
-	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
-	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
-	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
+	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= ACL_SELECT;
 
@@ -4294,8 +4290,7 @@ CTranslatorDXLToPlStmt::PplanDIS
 	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
 
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
-	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
-	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
+	RangeTblEntry *prte = PrteFromTblDescr(pdxlop->Pdxltabdesc(), NULL /*pdxlid*/, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= ACL_SELECT;
 	m_pctxdxltoplstmt->AddRTE(prte);
@@ -4455,10 +4450,9 @@ CTranslatorDXLToPlStmt::PplanDML
 	m_plResultRelations = gpdb::PlAppendInt(m_plResultRelations, iRel);
 
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxlop->Pdxltabdesc()->Pmdid());
-	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
 
 	CDXLTableDescr *pdxltabdesc = pdxlop->Pdxltabdesc();
-	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
+	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= aclmode;
 	m_pctxdxltoplstmt->AddRTE(prte);
@@ -4920,11 +4914,15 @@ CTranslatorDXLToPlStmt::PrteFromTblDescr
 	(
 	const CDXLTableDescr *pdxltabdesc,
 	const CDXLIndexDescr *pdxlid, // should be NULL unless we have an index-only scan
-	ULONG ulRelColumns,
 	Index iRel,
 	CDXLTranslateContextBaseTable *pdxltrctxbtOut
 	)
 {
+	GPOS_ASSERT(NULL != pdxltabdesc);
+
+	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
+	const ULONG ulRelColumns = CTranslatorUtils::UlNonSystemColumns(pmdrel);
+
 	RangeTblEntry *prte = MakeNode(RangeTblEntry);
 	prte->rtekind = RTE_RELATION;
 
@@ -5970,9 +5968,8 @@ CTranslatorDXLToPlStmt::PplanBitmapTableScan
 	Index iRel = gpdb::UlListLength(m_pctxdxltoplstmt->PlPrte()) + 1;
 
 	const IMDRelation *pmdrel = m_pmda->Pmdrel(pdxltabdesc->Pmdid());
-	const ULONG ulRelCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
 
-	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, ulRelCols, iRel, &dxltrctxbt);
+	RangeTblEntry *prte = PrteFromTblDescr(pdxltabdesc, NULL /*pdxlid*/, iRel, &dxltrctxbt);
 	GPOS_ASSERT(NULL != prte);
 	prte->requiredPerms |= ACL_SELECT;
 

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -686,14 +686,15 @@ CTranslatorQueryToDXL::PdxlnInsert()
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("INSERT with constraints"));
 	}
 	
-	const ULONG ulLenTblCols = pmdrel->UlColumns() - pmdrel->UlSystemColumns();
+	const ULONG ulLenTblCols = CTranslatorUtils::UlNonSystemColumns(pmdrel);
 	const ULONG ulLenTL = gpdb::UlListLength(m_pquery->targetList);
 	GPOS_ASSERT(ulLenTblCols >= ulLenTL);
 	GPOS_ASSERT(ulLenTL == m_pdrgpdxlnQueryOutput->UlLength());
 
 	CDXLNode *pdxlnPrL = NULL;
 	
-	const ULONG ulLenNonDroppedCols = pmdrel->UlNonDroppedCols() - pmdrel->UlSystemColumns();
+	const ULONG ulSystemCols = pmdrel->UlColumns() - ulLenTblCols;
+	const ULONG ulLenNonDroppedCols = pmdrel->UlNonDroppedCols() - ulSystemCols;
 	if (ulLenNonDroppedCols > ulLenTL)
 	{
 		// missing target list entries

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -811,7 +811,7 @@ CTranslatorUtils::PdrgdxlcdComposite
 
 	for (ULONG ul = 0; ul < pdrgPmdCol->UlLength(); ul++)
 	{
-		CMDColumn *pmdcol = (*pdrgPmdCol)[ul];
+		IMDColumn *pmdcol = (*pdrgPmdCol)[ul];
 
 		CMDName *pmdColName = GPOS_NEW(pmp) CMDName(pmp, pmdcol->Mdname().Pstr());
 		IMDId *pmdidColType = pmdcol->PmdidType();
@@ -3074,5 +3074,36 @@ CTranslatorUtils::PlAssertErrorMsgs
 	return plErrorMsgs;
 }
 
+//---------------------------------------------------------------------------
+//	@function:
+//		CTranslatorUtils::UlNonSystemColumns
+//
+//	@doc:
+//		Return the count of non-system columns in the relation
+//
+//---------------------------------------------------------------------------
+ULONG
+CTranslatorUtils::UlNonSystemColumns
+	(
+	const IMDRelation *pmdrel
+	)
+{
+	GPOS_ASSERT(NULL != pmdrel);
+
+	ULONG ulNonSystemCols = 0;
+
+	const ULONG ulCols = pmdrel->UlColumns();
+	for (ULONG ul = 0; ul < ulCols; ul++)
+	{
+		const IMDColumn *pmdcol  = pmdrel->Pmdcol(ul);
+
+		if (!pmdcol->FSystemColumn())
+		{
+			ulNonSystemCols++;
+		}
+	}
+
+	return ulNonSystemCols;
+}
 
 // EOF

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -607,7 +607,6 @@ namespace gpdxl
 				(
 				const CDXLTableDescr *pdxltabdesc,
 				const CDXLIndexDescr *pdxlid,
-				ULONG ulRelColumns,
 				Index iRel,
 				CDXLTranslateContextBaseTable *pdxltrctxbtOut
 				);

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -461,6 +461,10 @@ namespace gpdxl
 			// translate the list of error messages from an assert constraint list
 			static 
 			List *PlAssertErrorMsgs(CDXLNode *pdxlnAssertConstraintList);
+
+			// return the count of non-system columns in the relation
+			static
+			ULONG UlNonSystemColumns(const IMDRelation *pmdrel);
 	};
 }
 


### PR DESCRIPTION
Related to https://github.com/greenplum-db/gporca/pull/47

There was several GPDB specific implicit assumption inside Orca w.r.t system columns are always in the end.

@oarap @d @hsyuan @xinzweb please take a look