### PR TITLE
Use the resolved path for gpstringsubs.pl instead of hardcoding

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -545,7 +545,7 @@ convert_sourcefiles_in(char *source, char *dest, char *suffix)
 		{
 			char		cmd[MAXPGPATH * 3];
 			snprintf(cmd, sizeof(cmd),
-					 SYSTEMQUOTE "%s/gpstringsubs.pl %s" SYSTEMQUOTE, bindir, destfile);
+					 SYSTEMQUOTE "%s %s" SYSTEMQUOTE, gpstringsubsprog, destfile);
 			if (run_diff(cmd, destfile) != 0)
 			{
 				fprintf(stderr, _("%s: could not convert %s\n"),


### PR DESCRIPTION
We resolve the path for `gpstringsubs.pl` with `find_other_exec()` like we do for `gpdiff.pl` so use the outcome of that rather than hardcoding it at invocation. Builds green on Pulse.