### PR TITLE
Explicitly close socket after processing cancel packet.

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -3743,6 +3743,13 @@ processCancelRequest(Port *port, void *pkt, MsgType code)
 	int			i;
 #endif
 
+	/*
+	 * Close the socket connected with QD, since we will not use it anymore, and
+	 * QD is waiting for the close
+	 */
+	closesocket(port->sock);
+	port->sock = -1;
+
 	backendPID = (int) ntohl(canc->backendPID);
 	cancelAuthCode = (long) ntohl(canc->cancelAuthCode);
 


### PR DESCRIPTION
It was believed that this socket would be closed by OS when the process
went to die, however, for some unknown reasons, it was still there, and
hence QD would hang and cannot be canceled.