### PR TITLE
Add a rudimentary regression test suite for Distributed Transactions.

### DIFF
--- a/src/test/dtm/Makefile
+++ b/src/test/dtm/Makefile
@@ -1,0 +1,16 @@
+MODULE_big = faultinject_helper
+OBJS = faultinject_helper.o
+
+REGRESS = setup errors-at-eox
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = src/test/dtm/
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
+

--- a/src/test/dtm/expected/errors-at-eox.out
+++ b/src/test/dtm/expected/errors-at-eox.out
@@ -1,0 +1,39 @@
+--
+-- Test what happens, when an ERROR occurs at various stages of COMMIT
+-- or ABORT processing. This test uses the fault injection mechanism
+-- built in to the server, to induce an ERROR at strategic places.
+--
+-- Create a plain table that we can insert to, to verify after the
+-- transaction whether the transaction's effects are visible.
+CREATE TABLE dtm_testtab(id int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- throw an ERROR, just after we have broadcast the PREPARE of the
+-- transaction to segments.
+select gp_inject_fault('dtm_broadcast_prepare', 'error', '', '', '', 1, 0);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+insert into dtm_testtab values (1), (2);
+ERROR:  fault triggered, fault name:'dtm_broadcast_prepare' fault type:'error' (faultinjector.c:671)
+select * from dtm_testtab;
+ id 
+----
+(0 rows)
+
+-- throw an ERROR, in master, just before we have broadcast the COMMIT
+-- PREPARED to segments.
+select gp_inject_fault('dtm_broadcast_commit_prepared', 'error', '', '', '', 1, 0);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+insert into dtm_testtab values (3), (4);
+ERROR:  fault triggered, fault name:'dtm_broadcast_commit_prepared' fault type:'error' (faultinjector.c:671)
+select * from dtm_testtab;
+-- FIXME: You currently get an:
+--   "We should not be trying to execute a query in state 'Segment Prepared'"
+-- error  at this point. That's not good.

--- a/src/test/dtm/faultinject_helper.c
+++ b/src/test/dtm/faultinject_helper.c
@@ -1,0 +1,82 @@
+/*
+ * An little helper function that provides SQL-level access to the fault
+ * injection mechanism in the server.
+ */
+#include "postgres.h"
+
+#include "funcapi.h"
+#include "utils/builtins.h"
+#include "utils/faultinjector.h"
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
+Datum gp_inject_fault(PG_FUNCTION_ARGS);
+
+PG_FUNCTION_INFO_V1(gp_inject_fault);
+
+Datum
+gp_inject_fault(PG_FUNCTION_ARGS)
+{
+	char	   *faultName = TextDatumGetCString(PG_GETARG_DATUM(0));
+	char	   *type = TextDatumGetCString(PG_GETARG_DATUM(1));
+	char	   *ddlStatement = TextDatumGetCString(PG_GETARG_DATUM(2));
+	char	   *databaseName = TextDatumGetCString(PG_GETARG_DATUM(3));
+	char	   *tableName = TextDatumGetCString(PG_GETARG_DATUM(4));
+	int			numOccurrences = PG_GETARG_INT32(5);
+	int			sleepTimeSeconds = PG_GETARG_INT32(6);
+	FaultInjectorEntry_s	faultInjectorEntry;
+	char buf[1000];
+
+	elog(DEBUG1, "FAULT INJECTED: Name %s Type %s, DDL %s, DB %s, Table %s, NumOccurrences %d  SleepTime %d",
+		 faultName, type, ddlStatement, databaseName, tableName, numOccurrences, sleepTimeSeconds );
+
+	faultInjectorEntry.faultInjectorIdentifier = FaultInjectorIdentifierStringToEnum(faultName);
+	if (faultInjectorEntry.faultInjectorIdentifier == FaultInjectorIdNotSpecified ||
+		faultInjectorEntry.faultInjectorIdentifier == FaultInjectorIdMax)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("could not recognize fault name")));
+
+	faultInjectorEntry.faultInjectorType = FaultInjectorTypeStringToEnum(type);
+	if (faultInjectorEntry.faultInjectorType == FaultInjectorTypeNotSpecified ||
+		faultInjectorEntry.faultInjectorType == FaultInjectorTypeMax)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("could not recognize fault type")));
+
+	faultInjectorEntry.sleepTime = sleepTimeSeconds;
+	if (sleepTimeSeconds < 0 || sleepTimeSeconds > 7200)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							errmsg("invalid sleep time, allowed range [0, 7200 sec]")));
+
+	faultInjectorEntry.ddlStatement = FaultInjectorDDLStringToEnum(ddlStatement);
+	if (faultInjectorEntry.ddlStatement == DDLMax)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("could not recognize DDL statement")));
+
+	snprintf(faultInjectorEntry.databaseName, sizeof(faultInjectorEntry.databaseName), "%s", databaseName);
+
+	snprintf(faultInjectorEntry.tableName, sizeof(faultInjectorEntry.tableName), "%s", tableName);
+
+	faultInjectorEntry.occurrence = numOccurrences;
+	if (numOccurrences > 1000)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid occurrence number, allowed range [1, 1000]")));
+
+	if (FaultInjector_SetFaultInjection(&faultInjectorEntry) == STATUS_OK)
+	{
+		if (faultInjectorEntry.faultInjectorType == FaultInjectorTypeStatus)
+			snprintf(buf, sizeof(buf), "%s", faultInjectorEntry.bufOutput);
+		else
+			snprintf(buf, sizeof(buf), "Success:");
+	}
+	else
+		snprintf(buf, sizeof(buf), "Failure: %s", faultInjectorEntry.bufOutput);
+
+	PG_RETURN_DATUM(CStringGetTextDatum(buf));
+}

--- a/src/test/dtm/input/setup.source
+++ b/src/test/dtm/input/setup.source
@@ -1,0 +1,13 @@
+-- Install a helper function to inject faults, using the fault injection
+-- mechanism built into the server.
+CREATE FUNCTION gp_inject_fault(
+  faultname text,
+  type text,
+  ddl text,
+  database text,
+  tablename text,
+  numoccurrences int4,
+  sleeptime int4)
+RETURNS text
+AS '@abs_builddir@/faultinject_helper@DLSUFFIX@'
+LANGUAGE C VOLATILE STRICT NO SQL;

--- a/src/test/dtm/output/setup.source
+++ b/src/test/dtm/output/setup.source
@@ -1,0 +1,13 @@
+-- Install a helper function to inject faults, using the fault injection
+-- mechanism built into the server.
+CREATE FUNCTION gp_inject_fault(
+  faultname text,
+  type text,
+  ddl text,
+  database text,
+  tablename text,
+  numoccurrences int4,
+  sleeptime int4)
+RETURNS text
+AS '@abs_builddir@/faultinject_helper@DLSUFFIX@'
+LANGUAGE C VOLATILE STRICT NO SQL;

--- a/src/test/dtm/sql/errors-at-eox.sql
+++ b/src/test/dtm/sql/errors-at-eox.sql
@@ -1,0 +1,34 @@
+--
+-- Test what happens, when an ERROR occurs at various stages of COMMIT
+-- or ABORT processing. This test uses the fault injection mechanism
+-- built in to the server, to induce an ERROR at strategic places.
+--
+
+-- Create a plain table that we can insert to, to verify after the
+-- transaction whether the transaction's effects are visible.
+CREATE TABLE dtm_testtab(id int4);
+
+-- throw an ERROR, just after we have broadcast the PREPARE of the
+-- transaction to segments.
+select gp_inject_fault('dtm_broadcast_prepare', 'error', '', '', '', 1, 0);
+
+insert into dtm_testtab values (1), (2);
+
+select * from dtm_testtab;
+
+-- throw an ERROR, in master, just before we have broadcast the COMMIT
+-- PREPARED to segments.
+select gp_inject_fault('dtm_broadcast_commit_prepared', 'error', '', '', '', 1, 0);
+
+insert into dtm_testtab values (3), (4);
+
+select * from dtm_testtab;
+
+-- throw an ERROR, after we have flushed the (two-phase) commit record
+-- to disk in master.
+select gp_inject_fault('dtm_xlog_distributed_commit', 'error', '', '', '', 1, 0);
+
+insert into dtm_testtab values (3), (4);
+
+select * from dtm_testtab;
+


### PR DESCRIPTION
These tests use the existing fault injection mechanism built into the
server, to cause errors to happen at strategic places, and checks the
results.

This is almost just a placeholder, there are very few actual tests for
now. But it's a start.

The suite uses plain old pg_regress to run the tests and check the
results. That's enough for the tests included here, but in the future
we'll probably want to do server restarts, crashes, etc. as part of
the suite, and will have to refactor this to something that can do those
things more easily. But let's cross that bridge when we get there.

Also, the test actually leaves the connections to the segments in a
funny state, which shouldn't really happen. The test fails currently
because of that; let's fix it together with the state issue. But
even in this state, this has been useful to me right now, to reproduce
an issue on the merge_8_3_22 branch that I'm working on at the same
time (this test currently causes a PANIC there).

This also isn't hooked up to any top-level targets yet; you have to
run the suite manually from the src/test/dtm directory.