### PR TITLE
Change Resource Queue locking and rewrite the way resource locks are managed

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3329,6 +3329,8 @@ CommitTransaction(void)
 	/* Close any open regular cursors */
 	AtCommit_Portals();
 
+	ResLockPreEmptiveUnlock();
+
 	/* Perform any Resource Scheduler commit procesing. */
 	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
 		AtCommit_ResScheduler();
@@ -3707,6 +3709,7 @@ PrepareTransaction(void)
 	/* Close any open regular cursors */
 	AtCommit_Portals();
 
+	ResLockPreEmptiveUnlock();
 	/*
 	 * Let ON COMMIT management do its thing (must happen after closing
 	 * cursors, to avoid dangling-reference problems)
@@ -4001,6 +4004,8 @@ AbortTransaction(void)
 	AfterTriggerEndXact(false);
 	AtAbort_Portals();
 	AtAbort_ExtTables();
+
+	ResLockPreEmptiveUnlock();
 
 	/* Perform any Resource Scheduler abort procesing. */
 	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -372,6 +372,7 @@ PortalCleanupHelper(Portal portal, volatile int *cleanupstate)
 	/* 
 	 * If resource scheduling is enabled, release the resource lock. 
 	 */
+		if(ResourceScheduler && ResourceQueueUseCost)
         ResUnLockPortal(portal);
 
 	/**

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2020,9 +2020,8 @@ _SPI_pquery(QueryDesc * queryDesc, bool fire_triggers, long tcount)
 			 * If the Active portal already hold a lock on the queue, we cannot
 			 * acquire it again.
 			 */
-			if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler &&
-					!superuser()
-			   )
+			if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler && ResourceQueueUseCost
+				&& !superuser())
 			{
 				/*
 				 * This is SELECT, so we should have planTree anyway.

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -2229,6 +2229,12 @@ PostPrepare_Locks(TransactionId xid)
 		LWLockRelease(partitionLock);
 	}							/* loop over partitions */
 
+	/* If holding a Resource Queue Slot lock, release it */
+	if (ResourceScheduler && !superuser() && !ResourceQueueUseCost)
+	{
+		ResLockPreEmptiveUnlock();
+	}
+
 	END_CRIT_SECTION();
 }
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -85,6 +85,7 @@
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbgang.h"
+#include "cdb/memquota.h"
 #include "cdb/ml_ipc.h"
 #include "utils/guc.h"
 #include "access/twophase.h"
@@ -1542,6 +1543,8 @@ exec_simple_query(const char *query_string, const char *seqServerHost, int seqSe
 	bool		was_logged = false;
 	bool		isTopLevel = false;
 	char		msec_str[32];
+	ResPortalIncrement	incData;
+	bool takeLock = false;
 
 	if (Gp_role != GP_ROLE_EXECUTE)
 	{
@@ -1699,7 +1702,92 @@ exec_simple_query(const char *query_string, const char *seqServerHost, int seqSe
 
 		/* If we got a cancel signal in parsing or prior command, quit */
 		CHECK_FOR_INTERRUPTS();
-		
+
+		/* Check if resource scheduling is enabled and process accordingly */
+		if (Gp_role == GP_ROLE_DISPATCH && !superuser() && ResourceScheduler && !ResourceQueueUseCost)
+		{
+			memset(&incData, 0x00, sizeof(incData));
+			switch (nodeTag(parsetree))
+			{
+
+				/*
+			 	* For INSERT/UPDATE/DELETE Skip if we have specified only SELECT,
+			 	* otherwise drop through to handle like a SELECT.
+			 	*/
+				case T_InsertStmt:
+				case T_DeleteStmt:
+				case T_UpdateStmt:
+				{
+					if (ResourceSelectOnly)
+					{
+						takeLock = false;
+						break;
+					}
+				}
+
+				case T_SelectStmt:
+				case T_DeclareCursorStmt:
+				{
+					/*
+				 	* Setup the resource portal increments, ready to be added.
+					*/
+					incData.pid = MyProc->pid;
+					// Setup with INVALID_PORTALID as in this case we have one increment per session, not per portal
+					incData.portalId = INVALID_PORTALID;
+					incData.increments[RES_COUNT_LIMIT] = 1;
+
+					if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
+					{
+						Assert(gp_resqueue_memory_policy == RESQUEUE_MEMORY_POLICY_AUTO ||
+								gp_resqueue_memory_policy == RESQUEUE_MEMORY_POLICY_EAGER_FREE);
+
+						uint64 queryMemory = ResourceQueueGetQueryMemoryLimit(NULL, GetResQueueId());
+						Assert(queryMemory > 0);
+						if (gp_log_resqueue_memory)
+						{
+							elog(gp_resqueue_memory_log_level, "query requested %.0fKB", (double) queryMemory / 1024.0);
+						}
+
+						incData.increments[RES_MEMORY_LIMIT] = (Cost) queryMemory;
+					}
+					else 
+					{
+						Assert(gp_resqueue_memory_policy == RESQUEUE_MEMORY_POLICY_NONE);
+						incData.increments[RES_MEMORY_LIMIT] = (Cost) 0.0;				
+					}
+					takeLock = true;
+				}
+				break;
+
+				case T_CopyStmt:
+				{
+					incData.pid = MyProc->pid;
+					// Setup with INVALID_PORTALID as in this case we have one increment per session, not per portal
+					incData.portalId = INVALID_PORTALID;
+					incData.increments[RES_COUNT_LIMIT] = 1;
+					incData.increments[RES_MEMORY_LIMIT] = (Cost) 0.0;
+
+					takeLock = true;
+				}
+				break;
+
+				/*
+				 * We do not want to lock any of these query types.
+				*/
+				default:
+				{
+
+					takeLock = false;
+				}
+				break;
+			}
+
+			if (takeLock)
+			{
+				ResLockPreEmptivelock(&incData);
+			}
+		}
+
 		/*
 		 * Set up a snapshot if parse analysis/planning will need one.
 		 */
@@ -1851,7 +1939,6 @@ exec_simple_query(const char *query_string, const char *seqServerHost, int seqSe
 		 */
 		EndCommand(completionTag, dest);
 	}							/* end loop over parsetrees */
-
 	/*
 	 * Close down transaction statement, if one is open.
 	 */
@@ -1912,6 +1999,8 @@ exec_parse_message(const char *query_string,	/* string to execute */
 	bool		save_log_statement_stats = log_statement_stats;
 	char		msec_str[32];
 	NodeTag		sourceTag = T_Query;
+	ResPortalIncrement	incData;
+	bool takeLock = false;
 
 	/*
 	 * Report query to various monitoring facilities.
@@ -1998,6 +2087,87 @@ exec_parse_message(const char *query_string,	/* string to execute */
 		Node	   *parsetree = (Node *) linitial(parsetree_list);
 		Snapshot        mySnapshot = NULL;
 		int			i;
+
+		memset(&incData, 0x00, sizeof(incData));
+		switch (nodeTag(parsetree))
+		{
+
+			/*
+			* For INSERT/UPDATE/DELETE Skip if we have specified only SELECT,
+			* otherwise drop through to handle like a SELECT.
+			*/
+			case T_InsertStmt:
+			case T_DeleteStmt:
+			case T_UpdateStmt:
+			{
+				if (ResourceSelectOnly)
+				{
+					takeLock = false;
+					break;
+				}
+			}
+
+			case T_SelectStmt:
+			case T_DeclareCursorStmt:
+			{
+				/*
+				* Setup the resource portal increments, ready to be added.
+				*/
+				incData.pid = MyProc->pid;
+				// Setup with INVALID_PORTALID as in this case we have one increment per session, not per portal
+				incData.portalId = INVALID_PORTALID;
+				incData.increments[RES_COUNT_LIMIT] = 1;
+
+				if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
+				{
+					Assert(gp_resqueue_memory_policy == RESQUEUE_MEMORY_POLICY_AUTO ||
+							gp_resqueue_memory_policy == RESQUEUE_MEMORY_POLICY_EAGER_FREE);
+
+					uint64 queryMemory = ResourceQueueGetQueryMemoryLimit(NULL, GetResQueueId());
+					Assert(queryMemory > 0);
+					if (gp_log_resqueue_memory)
+					{
+						elog(gp_resqueue_memory_log_level, "query requested %.0fKB", (double) queryMemory / 1024.0);
+					}
+
+					incData.increments[RES_MEMORY_LIMIT] = (Cost) queryMemory;
+				}
+				else
+				{
+					Assert(gp_resqueue_memory_policy == RESQUEUE_MEMORY_POLICY_NONE);
+					incData.increments[RES_MEMORY_LIMIT] = (Cost) 0.0;
+				}
+				takeLock = true;
+			}
+			break;
+
+			case T_CopyStmt:
+			{
+				incData.pid = MyProc->pid;
+				// Setup with INVALID_PORTALID as in this case we have one increment per session, not per portal
+				incData.portalId = INVALID_PORTALID;
+				incData.increments[RES_COUNT_LIMIT] = 1;
+				incData.increments[RES_MEMORY_LIMIT] = (Cost) 0.0;
+
+				takeLock = true;
+			}
+			break;
+
+			/*
+			 * We do not want to lock any of these query types.
+			*/
+			default:
+			{
+
+				takeLock = false;
+			}
+			break;
+		}
+
+		if (takeLock)
+		{
+			ResLockPreEmptivelock(&incData);
+		}
 
 		/*
 		 * Get the command name for possible use in status display.
@@ -2110,6 +2280,8 @@ exec_parse_message(const char *query_string,	/* string to execute */
 							   commandTag,
 							   querytree_list,
 							   param_list,
+							   takeLock,
+							   &incData,
 							   false);
 	}
 	else
@@ -2125,6 +2297,9 @@ exec_parse_message(const char *query_string,	/* string to execute */
 		pstmt->query_list = querytree_list;
 		pstmt->argtype_list = param_list;
 		pstmt->from_sql = false;
+		pstmt->take_lock = takeLock;
+		pstmt->lock_isacquired = takeLock;
+		pstmt->incData = &incData;
 		pstmt->context = unnamed_stmt_context;
 		/* XXX prepare_time and from_sql default to 0! Correct? */
 		/* Now the unnamed statement is complete and valid */
@@ -2575,6 +2750,7 @@ exec_execute_message(const char *portal_name, int64 max_rows)
 	bool		execute_is_fetch = false;
 	bool		was_logged = false;
 	char		msec_str[32];
+	PreparedStatement *current_stmt = NULL;
 
 	/* Adjust destination to tell printtup.c what to do */
 	dest = whereToSendOutput;
@@ -2668,6 +2844,20 @@ exec_execute_message(const char *portal_name, int64 max_rows)
 		else
 			prepStmtName = "<unnamed>";
 		portalParams = portal->portalParams;
+	}
+
+	current_stmt = FetchPreparedStatement(prepStmtName, false);
+
+	/*
+	 * When the prepared statement was first stored in the structure, ResourceQueueUseCost
+	 * Queue Slot lock was acquired. This is for case when a stored prepared statement is
+	 * executed */
+	if (current_stmt)
+	{
+		if (current_stmt->take_lock && !(current_stmt->lock_isacquired))
+		{
+			ResLockPreEmptivelock(current_stmt->incData);
+		}
 	}
 
 	/*

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -248,7 +248,7 @@ ProcessQuery(Portal portal,
 	 * we are superuser.
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH && 
-		ResourceScheduler && 
+		ResourceScheduler && ResourceQueueUseCost &&
 		(!ResourceSelectOnly || portal->sourceTag == T_SelectStmt) && 
 		stmt->canSetTag
 		&& !superuser())
@@ -778,6 +778,7 @@ PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
 				 */
 				if (Gp_role == GP_ROLE_DISPATCH
 						&& ResourceScheduler
+						&& ResourceQueueUseCost
 						&& !superuser() )
 				{
 					/* 
@@ -815,6 +816,7 @@ PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
 				if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE
 						&& Gp_role == GP_ROLE_DISPATCH
 						&& gp_session_id > -1
+						&& ResourceQueueUseCost
 						&& superuser())
 				{
 					queryDesc->plannedstmt->query_mem = ResourceQueueGetSuperuserQueryMemoryLimit();

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1453,6 +1453,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&ResourceScheduler,
 		true, NULL, NULL
 	},
+
+	{
+		{"resource_usecost", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("Use cost based checking in resource queues."),
+			NULL
+		},
+		&ResourceQueueUseCost,
+		true, NULL, NULL
+	},
+
 	{
 		{"resource_select_only", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("Enable resource locking of SELECT only."),

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -468,6 +468,7 @@ log_autostats=off	# print additional autostats information
 #max_resource_queues = 9		# no. of resource queues to create.
 #max_resource_portals_per_transaction = 64	# no. of portals per backend.
 #resource_select_only = on		# resource lock SELECT queries only.
+#resource_usecost = on		# resource queue use cost checking.
 #resource_cleanup_gangs_on_wait = on	# Cleanup idle reader gangs before
 										# resource lockwait.
 gp_resqueue_memory_policy = 'eager_free'	# memory request based queueing. 

--- a/src/backend/utils/resscheduler/README
+++ b/src/backend/utils/resscheduler/README
@@ -134,6 +134,8 @@ step.
 Also deadlocks with oneself are possible, usually only achiveable with several
 open cursors:
     ResCheckSelfDeadLock(LOCK *lock);
+
+NOTE: This specifically is not applicable to case when cost is not being used.
 -----------------------------------------------------------------------------
 
 Lock Design
@@ -270,16 +272,18 @@ however the symbol RESLOCK_DEBUG must be defined before they are enabled
 
 -----------------------------------------------------------------------------
 
-Notes
+Resource Queue Cost Checking Not Enabled
 -----
+The behaviour of disabling cost based checking for Resource Queues is a bit different.
+To disable cost based checking, use resource_usecost GUC and set it to false. This will
+lead to Resource Queues not using plan cost based checks and the only checks that will be used
+will be number of active statements and memory limit checks. This is for ensuring that taking
+Resource Queue Slot locks at time of query admission is safe and that this does not lead to
+problems later on. In case where plan cost based checking is enabled, we need to take the lock
+at Portal creation time so that the plan is generated and the cost based checking can be done successfully.
+With no cost based checking, we take the lock at query admission and release the lock only at end of transaction.
+This is in line with way other heavyweight locks are managed.
+Please note that SET SESSION AUTHORIZATION and SET ROLE inside explicit transactions are not allowed since Resource Queue Slot locks are now
+held across entire life of transaction
 
-[1] "Managed by the Resource Scheduler" - this deserves some explanation,
-     In the current incarnation of the code it means:
-
-       portal->queueId != InvalidOid
-       portal->releaseResLock == true
-
-     
-     Typically every portal gets queueId set at creation, but this may get 
-     reset when the to-lock-or-not-to-lock decision comes around (see 
-     ResLockPortal).
+-----------------------------------------------------------------------------

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -741,6 +741,9 @@ ResLockCheckLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementS
 
 			case RES_COST_LIMIT:
 			{
+				if (!ResourceQueueUseCost)
+					break;
+
 				Assert((limits[i].threshold_is_max));
 
 				/* Setup whether to increment or decrement the cost. */

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -127,7 +127,7 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 	bool			found;
 	ResourceOwner	owner;
 	ResQueue		queue;
-	int				status;
+	int				status = 0;
 
 	/* Setup the lock method bits. */
 	Assert(locktag->locktag_lockmethodid == RESOURCE_LOCKMETHOD);
@@ -227,7 +227,7 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 														HASH_ENTER_NULL,
 														&found);
 	locallock->proclock = proclock;
-    if (!proclock)
+	if (!proclock)
 	{
 		/* Not enough shmem for the proclock. */
 		if (lock->nRequested == 0)
@@ -306,38 +306,42 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 	}
 	PG_END_TRY();
 
-	/*
-	 * If the query cost is smaller than the ignore cost limit for this queue
-	 * then don't try to take a lock at all.
-	 */
-	if (incrementSet->increments[RES_COST_LIMIT] < queue->ignorecostlimit)
+	if (ResourceQueueUseCost)
 	{
-		/* Decrement requested. */
-		lock->nRequested--;
-		lock->requested[lockmode]--;
-		Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
-
-		/* Clean up this lock. */
-        if (proclock->nLocks == 0)
-		    RemoveLocalLock(locallock);
-
-		ResCleanUpLock(lock, proclock, hashcode, false);
-
-		LWLockRelease(ResQueueLock);
-		LWLockRelease(partitionLock);
-
 		/*
-		 * To avoid queue accounting problems, we will need to reset the
-		 * queueId and portalId for this portal *after* returning from
-		 * here.
-		 */
-		return LOCKACQUIRE_NOT_AVAIL;
+		 * If the query cost is smaller than the ignore cost limit for this queue
+		 * then don't try to take a lock at all.
+		*/
+		if (incrementSet->increments[RES_COST_LIMIT] < queue->ignorecostlimit)
+		{
+			/* Decrement requested. */
+			lock->nRequested--;
+			lock->requested[lockmode]--;
+			Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
+
+			/* Clean up this lock. */
+			if (proclock->nLocks == 0)
+				RemoveLocalLock(locallock);
+
+			ResCleanUpLock(lock, proclock, hashcode, false);
+
+			LWLockRelease(ResQueueLock);
+			LWLockRelease(partitionLock);
+
+			/*
+			 * To avoid queue accounting problems, we will need to reset the
+			 * queueId and portalId for this portal *after* returning from
+			 * here.
+			 */
+			return LOCKACQUIRE_NOT_AVAIL;
+		}
+
 	}
 
 	/*
-	 * Otherwise, we are going to take a lock, Add an increment to the 
+	 * Otherwise, we are going to take a lock, Add an increment to the
 	 * increment hash for this process.
-	 */
+	*/
 	incrementSet = ResIncrementAdd(incrementSet, proclock, owner);
 	if (!incrementSet)
 	{
@@ -375,15 +379,15 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
 
 		/* Clean up this lock. */
-        if (proclock->nLocks == 0)
-    		RemoveLocalLock(locallock);
+		if (proclock->nLocks == 0)
+			RemoveLocalLock(locallock);
 
 		ResCleanUpLock(lock, proclock, hashcode, false);
 
 		/* Kill off the increment. */
 		MemSet(&portalTag, 0, sizeof(ResPortalTag));
 		portalTag.pid = incrementSet->pid;
-		portalTag.portalId = incrementSet->portalId;
+		portalTag.portalId = ResourceQueueUseCost ? incrementSet->portalId : INVALID_PORTALID;
 
 		ResIncrementRemove(&portalTag);
 
@@ -400,6 +404,7 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		 * queue, so record this in the local lock hash, and grant it.
 		 */
 		ResGrantLock(lock, proclock);
+
 		ResLockUpdateLimit(lock, proclock, incrementSet, true);
 
 		LWLockRelease(ResQueueLock);
@@ -436,11 +441,10 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 
 			ResCleanUpLock(lock, proclock, hashcode, false);
 
-
 			/* Kill off the increment. */
 			MemSet(&portalTag, 0, sizeof(ResPortalTag));
 			portalTag.pid = incrementSet->pid;
-			portalTag.portalId = incrementSet->portalId;
+			portalTag.portalId = ResourceQueueUseCost ? incrementSet->portalId : INVALID_PORTALID;
 
 			ResIncrementRemove(&portalTag);
 
@@ -624,7 +628,7 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 			RemoveLocalLock(locallock);
 		}
 		/* no need to do the wakeups */
-		ResCleanUpLock(lock, proclock, hashcode, false);
+		ResCleanUpLock(lock, proclock, hashcode, true);
 		LWLockRelease(ResQueueLock);
 		LWLockRelease(partitionLock);
 		return false;			
@@ -633,6 +637,7 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	/*
 	 * Un-grant the lock.
 	 */
+
 	ResUnGrantLock(lock, proclock);
 	ResLockUpdateLimit(lock, proclock, incrementSet, false);
 
@@ -753,7 +758,7 @@ ResLockCheckLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementS
 
 					/* Check if this will overcommit */
 					if (increment_amt > limits[i].threshold_value)
-						will_overcommit = true;
+					will_overcommit = true;
 
 					if (queue->overcommit)
 					{
@@ -762,15 +767,15 @@ ResLockCheckLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementS
 						 * blowout the limit if noone else is active!
 						 */
 						if ((limits[i].current_value + increment_amt > limits[i].threshold_value) &&
-							(limits[i].current_value > 0.1))
-							over_limit = true;
-					} 
+						(limits[i].current_value > 0.1))
+						over_limit = true;
+					}
 					else
 					{
 						/*
-						 * No autocommit, so always fail statements that
-						 * blowout the limit.
-						 */
+						* No autocommit, so always fail statements that
+						* blowout the limit.
+						*/
 						if (limits[i].current_value + increment_amt > limits[i].threshold_value)
 							over_limit = true;
 					}
@@ -781,8 +786,8 @@ ResLockCheckLimit(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incrementS
 				}
 
 #ifdef RESLOCK_DEBUG
-				elog(DEBUG1, "checking cost limit threshold %.2f current %.2f",
-					 limits[i].threshold_value, limits[i].current_value);
+	elog(DEBUG1, "checking cost limit threshold %.2f current %.2f",
+		 limits[i].threshold_value, limits[i].current_value);
 #endif
 			}
 			break;
@@ -1187,7 +1192,7 @@ ResProcLockRemoveSelfAndWakeup(LOCK *lock)
 
 		MemSet(&portalTag, 0, sizeof(ResPortalTag));
 		portalTag.pid = proc->pid;
-		portalTag.portalId = proc->waitPortalId;
+		portalTag.portalId = ResourceQueueUseCost ? proc->waitPortalId : INVALID_PORTALID;
 
 		incrementSet = ResIncrementFind(&portalTag);
 		if (!incrementSet)
@@ -1306,7 +1311,7 @@ ResRemoveFromWaitQueue(PGPROC *proc, uint32 hashcode)
 	 */
 	MemSet(&portalTag, 0, sizeof(ResPortalTag));
 	portalTag.pid = MyProc->pid;
-	portalTag.portalId = MyProc->waitPortalId;
+	portalTag.portalId = ResourceQueueUseCost ? MyProc->waitPortalId : INVALID_PORTALID;
 
 	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
 	ResIncrementRemove(&portalTag);
@@ -1477,7 +1482,7 @@ ResIncrementAdd(ResPortalIncrement *incSet, PROCLOCK *proclock, ResourceOwner ow
 	/*  Set up the key.*/
 	MemSet(&portaltag, 0, sizeof(ResPortalTag));
 	portaltag.pid = incSet->pid;
-	portaltag.portalId = incSet->portalId;
+	portaltag.portalId = ResourceQueueUseCost ? incSet->portalId : INVALID_PORTALID;
 
 	/* Add (or find) the value. */
 	incrementSet = (ResPortalIncrement *)
@@ -1556,7 +1561,7 @@ ResIncrementRemove(ResPortalTag *portaltag)
 	bool				found;
 
 	Assert(LWLockHeldExclusiveByMe(ResQueueLock));
-	
+
 	incrementSet = (ResPortalIncrement *)
 		hash_search(ResPortalIncrementHash, (void *)portaltag, HASH_REMOVE, &found);
 

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -49,6 +49,7 @@ int		MaxResourcePortalsPerXact;				/* Max # tracked portals -
 												 * per backend . */
 bool	ResourceSelectOnly;						/* Only lock SELECT/DECLARE? */
 bool	ResourceCleanupIdleGangs;				/* Cleanup idle gangs? */
+bool	ResourceQueueUseCost;				/* Use Cost checking */
 
 
 /*
@@ -1063,6 +1064,7 @@ ResHandleUtilityStmt(Portal portal, Node *stmt)
 	if (Gp_role == GP_ROLE_DISPATCH
 		&& ResourceScheduler
 		&& (!ResourceSelectOnly)
+		&& ResourceQueueUseCost
 		&& !superuser())
 	{
 		Assert(!LWLockHeldExclusiveByMe(ResQueueLock));

--- a/src/include/commands/prepare.h
+++ b/src/include/commands/prepare.h
@@ -15,6 +15,7 @@
 
 #include "executor/execdesc.h"
 #include "utils/timestamp.h"
+#include "utils/resscheduler.h"
 
 struct TupOutputState;                  /* #include "executor/executor.h" */
 
@@ -41,7 +42,10 @@ typedef struct
 	List	   *query_list;		/* list of queries, rewritten, in case of replan */
 	List	   *argtype_list;	/* list of parameter type OIDs */
 	TimestampTz prepare_time;	/* the time when the stmt was prepared */
+	bool		take_lock;  /* Take a Resource Queue Slot lock */
+	bool		lock_isacquired;  /* If Resource Queue Slot lock is already taken */
 	bool		from_sql;		/* stmt prepared via SQL, not FE/BE protocol? */
+	ResPortalIncrement *incData;  /* For case when Resource Queue Slot lock has to be taken */
 	MemoryContext context;		/* context containing this query */
 } PreparedStatement;
 
@@ -64,6 +68,8 @@ extern void StorePreparedStatement(const char *stmt_name,
 					   const char *commandTag,
 					   List *query_list,
 					   List *argtype_list,
+					   bool takeLock,
+					   ResPortalIncrement *incData,
 					   bool from_sql);
 extern PreparedStatement *FetchPreparedStatement(const char *stmt_name,
 					   bool throwError);

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -28,6 +28,7 @@ extern int	MaxResourceQueues;
 extern int	MaxResourcePortalsPerXact;
 extern bool	ResourceSelectOnly;
 extern bool	ResourceCleanupIdleGangs;
+extern bool ResourceQueueUseCost;
 
 extern Oid MyQueueId; /* resource queue for current role. */
 

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -180,6 +180,8 @@ extern void AtCommit_ResScheduler(void);
 extern void AtAbort_ResScheduler(void);
 extern void ResHandleUtilityStmt(Portal portal, Node *stmt);
 extern bool ResLockUtilityPortal(Portal portal, float4 ignoreCostLimit);
+extern bool ResLockPreEmptivelock(ResPortalIncrement *incrementSet);
+extern void ResLockPreEmptiveUnlock(void);
 
 /**
  * Assert that the in-memory state matches the catalog table.


### PR DESCRIPTION
Change the locking logic for Resource Queues and prevent deadlocks occurring due to them. This also makes COST based resource checking optional which has to be set using resource_usecost GUC.

Thanks @lpetrov-pivotal for design ideas, code reviews and design reviews and other help!