### PR TITLE
Remove -O3 -funroll-loops -finline-limit=1800 from "standard" gcc opt…

### DIFF
--- a/configure
+++ b/configure
@@ -4251,7 +4251,7 @@ unset CFLAGS
 # If the user specifies something in the environment, that is used.
 # else:  If the template file set something, that is used.
 # else:  If coverage was enabled, don't set anything.
-# else:  If the compiler is GCC, then we use -O3.
+# else:  If the compiler is GCC, then we use -O2.
 # else:  If the compiler is something else, then we use -O, unless debugging.
 
 if test "$ac_env_CFLAGS_set" = set; then
@@ -4261,7 +4261,7 @@ elif test "${CFLAGS+set}" = set; then
 elif test "$enable_coverage" = yes; then
   : # no optimization by default
 elif test "$GCC" = yes; then
-  CFLAGS="-O3"
+  CFLAGS="-O2"
 else
   # if the user selected debug mode, don't use -O
   if test "$enable_debug" != yes; then

--- a/configure.in
+++ b/configure.in
@@ -317,7 +317,7 @@ unset CFLAGS
 # If the user specifies something in the environment, that is used.
 # else:  If the template file set something, that is used.
 # else:  If coverage was enabled, don't set anything.
-# else:  If the compiler is GCC, then we use -O3.
+# else:  If the compiler is GCC, then we use -O2.
 # else:  If the compiler is something else, then we use -O, unless debugging.
 
 if test "$ac_env_CFLAGS_set" = set; then
@@ -327,7 +327,7 @@ elif test "${CFLAGS+set}" = set; then
 elif test "$enable_coverage" = yes; then
   : # no optimization by default
 elif test "$GCC" = yes; then
-  CFLAGS="-O3"
+  CFLAGS="-O2"
 else
   # if the user selected debug mode, don't use -O
   if test "$enable_debug" != yes; then

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -136,13 +136,11 @@ GPPKG_PLATFORMS=rhel5_x86_64 rhel6_x86_64 suse10_x86_64 suse11_x86_64
 # Compiler options
 #---------------------------------------------------------------------
 
-INLINE_FLAGS=-finline-limit=1800
-
-OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -funroll-loops -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(INLINE_FLAGS) $(TRACE_GCC_FLAG))"
-PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -funroll-loops -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(INLINE_FLAGS) $(TRACE_GCC_FLAG))"
+OPTFLAGS="$(strip $(BLD_CFLAGS) -fno-omit-frame-pointer $(COPTX) -g $(TRACE_GCC_FLAG))"
+PROFFLAGS="$(strip $(BLD_CFLAGS) -fno-omit-frame-pointer $(COPTX) -g $(TRACE_GCC_FLAG))"
 
 ifeq (on, ${GPDBGINLINE})
-CFLAGS_INLINE=$(INLINE_FLAGS)
+CFLAGS_INLINE=
 else
 CFLAGS_INLINE=-fno-inline
 endif


### PR DESCRIPTION
…ions.

The "standard" gcc options in gpAux/Makefile, used to do a full build of
the installers, were using dubious compiler flags. -O3 enables some extra
optimizations that might be beneficial in some cases, but it also makes
binaries larger which can in fact hurt performance. Likewise, aggressive
inlining can improve performance in hot spots, but when applied
indiscriminately, it makes binaries larger for little gain. For lack of
better evidence, let's trust the compiler defaults. This makes the build
faster, and the binaries smaller. If we find out that these options are
beneficial for some specific functions or source files, let's add them
back to those special cases.

Per discussion on gpdb-dev: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/FtDFjoZ9Ixc/baLzCrxPBQAJ