### PR TITLE
Handle incorrect relation OID passed to pg_partition_oid()

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -2148,7 +2148,7 @@ partMakePartition(HeapTuple tuple, TupleDesc tupdesc)
 
 /*
  * Construct a PartitionNode-PartitionRule tree for the given part.
- * Recurs to contruct branches.  Note that the ParitionRule (and,
+ * Recurs to construct branches.  Note that the PartitionRule (and,
  * hence, the Oid) of the given part itself is not included in the
  * result.
  *

--- a/src/backend/optimizer/plan/planpartition.c
+++ b/src/backend/optimizer/plan/planpartition.c
@@ -1064,6 +1064,10 @@ static void InitPMI(PartitionMatchInfo *pmi, Oid partitionOid, MemoryContext mct
 
 	pmi->partitionOid = partitionOid;
 	pmi->partitionInfo = RelationBuildPartitionDescByOid(pmi->partitionOid, false);
+	if (!pmi->partitionInfo)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("relation with OID %u does not exist", partitionOid)));
 
 	pmi->partitionState = createPartitionState(pmi->partitionInfo, 0);
 

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -7786,6 +7786,9 @@ select * from deep_part;
  5 | 5 | 5 | M    
 (6 rows)
 
+-- Incorrect relation OID in pg_partition_oid()
+select pg_partition_oid(1, deep_part.*) from deep_part;
+ERROR:  relation with OID 1 does not exist
 drop table input2;
 drop table input1;
 drop table part_tab;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -7757,6 +7757,9 @@ select * from deep_part;
  5 | 5 | 5 | M    
 (5 rows)
 
+-- Incorrect relation OID in pg_partition_oid()
+select pg_partition_oid(1, deep_part.*) from deep_part;
+ERROR:  relation with OID 1 does not exist
 drop table input2;
 drop table input1;
 drop table part_tab;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3690,6 +3690,9 @@ select * from deep_part_1_prt_female_2_prt_5_3_prt_5;
 insert into deep_part values (9, 9, 10, 'F');
 select * from deep_part;
 
+-- Incorrect relation OID in pg_partition_oid()
+select pg_partition_oid(1, deep_part.*) from deep_part;
+
 drop table input2;
 drop table input1;
 drop table part_tab;


### PR DESCRIPTION
The PartitionNode tree returned from `RelationBuildPartitionDescByOid` will be NULL in case the OID passed isn't present in `pg_partition` so we must abort with error to avoid segfaulting on NULL pointer deref. Also add a test in the partition suite for this and fixed a typo in related code. Not sure if there is anything more helpful we can do here except error out but it seems the safe way.

Reported in #264.