### PR TITLE
Misc comment and documentation cleanups on Perl scripts

### DIFF
--- a/src/include/catalog/catullus.pl
+++ b/src/include/catalog/catullus.pl
@@ -85,7 +85,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2011 Greenplum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 =cut
 # SLZY_POD_HDR_END

--- a/src/include/catalog/catullus.pl
+++ b/src/include/catalog/catullus.pl
@@ -1,11 +1,8 @@
 #!/usr/bin/perl
 #
-# $Header$
-#
 # copyright (c) 2011
 # Author: Jeffrey I Cohen
-#
-# SLZY_HDR_END
+
 use POSIX;
 use Pod::Usage;
 use Getopt::Long;

--- a/src/include/catalog/sleazy.pl
+++ b/src/include/catalog/sleazy.pl
@@ -1,11 +1,4 @@
 #!/usr/bin/perl
-#
-# $Header: $
-#
-# copyright (c) 
-# Author: 
-#
-# SLZY_HDR_END
 
 use POSIX;
 use Pod::Usage;

--- a/src/include/catalog/sleazy.pl
+++ b/src/include/catalog/sleazy.pl
@@ -260,7 +260,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2012, 2013 Greenplum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 =cut
 # SLZY_POD_HDR_END

--- a/src/include/catalog/tidycat.pl
+++ b/src/include/catalog/tidycat.pl
@@ -1,11 +1,7 @@
 #!/usr/bin/perl
 #
-# $Header$
-#
 # copyright (c) 2009, 2010, 2011
 # Author: Jeffrey I Cohen
-#
-# SLZY_HDR_END
 
 use POSIX;
 use Pod::Usage;

--- a/src/include/catalog/tidycat.pl
+++ b/src/include/catalog/tidycat.pl
@@ -281,7 +281,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2009-2012 Greenplum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 =cut
 # SLZY_POD_HDR_END

--- a/src/test/regress/atmsort.pl
+++ b/src/test/regress/atmsort.pl
@@ -345,7 +345,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2007, 2008, 2009 GreenPlum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 
 =cut

--- a/src/test/regress/atmsort.pl
+++ b/src/test/regress/atmsort.pl
@@ -1,17 +1,8 @@
 #!/usr/bin/env perl
 #
-# $Header$
-#
 # copyright (c) 2007, 2008, 2009 GreenPlum.  All rights reserved.  
 # Author: Jeffrey I Cohen
 #
-#
-
-# Pod::Usage is loaded lazily when needed, if the --help or other such option
-# is actually used. Loading the module takes some time, which adds up when
-# running hundreds of regression tests, and gpdiff.pl calls this script twice
-# for every test. See lazy_pod2usage().
-#use Pod::Usage;
 
 use Getopt::Long;
 #use Data::Dumper; # only used by commented-out debug statements.
@@ -359,7 +350,10 @@ Address bug reports and comments to: jcohen@greenplum.com
 
 =cut
 
-# Calls pod2usage, but lodas the module first.
+# Calls pod2usage, but loads the module first.
+# Pod::Usage is loaded lazily when needed, if the --help or other such option
+# is actually used. Loading the module takes some time, which adds up when
+# running hundreds of regression tests.
 sub lazy_pod2usage
 {
     require Pod::Usage;

--- a/src/test/regress/atmsort.pl
+++ b/src/test/regress/atmsort.pl
@@ -4,6 +4,7 @@
 # Author: Jeffrey I Cohen
 #
 
+#use Pod::Usage #see lazy_pod2usage()
 use Getopt::Long;
 #use Data::Dumper; # only used by commented-out debug statements.
 use strict;

--- a/src/test/regress/dld.pl
+++ b/src/test/regress/dld.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 #
-# $Header$
-#
 # copyright (c) 2007-2010
 # Author: Jeffrey I Cohen
 #

--- a/src/test/regress/dld.pl
+++ b/src/test/regress/dld.pl
@@ -58,7 +58,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2007-2010 GreenPlum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 
 =cut

--- a/src/test/regress/explain.pl
+++ b/src/test/regress/explain.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 #
-# $Header$
-#
 # copyright (c) 2006, 2007, 2008, 2009 
 # Author: Jeffrey I Cohen
 #

--- a/src/test/regress/explain.pl
+++ b/src/test/regress/explain.pl
@@ -242,7 +242,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2006, 2007, 2008, 2009 GreenPlum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 
 =cut

--- a/src/test/regress/get_ereport.pl
+++ b/src/test/regress/get_ereport.pl
@@ -77,7 +77,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2009-2011 GreenPlum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 
 =cut

--- a/src/test/regress/get_ereport.pl
+++ b/src/test/regress/get_ereport.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 #
-# $Header$
-#
 # copyright (c) 2009, 2010, 2011
 # Author: Jeffrey I Cohen
 #

--- a/src/test/regress/gpdiff.pl
+++ b/src/test/regress/gpdiff.pl
@@ -118,7 +118,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2007, 2008, 2009 GreenPlum.  All rights reserved.
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 
 =cut

--- a/src/test/regress/gpdiff.pl
+++ b/src/test/regress/gpdiff.pl
@@ -1,16 +1,8 @@
 #!/usr/bin/env perl
 #
-# $Header$
-#
 # Copyright (c) 2007, 2008, 2009 GreenPlum.  All rights reserved.
 # Author: Jeffrey I Cohen
 #
-#
-# Pod::Usage is loaded lazily when needed, if the --help or other such option
-# is actually used. Loading the module takes some time, which adds up when
-# running hundreds of regression tests, and gpdiff.pl calls this script twice
-# for every test. See lazy_pod2usage().
-#use Pod::Usage;
 
 use strict;
 use warnings;
@@ -67,7 +59,7 @@ on the standard options.  The following options are specific to gpdiff:
 
 =item B<-gpd_ignore_headers>
 
-gpdiff/atmsort expect Postgresql "psql-style" output for SELECT
+gpdiff/atmsort expect PostgreSQL "psql-style" output for SELECT
 statements, with a two line header composed of the column names,
 separated by vertical bars (|), and a "separator" line of dashes and
 pluses beneath, followed by the row output.  The psql utility performs
@@ -93,11 +85,11 @@ specify multiple initialization files, use multiple gpd_init arguments, eg:
 
 =head1 DESCRIPTION
 
-gpdiff compares files using diff after processing them with atmsort.pl.
+gpdiff compares files using diff after processing them with atmsort.pm.
 This comparison is designed to ignore certain Greenplum-specific
 informational messages, as well as handle the cases where query output
 order may differ for a multi-segment Greenplum database versus a
-single Postgresql instance.  Type "atmsort.pl --man" for more details.
+single PostgreSQL instance.  Type "atmsort.pl --man" for more details.
 gpdiff is invoked by pg_regress as part of "make install-check".
 In this case the diff options are something like:
 
@@ -131,7 +123,11 @@ Address bug reports and comments to: jcohen@greenplum.com
 
 =cut
 
-# Calls pod2usage, but lodas the module first.
+# Calls pod2usage, but loads the module first.
+# Pod::Usage is loaded lazily when needed, if the --help or other such option
+# is actually used. Loading the module takes some time, which adds up when
+# running hundreds of regression tests, and pg_regress calls this script twice
+# for every test.
 sub lazy_pod2usage
 {
     require Pod::Usage;

--- a/src/test/regress/gpsourcify.pl
+++ b/src/test/regress/gpsourcify.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 #
-# $Header$
-#
 # Copyright (c) 2007-2012 GreenPlum.  All rights reserved.  
 # Author: Jeffrey I Cohen
 #

--- a/src/test/regress/gpsourcify.pl
+++ b/src/test/regress/gpsourcify.pl
@@ -78,7 +78,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2007-2012 GreenPlum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 
 =cut

--- a/src/test/regress/gpstringsubs.pl
+++ b/src/test/regress/gpstringsubs.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 #
-# $Header$
-#
 # Copyright (c) 2007-2010 GreenPlum.  All rights reserved.  
 # Author: Jeffrey I Cohen
 #

--- a/src/test/regress/gpstringsubs.pl
+++ b/src/test/regress/gpstringsubs.pl
@@ -98,7 +98,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2007-2010 GreenPlum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 
 =cut

--- a/src/test/regress/gptorment.pl
+++ b/src/test/regress/gptorment.pl
@@ -137,7 +137,7 @@ Jeffrey I Cohen
 
 Copyright (c) 2008-2010 GreenPlum.  All rights reserved.  
 
-Address bug reports and comments to: jcohen@greenplum.com
+Address bug reports and comments to: bugs@greenplum.org
 
 
 =cut

--- a/src/test/regress/gptorment.pl
+++ b/src/test/regress/gptorment.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 #
-# $Header$
-#
 # copyright (c) 2008-2010 GreenPlum.  All rights reserved.  
 # Author: Jeffrey I Cohen
 #

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -1879,8 +1879,7 @@ run_single_test(const char *test, test_function tfunc)
 
 /*
  * Find the other binaries that we need. Currently, gpdiff.pl and
- * gpstringsubs.pl. gpdiff.pl in turn will call atmsort.pl and explain.pl,
- * but it's up to gpdiff.pl to find them.
+ * gpstringsubs.pl.
  */
 static void
 find_helper_programs(const char *argv0)


### PR DESCRIPTION
Some random minor touchups on documentation and comments in our Perl scripts (and code mentioning the Perl scripts) I had sitting in an old branch:

Update the bug report email listed in Perl scripts; this is a follow-up to commit b7365f5 which replaced the PostgreSQL bug report email with the Greenplum one. Do the same for the Perl script by replacing the personal addresses of the original authors.

Removes unused CVS `$Header$` tags and moves comments closer to where they make sense as well as updates a few comments to match reality.

There are no functional changes in this PR but wanted a second opinion on changing all the email addresses.