### PR TITLE
Refactored argument passing in backup and restore to use a context variable

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -32,11 +32,9 @@ try:
     from gppylib.gpversion import GpVersion
     from gppylib.db import dbconn
     from gppylib.operations.unix import CheckDir, CheckFile, MakeDir
-    from gppylib.operations.dump import get_partition_state_tuples, compare_metadata, \
-                                        compare_dict, get_pgstatlastoperations_dict, \
-                                        write_lines_to_file, verify_lines_in_file, ValidateIncludeTargets, \
-                                        ValidateSchemaExists
-    from gppylib.operations.backup_utils import execute_sql, get_lines_from_file
+    from gppylib.operations.dump import get_partition_state_tuples, compare_metadata, compare_dict, get_pgstatlastoperations_dict, \
+                                        write_lines_to_file, verify_lines_in_file, ValidateSchemaExists
+    from gppylib.operations.backup_utils import execute_sql, get_lines_from_file, Context
     from pygresql import pg
 
 except ImportError, e:
@@ -273,6 +271,11 @@ class AnalyzeDb(Operation):
             global CURR_TIME
             CURR_TIME = generate_timestamp()
 
+            # The below object is needed for some functions imported from dump.py
+            self.context = Context()
+            self.context.master_port = self.pg_port
+            self.context.dump_database = self.dbname
+
             # The input_col_dict keeps track of the requested columns to analyze.
             # key: table name (e.g. 'public.foo')
             # value: a set of requested column names (e.g. set(['col1','col2']), or '-1' indicating all columns
@@ -447,7 +450,7 @@ class AnalyzeDb(Operation):
             self._parse_column(col_dict, self.single_table, schema, table, self.include_cols, self.exclude_cols, True)
 
         elif self.schema: # all tables in a schema
-            ValidateSchemaExists(self.dbname, self.schema, self.pg_port).run()
+            ValidateSchemaExists(self.context, self.schema).run()
             logger.debug("getting all tables in the schema...")
             all_schema_tables = run_sql(self.conn, GET_ALL_DATA_TABLES_IN_SCHEMA_SQL % self.schema)
             # convert table name from ['public','foo'] to 'public.foo' and populate col_dict as all columns requested
@@ -547,7 +550,7 @@ class AnalyzeDb(Operation):
         logger.debug("getting ao state...")
         oid_str = get_oid_str(input_tables_set)
         ao_partition_info = run_sql(self.conn, GET_REQUESTED_AO_DATA_TABLE_INFO_SQL % oid_str)
-        return get_partition_state_tuples(self.pg_port, self.dbname, 'pg_aoseg', ao_partition_info)
+        return get_partition_state_tuples(self.context, 'pg_aoseg', ao_partition_info)
 
     def _get_lastop_state(self, input_tables_set):
         # oid, action, subtype, timestamp

--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -29,37 +29,18 @@ try:
     from gppylib.gparray import GpArray
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.operations import Operation
-    from gppylib.operations.backup_utils import check_funny_chars_in_names, create_temp_file_from_list, expand_partitions_and_populate_filter_file, \
-                                                generate_files_filename, generate_pipes_filename, generate_schema_filename, get_backup_directory, \
-                                                get_latest_full_dump_timestamp, get_latest_full_ts_with_nbu, get_lines_from_file, remove_file_on_segments, \
-                                                validate_timestamp, verify_lines_in_file, write_lines_to_file, formatSQLString
-    from gppylib.operations.dump import CreateIncrementsFile, DeleteCurrentDump, DeleteOldestDumps, DumpConfig, DumpDatabase, DumpGlobal, DumpStats, \
-                                        MailDumpEvent, PostDumpDatabase, UpdateHistoryTable, VacuumDatabase, ValidateDatabaseExists, ValidateGpToolkit, \
-                                        ValidateSchemaExists, backup_cdatabase_file_with_nbu, backup_config_files_with_nbu, backup_dirty_file_with_nbu, \
-                                        backup_global_file_with_nbu, backup_statistics_file_with_nbu, backup_increments_file_with_ddboost, \
-                                        backup_increments_file_with_nbu, backup_partition_list_file_with_nbu, backup_report_file_with_ddboost, \
-                                        backup_report_file_with_nbu, backup_schema_file_with_ddboost, backup_schema_file_with_nbu, backup_state_files_with_nbu, \
-                                        filter_dirty_tables, generate_dump_timestamp, get_ao_partition_state, get_co_partition_state, get_dirty_heap_tables, \
-                                        get_dirty_tables, get_filter_file, get_include_schema_list_from_exclude_schema, get_last_operation_data, \
-                                        get_user_table_list_for_schema, update_filter_file, validate_current_timestamp, write_dirty_file, write_dirty_file_to_temp, \
-                                        write_last_operation_file, write_partition_list_file, write_state_file
+    from gppylib.operations.backup_utils import *
+    from gppylib.operations.dump import *
     from gppylib.operations.utils import DEFAULT_NUM_WORKERS
 except ImportError, e:
     sys.exit('Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
 INJECT_ROLLBACK = False
 
+
 EXECNAME = 'gpcrondump'
 GPCRONDUMP_PID_FILE = 'gpcrondump.pid'
 FREE_SPACE_PERCENT = 10
-CATALOG_SCHEMA = [
-    'gp_toolkit',
-    'information_schema',
-    'pg_aoseg',
-    'pg_bitmapindex',
-    'pg_catalog',
-    'pg_toast'
-]
 
 logger = gplog.get_default_logger()
 conn = None
@@ -70,151 +51,92 @@ class GpCronDump(Operation):
     def __init__(self, options, args):
         if args:
             logger.warn("please note that some of the arguments (%s) aren't valid and will be ignored.", args)
-        if options.masterDataDirectory is None:
-            options.masterDataDirectory = gp.get_masterdatadir()
-        self.interactive = options.interactive
-        self.master_datadir = options.masterDataDirectory
-        self.master_port = self._get_master_port(self.master_datadir)
-        self.pgport = self._get_pgport()
+
+        self.context = Context(options)
         self.options_list = " ".join(sys.argv[1:])
+
+        self.interactive = options.interactive
         self.cur_host = socket.gethostname()
-
-        self.clear_dumps_only = options.clear_dumps_only
-        self.clear_dumps = options.clear_dumps
-        self.cleanup_date = options.cleanup_date
-        self.cleanup_total = options.cleanup_total
-        if not (self.clear_dumps_only or self.clear_dumps) and self.cleanup_date:
-            raise ExceptionNoStackTraceNeeded("Must supply -c or -o with --cleanup-date option")
-        elif not (self.clear_dumps_only or self.clear_dumps) and self.cleanup_total:
-            raise ExceptionNoStackTraceNeeded("Must supply -c or -o with --cleanup-total option")
-        elif (self.clear_dumps_only or self.clear_dumps) and not (self.cleanup_date or self.cleanup_total):
-            self.cleanup_total = '1'
-
-        self.post_script = options.post_script
-        self.dump_config = options.dump_config
-        self.history = options.history
         self.pre_vacuum = options.pre_vacuum
         self.post_vacuum = options.post_vacuum
         self.rollback = options.rollback
 
-        self.compress = options.compress
-        self.free_space_percent = options.free_space_percent
-        self.dump_schema = options.dump_schema
-        self.include_schema_file = options.include_schema_file
-        self.exclude_schema_file = options.exclude_schema_file
-        self.exclude_dump_schema = options.exclude_dump_schema
-        self.dump_databases = options.dump_databases
-        self.dump_global = options.dump_global
-        self.clear_catalog_dumps = options.clear_catalog_dumps
-        self.batch_default = options.batch_default
-        self.include_dump_tables = options.include_dump_tables
-        self.exclude_dump_tables = options.exclude_dump_tables
-        self.include_dump_tables_file = options.include_dump_tables_file
-        self.exclude_dump_tables_file = options.exclude_dump_tables_file
-        self.backup_dir = options.backup_dir
-        self.encoding = options.encoding
-        self.output_options = options.output_options
-        self.incremental = options.incremental
-        self.timestamp_key = options.timestamp_key
         self.list_backup_files = options.list_backup_files
-        self.ddboost_storage_unit = options.ddboost_storage_unit
         self.list_filter_tables = options.list_filter_tables
 
-        if options.local_dump_prefix:
-             self.dump_prefix = options.local_dump_prefix + "_"
-        else:
-            self.dump_prefix = options.local_dump_prefix
-
-        self.include_email_file = options.include_email_file
         self.email_details = None
-        self.dump_stats = options.dump_stats
-        self.ddboost_hosts = options.ddboost_hosts
-        self.ddboost_user = options.ddboost_user
-        self.ddboost_config_remove = options.ddboost_config_remove
-        self.ddboost_verify = options.ddboost_verify
-        self.ddboost_remote = options.ddboost_remote
-        self.ddboost_ping = options.ddboost_ping
-        self.ddboost_backupdir = options.ddboost_backupdir
-        self.ddboost_show_config = options.ddboost_show_config
         # This variable indicates whether we need to exit after verifying the DDBoost credentials
-        self.ddboost_verify_and_exit = False
-        # NetBackup params
-        self.netbackup_service_host = options.netbackup_service_host
-        self.netbackup_policy = options.netbackup_policy
-        self.netbackup_schedule = options.netbackup_schedule
-        self.netbackup_block_size = options.netbackup_block_size
-        self.netbackup_keyword = options.netbackup_keyword
-        if (self.netbackup_keyword is not None) and (len(self.netbackup_keyword) > 100):
-            raise Exception('NetBackup Keyword provided has more than max limit (100) characters. Cannot proceed with backup.')
+        self.context.ddboost_verify_and_exit = False
 
         # TODO: if action is 'append', wouldn't you expect a lack of input to result in [], as opposed to None?
-        if self.include_dump_tables is None: self.include_dump_tables = []
-        if self.exclude_dump_tables is None: self.exclude_dump_tables = []
-        if self.output_options is None: self.output_options = []
-        if self.ddboost_hosts is None: self.ddboost_hosts = []
-        if self.dump_schema is None: self.dump_schema = []
-        if self.exclude_dump_schema is None: self.exclude_dump_schema = []
+        if not self.context.ddboost_hosts: self.context.ddboost_hosts = []
 
+        if len(self.context.dump_databases) > 0:
+            self.context.dump_database = self.context.dump_databases[0]
+
+        self.include_email_file = options.include_email_file
         if options.report_dir:
             logger.warn("-y is a deprecacted option.  Report files are always generated with the backup set.")
 
-        if self.incremental and len(self.dump_databases) == 0:
+        if self.context.incremental and len(self.context.dump_databases) == 0:
             raise ExceptionNoStackTraceNeeded("Must supply -x <database name> with incremental option")
 
-        if len(self.dump_databases) > 0:
-            if self.incremental and len(self.dump_databases) > 1:
-                raise ExceptionNoStackTraceNeeded('multi-database backup is not supported with incremental backup: %s databases selected' % len(self.dump_databases))
-
-        if self.clear_dumps_only and self.incremental:
-            raise Exception('-o option cannot be selected with incremental backup')
-
-        if self.list_backup_files and not self.timestamp_key:
-            raise Exception('Must supply -K option when listing backup files')
-
-
-        if len(self.dump_databases) > 0:
-            if self.timestamp_key and len(self.dump_databases) > 1:
+        if len(self.context.dump_databases) > 1:
+            if self.context.incremental:
+                raise ExceptionNoStackTraceNeeded('multi-database backup is not supported with incremental backup: %s databases selected' % len(self.context.dump_databases))
+            if self.context.timestamp_key:
                 raise ExceptionNoStackTraceNeeded('multi-database backup is not supported with -K option')
 
-        if not (self.clear_dumps_only or bool(self.ddboost_hosts) or bool(self.ddboost_user) or
-                self.ddboost_config_remove or self.ddboost_show_config):
-            if len(self.dump_databases) == 0:
+        if self.context.clear_dumps_only and self.context.incremental:
+            raise Exception('-o option cannot be selected with incremental backup')
+
+        if not (self.context.clear_dumps_only or self.context.clear_dumps) and self.context.cleanup_date:
+            raise ExceptionNoStackTraceNeeded("Must supply -c or -o with --cleanup-date option")
+        elif not (self.context.clear_dumps_only or self.context.clear_dumps) and self.context.cleanup_total:
+            raise ExceptionNoStackTraceNeeded("Must supply -c or -o with --cleanup-total option")
+        elif (self.context.clear_dumps_only or self.context.clear_dumps) and not (self.context.cleanup_date or self.context.cleanup_total):
+            self.context.cleanup_total = '1'
+
+        if self.list_backup_files and not self.context.timestamp_key:
+            raise Exception('Must supply -K option when listing backup files')
+
+        if not (self.context.clear_dumps_only or bool(self.context.ddboost_hosts) or bool(self.context.ddboost_user) or 
+                self.context.ddboost_config_remove or self.context.ddboost_show_config):
+            if len(self.context.dump_databases) == 0:
                 if 'PGDATABASE' in os.environ:
-                    self.dump_databases = [os.environ['PGDATABASE']]
-                    logger.info("Setting dump database to value of $PGDATABASE which is %s" % self.dump_databases[0])
+                    self.context.dump_databases = [os.environ['PGDATABASE']]
+                    logger.info("Setting dump database to value of $PGDATABASE which is %s" % self.context.dump_databases[0])
                 else:
-                    if self.ddboost_verify is True:
+                    if self.context.ddboost_verify is True:
                         # We would expect to verify the credentials here and return some exit code,
                         # but __init__() should return None, not 'int' - hence we are forced to use
                         # some kind of flag
-                        self.ddboost_verify_and_exit = True
+                        self.context.ddboost_verify_and_exit = True
                     else:
                         raise ExceptionNoStackTraceNeeded("Must supply -x <database name> because $PGDATABASE is not set")
 
-        self.ddboost = options.ddboost
-
-        if self.ddboost_storage_unit and not self.ddboost and not self.only_ddboost_options():
+        if self.context.ddboost_storage_unit and not self.context.ddboost and not self.only_ddboost_options():
             raise Exception('Must specify --ddboost option together with the --ddboost-storage-unit')
 
-        if self.list_backup_files and (self.ddboost or bool(self.ddboost_verify) or bool(self.ddboost_hosts) or bool(self.ddboost_user) or bool(self.ddboost_config_remove)):
+        if self.list_backup_files and (self.context.ddboost or bool(self.context.ddboost_verify) or bool(self.context.ddboost_hosts) or bool(self.context.ddboost_user) or bool(self.context.ddboost_config_remove)):
             raise Exception('list backup files not supported with ddboost option')
 
-        if self.list_filter_tables and (not self.dump_prefix or not self.incremental):
+        if self.list_filter_tables and (not self.context.dump_prefix or not self.context.incremental):
             raise Exception('list filter tables option requires --prefix and --incremental')
 
         if self.include_email_file:
             self._validate_parse_email_File()
 
         # NetBackup params check
-        if self.netbackup_service_host or self.netbackup_policy or self.netbackup_schedule:
-            if self.netbackup_service_host is None:
+        if self.context.netbackup_service_host or self.context.netbackup_policy or self.context.netbackup_schedule:
+            if not self.context.netbackup_service_host:
                 raise Exception("NetBackup service hostname (--netbackup-service-host) param should be provided in order to use NetBackup")
-            if self.netbackup_policy is None:
+            if not self.context.netbackup_policy:
                 raise Exception("NetBackup policy name (--netbackup-policy) param should be provided in order to use NetBackup")
-            if self.netbackup_schedule is None:
+            if not self.context.netbackup_schedule:
                 raise Exception("NetBackup schedule name (--netbackup-schedule) param should be provided in order to use NetBackup")
 
-        if self.ddboost and self.netbackup_service_host:
+        if self.context.ddboost and self.context.netbackup_service_host:
             raise Exception('--ddboost is not supported with NetBackup')
 
         self.replicate = options.replicate
@@ -223,34 +145,34 @@ class GpCronDump(Operation):
         self.verbose = options.verbose
 
         # disk space checks
-        if self.free_space_percent and self.ddboost:
+        if self.context.free_space_percent and self.context.ddboost:
             raise Exception('-f option cannot be selected with ddboost')
 
-        if self.free_space_percent and self.incremental:
+        if self.context.free_space_percent and self.context.incremental:
             raise Exception('-f option cannot be selected with incremental backup')
 
-        if self.free_space_percent:
-            self.free_space_percent = int(self.free_space_percent)
+        if self.context.free_space_percent:
+            self.context.free_space_percent = int(self.context.free_space_percent)
         else:
-            self.free_space_percent = FREE_SPACE_PERCENT
+            self.context.free_space_percent = FREE_SPACE_PERCENT
 
-        if self.ddboost:
-            self.free_space_percent = None
+        if self.context.ddboost:
+            self.context.free_space_percent = None
             logger.info('Bypassing disk space checks due to DDBoost parameters')
-        elif self.incremental:
-            self.free_space_percent = None
+        elif self.context.incremental:
+            self.context.free_space_percent = None
             logger.info('Bypassing disk space checks for incremental backup')
         elif options.bypass_disk_check:
             logger.info("Bypassing disk space check as '-b' option is specified")
-            self.free_space_percent = None
+            self.context.free_space_percent = None
 
         #Check if backup_dir contains the absolute path
-        if self.backup_dir is not None:
-            if not os.path.isabs(self.backup_dir):
-                raise Exception("\"%s\" is not an absolute path. Please specify the absolute path where the backup files will be placed on each host." % self.backup_dir)
+        if self.context.backup_dir:
+            if not os.path.isabs(self.context.backup_dir):
+                raise Exception("\"%s\" is not an absolute path. Please specify the absolute path where the backup files will be placed on each host." % self.context.backup_dir)
 
-        if self.ddboost:
-            if (not self.replicate and self.max_streams is not None) or (self.replicate and self.max_streams is None):
+        if self.context.ddboost:
+            if (not self.replicate and self.max_streams) or (self.replicate and self.max_streams is None):
                 raise ExceptionNoStackTraceNeeded("--max-streams must be specified along with --replicate")
             if self.replicate:
                 try:
@@ -261,154 +183,148 @@ class GpCronDump(Operation):
                 # List of tuples (dbname, timestamp), to be replicated to remote
                 # Data Domain after they are backed up to local Data Domain.
                 self.dump_timestamps = []
-            if self.backup_dir is not None:
+            if self.context.backup_dir:
                 raise ExceptionNoStackTraceNeeded('-u cannot be used with DDBoost parameters.')
             dd = gpmfr.DDSystem("local")
-            self.dump_dir = dd.DDBackupDir
+            self.context.dump_dir = dd.DDBackupDir
         elif self.replicate or self.max_streams:
             raise ExceptionNoStackTraceNeeded("--replicate and --max-streams cannot be used without --ddboost")
         else:
-            self.dump_dir = 'db_dumps'
+            self.context.dump_dir = 'db_dumps'
 
         # Cannot combine include and exclude schema filters
-        if self.exclude_schema_file and self.dump_schema:
+        if self.context.exclude_schema_file and self.context.dump_schema:
             raise Exception('-s can not be selected with --exclude-schema-file option')
 
-        if self.include_schema_file and self.dump_schema:
+        if self.context.include_schema_file and self.context.dump_schema:
             raise Exception('-s can not be selected with --schema-file option')
 
-        if self.dump_schema and self.exclude_dump_schema:
+        if self.context.dump_schema and self.context.exclude_dump_schema:
             raise Exception('-s can not be selected with -S option')
 
-        if self.exclude_schema_file and self.exclude_dump_schema:
+        if self.context.exclude_schema_file and self.context.exclude_dump_schema:
             raise Exception('-S can not be selected with --exclude-schema-file option')
 
-        if self.include_schema_file and self.exclude_dump_schema:
+        if self.context.include_schema_file and self.context.exclude_dump_schema:
             raise Exception('-S can not be selected with --schema-file option')
 
-        if self.include_schema_file and self.exclude_schema_file:
+        if self.context.include_schema_file and self.context.exclude_schema_file:
             raise Exception('--exclude-schema-file can not be selected with --schema-file option')
 
 
         # Incremental selections not allowed with schema filters
-        if self.dump_schema and self.incremental:
+        if self.context.dump_schema and self.context.incremental:
             raise Exception('-s option can not be selected with incremental backup')
 
-        if self.exclude_dump_schema and self.incremental:
+        if self.context.exclude_dump_schema and self.context.incremental:
             raise Exception('-S option can not be selected with incremental backup')
 
-        if self.include_schema_file and self.incremental:
+        if self.context.include_schema_file and self.context.incremental:
             raise Exception('--schema-file option can not be selected with incremental backup')
 
-        if self.exclude_schema_file and self.incremental:
+        if self.context.exclude_schema_file and self.context.incremental:
             raise Exception('--exclude-schema-file option can not be selected with incremental backup')
 
 
         # Cannot combine table and schema filters
-        if self.exclude_schema_file and (self.include_dump_tables_file or self.exclude_dump_tables_file):
+        if self.context.exclude_schema_file and (self.context.include_dump_tables_file or self.context.exclude_dump_tables_file):
             raise Exception('--table-file and --exclude-table-file can not be selected with --exclude-schema-file option')
 
-        if self.include_schema_file and (self.include_dump_tables_file or self.exclude_dump_tables_file):
+        if self.context.include_schema_file and (self.context.include_dump_tables_file or self.context.exclude_dump_tables_file):
             raise Exception('--table-file and --exclude-table-file can not be selected with --schema-file option')
 
-        if self.dump_schema and (self.include_dump_tables_file or self.exclude_dump_tables_file):
+        if self.context.dump_schema and (self.context.include_dump_tables_file or self.context.exclude_dump_tables_file):
             raise Exception('--table-file and --exclude-table-file can not be selected with -s option')
 
-        if self.exclude_dump_schema and (self.include_dump_tables_file or self.exclude_dump_tables_file):
+        if self.context.exclude_dump_schema and (self.context.include_dump_tables_file or self.context.exclude_dump_tables_file):
             raise Exception('--table-file and --exclude-table-file can not be selected with -S option')
 
-        if self.exclude_schema_file and (self.include_dump_tables or self.exclude_dump_tables):
+        if self.context.exclude_schema_file and (self.context.include_dump_tables or self.context.exclude_dump_tables):
             raise Exception('-t and -T can not be selected with --exclude-schema-file option')
 
-        if self.include_schema_file and (self.include_dump_tables or self.exclude_dump_tables):
+        if self.context.include_schema_file and (self.context.include_dump_tables or self.context.exclude_dump_tables):
             raise Exception('-t and -T can not be selected with --schema-file option')
 
-        if self.dump_schema and (self.include_dump_tables or self.exclude_dump_tables):
+        if self.context.dump_schema and (self.context.include_dump_tables or self.context.exclude_dump_tables):
             raise Exception('-t and -T can not be selected with -s option')
 
-        if self.exclude_dump_schema and (self.include_dump_tables or self.exclude_dump_tables):
+        if self.context.exclude_dump_schema and (self.context.include_dump_tables or self.context.exclude_dump_tables):
             raise Exception('-t and -T can not be selected with -S option')
 
 
-        if self.include_dump_tables and self.incremental:
+        if self.context.include_dump_tables and self.context.incremental:
             raise Exception('include table list can not be selected with incremental backup')
 
-        if self.exclude_dump_tables and self.incremental:
+        if self.context.exclude_dump_tables and self.context.incremental:
             raise Exception('exclude table list can not be selected with incremental backup')
 
-        if self.include_dump_tables_file and self.incremental:
+        if self.context.include_dump_tables_file and self.context.incremental:
             raise Exception('include table file can not be selected with incremental backup')
 
-        if self.exclude_dump_tables_file and self.incremental:
+        if self.context.exclude_dump_tables_file and self.context.incremental:
             raise Exception('exclude table file can not be selected with incremental backup')
 
-        if self.clear_dumps and self.incremental:
+        if self.context.clear_dumps and self.context.incremental:
             raise Exception('-c option can not be selected with incremental backup')
 
-        if self.clear_catalog_dumps and self.incremental:
+        if self.context.clear_catalog_dumps and self.context.incremental:
             raise Exception('-C option can not be selected with incremental backup')
 
-        if self.include_schema_file and self.include_dump_tables:
+        if self.context.include_schema_file and self.context.include_dump_tables:
             raise Exception('-t can not be selected with --schema-file option')
 
-        if self.include_dump_tables and self.include_dump_tables_file:
+        if self.context.include_dump_tables and self.context.include_dump_tables_file:
             raise Exception('-t can not be selected with --table-file option')
 
-        if self.include_dump_tables and self.exclude_dump_tables_file:
+        if self.context.include_dump_tables and self.context.exclude_dump_tables_file:
             raise Exception('-t can not be selected with --exclude-table-file option')
 
-        if self.exclude_dump_tables and self.exclude_dump_tables_file:
+        if self.context.exclude_dump_tables and self.context.exclude_dump_tables_file:
             raise Exception('-T can not be selected with --exclude-table-file option')
 
-        if self.exclude_dump_tables and self.include_dump_tables_file:
+        if self.context.exclude_dump_tables and self.context.include_dump_tables_file:
             raise Exception('-T can not be selected with --table-file option')
 
-        if self.include_dump_tables and self.exclude_dump_tables:
+        if self.context.include_dump_tables and self.context.exclude_dump_tables:
             raise Exception('-t can not be selected with -T option')
 
-        if self.include_dump_tables_file and self.exclude_dump_tables_file:
+        if self.context.include_dump_tables_file and self.context.exclude_dump_tables_file:
             raise Exception('--table-file can not be selected with --exclude-table-file option')
 
-        if ('--inserts' in self.output_options or '--oids' in self.output_options or '--column-inserts' in self.output_options) and self.incremental:
+        if ('--inserts' in self.context.output_options or '--oids' in self.context.output_options or '--column-inserts' in self.context.output_options) and self.context.incremental:
             raise Exception('--inserts, --column-inserts, --oids cannot be selected with incremental backup')
 
-        if self.include_schema_file or self.dump_schema or self.exclude_schema_file or self.exclude_dump_schema:
+        if self.context.include_schema_file or self.context.dump_schema or self.context.exclude_schema_file or self.context.exclude_dump_schema:
             self.validate_dump_schema()
 
-        if self.incremental:
-            if self.netbackup_service_host is None:
-                self.full_dump_timestamp = get_latest_full_dump_timestamp(self.dump_databases[0], self.getBackupDirectoryRoot(), self.dump_dir, self.dump_prefix, self.ddboost, self.ddboost_storage_unit)
+        if self.context.incremental:
+            if not self.context.netbackup_service_host:
+                self.context.full_dump_timestamp = get_latest_full_dump_timestamp(self.context)
             else:
-                self.full_dump_timestamp = get_latest_full_ts_with_nbu(self.dump_databases[0], self.getBackupDirectoryRoot(), self.dump_prefix, self.netbackup_service_host, self.netbackup_block_size)
+                self.context.full_dump_timestamp = get_latest_full_ts_with_nbu(self.context)
 
     def validate_dump_schema(self):
-        if self.dump_schema:
-            for schema in self.dump_schema:
+        if self.context.dump_schema:
+            for schema in self.context.dump_schema:
                 if schema in CATALOG_SCHEMA:
                     raise Exception("can not specify catalog schema '%s' using -s option" % schema)
-        elif self.include_schema_file:
-            schema_list = get_lines_from_file(self.include_schema_file)
+        elif self.context.include_schema_file:
+            schema_list = get_lines_from_file(self.context.include_schema_file)
             for schema in schema_list:
                 if schema in CATALOG_SCHEMA:
-                    raise Exception("can not include catalog schema '%s' in schema file '%s'" % (schema, self.include_schema_file))
-        elif self.exclude_dump_schema:
-            for schema in self.exclude_dump_schema:
+                    raise Exception("can not include catalog schema '%s' in schema file '%s'" % (schema, self.context.include_schema_file))
+        elif self.context.exclude_dump_schema:
+            for schema in self.context.exclude_dump_schema:
                 if schema in CATALOG_SCHEMA:
                     raise Exception("can not specify catalog schema '%s' using -S option" % schema)
-        elif self.exclude_schema_file:
-            schema_list = get_lines_from_file(self.exclude_schema_file)
+        elif self.context.exclude_schema_file:
+            schema_list = get_lines_from_file(self.context.exclude_schema_file)
             for schema in schema_list:
                 if schema in CATALOG_SCHEMA:
-                    raise Exception("can not exclude catalog schema '%s' in schema file '%s'" % (schema, self.exclude_schema_file))
-
-    def getBackupDirectoryRoot(self):
-        if self.backup_dir:
-            return self.backup_dir
-        else:
-            return self.master_datadir
+                    raise Exception("can not exclude catalog schema '%s' in schema file '%s'" % (schema, self.context.exclude_schema_file))
 
     def getGpArray(self):
-        return GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port), utility=True)
+        return GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
 
     def getHostSet(self, gparray):
         hostlist = gparray.get_hostlist(includeMaster=True)
@@ -417,25 +333,25 @@ class GpCronDump(Operation):
 
     # check if one of gpcrondump option was specified, except of ddboost options
     def only_ddboost_options(self):
-        return ((len(self.dump_databases) == 0) and (not self.dump_schema)
-                and (self.backup_dir is None)
-                and not (self.include_dump_tables or self.output_options or self.clear_dumps_only or self.pre_vacuum
-                         or self.clear_dumps_only or self.dump_global or self.rollback or self.exclude_dump_tables
-                         or self.dump_config or self.clear_dumps_only or self.clear_dumps or self.post_vacuum or self.history))
+        return (len(self.context.dump_databases) == 0 and (not self.context.dump_schema)
+                and (not self.context.backup_dir)
+                and not (self.context.include_dump_tables or self.context.output_options or self.context.clear_dumps_only or self.pre_vacuum
+                         or self.context.clear_dumps_only or self.context.dump_global or self.rollback or self.context.exclude_dump_tables
+                         or self.context.dump_config or self.context.clear_dumps_only or self.context.clear_dumps or self.post_vacuum or self.context.history))
 
     def validateUserName(self, userName):
         if not re.search(r'^[a-zA-Z0-9-_]{1,30}$', userName):
             legal_username_str = """
-			The username length must be between 1 to 30 characters.
+            The username length must be between 1 to 30 characters.
 
-			The following characters are allowed:
+            The following characters are allowed:
                 1) Lowercase letters (a-z)
                 2) Uppercase letters (A-Z)
                 3) Numbers (0-9)
                 4) Special characters (- and _)
 
-		    Note: whitespace characters are not allowed.
-			"""
+            Note: whitespace characters are not allowed.
+            """
             raise ExceptionNoStackTraceNeeded(legal_username_str)
 
     def validatePassword(self, password):
@@ -474,7 +390,7 @@ class GpCronDump(Operation):
                 return
         logger.debug("DD Boost config removed from all GPDB servers.")
 
-    def createDDBoostConfig(self, gpHostsSet, ddboostHostsSet, user, password, backupDir, ddboost_storage_unit):
+    def createDDBoostConfig(self, gpHostsSet, password):
         """
         Creates config file for local/remote Data Domain on master and all the
         segment servers.  A brief outline of this function is as follows.
@@ -513,10 +429,10 @@ class GpCronDump(Operation):
            succeed without error.  As of Q1, 2013, we leave this issue to future
            releases.
         """
-        logger.debug("DDboost host(s): %s" % ddboostHostsSet)
-        numberOfDdboostNics = len(ddboostHostsSet)
-        if self.ddboost_ping:
-            for dd in ddboostHostsSet:
+        logger.debug("DDboost host(s): %s" % self.context.ddboost_hosts)
+        numberOfDdboostNics = len(self.context.ddboost_hosts)
+        if self.context.ddboost_ping:
+            for dd in self.context.ddboost_hosts:
                 cmd = Command("Ping DD Host", "ping -c 5 %s" % dd)
                 cmd.run()
                 if not cmd.was_successful():
@@ -539,13 +455,13 @@ class GpCronDump(Operation):
                 "Found existing configuration for remote Data Domain.")
         except:
             pass
-        if self.ddboost_remote:
+        if self.context.ddboost_remote:
             pairDD = localDD
             selfDD = remoteDD
         else:
             pairDD = remoteDD
             selfDD = localDD
-        if pairDD and pairDD.hostname in ddboostHostsSet:
+        if pairDD and pairDD.hostname in self.context.ddboost_hosts:
             msg = "%s Data Domain is already configured with hostname %s." +\
                 " Local and remote Data Domains must be different."
             logger.error(msg % (pairDD.id, pairDD.hostname))
@@ -564,20 +480,20 @@ class GpCronDump(Operation):
         ddcmdTemplate = "source " + os.environ["GPHOME"] + \
             "/greenplum_path.sh; " + os.environ["GPHOME"] + \
             "/bin/gpddboost  --setCredential "+ \
-            "--hostname=%s --user=" + re.escape(user)
+            "--hostname=%s --user=" + re.escape(self.context.ddboost_user)
 
         # Backup directory and DDBoost storage unit will not be part of config file for remote DD server
-        if self.ddboost_remote:
+        if self.context.ddboost_remote:
             ddcmdTemplate += " --remote"
         else:
             ddcmdTemplate += " --defaultBackupDirectory=" + backupDir
 
-            if ddboost_storage_unit:
-                ddcmdTemplate += " --ddboost-storage-unit=" + ddboost_storage_unit
+            if self.context.ddboost_storage_unit:
+                ddcmdTemplate += " --ddboost-storage-unit=" + self.context.ddboost_storage_unit
 
         # Create a DD Boost config on master for each DD Boost host.  Try
         # logging into each DD Boost using the config.
-        for dd in ddboostHostsSet:
+        for dd in self.context.ddboost_hosts:
             ddcmd = ddcmdTemplate % dd
             logger.debug("Verifying configuration: "+ddcmd)
             ddcmd += " --password=" + re.escape(password)
@@ -587,10 +503,11 @@ class GpCronDump(Operation):
                 r = cmd.get_results()
                 raise Exception("gpddboost failed to run on localhost. %s" % \
                                     r.printResult())
-            if self.ddboost_remote:
-                selfDD = gpmfr.DDSystem("remote", backupDir, ddboost_storage_unit)
+
+            if self.context.ddboost_remote:
+                selfDD = gpmfr.DDSystem("remote", self.context.ddboost_backupdir, self.context.ddboost_storage_unit)
             else:
-                selfDD = gpmfr.DDSystem("local", backupDir, ddboost_storage_unit)
+                selfDD = gpmfr.DDSystem("local", self.context.ddboost_backupdir, self.context.ddboost_storage_unit)
 
             # This step creates storage unit specified by ddboost_storage_unit or read
             # from cluster's config file on the Data Domain if one doesn't exist.
@@ -608,7 +525,7 @@ class GpCronDump(Operation):
             # the case when a single Data Domain host has multiple IP addresses
             # for load balancing.  We distribute segment servers evenly across
             # the NICs.
-            currentDdboostHost = ddboostHostsSet[index % numberOfDdboostNics]
+            currentDdboostHost = self.context.ddboost_hosts[index % numberOfDdboostNics]
             ddcmd = ddcmdTemplate % currentDdboostHost
             logger.debug("Writing configuration on host %s: %s --password=*" %
                          (host, ddcmd))
@@ -624,49 +541,48 @@ class GpCronDump(Operation):
         logger.debug("DD Boost configured on all GPDB servers.")
 
     # Verify the DDBoost credentials using the credentials that stored on the Master
-    # TODO: verify also all the hosts in self.ddboost_hosts (ping to the hosts, I think there is some Python function for that)
+    # TODO: verify also all the hosts in self.context.ddboost_hosts (ping to the hosts, I think there is some Python function for that)
     def _ddboostVerify(self):
         verifyCmdLine = os.environ['GPHOME'] + '/bin/gpddboost --verify' 
-        if self.ddboost_storage_unit:
-            verifyCmdLine += ' --ddboost-storage-unit %s' % self.ddboost_storage_unit
+        if self.context.ddboost_storage_unit:
+            verifyCmdLine += ' --ddboost-storage-unit %s' % self.context.ddboost_storage_unit
         logger.debug("Executing gpddboost to verify DDBoost credentials: %s" % verifyCmdLine)
         if not os.system(verifyCmdLine):
             logger.info("The specified DDBoost credentials are OK")
         else:
             raise ExceptionNoStackTraceNeeded('Failed to connect to DD_host with DD_user and the DD_password')
 
-    # Creating a temp file from the schema list provided by user,
-    # if include_schema_file is not provided else returns include_schema_file
-    def get_schema_list_file(self, dbname):
+    # Creates a temp file from the schema list provided by user if include_schema_file is not provided,
+    # else sets schema_file to include_schema_file
+    def generate_schema_list_file(self):
         schema_file = None
-        if self.include_schema_file:
-            schema_list = get_lines_from_file(self.include_schema_file)
+        if self.context.include_schema_file:
+            schema_list = get_lines_from_file(self.context.include_schema_file)
             schema_file = create_temp_file_from_list(schema_list, 'schema_list')
-        elif self.dump_schema:
-            schema_file = create_temp_file_from_list(self.dump_schema, 'schema_list')
-            self.dump_schema = []
-        elif self.exclude_dump_schema:
-            schema_list = get_include_schema_list_from_exclude_schema(self.exclude_dump_schema, CATALOG_SCHEMA, self.master_port, dbname)
+        elif self.context.dump_schema:
+            schema_file = create_temp_file_from_list(self.context.dump_schema, 'schema_list')
+            self.context.dump_schema = []
+        elif self.context.exclude_dump_schema:
+            schema_list = get_include_schema_list_from_exclude_schema(self.context, self.context.exclude_dump_schema)
             schema_file = create_temp_file_from_list(schema_list, 'schema_list')
-            self.exclude_dump_schema = []
-        elif self.exclude_schema_file:
-            schema_list = get_include_schema_list_from_exclude_schema(get_lines_from_file(self.exclude_schema_file), CATALOG_SCHEMA, self.master_port, dbname)
+            self.context.exclude_dump_schema = []
+        elif self.context.exclude_schema_file:
+            schema_list = get_include_schema_list_from_exclude_schema(self.context, get_lines_from_file(self.context.exclude_schema_file))
             schema_file = create_temp_file_from_list(schema_list, 'schema_list')
-
-        return schema_file
+        self.context.schema_file = schema_file
 
     # This method is called only when prefix option is specified with schema filter,
     # for full backup.
     # Method updates the include_dump_tables_file based on the schema list provided,
     # i.e All the tables in the specified schema's are added to the include_dump_tables_file.
 
-    def generate_include_table_list_from_schema_file(self, dbname, schema_file):
-        dump_schemas = get_lines_from_file(schema_file)
+    def generate_include_table_list_from_schema_file(self):
+        dump_schemas = get_lines_from_file(self.context.schema_file)
         table_list = []
         for schema in dump_schemas:
-            tables = get_user_table_list_for_schema(self.master_port, dbname, schema)
+            tables = get_user_table_list_for_schema(self.context, schema)
             for table in tables:
-                table_name = table[0].strip() + "." + table[1].strip()
+                table_name = table[0] + "." + table[1]
                 table_list.append(table_name)
         return create_temp_file_from_list(table_list, 'include_dump_tables_file')
 
@@ -678,29 +594,23 @@ class GpCronDump(Operation):
         include_file = None
         exclude_file = None
 
-        if self.incremental:
+        if self.context.incremental:
             return (dirty_file, exclude_file)
 
-        if self.include_dump_tables:
-            include_file = expand_partitions_and_populate_filter_file(dbname,
-                                                                      self.include_dump_tables,
-                                                                      'include_dump_tables_file')
-            self.include_dump_tables = []
+        if self.context.include_dump_tables:
+            include_file = expand_partitions_and_populate_filter_file(dbname, self.context.include_dump_tables, 'include_dump_tables_file')
+            self.context.include_dump_tables = []
 
-        if self.exclude_dump_tables:
-            exclude_file = expand_partitions_and_populate_filter_file(dbname,
-                                                                      self.exclude_dump_tables,
-                                                                      'exclude_dump_tables_file')
-            self.exclude_dump_tables = []
+        if self.context.exclude_dump_tables:
+            exclude_file = expand_partitions_and_populate_filter_file(dbname, self.context.exclude_dump_tables, 'exclude_dump_tables_file')
+            self.context.exclude_dump_tables = []
 
-        if self.include_dump_tables_file:
-            include_tables = get_lines_from_file(self.include_dump_tables_file)
-            include_file = expand_partitions_and_populate_filter_file(dbname,
-                                                                      include_tables,
-                                                                      'include_dump_tables_file')
+        if self.context.include_dump_tables_file:
+            include_tables = get_lines_from_file(self.context.include_dump_tables_file)
+            include_file = expand_partitions_and_populate_filter_file(dbname, include_tables, 'include_dump_tables_file')
 
-        if self.exclude_dump_tables_file:
-            exclude_tables = get_lines_from_file(self.exclude_dump_tables_file)
+        if self.context.exclude_dump_tables_file:
+            exclude_tables = get_lines_from_file(self.context.exclude_dump_tables_file)
             exclude_file = expand_partitions_and_populate_filter_file(dbname,
                                                                       exclude_tables,
                                                                       'exclude_dump_tables_file')
@@ -709,7 +619,7 @@ class GpCronDump(Operation):
 
     # Thread to poll for existence of a signal file telling us that we can drop the pg_class lock
     def lock_handler(self, timestamp, thread_stop):
-        dump_dir = get_backup_directory(self.master_datadir, self.backup_dir, self.dump_dir, timestamp)
+        dump_dir = self.context.get_backup_dir(timestamp)
         global lock_file_name
         lock_file_name = "%s/gp_lockfile_%s" % (dump_dir, timestamp[8:])
         while not thread_stop.is_set():
@@ -734,28 +644,28 @@ class GpCronDump(Operation):
                 os.remove(lock_file_name)
         # This should only throw the Exception if "os.remove" fails which means there was a genuine failure.
         except Exception, e:
-            logger.warning("Could not remove signal file %s, backup will proceed without releasing pg_class lock." % lock_file_name)
+            logger.warn("Could not remove signal file %s, backup will proceed without releasing pg_class lock." % lock_file_name)
 
     def execute(self):
-        if bool(self.ddboost_hosts) or bool(self.ddboost_user):
+        if bool(self.context.ddboost_hosts) or bool(self.context.ddboost_user):
             # check that both options are specified
-            if not (bool(self.ddboost_hosts) and bool(self.ddboost_user)):
+            if not (bool(self.context.ddboost_hosts) and bool(self.context.ddboost_user)):
                 raise ExceptionNoStackTraceNeeded('For DDBoost config, both options are required --ddboost-host <ddboost_hostname> --ddboost-user <ddboost_user>.')
 
             # check that no other gpcrondump option was specified
-            if self.only_ddboost_options() and not self.ddboost_config_remove:
-                if not self.ddboost_remote and not self.ddboost_backupdir:
+            if self.only_ddboost_options() and not self.context.ddboost_config_remove:
+                if not self.context.ddboost_remote and not self.context.ddboost_backupdir:
                     raise ExceptionNoStackTraceNeeded("--ddboost-backupdir must be specified when configuring local Data Domain.")
-                self.validateUserName(userName=self.ddboost_user)
+                self.validateUserName(userName=self.context.ddboost_user)
                 hostset = self.getHostSet(self.getGpArray())
                 p = getpass()
                 self.validatePassword(password=p)
-                self.createDDBoostConfig(hostset, self.ddboost_hosts, self.ddboost_user, p, self.ddboost_backupdir, self.ddboost_storage_unit)
+                self.createDDBoostConfig(hostset, p)
                 return 0
             else:
                 raise ExceptionNoStackTraceNeeded('The options --ddboost-host and --ddboost-user are standalone. They are NOT used in conjunction with any other gocrondump options (only with --ddboost-verify).')
 
-        if self.ddboost_config_remove:
+        if self.context.ddboost_config_remove:
             if self.only_ddboost_options():
                 hostset = self.getHostSet(self.getGpArray())
                 # The username and the password must be at least 2 characters long, so we just use 2 spaces for each
@@ -764,21 +674,15 @@ class GpCronDump(Operation):
             else:
                 raise ExceptionNoStackTraceNeeded('The option --ddboost-config-remove is standalone. It is NOT used in conjunction with any other gocrondump options.')
 
-        if self.clear_dumps_only:
+        if self.context.clear_dumps_only:
             logger.info('Clearing dumps only...')
-            generate_dump_timestamp(self._get_timestamp_object(self.timestamp_key))
-            DeleteOldestDumps(master_datadir = self.master_datadir,
-                              master_port = self.master_port,
-                              dump_dir = self.dump_dir,
-                              cleanup_date = self.cleanup_date,
-                              cleanup_total = self.cleanup_total,
-                              ddboost = self.ddboost,
-                              ddboost_storage_unit=self.ddboost_storage_unit).run()
+            self.context.generate_dump_timestamp()
+            DeleteOldestDumps(self.context).run()
             return 0
 
         # If --ddboost-verify or --ddboost is specified, we check the credentials that stored on the Master
         # In case of --ddboost we force the verification (MPP-17510)
-        if bool(self.ddboost_verify) or bool(self.ddboost):
+        if bool(self.context.ddboost_verify) or bool(self.context.ddboost):
             # DDBoost verify will create storage unit on DDBoost Server if not exist, few scenairos which do not need:
             # --list-backup-file (already pre checked and not supported with --ddboost)
             # --ddboost-config-remove (a return issued ahead), clear dumps only( -o option handled ahead),
@@ -789,10 +693,10 @@ class GpCronDump(Operation):
                 self._ddboostVerify()
 
             # Check if we need to exit now
-            if self.ddboost_verify_and_exit is True:
+            if self.context.ddboost_verify_and_exit is True:
                 return 0
 
-        if self.post_script is not None:
+        if self.context.post_script:
             self._validate_run_program()
 
         self._validate_dump_target()
@@ -803,216 +707,137 @@ class GpCronDump(Operation):
         #                        in this loop over the -x arguments
         final_exit_status = current_exit_status = 0
 
-        if self.ddboost_show_config:
+        if self.context.ddboost_show_config:
             self.show_ddboost_config()
             return 0
 
-        for dump_database in self.dump_databases:
-            timestamp = self._get_timestamp_object(self.timestamp_key)
-            timestamp_str = timestamp.strftime('%Y%m%d%H%M%S')
-            generate_dump_timestamp(timestamp)
+        for dumpdb in self.context.dump_databases:
+            self.context.dump_database = dumpdb
+            self.context.generate_dump_timestamp()
             if self.list_backup_files:
-                self._list_backup_files(timestamp_str)
+                self._list_backup_files()
                 logger.info('Successfully listed the names of backup files and pipes')
                 return 0
             if self.list_filter_tables:
-                db = self.dump_databases[0]
-                self._list_filter_tables(db, get_filter_file(db, self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.ddboost, self.ddboost_storage_unit))
+                db = self.context.dump_database
+                self._list_filter_tables(db, get_filter_file(self.context))
                 return 0
 
-            validate_current_timestamp(self.getBackupDirectoryRoot(), self.dump_dir, self.dump_prefix)
+            validate_current_timestamp(self.context)
             if self.interactive:
-                self._prompt_continue(dump_database)
+                self._prompt_continue(self.context)
 
             if self.pre_vacuum:
                 logger.info('Commencing pre-dump vacuum')
-                VacuumDatabase(database=dump_database,
-                               master_port=self.master_port).run()
+                VacuumDatabase(self.context)
 
-            if self.free_space_percent is not None:
-                ValidateGpToolkit(database=dump_database,
-                                  master_port=self.master_port).run()
+            if self.context.free_space_percent:
+                ValidateGpToolkit(self.context)
 
             global conn
             conn = None
             try:
                 thread_stop = threading.Event()
-                lock_thread = threading.Thread(target=self.lock_handler, args=(timestamp_str, thread_stop))
+                lock_thread = threading.Thread(target=self.lock_handler, args=(self.context.timestamp, thread_stop))
                 lock_thread.start()
 
                 LOCK_TABLE_SQL = "LOCK TABLE pg_catalog.pg_class IN EXCLUSIVE MODE;"
-                conn = dbconn.connect(dbconn.DbURL(port=self.pgport, dbname=dump_database), utility=True)
+                conn = dbconn.connect(dbconn.DbURL(port=self.context.master_port, dbname=self.context.dump_database), utility=True)
                 dbconn.execSQL(conn, LOCK_TABLE_SQL)
 
-                ao_partition_list = get_ao_partition_state(self.master_port, dump_database)
-                co_partition_list = get_co_partition_state(self.master_port, dump_database)
-                heap_partitions = get_dirty_heap_tables(self.master_port, dump_database)
-                last_operation_list = get_last_operation_data(self.master_port, dump_database)
+                ao_partition_list = get_ao_partition_state(self.context)
+                co_partition_list = get_co_partition_state(self.context)
+                heap_partitions = get_dirty_heap_tables(self.context)
+                last_operation_list = get_last_operation_data(self.context)
 
                 self._verify_tablenames(ao_partition_list, co_partition_list, heap_partitions)
 
                 dirty_partitions = None
                 dirty_file = None
-                if self.incremental:
-                    dirty_partitions = get_dirty_tables(self.master_port, dump_database,
-                                                        self.master_datadir, self.backup_dir,
-                                                        self.dump_dir, self.dump_prefix,
-                                                        self.full_dump_timestamp, ao_partition_list,
-                                                        co_partition_list, last_operation_list,
-                                                        self.netbackup_service_host, self.netbackup_block_size)
-                    if self.dump_prefix and \
-                       get_filter_file(dump_database, self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix,
-                                       self.ddboost, self.ddboost_storage_unit, self.netbackup_service_host, self.netbackup_block_size):
-                        update_filter_file(dump_database, self.master_datadir, self.backup_dir, self.master_port, self.dump_dir, self.dump_prefix,
-                                           self.ddboost, self.ddboost_storage_unit, self.netbackup_service_host, self.netbackup_policy,
-                                           self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
-                    dirty_partitions = filter_dirty_tables(dirty_partitions, dump_database, self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix,
-                                                           self.ddboost, self.ddboost_storage_unit, self.netbackup_service_host, self.netbackup_block_size)
-
+                if self.context.incremental:
+                    dirty_partitions = get_dirty_tables(self.context, ao_partition_list, co_partition_list, last_operation_list)
+                    if self.context.dump_prefix and get_filter_file(self.context):
+                        update_filter_file(self.context)
+                    dirty_partitions = filter_dirty_tables(self.context, dirty_partitions)
                     dirty_file = write_dirty_file_to_temp(dirty_partitions)
 
-                schema_file = self.get_schema_list_file(dump_database)
-                (include_file, exclude_file) = self.get_include_exclude_for_dump_database(dirty_file, dump_database)
+                self.generate_schema_list_file()
+                (include_file, exclude_file) = self.get_include_exclude_for_dump_database(dirty_file, self.context.dump_database)
+                self.context.include_dump_tables_file = include_file
+                self.context.exclude_dump_tables_file = exclude_file
 
-                if self.dump_prefix and schema_file and not self.incremental:
-                    include_file = self.generate_include_table_list_from_schema_file(dump_database, schema_file)
+                if self.context.schema_file and not self.context.incremental:
+                    self.context.include_dump_tables_file = self.generate_include_table_list_from_schema_file()
 
-                dump_outcome = DumpDatabase(dump_database = dump_database,
-                                            dump_schema = self.dump_schema,
-                                            include_dump_tables = self.include_dump_tables,
-                                            exclude_dump_tables = self.exclude_dump_tables,
-                                            include_dump_tables_file = include_file,
-                                            exclude_dump_tables_file = exclude_file,
-                                            backup_dir = self.backup_dir,
-                                            free_space_percent = self.free_space_percent,
-                                            compress = self.compress,
-                                            clear_catalog_dumps = self.clear_catalog_dumps,
-                                            encoding = self.encoding,
-                                            output_options = self.output_options,
-                                            batch_default = self.batch_default,
-                                            master_datadir = self.master_datadir,
-                                            master_port = self.master_port,
-                                            dump_dir = self.dump_dir,
-                                            dump_prefix = self.dump_prefix,
-                                            ddboost = self.ddboost,
-                                            netbackup_service_host = self.netbackup_service_host,
-                                            netbackup_policy = self.netbackup_policy,
-                                            netbackup_schedule = self.netbackup_schedule,
-                                            netbackup_block_size = self.netbackup_block_size,
-                                            netbackup_keyword = self.netbackup_keyword,
-                                            incremental = self.incremental,
-                                            include_schema_file = schema_file,
-                                            ddboost_storage_unit = self.ddboost_storage_unit).run()
+                dump_outcome = DumpDatabase(self.context).run()
 
-                post_dump_outcome = PostDumpDatabase(timestamp_start = dump_outcome['timestamp_start'],
-                                                     compress = self.compress,
-                                                     backup_dir = self.backup_dir,
-                                                     batch_default = self.batch_default,
-                                                     master_datadir = self.master_datadir,
-                                                     master_port = self.master_port,
-                                                     dump_dir = self.dump_dir,
-                                                     dump_prefix = self.dump_prefix,
-                                                     ddboost = self.ddboost,
-                                                     netbackup_service_host = self.netbackup_service_host,
-                                                     incremental = self.incremental).run()
+                post_dump_outcome = PostDumpDatabase(self.context, timestamp_start = dump_outcome['timestamp_start']).run()
 
-                if self.dump_stats:
+                if self.context.dump_stats:
                     if current_exit_status == 0:
-                        DumpStats(timestamp = post_dump_outcome['timestamp'],
-                                   master_datadir = self.master_datadir,
-                                   dump_database = dump_database,
-                                   master_port = self.master_port,
-                                   backup_dir = self.backup_dir,
-                                   dump_dir = self.dump_dir,
-                                   dump_prefix = self.dump_prefix,
-                                   include_table_file = include_file,
-                                   exclude_table_file = exclude_file,
-                                   include_schema_file = schema_file,
-                                   ddboost = self.ddboost,
-                                   ddboost_storage_unit = self.ddboost_storage_unit
-                                   ).run()
-                        if self.netbackup_service_host and self.netbackup_policy and self.netbackup_schedule:
-                            backup_statistics_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host,
-                                                            self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
+                        self.context.timestamp = post_dump_outcome['timestamp']
+                        DumpStats(self.context).run()
+                        if self.context.netbackup_service_host and self.context.netbackup_policy and self.context.netbackup_schedule:
+                            backup_file_with_nbu(self.context, "stats")
                     else:
                         logger.info("Skipping statistics dump due to issues during post-dump checks.")
 
-                if self.netbackup_service_host and self.netbackup_policy and self.netbackup_schedule:
-                    backup_cdatabase_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host, self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
-                    backup_report_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host, self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
+                if self.context.netbackup_service_host and self.context.netbackup_policy and self.context.netbackup_schedule:
+                    backup_file_with_nbu(self.context, "cdatabase")
+                    backup_file_with_nbu(self.context, "report")
 
-                if self.incremental:
-                    if dirty_file is not None and os.path.isfile(dirty_file):
-                        if self.ddboost:
+                if self.context.incremental:
+                    if dirty_file and os.path.isfile(dirty_file):
+                        if self.context.ddboost:
                             time.sleep(5)
                         os.remove(dirty_file)
-                        remove_file_on_segments(self.master_port, dirty_file)
-                    write_dirty_file(self.master_datadir, dirty_partitions, self.backup_dir, self.dump_dir, self.dump_prefix, None, self.ddboost, self.ddboost_storage_unit)
-                    if self.netbackup_service_host:
-                        backup_dirty_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host, self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
+                        remove_file_on_segments(self.context, dirty_file)
+                    write_dirty_file(self.context, dirty_partitions)
+                    if self.context.netbackup_service_host:
+                        backup_file_with_nbu(self.context, "dirty_table")
 
-                if include_file is not None and os.path.exists(include_file):
-                    os.remove(include_file)
-                    remove_file_on_segments(self.master_port, include_file)
-                if exclude_file is not None and os.path.exists(exclude_file):
-                    os.remove(exclude_file)
-                    remove_file_on_segments(self.master_port, exclude_file)
-                if schema_file:
-                    schema_filename = generate_schema_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp_str, self.ddboost)
-                    shutil.copyfile(schema_file, schema_filename)
-                    remove_file_on_segments(self.master_port, schema_file)
-                if schema_file is not None and os.path.exists(schema_file):
-                    os.remove(schema_file)
+                if self.context.schema_file:
+                    schema_filename = self.context.generate_filename("schema")
+                    shutil.copyfile(self.context.schema_file, schema_filename)
+                    remove_file_on_segments(self.context, self.context.schema_file)
+                if self.context.schema_file and os.path.exists(self.context.schema_file):
+                    os.remove(self.context.schema_file)
+                self.cleanup_files_on_segments()
 
-                write_state_file('ao', self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, ao_partition_list, self.ddboost, self.ddboost_storage_unit)
-                write_state_file('co', self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, co_partition_list, self.ddboost, self.ddboost_storage_unit)
-                write_last_operation_file(self.master_datadir, self.backup_dir, last_operation_list, self.dump_dir, self.dump_prefix, timestamp_key=None, ddboost=self.ddboost)
+                write_state_file(self.context, "ao", ao_partition_list)
+                write_state_file(self.context, "co", co_partition_list)
+                write_last_operation_file(self.context, last_operation_list)
 
-                if self.netbackup_service_host and self.netbackup_policy and self.netbackup_schedule:
-                    backup_state_files_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host,
-                                                self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
-                    schema_filename = generate_schema_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp_str, self.ddboost)
-                    if os.path.exists(schema_filename) and not self.incremental:
-                        backup_schema_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host,
-                                                    self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
+                if self.context.netbackup_service_host and self.context.netbackup_policy and self.context.netbackup_schedule:
+                    backup_state_files_with_nbu(self.context)
+                    schema_filename = self.context.generate_filename("schema")
+                    if os.path.exists(schema_filename) and not self.context.incremental:
+                        backup_file_with_nbu(self.context, "schema")
 
-                if self.ddboost:
-                    backup_report_file_with_ddboost(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, ddboost_storage_unit= self.ddboost_storage_unit)
-                    schema_filename = generate_schema_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp_str, self.ddboost)
-                    if os.path.exists(schema_filename) and not self.incremental:
-                        backup_schema_file_with_ddboost(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.ddboost_storage_unit)
+                if self.context.ddboost:
+                    backup_file_with_ddboost(self.context, "report")
+                    schema_filename = self.context.generate_filename("schema")
+                    if os.path.exists(schema_filename) and not self.context.incremental:
+                        backup_file_with_ddboost(self.context, "schema")
 
                 current_exit_status = max(dump_outcome['exit_status'], post_dump_outcome['exit_status'])
                 if self.replicate and current_exit_status == 0:
-                    self.dump_timestamps.append((dump_database, post_dump_outcome["timestamp"]))
+                    self.dump_timestamps.append((self.context.dump_database, post_dump_outcome["timestamp"]))
                 final_exit_status = max(final_exit_status, current_exit_status)
 
-                if self.incremental:
+                if self.context.incremental:
                     if final_exit_status:
                         logger.info('non-zero exit status from gp_dump, skipping generation of increments file')
                     else:
                         # if this fails, it raises an exception and bombs out RC and to the screen
-                        CreateIncrementsFile(dump_database = dump_database,
-                                             full_timestamp = self.full_dump_timestamp,
-                                             timestamp = post_dump_outcome['timestamp'],
-                                             master_datadir = self.master_datadir,
-                                             backup_dir = self.backup_dir,
-                                             ddboost = self.ddboost,
-                                             dump_dir = self.dump_dir,
-                                             dump_prefix = self.dump_prefix,
-                                             netbackup_service_host = self.netbackup_service_host,
-                                             netbackup_block_size = self.netbackup_block_size,
-                                             ddboost_storage_unit = self.ddboost_storage_unit).run()
-                        if self.ddboost:
-                            backup_increments_file_with_ddboost(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, 
-                                                                self.full_dump_timestamp, self.ddboost_storage_unit)
+                        CreateIncrementsFile(self.context).run()
+                        if self.context.ddboost:
+                            backup_file_with_ddboost(self.context, "increments", self.context.full_dump_timestamp)
 
-                        write_partition_list_file(self.master_datadir, self.backup_dir, post_dump_outcome['timestamp'],
-                                                  self.master_port, dump_database, self.dump_dir, self.dump_prefix, 
-                                                  self.ddboost, self.netbackup_service_host, self.ddboost_storage_unit)
-                        if self.netbackup_service_host:
-                            backup_increments_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.full_dump_timestamp, self.netbackup_service_host, self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
-                            backup_partition_list_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host, self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
+                        write_partition_list_file(self.context, post_dump_outcome['timestamp'])
+                        if self.context.netbackup_service_host:
+                            backup_file_with_nbu(self.context, "increments")
+                            backup_file_with_nbu(self.context, "partition_list")
 
             finally:
                 thread_stop.set()
@@ -1026,30 +851,21 @@ class GpCronDump(Operation):
                 except Exception, e:
                     logger.debug("Failed to remove signal file or close connection, lock_handler thread probably already got to it.")
 
-            if self.history:
+            if self.context.history:
                 # This certainly does not belong under DumpDatabase, due to CLI assumptions. Note the use of options_list.
-                UpdateHistoryTable(dump_database = dump_database,
-                                   options_list = self.options_list,
+                UpdateHistoryTable(self.context,
+                                   self.options_list,
                                    time_start = dump_outcome['time_start'],
                                    time_end = dump_outcome['time_end'],
                                    dump_exit_status = dump_outcome['exit_status'],
                                    timestamp = post_dump_outcome['timestamp'],
-                                   pseudo_exit_status = current_exit_status,
-                                   master_port = self.master_port).run()
+                                   pseudo_exit_status = current_exit_status).run()
 
-            if self.dump_global:
+            if self.context.dump_global:
                 if current_exit_status == 0:
-                    DumpGlobal(timestamp = post_dump_outcome['timestamp'],
-                               master_datadir = self.master_datadir,
-                               master_port = self.master_port,
-                               backup_dir = self.backup_dir,
-                               dump_dir = self.dump_dir,
-                               dump_prefix = self.dump_prefix,
-                               ddboost = self.ddboost,
-                               ddboost_storage_unit = self.ddboost_storage_unit).run()
-                    if self.netbackup_service_host and self.netbackup_policy and self.netbackup_schedule:
-                        backup_global_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host,
-                                                    self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
+                    DumpGlobal(self.context, timestamp = post_dump_outcome['timestamp']).run()
+                    if self.context.netbackup_service_host and self.context.netbackup_policy and self.context.netbackup_schedule:
+                        backup_file_with_nbu(self.context, "global")
                 else:
                     logger.info("Skipping global dump due to issues during post-dump checks.")
 
@@ -1061,53 +877,41 @@ class GpCronDump(Operation):
                     logger.warn("Dump request was incomplete, however cannot rollback since no timestamp was found.")
                     MailDumpEvent("Report from gpcrondump on host %s [FAILED]" % self.cur_host,
                                   "Failed for database %s with return code %d, dump files not rolled back, because no new timestamp was found. [Start=%s End=%s] Options passed [%s]"
-                                  % (dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
+                                  % (self.context.dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
                     raise ExceptionNoStackTraceNeeded("Dump incomplete, rollback not processed")
                 elif self.rollback:
                     logger.warn("Dump request was incomplete, rolling back dump")
-                    DeleteCurrentDump(timestamp = post_dump_outcome['timestamp'],
-                                      master_datadir = self.master_datadir,
-                                      master_port = self.master_port,
-                                      dump_dir = self.dump_dir,
-                                      ddboost = self.ddboost,
-                                      ddboost_storage_unit=self.ddboost_storage_unit).run()
+                    DeleteCurrentDump(self.context, timestamp = post_dump_outcome['timestamp']).run()
                     MailDumpEvent("Report from gpcrondump on host %s [FAILED]" % self.cur_host,
                                   "Failed for database %s with return code %d dump files rolled back. [Start=%s End=%s] Options passed [%s]"
-                                  % (dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
+                                  % (self.context.dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
                     raise ExceptionNoStackTraceNeeded("Dump incomplete, completed rollback")
                 else:
                     logger.warn("Dump request was incomplete, not rolling back because -r option was not supplied")
                     MailDumpEvent("Report from gpcrondump on host %s [FAILED]" % self.cur_host,
                                   "Failed for database %s with return code %s dump files not rolled back. [Start=%s End=%s] Options passed [%s]"
-                                  % (dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
+                                  % (self.context.dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
                     raise ExceptionNoStackTraceNeeded("Dump incomplete, rollback not processed")
             else:
-                if self.clear_dumps:
-                    deleted_dump_set = DeleteOldestDumps(master_datadir = self.master_datadir,
-                                                         master_port = self.master_port,
-                                                         dump_dir = self.dump_dir,
-                                                         cleanup_date = self.cleanup_date,
-                                                         cleanup_total = self.cleanup_total,
-                                                         ddboost = self.ddboost,
-                                                         ddboost_storage_unit=self.ddboost_storage_unit).run()
+                if self.context.clear_dumps:
+                    deleted_dump_set = DeleteOldestDumps(self.context).run()
 
             if self.post_vacuum:
                 logger.info('Commencing post-dump vacuum...')
-                VacuumDatabase(database = dump_database,
-                               master_port = self.master_port).run()
+                VacuumDatabase(database = self.context.dump_database,
+                               master_port = self.context.master_port).run()
 
-            dump_type = 'Incremental' if self.incremental else 'Full database'
-            self._status_report(dump_database,
-                                post_dump_outcome['timestamp'],
+            dump_type = 'Incremental' if self.context.incremental else 'Full database'
+            self._status_report(post_dump_outcome['timestamp'],
                                 dump_outcome,
                                 current_exit_status,
                                 deleted_dump_set,
                                 dump_type)
 
-            if self.dump_config:
+            if self.context.dump_config:
                 dump_info_dict = defaultdict(dict)
                 dump_info_dict['host'] = self.cur_host
-                dump_info_dict['dbname'] = dump_database
+                dump_info_dict['dbname'] = self.context.dump_database
                 dump_info_dict['exit_status'] = current_exit_status
                 dump_info_dict['start_time'] = dump_outcome['time_start']
                 dump_info_dict['end_time'] = dump_outcome['time_end']
@@ -1115,35 +919,28 @@ class GpCronDump(Operation):
 
                 dump_db_info_list.append(dump_info_dict)
             else:
-                self._send_email(dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'])
+                self._send_email(self.context.dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'])
 
-        if self.dump_config:
-            config_outcome = DumpConfig(backup_dir = self.backup_dir,
-                                        master_datadir = self.master_datadir,
-                                        master_port = self.master_port,
-                                        dump_dir = self.dump_dir,
-                                        dump_prefix = self.dump_prefix,
-                                        ddboost = self.ddboost,
-                                        ddboost_storage_unit=self.ddboost_storage_unit).run()
-            if self.netbackup_service_host and self.netbackup_policy and self.netbackup_schedule:
-                backup_config_files_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.master_port,
-                                             self.netbackup_service_host, self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword)
+        if self.context.dump_config:
+            config_outcome = DumpConfig(self.context).run()
+            if self.context.netbackup_service_host and self.context.netbackup_policy and self.context.netbackup_schedule:
+                backup_config_files_with_nbu(self.context)
 
             for dump_db_info in dump_db_info_list:
                 self._send_email(dump_db_info['dbname'], dump_db_info['exit_status'], dump_db_info['start_time'], dump_outcome['time_end'])
 
-        if self.ddboost and self.replicate:
+        if self.context.ddboost and self.replicate:
             logger.info("Backup to local Data Domain successful.")
             for name, ts in self.dump_timestamps:
                 p = gpmfr.mfr_parser()
-                arglist = ["--replicate", ts, "--max-streams", self.max_streams, "--master-port", str(self.master_port)]
+                arglist = ["--replicate", ts, "--max-streams", self.max_streams, "--master-port", str(self.context.master_port)]
                 if self.quiet:
                     arglist.append("--quiet")
                 if self.verbose:
                     arglist.append("--verbose")
                 if not self.interactive:
                     arglist.append("-a")
-                if not self.ddboost_ping:
+                if not self.context.ddboost_ping:
                     arglist.append("--skip-ping")
                 if self.ddboost_storage_unit:
                     arglist.append('--ddboost-storage-unit')
@@ -1159,7 +956,7 @@ class GpCronDump(Operation):
                 finally:
                     mfr.restoreLogLevel()
 
-        if self.post_script is not None:
+        if self.context.post_script:
             self._run_program()
 
         if final_exit_status == 0:
@@ -1167,66 +964,55 @@ class GpCronDump(Operation):
 
         return final_exit_status
 
-    def _get_files_file_list(self, master, dump_dir, timestamp):
+    def cleanup_files_on_segments(self):
+        for tmp_file in [self.context.include_dump_tables_file, self.context.exclude_dump_tables_file, self.context.schema_file]:
+            if tmp_file and os.path.isfile(tmp_file):
+                os.remove(tmp_file)
+                remove_file_on_segments(self.context, tmp_file)
+
+    def _get_files_file_list(self, master):
         file_list = []
-        master_file_list = ['%sgp_cdatabase_1_1_%s', '%sgp_dump_%s_ao_state_file', '%sgp_dump_%s_co_state_file',
-                            '%sgp_dump_%s_last_operation', '%sgp_dump_%s.rpt', '%sgp_dump_status_1_1_%s']
+        master_file_list = ['cdatabase', 'ao', 'co', 'last_operation', 'report', 'status']
 
-        if self.dump_prefix and (self.include_dump_tables_file or self.exclude_dump_tables_file or \
-                                         self.include_dump_tables or self.exclude_dump_tables):
-            master_file_list.append('%sgp_dump_%s_filter')
+        if self.context.dump_prefix and (self.context.include_dump_tables_file or self.context.exclude_dump_tables_file or \
+                                         self.context.include_dump_tables or self.context.exclude_dump_tables):
+            master_file_list.append('filter')
 
-        for master_file in master_file_list:
-            file_list.append('%s:%s/%s' % (master.getSegmentHostName(), dump_dir,
-                                           master_file % (self.dump_prefix, timestamp)))
+        for filetype in master_file_list:
+            file_list.append('%s:%s' % (master.getSegmentHostName(), self.context.generate_filename(filetype)))
 
-        if self.incremental:
-            file_list.append('%s:%s/%sgp_dump_%s_increments' % (master.getSegmentHostName(), dump_dir,
-                                                                self.dump_prefix, self.full_dump_timestamp))
+        if self.context.incremental:
+            file_list.append('%s:%s' % (master.getSegmentHostName(), self.context.generate_filename("increments", timestamp=self.context.full_dump_timestamp)))
 
         return file_list
 
-    def _get_pipes_file_list(self, master, segdbs, dump_dir, timestamp):
+    def _get_pipes_file_list(self, master, segdbs):
         pipe_list = []
-        master_pipe_list = ['%sgp_dump_1_1_%s', '%sgp_dump_1_1_%s_post_data']
-        seg_pipe = '%sgp_dump_0_%s_%s'
-        config_pipe = '%sgp_master_config_files_%s.tar'
-        seg_config = '%sgp_segment_config_files_0_%s_%s.tar'
-        global_pipe = '%sgp_global_1_1_%s'
+        master_pipe_list = ['metadata', 'postdata']
 
+        mdd = self.context.master_datadir
         for segdb in segdbs:
-            seg_dump_dir = get_backup_directory(segdb.getSegmentDataDirectory(), self.backup_dir, self.dump_dir, str(timestamp))
-            pipe_list.append('%s:%s/%s' % (segdb.getSegmentHostName(),
-                                           seg_dump_dir,
-                                           seg_pipe % (self.dump_prefix, segdb.getSegmentDbId(), timestamp)))
-            if self.compress:
-                pipe_list[-1] += '.gz'
+            self.context.master_datadir = segdb.getSegmentDataDirectory()
+            pipe_list.append('%s:%s' % (segdb.getSegmentHostName(), self.context.generate_filename("dump", dbid=segdb.getSegmentDbId())))
+            if self.context.dump_config:
+                pipe_list.append('%s:%s' % (segdb.getSegmentHostName(), self.context.generate_filename("segment_config", dbid=segdb.getSegmentDbId())))
+        self.context.master_datadir = mdd
 
-        for pipe_file in master_pipe_list:
-            pipe_list.append('%s:%s/%s' % (master.getSegmentHostName(), dump_dir,
-                                           pipe_file % (self.dump_prefix, timestamp)))
-            if self.compress:
-                pipe_list[-1] += '.gz'
+        pipe_list.append('%s:%s' % (master.getSegmentHostName(), self.context.generate_filename("metadata")))
+        pipe_list.append('%s:%s' % (master.getSegmentHostName(), self.context.generate_filename("postdata")))
 
-        if self.dump_global:
-            pipe_list.append('%s:%s/%s' % (master.getSegmentHostName(), dump_dir,
-                                           global_pipe % (self.dump_prefix, timestamp)))
+        if self.context.dump_global:
+            pipe_list.append('%s:%s' % (master.getSegmentHostName(), self.context.generate_filename("global")))
 
-        if self.dump_config:
-            pipe_list.append('%s:%s/%s' % (master.getSegmentHostName(), dump_dir,
-                                           config_pipe % (self.dump_prefix, timestamp)))
-            for segdb in segdbs:
-                seg_dump_dir = get_backup_directory(segdb.getSegmentDataDirectory(), self.backup_dir, self.dump_dir, str(timestamp))
-                pipe_list.append('%s:%s/%s' % (segdb.getSegmentHostName(),
-                                               seg_dump_dir,
-                                               seg_config % (self.dump_prefix, segdb.getSegmentDbId(), timestamp)))
+        if self.context.dump_config:
+            pipe_list.append('%s:%s' % (master.getSegmentHostName(), self.context.generate_filename("master_config")))
 
         return pipe_list
 
 
     def show_ddboost_config(self):
         cmdStr = 'gpddboost --show-config'
-        if self.ddboost_remote:
+        if self.context.ddboost_remote:
             cmdStr += ' --remote'
         cmd = Command('Get the ddboost configuration information', cmdStr)
         cmd.run(validateAfter=True)
@@ -1239,57 +1025,36 @@ class GpCronDump(Operation):
         logger.info('-----------------------------------------------------')
 
 
-    def _list_backup_files(self, timestamp):
-        pipe_list = []
-        file_list = []
-
+    def _list_backup_files(self):
         gparray = self.getGpArray()
         segdbs = [segdb for segdb in gparray.getDbList() if segdb.isSegmentPrimary()]
 
-        dump_dir = get_backup_directory(self.master_datadir, self.backup_dir, self.dump_dir, timestamp)
-        pipe_list = self._get_pipes_file_list(gparray.master, segdbs, dump_dir, timestamp)
-        file_list = self._get_files_file_list(gparray.master, dump_dir, timestamp)
+        pipe_list = self._get_pipes_file_list(gparray.master, segdbs)
+        file_list = self._get_files_file_list(gparray.master)
 
-        pipes_list_fname = generate_pipes_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        files_list_fname = generate_files_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+        pipes_list_fname = self.context.generate_filename("pipes")
+        files_list_fname = self.context.generate_filename("files")
 
         dirname = os.path.dirname(pipes_list_fname)
         if not os.path.isdir(dirname):
             os.makedirs(dirname)
 
         write_lines_to_file(pipes_list_fname, pipe_list)
-        verify_lines_in_file(pipes_list_fname, pipe_list)
         logger.info('Added the list of pipe names to the file: %s' % pipes_list_fname)
 
         write_lines_to_file(files_list_fname, file_list)
-        verify_lines_in_file(files_list_fname, file_list)
         logger.info('Added the list of file names to the file: %s' % files_list_fname)
 
     def _list_filter_tables(self, db, filter_filename):
         logger.info("---------------------------------------------------")
         if not filter_filename:
-            logger.info('No filter file found for database %s and prefix %s.' % (db, self.dump_prefix[:-1]))
+            logger.info('No filter file found for database %s and prefix %s.' % (db, self.context.dump_prefix[:-1]))
             logger.info('All tables in %s will be included in the dump.' % db)
             return
         tables = get_lines_from_file(filter_filename)
         logger.info('Filtering %s for the following tables:' % db)
         for table in tables:
             logger.info('%s' % table)
-
-    def _get_timestamp_object(self, timestamp_key):
-        if timestamp_key is None:
-            return datetime.now()
-
-        if not validate_timestamp(timestamp_key):
-            raise Exception('Invalid timestamp key')
-
-        year = int(self.timestamp_key[:4])
-        month = int(self.timestamp_key[4:6])
-        day = int(self.timestamp_key[6:8])
-        hours = int(self.timestamp_key[8:10])
-        minutes = int(self.timestamp_key[10:12])
-        seconds = int(self.timestamp_key[12:14])
-        return datetime(year, month, day, hours, minutes, seconds)
 
     def _get_table_names_from_partition_list(self, partition_list):
         tablenames = []
@@ -1312,54 +1077,53 @@ class GpCronDump(Operation):
 
         check_funny_chars_in_names(tablenames)
 
-    def _prompt_continue(self, dump_database):
+    def _prompt_continue(self):
         logger.info("---------------------------------------------------")
         logger.info("Master Greenplum Instance dump parameters")
         logger.info("---------------------------------------------------")
-        if len(self.include_dump_tables) > 0 or self.include_dump_tables_file is not None:
+        if len(self.context.include_dump_tables) > 0 or self.context.include_dump_tables_file:
             logger.info("Dump type                            = Single database, specific table")
             logger.info("---------------------------------------------------")
-            if len(self.include_dump_tables) > 0:
+            if len(self.context.include_dump_tables) > 0:
                 logger.info("Table inclusion list ")
                 logger.info("---------------------------------------------------")
-                for table in self.include_dump_tables:
+                for table in self.context.include_dump_tables:
                     logger.info("Table name                             = %s" % table)
                 logger.info("---------------------------------------------------")
-            if self.include_dump_tables_file is not None:
-                logger.info("Table file name                      = %s" % self.include_dump_tables_file)
+            if self.context.include_dump_tables_file:
+                logger.info("Table file name                      = %s" % self.context.include_dump_tables_file)
                 logger.info("---------------------------------------------------")
-        elif len(self.exclude_dump_tables) > 0 or self.exclude_dump_tables_file is not None:
+        elif len(self.context.exclude_dump_tables) > 0 or self.context.exclude_dump_tables_file:
             logger.info("Dump type                            = Single database, exclude table")
             logger.info("---------------------------------------------------")
-            if len(self.exclude_dump_tables) > 0:
+            if len(self.context.exclude_dump_tables) > 0:
                 logger.info("Table exclusion list ")
                 logger.info("---------------------------------------------------")
-                for table in self.exclude_dump_tables:
+                for table in self.context.exclude_dump_tables:
                     logger.info("Table name                               = %s" % table)
                 logger.info("---------------------------------------------------")
-            if self.exclude_dump_tables_file is not None:
-                logger.info("Table file name                      = %s" % self.exclude_dump_tables_file)
+            if self.context.exclude_dump_tables_file:
+                logger.info("Table file name                      = %s" % self.context.exclude_dump_tables_file)
                 logger.info("---------------------------------------------------")
-        elif self.incremental:
+        elif self.context.incremental:
             logger.info("Dump type                            = Incremental")
-            filter_name = get_filter_file(dump_database, self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix,
-                                          self.ddboost, self.netbackup_service_host)
-            if filter_name is not None:
+            filter_name = get_filter_file(self.context)
+            if filter_name:
                 logger.info("Filtering tables using:")
-                logger.info("\t Prefix                        = %s" % (self.dump_prefix[:-1]))
-                logger.info("\t Full dump timestamp           = %s" % (self.full_dump_timestamp))
+                logger.info("\t Prefix                        = %s" % (self.context.dump_prefix[:-1]))
+                logger.info("\t Full dump timestamp           = %s" % (self.context.full_dump_timestamp))
                 logger.info("---------------------------------------------------")
         else:
             logger.info("Dump type                            = Full database")
-        logger.info("Database to be dumped                = %s" % dump_database)
-        if self.dump_schema:
-            logger.info("Schema to be dumped                  = %s" % self.dump_schema)
-        if self.backup_dir is not None:
-            logger.info("Dump directory                       = %s" % self.backup_dir)
-        logger.info("Master port                          = %s" % self.master_port)
-        logger.info("Master data directory                = %s" % self.master_datadir)
-        if self.post_script is not None:
-            logger.info("Run post dump program                = %s" % self.post_script)
+        logger.info("Database to be dumped                = %s" % self.context.dump_database)
+        if self.context.dump_schema:
+            logger.info("Schema to be dumped                  = %s" % self.context.dump_schema)
+        if self.context.backup_dir:
+            logger.info("Dump directory                       = %s" % self.context.backup_dir)
+        logger.info("Master port                          = %s" % self.context.master_port)
+        logger.info("Master data directory                = %s" % self.context.master_datadir)
+        if self.context.post_script:
+            logger.info("Run post dump program                = %s" % self.context.post_script)
         else:
             logger.info("Run post dump program                = Off")
                     # TODO: failed_primary_count. do we care though? the end user shouldn't be continuing if
@@ -1380,11 +1144,11 @@ class GpCronDump(Operation):
                     #fi
         on_or_off = {False: "Off", True: "On"}
         logger.info("Rollback dumps                       = %s" % on_or_off[self.rollback])
-        logger.info("Dump file compression                = %s" % on_or_off[self.compress])
-        logger.info("Clear old dump files                 = %s" % on_or_off[self.clear_dumps])
-        logger.info("Update history table                 = %s" % on_or_off[self.history])
-        logger.info("Secure config files                  = %s" % on_or_off[self.dump_config])
-        logger.info("Dump global objects                  = %s" % on_or_off[self.dump_global])
+        logger.info("Dump file compression                = %s" % on_or_off[self.context.compress])
+        logger.info("Clear old dump files                 = %s" % on_or_off[self.context.clear_dumps])
+        logger.info("Update history table                 = %s" % on_or_off[self.context.history])
+        logger.info("Secure config files                  = %s" % on_or_off[self.context.dump_config])
+        logger.info("Dump global objects                  = %s" % on_or_off[self.context.dump_global])
         if self.pre_vacuum and self.post_vacuum:
             logger.info("Vacuum mode type                     = pre-dump, post-dump")
         elif self.pre_vacuum:
@@ -1393,21 +1157,21 @@ class GpCronDump(Operation):
             logger.info("Vacuum mode type                     = post-dump")
         else:
             logger.info("Vacuum mode type                     = Off")
-        if self.clear_catalog_dumps:
+        if self.context.clear_catalog_dumps:
             logger.info("Additional options                   = -c")
-        if self.free_space_percent is not None:
-            logger.info("Ensuring remaining free disk         > %d" % self.free_space_percent)
+        if self.context.free_space_percent:
+            logger.info("Ensuring remaining free disk         > %d" % self.context.free_space_percent)
 
         if not userinput.ask_yesno(None, "\nContinue with Greenplum dump", 'N'):
             raise UserAbortedException()
 
-    def _status_report(self, dump_database, timestamp, dump_outcome, exit_status, deleted_dump_set, dump_type):
+    def _status_report(self, timestamp, dump_outcome, exit_status, deleted_dump_set, dump_type):
         logger.info("Dump status report")
         logger.info("---------------------------------------------------")
-        logger.info("Target database                          = %s" % dump_database)
+        logger.info("Target database                          = %s" % self.context.dump_database)
         logger.info("Dump subdirectory                        = %s" % timestamp[0:8])
         logger.info("Dump type                                = %s" % dump_type)
-        if self.clear_dumps:
+        if self.context.clear_dumps:
             logger.info("Clear old dump directories               = On")
             logger.info("Backup set deleted                       = %s" % deleted_dump_set)
         else:
@@ -1425,7 +1189,7 @@ class GpCronDump(Operation):
         else:
             logger.info("Status                                   = COMPLETED")
             logger.info("Dump key                                 = %s" % timestamp)
-        if self.compress:
+        if self.context.compress:
             logger.info("Dump file compression                    = On")
         else:
             logger.info("Dump file compression                    = Off")
@@ -1444,55 +1208,46 @@ class GpCronDump(Operation):
         logger.info("---------------------------------------------------")
 
     def _validate_dump_target(self):
-        if len(self.dump_databases) > 1:
-            if self.dump_schema or self.include_schema_file is not None:
+        if len(self.context.dump_databases) > 1:
+            if self.context.dump_schema or self.context.include_schema_file:
                 raise ExceptionNoStackTraceNeeded("Cannot include specific schema if multiple database dumps are requested")
-            if self.exclude_dump_schema or self.exclude_schema_file is not None:
+            if self.context.exclude_dump_schema or self.context.exclude_schema_file:
                 raise ExceptionNoStackTraceNeeded("Cannot exclude specific schema if multiple database dumps are requested")
-            if len(self.include_dump_tables) > 0 or self.include_dump_tables_file is not None:
+            if len(self.context.include_dump_tables) > 0 or self.context.include_dump_tables_file:
                 raise ExceptionNoStackTraceNeeded("Cannot supply a table dump list if multiple database dumps are requested")
-            if len(self.exclude_dump_tables) > 0 or self.exclude_dump_tables_file is not None:
+            if len(self.context.exclude_dump_tables) > 0 or self.context.exclude_dump_tables_file:
                 raise ExceptionNoStackTraceNeeded("Cannot exclude specific tables if multiple database dumps are requested")
             logger.info("Configuring for multiple database dump")
 
-        for dump_database in self.dump_databases:
-            ValidateDatabaseExists(database=dump_database, master_port=self.master_port).run()
+        for dumpdb in self.context.dump_databases:
+            self.context.dump_database = dumpdb
+            ValidateDatabaseExists(self.context).run()
 
-        if self.dump_schema:
-            for schema in self.dump_schema:
-                ValidateSchemaExists(database = self.dump_databases[0],
-                                     schema = schema,
-                                     master_port = self.master_port).run()
+        if self.context.dump_schema:
+            for schema in self.context.dump_schema:
+                ValidateSchemaExists(self.context, schema).run()
 
     def _validate_run_program(self):
         #Check to see if the file exists
-        cmd = Command('Seeking post script', "which %s" % self.post_script)
+        cmd = Command('Seeking post script', "which %s" % self.context.post_script)
         cmd.run()
         if cmd.get_results().rc != 0:
-            cmd = Command('Seeking post script file', '[ -f %s ]' % self.post_script)
+            cmd = Command('Seeking post script file', '[ -f %s ]' % self.context.post_script)
             cmd.run()
             if cmd.get_results().rc != 0:
-                logger.warn("Could not locate %s" % self.post_script)
-                self.post_script = None
+                logger.warn("Could not locate %s" % self.context.post_script)
+                self.context.post_script = None
                 return
-        logger.info("Located %s, will call after dump completed" % self.post_script)
+        logger.info("Located %s, will call after dump completed" % self.context.post_script)
 
     def _run_program(self):
-        Command('Invoking post script', self.post_script).run()
+        Command('Invoking post script', self.context.post_script).run()
 
     def _get_pgport(self):
         env_pgport = os.getenv('PGPORT')
         if not env_pgport:
-            return self.master_port
+            return self.context.master_port
         return env_pgport
-
-    def _get_master_port(self, datadir):
-        """ TODO: This function will be widely used. Move it elsewhere?
-            Its necessity is a direct consequence of allowing the -d <master_data_directory> option. From this,
-            we need to deduce the proper port so that the GpArrays can be generated properly. """
-        logger.debug("Obtaining master's port from master data directory")
-        pgconf_dict = pgconf.readfile(datadir + "/postgresql.conf")
-        return pgconf_dict.int('port')
 
     def _validate_parse_email_File(self):
         if os.path.isfile(self.include_email_file) is False:
@@ -1509,7 +1264,7 @@ class GpCronDump(Operation):
             for email in self.email_details:
                 if not all(keys in email for keys in email_key_list):
                     raise Exception("File not formatted")
-                if email['DBNAME'] is None:
+                if not email['DBNAME']:
                     raise Exception("Database name is not provided")
         except Exception as e:
             raise Exception("\'%s\' file is not formatted properly:" % self.include_email_file)
@@ -1522,9 +1277,9 @@ class GpCronDump(Operation):
             for email in self.email_details:
                 if dump_database in email['DBNAME']:
                     default_email = False
-                    if email['FROM'] is None:
+                    if not email['FROM']:
                         MailDumpEvent(email['SUBJECT'], default_msg).run()
-                    elif email['SUBJECT'] is None:
+                    elif not email['SUBJECT']:
                         MailDumpEvent(default_subject, default_msg, email['FROM']).run()
                     else:
                         MailDumpEvent(email['SUBJECT'], default_msg, email['FROM']).run()

--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -25,16 +25,8 @@ try:
     from gppylib.gparray import GpArray
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.operations import Operation
-    from gppylib.operations.backup_utils import check_dir_writable, generate_createdb_prefix, generate_master_dbdump_prefix, \
-                                                generate_report_filename, get_lines_from_file, check_schema_exists, check_funny_chars_in_names, \
-                                                get_full_timestamp_for_incremental, get_master_dump_file
-    from gppylib.operations.restore import GetDbName, GetDumpTables, RecoverRemoteDumps, RestoreDatabase, ValidateTimestamp, \
-                                           config_files_dumped, create_restore_plan, get_restore_dir, get_restore_tables_from_table_file, \
-                                           global_file_dumped, is_begin_incremental_run, is_incremental_restore, restore_cdatabase_file_with_nbu, \
-                                           restore_config_files_with_nbu, restore_global_file_with_nbu, restore_statistics_file_with_nbu, \
-                                           restore_increments_file_with_nbu, restore_partition_list_file_with_nbu, restore_report_file_with_nbu, \
-                                           restore_state_files_with_nbu, statistics_file_dumped, truncate_restore_tables, check_table_name_format_and_duplicate, \
-                                           get_incremental_restore_timestamps, validate_tablenames_exist_in_dump_file
+    from gppylib.operations.backup_utils import *
+    from gppylib.operations.restore import *
     from gppylib.operations.utils import DEFAULT_NUM_WORKERS
     from gppylib.operations.unix import CheckFile, CheckRemoteFile, ListFilesByPattern, ListRemoteFilesByPattern
 except ImportError, e:
@@ -49,117 +41,86 @@ logger = gplog.get_default_logger()
 
 class GpdbRestore(Operation):
     def __init__(self, options, args):
+        self.context = Context(options)
+        self.options_list = " ".join(sys.argv[1:])
+        self.search_for_dbname = options.search_for_dbname
         # only one of -t, -b, -R, and -s can be provided
-        count = sum([1 for opt in ['db_timestamp', 'db_date_dir', 'db_host_path', 'search_for_dbname']
-                       if options.__dict__[opt] is not None])
+        count = sum([1 for opt in ['timestamp', 'db_date_dir', 'db_host_path', 'search_for_dbname'] if options.__dict__[opt]])
         if count == 0:
             raise ProgramArgumentValidationException("Must supply one of -t, -b, -R, or -s.")
         elif count > 1:
             raise ProgramArgumentValidationException("Only supply one of -t, -b, -R, or -s.")
 
-        if options.list_tables and options.db_timestamp is None:
+        if options.list_tables and not options.timestamp:
             raise ProgramArgumentValidationException("Need to supply -t <timestamp> for -L option")
 
-        if options.list_backup and options.db_timestamp is None:
+        if options.list_backup and not options.timestamp:
             raise ProgramArgumentValidationException("Need to supply -t <timestamp> for --list-backup option")
 
         if options.list_backup and options.drop_db:
             raise ProgramArgumentValidationException("Cannot specify --list-backup and -e together")
 
-        if options.masterDataDirectory is None:
+        if not options.masterDataDirectory:
             options.masterDataDirectory = gp.get_masterdatadir()
 
-        self.db_timestamp = options.db_timestamp
-        self.list_tables = options.list_tables
-        self.db_date_dir = options.db_date_dir
-        self.db_host_path = options.db_host_path
-        self.search_for_dbname = options.search_for_dbname
-        self.drop_db = options.drop_db
-        self.restore_global = options.restore_global
-        self.restore_tables = options.restore_tables
-        self.batch_default = options.batch_default
-        self.keep_dump_files = options.keep_dump_files
-        self.no_analyze = options.no_analyze
-        self.no_plan = options.no_plan
-        self.no_ao_stats = options.no_ao_stats
-        self.backup_dir = options.backup_dir
-        self.table_file = options.table_file
-        self.list_backup = options.list_backup
-        self.redirected_restore_db = options.redirected_restore_db
-        self.report_status_dir = options.report_status_dir
-        self.truncate = options.truncate
-        self.change_schema = options.change_schema
-        self.restore_stats = options.restore_stats
-        self.metadata_only = options.metadata_only
-        self.schema_level_restore_list = options.restore_schemas
-        self.no_validate_table_name = options.no_validate_table_name
-
-        if self.restore_stats:
-            self.no_analyze = True
+        if self.context.restore_stats:
+            self.context.no_analyze = True
 
         # NetBackup params
-        self.netbackup_service_host = options.netbackup_service_host
-        self.netbackup_block_size = options.netbackup_block_size
-        if options.local_dump_prefix:
-            self.dump_prefix = options.local_dump_prefix + '_'
-        else:
-            self.dump_prefix = options.local_dump_prefix
-
-        if self.truncate and not (len(self.restore_tables) > 0 or self.table_file):
+        if self.context.truncate and not (self.context.restore_tables or self.context.table_file):
             raise Exception('--truncate can be specified only with -T or --table-file option')
 
-        if self.truncate and self.drop_db:
+        if self.context.truncate and self.context.drop_db:
             raise Exception('Cannot specify --truncate and -e together')
 
-        if self.restore_stats == "only" and self.drop_db:
+        if self.context.restore_stats == "only" and self.context.drop_db:
             raise Exception('Cannot specify --restore-stats only and -e together')
 
-        if self.table_file and len(self.restore_tables) > 0:
+        if self.context.table_file and self.context.restore_tables:
             raise Exception('Cannot specify -T and --table-file together')
 
-        if self.list_backup and len(self.restore_tables) > 0:
+        if self.context.list_backup and self.context.restore_tables:
             raise Exception('Cannot specify -T and --list-backup together')
 
-        if self.metadata_only and self.no_plan:
+        if self.context.metadata_only and self.context.no_plan:
             raise Exception('Cannot specify --noplan and -m together.')
 
-        if self.metadata_only and self.no_analyze:
+        if self.context.metadata_only and self.context.no_analyze:
             raise Exception('Cannot specify --noanalyze and -m together.')
 
-        if self.change_schema and len(self.change_schema) == 0:
-            raise Exception('--change-schema name can not be empty')
+        if self.context.change_schema and len(self.context.change_schema) == 0:
+            raise Exception('--change-schema name cannot be empty')
 
-        if self.change_schema and not (len(self.restore_tables) > 0 or self.table_file):
+        if self.context.change_schema and not (self.context.restore_tables or self.context.table_file):
             raise Exception('-T or --table-file option must be specified with the --change-schema option')
+        if self.context.change_schema and len(self.context.restore_schemas) > 0:
+            raise Exception('-S option cannot be used with --change-schema option')
 
-        if self.change_schema and len(self.schema_level_restore_list) > 0:
-            raise Exception('-S schema level restore does not work with --change-schema option')
+        if self.context.table_file:
+            self.context.restore_tables = get_restore_tables_from_table_file(self.context.table_file)
 
-        if self.table_file is not None:
-            self.restore_tables = get_restore_tables_from_table_file(self.table_file)
-
-        if self.db_host_path is not None:
+        if self.context.db_host_path:
             # MPP-13617
-            m = re.match(RE1, self.db_host_path)
+            m = re.match(RE1, self.context.db_host_path)
             if m:
-                self.db_host_path = m.groups()
+                self.context.db_host_path = m.groups()
             else:
-                self.db_host_path = self.db_host_path.split(':')
+                self.context.db_host_path = self.context.db_host_path.split(':')
 
-        if self.db_host_path and self.netbackup_service_host:
+        if self.context.db_host_path and self.context.netbackup_service_host:
             raise Exception('-R is not supported for restore with NetBackup.')
 
-        if self.search_for_dbname and self.netbackup_service_host:
+        if self.search_for_dbname and self.context.netbackup_service_host:
             raise Exception('-s is not supported with NetBackup.')
 
-        if self.db_date_dir and self.netbackup_service_host:
+        if self.context.db_date_dir and self.context.netbackup_service_host:
             raise Exception('-b is not supported with NetBackup.')
 
-        if self.list_tables and self.netbackup_service_host:
+        if self.context.list_tables and self.context.netbackup_service_host:
             raise Exception('-L is not supported with NetBackup.')
 
-        if self.redirected_restore_db:
-            check_funny_chars_in_names(self.redirected_restore_db, is_full_qualified_name = False)
+        if self.context.redirected_restore_db:
+            check_funny_chars_in_names(self.context.redirected_restore_db, is_full_qualified_name = False)
 
         if self.search_for_dbname:
             check_funny_chars_in_names(self.search_for_dbname, is_full_qualified_name = False)
@@ -169,91 +130,84 @@ class GpdbRestore(Operation):
         else:
             self.interactive = options.interactive
 
-        self.master_datadir = options.masterDataDirectory
-        self.master_port = self._get_master_port(self.master_datadir)
-
         self.gparray = None
 
         try:
-            if self.report_status_dir:
-                check_dir_writable(self.report_status_dir)
+            if self.context.report_status_dir:
+                check_dir_writable(self.context.report_status_dir)
         except Exception as e:
-            logger.warning('Directory %s should be writable' % self.report_status_dir)
+            logger.warning('Directory %s should be writable' % self.context.report_status_dir)
             raise Exception(str(e))
 
-        self.ddboost = options.ddboost
-        self.ddboost_storage_unit = options.ddboost_storage_unit
-
-        if self.ddboost_storage_unit and not self.ddboost:
+        if self.context.ddboost_storage_unit and not self.context.ddboost:
             raise Exception('Cannot use ddboost storage unit option without specifying --ddboost option.')
 
-        if self.ddboost:
-            if self.netbackup_service_host:
+        if self.context.ddboost:
+            if self.context.netbackup_service_host:
                 raise Exception('--ddboost option is not supported with NetBackup')
 
-            if self.db_host_path is not None:
+            if self.context.db_host_path:
                 raise ExceptionNoStackTraceNeeded("-R cannot be used with DDBoost parameters.")
-            elif self.backup_dir:
+            elif self.context.backup_dir:
                 raise ExceptionNoStackTraceNeeded('-u cannot be used with DDBoost parameters.')
             dd = gpmfr.DDSystem("local")
-            self.dump_dir = dd.DDBackupDir
+            self.context.dump_dir = dd.DDBackupDir
         else:
-            self.dump_dir = 'db_dumps'
+            self.context.dump_dir = 'db_dumps'
 
     def execute(self):
-        if self.ddboost:
-            cmdline = 'gpddboost --sync --dir=%s' % self.master_datadir
-            if self.ddboost_storage_unit:
-                cmdline += ' --ddboost-storage-unit %s' % self.ddboost_storage_unit
+        if self.context.ddboost:
+            cmdline = 'gpddboost --sync --dir=%s' % self.context.master_datadir
+            if self.context.ddboost_storage_unit:
+                cmdline += ' --ddboost-storage-unit %s' % self.context.ddboost_storage_unit
             cmd = Command('DDBoost sync', cmdline)
             cmd.run(validateAfter=True)
 
-        self.gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port, dbname='template1'), utility=True)
+        self.gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port, dbname='template1'), utility=True)
 
-        if self.netbackup_service_host:
+        if self.context.netbackup_service_host:
             logger.info("Restoring metadata files with NetBackup")
-            restore_state_files_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host, self.netbackup_block_size)
-            restore_report_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host, self.netbackup_block_size)
-            restore_cdatabase_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host, self.netbackup_block_size)
-            if config_files_dumped(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host):
-                restore_config_files_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.master_port, self.netbackup_service_host, self.netbackup_block_size)
-            if global_file_dumped(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host):
-                restore_global_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host, self.netbackup_block_size)
-            if statistics_file_dumped(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host):
-                restore_statistics_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.db_timestamp, self.netbackup_service_host, self.netbackup_block_size)
+            restore_state_files_with_nbu(self.context)
+            restore_file_with_nbu(self.context, "report")
+            restore_file_with_nbu(self.context, "cdatabase")
+            if check_file_dumped_with_nbu(self.context, "master_config"):
+                restore_config_files_with_nbu(self.context)
+            if check_file_dumped_with_nbu(self.context, "global"):
+                restore_file_with_nbu(self.context, "global")
+            if check_file_dumped_with_nbu(self.context, "stats"):
+                restore_file_with_nbu(self.context, "stats")
 
-        info = self._gather_dump_info()
+        self._gather_dump_info()
 
-        if self.list_tables and self.db_timestamp is not None:
-            return self._list_dump_tables(info['restore_timestamp'], info['dump_host'], info['dump_file'], info['compress'])
+        if self.context.list_tables and self.context.timestamp:
+            return self._list_dump_tables()
 
-        info.update(self._gather_cluster_info())
+        info = self._gather_cluster_info()
 
-        self.validate_tablename_from_filtering_options(info['restore_timestamp'], info['dump_host'], info['dump_file'], info['compress'])
+        self.validate_tablename_from_filtering_options()
 
-        if self.restore_stats == "only":
+        if self.context.restore_stats == "only":
             restore_type = "Statistics-Only Restore"
 
-        if self.metadata_only:
+        if self.context.metadata_only:
             restore_type = "Metadata-Only Restore"
 
-        elif is_incremental_restore(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, info['restore_timestamp']):
-            if len(self.restore_tables) > 0:
+        elif is_incremental_restore(self.context):
+            if len(self.context.restore_tables) > 0:
                 restore_type = "Incremental Table Restore"
             else:
                 restore_type = "Incremental Restore"
-        elif len(self.restore_tables) > 0:
+        elif len(self.context.restore_tables) > 0:
             restore_type = "Table Restore"
         else:
             restore_type = "Full Database"
 
-        if self.change_schema:
-            check_funny_chars_in_names(self.change_schema, is_full_qualified_name = False)
-
-            if not self.redirected_restore_db and not check_schema_exists(self.change_schema, info['restore_db']):
-                raise Exception('Cannot restore tables to schema %s: schema does not exist' % self.change_schema)
-            elif self.redirected_restore_db and not check_schema_exists(self.change_schema, self.redirected_restore_db):
-                raise Exception('Cannot restore tables to the database %s: schema %s does not exist' % (self.redirected_restore_db, self.change_schema))
+        if self.context.change_schema:
+            check_funny_chars_in_names(self.context.change_schema, is_full_qualified_name = False)
+            if not self.context.redirected_restore_db and not check_schema_exists(self.context.change_schema, self.context.restore_db):
+                raise Exception('Cannot restore tables to schema %s: schema does not exist' % self.context.change_schema)
+            elif self.context.redirected_restore_db and not check_schema_exists(self.context.change_schema, self.context.redirected_restore_db):
+                raise Exception('Cannot restore tables to the database %s: schema %s does not exist' % (self.context.redirected_restore_db, self.context.change_schema))
 
         self._output_info(info, restore_type)
 
@@ -261,64 +215,28 @@ class GpdbRestore(Operation):
             if not userinput.ask_yesno(None, "\nContinue with Greenplum restore", 'N'):
                 raise UserAbortedException()
 
-        if self.db_host_path is not None:
-            host, path = self.db_host_path
-            RecoverRemoteDumps(host = host, path = path,
-                               restore_timestamp = info['restore_timestamp'],
-                               compress = info['compress'],
-                               restore_global = self.restore_global,
-                               batch_default = self.batch_default,
-                               master_datadir = self.master_datadir,
-                               master_port = self.master_port,
-                               dump_dir = self.dump_dir,
-                               dump_prefix = self.dump_prefix).run()
+        if self.context.db_host_path:
+            host, path = self.context.db_host_path
+            RecoverRemoteDumps(self.context, host = host, path = path).run()
 
-            if is_incremental_restore(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, info['restore_timestamp']):
-                raise Exception('-R is not supported for restore with incremental timestamp %s' % info['restore_timestamp'])
+            if is_incremental_restore(self.context):
+                raise Exception('-R is not supported for restore with incremental timestamp %s' % self.context.timestamp)
 
-        if not is_incremental_restore(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, info['restore_timestamp']) and self.list_backup:
+        if not is_incremental_restore(self.context) and self.context.list_backup:
             raise Exception('--list-backup is not supported for restore with full timestamps')
 
-        if len(self.restore_tables) > 0 and self.truncate:
-            if self.redirected_restore_db:
-                truncate_restore_tables(self.restore_tables, self.master_port, self.redirected_restore_db, self.schema_level_restore_list)
-            else:
-                truncate_restore_tables(self.restore_tables, self.master_port, info['restore_db'], self.schema_level_restore_list)
+        if is_incremental_restore(self.context) and not self.context.no_plan:
+            if self.context.netbackup_service_host:
+                restore_file_with_nbu(self.context, "partition_list")
+                restore_file_with_nbu(self.context, "increments")
+            plan_file = create_restore_plan(self.context)
 
-        if is_begin_incremental_run(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, info['restore_timestamp'], self.no_plan):
-            if self.netbackup_service_host:
-                restore_partition_list_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, info['restore_timestamp'], self.netbackup_service_host, self.netbackup_block_size)
-                restore_increments_file_with_nbu(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, info['restore_timestamp'], self.netbackup_service_host, self.netbackup_block_size)
-            plan_file = create_restore_plan(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, info['restore_timestamp'], self.ddboost, self.netbackup_service_host, self.netbackup_block_size)
-
-            if self.list_backup and self.db_timestamp is not None:
+            if self.context.list_backup and self.context.timestamp:
                 return self._list_backup_timestamps(plan_file)
 
-        RestoreDatabase(restore_timestamp = info['restore_timestamp'],
-                        no_analyze = self.no_analyze,
-                        drop_db = self.drop_db,
-                        restore_global = self.restore_global,
-                        master_datadir = self.master_datadir,
-                        backup_dir = self.backup_dir,
-                        master_port = self.master_port,
-                        dump_dir = self.dump_dir,
-                        dump_prefix = self.dump_prefix,
-                        ddboost = self.ddboost,
-                        ddboost_storage_unit = self.ddboost_storage_unit,
-                        no_plan = self.no_plan,
-                        restore_tables = self.restore_tables,
-                        batch_default = self.batch_default,
-                        no_ao_stats = self.no_ao_stats,
-                        redirected_restore_db = self.redirected_restore_db,
-                        report_status_dir = self.report_status_dir,
-                        restore_stats = self.restore_stats,
-                        metadata_only = self.metadata_only,
-                        netbackup_service_host = self.netbackup_service_host,
-                        netbackup_block_size = self.netbackup_block_size,
-                        change_schema = self.change_schema,
-                        schema_level_restore_list = self.schema_level_restore_list).run()
+        RestoreDatabase(self.context).run()
 
-        if self.no_analyze and not self.restore_stats:
+        if self.context.no_analyze and not self.context.restore_stats:
             logger.warn('--------------------------------------------------------------------------------------------------')
             logger.warn('Analyze bypassed on request; database performance may be adversely impacted until analyze is done.')
             logger.warn('--------------------------------------------------------------------------------------------------')
@@ -332,44 +250,44 @@ class GpdbRestore(Operation):
 
         logger.info("Restore type               = %s" % restore_type)
 
-        if len(self.restore_tables) > 0:
-            logger.info("Database name              = %s" % info['restore_db'])
+        if len(self.context.restore_tables) > 0:
+            logger.info("Database name              = %s" % self.context.restore_db)
             logger.info("------------------------------------------")
             logger.info("Table restore list")
             logger.info("------------------------------------------")
-            for restore_table in self.restore_tables:
+            for restore_table in self.context.restore_tables:
                 logger.info("Table                      = %s" % restore_table)
-            if info['table_counts']:
+            if self.table_counts:
                 logger.info("------------------------------------------")
                 logger.warn("Following tables have non-zero row counts %s" % WARN_MARK)
                 logger.info("------------------------------------------")
-                for table, count in info['table_counts']:
+                for table, count in self.table_counts:
                     logger.warn("Table:Row count            = %s:%s" % (table, count))
                 logger.info("------------------------------------------")
         else:
-            logger.info("Database to be restored    = %s" % info['restore_db'])
-            if self.drop_db:
+            logger.info("Database to be restored    = %s" % self.context.restore_db)
+            if self.context.drop_db:
                 logger.info("Drop and re-create db      = On")
             else:
                 logger.info("Drop and re-create db      = Off")
 
-        if self.db_timestamp is not None and len(self.restore_tables) == 0:
+        if self.context.timestamp and not self.context.restore_tables:
             logger.info("Restore method             = Restore specific timestamp")
-        if self.search_for_dbname is not None and len(self.restore_tables) == 0:
+        if self.search_for_dbname and not self.context.restore_tables:
             logger.info("Restore method             = Search for latest")
-        if self.redirected_restore_db is not None:
-            logger.info("Redirect Restore database  = %s" % self.redirected_restore_db)
-        if self.db_date_dir is not None and len(self.restore_tables) ==0:
+        if self.context.redirected_restore_db:
+            logger.info("Redirect Restore database  = %s" % self.context.redirected_restore_db)
+        if self.context.db_date_dir and not self.context.restore_tables:
             logger.info("Restore method             = Restore specific date")
-        if len(self.restore_tables) > 0:
+        if len(self.context.restore_tables) > 0:
             logger.info("Restore method             = Specific table restore")
-        if self.db_host_path is not None:
-            host, path = self.db_host_path
+        if self.context.db_host_path:
+            host, path = self.context.db_host_path
             logger.info("Restore method             = Remote host")
             logger.info("Recovery hostname          = %s" % host)
             logger.info("Remote recovery path       = %s" % path)
-        logger.info("Restore timestamp          = %s" % info['restore_timestamp'])
-        if info['compress']:
+        logger.info("Restore timestamp          = %s" % self.context.timestamp)
+        if self.context.compress:
             logger.info("Restore compressed dump    = On")
         else:
             logger.info("Restore compressed dump    = Off")
@@ -381,38 +299,18 @@ class GpdbRestore(Operation):
         #logger.info("Restore type               = %s" % restore_type)
         """
 
-        if self.restore_global:
+        if self.context.restore_global:
             logger.info("Restore global objects     = On")
         else:
             logger.info("Restore global objects     = Off")
         logger.info("Array fault tolerance      = %s" % info['fault_action'])
         logger.info("------------------------------------------")
 
-    def _get_master_port(self, datadir):
-        """ TODO: This function will be widely used. Move it elsewhere?
-            Its necessity is a direct consequence of allowing the -d <master_data_directory> option. From this,
-            we need to deduce the proper port so that the GpArrays can be generated properly. """
-        logger.debug("Obtaining master's port from master data directory")
-        pgconf_dict = pgconf.readfile(datadir + "/postgresql.conf")
-        return pgconf_dict.int('port')
-
-    def _list_dump_tables(self, restore_timestamp, dump_host, dump_file, compress):
-        """
-           Only list dumped tables for specified timestamp, this is specified through the -t option along with the -L option
-        """
-        dump_tables = GetDumpTables(master_datadir=self.master_datadir,
-                                    backup_dir=self.backup_dir,
-                                    restore_timestamp=restore_timestamp,
-                                    dump_dir=self.dump_dir,
-                                    dump_prefix=self.dump_prefix,
-                                    compress=compress,
-                                    ddboost=self.ddboost,
-                                    netbackup_service_host=self.netbackup_service_host,
-                                    remote_host=dump_host,
-                                    dump_file=dump_file).get_dump_tables()
+    def _list_dump_tables(self):
+        dump_tables = GetDumpTables(self.context).get_dump_tables()
 
         logger.info("--------------------------------------------------------------------")
-        logger.info("List of database tables for dump file with time stamp %s" % self.db_timestamp)
+        logger.info("List of database tables for dump file with time stamp %s" % self.context.timestamp)
         logger.info("--------------------------------------------------------------------")
         for schema, table, owner in dump_tables:
             logger.info("Table %s.%s Owner %s" % (schema, table, owner))
@@ -421,7 +319,7 @@ class GpdbRestore(Operation):
     def _list_backup_timestamps(self, plan_file):
         plan_file_contents = get_lines_from_file(plan_file)
         logger.info("--------------------------------------------------------------------")
-        logger.info("List of backup timestamps required for the restore time stamp %s" % self.db_timestamp)
+        logger.info("List of backup timestamps required for the restore time stamp %s" % self.context.timestamp)
         logger.info("--------------------------------------------------------------------")
         for line in plan_file_contents:
             logger.info("Backup Timestamp: %s" % (line.split(':')[0].strip()))
@@ -431,7 +329,6 @@ class GpdbRestore(Operation):
         """
         Checking cluster status, no primary should be down.
         """
-
         fault_action = self.gparray.getFaultStrategy()
         primaries = [seg for seg in self.gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
         fail_count = len([seg for seg in primaries if seg.isSegmentDown()])
@@ -450,186 +347,143 @@ class GpdbRestore(Operation):
         Validate the restore timestamp, collect information of the dump path and location.
         """
 
-        (restore_timestamp, restore_db, compress, dump_host, dump_file) = (None, None, None, None, None)
-        if self.db_timestamp is not None:
-            (restore_timestamp, restore_db, compress) = ValidateTimestamp(candidate_timestamp = self.db_timestamp,
-                                                                          master_datadir = self.master_datadir,
-                                                                          backup_dir = self.backup_dir,
-                                                                          dump_dir = self.dump_dir,
-                                                                          dump_prefix = self.dump_prefix,
-                                                                          netbackup_service_host = self.netbackup_service_host,
-                                                                          ddboost = self.ddboost).run()
-        elif self.db_date_dir is not None:
-            (restore_timestamp, restore_db, compress) = self._validate_db_date_dir()
-        elif self.db_host_path is not None:
-            (restore_timestamp, restore_db, compress, dump_host, dump_file) = self._validate_db_host_path()
-        elif self.search_for_dbname is not None:
-            (restore_timestamp, restore_db, compress) = self._search_for_latest()
+        if self.context.timestamp:
+            (restore_timestamp, restore_db, compress) = ValidateTimestamp(self.context).run()
+            self.context.timestamp = restore_timestamp
+            self.context.restore_db = restore_db
+            self.context.compress = compress
+        elif self.context.db_date_dir:
+            self._validate_db_date_dir()
+        elif self.context.db_host_path:
+            self._validate_db_host_path()
+        elif self.search_for_dbname:
+            self._search_for_latest()
 
-        if not self.drop_db and not self.redirected_restore_db:
-            dburl = dbconn.DbURL(port=self.master_port)
+        if not self.context.drop_db and not self.context.redirected_restore_db:
+            dburl = dbconn.DbURL(port=self.context.master_port)
             conn = dbconn.connect(dburl)
-            count = dbconn.execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" % pg.escape_string(restore_db))
+            count = dbconn.execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" % pg.escape_string(self.context.restore_db))
             # TODO: -e is needed even if the database doesn't exist yet?
             if count == 0:
-                raise ExceptionNoStackTraceNeeded("Database %s does not exist and -e option not supplied" % restore_db)
+                raise ExceptionNoStackTraceNeeded("Database %s does not exist and -e option not supplied" % self.context.restore_db)
 
         table_counts = []
 
-        if not self.db_host_path and not self.ddboost:
-            report_filename = generate_report_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, restore_timestamp)
+        if not self.context.db_host_path and not self.context.ddboost:
+            report_filename = self.context.generate_filename("report")
             if not os.path.isfile(report_filename):
-                raise ExceptionNoStackTraceNeeded("Report file does not exist for the given restore timestamp %s: '%s'" % (restore_timestamp, report_filename))
+                raise ExceptionNoStackTraceNeeded("Report file does not exist for the given restore timestamp %s: '%s'" % (self.context.timestamp, report_filename))
 
-        if not self.db_host_path:
-            dump_file = get_master_dump_file(self.master_datadir, self.backup_dir, self.dump_dir, restore_timestamp, self.dump_prefix, self.ddboost)
-            dump_file = dump_file + ('.gz' if compress else '')
+        if not self.context.db_host_path:
+            self.context.dump_host = None
+        else:
+            self.context.dump_host = self.context.db_host_path[0]
 
-        return {'restore_timestamp': restore_timestamp,
-                'restore_db': restore_db,
-                'compress': compress,
-                'dump_host': dump_host,
-                'dump_file': dump_file,
-                'table_counts': table_counts}
+        self.table_counts = table_counts
 
-    def validate_tablename_from_filtering_options(self, restore_timestamp, dump_host=None, dump_file=None, compress=None):
+    def validate_tablename_from_filtering_options(self):
         """
         This validates table name format and resolves duplicates of user inputs from any of the gpdbrestore filtering options
         """
 
-        if len(self.restore_tables) > 0 or len(self.schema_level_restore_list) > 0:
-            self.restore_tables, self.schema_level_restore_list = check_table_name_format_and_duplicate(self.restore_tables, self.schema_level_restore_list)
+        if len(self.context.restore_tables) > 0 or len(self.context.restore_schemas) > 0:
+            self.context.restore_tables, self.context.restore_schemas = check_table_name_format_and_duplicate(self.context.restore_tables, self.context.restore_schemas)
 
-        if not self.no_validate_table_name and len(self.restore_tables) > 0:
+        if not self.context.no_validate_table_name and len(self.context.restore_tables) > 0:
 
-            is_remote_service = self.ddboost or self.netbackup_service_host or self.db_host_path
-            if not is_remote_service and stat.S_ISFIFO(os.stat(dump_file).st_mode):
+            is_remote_service = self.context.ddboost or self.context.netbackup_service_host or self.context.db_host_path
+            if not is_remote_service and stat.S_ISFIFO(os.stat(self.context.generate_filename("dump")).st_mode):
                 logger.warn('Skipping validation of tables in dump file due to the use of named pipes')
             else:
-                dumped_tables = GetDumpTables(
-                                restore_timestamp = restore_timestamp,
-                                master_datadir = self.master_datadir,
-                                backup_dir = self.backup_dir,
-                                dump_dir = self.dump_dir,
-                                dump_prefix = self.dump_prefix,
-                                compress = compress,
-                                ddboost = self.ddboost,
-                                ddboost_storage_unit = self.ddboost_storage_unit,
-                                netbackup_service_host = self.netbackup_service_host,
-                                remote_host = dump_host,
-                                dump_file = dump_file).get_dump_tables()
-                validate_tablenames_exist_in_dump_file(self.restore_tables, dumped_tables)
+                dumped_tables = GetDumpTables(self.context).get_dump_tables()
+                validate_tablenames_exist_in_dump_file(self.context.restore_tables, dumped_tables)
 
     def _validate_db_date_dir(self):
-        root = os.path.join(get_restore_dir(self.master_datadir, self.backup_dir), self.dump_dir, self.db_date_dir)
+        root = self.context.get_date_dir()
         if not os.path.isdir(root):
             raise ExceptionNoStackTraceNeeded("Directory %s does not exist" % root)
-        matching = ListFilesByPattern(root, "%s*" % generate_createdb_prefix(self.dump_prefix)).run()
+        prefix = self.context.generate_prefix("cdatabase")
+        matching = ListFilesByPattern(root, "%s*" % prefix).run()
         if len(matching) == 0:
             raise ExceptionNoStackTraceNeeded("Could not locate Master database dump files under %s" % root)
-        matching = sorted(matching, key=lambda x: int(x[len(generate_createdb_prefix(self.dump_prefix)):].strip()))
+        matching = sorted(matching, key=lambda x: int(x[len(prefix):].strip()))
         if len(matching) > 1:
             dates_and_times = []
             for match in matching:
-                temp = match[len(generate_createdb_prefix(self.dump_prefix)):]
+                temp = match[len(prefix):]
                 date, time = temp[0:8], temp[8:14]
                 dates_and_times.append((date, time))
-            restore_timestamp = self._select_multi_file(dates_and_times)
+            self.context.timestamp = self._select_multi_file(dates_and_times)
         else:
             match = matching[0]
-            temp = match[len(generate_createdb_prefix(self.dump_prefix)):]
-            restore_timestamp = temp[0:14]
-        restore_db = GetDbName(os.path.join(root, "%s%s" % (generate_createdb_prefix(self.dump_prefix), restore_timestamp))).run()
-        if not self.ddboost:
-            compressed_file = os.path.join(root, "%s%s.gz" % (generate_master_dbdump_prefix(self.dump_prefix), restore_timestamp))
-        else:
-            compressed_file = os.path.join(root, "%s%s_post_data.gz" % (generate_master_dbdump_prefix(self.dump_prefix), restore_timestamp))
-        compress = CheckFile(compressed_file).run()
-        return (restore_timestamp, restore_db, compress)
+            temp = match[len(prefix):]
+            self.context.timestamp = temp[0:14]
+        self.context.restore_db = GetDbName(self.context.generate_filename("cdatabase")).run()
+        compressed_file = self.context.generate_filename("metadata")
+        self.context.compress = CheckFile(compressed_file).run()
 
     def _validate_db_host_path(self):
         # The format of the -R option should be 'hostname:path_to_dumpset', hence the length should be 2 (hostname, path_to_dumpset)
-        if len(self.db_host_path) != 2:
+        if len(self.context.db_host_path) != 2:
             raise ProgramArgumentValidationException("The arguments of the -R flag are incorrect. The correct form should be as "
                                                      "follows:\nIPv4_address:path_to_dumpset\n-OR-\n[IPv6_address]:path_to_dumpset\n", False)
 
-        host, path = self.db_host_path
+        host, path = self.context.db_host_path
         logger.debug("The host is %s" % host)
         logger.debug("The path is %s" % path)
+        self.context.backup_dir = path[0:path.index(self.context.dump_dir)]
 
         Ping.local('Pinging %s' % host, host)
-
-        matching = ListRemoteFilesByPattern(path, "%s*" % generate_createdb_prefix(self.dump_prefix), host).run()
+        prefix = self.context.generate_prefix("cdatabase")
+        matching = ListRemoteFilesByPattern(path, "%s*" % prefix, host).run()
         if len(matching) == 0:
             raise ExceptionNoStackTraceNeeded("Could not locate Master database dump files at %s:%s" % (host, path))
-        matching = sorted(matching, key=lambda x: int(x[len(generate_createdb_prefix(self.dump_prefix)):].strip()))
-
+        matching = sorted(matching, key=lambda x: int(x[len(prefix):].strip()))
         if len(matching) > 1:
             dates_and_times = []
             for match in matching:
-                temp = match[len(generate_createdb_prefix(self.dump_prefix)):]
+                temp = match[len(prefix):]
                 date, time = temp[0:8], temp[8:14]
                 dates_and_times.append((date, time))
-            restore_timestamp = self._select_multi_file(dates_and_times)
+            self.context.timestamp = self._select_multi_file(dates_and_times)
         else:
             match = matching[0]
-            temp = match[len(generate_createdb_prefix(self.dump_prefix)):]
-            restore_timestamp = temp[0:14]
+            temp = match[len(prefix):]
+            self.context.timestamp = temp[0:14]
 
-        # TODO: do a local GetDbName after Scp
         handle, filename = mkstemp()
-        srcFile = os.path.join(path, "%s%s" % (generate_createdb_prefix(self.dump_prefix), restore_timestamp))
+        srcFile = self.context.generate_filename("cdatabase", directory=path)
         Scp('Copying cdatabase file', srcHost=host, srcFile=srcFile, dstFile=filename).run(validateAfter=True)
-        restore_db = GetDbName(filename).run()
+        self.context.restore_db = GetDbName(filename).run()
         os.remove(filename)
 
-        compress = False
-        file_name = "%s%s" % (generate_master_dbdump_prefix(self.dump_prefix), restore_timestamp)
-        uncompressed_file_path = os.path.join(path, file_name)
-        compressed_file_path = uncompressed_file_path + '.gz'
-
-        res = CheckRemoteFile(uncompressed_file_path, host).run()
-        if not res:
-            res = CheckRemoteFile(compressed_file_path, host).run()
-            if not res:
-                raise Exception("Cannot find dump file %s on remote %s" % (compressed_file_path, host))
-            else:
-                compress = True
-                return (restore_timestamp, restore_db, compress, host, compressed_file_path)
-        else:
-            return (restore_timestamp, restore_db, compress, host, uncompressed_file_path)
+        self.context.compress = CheckRemoteFile(srcFile, host).run()
 
     def _search_for_latest(self):
         logger.info("Scanning Master host for latest dump file set for database %s" % self.search_for_dbname)
-        root = os.path.join(get_restore_dir(self.master_datadir, self.backup_dir), self.dump_dir)
+        root = os.path.join(self.context.get_backup_root(), self.context.dump_dir)
         candidates, timestamps = [], []
+        prefix = self.context.generate_prefix("cdatabase")
         for path, dirs, files in os.walk(root):
-            matching = fnmatch.filter(files, "%s*" % generate_createdb_prefix(self.dump_prefix))
+            matching = fnmatch.filter(files, "%s*" % prefix)
             candidates.extend([(path, filename) for filename in matching])
         if len(candidates) == 0:
-            raise ExceptionNoStackTraceNeeded("No %s* files located" % generate_createdb_prefix(self.dump_prefix))
+            raise ExceptionNoStackTraceNeeded("No %s* files located" % prefix)
         for path, filename in candidates:
             db_name = GetDbName(os.path.join(path, filename)).run()
+            logger.info("Looking for %s, found %s" % (self.search_for_dbname, db_name))
             if self.search_for_dbname == db_name:
                 logger.info('Located dump file %s for database %s, adding to list' % (filename, self.search_for_dbname))
-                timestamps.append(int(filename[len(generate_createdb_prefix(self.dump_prefix)):]))
+                timestamps.append(int(filename[len(prefix):]))
             else:
                 logger.info("Dump file has incorrect database name of %s, skipping..." % db_name)
         if len(timestamps) == 0:
-            raise ExceptionNoStackTraceNeeded("No %s* files located with database %s" % (generate_createdb_prefix(self.dump_prefix), self.search_for_dbname))
-        restore_timestamp = str(max(timestamps))
-        logger.info("Identified latest dump timestamp for %s as %s" %  (self.search_for_dbname, restore_timestamp))
-        restore_db = self.search_for_dbname
-        if not self.ddboost:
-            compressed_file = os.path.join(get_restore_dir(self.master_datadir, self.backup_dir),
-                                           self.dump_dir, restore_timestamp[0:8],
-                                           "%s%s.gz" % (generate_master_dbdump_prefix(self.dump_prefix), restore_timestamp))
-        else:
-            compressed_file = os.path.join(get_restore_dir(self.master_datadir, self.backup_dir),
-                                           self.dump_dir, restore_timestamp[0:8],
-                                           "%s%s_post_data.gz" % (generate_master_dbdump_prefix(self.dump_prefix), restore_timestamp))
-        compress = CheckFile(compressed_file).run()
-        return (restore_timestamp, restore_db, compress)
+            raise ExceptionNoStackTraceNeeded("No %s* files located with database %s" % (prefix, self.search_for_dbname))
+        self.context.timestamp = str(max(timestamps))
+        logger.info("Identified latest dump timestamp for %s as %s" %  (self.search_for_dbname, self.context.timestamp))
+        self.context.restore_db = self.search_for_dbname
+        compressed_file = self.context.generate_filename("cdatabase")
+        self.context.compress = CheckFile(compressed_file).run()
 
     def _select_multi_file(self, dates_and_times):
         spc = "        "
@@ -696,7 +550,7 @@ def create_parser():
     addMasterDirectoryOptionForSingleClusterProgram(addTo)
 
     addTo = OptionGroup(parser, 'Restore options: ')
-    addTo.add_option('-t', dest='db_timestamp', metavar='<timestamp>',
+    addTo.add_option('-t', dest='timestamp', metavar='<timestamp>',
                      help="Timestamp key of backup file set that should be used for restore. Mandatory if -b, -R, -s are not supplied. Expects dumpset to reside on Greenplum array.")
     addTo.add_option('-L', action='store_true', dest='list_tables', default=False,
                      help="List table names in dump file, can only be used with -t <timestamp> option. Will display all tables in dump file, and then exit.")

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1340,7 +1340,7 @@ def get_gphome():
 def get_masterdatadir():
     logger.debug("Checking if MASTER_DATA_DIRECTORY env variable is set.")
     master_datadir = os.environ.get('MASTER_DATA_DIRECTORY')
-    if master_datadir is None:
+    if not master_datadir:
         raise GpError("Environment Variable MASTER_DATA_DIRECTORY not set!")
     return master_datadir
 

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -761,6 +761,18 @@ class Segment:
             if (prim_status, prim_mode, mirror_status, mirror_role) not in VALID_SEGMENT_STATES:
                 return False
         return True
+
+    def get_active_primary(self):
+        if self.primaryDB.isSegmentPrimary(current_role=True):
+            return self.primaryDB
+        else:
+            for mirror in mirrorDBs:
+                if mirror.isSegmentPrimary(current_role=True):
+                    return mirror
+
+    def get_primary_dbid(self):
+        return self.primaryDB.getSegmentDbId()
+
 # --------------------------------------------------------------------
 # --------------------------------------------------------------------
 class SegmentRow():
@@ -1723,6 +1735,14 @@ class GpArray:
                 dbs.extend(seg.get_dbs()) 
         return dbs
 
+    # --------------------------------------------------------------------
+    def getSegmentList(self, includeExpansionSegs=False):
+        """Return a list of all GpDb objects for all segments in the array"""
+        dbs=[]
+        dbs.extend(self.segments)
+        if includeExpansionSegs:
+            dbs.extend(self.expansionSegments)
+        return dbs
 
     # --------------------------------------------------------------------
     def getSegDbMap(self):

--- a/gpMgmt/bin/gppylib/operations/dump.py
+++ b/gpMgmt/bin/gppylib/operations/dump.py
@@ -18,47 +18,41 @@ from gppylib.utils import shellEscape
 from gppylib.operations import Operation
 from gppylib.operations.unix import CheckDir, CheckFile, ListFiles, ListFilesByPattern, MakeDir, RemoveFile, RemoveTree, RemoveRemoteTree
 from gppylib.operations.utils import RemoteOperation, ParallelOperation
-from gppylib.operations.backup_utils import backup_file_with_nbu, check_file_dumped_with_nbu, create_temp_file_from_list, execute_sql, \
-                                            generate_ao_state_filename, generate_cdatabase_filename, generate_co_state_filename, generate_dirtytable_filename, \
-                                            generate_filter_filename, generate_global_filename, generate_global_prefix, generate_increments_filename, \
-                                            generate_master_config_filename, generate_master_dbdump_prefix, generate_master_status_prefix, \
-                                            generate_partition_list_filename, generate_stats_filename, \
-                                            generate_pgstatlastoperation_filename, generate_report_filename, generate_schema_filename, generate_seg_dbdump_prefix, \
-                                            generate_seg_status_prefix, generate_segment_config_filename, get_incremental_ts_from_report_file, \
-                                            get_latest_full_dump_timestamp, get_latest_full_ts_with_nbu, get_latest_report_timestamp, get_lines_from_file, \
-                                            restore_file_with_nbu, validate_timestamp, verify_lines_in_file, write_lines_to_file, isDoubleQuoted, formatSQLString, \
-                                            checkAndAddEnclosingDoubleQuote, split_fqn, remove_file_on_segments, generate_stats_prefix
+from gppylib.operations.backup_utils import *
 
 logger = gplog.get_default_logger()
 
-# MPP-15307
-# DUMP_DATE dictates the db_dumps/ subdirectory to which gpcrondump will dump.
-# It is computed just once to ensure different pieces of logic herein operate on the same subdirectory.
-TIMESTAMP = datetime.now()
-TIMESTAMP_KEY = TIMESTAMP.strftime("%Y%m%d%H%M%S")
-DUMP_DATE = TIMESTAMP.strftime("%Y%m%d")
 FULL_DUMP_TS_WITH_NBU = None
 
 COMPRESSION_FACTOR = 12                 # TODO: Where did 12 come from?
 
 INJECT_GP_DUMP_FAILURE = None
 
-GET_ALL_DATATABLES_SQL = """
-SELECT ALLTABLES.oid, ALLTABLES.schemaname, ALLTABLES.tablename FROM 
+CATALOG_SCHEMA = [
+    'gp_toolkit',
+    'information_schema',
+    'pg_aoseg',
+    'pg_bitmapindex',
+    'pg_catalog',
+    'pg_toast'
+]
 
-    (SELECT c.oid, n.nspname AS schemaname, c.relname AS tablename FROM pg_class c, pg_namespace n 
+GET_ALL_DATATABLES_SQL = """
+SELECT ALLTABLES.oid, ALLTABLES.schemaname, ALLTABLES.tablename FROM
+
+    (SELECT c.oid, n.nspname AS schemaname, c.relname AS tablename FROM pg_class c, pg_namespace n
     WHERE n.oid = c.relnamespace) as ALLTABLES,
 
     (SELECT n.nspname AS schemaname, c.relname AS tablename
     FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
     LEFT JOIN pg_tablespace t ON t.oid = c.reltablespace
-    WHERE c.relkind = 'r'::"char" AND c.oid > 16384 AND (c.relnamespace > 16384 or n.nspname = 'public') 
+    WHERE c.relkind = 'r'::"char" AND c.oid > 16384 AND (c.relnamespace > 16384 or n.nspname = 'public')
     EXCEPT
-    ((SELECT x.schemaname, x.partitiontablename FROM 
+    ((SELECT x.schemaname, x.partitiontablename FROM
     (SELECT distinct schemaname, tablename, partitiontablename, partitionlevel FROM pg_partitions) as X,
-    (SELECT schemaname, tablename maxtable, max(partitionlevel) maxlevel FROM pg_partitions group by (tablename, schemaname)) as Y    
-    WHERE x.schemaname = y.schemaname and x.tablename = Y.maxtable and x.partitionlevel != Y.maxlevel) 
-    UNION (SELECT distinct schemaname, tablename FROM pg_partitions))) as DATATABLES 
+    (SELECT schemaname, tablename maxtable, max(partitionlevel) maxlevel FROM pg_partitions group by (tablename, schemaname)) as Y
+    WHERE x.schemaname = y.schemaname and x.tablename = Y.maxtable and x.partitionlevel != Y.maxlevel)
+    UNION (SELECT distinct schemaname, tablename FROM pg_partitions))) as DATATABLES
 
 WHERE ALLTABLES.schemaname = DATATABLES.schemaname and ALLTABLES.tablename = DATATABLES.tablename AND ALLTABLES.oid not in (select reloid from pg_exttable) AND ALLTABLES.schemaname NOT LIKE 'pg_temp_%'
 """
@@ -80,7 +74,7 @@ SELECT n.nspname AS schemaname, c.relname AS tablename
 GET_APPENDONLY_DATA_TABLE_INFO_SQL = """
     SELECT ALL_DATA_TABLES.oid, ALL_DATA_TABLES.schemaname, ALL_DATA_TABLES.tablename, OUTER_PG_CLASS.relname as tupletable FROM
     (%s) as ALL_DATA_TABLES, pg_appendonly, pg_class OUTER_PG_CLASS
-    WHERE ALL_DATA_TABLES.oid = pg_appendonly.relid 
+    WHERE ALL_DATA_TABLES.oid = pg_appendonly.relid
     AND OUTER_PG_CLASS.oid = pg_appendonly.segrelid
 """ % GET_ALL_DATATABLES_SQL
 
@@ -102,78 +96,37 @@ GET_ALL_AO_CO_DATATABLES_SQL = """
 
 GET_LAST_OPERATION_SQL = """
     SELECT PGN.nspname, PGC.relname, objid, staactionname, stasubtype, statime FROM pg_stat_last_operation, pg_class PGC, pg_namespace PGN
-    WHERE objid = PGC.oid 
+    WHERE objid = PGC.oid
     AND PGC.relnamespace = PGN.oid
-    AND staactionname IN ('CREATE', 'ALTER', 'TRUNCATE') 
+    AND staactionname IN ('CREATE', 'ALTER', 'TRUNCATE')
     AND objid IN (SELECT oid FROM (%s) as AOCODATATABLES)
     ORDER BY objid, staactionname
 """ % GET_ALL_AO_CO_DATATABLES_SQL
 
 GET_ALL_SCHEMAS_SQL = "SELECT nspname from pg_namespace;"
 
-def get_include_schema_list_from_exclude_schema(exclude_schema_list, catalog_schema_list, master_port, dbname):
+def get_include_schema_list_from_exclude_schema(context, exclude_schema_list):
     """
     If schema name is already double quoted, remove it so comparing with
     schemas returned by database will be correct.
     Don't do strip, that will remove white space inside schema name
     """
     include_schema_list = []
-    schema_list = execute_sql(GET_ALL_SCHEMAS_SQL, master_port, dbname)
+    schema_list = execute_sql(GET_ALL_SCHEMAS_SQL, context.master_port, context.dump_database)
     for schema in schema_list:
-        if schema[0] not in exclude_schema_list and schema[0] not in catalog_schema_list:
+        if schema[0] not in exclude_schema_list and schema[0] not in CATALOG_SCHEMA:
             include_schema_list.append(schema[0])
 
     return include_schema_list
 
-def backup_schema_file_with_ddboost(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key=None, ddboost_storage_unit=None):
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    filename = generate_schema_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key, True)
-    copy_file_to_dd(filename, dump_dir, timestamp_key, ddboost_storage_unit=ddboost_storage_unit)
-
-def backup_report_file_with_ddboost(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key=None, ddboost_storage_unit=None):
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    filename = generate_report_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key, True)
-    copy_file_to_dd(filename, dump_dir, timestamp_key, ddboost_storage_unit=ddboost_storage_unit)
-
-def backup_increments_file_with_ddboost(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, ddboost_storage_unit=None):
-    filename = generate_increments_filename(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, True)
-    copy_file_to_dd(filename, dump_dir, full_timestamp, ddboost_storage_unit=ddboost_storage_unit)
-
-def copy_file_to_dd(filename, dump_dir, timestamp_key=None, ddboost_storage_unit=None):
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    basefilename = os.path.basename(filename)
-    cmdStr = "gpddboost --copyToDDBoost --from-file=%s --to-file=%s/%s/%s" % (filename, dump_dir, timestamp_key[0:8], basefilename)
-    if ddboost_storage_unit:
-        cmdStr += " --ddboost-storage-unit=%s" % ddboost_storage_unit
-    cmd = Command('copy file %s to DD machine' % basefilename, cmdStr)
-    cmd.run(validateAfter=True)
-
-def generate_dump_timestamp(timestamp):
-    global TIMESTAMP
-    global TIMESTAMP_KEY
-    global DUMP_DATE
-
-    if timestamp is not None:
-        TIMESTAMP = timestamp
-    else:
-        TIMESTAMP = datetime.now()
-    TIMESTAMP_KEY = TIMESTAMP.strftime("%Y%m%d%H%M%S")
-    DUMP_DATE = TIMESTAMP.strftime("%Y%m%d")
-
-def get_ao_partition_state(master_port, dbname):
-    ao_partition_info = get_ao_partition_list(master_port, dbname)
-    ao_partition_list = get_partition_state(master_port, dbname, 'pg_aoseg', ao_partition_info)
+def get_ao_partition_state(context):
+    ao_partition_info = get_ao_partition_list(context)
+    ao_partition_list = get_partition_state(context, 'pg_aoseg', ao_partition_info)
     return ao_partition_list
 
-def get_co_partition_state(master_port, dbname):
-    co_partition_info = get_co_partition_list(master_port, dbname)
-    co_partition_list = get_partition_state(master_port, dbname, 'pg_aoseg', co_partition_info)
+def get_co_partition_state(context):
+    co_partition_info = get_co_partition_list(context)
+    co_partition_list = get_partition_state(context, 'pg_aoseg', co_partition_info)
     return co_partition_list
 
 def validate_modcount(schema, tablename, cnt):
@@ -184,7 +137,7 @@ def validate_modcount(schema, tablename, cnt):
     if len(cnt) > 15:
         raise Exception("Exceeded backup max tuple count of 1 quadrillion rows per table for: '%s.%s' '%s'" % (schema, tablename, cnt))
 
-def get_partition_state_tuples(master_port, dbname, catalog_schema, partition_info):
+def get_partition_state_tuples(context, catalog_schema, partition_info):
     """
         Reads the partition state for an AO or AOCS relation, which is the sum of
         the modication counters over all ao segment files.
@@ -208,7 +161,7 @@ def get_partition_state_tuples(master_port, dbname, catalog_schema, partition_in
     """
     partition_list = list()
 
-    dburl = dbconn.DbURL(port=master_port, dbname=dbname)
+    dburl = dbconn.DbURL(port=context.master_port, dbname=context.dump_database)
     num_sqls = 0
     with dbconn.connect(dburl) as conn:
         for (oid, schemaname, partition_name, tupletable) in partition_info:
@@ -226,45 +179,43 @@ def get_partition_state_tuples(master_port, dbname, catalog_schema, partition_in
 
     return partition_list
 
-def get_partition_state(master_port, dbname, catalog_schema, partition_info):
+def get_partition_state(context, catalog_schema, partition_info):
     """
     A legacy version of get_partition_state_tuples() that returns a list of strings
     instead of tuples. Should not be used in new code, because the string
     representation doesn't handle schema or table names with commas.
     """
-    tuples = get_partition_state_tuples(master_port, dbname, catalog_schema, partition_info)
+    tuples = get_partition_state_tuples(context, catalog_schema, partition_info)
 
     # Don't put space after comma, which can mess up with the space in schema and table name
-    return map((lambda x: '%s,%s,%s' % x), tuples)
+    return map((lambda x: '%s, %s, %s' % x), tuples)
 
-def get_tables_with_dirty_metadata(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, cur_pgstatoperations,
-                                   netbackup_service_host=None, netbackup_block_size=None):
-    last_dump_timestamp = get_last_dump_timestamp(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, netbackup_service_host, netbackup_block_size)
-    old_pgstatoperations_file = generate_pgstatlastoperation_filename(master_datadir, backup_dir, dump_dir, dump_prefix, last_dump_timestamp)
-    if netbackup_service_host:
-        restore_file_with_nbu(netbackup_service_host, netbackup_block_size, old_pgstatoperations_file)
-    old_pgstatoperations = get_lines_from_file(old_pgstatoperations_file)
+def get_tables_with_dirty_metadata(context, cur_pgstatoperations):
+    last_dump_timestamp = get_last_dump_timestamp(context)
+    old_file = context.generate_filename("last_operation", timestamp=last_dump_timestamp)
+    if context.netbackup_service_host:
+        restore_file_with_nbu(context, path=old_file)
+    old_pgstatoperations = get_lines_from_file(old_file)
     old_pgstatoperations_dict = get_pgstatlastoperations_dict(old_pgstatoperations)
     dirty_tables = compare_metadata(old_pgstatoperations_dict, cur_pgstatoperations)
     return dirty_tables
 
-def get_dirty_partition_tables(table_type, curr_state_partition_list, master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp,
-                               netbackup_service_host=None, netbackup_block_size=None):
-    last_state_partition_list = get_last_state(table_type, master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, netbackup_service_host, netbackup_block_size)
+def get_dirty_partition_tables(context, table_type, curr_state_partition_list):
+    last_state_partition_list = get_last_state(context, table_type)
     last_state_dict = create_partition_dict(last_state_partition_list)
     curr_state_dict = create_partition_dict(curr_state_partition_list)
     return compare_dict(last_state_dict, curr_state_dict)
 
-def get_last_state(table_type, master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, netbackup_service_host=None, netbackup_block_size=None):
-    last_ts = get_last_dump_timestamp(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, netbackup_service_host, netbackup_block_size)
-    last_state_filename = get_filename_from_filetype(table_type, master_datadir, backup_dir, dump_dir, dump_prefix, last_ts.strip())
-    if netbackup_service_host is None:
+def get_last_state(context, table_type):
+    last_ts = get_last_dump_timestamp(context)
+    last_state_filename = get_filename_from_filetype(context, table_type, last_ts.strip())
+    if context.netbackup_service_host is None:
         if not os.path.isfile(last_state_filename):
             raise Exception('%s state file does not exist: %s' % (table_type, last_state_filename))
     else:
-        if check_file_dumped_with_nbu(netbackup_service_host, last_state_filename):
+        if check_file_dumped_with_nbu(context, path=last_state_filename):
             if not os.path.exists(last_state_filename):
-                restore_file_with_nbu(netbackup_service_host, netbackup_block_size, last_state_filename)
+                restore_file_with_nbu(context, path=last_state_filename)
 
     return get_lines_from_file(last_state_filename)
 
@@ -288,19 +239,20 @@ def get_pgstatlastoperations_dict(last_operations):
         last_operations_dict[(toks[2], toks[3])] = operation
     return last_operations_dict
 
-def get_last_dump_timestamp(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, netbackup_service_host=None, netbackup_block_size=None):
-    increments_filename = generate_increments_filename(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp)
-    if netbackup_service_host is None:
+def get_last_dump_timestamp(context):
+    full_dump_timestamp = get_latest_full_dump_timestamp(context)
+    increments_filename = context.generate_filename("increments", timestamp=full_dump_timestamp)
+    if context.netbackup_service_host is None:
         if not os.path.isfile(increments_filename):
-            return full_timestamp
+            return full_dump_timestamp
     else:
-        if check_file_dumped_with_nbu(netbackup_service_host, increments_filename):
+        if check_file_dumped_with_nbu(context, path=increments_filename):
             if not os.path.exists(increments_filename):
                 logger.debug('Increments file %s was dumped with NBU, so restoring it now...' % increments_filename)
-                restore_file_with_nbu(netbackup_service_host, netbackup_block_size, increments_filename)
+                restore_file_with_nbu(context, "increments")
         else:
             logger.debug('Increments file %s was NOT dumped with NBU, returning full timestamp as last dump timestamp' % increments_filename)
-            return full_timestamp
+            return full_dump_timestamp
 
     lines = get_lines_from_file(increments_filename)
     if not lines:
@@ -313,15 +265,15 @@ def get_last_dump_timestamp(master_datadir, backup_dir, dump_dir, dump_prefix, f
 def create_partition_dict(partition_list):
     table_dict = dict()
     for partition in partition_list:
-        fields = partition.split(',')
+        # As of version 4.3.8.0, gpcrondump supports spaces in schema name (field[0]) and table name (field[1])
+        # so we explicitly split on "comma followed by space" instead of just commas since we can't strip() the string
+        fields = partition.split(', ')
         if len(fields) != 3:
             raise Exception('Invalid state file format %s' % partition)
-        # new version 4.3.8.0 retains and supports spaces in schema name: field[0] and table name: field[1]
-        # below to determine if previous state file was from an old version which uses comma and space separated "schema, table, modcount"
         if fields[2].startswith(' '):
-            fields = [x.strip() for x in fields]
+            fields = [x for x in fields]
         key = '%s.%s' % (fields[0], fields[1])
-        table_dict[key] = fields[2].strip()
+        table_dict[key] = fields[2]
 
     return table_dict
 
@@ -332,49 +284,36 @@ def compare_dict(last_dict, curr_dict):
             diffkeys.add(k)
     return diffkeys
 
-def get_filename_from_filetype(table_type, master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key=None, ddboost=False):
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    if table_type == 'ao':
-        filename = generate_ao_state_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key, ddboost)
-    elif table_type == 'co':
-        filename = generate_co_state_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key, ddboost)
-    else:
+def get_filename_from_filetype(context, table_type, timestamp=None):
+    if not timestamp:
+        timestamp = context.timestamp
+    if table_type not in ["ao", "co"]:
         raise Exception('Invalid table type %s provided. Supported table types ao/co.' % table_type)
+    filename = context.generate_filename(table_type, timestamp=timestamp)
 
     return filename
 
-def write_state_file(table_type, master_datadir, backup_dir, dump_dir, dump_prefix, partition_list, ddboost=False, ddboost_storage_unit=None):
-    filename = get_filename_from_filetype(table_type, master_datadir, backup_dir, dump_dir, dump_prefix, None, ddboost)
+def write_state_file(context, table_type, partition_list):
+    filename = get_filename_from_filetype(context, table_type, None)
 
     write_lines_to_file(filename, partition_list)
-    verify_lines_in_file(filename, partition_list)
 
-    if ddboost:
-        copy_file_to_dd(filename, dump_dir, ddboost_storage_unit=ddboost_storage_unit)
+    if context.ddboost:
+        copy_file_to_dd(context, filename)
 
 # return a list of dirty tables
-def get_dirty_tables(master_port, dbname, master_datadir, backup_dir, dump_dir, dump_prefix, fulldump_ts,
-                     ao_partition_list, co_partition_list, last_operation_data,
-                     netbackup_service_host, netbackup_block_size):
-
-    dirty_heap_tables = get_dirty_heap_tables(master_port, dbname)
-
-    dirty_ao_tables = get_dirty_partition_tables('ao', ao_partition_list, master_datadir, backup_dir, dump_dir, dump_prefix,
-                                                 fulldump_ts, netbackup_service_host, netbackup_block_size)
-
-    dirty_co_tables = get_dirty_partition_tables('co', co_partition_list, master_datadir, backup_dir, dump_dir, dump_prefix,
-                                                 fulldump_ts, netbackup_service_host, netbackup_block_size)
-
-    dirty_metadata_set = get_tables_with_dirty_metadata(master_datadir, backup_dir, dump_dir, dump_prefix, fulldump_ts, last_operation_data,
-                                                        netbackup_service_host, netbackup_block_size)
+def get_dirty_tables(context, ao_partition_list, co_partition_list, last_operation_data):
+    dirty_heap_tables = get_dirty_heap_tables(context)
+    dirty_ao_tables = get_dirty_partition_tables(context, 'ao', ao_partition_list)
+    dirty_co_tables = get_dirty_partition_tables(context, 'co', co_partition_list)
+    dirty_metadata_set = get_tables_with_dirty_metadata(context, last_operation_data)
+    logger.info("%s" % list(dirty_heap_tables | dirty_ao_tables | dirty_co_tables | dirty_metadata_set))
 
     return list(dirty_heap_tables | dirty_ao_tables | dirty_co_tables | dirty_metadata_set)
 
-def get_dirty_heap_tables(master_port, dbname):
+def get_dirty_heap_tables(context):
     dirty_tables = set()
-    qresult = get_heap_partition_list(master_port, dbname)
+    qresult = get_heap_partition_list(context)
     for row in qresult:
         if len(row) != 3:
             raise Exception("Heap tables query returned rows with unexpected number of columns %d" % len(row))
@@ -385,35 +324,33 @@ def get_dirty_heap_tables(master_port, dbname):
 def write_dirty_file_to_temp(dirty_tables):
     return create_temp_file_from_list(dirty_tables, 'dirty_backup_list_')
 
-def write_dirty_file(mdd, dirty_tables, backup_dir, dump_dir, dump_prefix, timestamp_key=None, ddboost=False, ddboost_storage_unit=None):
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
+def write_dirty_file(context, dirty_tables, timestamp=None):
     if dirty_tables is None:
         return None
+    if not timestamp:
+        timestamp = context.timestamp
 
-    dirty_list_file = generate_dirtytable_filename(mdd, backup_dir, dump_dir, dump_prefix, timestamp_key, ddboost)
+    dirty_list_file = context.generate_filename("dirty_table", timestamp)
     write_lines_to_file(dirty_list_file, dirty_tables)
 
-    verify_lines_in_file(dirty_list_file, dirty_tables)
-    if ddboost:
-        copy_file_to_dd(dirty_list_file, dump_dir, ddboost_storage_unit=ddboost_storage_unit)
+    if context.ddboost:
+        copy_file_to_dd(context, dirty_list_file)
 
     return dirty_list_file
 
-def get_heap_partition_list(master_port, dbname):
-    return execute_sql(GET_ALL_HEAP_DATATABLES_SQL, master_port, dbname)
+def get_heap_partition_list(context):
+    return execute_sql(GET_ALL_HEAP_DATATABLES_SQL, context.master_port, context.dump_database)
 
-def get_ao_partition_list(master_port, dbname):
-    partition_list = execute_sql(GET_ALL_AO_DATATABLES_SQL, master_port, dbname)
+def get_ao_partition_list(context):
+    partition_list = execute_sql(GET_ALL_AO_DATATABLES_SQL, context.master_port, context.dump_database)
     for line in partition_list:
         if len(line) != 4:
             raise Exception('Invalid results from query to get all AO tables: [%s]' % (','.join(line)))
 
     return partition_list
 
-def get_co_partition_list(master_port, dbname):
-    partition_list = execute_sql(GET_ALL_CO_DATATABLES_SQL, master_port, dbname)
+def get_co_partition_list(context):
+    partition_list = execute_sql(GET_ALL_CO_DATATABLES_SQL, context.master_port, context.dump_database)
     for line in partition_list:
         if len(line) != 4:
             raise Exception('Invalid results from query to get all CO tables: [%s]' % (','.join(line)))
@@ -423,16 +360,16 @@ def get_co_partition_list(master_port, dbname):
 def get_partition_list(master_port, dbname):
     return execute_sql(GET_ALL_DATATABLES_SQL, master_port, dbname)
 
-def get_user_table_list(master_port, dbname):
-    return execute_sql(GET_ALL_USER_TABLES_SQL, master_port, dbname)
+def get_user_table_list(context):
+    return execute_sql(GET_ALL_USER_TABLES_SQL, context.master_port, context.dump_database)
 
-def get_user_table_list_for_schema(master_port, dbname, schema):
+def get_user_table_list_for_schema(context, schema):
     sql = GET_ALL_USER_TABLES_FOR_SCHEMA_SQL % pg.escape_string(schema)
-    return execute_sql(sql, master_port, dbname)
+    return execute_sql(sql, context.master_port, context.dump_database)
 
-def get_last_operation_data(master_port, dbname):
+def get_last_operation_data(context):
     # oid, action, subtype, timestamp
-    rows = execute_sql(GET_LAST_OPERATION_SQL, master_port, dbname)
+    rows = execute_sql(GET_LAST_OPERATION_SQL, context.master_port, context.dump_database)
     data = []
     for row in rows:
         if len(row) != 6:
@@ -441,16 +378,16 @@ def get_last_operation_data(master_port, dbname):
         data.append(line)
     return data
 
-def write_partition_list_file(master_datadir, backup_dir, timestamp_key, master_port, dbname, dump_dir, dump_prefix,
-                              ddboost=False, netbackup_service_host=None, ddboost_storage_unit=None):
-    filter_file = get_filter_file(dbname, master_datadir, backup_dir, dump_dir, dump_prefix, ddboost, ddboost_storage_unit, netbackup_service_host)
-    partition_list_file_name = generate_partition_list_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key)
+def write_partition_list_file(context, timestamp=None):
+    if not timestamp:
+        timestamp = context.timestamp
+    filter_file = get_filter_file(context)
+    partition_list_file_name = context.generate_filename("partition_list", timestamp=timestamp)
 
     if filter_file:
         shutil.copyfile(filter_file, partition_list_file_name)
-        verify_lines_in_file(partition_list_file_name, get_lines_from_file(filter_file))
     else:
-        lines_to_write = get_partition_list(master_port, dbname)
+        lines_to_write = get_partition_list(context.master_port, context.dump_database)
         partition_list = []
         for line in lines_to_write:
             if len(line) != 3:
@@ -458,75 +395,63 @@ def write_partition_list_file(master_datadir, backup_dir, timestamp_key, master_
             partition_list.append("%s.%s" % (line[1], line[2]))
 
         write_lines_to_file(partition_list_file_name, partition_list)
-        verify_lines_in_file(partition_list_file_name, partition_list)
 
-    if ddboost:
-        copy_file_to_dd(partition_list_file_name, dump_dir, ddboost_storage_unit=ddboost_storage_unit)
+    if context.ddboost:
+        copy_file_to_dd(context, partition_list_file_name)
 
-def write_last_operation_file(master_datadir, backup_dir, rows, dump_dir, dump_prefix, timestamp_key=None, ddboost=False, ddboost_storage_unit=None):
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    filename = generate_pgstatlastoperation_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key, ddboost)
+def write_last_operation_file(context, rows):
+    filename = context.generate_filename("last_operation")
     write_lines_to_file(filename, rows)
-    verify_lines_in_file(filename, rows)
 
-    if ddboost:
-        copy_file_to_dd(filename, dump_dir, ddboost_storage_unit=ddboost_storage_unit)
+    if context.ddboost:
+        copy_file_to_dd(context, filename)
 
-def validate_current_timestamp(backup_dir, dump_dir, dump_prefix, current=None):
+def validate_current_timestamp(context, current=None):
     if current is None:
-        current = TIMESTAMP_KEY
-
-    latest = get_latest_report_timestamp(backup_dir, dump_dir, dump_prefix)
+        current = context.timestamp
+    latest = get_latest_report_timestamp(context)
     if not latest:
         return
     if latest >= current:
         raise Exception('There is a future dated backup on the system preventing new backups')
 
-def get_backup_dir(master_datadir, backup_dir):
-    if backup_dir:
-        return backup_dir
-    return master_datadir
-
-def update_filter_file(dump_database, master_datadir, backup_dir, master_port, dump_dir, dump_prefix, ddboost=False, ddboost_storage_unit=None, netbackup_service_host=None,
-                       netbackup_policy=None, netbackup_schedule=None, netbackup_block_size=None, netbackup_keyword=None):
-    filter_filename = get_filter_file(dump_database, master_datadir, backup_dir, dump_dir, dump_prefix, ddboost, ddboost_storage_unit, netbackup_service_host, netbackup_block_size)
-    if netbackup_service_host:
-        restore_file_with_nbu(netbackup_service_host, netbackup_block_size, filter_filename)
+def update_filter_file(context):
+    filter_filename = get_filter_file(context)
+    if context.netbackup_service_host:
+        restore_file_with_nbu(context, path=filter_filename)
     filter_tables = get_lines_from_file(filter_filename)
     tables_sql = "SELECT DISTINCT schemaname||'.'||tablename FROM pg_partitions"
     partitions_sql = "SELECT schemaname||'.'||partitiontablename FROM pg_partitions WHERE schemaname||'.'||tablename='%s';"
-    table_list = execute_sql(tables_sql, master_port, dump_database)
+    table_list = execute_sql(tables_sql, context.master_port, context.dump_database)
 
     for table in table_list:
         if table[0] in filter_tables:
-            partitions_list = execute_sql(partitions_sql % table[0], master_port, dump_database)
+            partitions_list = execute_sql(partitions_sql % table[0], context.master_port, context.dump_database)
             filter_tables.extend([x[0] for x in partitions_list])
 
     write_lines_to_file(filter_filename, list(set(filter_tables)))
-    if netbackup_service_host:
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, filter_filename)
+    if context.netbackup_service_host:
+        backup_file_with_nbu(context, path=filter_filename)
 
-def get_filter_file(dump_database, master_datadir, backup_dir, dump_dir, dump_prefix, ddboost=False, ddboost_storage_unit=None, netbackup_service_host=None, netbackup_block_size=None):
-    if netbackup_service_host is None:
-        timestamp = get_latest_full_dump_timestamp(dump_database, get_backup_dir(master_datadir, backup_dir), dump_dir, dump_prefix, ddboost, ddboost_storage_unit)
+def get_filter_file(context):
+    if context.netbackup_service_host is None:
+        timestamp = get_latest_full_dump_timestamp(context)
     else:
         if FULL_DUMP_TS_WITH_NBU is None:
-            timestamp = get_latest_full_ts_with_nbu(dump_database, get_backup_dir(master_datadir, backup_dir), dump_prefix, netbackup_service_host, netbackup_block_size)
+            timestamp = get_latest_full_ts_with_nbu(context)
         else:
             timestamp = FULL_DUMP_TS_WITH_NBU
         if timestamp is None:
             raise Exception("No full backup timestamp found for given NetBackup server.")
-    filter_file = generate_filter_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp)
-    if netbackup_service_host is None:
+    filter_file = context.generate_filename("filter", timestamp=timestamp)
+    if context.netbackup_service_host is None:
         if os.path.isfile(filter_file):
             return filter_file
         return None
     else:
-        if check_file_dumped_with_nbu(netbackup_service_host, filter_file):
+        if check_file_dumped_with_nbu(context, path=filter_file):
             if not os.path.exists(filter_file):
-                restore_file_with_nbu(netbackup_service_host, netbackup_block_size, filter_file)
+                restore_file_with_nbu(context, path=filter_file)
             return filter_file
         return None
 
@@ -541,18 +466,17 @@ def update_filter_file_with_dirty_list(filter_file, dirty_tables):
 
         write_lines_to_file(filter_file, filter_list)
 
-def filter_dirty_tables(dirty_tables, dump_database, master_datadir, backup_dir, dump_dir, dump_prefix, ddboost=False, ddboost_storage_unit=None,
-                        netbackup_service_host=None, netbackup_block_size=None):
-    if netbackup_service_host is None:
-        timestamp = get_latest_full_dump_timestamp(dump_database, get_backup_dir(master_datadir, backup_dir), dump_dir, dump_prefix, ddboost, ddboost_storage_unit)
+def filter_dirty_tables(context, dirty_tables):
+    if context.netbackup_service_host is None:
+        timestamp = get_latest_full_dump_timestamp(context)
     else:
         if FULL_DUMP_TS_WITH_NBU is None:
-            timestamp = get_latest_full_ts_with_nbu(dump_database, get_backup_dir(master_datadir, backup_dir), dump_prefix, netbackup_service_host, netbackup_block_size)
+            timestamp = get_latest_full_ts_with_nbu(context)
         else:
             timestamp = FULL_DUMP_TS_WITH_NBU
 
-    schema_filename = generate_schema_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp, ddboost)
-    filter_file = get_filter_file(dump_database, master_datadir, backup_dir, dump_dir, dump_prefix, ddboost, ddboost_storage_unit, netbackup_service_host, netbackup_block_size)
+    schema_filename = context.generate_filename("schema", timestamp=timestamp)
+    filter_file = get_filter_file(context)
     if filter_file:
         tables_to_filter = get_lines_from_file(filter_file)
         dirty_copy = dirty_tables[:]
@@ -575,227 +499,56 @@ def filter_dirty_tables(dirty_tables, dump_database, master_datadir, backup_dir,
 
     return dirty_tables
 
-def backup_state_files_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, netbackup_service_host, netbackup_policy,
-                                netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key=None):
+def backup_state_files_with_nbu(context):
     logger.debug("Inside backup_state_files_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
 
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
+    backup_file_with_nbu(context, "ao")
+    backup_file_with_nbu(context, "co")
+    backup_file_with_nbu(context, "last_operation")
 
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         get_filename_from_filetype('ao', master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key))
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         get_filename_from_filetype('co', master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key))
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         generate_pgstatlastoperation_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key))
-
-def backup_schema_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, netbackup_service_host, netbackup_policy,
-                                netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key=None):
-    logger.debug("Inside backup_schema_file_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         generate_schema_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key))
-
-def backup_cdatabase_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, netbackup_service_host, netbackup_policy,
-                                   netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key=None):
-    logger.debug("Inside backup_cdatabase_file_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         generate_cdatabase_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key))
-
-def backup_report_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, netbackup_service_host, netbackup_policy,
-                                netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key=None):
-    logger.debug("Inside backup_report_file_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         generate_report_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key))
-
-def backup_global_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule,
-                                netbackup_block_size, netbackup_keyword, timestamp_key=None):
-    logger.debug("Inside backup_global_file_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         generate_global_filename(master_datadir, backup_dir, dump_dir, dump_prefix, DUMP_DATE, timestamp_key))
-
-def backup_statistics_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule,
-                                    netbackup_block_size, netbackup_keyword, timestamp_key=None):
-    logger.debug("Inside backup_statistics_file_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         generate_stats_filename(master_datadir, backup_dir, dump_dir, dump_prefix, DUMP_DATE, timestamp_key))
-
-def backup_config_files_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, master_port, netbackup_service_host, netbackup_policy,
-                                 netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key=None):
-    logger.debug("Inside backup_config_files_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    #backing up master config file
-    config_backup_file = generate_master_config_filename(dump_prefix, timestamp_key)
-    if backup_dir is not None:
-        path = os.path.join(backup_dir, 'db_dumps', DUMP_DATE, config_backup_file)
-    else:
-        path = os.path.join(master_datadir, dump_dir, DUMP_DATE, config_backup_file)
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, path)
+def backup_config_files_with_nbu(context):
+    backup_file_with_nbu(context, "master_config")
 
     #backing up segment config files
-    gparray = GpArray.initFromCatalog(dbconn.DbURL(port=master_port), utility=True)
-    primaries = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
-    for seg in primaries:
-        config_backup_file = generate_segment_config_filename(dump_prefix, seg.getSegmentDbId(), timestamp_key)
-        if backup_dir is not None:
-            path = os.path.join(backup_dir, 'db_dumps', DUMP_DATE, config_backup_file)
-        else:
-            path = os.path.join(seg.getSegmentDataDirectory(), dump_dir, DUMP_DATE, config_backup_file)
-        host = seg.getSegmentHostName()
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, path, host)
-
-def backup_dirty_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, netbackup_service_host, netbackup_policy,
-                               netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key=None):
-    logger.debug("Inside backup_dirty_file_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         generate_dirtytable_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key))
-
-def backup_increments_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, netbackup_service_host,
-                                    netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key=None):
-    logger.debug("Inside backup_increments_file_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         generate_increments_filename(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp))
-
-def backup_partition_list_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, netbackup_service_host, netbackup_policy,
-                                        netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key=None):
-    logger.debug("Inside backup_partition_list_file_with_nbu\n")
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if timestamp_key is None:
-        timestamp_key = TIMESTAMP_KEY
-
-    backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                         generate_partition_list_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key))
+    gparray = GpArray.initFromCatalog(dbconn.DbURL(port=context.master_port), utility=True)
+    segments = gparray.getSegmentList()
+    for segment in segments:
+        context.master_datadir = segment.getSegmentDataDirectory()
+        host = segment.get_active_primary().getSegmentHostName()
+        backup_file_with_nbu(context, "segment_config", dbid=segment.get_primary_dbid(), hostname=host)
 
 class DumpDatabase(Operation):
-    # TODO: very verbose constructor = room for improvement. in the parent constructor, we could use kwargs
-    # to automatically take in all arguments and perhaps do some data type validation.
-    def __init__(self, dump_database, dump_schema, include_dump_tables, exclude_dump_tables, include_dump_tables_file,
-                 exclude_dump_tables_file, backup_dir, free_space_percent, compress, clear_catalog_dumps, encoding,
-                 output_options, batch_default, master_datadir, master_port, dump_dir, dump_prefix, ddboost,
-                 netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
-                 incremental=False, include_schema_file=None, ddboost_storage_unit=None):
-        self.dump_database = dump_database
-        self.dump_schema = dump_schema
-        self.include_dump_tables = include_dump_tables
-        self.exclude_dump_tables = exclude_dump_tables
-        self.include_dump_tables_file = include_dump_tables_file
-        self.exclude_dump_tables_file = exclude_dump_tables_file
-        self.backup_dir = backup_dir
-        self.free_space_percent = free_space_percent
-        self.compress = compress
-        self.clear_catalog_dumps = clear_catalog_dumps
-        self.encoding = encoding
-        self.output_options = output_options
-        self.batch_default = batch_default
-        self.master_datadir = master_datadir
-        self.master_port = master_port
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.include_schema_file = include_schema_file
-        self.ddboost = ddboost
-        self.ddboost_storage_unit = ddboost_storage_unit
-        self.incremental = incremental
-        self.netbackup_service_host = netbackup_service_host
-        self.netbackup_policy = netbackup_policy
-        self.netbackup_schedule = netbackup_schedule
-        self.netbackup_block_size = netbackup_block_size
-        self.netbackup_keyword = netbackup_keyword
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
-        self.exclude_dump_tables = ValidateDumpDatabase(dump_database = self.dump_database,
-                                                        dump_schema = self.dump_schema,
-                                                        include_dump_tables = self.include_dump_tables,
-                                                        exclude_dump_tables = self.exclude_dump_tables,
-                                                        include_dump_tables_file = self.include_dump_tables_file,
-                                                        exclude_dump_tables_file = self.exclude_dump_tables_file,
-                                                        backup_dir = self.backup_dir,
-                                                        free_space_percent = self.free_space_percent,
-                                                        compress = self.compress,
-                                                        batch_default = self.batch_default,
-                                                        master_datadir = self.master_datadir,
-                                                        master_port = self.master_port,
-                                                        dump_dir = self.dump_dir,
-                                                        incremental = self.incremental,
-                                                        include_schema_file = self.include_schema_file).run()
+        self.context.exclude_dump_tables = ValidateDumpDatabase(self.context).run()
 
         # create filter file based on the include_dump_tables_file before we do formating of contents
-        if self.dump_prefix and not self.incremental:
+        if self.context.dump_prefix and not self.context.incremental:
             self.create_filter_file()
 
         # Format sql strings for all schema and table names
-        self.include_dump_tables_file = formatSQLString(rel_file=self.include_dump_tables_file, isTableName=True)
-        self.exclude_dump_tables_file = formatSQLString(rel_file=self.exclude_dump_tables_file, isTableName=True)
-        self.include_schema_file = formatSQLString(rel_file=self.include_schema_file, isTableName=False)
-        
-        #here
-        if (self.incremental and self.dump_prefix and
-            get_filter_file(self.dump_database, self.master_datadir, self.backup_dir, self.dump_dir,
-                            self.dump_prefix, self.ddboost, self.ddboost_storage_unit, self.netbackup_service_host)):
+        self.context.include_dump_tables_file = formatSQLString(rel_file=self.context.include_dump_tables_file, isTableName=True)
+        self.context.exclude_dump_tables_file = formatSQLString(rel_file=self.context.exclude_dump_tables_file, isTableName=True)
+        self.context.schema_file = formatSQLString(rel_file=self.context.schema_file, isTableName=False)
 
-            filtered_dump_line = self.create_filtered_dump_string(getUserName(), DUMP_DATE, TIMESTAMP_KEY)
+        if self.context.incremental and self.context.dump_prefix and get_filter_file(self.context):
+            filtered_dump_line = self.create_filtered_dump_string()
             (start, end, rc) = self.perform_dump('Dump process', filtered_dump_line)
         else:
-            dump_line = self.create_dump_string(getUserName(), DUMP_DATE, TIMESTAMP_KEY)
+            dump_line = self.create_dump_string()
             (start, end, rc) = self.perform_dump('Dump process', dump_line)
-
-        self.cleanup_files_on_segments()
         return self.create_dump_outcome(start, end, rc)
-
-    def cleanup_files_on_segments(self):
-        for tmp_file in [self.include_dump_tables_file, self.exclude_dump_tables_file, self.include_schema_file]:
-            if tmp_file and os.path.isfile(tmp_file):
-                os.remove(tmp_file)
-                remove_file_on_segments(self.master_port, tmp_file, self.batch_default)
 
     def perform_dump(self, title, dump_line):
         logger.info("%s command line %s" % (title, dump_line))
         logger.info("Starting %s" % title)
-        start = TIMESTAMP
+        start = self.context.timestamp_object
         cmd = Command('Invoking gp_dump', dump_line)
         cmd.run()
         rc = cmd.get_results().rc
-        if INJECT_GP_DUMP_FAILURE is not None:
+        if INJECT_GP_DUMP_FAILURE:
             rc = INJECT_GP_DUMP_FAILURE
         if rc != 0:
             logger.warn("%s returned exit code %d" % (title, rc))
@@ -808,27 +561,22 @@ class DumpDatabase(Operation):
     # If using -T, get the intersection of the filter and the table list
     # In either case, the filter file contains the list of tables to include
     def create_filter_file(self):
-        filter_name = generate_filter_filename(self.master_datadir,
-                                               get_backup_dir(self.master_datadir, self.backup_dir),
-                                               self.dump_dir,
-                                               self.dump_prefix,
-                                               TIMESTAMP_KEY)
-        if self.include_dump_tables_file:
-            shutil.copyfile(self.include_dump_tables_file, filter_name)
-            verify_lines_in_file(filter_name, get_lines_from_file(self.include_dump_tables_file))
-            if self.netbackup_service_host:
-                backup_file_with_nbu(self.netbackup_service_host, self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword, filter_name)
-        elif self.exclude_dump_tables_file:
-            filters = get_lines_from_file(self.exclude_dump_tables_file)
-            partitions = get_user_table_list(self.master_port, self.dump_database)
+        filter_name = self.context.generate_filename("filter")
+        if self.context.include_dump_tables_file:
+            shutil.copyfile(self.context.include_dump_tables_file, filter_name)
+            if self.context.netbackup_service_host:
+                backup_file_with_nbu(self.context, path=filter_name)
+        elif self.context.exclude_dump_tables_file:
+            filters = get_lines_from_file(self.context.exclude_dump_tables_file)
+            partitions = get_user_table_list(self.context)
             tables = []
             for p in partitions:
                 tablename = '%s.%s' % (p[0], p[1])
                 if tablename not in filters:
                     tables.append(tablename)
             write_lines_to_file(filter_name, tables)
-            if self.netbackup_service_host:
-                backup_file_with_nbu(self.netbackup_service_host, self.netbackup_policy, self.netbackup_schedule, self.netbackup_block_size, self.netbackup_keyword, filter_name)
+            if self.context.netbackup_service_host:
+                backup_file_with_nbu(self.context, path=filter_name)
         logger.info('Creating filter file: %s' % filter_name)
 
     def create_dump_outcome(self, start, end, rc):
@@ -837,44 +585,39 @@ class DumpDatabase(Operation):
                 'time_end': end.strftime("%H:%M:%S"),
                 'exit_status': rc}
 
-    def create_filtered_dump_string(self, user_name, dump_date, timestamp_key):
-        filter_filename = get_filter_file(self.dump_database, self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.ddboost, self.ddboost_storage_unit, self.netbackup_service_host)
-        dump_string = self.create_dump_string(user_name, dump_date, timestamp_key)
+    def create_filtered_dump_string(self):
+        filter_filename = get_filter_file(self.context)
+        dump_string = self.create_dump_string()
         dump_string += ' --incremental-filter=%s' % filter_filename
         return dump_string
 
-    def create_dump_and_report_path(self, dump_date):
+    def create_dump_and_report_path(self, context):
         dump_path = None
         report_path = None
-        if self.backup_dir is not None:
-            dump_path = report_path = os.path.join(self.backup_dir, self.dump_dir, dump_date)
+        if context.backup_dir:
+            dump_path = report_path = context.get_backup_dir()
         else:
-            dump_path = os.path.join(self.dump_dir, dump_date)
-            report_path = os.path.join(self.master_datadir, self.dump_dir, dump_date)
-
-        if self.incremental:
-            if self.backup_dir:
-                report_path = dump_path
-            else:
-                report_path = os.path.join(self.master_datadir, dump_path)
-
+            dump_path = context.get_gpd_path()
+            report_path = context.get_backup_dir()
+            if not context.incremental:
+                report_path = context.get_backup_dir()
         return (dump_path, report_path)
 
-    def create_dump_string(self, user_name, dump_date, timestamp_key):
-        (dump_path, report_path) = self.create_dump_and_report_path(dump_date)
+    def create_dump_string(self):
+        (dump_path, report_path) = self.create_dump_and_report_path(self.context)
 
-        dump_line = "gp_dump -p %d -U %s --gp-d=%s --gp-r=%s --gp-s=p --gp-k=%s --no-lock" % (self.master_port, user_name, dump_path, report_path, timestamp_key)
-        if self.clear_catalog_dumps:
+        dump_line = "gp_dump -p %d -U %s --gp-d=%s --gp-r=%s --gp-s=p --gp-k=%s --no-lock" % (self.context.master_port, getUserName(), dump_path, report_path, self.context.timestamp)
+        if self.context.clear_catalog_dumps:
             dump_line += " -c"
-        if self.compress:
+        if self.context.compress:
             logger.info("Adding compression parameter")
             dump_line += " --gp-c"
-        if self.encoding is not None:
-            logger.info("Adding encoding %s" % self.encoding)
-            dump_line += " --encoding=%s" % self.encoding
-        if self.dump_prefix:
+        if self.context.encoding:
+            logger.info("Adding encoding %s" % self.context.encoding)
+            dump_line += " --encoding=%s" % self.context.encoding
+        if self.context.dump_prefix:
             logger.info("Adding --prefix")
-            dump_line += " --prefix=%s" % self.dump_prefix
+            dump_line += " --prefix=%s" % self.context.dump_prefix
 
         logger.info('Adding --no-expand-children')
         dump_line += " --no-expand-children"
@@ -884,104 +627,90 @@ class DumpDatabase(Operation):
         These options get passed-through gp_dump to gp_dump_agent.
         Commented out lines use escaping that would be reasonable, if gp_dump escaped properly.
         """
-        should_dump_schema = self.include_schema_file is not None
-        if self.dump_schema:
-            logger.info("Adding schema name %s" % self.dump_schema)
-            dump_line += " -n \"\\\"%s\\\"\"" % self.dump_schema
-            #dump_line += " -n \"%s\"" % self.dump_schema
-
-        db_name = shellEscape(self.dump_database)
+        if self.context.dump_schema:
+            logger.info("Adding schema name %s" % self.context.dump_schema)
+            dump_line += " -n \"\\\"%s\\\"\"" % self.context.dump_schema
+            #dump_line += " -n \"%s\"" % self.context.dump_schema
+        db_name = shellEscape(self.context.dump_database)
         dump_line += " %s" % checkAndAddEnclosingDoubleQuote(db_name)
-
-        for dump_table in self.include_dump_tables:
-            schema, table = split_fqn(dump_table)
+        for dump_table in self.context.include_dump_tables:
+            schema, table = dump_table.split('.')
             dump_line += " --table=\"\\\"%s\\\"\".\"\\\"%s\\\"\"" % (schema, table)
             #dump_line += " --table=\"%s\".\"%s\"" % (schema, table)
-        for dump_table in self.exclude_dump_tables:
-            schema, table = split_fqn(dump_table)
+        for dump_table in self.context.exclude_dump_tables:
+            schema, table = dump_table.split('.')
             dump_line += " --exclude-table=\"\\\"%s\\\"\".\"\\\"%s\\\"\"" % (schema, table)
             #dump_line += " --exclude-table=\"%s\".\"%s\"" % (schema, table)
-        if self.include_dump_tables_file is not None and not should_dump_schema:
-            dump_line += " --table-file=%s" % self.include_dump_tables_file
-        if self.exclude_dump_tables_file is not None:
-            dump_line += " --exclude-table-file=%s" % self.exclude_dump_tables_file
-        if should_dump_schema:
-            dump_line += " --schema-file=%s" % self.include_schema_file
-
-        for opt in self.output_options:
+        if self.context.include_dump_tables_file and not self.context.schema_file:
+            dump_line += " --table-file=%s" % self.context.include_dump_tables_file
+        if self.context.exclude_dump_tables_file:
+            dump_line += " --exclude-table-file=%s" % self.context.exclude_dump_tables_file
+        if self.context.schema_file:
+            dump_line += " --schema-file=%s" % self.context.schema_file
+        for opt in self.context.output_options:
             dump_line += " %s" % opt
 
-        if self.ddboost:
+        if self.context.ddboost:
             dump_line += " --ddboost"
-        if self.ddboost_storage_unit:
-            dump_line += " --ddboost-storage-unit=%s" % self.ddboost_storage_unit
-        if self.incremental:
+        if self.context.ddboost_storage_unit:
+            dump_line += " --ddboost-storage-unit=%s" % self.context.ddboost_storage_unit
+        if self.context.incremental:
             logger.info("Adding --incremental")
             dump_line += " --incremental"
-        if self.netbackup_service_host is not None:
+        if self.context.netbackup_service_host:
             logger.info("Adding NetBackup params")
-            dump_line += " --netbackup-service-host=%s --netbackup-policy=%s --netbackup-schedule=%s" % (self.netbackup_service_host, self.netbackup_policy, self.netbackup_schedule)
-        if self.netbackup_block_size is not None:
-            dump_line += " --netbackup-block-size=%s" % self.netbackup_block_size
-        if self.netbackup_keyword is not None:
-            dump_line += " --netbackup-keyword=%s" % self.netbackup_keyword
+            dump_line += " --netbackup-service-host=%s --netbackup-policy=%s --netbackup-schedule=%s" % (self.context.netbackup_service_host, self.context.netbackup_policy, self.context.netbackup_schedule)
+        if self.context.netbackup_block_size:
+            dump_line += " --netbackup-block-size=%s" % self.context.netbackup_block_size
+        if self.context.netbackup_keyword:
+            dump_line += " --netbackup-keyword=%s" % self.context.netbackup_keyword
 
         return dump_line
 
 class CreateIncrementsFile(Operation):
 
-    def __init__(self, dump_database, full_timestamp, timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, ddboost, ddboost_storage_unit, netbackup_service_host, netbackup_block_size):
-        self.full_timestamp = full_timestamp
-        self.timestamp = timestamp
-        self.master_datadir = master_datadir
-        self.backup_dir = backup_dir
-        self.increments_filename = generate_increments_filename(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp)
+    def __init__(self, context):
         self.orig_lines_in_file = []
-        self.dump_database = dump_database
-        self.ddboost = ddboost
-        self.ddboost_storage_unit = ddboost_storage_unit
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.netbackup_service_host = netbackup_service_host
-        self.netbackup_block_size = netbackup_block_size
+        full_dump_timestamp = get_latest_full_dump_timestamp(context)
+        self.increments_filename = context.generate_filename("increments", timestamp=full_dump_timestamp)
+        self.context = context
 
     def execute(self):
         if os.path.isfile(self.increments_filename):
-            CreateIncrementsFile.validate_increments_file(self.dump_database, self.increments_filename, self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix,
-                                                          self.ddboost, self.ddboost_storage_unit, self.netbackup_service_host, self.netbackup_block_size)
+            CreateIncrementsFile.validate_increments_file(self.context, self.increments_filename)
             self.orig_lines_in_file = get_lines_from_file(self.increments_filename)
 
-        with open(self.increments_filename, 'a') as fd:
-            fd.write('%s\n' % self.timestamp)
+        with open(self.increments_filename, 'a+') as fd:
+            fd.write('%s\n' % self.context.timestamp)
 
         newlines_in_file = get_lines_from_file(self.increments_filename)
 
         if len(newlines_in_file) < 1:
             raise Exception("File not written to: %s" % self.increments_filename)
 
-        if newlines_in_file[-1].strip() != self.timestamp:
-            raise Exception("Timestamp '%s' not written to: %s" % (self.timestamp, self.increments_filename))
+        if newlines_in_file[-1].strip() != self.context.timestamp:
+            raise Exception("Timestamp '%s' not written to: %s" % (self.context.timestamp, self.increments_filename))
 
         # remove the last line and the contents should be the same as before
         newlines_in_file = newlines_in_file[0:-1]
 
         if self.orig_lines_in_file != newlines_in_file:
-            raise Exception("trouble adding timestamp '%s' to file '%s'" % (self.timestamp, self.increments_filename))
+            raise Exception("trouble adding timestamp '%s' to file '%s'" % (self.context.timestamp, self.increments_filename))
 
         return len(newlines_in_file) + 1
 
     @staticmethod
-    def validate_increments_file(dump_database, inc_file_name, master_data_dir, backup_dir, dump_dir, dump_prefix, ddboost=False, ddboost_storage_unit=None, netbackup_service_host=None, netbackup_block_size=None):
+    def validate_increments_file(context, inc_file_name):
 
         tstamps = get_lines_from_file(inc_file_name)
         for ts in tstamps:
             ts = ts.strip()
             if not ts:
                 continue
-            fn = generate_report_filename(master_data_dir, backup_dir, dump_dir, dump_prefix, ts, ddboost)
+            fn = context.generate_filename("report", ts)
             ts_in_rpt = None
             try:
-                ts_in_rpt = get_incremental_ts_from_report_file(dump_database, fn, dump_prefix, ddboost, ddboost_storage_unit, netbackup_service_host, netbackup_block_size)
+                ts_in_rpt = get_incremental_ts_from_report_file(context, fn)
             except Exception as e:
                 logger.error(str(e))
 
@@ -989,26 +718,12 @@ class CreateIncrementsFile(Operation):
                 raise Exception("Timestamp '%s' from increments file '%s' is not a valid increment" % (ts, inc_file_name))
 
 class PostDumpDatabase(Operation):
-    def __init__(self, timestamp_start, compress, backup_dir, batch_default, master_datadir, master_port, dump_dir, dump_prefix, ddboost, netbackup_service_host, incremental=False):
+    def __init__(self, context, timestamp_start):
+        self.context = context
         self.timestamp_start = timestamp_start
-        self.compress = compress
-        self.backup_dir = backup_dir
-        self.batch_default = batch_default
-        self.master_datadir = master_datadir
-        self.master_port = master_port
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.incremental = incremental
-        self.ddboost = ddboost
-        self.netbackup_service_host = netbackup_service_host
-
-    def get_report_dir(self, dump_date):
-        path = self.backup_dir if self.backup_dir is not None else self.master_datadir
-        path = os.path.join(path, self.dump_dir, dump_date)
-        return path
 
     def execute(self):
-        report_dir = self.get_report_dir(DUMP_DATE)
+        report_dir = self.context.get_backup_dir()
         reports = ListFilesByPattern(report_dir, "*gp_dump_*.rpt").run()
         if not reports:
             logger.error("Could not locate a report file on master.")
@@ -1022,23 +737,19 @@ class PostDumpDatabase(Operation):
             return {'exit_status': 2, 'timestamp': 'n/a'}
         logger.info("Timestamp key = %s" % timestamp)
 
-        if self.ddboost:
+        if self.context.ddboost:
             return {'exit_status': 0,               # feign success with exit_status = 0
                     'timestamp': timestamp}
 
-        if self.netbackup_service_host:
+        if self.context.netbackup_service_host:
             return {'exit_status': 0,               # feign success with exit_status = 0
                     'timestamp': timestamp}
 
         # Check master dumps
-        path = self.backup_dir if self.backup_dir is not None else self.master_datadir
-        path = os.path.join(path, self.dump_dir, DUMP_DATE)
-        status_file = os.path.join(path, "%s%s" % (generate_master_status_prefix(self.dump_prefix), timestamp))
-        dump_file = os.path.join(path, "%s%s" % (generate_master_dbdump_prefix(self.dump_prefix), timestamp))
-        if self.compress: dump_file += ".gz"
+        status_file = self.context.generate_filename("status", timestamp=timestamp)
+        dump_file = self.context.generate_filename("metadata", timestamp=timestamp)
         try:
-            PostDumpSegment(status_file=status_file,
-                            dump_file=dump_file).run()
+            PostDumpSegment(self.context, status_file, dump_file).run()
         except NoStatusFile, e:
             logger.warn('Status file %s not found on master' % status_file)
             return {'exit_status': 1, 'timestamp': timestamp}
@@ -1053,18 +764,19 @@ class PostDumpDatabase(Operation):
 
         # Perform similar checks for primary segments
         operations = []
-        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port), utility=True)
-        segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
-        for seg in segs:
-            path = self.backup_dir if self.backup_dir is not None else seg.getSegmentDataDirectory()
-            path = os.path.join(path, self.dump_dir, DUMP_DATE)
-            status_file = os.path.join(path, "%s%d_%s" % (generate_seg_status_prefix(self.dump_prefix), seg.getSegmentDbId(), timestamp))
-            dump_file = os.path.join(path, "%s%d_%s" % (generate_seg_dbdump_prefix(self.dump_prefix), seg.getSegmentDbId(), timestamp))
-            if self.compress: dump_file += ".gz"
-            operations.append(RemoteOperation(PostDumpSegment(status_file=status_file, dump_file=dump_file),
-                                              seg.getSegmentHostName()))
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
+        segments = gparray.getSegmentList()
+        mdd = self.context.master_datadir
+        for segment in segments:
+            seg = segment.get_active_primary()
+            self.context.master_datadir = seg.getSegmentDataDirectory()
+            # If we're backing up the mirror of a failed-over primary, use the primary's dbid, not the mirror's
+            status_file = self.context.generate_filename("status", segment.get_primary_dbid(), timestamp)
+            dump_file = self.context.generate_filename("dump", segment.get_primary_dbid(), timestamp)
+            operations.append(RemoteOperation(PostDumpSegment(self.context, status_file, dump_file), seg.getSegmentHostName()))
+        self.context.master_datadir = mdd
 
-        ParallelOperation(operations, self.batch_default).run()
+        ParallelOperation(operations, self.context.batch_default).run()
 
         success = 0
         for remote in operations:
@@ -1088,7 +800,8 @@ class PostDumpDatabase(Operation):
         return {'exit_status': 0, 'timestamp': timestamp}
 
 class PostDumpSegment(Operation):
-    def __init__(self, status_file, dump_file):
+    def __init__(self, context, status_file, dump_file):
+        self.context = context
         self.status_file = status_file
         self.dump_file = dump_file
 
@@ -1126,93 +839,50 @@ class StatusFileError(Exception): pass
 class NoDumpFile(Exception): pass
 
 class ValidateDumpDatabase(Operation):
-    def __init__(self, dump_database, dump_schema, include_dump_tables, exclude_dump_tables,
-                 include_dump_tables_file, exclude_dump_tables_file, backup_dir,
-                 free_space_percent, compress, batch_default, master_datadir, master_port,
-                 dump_dir, incremental, include_schema_file):
-        self.dump_database = dump_database
-        self.dump_schema = dump_schema
-        self.include_dump_tables = include_dump_tables
-        self.exclude_dump_tables = exclude_dump_tables
-        self.include_dump_tables_file = include_dump_tables_file
-        self.exclude_dump_tables_file = exclude_dump_tables_file
-        self.backup_dir = backup_dir
-        self.free_space_percent = free_space_percent
-        self.compress = compress
-        self.batch_default = batch_default
-        self.master_datadir = master_datadir
-        self.master_port = master_port
-        self.dump_dir = dump_dir
-        self.incremental = incremental
-        self.include_schema_file = include_schema_file
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
-        ValidateDatabaseExists(database = self.dump_database,
-                               master_port = self.master_port).run()
+        ValidateDatabaseExists(self.context).run()
 
         dump_schemas = []
-        if self.dump_schema:
-            dump_schemas = self.dump_schema
-        elif self.include_schema_file is not None:
-            dump_schemas = get_lines_from_file(self.include_schema_file)
+        if self.context.dump_schema:
+            dump_schemas = self.context.dump_schema
+        elif self.context.schema_file:
+            dump_schemas = get_lines_from_file(self.context.schema_file)
 
         for schema in dump_schemas:
-            ValidateSchemaExists(database = self.dump_database,
-                                 schema = schema,
-                                 master_port = self.master_port).run()
+            ValidateSchemaExists(self.context, schema).run()
 
-        ValidateCluster(master_port = self.master_port).run()
+        ValidateCluster(self.context).run()
 
-        ValidateAllDumpDirs(backup_dir = self.backup_dir,
-                            batch_default = self.batch_default,
-                            master_datadir = self.master_datadir,
-                            master_port = self.master_port,
-                            dump_dir = self.dump_dir).run()
+        ValidateAllDumpDirs(self.context).run()
 
-        if not self.incremental:
-            self.exclude_dump_tables = ValidateDumpTargets(dump_database = self.dump_database,
-                                                           dump_schema = self.dump_schema,
-                                                           include_dump_tables = self.include_dump_tables,
-                                                           exclude_dump_tables = self.exclude_dump_tables,
-                                                           include_dump_tables_file = self.include_dump_tables_file,
-                                                           exclude_dump_tables_file = self.exclude_dump_tables_file,
-                                                           master_port = self.master_port).run()
+        if not self.context.incremental:
+            self.context.exclude_dump_tables = ValidateDumpTargets(self.context).run()
 
-        if self.free_space_percent is not None:
+        if self.context.free_space_percent:
             logger.info('Validating disk space')
-            ValidateDiskSpace(free_space_percent = self.free_space_percent,
-                              compress = self.compress,
-                              dump_database = self.dump_database,
-                              include_dump_tables = self.include_dump_tables,
-                              batch_default = self.batch_default,
-                              master_port = self.master_port).run()
+            ValidateDiskSpace(self.context).run()
 
-        return self.exclude_dump_tables
+        return self.context.exclude_dump_tables
 
 class ValidateDiskSpace(Operation):
     # TODO: this doesn't take into account that multiple segments may be dumping to the same logical disk.
-    def __init__(self, free_space_percent, compress, dump_database, include_dump_tables, batch_default, master_port):
-        self.free_space_percent = free_space_percent
-        self.compress = compress
-        self.dump_database = dump_database
-        self.include_dump_tables = include_dump_tables
-        self.batch_default = batch_default
-        self.master_port = master_port
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
         operations = []
-        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port), utility=True)
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
         segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
         for seg in segs:
-            operations.append(RemoteOperation(ValidateSegDiskSpace(free_space_percent = self.free_space_percent,
-                                                                   compress = self.compress,
-                                                                   dump_database = self.dump_database,
-                                                                   include_dump_tables = self.include_dump_tables,
+            operations.append(RemoteOperation(ValidateSegDiskSpace(self.context,
                                                                    datadir = seg.getSegmentDataDirectory(),
                                                                    segport = seg.getSegmentPort()),
                                               seg.getSegmentHostName()))
 
-        ParallelOperation(operations, self.batch_default).run()
+        ParallelOperation(operations, self.context.batch_default).run()
 
         success = 0
         for remote in operations:
@@ -1228,36 +898,33 @@ class ValidateDiskSpace(Operation):
 
 class ValidateSegDiskSpace(Operation):
     # TODO: this estimation of needed space needs work. it doesn't include schemas or exclusion tables.
-    def __init__(self, free_space_percent, compress, dump_database, include_dump_tables, datadir, segport):
-        self.free_space_percent = free_space_percent
-        self.compress = compress
-        self.dump_database = dump_database
-        self.include_dump_tables = include_dump_tables
+    def __init__(self, context, datadir, segport):
+        self.context = context
         self.datadir = datadir
         self.segport = segport
 
     def execute(self):
         needed_space = 0
-        dburl = dbconn.DbURL(dbname=self.dump_database, port=self.segport)
+        dburl = dbconn.DbURL(dbname=self.context.dump_database, port=self.segport)
         conn = None
         try:
             conn = dbconn.connect(dburl, utility=True)
-            if self.include_dump_tables:
-                for dump_table in self.include_dump_tables:
+            if self.context.include_dump_tables:
+                for dump_table in self.context.include_dump_tables:
                     needed_space += execSQLForSingleton(conn, "SELECT pg_relation_size('%s')/1024;" % pg.escape_string(dump_table))
             else:
-                needed_space = execSQLForSingleton(conn, "SELECT pg_database_size('%s')/1024;" % pg.escape_string(self.dump_database))
+                needed_space = execSQLForSingleton(conn, "SELECT pg_database_size('%s')/1024;" % pg.escape_string(self.context.dump_database))
         finally:
-            if conn is not None:
+            if conn:
                 conn.close()
-        if self.compress:
+        if self.context.compress:
             needed_space = needed_space / COMPRESSION_FACTOR
 
         # get free available space
         stat_res = os.statvfs(self.datadir)
         free_space = (stat_res.f_bavail * stat_res.f_frsize) / 1024
 
-        if free_space == 0 or (free_space - needed_space) / free_space < self.free_space_percent / 100:
+        if free_space == 0 or (free_space - needed_space) / free_space < self.context.free_space_percent / 100:
             logger.error("Disk space: [Need: %dK, Free %dK]" % (needed_space, free_space))
             raise NotEnoughDiskSpace(free_space, needed_space)
         logger.info("Disk space: [Need: %dK, Free %dK]" % (needed_space, free_space))
@@ -1268,40 +935,35 @@ class NotEnoughDiskSpace(Exception):
         Exception.__init__(self, free_space, needed_space)
 
 class ValidateGpToolkit(Operation):
-    def __init__(self, database, master_port):
-        self.database = database
-        self.master_port = master_port
+    def __init__(self, context):
+        pass
 
     def execute(self):
-        dburl = dbconn.DbURL(dbname=self.database, port=self.master_port)
+        dburl = dbconn.DbURL(dbname=context.database, port=context.master_port)
         conn = None
         try:
             conn = dbconn.connect(dburl)
             count = execSQLForSingleton(conn, "select count(*) from pg_class, pg_namespace where pg_namespace.nspname = 'gp_toolkit' and pg_class.relnamespace = pg_namespace.oid")
         finally:
-            if conn is not None:
+            if conn:
                 conn.close()
         if count > 0:
-            logger.debug("gp_toolkit exists within database %s." % self.database)
+            logger.debug("gp_toolkit exists within database %s." % context.database)
             return
         logger.info("gp_toolkit not found. Installing...")
         Psql('Installing gp_toolkit',
              filename='$GPHOME/share/postgresql/gp_toolkit.sql',
-             database=self.database,
-             port=self.master_port).run(validateAfter=True)
+             database=context.dump_database,
+             port=context.master_port).run(validateAfter=True)
 
 class ValidateAllDumpDirs(Operation):
-    def __init__(self, backup_dir, batch_default, master_datadir, master_port, dump_dir):
-        self.backup_dir = backup_dir
-        self.batch_default = batch_default
-        self.master_datadir = master_datadir
-        self.master_port = master_port
-        self.dump_dir = dump_dir
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
-        directory = self.backup_dir if self.backup_dir is not None else self.master_datadir
+        directory = self.context.backup_dir if self.context.backup_dir else self.context.master_datadir
         try:
-            ValidateDumpDirs(directory, self.dump_dir).run()
+            ValidateDumpDirs(directory, self.context).run()
         except DumpDirCreateFailed, e:
             raise ExceptionNoStackTraceNeeded('Could not create %s on master. Cannot continue.' % directory)
         except DumpDirNotWritable, e:
@@ -1311,13 +973,13 @@ class ValidateAllDumpDirs(Operation):
 
         # Check backup target on segments (either master_datadir or backup_dir, if present)
         operations = []
-        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port), utility=True)
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
         segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
         for seg in segs:
-            directory = self.backup_dir if self.backup_dir is not None else seg.getSegmentDataDirectory()
-            operations.append(RemoteOperation(ValidateDumpDirs(directory, self.dump_dir), seg.getSegmentHostName()))
+            directory = self.context.backup_dir if self.context.backup_dir else seg.getSegmentDataDirectory()
+            operations.append(RemoteOperation(ValidateDumpDirs(directory, self.context), seg.getSegmentHostName()))
 
-        ParallelOperation(operations, self.batch_default).run()
+        ParallelOperation(operations, self.context.batch_default).run()
 
         success = 0
         for remote in operations:
@@ -1336,12 +998,12 @@ class ValidateAllDumpDirs(Operation):
             raise ExceptionNoStackTraceNeeded("Cannot continue. %d segment(s) failed directory checks" % (len(operations) - success))
 
 class ValidateDumpDirs(Operation):
-    def __init__(self, directory, dump_dir):
+    def __init__(self, directory, context):
         self.directory = directory
-        self.dump_dir = dump_dir
+        self.context = context
 
     def execute(self):
-        path = os.path.join(self.directory, self.dump_dir, DUMP_DATE)
+        path = os.path.join(self.directory, self.context.dump_dir, self.context.db_date_dir)
         exists = CheckDir(path).run()
         if exists:
             logger.info("Directory %s exists" % path)
@@ -1365,55 +1027,36 @@ class DumpDirCreateFailed(Exception): pass
 class DumpDirNotWritable(Exception): pass
 
 class ValidateDumpTargets(Operation):
-    def __init__(self, dump_database, dump_schema, include_dump_tables, exclude_dump_tables,
-                 include_dump_tables_file, exclude_dump_tables_file, master_port):
-        self.dump_database = dump_database
-        self.dump_schema = dump_schema
-        self.include_dump_tables = include_dump_tables
-        self.exclude_dump_tables = exclude_dump_tables
-        self.include_dump_tables_file = include_dump_tables_file
-        self.exclude_dump_tables_file = exclude_dump_tables_file
-        self.master_port = master_port
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
-        if ((len(self.include_dump_tables) > 0 or (self.include_dump_tables_file is not None)) and
-            (len(self.exclude_dump_tables) > 0 or (self.exclude_dump_tables_file is not None))):
+        if ((len(self.context.include_dump_tables) > 0 or (self.context.include_dump_tables_file)) and
+            (len(self.context.exclude_dump_tables) > 0 or (self.context.exclude_dump_tables_file))):
             raise ExceptionNoStackTraceNeeded("Cannot use -t/--table-file and -T/--exclude-table-file options at same time")
-        elif len(self.include_dump_tables) > 0 or self.include_dump_tables_file is not None:
+        elif len(self.context.include_dump_tables) > 0 or self.context.include_dump_tables_file:
             logger.info("Configuring for single-database, include-table dump")
-            ValidateIncludeTargets(dump_database = self.dump_database,
-                                   dump_schema = self.dump_schema,
-                                   include_dump_tables = self.include_dump_tables,
-                                   include_dump_tables_file = self.include_dump_tables_file,
-                                   master_port = self.master_port).run()
-        elif len(self.exclude_dump_tables) > 0 or self.exclude_dump_tables_file is not None:
+            ValidateIncludeTargets(self.context).run()
+        elif len(self.context.exclude_dump_tables) > 0 or self.context.exclude_dump_tables_file:
             logger.info("Configuring for single-database, exclude-table dump")
-            self.exclude_dump_tables = ValidateExcludeTargets(dump_database = self.dump_database,
-                                                              dump_schema = self.dump_schema,
-                                                              exclude_dump_tables = self.exclude_dump_tables,
-                                                              exclude_dump_tables_file = self.exclude_dump_tables_file,
-                                                              master_port = self.master_port).run()
+            self.context.exclude_dump_tables = ValidateExcludeTargets(self.context).run()
         else:
             logger.info("Configuring for single database dump")
-        return self.exclude_dump_tables
+        return self.context.exclude_dump_tables
 
 class ValidateIncludeTargets(Operation):
-    def __init__(self, dump_database, dump_schema, include_dump_tables, include_dump_tables_file, master_port):
-        self.dump_database = dump_database
-        self.dump_schema = dump_schema
-        self.include_dump_tables = include_dump_tables
-        self.include_dump_tables_file = include_dump_tables_file
-        self.master_port = master_port
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
         dump_tables = []
-        for dump_table in self.include_dump_tables:
+        for dump_table in self.context.include_dump_tables:
             dump_tables.append(dump_table)
 
-        if self.include_dump_tables_file is not None:
-            include_file = open(self.include_dump_tables_file, 'rU')
+        if self.context.include_dump_tables_file:
+            include_file = open(self.context.include_dump_tables_file, 'rU')
             if not include_file:
-                raise ExceptionNoStackTraceNeeded("Can't open file %s" % self.include_dump_tables_file)
+                raise ExceptionNoStackTraceNeeded("Can't open file %s" % self.context.include_dump_tables_file)
             for line in include_file:
                 dump_tables.append(line.strip('\n'))
             include_file.close()
@@ -1422,36 +1065,29 @@ class ValidateIncludeTargets(Operation):
             if '.' not in dump_table:
                 raise ExceptionNoStackTraceNeeded("No schema name supplied for table %s" % dump_table)
             schema, table = split_fqn(dump_table)
-            exists = CheckTableExists(schema = schema,
-                                      table = table,
-                                      database = self.dump_database,
-                                      master_port = self.master_port).run()
+            exists = CheckTableExists(self.context, schema, table).run()
             if not exists:
-                raise ExceptionNoStackTraceNeeded("Table %s does not exist in %s database" % (dump_table, self.dump_database))
-            if self.dump_schema:
-                for dump_schema in self.dump_schema:
+                raise ExceptionNoStackTraceNeeded("Table %s does not exist in %s database" % (dump_table, self.context.dump_database))
+            if self.context.dump_schema:
+                for dump_schema in self.context.dump_schema:
                     if dump_schema != schema:
                         raise ExceptionNoStackTraceNeeded("Schema name %s not same as schema on %s" % (dump_schema, dump_table))
 
 class ValidateExcludeTargets(Operation):
-    def __init__(self, dump_database, dump_schema, exclude_dump_tables, exclude_dump_tables_file, master_port):
-        self.dump_database = dump_database
-        self.dump_schema = dump_schema
-        self.exclude_dump_tables = exclude_dump_tables
-        self.exclude_dump_tables_file = exclude_dump_tables_file
-        self.master_port = master_port
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
         rebuild_excludes = []
 
         dump_tables = []
-        for dump_table in self.exclude_dump_tables:
+        for dump_table in self.context.exclude_dump_tables:
             dump_tables.append(dump_table)
 
-        if self.exclude_dump_tables_file is not None:
-            exclude_file = open(self.exclude_dump_tables_file, 'rU')
+        if self.context.exclude_dump_tables_file:
+            exclude_file = open(self.context.exclude_dump_tables_file, 'rU')
             if not exclude_file:
-                raise ExceptionNoStackTraceNeeded("Can't open file %s" % self.exclude_dump_tables_file)
+                raise ExceptionNoStackTraceNeeded("Can't open file %s" % self.context.exclude_dump_tables_file)
             for line in exclude_file:
                 dump_tables.append(line.strip('\n'))
             exclude_file.close()
@@ -1460,75 +1096,66 @@ class ValidateExcludeTargets(Operation):
             if '.' not in dump_table:
                 raise ExceptionNoStackTraceNeeded("No schema name supplied for exclude table %s" % dump_table)
             schema, table = split_fqn(dump_table)
-            exists = CheckTableExists(schema = schema,
-                                      table = table,
-                                      database = self.dump_database,
-                                      master_port = self.master_port).run()
+            exists = CheckTableExists(self.context, schema, table).run()
             if exists:
-                if self.dump_schema:
-                    for dump_schema in self.dump_schema:
+                if self.context.dump_schema:
+                    for dump_schema in self.context.dump_schema:
                         if dump_schema != schema:
                             logger.info("Adding table %s to exclude list" % dump_table)
                             rebuild_excludes.append(dump_table)
                         else:
                             logger.warn("Schema dump request and exclude table %s in that schema, ignoring" % dump_table)
             else:
-                logger.warn("Exclude table %s does not exist in %s database, ignoring" % (dump_table, self.dump_database))
+                logger.warn("Exclude table %s does not exist in %s database, ignoring" % (dump_table, self.context.dump_database))
         if len(rebuild_excludes) == 0:
             logger.warn("All exclude table names have been removed due to issues, see log file")
-        return self.exclude_dump_tables
+        return self.context.exclude_dump_tables
 
 class ValidateDatabaseExists(Operation):
     """ TODO: move this to gppylib.operations.common? """
-    def __init__(self, database, master_port):
-        self.master_port = master_port
-        self.database = database
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
         conn = None
         try:
-            dburl = dbconn.DbURL(port=self.master_port)
+            dburl = dbconn.DbURL(port=self.context.master_port)
             conn = dbconn.connect(dburl)
-            count = execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" %
-                                        pg.escape_string(self.database))
+            count = execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" % pg.escape_string(self.context.dump_database))
             if count == 0:
-                raise ExceptionNoStackTraceNeeded("Database %s does not exist." % self.database)
+                raise ExceptionNoStackTraceNeeded("Database %s does not exist." % self.context.dump_database)
         finally:
-            if conn is not None:
+            if conn:
                 conn.close()
 
 class ValidateSchemaExists(Operation):
     """ TODO: move this to gppylib.operations.common? """
-    def __init__(self, database, schema, master_port):
-        self.database = database
+    def __init__(self, context, schema):
+        self.context = context
         self.schema = schema
-        self.master_port = master_port
 
     def execute(self):
         conn = None
         try:
-            dburl = dbconn.DbURL(port=self.master_port, dbname=self.database)
+            dburl = dbconn.DbURL(port=self.context.master_port, dbname=self.context.dump_database)
             conn = dbconn.connect(dburl)
-            count = execSQLForSingleton(conn, "select count(*) from pg_namespace where nspname='%s';" %
-                                        pg.escape_string(self.schema))
+            count = execSQLForSingleton(conn, "select count(*) from pg_namespace where nspname='%s';" % pg.escape_string(self.schema))
             if count == 0:
-                raise ExceptionNoStackTraceNeeded("Schema %s does not exist in database %s." % (self.schema, self.database))
+                raise ExceptionNoStackTraceNeeded("Schema %s does not exist in database %s." % (self.schema, self.context.dump_database))
         finally:
-            if conn is not None:
+            if conn:
                 conn.close()
 
 class CheckTableExists(Operation):
     all_tables = None
-    def __init__(self, database, schema, table, master_port):
-        self.database = database
+    def __init__(self, context, schema, table):
         self.schema = schema
         self.table = table
-        self.master_port = master_port
         if CheckTableExists.all_tables is None:
             CheckTableExists.all_tables = set()
-            for (schema, table) in get_user_table_list(self.master_port, self.database):
-                CheckTableExists.all_tables.add((schema,
-                                                 table))
+            for (schema, table) in get_user_table_list(context):
+                CheckTableExists.all_tables.add((schema, table))
+
     def execute(self):
         if (self.schema, self.table) in CheckTableExists.all_tables:
             return True
@@ -1536,11 +1163,11 @@ class CheckTableExists(Operation):
 
 
 class ValidateCluster(Operation):
-    def __init__(self, master_port):
-        self.master_port = master_port
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
-        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port), utility=True)
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
         failed_segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True) and seg.isSegmentDown()]
         if len(failed_segs) != 0:
             logger.warn("Failed primary segment instances detected")
@@ -1549,37 +1176,33 @@ class ValidateCluster(Operation):
 
 class UpdateHistoryTable(Operation):
     HISTORY_TABLE = "public.gpcrondump_history"
-    def __init__(self, dump_database, time_start, time_end, options_list, timestamp, dump_exit_status, pseudo_exit_status, master_port):
-        self.dump_database = dump_database
+    def __init__(self, context, time_start, time_end, options_list, timestamp, dump_exit_status, pseudo_exit_status):
+        self.context = context
         self.time_start = time_start
         self.time_end = time_end
         self.options_list = options_list
         self.timestamp = timestamp
         self.dump_exit_status = dump_exit_status
         self.pseudo_exit_status = pseudo_exit_status
-        self.master_port = master_port
 
     def execute(self):
         schema, table = split_fqn(UpdateHistoryTable.HISTORY_TABLE)
-        exists = CheckTableExists(database = self.dump_database,
-                                  schema = schema,
-                                  table = table,
-                                  master_port = self.master_port).run()
+        exists = CheckTableExists(self.context, schema, table).run()
         if not exists:
             conn = None
             CREATE_HISTORY_TABLE = """ create table %s (rec_date timestamp, start_time char(8), end_time char(8), options text, dump_key varchar(20), dump_exit_status smallint, script_exit_status smallint, exit_text varchar(10)) distributed by (rec_date); """ % UpdateHistoryTable.HISTORY_TABLE
             try:
-                dburl = dbconn.DbURL(port=self.master_port, dbname=self.dump_database)
+                dburl = dbconn.DbURL(port=self.context.master_port, dbname=self.context.dump_database)
                 conn = dbconn.connect(dburl)
                 execSQL(conn, CREATE_HISTORY_TABLE)
                 conn.commit()
             except Exception, e:
-                logger.exception("Unable to create %s in %s database" % (UpdateHistoryTable.HISTORY_TABLE, self.dump_database))
+                logger.exception("Unable to create %s in %s database" % (UpdateHistoryTable.HISTORY_TABLE, self.context.dump_database))
                 return
             else:
-                logger.info("Created %s in %s database" % (UpdateHistoryTable.HISTORY_TABLE, self.dump_database))
+                logger.info("Created %s in %s database" % (UpdateHistoryTable.HISTORY_TABLE, self.context.dump_database))
             finally:
-                if conn is not None:
+                if conn:
                     conn.close()
 
         translate_rc_to_msg = {0: "COMPLETED", 1: "WARNING", 2: "FATAL"}
@@ -1587,38 +1210,31 @@ class UpdateHistoryTable(Operation):
         APPEND_HISTORY_TABLE = """ insert into %s values (now(), '%s', '%s', '%s', '%s', %d, %d, '%s'); """ % (UpdateHistoryTable.HISTORY_TABLE, self.time_start, self.time_end, self.options_list, self.timestamp, self.dump_exit_status, self.pseudo_exit_status, exit_msg)
         conn = None
         try:
-            dburl = dbconn.DbURL(port=self.master_port, dbname=self.dump_database)
+            dburl = dbconn.DbURL(port=self.context.master_port, dbname=self.context.dump_database)
             conn = dbconn.connect(dburl)
             execSQL(conn, APPEND_HISTORY_TABLE)
             conn.commit()
         except Exception, e:
-            logger.exception("Failed to insert record into %s in %s database" % (UpdateHistoryTable.HISTORY_TABLE, self.dump_database))
+            logger.exception("Failed to insert record into %s in %s database" % (UpdateHistoryTable.HISTORY_TABLE, self.context.dump_database))
         else:
-            logger.info("Inserted dump record into %s in %s database" % (UpdateHistoryTable.HISTORY_TABLE, self.dump_database))
+            logger.info("Inserted dump record into %s in %s database" % (UpdateHistoryTable.HISTORY_TABLE, self.context.dump_database))
         finally:
-            if conn is not None:
+            if conn:
                 conn.close()
 
 class DumpGlobal(Operation):
-    def __init__(self, timestamp, master_datadir, master_port, backup_dir, dump_dir, dump_prefix, ddboost, ddboost_storage_unit=None):
+    def __init__(self, context, timestamp=None):
+        self.context = context
         self.timestamp = timestamp
-        self.master_datadir = master_datadir
-        self.master_port = master_port
-        self.backup_dir = backup_dir
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.ddboost = ddboost
-        self.ddboost_storage_unit = ddboost_storage_unit
-        self.global_filename = generate_global_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, DUMP_DATE, self.timestamp)
 
     def execute(self):
         logger.info("Commencing pg_catalog dump")
         Command('Dump global objects',
                 self.create_pgdump_command_line()).run(validateAfter=True)
 
-        if self.ddboost:
-            abspath = self.global_filename
-            relpath = os.path.join(self.dump_dir, DUMP_DATE, "%s%s" % (generate_global_prefix(self.dump_prefix), self.timestamp))
+        if self.context.ddboost:
+            abspath = self.context.generate_filename("global", self.timestamp)
+            relpath = abspath.split(self.context.backup_dir+"/")[1]
             logger.debug('Copying %s to DDBoost' % abspath)
             cmdStr = 'gpddboost --copyToDDBoost --from-file=%s --to-file=%s' % (abspath, relpath)
             if self.ddboost_storage_unit:
@@ -1627,33 +1243,22 @@ class DumpGlobal(Operation):
             cmd.run(validateAfter=True)
 
     def create_pgdump_command_line(self):
-        return "pg_dumpall -p %s -g --gp-syntax > %s" % (self.master_port, self.global_filename)
+        return "pg_dumpall -p %s -g --gp-syntax > %s" % (self.context.master_port, self.context.generate_filename("global", self.timestamp))
 
 class DumpConfig(Operation):
     # TODO: Should we really just give up if one of the tars fails?
     # TODO: WorkerPool
-    def __init__(self, backup_dir, master_datadir, master_port, dump_dir, dump_prefix, ddboost, ddboost_storage_unit=None):
-        self.backup_dir = backup_dir
-        self.master_datadir = master_datadir
-        self.master_port = master_port
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.ddboost = ddboost
-        self.ddboost_storage_unit = ddboost_storage_unit
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
-        timestamp = TIMESTAMP_KEY
-        config_backup_file = generate_master_config_filename(self.dump_prefix, timestamp)
-        if self.backup_dir is not None:
-            path = os.path.join(self.backup_dir, 'db_dumps', DUMP_DATE, config_backup_file)
-        else:
-            path = os.path.join(self.master_datadir, self.dump_dir, DUMP_DATE, config_backup_file)
+        config_backup_file = self.context.generate_filename("master_config")
         logger.info("Dumping master config files")
         Command("Dumping master configuration files",
-                "tar cf %s %s/*.conf" % (path, self.master_datadir)).run(validateAfter=True)
-        if self.ddboost:
-            abspath = path
-            relpath = os.path.join(self.dump_dir, DUMP_DATE, config_backup_file)
+                "tar cf %s %s/*.conf" % (config_backup_file, self.context.master_datadir)).run(validateAfter=True)
+        if self.context.ddboost:
+            abspath = config_backup_file
+            relpath = os.path.join(self.context.dump_dir, self.context.db_date_dir, config_backup_file)
             logger.debug('Copying %s to DDBoost' % abspath)
             cmdStr = 'gpddboost --copyToDDBoost --from-file=%s --to-file=%s' % (abspath, relpath)
             if self.ddboost_storage_unit:
@@ -1666,22 +1271,21 @@ class DumpConfig(Operation):
             rc = res.rc
 
         logger.info("Dumping segment config files")
-        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port), utility=True)
-        primaries = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
-        for seg in primaries:
-            config_backup_file = generate_segment_config_filename(self.dump_prefix, seg.getSegmentDbId(), timestamp)
-            if self.backup_dir is not None:
-                path = os.path.join(self.backup_dir, 'db_dumps', DUMP_DATE, config_backup_file)
-            else:
-                path = os.path.join(seg.getSegmentDataDirectory(), self.dump_dir, DUMP_DATE, config_backup_file)
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
+        segments = gparray.getSegmentList()
+        mdd = self.context.master_datadir
+        for segment in segments:
+            seg = segment.get_active_primary()
+            self.context.master_datadir = seg.getSegmentDataDirectory()
+            config_backup_file = self.context.generate_filename("segment_config", dbid=segment.get_primary_dbid())
             host = seg.getSegmentHostName()
             Command("Dumping segment config files",
-                    "tar cf %s %s/*.conf" % (path, seg.getSegmentDataDirectory()),
+                    "tar cf %s %s/*.conf" % (config_backup_file, seg.getSegmentDataDirectory()),
                     ctxt=REMOTE,
                     remoteHost=host).run(validateAfter=True)
-            if self.ddboost:
-                abspath = path
-                relpath = os.path.join(self.dump_dir, DUMP_DATE, config_backup_file)
+            if self.context.ddboost:
+                abspath = config_backup_file
+                relpath = config_backup_file[config_backup_file.index(self.context.dump_dir):]
                 logger.debug('Copying %s to DDBoost' % abspath)
                 cmdStr = 'gpddboost --copyToDDBoost --from-file=%s --to-file=%s' % (abspath, relpath)
                 if self.ddboost_storage_unit:
@@ -1695,43 +1299,39 @@ class DumpConfig(Operation):
                 if res.rc != 0:
                     logger.error("DDBoost command to copy segment config file failed. %s" % res.printResult())
                 rc = rc + res.rc
-        if self.ddboost:
+        self.context.master_datadir = mdd
+        if self.context.ddboost:
             return {"exit_status": rc, "timestamp": timestamp}
 
 class DeleteCurrentDump(Operation):
-    def __init__(self, timestamp, master_datadir, master_port, dump_dir, ddboost, ddboost_storage_unit):
-        self.timestamp = timestamp
-        self.master_datadir = master_datadir
-        self.master_port = master_port
-        self.dump_dir = dump_dir
-        self.ddboost = ddboost
-        self.ddboost_storage_unit = ddboost_storage_unit
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
         try:
-            DeleteCurrentSegDump(self.timestamp, self.master_datadir, self.dump_dir).run()
+            DeleteCurrentSegDump(self.context.timestamp, self.context.master_datadir, self.context.dump_dir).run()
         except OSError, e:
-            logger.warn("Error encountered during deletion of %s on master" % self.timestamp)
-        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port), utility=True)
+            logger.warn("Error encountered during deletion of %s on master" % self.context.timestamp)
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
         segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
         for seg in segs:
             try:
-                RemoteOperation(DeleteCurrentSegDump(self.timestamp, seg.getSegmentDataDirectory(), self.dump_dir),
+                RemoteOperation(DeleteCurrentSegDump(self.context.timestamp, seg.getSegmentDataDirectory(), self.context.dump_dir),
                                 seg.getSegmentHostName()).run()
             except OSError, e:
-                logger.warn("Error encountered during deletion of %s on %s" % (self.timestamp, seg.getSegmentHostName()))
+                logger.warn("Error encountered during deletion of %s on %s" % (self.context.timestamp, seg.getSegmentHostName()))
 
-        if self.ddboost:
-            relpath = os.path.join(self.dump_dir, DUMP_DATE)
-            logger.debug('Listing %s on DDBoost to locate dump files with timestamp %s' % (relpath, self.timestamp))
+        if self.context.ddboost:
+            relpath = os.path.join(self.context.dump_dir, self.context.db_date_dir)
+            logger.debug('Listing %s on DDBoost to locate dump files with timestamp %s' % (relpath, self.context.timestamp))
             cmdStr = 'gpddboost --listDirectory --dir=%s' % relpath
-            if self.ddboost_storage_unit:
-                cmdStr += ' --ddboost-storage-unit=%s' % self.ddboost_storage_unit
+            if self.context.ddboost_storage_unit:
+                cmdStr += ' --ddboost-storage-unit=%s' % self.context.ddboost_storage_unit
             cmd = Command('DDBoost list dump files', cmdStr)
             cmd.run(validateAfter=True)
             for line in cmd.get_results().stdout.splitlines():
                 line = line.strip()
-                if self.timestamp in line:
+                if self.context.timestamp in line:
                     abspath = os.path.join(relpath, line)
                     logger.debug('Deleting %s from DDBoost' % abspath)
                     cmdStr = 'gpddboost --del-file=%s' % abspath
@@ -1742,34 +1342,27 @@ class DeleteCurrentDump(Operation):
 
 class DeleteCurrentSegDump(Operation):
     """ TODO: Improve with grouping by host. """
-    def __init__(self, timestamp, datadir, dump_dir):
-        self.timestamp = timestamp
+    def __init__(self, context, datadir):
+        self.context = context
         self.datadir = datadir
-        self.dump_dir = dump_dir
 
     def execute(self):
-        path = os.path.join(self.datadir, self.dump_dir, DUMP_DATE)
-        filenames = ListFilesByPattern(path, "*%s*" % self.timestamp).run()
+        path = os.path.join(self.datadir, self.context.dump_dir, self.context.db_date_dir)
+        filenames = ListFilesByPattern(path, "*%s*" % self.context.timestamp).run()
         for filename in filenames:
             RemoveFile(os.path.join(path, filename)).run()
 
 class DeleteOldestDumps(Operation):
-    def __init__(self, master_datadir, master_port, dump_dir, cleanup_date=None, cleanup_total=None, ddboost=False, ddboost_storage_unit=None):
-        self.master_datadir = master_datadir
-        self.master_port = master_port
-        self.dump_dir = dump_dir
-        self.cleanup_date = cleanup_date  # delete specific dump <YYYYMMDD timestamp>
-        self.cleanup_total = cleanup_total  # delete oldest N dumps <int>
-        self.ddboost = ddboost
-        self.ddboost_storage_unit = ddboost_storage_unit
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
-        dburl = dbconn.DbURL(port=self.master_port)
-        if self.ddboost:
+        dburl = dbconn.DbURL(port=self.context.master_port)
+        if self.context.ddboost:
             cmdStr = 'gpddboost'
-            if self.ddboost_storage_unit:
-                cmdStr += ' --ddboost-storage-unit %s' % self.ddboost_storage_unit
-            cmdStr += ' --listDir --dir=%s/ | grep ^[0-9] ' % self.dump_dir
+            if self.context.ddboost_storage_unit:
+                cmdStr += ' --ddboost-storage-unit %s' % self.context.ddboost_storage_unit
+            cmdStr += ' --listDir --dir=%s/ | grep ^[0-9] ' % self.context.dump_dir
             cmd = Command('List directories in DDBoost db_dumps dir', cmdStr)
             cmd.run(validateAfter=False)
             rc = cmd.get_results().rc
@@ -1778,11 +1371,11 @@ class DeleteOldestDumps(Operation):
                 return
             old_dates = cmd.get_results().stdout.splitlines()
         else:
-            old_dates = ListFiles(os.path.join(self.master_datadir, 'db_dumps')).run()
+            old_dates = ListFiles(os.path.join(self.context.master_datadir, 'db_dumps')).run()
 
         try:
-            old_dates.remove(DUMP_DATE)
-        except ValueError:            # DUMP_DATE was not found in old_dates
+            old_dates.remove(self.context.db_date_dir)
+        except ValueError:            # db_date_dir was not found in old_dates
             pass
 
         if len(old_dates) == 0:
@@ -1790,41 +1383,41 @@ class DeleteOldestDumps(Operation):
             return
 
         delete_old_dates = []
-        if self.cleanup_total:
-            if len(old_dates) < int(self.cleanup_total):
-                logger.warning("Unable to delete %s backups.  Only have %d backups." % (self.cleanup_total, len(old_dates)))
+        if self.context.cleanup_total:
+            if len(old_dates) < int(self.context.cleanup_total):
+                logger.warning("Unable to delete %s backups.  Only have %d backups." % (self.context.cleanup_total, len(old_dates)))
                 return
 
             old_dates.sort()
-            delete_old_dates = delete_old_dates + old_dates[0:int(self.cleanup_total)]
+            delete_old_dates = delete_old_dates + old_dates[0:int(self.context.cleanup_total)]
 
-        if self.cleanup_date and self.cleanup_date not in delete_old_dates:
-            if self.cleanup_date not in old_dates:
-                logger.warning("Timestamp dump %s does not exist." % self.cleanup_date)
+        if self.context.cleanup_date and self.context.cleanup_date not in delete_old_dates:
+            if self.context.cleanup_date not in old_dates:
+                logger.warning("Timestamp dump %s does not exist." % self.context.cleanup_date)
                 return
-            delete_old_dates.append(self.cleanup_date)
+            delete_old_dates.append(self.context.cleanup_date)
 
-        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port), utility=True)
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
         primaries = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
         for old_date in delete_old_dates:
             # Remove the directories on DDBoost only. This will avoid the problem
             # where we might accidently end up deleting local backup files, but
             # the intention was to delete only the files on DDboost.
-            if self.ddboost:
+            if self.context.ddboost:
                 logger.info("Preparing to remove dump %s from DDBoost" % old_date)
-                cmdStr = 'gpddboost --del-dir=%s' % os.path.join(self.dump_dir, old_date)
+                cmdStr = 'gpddboost --del-dir=%s' % os.path.join(self.context.dump_dir, old_date)
                 if self.ddboost_storage_unit:
-                    cmdStr += ' --ddboost-storage-unit %s' % self.ddboost_storage_unit
+                    cmdStr += ' --ddboost-storage-unit %s' % self.context.ddboost_storage_unit
                 cmd = Command('DDBoost cleanup', cmdStr)
                 cmd.run(validateAfter=False)
                 rc = cmd.get_results().rc
                 if rc != 0:
-                    logger.info("Error encountered during deletion of %s on DDBoost" % os.path.join(self.dump_dir, old_date))
+                    logger.info("Error encountered during deletion of %s on DDBoost" % os.path.join(self.context.dump_dir, old_date))
                     logger.debug(cmd.get_results().stdout)
                     logger.debug(cmd.get_results().stderr)
             else:
                 logger.info("Preparing to remove dump %s from all hosts" % old_date)
-                path = os.path.join(self.master_datadir, 'db_dumps', old_date)
+                path = os.path.join(self.context.master_datadir, 'db_dumps', old_date)
 
                 try:
                     RemoveTree(path).run()
@@ -1842,26 +1435,25 @@ class DeleteOldestDumps(Operation):
 
 class VacuumDatabase(Operation):
     # TODO: move this to gppylib.operations.common?
-    def __init__(self, database, master_port):
-        self.database = database
-        self.master_port = master_port
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
         conn = None
-        logger.info('Commencing vacuum of %s database, please wait' % self.database)
+        logger.info('Commencing vacuum of %s database, please wait' % self.context.dump_database)
         try:
-            dburl = dbconn.DbURL(port=self.master_port, dbname=self.database)
+            dburl = dbconn.DbURL(port=self.context.master_port, dbname=self.context.dump_database)
             conn = dbconn.connect(dburl)
             cursor = conn.cursor()
             cursor.execute("commit")                          # hack to move drop stmt out of implied transaction
             cursor.execute("vacuum")
             cursor.close()
         except Exception, e:
-            logger.exception('Error encountered with vacuum of %s database' % self.database)
+            logger.exception('Error encountered with vacuum of %s database' % self.context.dump_database)
         else:
-            logger.info('Vacuum of %s completed without error' % self.database)
+            logger.info('Vacuum of %s completed without error' % self.context.dump_database)
         finally:
-            if conn is not None:
+            if conn:
                 conn.close()
 
 class MailDumpEvent(Operation):
@@ -1915,45 +1507,33 @@ class MailEvent(Operation):
         Command('Sending email', command_str).run(validateAfter=True)
 
 class DumpStats(Operation):
-    def __init__(self, timestamp, master_datadir, dump_database, master_port, backup_dir, dump_dir, dump_prefix,
-                 include_table_file, exclude_table_file, include_schema_file, ddboost, ddboost_storage_unit):
-        self.timestamp = timestamp
-        self.master_datadir = master_datadir
-        self.dump_database = dump_database
-        self.master_port = master_port
-        self.backup_dir = backup_dir
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.include_table_file = include_table_file
-        self.exclude_table_file = exclude_table_file
-        self.include_schema_file = include_schema_file
-        self.ddboost = ddboost
-        self.ddboost_storage_unit = ddboost_storage_unit
-        self.stats_filename = generate_stats_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, DUMP_DATE, self.timestamp)
+    def __init__(self, context):
+        self.stats_filename = context.generate_filename("stats")
+        self.context = context
 
     def execute(self):
         logger.info("Commencing pg_statistic dump")
 
         include_tables = []
-        if self.exclude_table_file:
-            exclude_tables = get_lines_from_file(self.exclude_table_file)
-            user_tables = get_user_table_list(self.master_port, self.dump_database)
+        if self.context.exclude_dump_tables_file:
+            exclude_tables = get_lines_from_file(self.context.exclude_dump_tables_file)
+            user_tables = get_user_table_list(self.context)
             tables = []
             for table in user_tables:
                 tables.append("%s.%s" % (table[0], table[1]))
             include_tables = list(set(tables) - set(exclude_tables))
-        elif self.include_table_file:
-            include_tables = get_lines_from_file(self.include_table_file)
-        elif self.include_schema_file:
-            include_schemas = get_lines_from_file(self.include_schema_file)
+        elif self.context.include_dump_tables_file:
+            include_tables = get_lines_from_file(self.context.include_dump_tables_file)
+        elif self.context.schema_file:
+            include_schemas = get_lines_from_file(self.context.schema_file)
             for schema in include_schemas:
-                user_tables = get_user_table_list_for_schema(self.master_port, self.dump_database, schema)
+                user_tables = get_user_table_list_for_schema(self.context, schema)
                 tables = []
                 for table in user_tables:
                     tables.append("%s.%s" % (table[0], table[1]))
                 include_tables.extend(tables)
         else:
-            user_tables = get_user_table_list(self.master_port, self.dump_database)
+            user_tables = get_user_table_list(self.context)
             for table in user_tables:
                 include_tables.append("%s.%s" % (table[0], table[1]))
 
@@ -1967,9 +1547,9 @@ set allow_system_table_mods="DML";
         for table in sorted(include_tables):
             self.dump_table(table)
 
-        if self.ddboost:
-            abspath = self.stats_filename
-            relpath = os.path.join(self.dump_dir, DUMP_DATE, "%s%s" % (generate_stats_prefix(self.dump_prefix), self.timestamp))
+        if self.context.ddboost:
+            abspath = self.context.generate_filename("stats")
+            relpath = abspath.split(self.context.backup_dir + "/")[1]
             logger.debug('Copying %s to DDBoost' % abspath)
             cmdStr = 'gpddboost'
             if self.ddboost_storage_unit:
@@ -1980,8 +1560,8 @@ set allow_system_table_mods="DML";
 
     def dump_table(self, table):
         schemaname, tablename = table.split(".")
-        schemaname = pg.escape_string(schemaname)
-        tablename = pg.escape_string(tablename)
+        schemaname = checkAndRemoveEnclosingDoubleQuote(schemaname)
+        tablename = checkAndRemoveEnclosingDoubleQuote(tablename)
         tuples_query = """SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples
                           FROM pg_class pgc, pg_namespace pgn
                           WHERE pgc.relnamespace = pgn.oid
@@ -2002,14 +1582,14 @@ set allow_system_table_mods="DML";
         self.dump_stats(stats_query)
 
     def dump_tuples(self, query):
-        rows = execute_sql(query, self.master_port, self.dump_database)
+        rows = execute_sql(query, self.context.master_port, self.context.dump_database)
         for row in rows:
             if len(row) != 4:
                 raise Exception("Invalid return from query: Expected 4 columns, got % columns" % (len(row)))
             self.print_tuples(row)
 
     def dump_stats(self, query):
-        rows = execute_sql(query, self.master_port, self.dump_database)
+        rows = execute_sql(query, self.context.master_port, self.context.dump_database)
         for row in rows:
             if len(row) != 25:
                 raise Exception("Invalid return from query: Expected 25 columns, got % columns" % (len(row)))

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -16,19 +16,7 @@ from gppylib.db.dbconn import execSQL, execSQLForSingleton
 from gppylib.gparray import GpArray
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations import Operation
-from gppylib.operations.backup_utils import check_backup_type, check_dir_writable, check_file_dumped_with_nbu, create_temp_file_with_tables, \
-                                            execute_sql, expand_partition_tables, generate_ao_state_filename, generate_cdatabase_filename, \
-                                            generate_co_state_filename, generate_createdb_filename, generate_createdb_prefix, generate_dbdump_prefix, \
-                                            generate_dirtytable_filename, generate_global_filename, generate_global_prefix, generate_increments_filename, \
-                                            generate_master_config_filename, generate_master_dbdump_prefix, generate_stats_filename, generate_stats_prefix, \
-                                            generate_metadata_filename, get_lines_from_zipped_file, \
-                                            generate_partition_list_filename, generate_pgstatlastoperation_filename, generate_plan_filename, generate_report_filename, \
-                                            generate_segment_config_filename, get_all_segment_addresses, get_backup_directory, get_full_timestamp_for_incremental, \
-                                            get_full_timestamp_for_incremental_with_nbu, get_lines_from_file, restore_file_with_nbu, run_pool_command, scp_file_to_hosts, \
-                                            verify_lines_in_file, write_lines_to_file, split_fqn, escapeDoubleQuoteInSQLString, get_dbname_from_cdatabaseline, \
-                                            checkAndRemoveEnclosingDoubleQuote, checkAndAddEnclosingDoubleQuote, removeEscapingDoubleQuoteInSQLString, \
-                                            create_temp_file_with_schemas, check_funny_chars_in_names, remove_file_on_segments, get_restore_dir, get_nonquoted_keyword_index, \
-                                            unescape_string, get_table_info
+from gppylib.operations.backup_utils import *
 from gppylib.operations.unix import CheckFile, CheckRemoteDir, MakeRemoteDir, CheckRemotePath
 from re import compile, search, sub
 
@@ -41,8 +29,6 @@ So, after a dump, dump files must be pushed to mirrors. (This is a task for gpcr
 logger = gplog.get_default_logger()
 
 WARN_MARK = '<<<<<'
-POST_DATA_SUFFIX = '_post_data'
-
 # TODO: use CLI-agnostic custom exceptions instead of ExceptionNoStackTraceNeeded
 
 def update_ao_stat_func(conn, ao_schema, ao_table, counter, batch_size):
@@ -67,31 +53,24 @@ def generate_restored_tables(results, restored_tables, restored_schema, restore_
 
     return restored_ao_tables
 
-def update_ao_statistics(master_port, dbname, restored_tables, restored_schema=[], restore_all=False):
-    # Restored schema is different from restored tables as restored schema
-    # updates all tables within that schema.
+def update_ao_statistics(context, restored_tables, restored_schema=[], restore_all=False):
+    # Restored schema is different from restored tables as restored schema updates all tables within that schema.
     qry = """SELECT c.relname,n.nspname
              FROM pg_class c, pg_namespace n
              WHERE c.relnamespace=n.oid
                  AND (c.relstorage='a' OR c.relstorage='c')"""
 
-    conn = None
     counter = 1
-    restored_ao_tables = set()
 
     try:
-        results = execute_sql(qry, master_port, dbname)
-        restored_ao_tables = generate_restored_tables(results,
-                                                      restored_tables,
-                                                      restored_schema,
-                                                      restore_all)
-
+        results = execute_sql(qry, context.master_port, context.restore_db)
+        restored_ao_tables = generate_restored_tables(results, restored_tables, restored_schema, restore_all)
         if len(restored_ao_tables) == 0:
             logger.info("No AO/CO tables restored, skipping statistics update...")
             return
 
-        with dbconn.connect(dbconn.DbURL(port=master_port, dbname=dbname)) as conn:
-            for (ao_schema, ao_table) in sorted(restored_ao_tables):
+        with dbconn.connect(dbconn.DbURL(port=context.master_port, dbname=context.restore_db)) as conn:
+            for ao_schema, ao_table in sorted(restored_ao_tables):
                 update_ao_stat_func(conn, ao_schema, ao_table, counter, batch_size=1000)
                 counter = counter + 1
             conn.commit()
@@ -105,34 +84,34 @@ def get_restore_tables_from_table_file(table_file):
 
     return get_lines_from_file(table_file)
 
-def get_incremental_restore_timestamps(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, inc_timestamp):
-    inc_file = generate_increments_filename(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp)
+def get_incremental_restore_timestamps(context, full_timestamp):
+    inc_file = context.generate_filename("increments", timestamp=full_timestamp)
     timestamps = get_lines_from_file(inc_file)
     sorted_timestamps = sorted(timestamps, key=lambda x: int(x), reverse=True)
     incremental_restore_timestamps = []
     try:
-        incremental_restore_timestamps = sorted_timestamps[sorted_timestamps.index(inc_timestamp):]
+        incremental_restore_timestamps = sorted_timestamps[sorted_timestamps.index(context.timestamp):]
     except ValueError:
         pass
     return incremental_restore_timestamps
 
-def get_partition_list(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key):
-    partition_list_file = generate_partition_list_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key)
+def get_partition_list(context):
+    partition_list_file = context.generate_filename("partition_list")
     partition_list = get_lines_from_file(partition_list_file)
     partition_list = [split_fqn(p) for p in partition_list]
     return partition_list
 
-def get_dirty_table_file_contents(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key):
-    dirty_list_file = generate_dirtytable_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp_key)
+def get_dirty_table_file_contents(context, timestamp):
+    dirty_list_file = context.generate_filename("dirty_table", timestamp=timestamp)
     return get_lines_from_file(dirty_list_file)
 
-def create_plan_file_contents(master_datadir, backup_dir, dump_dir, dump_prefix, table_set_from_metadata_file, incremental_restore_timestamps, full_timestamp, netbackup_service_host, netbackup_block_size):
+def create_plan_file_contents(context, table_set_from_metadata_file, incremental_restore_timestamps, full_timestamp):
     restore_set = {}
     for ts in incremental_restore_timestamps:
         restore_set[ts] = []
-        if netbackup_service_host:
-            restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_dirtytable_filename(master_datadir, backup_dir, dump_dir, dump_prefix, ts))
-        dirty_tables = get_dirty_table_file_contents(master_datadir, backup_dir, dump_dir, dump_prefix, ts)
+        if context.netbackup_service_host:
+            restore_file_with_nbu(context, "dirty_table", timestamp=ts)
+        dirty_tables = get_dirty_table_file_contents(context, ts)
         for dt in dirty_tables:
             if dt in table_set_from_metadata_file:
                 table_set_from_metadata_file.remove(dt)
@@ -157,32 +136,30 @@ def write_to_plan_file(plan_file_contents, plan_file):
         lines_to_write.append(ts + ':' + tables_str)
 
     write_lines_to_file(plan_file, lines_to_write)
-    verify_lines_in_file(plan_file, lines_to_write)
 
     return lines_to_write
 
-def create_restore_plan(master_datadir, backup_dir, dump_dir, dump_prefix, db_timestamp, ddboost, netbackup_service_host=None, netbackup_block_size=None):
-    dump_tables = get_partition_list(master_datadir, backup_dir, dump_dir, dump_prefix, db_timestamp)
+def create_restore_plan(context):
+    dump_tables = get_partition_list(context)
 
     table_set_from_metadata_file = [schema + '.' + table for schema, table in dump_tables]
 
-    full_timestamp = get_full_timestamp_for_incremental(master_datadir, dump_dir, dump_prefix, db_timestamp, backup_dir, ddboost, netbackup_service_host, netbackup_block_size)
+    full_timestamp = get_full_timestamp_for_incremental(context)
 
-    incremental_restore_timestamps = get_incremental_restore_timestamps(master_datadir, backup_dir, dump_dir, dump_prefix, full_timestamp, db_timestamp)
+    incremental_restore_timestamps = get_incremental_restore_timestamps(context, full_timestamp)
 
-    plan_file_contents = create_plan_file_contents(master_datadir, backup_dir, dump_dir, dump_prefix, table_set_from_metadata_file, incremental_restore_timestamps, full_timestamp, netbackup_service_host, netbackup_block_size)
+    plan_file_contents = create_plan_file_contents(context, table_set_from_metadata_file, incremental_restore_timestamps, full_timestamp)
 
-    plan_file = generate_plan_filename(master_datadir, backup_dir, dump_dir, dump_prefix, db_timestamp)
+    plan_file = context.generate_filename("plan")
 
     write_to_plan_file(plan_file_contents, plan_file)
 
     return plan_file
 
-def is_incremental_restore(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp, ddboost=False):
-
-    filename = generate_report_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp, ddboost)
+def is_incremental_restore(context):
+    filename = context.generate_filename("report")
     if not os.path.isfile(filename):
-        logger.warn('Report file %s does not exist for restore timestamp %s' % (filename, timestamp))
+        logger.warn('Report file %s does not exist for restore timestamp %s' % (filename, context.timestamp))
         return False
 
     report_file_contents = get_lines_from_file(filename)
@@ -190,11 +167,10 @@ def is_incremental_restore(master_datadir, backup_dir, dump_dir, dump_prefix, ti
         return True
     return False
 
-def is_full_restore(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp, ddboost=False):
-
-    filename = generate_report_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp, ddboost)
+def is_full_restore(context):
+    filename = context.generate_filename("report")
     if not os.path.isfile(filename):
-        raise Exception('Report file %s does not exist for restore timestamp %s' % (filename, timestamp))
+        raise Exception('Report file %s does not exist for restore timestamp %s' % (filename, context.timestamp))
 
     report_file_contents = get_lines_from_file(filename)
     if check_backup_type(report_file_contents, 'Full'):
@@ -202,15 +178,9 @@ def is_full_restore(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp
 
     return False
 
-def is_begin_incremental_run(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp, noplan, ddboost=False):
-    if is_incremental_restore(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp, ddboost) and not noplan:
-        return True
-    else:
-        return False
-
-def get_plan_file_contents(master_datadir, backup_dir, timestamp, dump_dir, dump_prefix):
+def get_plan_file_contents(context):
     plan_file_items = []
-    plan_file = generate_plan_filename(master_datadir, backup_dir, dump_dir, dump_prefix, timestamp)
+    plan_file = context.generate_filename("plan")
     if not os.path.isfile(plan_file):
         raise Exception('Plan file %s does not exist' % plan_file)
     plan_file_lines = get_lines_from_file(plan_file)
@@ -245,7 +215,7 @@ def get_restore_table_list(table_list, restore_tables):
         return None
     return create_temp_file_with_tables(restore_list)
 
-def validate_restore_tables_list(plan_file_contents, restore_tables, schema_level_restore_list=None):
+def validate_restore_tables_list(plan_file_contents, restore_tables, restore_schemas=None):
     """
     Check if the tables in plan file match any of the restore tables.
 
@@ -266,7 +236,7 @@ def validate_restore_tables_list(plan_file_contents, restore_tables, schema_leve
     invalid_tables = []
     for table in restore_tables:
         schema_name, table_name = split_fqn(table)
-        if schema_level_restore_list and schema_name in schema_level_restore_list:
+        if restore_schemas and schema_name in restore_schemas:
             continue
         else:
             comp_set.add(table)
@@ -278,174 +248,65 @@ def validate_restore_tables_list(plan_file_contents, restore_tables, schema_leve
         raise Exception('Invalid tables for -T option: The following tables were not found in plan file : "%s"' % (invalid_tables))
 
 #NetBackup related functions
-def restore_state_files_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_ao_state_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp))
-    restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_co_state_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp))
-    restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_pgstatlastoperation_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp))
+def restore_state_files_with_nbu(context):
+    restore_file_with_nbu(context, "ao")
+    restore_file_with_nbu(context, "co")
+    restore_file_with_nbu(context, "last_operation")
 
-def restore_report_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_report_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp))
+def restore_config_files_with_nbu(context):
+    restore_file_with_nbu(context, "master_config")
 
-def restore_cdatabase_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_cdatabase_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp))
+    gparray = GpArray.initFromCatalog(dbconn.DbURL(port=context.master_port), utility=True)
+    segments = gparray.getSegmentList()
+    for segment in segments:
+        seg_config_filename = context.generate_filename("segment_config", dbid=segment.get_primary_dbid(), directory=segment.getSegmentDataDirectory())
+        seg_host = segment.get_active_primary().getSegmentHostName()
+        restore_file_with_nbu(context, path=seg_config_filename, hostname=seg_host)
 
-def restore_config_files_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    if master_port is None:
-        raise Exception('Master port is None.')
-    use_dir = get_backup_directory(master_datadir, backup_dir, dump_dir, restore_timestamp)
-    master_config_filename = os.path.join(use_dir, "%s" % generate_master_config_filename(dump_prefix, restore_timestamp))
-    restore_file_with_nbu(netbackup_service_host, netbackup_block_size, master_config_filename)
-
-    gparray = GpArray.initFromCatalog(dbconn.DbURL(port=master_port), utility=True)
-    segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
-    for seg in segs:
-        use_dir = get_backup_directory(seg.getSegmentDataDirectory(), backup_dir, dump_dir, restore_timestamp)
-        seg_config_filename = os.path.join(use_dir, "%s" % generate_segment_config_filename(dump_prefix, seg.getSegmentDbId(), restore_timestamp))
-        seg_host = seg.getSegmentHostName()
-        restore_file_with_nbu(netbackup_service_host, netbackup_block_size, seg_config_filename, seg_host)
-
-def restore_global_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_global_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp[0:8], restore_timestamp))
-
-def restore_statistics_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_stats_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp[0:8], restore_timestamp))
-
-def restore_partition_list_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_partition_list_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp))
-
-def restore_increments_file_with_nbu(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    full_ts = get_full_timestamp_for_incremental_with_nbu(dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-    if full_ts is not None:
-        restore_file_with_nbu(netbackup_service_host, netbackup_block_size, generate_increments_filename(master_datadir, backup_dir, dump_dir, dump_prefix, full_ts))
-    else:
-        raise Exception('Unable to locate full timestamp for given incremental timestamp "%s" using NetBackup' % restore_timestamp)
-
-def config_files_dumped(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    use_dir = get_backup_directory(master_datadir, backup_dir, dump_dir, restore_timestamp)
-    master_config_filename = os.path.join(use_dir, "%s" % generate_master_config_filename(dump_prefix, restore_timestamp))
-    return check_file_dumped_with_nbu(netbackup_service_host, master_config_filename)
-
-def global_file_dumped(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    global_filename = generate_global_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp[0:8], restore_timestamp)
-    return check_file_dumped_with_nbu(netbackup_service_host, global_filename)
-
-def statistics_file_dumped(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp, netbackup_service_host):
-    if (master_datadir is None) and (backup_dir is None):
-        raise Exception('Master data directory and backup directory are both none.')
-    if restore_timestamp is None:
-        raise Exception('Restore timestamp is None.')
-    if netbackup_service_host is None:
-        raise Exception('Netbackup service hostname is None.')
-    statistics_filename = generate_stats_filename(master_datadir, backup_dir, dump_dir, dump_prefix, restore_timestamp[0:8], restore_timestamp)
-    return check_file_dumped_with_nbu(netbackup_service_host, statistics_filename)
-
-def _build_gpdbrestore_cmd_line(ts, table_file, backup_dir, redirected_restore_db, report_status_dir, dump_prefix, ddboost=False, netbackup_service_host=None,
-                                netbackup_block_size=None, change_schema=None, schema_level_restore_file=None, ddboost_storage_unit=None):
+def _build_gpdbrestore_cmd_line(context, ts, table_file):
     cmd = 'gpdbrestore -t %s --table-file %s -a -v --noplan --noanalyze --noaostats --no-validate-table-name' % (ts, table_file)
-    if backup_dir is not None:
-        cmd += " -u %s" % backup_dir
-    if dump_prefix:
-        cmd += " --prefix=%s" % dump_prefix.strip('_')
-    if redirected_restore_db:
-        cmd += " --redirect=%s" % checkAndAddEnclosingDoubleQuote(shellEscape(redirected_restore_db))
-    if report_status_dir:
-        cmd += " --report-status-dir=%s" % report_status_dir
-    if ddboost:
+    if context.backup_dir:
+        cmd += " -u %s" % context.backup_dir
+    if context.dump_prefix:
+        cmd += " --prefix=%s" % context.dump_prefix.strip('_')
+    if context.redirected_restore_db:
+        cmd += " --redirect=%s" % context.redirected_restore_db
+    if context.report_status_dir:
+        cmd += " --report-status-dir=%s" % context.report_status_dir
+    if context.ddboost:
         cmd += " --ddboost"
-    if ddboost_storage_unit:
-        cmd += " --ddboost-storage-unit=%s" % ddboost_storage_unit
-    if netbackup_service_host:
-        cmd += " --netbackup-service-host=%s" % netbackup_service_host
-    if netbackup_block_size:
-        cmd += " --netbackup-block-size=%s" % netbackup_block_size
-    if change_schema:
-        cmd += " --change-schema=%s" % checkAndAddEnclosingDoubleQuote(shellEscape(change_schema))
-    if schema_level_restore_file:
-        cmd += " --schema-level-file=%s" % schema_level_restore_file
+    if context.ddboost_storage_unit:
+        cmd += " --ddboost-storage-unit=%s" % context.ddboost_storage_unit
+    if context.netbackup_service_host:
+        cmd += " --netbackup-service-host=%s" % context.netbackup_service_host
+    if context.netbackup_block_size:
+        cmd += " --netbackup-block-size=%s" % context.netbackup_block_size
+    if context.change_schema:
+        cmd += " --change-schema=%s" % context.change_schema
 
     return cmd
 
-def truncate_restore_tables(restore_tables, master_port, dbname, schema_level_restore_list=None):
+def truncate_restore_tables(context):
     """
     Truncate either specific table or all tables under a schema
     """
 
     try:
-        dburl = dbconn.DbURL(port=master_port, dbname=dbname)
+        dburl = dbconn.DbURL(port=context.master_port, dbname=context.restore_db)
         conn = dbconn.connect(dburl)
         truncate_list = []
 
-        if schema_level_restore_list:
-            for schemaname in schema_level_restore_list:
+        if context.restore_schemas:
+            for schemaname in context.restore_schemas:
                 truncate_list.extend(self.get_full_tables_in_schema(conn, schemaname))
         else:
-            for restore_table in restore_tables:
+            for restore_table in context.restore_tables:
                 schemaname, tablename = split_fqn(restore_table)
                 check_table_exists_qry = """SELECT EXISTS (
                                                    SELECT 1
                                                    FROM pg_catalog.pg_class c
                                                    JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace
-                                                   WHERE n.nspname = E'%s' and c.relname = E'%s')""" % (pg.escape_string(schemaname),
+                                                   WHERE n.nspname = '%s' and c.relname = '%s')""" % (pg.escape_string(schemaname),
                                                                                                       pg.escape_string(tablename))
                 exists_result = execSQLForSingleton(conn, check_table_exists_qry)
                 if exists_result:
@@ -454,7 +315,7 @@ def truncate_restore_tables(restore_tables, master_port, dbname, schema_level_re
                     truncate_table = '%s.%s' % (schema, table)
                     truncate_list.append(truncate_table)
                 else:
-                    logger.warning("Skipping truncate of %s.%s because the relation does not exist." % (dbname, restore_table))
+                    logger.warning("Skipping truncate of %s.%s because the relation does not exist." % (context.restore_db, restore_table))
 
         for t in truncate_list:
             try:
@@ -468,67 +329,33 @@ def truncate_restore_tables(restore_tables, master_port, dbname, schema_level_re
         raise Exception("Failure from truncating tables, %s" % (str(e).replace('\n', '')))
 
 class RestoreDatabase(Operation):
-    def __init__(self, restore_timestamp, no_analyze, drop_db, restore_global, master_datadir, backup_dir,
-                 master_port, dump_dir, dump_prefix, no_plan, restore_tables, batch_default, no_ao_stats,
-                 redirected_restore_db, report_status_dir, restore_stats, metadata_only, ddboost,
-                 netbackup_service_host, netbackup_block_size, change_schema, schema_level_restore_list,
-                 ddboost_storage_unit=None):
-        self.restore_timestamp = restore_timestamp
-        self.no_analyze = no_analyze
-        self.drop_db = drop_db
-        self.restore_global = restore_global
-        self.master_datadir = master_datadir
-        self.backup_dir = backup_dir
-        self.master_port = master_port
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.no_plan = no_plan
-        self.restore_tables = restore_tables
-        self.batch_default = batch_default
-        self.no_ao_stats = no_ao_stats
-        self.redirected_restore_db = redirected_restore_db
-        self.report_status_dir = report_status_dir
-        self.restore_stats = restore_stats
-        self.metadata_only = metadata_only
-        self.ddboost = ddboost
-        self.ddboost_storage_unit = ddboost_storage_unit
-        self.netbackup_service_host = netbackup_service_host
-        self.netbackup_block_size = netbackup_block_size
-        self.change_schema = change_schema
-        self.schema_level_restore_list = schema_level_restore_list
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
-        (restore_timestamp, restore_db, compress) = ValidateRestoreDatabase(restore_timestamp = self.restore_timestamp,
-                                                                            master_datadir = self.master_datadir,
-                                                                            backup_dir = self.backup_dir,
-                                                                            master_port = self.master_port,
-                                                                            dump_dir = self.dump_dir,
-                                                                            dump_prefix = self.dump_prefix,
-                                                                            ddboost = self.ddboost,
-                                                                            netbackup_service_host = self.netbackup_service_host).run()
+        if self.context.redirected_restore_db:
+            self.context.restore_db = self.context.redirected_restore_db
 
-        if self.redirected_restore_db and not self.drop_db:
-            restore_db = self.redirected_restore_db
-            self.create_database_if_not_exists(self.master_port, self.redirected_restore_db)
-            self.create_gp_toolkit(self.redirected_restore_db)
-        elif self.redirected_restore_db:
-            restore_db = self.redirected_restore_db
+        if len(self.context.restore_tables) > 0 and self.context.truncate:
+            truncate_restore_tables(self.context)
 
-        if self.restore_stats == "only":
-            self._restore_stats(restore_timestamp, self.master_datadir, self.backup_dir, self.master_port, restore_db, self.restore_tables)
+        if not self.context.ddboost:
+            ValidateSegments(self.context).run()
+
+        if self.context.redirected_restore_db and not self.context.drop_db:
+            self.create_database_if_not_exists()
+            self.create_gp_toolkit()
+
+        if self.context.restore_stats == "only":
+            self._restore_stats()
             return
 
-        if self.drop_db:
-            self._multitry_createdb(restore_timestamp,
-                                    restore_db,
-                                    self.redirected_restore_db,
-                                    self.master_datadir,
-                                    self.backup_dir,
-                                    self.master_port)
+        if self.context.drop_db:
+            self._multitry_createdb()
 
-        if self.restore_global:
-            self._restore_global(restore_timestamp, self.master_datadir, self.backup_dir)
-            if self.restore_global == "only":
+        if self.context.restore_global:
+            self._restore_global(self.context)
+            if self.context.restore_global == "only":
                 return
 
         """
@@ -538,59 +365,40 @@ class RestoreDatabase(Operation):
         """
 
         full_restore_with_filter = False
-        full_restore = is_full_restore(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.restore_timestamp, self.ddboost)
-        begin_incremental = is_begin_incremental_run(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.restore_timestamp, self.no_plan, self.ddboost)
+        full_restore = is_full_restore(self.context)
+        begin_incremental = (is_incremental_restore(self.context) and not self.context.no_plan)
 
         table_filter_file = self.create_filter_file() # returns None if nothing to filter
         change_schema_file = self.create_change_schema_file() # returns None if nothing to filter
         schema_level_restore_file = self.create_schema_level_file()
 
-        if (full_restore and len(self.restore_tables) > 0 and not self.no_plan) or begin_incremental or self.metadata_only:
-            if full_restore and not self.no_plan:
+        if (full_restore and len(self.context.restore_tables) > 0 and not self.context.no_plan) or begin_incremental or self.context.metadata_only:
+            if full_restore and not self.context.no_plan:
                 full_restore_with_filter = True
 
-            metadata_file = generate_metadata_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.restore_timestamp)
-            restore_line = self._build_schema_only_restore_line(restore_timestamp,
-                                                                restore_db, compress,
-                                                                self.master_port,
-                                                                metadata_file,
-                                                                table_filter_file,
-                                                                full_restore_with_filter,
-                                                                change_schema_file,
-                                                                schema_level_restore_file)
+            restore_line = self.create_schema_only_restore_string(table_filter_file, full_restore_with_filter, change_schema_file, schema_level_restore_file)
             logger.info("Running metadata restore")
             logger.info("Invoking commandline: %s" % restore_line)
             cmd = Command('Invoking gp_restore', restore_line)
             cmd.run(validateAfter=False)
             self._process_result(cmd)
             logger.info("Expanding parent partitions if any in table filter")
-            self.restore_tables = expand_partition_tables(restore_db, self.restore_tables)
+            self.context.restore_tables = expand_partition_tables(self.context.restore_db, self.context.restore_tables)
 
         if begin_incremental:
             logger.info("Running data restore")
-            self.restore_incremental_data_only(restore_db)
+            self.restore_incremental_data_only()
         else:
-            table_filter_file = self.create_filter_file() # returns None if nothing to filter
-
-            if not self.metadata_only:
-                restore_line = self._build_restore_line(restore_timestamp,
-                                                        restore_db, compress,
-                                                        self.master_port,
-                                                        self.no_plan, table_filter_file,
-                                                        self.no_ao_stats, full_restore_with_filter,
-                                                        change_schema_file, schema_level_restore_file)
+            table_filter_file = self.create_filter_file()
+            if not self.context.metadata_only:
+                restore_line = self.create_restore_string(table_filter_file, full_restore_with_filter, change_schema_file, schema_level_restore_file)
                 logger.info('gp_restore commandline: %s: ' % restore_line)
                 cmd = Command('Invoking gp_restore', restore_line)
                 cmd.run(validateAfter=False)
                 self._process_result(cmd)
 
             if full_restore_with_filter:
-                restore_line = self._build_post_data_schema_only_restore_line(restore_timestamp,
-                                                                              restore_db, compress,
-                                                                              self.master_port,
-                                                                              table_filter_file,
-                                                                              full_restore_with_filter,
-                                                                              change_schema_file, schema_level_restore_file)
+                restore_line = self.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter, change_schema_file, schema_level_restore_file)
                 logger.info("Running post data restore")
                 logger.info('gp_restore commandline: %s: ' % restore_line)
                 cmd = Command('Invoking gp_restore', restore_line)
@@ -598,23 +406,20 @@ class RestoreDatabase(Operation):
                 self._process_result(cmd)
 
             restore_all=False
-            if not self.no_ao_stats:
+            if not self.context.no_ao_stats:
                 logger.info("Updating AO/CO statistics on master")
-                # If we don't have a filter for table and schema, then we must
-                # be doing a full restore.
-                if len(self.schema_level_restore_list) == 0 and len(self.restore_tables) == 0:
+                # If we don't have a filter for table and schema, then we must be doing a full restore.
+                if len(self.context.restore_schemas) == 0 and len(self.context.restore_tables) == 0:
                     restore_all=True
-                update_ao_statistics(self.master_port, restore_db, self.restore_tables,
-                                     restored_schema=self.schema_level_restore_list, restore_all=restore_all,
-                                    )
+                update_ao_statistics(self.context, self.context.restore_tables, self.context.restore_schemas, restore_all=restore_all)
 
-        if not self.metadata_only:
-            if (not self.no_analyze) and (len(self.restore_tables) == 0):
-                self._analyze(restore_db, self.master_port)
-            elif (not self.no_analyze) and len(self.restore_tables) > 0:
-                self._analyze_restore_tables(restore_db, self.restore_tables, self.change_schema)
-        if self.restore_stats:
-            self._restore_stats(restore_timestamp, self.master_datadir, self.backup_dir, self.master_port, restore_db, self.restore_tables)
+        if not self.context.metadata_only:
+            if (not self.context.no_analyze) and len(self.context.restore_tables) == 0:
+                self._analyze(self.context)
+            elif (not self.context.no_analyze) and len(self.context.restore_tables) > 0:
+                self._analyze_restore_tables()
+        if self.context.restore_stats:
+            self._restore_stats()
 
         self.tmp_files = [table_filter_file, change_schema_file, schema_level_restore_file]
         self.cleanup_files_on_segments()
@@ -632,43 +437,43 @@ class RestoreDatabase(Operation):
         for tmp_file in self.tmp_files:
             if tmp_file and os.path.isfile(tmp_file):
                 os.remove(tmp_file)
-                remove_file_on_segments(self.master_port, tmp_file, self.batch_default)
+                remove_file_on_segments(self.context, tmp_file)
 
-    def _analyze(self, restore_db, master_port):
+    def _analyze(self, context):
         conn = None
-        logger.info('Commencing analyze of %s database, please wait' % restore_db)
+        logger.info('Commencing analyze of %s database, please wait' % context.restore_db)
         try:
-            dburl = dbconn.DbURL(port=master_port, dbname=restore_db)
+            dburl = dbconn.DbURL(port=context.master_port, dbname=context.restore_db)
             conn = dbconn.connect(dburl)
             execSQL(conn, 'analyze')
             conn.commit()
         except Exception, e:
-            logger.warn('Issue with analyze of %s database' % restore_db)
+            logger.warn('Issue with analyze of %s database' % context.restore_db)
         else:
-            logger.info('Analyze of %s completed without error' % restore_db)
+            logger.info('Analyze of %s completed without error' % context.restore_db)
         finally:
-            if conn is not None:
+            if conn:
                 conn.close()
 
-    def _analyze_restore_tables(self, restore_db, restore_tables, change_schema):
-        logger.info('Commencing analyze of restored tables in \'%s\' database, please wait' % restore_db)
+    def _analyze_restore_tables(self):
+        logger.info('Commencing analyze of restored tables in \'%s\' database, please wait' % self.context.restore_db)
         batch_count = 0
         try:
-            with dbconn.connect(dbconn.DbURL(dbname=restore_db, port=self.master_port)) as conn:
+            with dbconn.connect(dbconn.DbURL(port=self.context.master_port, dbname=self.context.restore_db)) as conn:
                 num_sqls = 0
                 analyze_list = []
                 # need to find out all tables under the schema and construct the new schema.table to analyze
-                if change_schema and self.schema_level_restore_list:
-                    schemaname = change_schema
+                if self.context.change_schema and self.context.restore_schemas:
+                    schemaname = self.context.change_schema
                     analyze_list = self.get_full_tables_in_schema(conn, schemaname)
-                elif self.schema_level_restore_list:
-                    for schemaname in self.schema_level_restore_list:
+                elif self.context.restore_schemas:
+                    for schemaname in self.context.restore_schemas:
                         analyze_list.extend(self.get_full_tables_in_schema(conn, schemaname))
                 else:
-                    for restore_table in restore_tables:
+                    for restore_table in self.context.restore_tables:
                         schemaname, tablename = split_fqn(restore_table)
-                        if change_schema:
-                            schema = escapeDoubleQuoteInSQLString(change_schema)
+                        if self.context.change_schema:
+                            schema = escapeDoubleQuoteInSQLString(self.context.change_schema)
                         else:
                             schema = escapeDoubleQuoteInSQLString(schemaname)
                         table = escapeDoubleQuoteInSQLString(tablename)
@@ -680,7 +485,7 @@ class RestoreDatabase(Operation):
                     try:
                         execSQL(conn, analyze_table)
                     except Exception as e:
-                        raise Exception('Issue with \'ANALYZE\' of restored table \'%s\' in \'%s\' database' % (restore_table, restore_db))
+                        raise Exception('Issue with \'ANALYZE\' of restored table \'%s\' in \'%s\' database' % (restore_table, self.context.restore_db))
                     else:
                         num_sqls += 1
                         if num_sqls == 1000: # The choice of batch size was choosen arbitrarily
@@ -689,11 +494,11 @@ class RestoreDatabase(Operation):
                             conn.commit()
                             num_sqls = 0
         except Exception as e:
-            logger.warn('Restore of \'%s\' database succeeded but \'ANALYZE\' of restored tables failed' % restore_db)
+            logger.warn('Restore of \'%s\' database succeeded but \'ANALYZE\' of restored tables failed' % self.context.restore_db)
             logger.warn('Please run ANALYZE manually on restored tables. Failure to run ANALYZE might result in poor database performance')
             raise Exception(str(e))
         else:
-            logger.info('\'Analyze\' of restored tables in \'%s\' database completed without error' % restore_db)
+            logger.info('\'Analyze\' of restored tables in \'%s\' database completed without error' % self.context.restore_db)
         return batch_count
 
     def get_full_tables_in_schema(self, conn, schemaname):
@@ -709,78 +514,70 @@ class RestoreDatabase(Operation):
         return res
 
     def create_schema_level_file(self):
-        if not self.schema_level_restore_list:
+        if not self.context.restore_schemas:
             return None
 
-        schema_level_restore_file = create_temp_file_with_schemas(list(self.schema_level_restore_list))
+        schema_level_restore_file = create_temp_file_with_schemas(list(self.context.restore_schemas))
 
-        addresses = get_all_segment_addresses(self.master_port)
+        addresses = get_all_segment_addresses(self.context.master_port)
 
-        scp_file_to_hosts(addresses, schema_level_restore_file, self.batch_default)
+        scp_file_to_hosts(addresses, schema_level_restore_file, self.context.batch_default)
 
         return schema_level_restore_file
 
     def create_change_schema_file(self):
-        if not self.change_schema:
+        if not self.context.change_schema:
             return None
 
-        schema_list = [self.change_schema]
+        schema_list = [self.context.change_schema]
 
         change_schema_file = create_temp_file_with_schemas(schema_list)
 
-        addresses = get_all_segment_addresses(self.master_port)
+        addresses = get_all_segment_addresses(self.context.master_port)
 
-        scp_file_to_hosts(addresses, change_schema_file, self.batch_default)
+        scp_file_to_hosts(addresses, change_schema_file, self.context.batch_default)
 
         return change_schema_file
 
     def create_filter_file(self):
-        if not self.restore_tables or len(self.restore_tables) == 0:
+        if not self.context.restore_tables or len(self.context.restore_tables) == 0:
             return None
 
-        table_filter_file = create_temp_file_with_tables(self.restore_tables)
+        table_filter_file = create_temp_file_with_tables(self.context.restore_tables)
 
-        addresses = get_all_segment_addresses(self.master_port)
+        addresses = get_all_segment_addresses(self.context.master_port)
 
-        scp_file_to_hosts(addresses, table_filter_file, self.batch_default)
+        scp_file_to_hosts(addresses, table_filter_file, self.context.batch_default)
 
         return table_filter_file
 
 
-    def restore_incremental_data_only(self, restore_db):
+    def restore_incremental_data_only(self):
         restore_data = False
-        plan_file_items = get_plan_file_contents(self.master_datadir, self.backup_dir,
-                                                 self.restore_timestamp, self.dump_dir,
-                                                 self.dump_prefix)
-        table_file = None
+        plan_file_items = get_plan_file_contents(self.context)
         table_files = []
         restored_tables = []
 
-        validate_restore_tables_list(plan_file_items, self.restore_tables, self.schema_level_restore_list)
+        validate_restore_tables_list(plan_file_items, self.context.restore_tables, self.context.restore_schemas)
 
         for (ts, table_list) in plan_file_items:
             if table_list:
                 restore_data = True
-                table_file = get_restore_table_list(table_list.strip('\n').split(','), self.restore_tables)
+                table_file = get_restore_table_list(table_list.strip('\n').split(','), self.context.restore_tables)
                 if table_file is None:
                     continue
-                cmd = _build_gpdbrestore_cmd_line(ts, table_file, self.backup_dir,
-                                                  self.redirected_restore_db,
-                                                  self.report_status_dir, self.dump_prefix,
-                                                  self.ddboost, self.netbackup_service_host,
-                                                  self.netbackup_block_size, self.change_schema,
-                                                  self.ddboost_storage_unit)
+                cmd = _build_gpdbrestore_cmd_line(self.context, ts, table_file)
                 logger.info('Invoking commandline: %s' % cmd)
                 Command('Invoking gpdbrestore', cmd).run(validateAfter=True)
                 table_files.append(table_file)
                 restored_tables.extend(get_restore_tables_from_table_file(table_file))
 
         if not restore_data:
-            raise Exception('There were no tables to restore. Check the plan file contents for restore timestamp %s' % self.restore_timestamp)
+            raise Exception('There were no tables to restore. Check the plan file contents for restore timestamp %s' % self.context.timestamp)
 
-        if not self.no_ao_stats:
+        if not self.context.no_ao_stats:
             logger.info("Updating AO/CO statistics on master")
-            update_ao_statistics(self.master_port, restore_db, restored_tables)
+            update_ao_statistics(self.context, restored_tables)
         else:
             logger.info("noaostats enabled. Skipping update of AO/CO statistics on master.")
 
@@ -790,17 +587,17 @@ class RestoreDatabase(Operation):
 
         return True
 
-    def _restore_global(self, restore_timestamp, master_datadir, backup_dir):
+    def _restore_global(self, context):
         logger.info('Commencing restore of global objects')
-        global_file = os.path.join(get_restore_dir(master_datadir, backup_dir), self.dump_dir, restore_timestamp[0:8], "%s%s" % (generate_global_prefix(self.dump_prefix), restore_timestamp))
+        global_file = context.generate_filename("global")
         if not os.path.exists(global_file):
-            raise Exception('Unable to locate global file %s%s in dump set' % (generate_global_prefix(self.dump_prefix), restore_timestamp))
+            raise Exception('Unable to locate global file %s in dump set' % (global_file))
         Psql('Invoking global dump', filename=global_file).run(validateAfter=True)
 
-    def _restore_stats(self, restore_timestamp, master_datadir, backup_dir, master_port, restore_db, restore_tables):
+    def _restore_stats(self):
         logger.info('Commencing restore of statistics')
-        stats_filename = "%s%s" % (generate_stats_prefix(self.dump_prefix), restore_timestamp)
-        stats_path = os.path.join(get_restore_dir(master_datadir, backup_dir), self.dump_dir, restore_timestamp[0:8], stats_filename)
+        stats_filename = self.context.generate_filename("stats", directory="/tmp")
+        stats_path = self.context.generate_filename("stats")
         if not os.path.exists(stats_path):
             raise Exception('Unable to locate statistics file %s in dump set' % stats_filename)
 
@@ -809,8 +606,7 @@ class RestoreDatabase(Operation):
         query = """SELECT t.schemaname || '.' || t.tablename, c.oid FROM pg_class c join pg_tables t ON c.relname = t.tablename
                          WHERE t.schemaname NOT IN ('pg_toast', 'pg_bitmapindex', 'pg_temp_1', 'pg_catalog', 'information_schema', 'gp_toolkit')"""
         relids = {}
-        rows = execute_sql(query, master_port, restore_db)
-        file = []
+        rows = execute_sql(query, self.context.master_port, self.context.restore_db)
         for row in rows:
             if len(row) != 2:
                 raise Exception("Invalid return from query: Expected 2 columns, got % columns" % (len(row)))
@@ -818,7 +614,7 @@ class RestoreDatabase(Operation):
 
         # Read in the statistics dump file, find each schemaname.tablename section, and replace the corresponding starelid
         # This section is also where we filter out tables that are not in restore_tables
-        with open("/tmp/%s" % stats_filename, "w") as outfile:
+        with open(stats_filename, "w") as outfile:
             with open(stats_path, "r") as infile:
                 table_pattern = compile("-- Schema: (\w+), Table: (\w+)")
                 print_toggle = True
@@ -828,7 +624,7 @@ class RestoreDatabase(Operation):
                     matches = search(table_pattern, line)
                     if matches:
                         tablename = '%s.%s' % (matches.group(1), matches.group(2))
-                        if len(restore_tables) == 0 or tablename in restore_tables:
+                        if len(self.context.restore_tables) == 0 or tablename in self.context.restore_tables:
                             try:
                                 new_oid = relids[tablename]
                                 print_toggle = True
@@ -846,101 +642,96 @@ class RestoreDatabase(Operation):
                     if print_toggle:
                         outfile.write(line)
 
-        Psql('Invoking statistics restore', filename="/tmp/%s" % stats_filename, database=restore_db).run(validateAfter=True)
+        Psql('Invoking statistics restore', filename=stats_filename, database=self.context.restore_db).run(validateAfter=True)
 
-    def _multitry_createdb(self, restore_timestamp, restore_db, redirected_restore_db, master_datadir, backup_dir, master_port):
+    def _multitry_createdb(self):
         no_of_trys = 600
         for _ in range(no_of_trys):
             try:
-                self._process_createdb(restore_timestamp, restore_db, redirected_restore_db, master_datadir, backup_dir, master_port)
+                self._process_createdb()
             except ExceptionNoStackTraceNeeded:
                 time.sleep(1)
             else:
                 return
-        raise ExceptionNoStackTraceNeeded('Failed to drop database %s' % restore_db)
+        raise ExceptionNoStackTraceNeeded('Failed to drop database %s' % self.context.restore_db)
 
-    def drop_database_if_exists(self, master_port, restore_db):
+    def drop_database_if_exists(self):
         conn = None
         try:
-            dburl = dbconn.DbURL(port=master_port, dbname='template1')
+            dburl = dbconn.DbURL(port=self.context.master_port, dbname='template1')
             conn = dbconn.connect(dburl)
-            count = execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" % pg.escape_string(restore_db))
+            count = execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" % pg.escape_string(self.context.restore_db))
 
-            logger.info("Dropping Database %s" % restore_db)
+            logger.info("Dropping Database %s" % self.context.restore_db)
             if count == 1:
-                cmd = Command(name='drop database %s' % restore_db,
-                              cmdStr='dropdb %s -p %s' % (checkAndAddEnclosingDoubleQuote(shellEscape(restore_db)), master_port))
+                cmd = Command(name='drop database %s' % self.context.restore_db,
+                              cmdStr='dropdb %s -p %s' % (checkAndAddEnclosingDoubleQuote(shellEscape(self.context.restore_db)), self.context.master_port))
                 cmd.run(validateAfter=True)
-            logger.info("Dropped Database %s" % restore_db)
+            logger.info("Dropped Database %s" % self.context.restore_db)
         except ExecutionError, e:
-            logger.exception("Could not drop database %s" % restore_db)
-            raise ExceptionNoStackTraceNeeded('Failed to drop database %s' % restore_db)
+            logger.exception("Could not drop database %s" % self.context.restore_db)
+            raise ExceptionNoStackTraceNeeded('Failed to drop database %s' % self.context.restore_db)
         finally:
             conn.close()
 
-    def create_database_if_not_exists(self, master_port, restore_db):
-        """
-        restore_db: true database name (non escaped or quoted)
-        """
+    def create_database_if_not_exists(self):
         conn = None
         try:
-            dburl = dbconn.DbURL(port=master_port, dbname='template1')
+            dburl = dbconn.DbURL(port=self.context.master_port, dbname='template1')
             conn = dbconn.connect(dburl)
-            count = execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" % pg.escape_string(restore_db))
+            count = execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" % pg.escape_string(self.context.restore_db))
 
-            logger.info("Creating Database %s" % restore_db)
+            logger.info("Creating Database %s" % self.context.restore_db)
             if count == 0:
-                cmd = Command(name='create database %s' % restore_db,
-                              cmdStr='createdb %s -p %s -T template0' % (checkAndAddEnclosingDoubleQuote(shellEscape(restore_db)), master_port))
+                cmd = Command(name='create database %s' % self.context.restore_db,
+                              cmdStr='createdb %s -p %s -T template0' % (checkAndAddEnclosingDoubleQuote(shellEscape(self.context.restore_db)), self.context.master_port))
                 cmd.run(validateAfter=True)
-            logger.info("Created Database %s" % restore_db)
+            logger.info("Created Database %s" % self.context.restore_db)
         except ExecutionError, e:
-            logger.exception("Could not create database %s" % restore_db)
-            raise ExceptionNoStackTraceNeeded('Failed to create database %s' % restore_db)
+            logger.exception("Could not create database %s" % self.context.restore_db)
+            raise ExceptionNoStackTraceNeeded('Failed to create database %s' % self.context.restore_db)
         finally:
             conn.close()
 
-    def check_gp_toolkit(self, restore_db):
+    def check_gp_toolkit(self):
         GP_TOOLKIT_QUERY = """SELECT count(*)
                               FROM pg_class pgc, pg_namespace pgn
                               WHERE pgc.relnamespace=pgn.oid AND
                                     pgn.nspname='gp_toolkit'
                            """
-        with dbconn.connect(dbconn.DbURL(dbname=restore_db, port=self.master_port)) as conn:
+        with dbconn.connect(dbconn.DbURL(dbname=self.context.restore_db, port=self.context.master_port)) as conn:
             res = dbconn.execSQLForSingleton(conn, GP_TOOLKIT_QUERY)
             if res == 0:
                 return False
             return True
 
-    def create_gp_toolkit(self, restore_db):
-        if not self.check_gp_toolkit(restore_db):
+    def create_gp_toolkit(self):
+        if not self.check_gp_toolkit():
             if 'GPHOME' not in os.environ:
                 logger.warn('Please set $GPHOME in your environment')
                 logger.warn('Skipping creation of gp_toolkit since $GPHOME/share/postgresql/gp_toolkit.sql could not be found')
             else:
-                logger.info('Creating gp_toolkit schema for database "%s"' % restore_db)
+                logger.info('Creating gp_toolkit schema for database "%s"' % self.context.restore_db)
                 Psql(name='create gp_toolkit',
                      filename=os.path.join(os.environ['GPHOME'],
                                            'share', 'postgresql',
                                            'gp_toolkit.sql'),
-                     database=restore_db).run(validateAfter=True)
+                     database=self.context.restore_db).run(validateAfter=True)
 
-    def _process_createdb(self, restore_timestamp, restore_db, redirected_restore_db, master_datadir, backup_dir, master_port):
-        if redirected_restore_db:
-            self.drop_database_if_exists(master_port, redirected_restore_db)
-            self.create_database_if_not_exists(master_port, redirected_restore_db)
+    def _process_createdb(self):
+        self.drop_database_if_exists()
+        if self.context.redirected_restore_db:
+            self.create_database_if_not_exists()
         else:
-            self.drop_database_if_exists(master_port, restore_db)
-            createdb_file = generate_createdb_filename(master_datadir, backup_dir, self.dump_dir, self.dump_prefix, restore_timestamp)
+            createdb_file = self.context.generate_filename("cdatabase")
             logger.info('Invoking sql file: %s' % createdb_file)
             Psql('Invoking schema dump', filename=createdb_file).run(validateAfter=True)
-        self.create_gp_toolkit(restore_db)
+        self.create_gp_toolkit()
 
     def backup_dir_is_writable(self):
-        if self.backup_dir and not self.report_status_dir:
+        if self.context.backup_dir and not self.context.report_status_dir:
             try:
-                path = os.path.join(self.dump_dir, self.restore_timestamp[0:8])
-                directory = os.path.join(self.backup_dir, path)
+                directory = context.get_backup_dir()
                 check_dir_writable(directory)
             except Exception as e:
                 logger.warning('Backup directory %s is not writable. Error %s' % (directory, str(e)))
@@ -948,25 +739,21 @@ class RestoreDatabase(Operation):
                 return False
         return True
 
-    def _build_restore_line(self, restore_timestamp, restore_db, compress, master_port, no_plan,
-                            table_filter_file, no_stats, full_restore_with_filter, change_schema_file, schema_level_restore_file=None):
-
+    def create_restore_string(self, table_filter_file, full_restore_with_filter, change_schema_file=None, schema_level_restore_file=None):
         user = getpass.getuser()
         hostname = socket.gethostname()    # TODO: can this just be localhost? bash was using `hostname`
-        path = os.path.join(self.dump_dir, restore_timestamp[0:8])
-        if self.backup_dir is not None:
-            path = os.path.join(self.backup_dir, path)
-        restore_line = "gp_restore -i -h %s -p %s -U %s --gp-i" % (hostname, master_port, user)
-        if self.dump_prefix:
+        path = self.context.get_gpd_path()
+        restore_line = "gp_restore -i -h %s -p %s -U %s --gp-i" % (hostname, self.context.master_port, user)
+        if self.context.dump_prefix:
             logger.info("Adding --prefix")
-            restore_line += " --prefix=%s" % self.dump_prefix
-        restore_line += " --gp-k=%s --gp-l=p" % (restore_timestamp)
+            restore_line += " --prefix=%s" % self.context.dump_prefix
+        restore_line += " --gp-k=%s --gp-l=p" % (self.context.timestamp)
         restore_line += " --gp-d=%s" % path
 
-        if self.report_status_dir:
-            restore_line += " --gp-r=%s" % self.report_status_dir
-            restore_line += " --status=%s" % self.report_status_dir
-        elif self.backup_dir and self.backup_dir_is_writable():
+        if self.context.report_status_dir:
+            restore_line += " --gp-r=%s" % self.context.report_status_dir
+            restore_line += " --status=%s" % self.context.report_status_dir
+        elif self.context.backup_dir and self.context.backup_dir_is_writable():
             restore_line += " --gp-r=%s" % path
             restore_line += " --status=%s" % path
         # else
@@ -975,23 +762,23 @@ class RestoreDatabase(Operation):
 
         if table_filter_file:
             restore_line += " --gp-f=%s" % table_filter_file
-        if compress:
+        if self.context.compress:
             restore_line += " --gp-c"
-        restore_line += " -d %s" % checkAndAddEnclosingDoubleQuote(shellEscape(restore_db))
+        restore_line += " -d %s" % checkAndAddEnclosingDoubleQuote(shellEscape(self.context.restore_db))
 
         # Restore only data if no_plan or full_restore_with_filter is True
-        if no_plan or full_restore_with_filter:
+        if self.context.no_plan or full_restore_with_filter:
             restore_line += " -a"
-        if no_stats:
+        if self.context.no_ao_stats:
             restore_line += " --gp-nostats"
-        if self.ddboost:
+        if self.context.ddboost:
             restore_line += " --ddboost"
-        if self.ddboost_storage_unit:
-            restore_line += " --ddboost-storage-unit=%s" % self.ddboost_storage_unit
-        if self.netbackup_service_host:
-            restore_line += " --netbackup-service-host=%s" % self.netbackup_service_host
-        if self.netbackup_block_size:
-            restore_line += " --netbackup-block-size=%s" % self.netbackup_block_size
+        if self.context.ddboost_storage_unit:
+            restore_line += " --ddboost-storage-unit=%s" % self.context.ddboost_storage_unit
+        if self.context.netbackup_service_host:
+            restore_line += " --netbackup-service-host=%s" % self.context.netbackup_service_host
+        if self.context.netbackup_block_size:
+            restore_line += " --netbackup-block-size=%s" % self.context.netbackup_block_size
         if change_schema_file:
             restore_line += " --change-schema-file=%s" % change_schema_file
         if schema_level_restore_file:
@@ -999,66 +786,61 @@ class RestoreDatabase(Operation):
 
         return restore_line
 
-    def _build_post_data_schema_only_restore_line(self, restore_timestamp, restore_db, compress, master_port,
-                                                  table_filter_file, full_restore_with_filter,
-                                                  change_schema_file=None, schema_level_restore_file=None):
+    def create_post_data_schema_only_restore_string(self, table_filter_file, full_restore_with_filter, change_schema_file=None, schema_level_restore_file=None):
         user = getpass.getuser()
         hostname = socket.gethostname()    # TODO: can this just be localhost? bash was using `hostname`
-        path = os.path.join(self.dump_dir, restore_timestamp[0:8])
-        if self.backup_dir is not None:
-            path = os.path.join(self.backup_dir, path)
-        restore_line = "gp_restore -i -h %s -p %s -U %s --gp-d=%s --gp-i" % (hostname, master_port, user, path)
-        restore_line += " --gp-k=%s --gp-l=p" % (restore_timestamp)
+        path = self.context.get_gpd_path()
+        restore_line = "gp_restore -i -h %s -p %s -U %s --gp-d=%s --gp-i" % (hostname, self.context.master_port, user, path)
+        restore_line += " --gp-k=%s --gp-l=p" % (self.context.timestamp)
 
         if full_restore_with_filter:
             restore_line += " -P"
-        if self.report_status_dir:
-            restore_line += " --gp-r=%s" % self.report_status_dir
-            restore_line += " --status=%s" % self.report_status_dir
-        elif self.backup_dir and self.backup_dir_is_writable():
+        if self.context.report_status_dir:
+            restore_line += " --gp-r=%s" % self.context.report_status_dir
+            restore_line += " --status=%s" % self.context.report_status_dir
+        elif self.context.backup_dir and self.context.backup_dir_is_writable():
             restore_line += " --gp-r=%s" % path
             restore_line += " --status=%s" % path
         # else
         # gp-r is not set, restore.c sets it to MASTER_DATA_DIRECTORY if not specified.
         # status file is not set, cdbbackup.c sets it to SEGMENT_DATA_DIRECTORY if not specified.
 
-        if self.dump_prefix:
+        if self.context.dump_prefix:
             logger.info("Adding --prefix")
-            restore_line += " --prefix=%s" % self.dump_prefix
+            restore_line += " --prefix=%s" % self.context.dump_prefix
         if table_filter_file:
             restore_line += " --gp-f=%s" % table_filter_file
         if change_schema_file:
             restore_line += " --change-schema-file=%s" % change_schema_file
         if schema_level_restore_file:
             restore_line += " --schema-level-file=%s" % schema_level_restore_file
-        if compress:
+        if self.context.compress:
             restore_line += " --gp-c"
-        restore_line += " -d %s" % checkAndAddEnclosingDoubleQuote(shellEscape(restore_db))
+        restore_line += " -d %s" % checkAndAddEnclosingDoubleQuote(shellEscape(self.context.restore_db))
 
-        if self.ddboost:
+        if self.context.ddboost:
             restore_line += " --ddboost"
-        if self.ddboost_storage_unit:
-            restore_line += " --ddboost-storage-unit=%s" % self.ddboost_storage_unit
-        if self.netbackup_service_host:
-            restore_line += " --netbackup-service-host=%s" % self.netbackup_service_host
-        if self.netbackup_block_size:
-            restore_line += " --netbackup-block-size=%s" % self.netbackup_block_size
+        if self.context.ddboost_storage_unit:
+            restore_line += " --ddboost-storage-unit=%s" % self.context.ddboost_storage_unit
+        if self.context.netbackup_service_host:
+            restore_line += " --netbackup-service-host=%s" % self.context.netbackup_service_host
+        if self.context.netbackup_block_size:
+            restore_line += " --netbackup-block-size=%s" % self.context.netbackup_block_size
 
         return restore_line
 
-    def _build_schema_only_restore_line(self, restore_timestamp, restore_db, compress, master_port,
-                                        metadata_filename, table_filter_file, full_restore_with_filter,
-                                        change_schema_file=None, schema_level_restore_file=None):
+    def create_schema_only_restore_string(self, table_filter_file, full_restore_with_filter, change_schema_file=None, schema_level_restore_file=None):
+        metadata_filename = self.context.generate_filename("metadata")
         user = getpass.getuser()
         hostname = socket.gethostname()    # TODO: can this just be localhost? bash was using `hostname`
-        (gpr_path, status_path, gpd_path) = self.get_restore_line_paths(restore_timestamp[0:8])
+        (gpr_path, status_path, gpd_path) = self.get_restore_line_paths()
 
-        restore_line = "gp_restore -i -h %s -p %s -U %s --gp-i" % (hostname, master_port, user)
-        restore_line += " --gp-k=%s --gp-l=p -s %s" % (restore_timestamp, metadata_filename)
+        restore_line = "gp_restore -i -h %s -p %s -U %s --gp-i" % (hostname, self.context.master_port, user)
+        restore_line += " --gp-k=%s --gp-l=p -s %s" % (self.context.timestamp, metadata_filename)
 
         if full_restore_with_filter:
             restore_line += " -P"
-        if gpr_path is not None and status_path is not None:
+        if gpr_path and status_path:
             restore_line += " --gp-r=%s" % gpr_path
             restore_line += " --status=%s" % status_path
         # else
@@ -1067,23 +849,23 @@ class RestoreDatabase(Operation):
 
         restore_line += " --gp-d=%s" % gpd_path
 
-        if self.dump_prefix:
+        if self.context.dump_prefix:
             logger.info("Adding --prefix")
-            restore_line += " --prefix=%s" % self.dump_prefix
+            restore_line += " --prefix=%s" % self.context.dump_prefix
         if table_filter_file:
             restore_line += " --gp-f=%s" % table_filter_file
-        if compress:
+        if self.context.compress:
             restore_line += " --gp-c"
-        restore_line += " -d %s" % checkAndAddEnclosingDoubleQuote(shellEscape(restore_db))
+        restore_line += " -d %s" % checkAndAddEnclosingDoubleQuote(shellEscape(self.context.restore_db))
 
-        if self.ddboost:
+        if self.context.ddboost:
             restore_line += " --ddboost"
-        if self.ddboost_storage_unit:
-            restore_line += " --ddboost-storage-unit=%s" % self.ddboost_storage_unit
-        if self.netbackup_service_host:
-            restore_line += " --netbackup-service-host=%s" % self.netbackup_service_host
-        if self.netbackup_block_size:
-            restore_line += " --netbackup-block-size=%s" % self.netbackup_block_size
+        if self.context.ddboost_storage_unit:
+            restore_line += " --ddboost-storage-unit=%s" % self.context.ddboost_storage_unit
+        if self.context.netbackup_service_host:
+            restore_line += " --netbackup-service-host=%s" % self.context.netbackup_service_host
+        if self.context.netbackup_block_size:
+            restore_line += " --netbackup-block-size=%s" % self.context.netbackup_block_size
         if change_schema_file:
             restore_line += " --change-schema-file=%s" % change_schema_file
         if schema_level_restore_file:
@@ -1091,121 +873,86 @@ class RestoreDatabase(Operation):
 
         return restore_line
 
-    def get_restore_line_paths(self, timestamp):
+    def get_restore_line_paths(self):
         (gpr_path, status_path, gpd_path) = (None, None, None)
 
-        gpd_path = os.path.join(self.dump_dir, timestamp)
-        if self.backup_dir is not None:
-            gpd_path = os.path.join(self.backup_dir, gpd_path)
+        gpd_path = self.context.get_gpd_path()
 
-        if self.report_status_dir:
-            gpr_path = self.report_status_dir
-            status_path = self.report_status_dir
-        elif self.backup_dir and self.backup_dir_is_writable():
+        if self.context.report_status_dir:
+            gpr_path = self.context.report_status_dir
+            status_path = self.context.report_status_dir
+        elif self.context.backup_dir and self.context.backup_dir_is_writable():
             gpr_path = gpd_path
             status_path = gpd_path
 
-        if self.ddboost:
-            gpd_path = "%s/%s" % (self.dump_dir, timestamp)
+        if self.context.ddboost:
+            gpd_path = "%s/%s" % (self.context.dump_dir, self.context.timestamp[0:8])
 
         return (gpr_path, status_path, gpd_path)
 
-class ValidateRestoreDatabase(Operation):
-    """ TODO: add other checks. check for _process_createdb? """
-    def __init__(self, restore_timestamp, master_datadir, backup_dir, master_port, dump_dir, dump_prefix, ddboost, netbackup_service_host):
-        self.restore_timestamp = restore_timestamp
-        self.master_datadir = master_datadir
-        self.backup_dir = backup_dir
-        self.master_port = master_port
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.ddboost = ddboost
-        self.netbackup_service_host = netbackup_service_host
-
-    def execute(self):
-        (restore_timestamp, restore_db, compress) = ValidateTimestamp(self.restore_timestamp, self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host, self.ddboost).run()
-        if not self.ddboost:
-            ValidateSegments(restore_timestamp, compress, self.master_port, self.backup_dir, self.dump_dir, self.dump_prefix, self.netbackup_service_host).run()
-        return (restore_timestamp, restore_db, compress)
-
 class ValidateTimestamp(Operation):
-    def __init__(self, candidate_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, netbackup_service_host, ddboost=False):
-        self.master_datadir = master_datadir
-        self.backup_dir = backup_dir
-        self.candidate_timestamp = candidate_timestamp
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.netbackup_service_host = netbackup_service_host
-        self.ddboost = ddboost
+    def __init__(self, context):
+        self.context = context
 
-    def validate_compressed_file(self, compressed_file):
-        if self.netbackup_service_host:
+    def validate_metadata_file(self, compressed_file):
+        if self.context.netbackup_service_host:
             logger.info('Backup for given timestamp was performed using NetBackup. Querying NetBackup server to check for the dump file.')
-            compress = check_file_dumped_with_nbu(self.netbackup_service_host, compressed_file)
+            compress = check_file_dumped_with_nbu(self.context, path=compressed_file)
         else:
             compress = os.path.exists(compressed_file)
             if not compress:
                 uncompressed_file = compressed_file[:compressed_file.index('.gz')]
                 if not os.path.exists(uncompressed_file):
-                    raise ExceptionNoStackTraceNeeded('Unable to find {ucfile} or {ucfile}.gz. Skipping restore.'
-                                                      .format(ucfile=uncompressed_file))
+                    raise ExceptionNoStackTraceNeeded('Unable to find {ucfile} or {ucfile}.gz. Skipping restore.'.format(ucfile=uncompressed_file))
         return compress
 
     def validate_timestamp_format(self):
-        if not self.candidate_timestamp:
+        if not self.context.timestamp:
             raise Exception('Timestamp must not be None.')
         else:
             # timestamp has to be a string of 14 digits(YYYYMMDDHHMMSS)
             timestamp_pattern = compile(r'\d{14}')
-            if not search(timestamp_pattern, self.candidate_timestamp):
+            if not search(timestamp_pattern, self.context.timestamp):
                 raise Exception('Invalid timestamp specified, please specify in the following format: YYYYMMDDHHMMSS.')
 
     def execute(self):
         self.validate_timestamp_format()
-
-        path = os.path.join(get_restore_dir(self.master_datadir, self.backup_dir), self.dump_dir, self.candidate_timestamp[0:8])
-        createdb_file = generate_createdb_filename(self.master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, self.candidate_timestamp, self.ddboost)
+        createdb_file = self.context.generate_filename("cdatabase")
         if not CheckFile(createdb_file).run():
             raise ExceptionNoStackTraceNeeded("Dump file '%s' does not exist on Master" % createdb_file)
         restore_db = GetDbName(createdb_file).run()
-        if not self.ddboost:
-            compressed_file = os.path.join(path, "%s%s.gz" % (generate_master_dbdump_prefix(self.dump_prefix), self.candidate_timestamp))
-            compress = self.validate_compressed_file(compressed_file)
+        if not self.context.ddboost:
+            compressed_file = self.context.generate_filename("metadata")
+            compress = self.validate_metadata_file(compressed_file)
         else:
-            compressed_file = os.path.join(path, "%sgp_dump_1_1_%s%s.gz" % (self.dump_prefix, self.candidate_timestamp, POST_DATA_SUFFIX))
+            compressed_file = self.context.generate_filename("postdata")
             compress = CheckFile(compressed_file).run()
-        return (self.candidate_timestamp, restore_db, compress)
+        return (self.context.timestamp, restore_db, compress)
 
 class ValidateSegments(Operation):
-    def __init__(self, restore_timestamp, compress, master_port, backup_dir, dump_dir, dump_prefix, netbackup_service_host):
-        self.restore_timestamp = restore_timestamp
-        self.compress = compress
-        self.master_port = master_port
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.backup_dir = backup_dir
-        self.netbackup_service_host = netbackup_service_host
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
         """ TODO: Improve with grouping by host and ParallelOperation dispatch. """
-        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port, dbname='template1'), utility=True)
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port, dbname='template1'), utility=True)
         primaries = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
+        mdd = self.context.master_datadir
         for seg in primaries:
             if seg.isSegmentDown():
                 """ Why must every Segment function have the word Segment in it ?! """
                 raise ExceptionNoStackTraceNeeded("Host %s dir %s dbid %d marked as invalid" % (seg.getSegmentHostName(), seg.getSegmentDataDirectory(), seg.getSegmentDbId()))
 
-            if self.netbackup_service_host is None:
-                path = os.path.join(get_restore_dir(seg.getSegmentDataDirectory(), self.backup_dir), self.dump_dir, self.restore_timestamp[0:8])
+            self.context.master_datadir = seg.getSegmentDataDirectory()
+            if self.context.netbackup_service_host is None:
                 host = seg.getSegmentHostName()
-                path = os.path.join(path, "%s0_%d_%s" % (generate_dbdump_prefix(self.dump_prefix), seg.getSegmentDbId(), self.restore_timestamp))
-                if self.compress:
-                    path += ".gz"
+                path = self.context.generate_filename("dump", dbid=seg.getSegmentDbId())
                 exists = CheckRemotePath(path, host).run()
                 if not exists:
                     raise ExceptionNoStackTraceNeeded("No dump file on %s at %s" % (seg.getSegmentHostName(), path))
+        self.context.master_datadir = mdd
 
-def check_table_name_format_and_duplicate(table_list, schema_level_restore_list=None):
+def check_table_name_format_and_duplicate(table_list, restore_schemas=None):
     """
     verify table list, and schema list, resolve duplicates and overlaps
     """
@@ -1214,23 +961,23 @@ def check_table_name_format_and_duplicate(table_list, schema_level_restore_list=
     table_set = set()
 
     # validate special characters
-    check_funny_chars_in_names(schema_level_restore_list, is_full_qualified_name = False)
+    check_funny_chars_in_names(restore_schemas, is_full_qualified_name = False)
     check_funny_chars_in_names(table_list)
 
     # validate schemas
-    if schema_level_restore_list:
-        schema_level_restore_list = list(set(schema_level_restore_list))
+    if restore_schemas:
+        restore_schemas = list(set(restore_schemas))
 
     for restore_table in table_list:
         if '.' not in restore_table:
             raise Exception("No schema name supplied for %s, removing from list of tables to restore" % restore_table)
         schema, table = split_fqn(restore_table)
         # schema level restore will be handled before specific table restore, treat as duplicate
-        if not ((schema_level_restore_list and schema in schema_level_restore_list) or (schema, table) in table_set):
+        if not ((restore_schemas and schema in restore_schemas) or (schema, table) in table_set):
             table_set.add((schema, table))
             restore_table_list.append(restore_table)
 
-    return restore_table_list, schema_level_restore_list
+    return restore_table_list, restore_schemas
 
 def validate_tablenames_exist_in_dump_file(restore_tables, dumped_tables):
     unmatched_table_names = []
@@ -1246,23 +993,21 @@ def validate_tablenames_exist_in_dump_file(restore_tables, dumped_tables):
         raise Exception("Tables %s not found in backup" % unmatched_table_names)
 
 class ValidateRestoreTables(Operation):
-    def __init__(self, restore_tables, restore_db, master_port):
-        self.restore_tables = restore_tables
-        self.restore_db = restore_db
-        self.master_port = master_port
+    def __init__(self, context):
+        self.context = context
 
     def execute(self):
         existing_tables = []
         table_counts = []
         conn = None
         try:
-            dburl = dbconn.DbURL(port=self.master_port, dbname=self.restore_db)
+            dburl = dbconn.DbURL(port=self.context.master_port, dbname=self.context.restore_db)
             conn = dbconn.connect(dburl)
-            for restore_table in self.restore_tables:
+            for restore_table in self.self.context.restore_tables:
                 schema, table = split_fqn(restore_table)
                 count = execSQLForSingleton(conn, "select count(*) from pg_class, pg_namespace where pg_class.relname = '%s' and pg_class.relnamespace = pg_namespace.oid and pg_namespace.nspname = '%s'" % (table, schema))
                 if count == 0:
-                    logger.warn("Table %s does not exist in database %s, removing from list of tables to restore" % (table, self.restore_db))
+                    logger.warn("Table %s does not exist in database %s, removing from list of tables to restore" % (table, self.context.restore_db))
                     continue
 
                 count = execSQLForSingleton(conn, "select count(*) from %s.%s" % (schema, table))
@@ -1271,7 +1016,7 @@ class ValidateRestoreTables(Operation):
                 existing_tables.append(restore_table)
                 table_counts.append((restore_table, count))
         finally:
-            if conn is not None:
+            if conn:
                 conn.close()
 
         if len(existing_tables) == 0:
@@ -1284,23 +1029,14 @@ class CopyPostData(Operation):
     ''' Copy _post_data when using fake timestamp.
         The same operation can be done with/without ddboost, because
         the _post_data file is always kept on the master, not on the dd server '''
-    def __init__(self, restore_timestamp, fake_timestamp, compress, master_datadir, dump_dir, dump_prefix, backup_dir):
-        self.restore_timestamp = restore_timestamp
+    def __init__(self, context, fake_timestamp):
         self.fake_timestamp = fake_timestamp
-        self.compress = compress
-        self.master_datadir = master_datadir
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.backup_dir = backup_dir
+        self.context = context
 
     def execute(self):
          # Build master _post_data file:
-        restore_dir = get_restore_dir(self.master_datadir, self.backup_dir)
-        real_post_data = os.path.join(restore_dir, self.dump_dir, self.restore_timestamp[0:8], "%s%s%s" % (generate_master_dbdump_prefix(self.dump_prefix), self.restore_timestamp, POST_DATA_SUFFIX))
-        fake_post_data = os.path.join(restore_dir, self.dump_dir, self.fake_timestamp[0:8], "%s%s%s" % (generate_master_dbdump_prefix(self.dump_prefix), self.fake_timestamp, POST_DATA_SUFFIX))
-        if self.compress:
-            real_post_data = real_post_data + ".gz"
-            fake_post_data = fake_post_data + ".gz"
+        real_post_data = self.context.generate_filename("postdata")
+        fake_post_data = self.context.generate_filename("postdata", self.fake_timestamp)
         shutil.copy(real_post_data, fake_post_data)
 
 class GetDbName(Operation):
@@ -1327,35 +1063,28 @@ class GetDbName(Operation):
     class DbNameGiveUp(Exception): pass
 
 class RecoverRemoteDumps(Operation):
-    def __init__(self, host, path, restore_timestamp, compress, restore_global, batch_default, master_datadir, master_port, dump_dir, dump_prefix):
+    def __init__(self, context, host, path):
         self.host = host
         self.path = path
-        self.restore_timestamp = restore_timestamp
-        self.compress = compress
-        self.restore_global = restore_global
-        self.batch_default = batch_default
-        self.master_datadir = master_datadir
-        self.master_port = master_port
-        self.pool = None
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
+        self.context = context
 
     def execute(self):
-        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.master_port), utility=True)
+        gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
         from_host, from_path = self.host, self.path
         logger.info("Commencing remote database dump file recovery process, please wait...")
         segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True) or seg.isSegmentMaster()]
-        self.pool = WorkerPool(numWorkers=min(len(segs), self.batch_default))
+        self.pool = WorkerPool(numWorkers=min(len(segs), self.context.batch_default))
         for seg in segs:
-            if seg.isSegmentMaster():
-                file = '%s%s' % (generate_master_dbdump_prefix(self.dump_prefix), self.restore_timestamp)
-            else:
-                file = '%s0_%d_%s' % (generate_dbdump_prefix(self.dump_prefix), seg.getSegmentDbId(), self.restore_timestamp)
-            if self.compress:
-                file += '.gz'
-
             to_host = seg.getSegmentHostName()
-            to_path = os.path.join(seg.getSegmentDataDirectory(), self.dump_dir, self.restore_timestamp[0:8])
+            to_path = os.path.join(seg.getSegmentDataDirectory(), self.context.dump_dir, self.context.timestamp[0:8])
+
+            if seg.isSegmentMaster():
+                from_file = self.context.generate_filename("metadata")
+                to_file = self.context.generate_filename("metadata", directory=to_path)
+            else:
+                from_file = self.context.generate_filename("dump", dbid=seg.getSegmentDbId())
+                to_file = self.context.generate_filename("dump", dbid=seg.getSegmentDbId(), directory=to_path)
+
             if not CheckRemoteDir(to_path, to_host).run():
                 logger.info('Creating directory %s on %s' % (to_path, to_host))
                 try:
@@ -1365,50 +1094,38 @@ class RecoverRemoteDumps(Operation):
 
             logger.info("Commencing remote copy from %s to %s:%s" % (from_host, to_host, to_path))
             self.pool.addCommand(Scp('Copying dump for seg %d' % seg.getSegmentDbId(),
-                                     srcFile=os.path.join(from_path, file),
-                                     dstFile=os.path.join(to_path, file),
+                                     srcFile=from_file,
+                                     dstFile=to_file,
                                      srcHost=from_host,
                                      dstHost=to_host))
-        createdb_file = '%s%s' % (generate_createdb_prefix(self.dump_prefix), self.restore_timestamp)
-        to_path = os.path.join(self.master_datadir, self.dump_dir, self.restore_timestamp[0:8])
         self.pool.addCommand(Scp('Copying schema dump',
                                  srcHost=from_host,
-                                 srcFile=os.path.join(from_path, createdb_file),
-                                 dstFile=generate_createdb_filename(self.master_datadir, None, self.dump_dir, self.dump_prefix, self.restore_timestamp)))
+                                 srcFile=self.context.generate_filename("cdatabase", directory=from_path),
+                                 dstFile=self.context.generate_filename("cdatabase")))
 
-        report_file = "%s%s.rpt" % (generate_dbdump_prefix(self.dump_prefix), self.restore_timestamp)
         self.pool.addCommand(Scp('Copying report file',
                                  srcHost=from_host,
-                                 srcFile=os.path.join(from_path, report_file),
-                                 dstFile=os.path.join(to_path, report_file)))
+                                 srcFile=self.context.generate_filename("report", directory=from_path),
+                                 dstFile=self.context.generate_filename("report")))
 
-        post_data_file = "%s%s%s" % (generate_master_dbdump_prefix(self.dump_prefix), self.restore_timestamp, POST_DATA_SUFFIX)
-        if self.compress:
-            post_data_file += ".gz"
         self.pool.addCommand(Scp('Copying post data schema dump',
                             srcHost=from_host,
-                            srcFile=os.path.join(from_path, post_data_file),
-                            dstFile=os.path.join(to_path, post_data_file)))
-        if self.restore_global:
-            global_file = "%s%s" % (generate_global_prefix(self.dump_prefix), self.restore_timestamp)
+                            srcFile=self.context.generate_filename("postdata", directory=from_path),
+                            dstFile=self.context.generate_filename("postdata")))
+
+        if self.context.restore_global:
             self.pool.addCommand(Scp("Copying global dump",
                                      srcHost=from_host,
-                                     srcFile=os.path.join(from_path, global_file),
-                                     dstFile=os.path.join(to_path, global_file)))
+                                     srcFile=self.context.generate_filename("global", directory=from_path),
+                                     dstFile=self.context.generate_filename("global")))
         self.pool.join()
         self.pool.check_results()
 
-
 class GetDumpTablesOperation(Operation):
-    def __init__(self, restore_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, compress):
-        self.master_datadir = master_datadir
-        self.restore_timestamp = restore_timestamp
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.backup_dir = backup_dir
+    def __init__(self, context):
+        self.context = context
         self.grep_cmdStr = ''' | grep -e "-- Name: " -e "^\W*START (" -e "^\W*PARTITION " -e "^\W*DEFAULT PARTITION " -e "^\W*SUBPARTITION " -e "^\W*DEFAULT SUBPARTITION "'''
-        self.compress = compress
-        self.gunzip_maybe = ' | gunzip' if self.compress else ''
+        self.gunzip_maybe = ' | gunzip' if self.context.compress else ''
 
     def extract_dumped_tables(self, lines):
         schema = ''
@@ -1443,13 +1160,12 @@ class GetDumpTablesOperation(Operation):
         return ret
 
 class GetDDboostDumpTablesOperation(GetDumpTablesOperation):
-    def __init__(self, restore_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, compress, dump_file, ddboost_storage_unit=None):
-        self.dump_file = dump_file
-        self.ddboost_storage_unit = ddboost_storage_unit
-        super(GetDDboostDumpTablesOperation, self).__init__(restore_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, compress)
+    def __init__(self, context):
+        self.context = context
+        super(GetDDboostDumpTablesOperation, self).__init__(context)
 
     def execute(self):
-        ddboost_cmdStr = 'gpddboost --readFile --from-file=%s' % self.dump_file
+        ddboost_cmdStr = 'gpddboost --readFile --from-file=%s' % self.context.generate_filename("dump")
 
         if self.ddboost_storage_unit:
             ddboost_cmdStr += ' --ddboost-storage-unit=%s' % self.ddboost_storage_unit
@@ -1463,15 +1179,13 @@ class GetDDboostDumpTablesOperation(GetDumpTablesOperation):
         ret = self.extract_dumped_tables(line_list)
         return ret
 
-
 class GetNetBackupDumpTablesOperation(GetDumpTablesOperation):
-    def __init__(self, restore_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, compress, netbackup_service_host, dump_file):
-        self.netbackup_service_host = netbackup_service_host
-        self.dump_file = dump_file
-        super(GetNetBackupDumpTablesOperation, self).__init__(restore_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, compress)
+    def __init__(self, context):
+        self.context = context
+        super(GetNetBackupDumpTablesOperation, self).__init__(context)
 
     def execute(self):
-        nbu_cmdStr = 'gp_bsa_restore_agent --netbackup-service-host %s --netbackup-filename %s' % (self.netbackup_service_host, self.dump_file)
+        nbu_cmdStr = 'gp_bsa_restore_agent --netbackup-service-host %s --netbackup-filename %s' % (self.context.netbackup_service_host, self.context.generate_filename("dump"))
         cmdStr = nbu_cmdStr + self.gunzip_maybe + self.grep_cmdStr
 
         cmd = Command('NetBackup copy of master dump file', cmdStr)
@@ -1482,35 +1196,34 @@ class GetNetBackupDumpTablesOperation(GetDumpTablesOperation):
         return ret
 
 class GetLocalDumpTablesOperation(GetDumpTablesOperation):
-    def __init__(self, restore_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, compress, dump_file):
-        self.dump_file = dump_file
-        super(GetLocalDumpTablesOperation, self).__init__(restore_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, compress)
+    def __init__(self, context):
+        self.context = context
+        super(GetLocalDumpTablesOperation, self).__init__(context)
 
     def execute(self):
-        ret = []
         f = None
         try:
-            if self.compress:
-                f = gzip.open(self.dump_file, 'r')
+            dump_file = self.context.generate_filename("dump")
+            if self.context.compress:
+                f = gzip.open(dump_file, 'r')
             else:
-                f = open(self.dump_file, 'r')
+                f = open(dump_file, 'r')
 
             lines = f.readlines()
             ret = self.extract_dumped_tables(lines)
-
+            return ret
         finally:
-            if f is not None:
+            if f:
                 f.close()
-        return ret
 
 class GetRemoteDumpTablesOperation(GetDumpTablesOperation):
-    def __init__(self, restore_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, compress, remote_host, dump_file):
+    def __init__(self, context, remote_host):
+        self.context = context
         self.host = remote_host
-        self.dump_file = dump_file
-        super(GetRemoteDumpTablesOperation, self).__init__(restore_timestamp, master_datadir, backup_dir, dump_dir, dump_prefix, compress)
+        super(GetRemoteDumpTablesOperation, self).__init__(context)
 
     def execute(self):
-        cat_cmdStr = 'cat %s%s' % (self.dump_file, self.gunzip_maybe)
+        cat_cmdStr = 'cat %s' % self.context.generate_filename("dump")
         get_remote_dump_tables = '''ssh %s %s%s''' % (self.host, cat_cmdStr, self.grep_cmdStr)
 
         cmd = Command('Get remote copy of dumped tables', get_remote_dump_tables)
@@ -1520,41 +1233,18 @@ class GetRemoteDumpTablesOperation(GetDumpTablesOperation):
         return self.extract_dumped_tables(line_list)
 
 class GetDumpTables():
-    def __init__(self, restore_timestamp, master_datadir, backup_dir,
-                        dump_dir, dump_prefix, compress, ddboost,
-                        netbackup_service_host, remote_host=None,
-                        dump_file=None, ddboost_storage_unit=None):
-        """
-        backup_dir: user specified backup directory, using -u option
-        dump_dir: dump directory name, e.g. ddboost default dump directory
-        compress: dump file is compressed or not
-        remote_host: not ddboost or netbackup server, a normal remote host name where a dump file exist
-        dump_file: the path to the dump file with exact file format(.gz)
-        """
-        self.restore_timestamp = restore_timestamp
-        self.master_datadir = master_datadir
-        self.backup_dir = backup_dir
-        self.dump_dir = dump_dir
-        self.dump_prefix = dump_prefix
-        self.compress = compress
-        self.ddboost = ddboost
-        self.netbackup_service_host = netbackup_service_host
+    def __init__(self, context, remote_host=None):
+        self.context = context
         self.remote_hostname = remote_host
-        self.dump_file = dump_file
-        self.ddboost_storage_unit = ddboost_storage_unit
 
     def get_dump_tables(self):
-        if self.ddboost:
-            get_dump_table_cmd = GetDDboostDumpTablesOperation(self.restore_timestamp, self.master_datadir, self.backup_dir,
-                                                                self.dump_dir, self.dump_prefix, self.compress, self.dump_file, self.ddboost_storage_unit)
-        elif self.netbackup_service_host:
-            get_dump_table_cmd = GetNetBackupDumpTablesOperation(self.restore_timestamp, self.master_datadir, self.backup_dir, self.dump_dir,
-                                                                 self.dump_prefix, self.compress, self.netbackup_service_host, self.dump_file)
+        if self.context.ddboost:
+            get_dump_table_cmd = GetDDboostDumpTablesOperation(self.context)
+        elif self.context.netbackup_service_host:
+            get_dump_table_cmd = GetNetBackupDumpTablesOperation(self.context)
         elif self.remote_hostname:
-            get_dump_table_cmd = GetRemoteDumpTablesOperation(self.restore_timestamp, self.master_datadir, self.backup_dir, self.dump_dir,
-                                                              self.dump_prefix, self.compress, self.remote_hostname, self.dump_file)
+            get_dump_table_cmd = GetRemoteDumpTablesOperation(self.context, self.remote_hostname)
         else:
-            get_dump_table_cmd = GetLocalDumpTablesOperation(self.restore_timestamp, self.master_datadir, self.backup_dir,
-                                                             self.dump_dir, self.dump_prefix, self.compress, self.dump_file)
+            get_dump_table_cmd = GetLocalDumpTablesOperation(self.context)
 
         return get_dump_table_cmd.run()

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
@@ -1,828 +1,574 @@
 #!/usr/bin/env python
 #
-# Copyright (c) Greenplum Inc 2012. All Rights Reserved.
+# Copyright (c) Greenplum Inc 2016. All Rights Reserved.
 #
 
 import os
 import shutil
 import unittest2 as unittest
 from gppylib.commands.base import CommandResult
-from gppylib.operations.backup_utils import generate_report_filename, validate_timestamp, generate_increments_filename,\
-                                            check_cdatabase_exists, check_successful_dump, convert_reportfilename_to_cdatabasefilename,\
-                                            get_backup_directory, generate_ao_state_filename, generate_co_state_filename,\
-                                            create_temp_file_with_tables, generate_dirtytable_filename, generate_plan_filename,\
-                                            generate_metadata_filename, generate_partition_list_filename, verify_lines_in_file,\
-                                            write_lines_to_file, get_lines_from_file, get_full_ts_from_report_file, get_incremental_ts_from_report_file,\
-                                            check_backup_type, get_timestamp_val, get_dump_dirs, get_latest_full_dump_timestamp, \
-                                            generate_pgstatlastoperation_filename, get_latest_report_timestamp, get_latest_report_in_dir, \
-                                            create_temp_file_from_list, get_timestamp_from_increments_filename, get_full_timestamp_for_incremental,\
-                                            check_funny_chars_in_names, expand_partition_tables, populate_filter_tables, expand_partitions_and_populate_filter_file, \
-                                            generate_files_filename, generate_pipes_filename, generate_master_config_filename, generate_segment_config_filename, \
-                                            generate_global_prefix, generate_master_dbdump_prefix, get_ddboost_backup_directory, \
-                                            generate_master_status_prefix, generate_seg_dbdump_prefix, generate_seg_status_prefix, \
-                                            generate_dbdump_prefix, generate_createdb_filename, generate_filter_filename, backup_file_with_nbu, \
-                                            restore_file_with_nbu, generate_global_filename, generate_cdatabase_filename, check_file_dumped_with_nbu, \
-                                            get_full_timestamp_for_incremental_with_nbu, get_latest_full_ts_with_nbu, generate_schema_filename, get_batch_from_list, list_to_quoted_string
+from gppylib.operations.backup_utils import *
 
 from mock import patch, MagicMock, Mock
+from optparse import Values
 
 class BackupUtilsTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.backup_dir = None
-        self.dump_dir = 'db_dumps'
-        self.dump_prefix = ''
+        self.context = Context()
+        self.context.master_datadir = '/data'
+        self.context.timestamp = '20160101010101'
+        self.netbackup_filepath = "/tmp/db_dumps/foo"
 
-    def create_backup_dirs(self, top_dir=os.getcwd(), dump_dirs=[]):
-        if dump_dirs is None:
-            return
-
-        for dump_dir in dump_dirs:
-            backup_dir = os.path.join(top_dir, 'db_dumps', dump_dir)
-            if not os.path.exists(backup_dir):
-                os.makedirs(backup_dir)
-                if not os.path.exists(backup_dir):
-                    raise Exception('Failed to create directory %s' % backup_dir)
-
-    def remove_backup_dirs(self, top_dir=os.getcwd(), dump_dirs=[]):
-        if dump_dirs is None:
-            return
-
-        for dump_dir in dump_dirs:
-            backup_dir = os.path.join(top_dir, 'db_dumps', dump_dir)
-            shutil.rmtree(backup_dir)
-            if os.path.exists(backup_dir):
-                raise Exception('Failed to remove directory %s' % backup_dir)
-
-    def test_generate_schema_filename_00(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/gp_dump_20120731093030_schema'
-        output = generate_schema_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_schema(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_schema'
+        output = self.context.generate_filename("schema")
         self.assertEquals(output, expected_output)
 
-    def test_generate_schema_filename_01(self):
-        master_data_dir = '/data'
-        backup_dir = '/datadomain'
-        timestamp = '20120731093030'
-        expected_output = '/datadomain/db_dumps/20120731/gp_dump_20120731093030_schema'
-        output = generate_schema_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_report(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101.rpt'
+        output = self.context.generate_filename("report")
         self.assertEquals(output, expected_output)
 
-    def test_generate_schema_filename_02(self):
-        master_data_dir = None
-        backup_dir = '/datadomain'
-        timestamp = '20120731093030'
-        expected_output = '/datadomain/db_dumps/20120731/gp_dump_20120731093030_schema'
-        output = generate_schema_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_increments(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_increments'
+        output = self.context.generate_filename("increments")
         self.assertEquals(output, expected_output)
 
-    def test_generate_schema_filename_03(self):
-        master_data_dir = None
-        timestamp = '20120731093030'
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory with existing parameters'):
-            generate_schema_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_last_operation(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_last_operation'
+        output = self.context.generate_filename("last_operation")
+        self.assertEquals(output, expected_output)
 
-    def test_generate_schema_filename_04(self):
-        master_data_dir = '/data'
-        timestamp = None
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory without timestamp'):
-            generate_schema_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_dirty_table(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_dirty_list'
+        output = self.context.generate_filename("dirty_table")
+        self.assertEquals(output, expected_output)
 
-    def test_generate_schema_filename_05(self):
-        master_data_dir = '/data'
-        timestamp = 'xx120731093030'
+    def test_generate_filename_plan(self):
+        expected_output = '/data/db_dumps/20160101/gp_restore_20160101010101_plan'
+        output = self.context.generate_filename("plan")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_metadata(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_1_1_20160101010101.gz'
+        output = self.context.generate_filename("metadata")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_postdata(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_1_1_20160101010101_post_data.gz'
+        output = self.context.generate_filename("postdata")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_partition_list(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_table_list'
+        output = self.context.generate_filename("partition_list")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_ao(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_ao_state_file'
+        output = self.context.generate_filename("ao")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_co_(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_co_state_file'
+        output = self.context.generate_filename("co")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_files(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_regular_files'
+        output = self.context.generate_filename("files")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_pipes(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_pipes'
+        output = self.context.generate_filename("pipes")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_master_config(self):
+        expected_output = '/data/db_dumps/20160101/gp_master_config_files_20160101010101.tar'
+        output = self.context.generate_filename("master_config")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_segment_config(self):
+        dbid = 2
+        expected_output = '/data/db_dumps/20160101/gp_segment_config_files_0_2_20160101010101.tar'
+        output = self.context.generate_filename("segment_config", dbid=dbid)
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_filter(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_filter'
+        output = self.context.generate_filename("filter")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_cgenerate(self):
+        expected_output = '/data/db_dumps/20160101/gp_cdatabase_1_1_20160101010101'
+        output = self.context.generate_filename("cdatabase")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_status_master(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_status_1_1_20160101010101'
+        output = self.context.generate_filename("status")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_status_segment(self):
+        dbid = 2
+        expected_output = '/data/db_dumps/20160101/gp_dump_status_0_2_20160101010101'
+        output = self.context.generate_filename("status", dbid=dbid)
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_global(self):
+        expected_output = '/data/db_dumps/20160101/gp_global_1_1_20160101010101'
+        output = self.context.generate_filename("global")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_stats(self):
+        expected_output = '/data/db_dumps/20160101/gp_statistics_1_1_20160101010101'
+        output = self.context.generate_filename("stats")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_dump_master(self):
+        expected_output = '/data/db_dumps/20160101/gp_dump_1_1_20160101010101.gz'
+        output = self.context.generate_filename("dump")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_dump_segment(self):
+        dbid = 2
+        expected_output = '/data/db_dumps/20160101/gp_dump_0_2_20160101010101.gz'
+        output = self.context.generate_filename("dump", dbid=dbid)
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_different_backup_dir(self):
+        self.context.backup_dir = '/datadomain'
+        expected_output = '/datadomain/db_dumps/20160101/gp_dump_20160101010101_schema'
+        output = self.context.generate_filename("schema")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_no_mdd(self):
+        self.context.master_datadir = None
+        self.context.backup_dir = '/datadomain'
+        expected_output = '/datadomain/db_dumps/20160101/gp_dump_20160101010101_schema'
+        output = self.context.generate_filename("schema")
+        self.assertEquals(output, expected_output)
+
+    def test_generate_filename_no_mdd_or_backup_dir(self):
+        self.context.master_datadir = None
+        with self.assertRaisesRegexp(Exception, 'Cannot locate backup directory with existing parameters'):
+            self.context.generate_filename("schema")
+
+    def test_generate_filename_no_timestamp(self):
+        self.context.timestamp = None
+        with self.assertRaisesRegexp(Exception, 'Cannot locate backup directory without timestamp'):
+            self.context.generate_filename("schema")
+
+    def test_generate_filename_bad_timestamp(self):
+        self.context.timestamp = 'xx160101010101'
         with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_schema_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+            self.context.generate_filename("schema")
 
-    def test_generate_schema_filename_06(self):
-        master_data_dir = '/data'
-        timestamp = '2012'
+    def test_generate_filename_short_timestamp(self):
+        self.context.timestamp = '2016'
         with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_schema_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+            self.context.generate_filename("schema")
 
-    def test00_generate_report_filename(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/gp_dump_20120731093030.rpt'
-        output = generate_report_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test01_generate_report_filename(self):
-        master_data_dir = '/data'
-        backup_dir = '/datadomain'
-        timestamp = '20120731093030'
-        expected_output = '/datadomain/db_dumps/20120731/gp_dump_20120731093030.rpt'
-        output = generate_report_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test02_generate_report_filename(self):
-        master_data_dir = None
-        backup_dir = '/datadomain'
-        timestamp = '20120731093030'
-        expected_output = '/datadomain/db_dumps/20120731/gp_dump_20120731093030.rpt'
-        output = generate_report_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test03_generate_report_filename(self):
-        master_data_dir = None
-        timestamp = '20120731093030'
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory with existing parameters'):
-            generate_report_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test04_generate_report_filename(self):
-        master_data_dir = '/data'
-        timestamp = None
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory without timestamp'):
-            generate_report_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test05_generate_report_filename(self):
-        master_data_dir = '/data'
-        timestamp = 'xx120731093030'
-        with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_report_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test06_generate_report_filename(self):
-        master_data_dir = '/data'
-        timestamp = '2012'
-        with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_report_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test07_validate_timestamp(self):
-        ts = "20100729093000"
+    def test_validate_timestamp_default(self):
+        ts = "20160101010101"
         result = validate_timestamp(ts)
         self.assertTrue(result)
 
-    def test08_validate_timestamp(self):
-        ts = "2010072909300"
+    def test_validate_timestamp_too_short(self):
+        ts = "2016010101010"
         result = validate_timestamp(ts)
         self.assertFalse(result)
 
-    def test09_validate_timestamp(self):
-        ts = "201007290930000"
+    def test_validate_timestamp_too_long(self):
+        ts = "201601010101010"
         result = validate_timestamp(ts)
         self.assertFalse(result)
 
-    def test10_validate_timestamp(self):
+    def test_validate_timestamp_zero(self):
         ts = "00000000000000"
         result = validate_timestamp(ts)
         self.assertTrue(result)
 
-    def test11_validate_timestamp(self):
+    def test_validate_timestamp_hex(self):
         ts = "0a000000000000"
         result = validate_timestamp(ts)
         self.assertFalse(result)
 
-    def test12_validate_timestamp(self):
-        ts = "0q000000000000"
-        result = validate_timestamp(ts)
-        self.assertFalse(result)
-
-    def test13_validate_timestamp(self):
+    def test_validate_timestamp_leading_space(self):
         ts = " 00000000000000"
         result = validate_timestamp(ts)
         self.assertFalse(result)
 
-    def test14_validate_timestamp(self):
+    def test_validate_timestamp_trailing_space(self):
         ts = "00000000000000 "
         result = validate_timestamp(ts)
         self.assertFalse(result);
 
-    def test15_validate_timestamp(self):
+    def test_validate_timestamp_none(self):
         ts = None
         result = validate_timestamp(ts)
         self.assertFalse(result)
 
-    def test16_generate_increments_filename(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/gp_dump_20120731093030_increments'
-        output = generate_increments_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_with_timestamp(self):
+        ts = '20150101010101'
+        expected_output = '/data/db_dumps/20150101/gp_dump_20150101010101_increments'
+        output = self.context.generate_filename("increments", timestamp=ts)
         self.assertEquals(output, expected_output)
 
-    def test17_generate_increments_filename(self):
-        master_data_dir = '/data'
-        backup_dir = '/datadomain'
-        timestamp = '20120731093030'
-        expected_output = '/datadomain/db_dumps/20120731/gp_dump_20120731093030_increments'
-        output = generate_increments_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_with_ddboost(self):
+        self.context.ddboost = True
+        self.context.backup_dir = "/tmp"
+        expected_output = '/data/db_dumps/20160101/gp_dump_20160101010101_increments'
+        output = self.context.generate_filename("increments")
         self.assertEquals(output, expected_output)
 
-    def test18_generate_increments_filename(self):
-        master_data_dir = None
-        backup_dir = '/datadomain'
-        timestamp = '20120731093030'
-        expected_output = '/datadomain/db_dumps/20120731/gp_dump_20120731093030_increments'
-        output = generate_increments_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test19_generate_increments_filename(self):
-        master_data_dir = None
-        timestamp = '20120731093030'
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory with existing parameters'):
-            generate_increments_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test20_generate_increments_filename(self):
-        master_data_dir = '/data'
-        timestamp = None
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory without timestamp'):
-            generate_increments_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test21_generate_increments_filename(self):
-        master_data_dir = '/data'
-        timestamp = 'xx120731093030'
-        with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_increments_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test22_generate_increments_filename(self):
-        master_data_dir = '/data'
-        timestamp = '2012'
-        with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_increments_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test23_convert_reportfilename_to_cdatabasefilename(self):
-        report_file = '/tmp/foo/foo/gp_dump_20130104133924.rpt'
-        expected_output = '/tmp/foo/foo/gp_cdatabase_1_1_20130104133924'
-        cdatabase_file = convert_reportfilename_to_cdatabasefilename(report_file, self.dump_prefix)
+    def test_convert_report_filename_to_cdatabase_filename(self):
+        report_file = '/data/db_dumps/20160101/gp_dump_20160101010101.rpt'
+        expected_output = '/data/db_dumps/20160101/gp_cdatabase_1_1_20160101010101'
+        cdatabase_file = convert_report_filename_to_cdatabase_filename(self.context, report_file)
         self.assertEquals(expected_output, cdatabase_file)
 
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['--', '-- Database creation', '--', '', "CREATE DATABASE testdb WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = dcddev;"])
-    def test24_check_cdatabase_exists(self, mock):
-        dbname = 'testdb'
-        report_file = '/tmp/foo/foo/gp_dump_20130104133924.rpt'
-        result = check_cdatabase_exists(dbname, report_file, self.dump_prefix)
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['--', '-- Database creation', '--', '', "CREATE DATABASE bkdb WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = dcddev;"])
+    def test_check_cdatabase_exists_default(self, mock):
+        self.context.dump_database = 'bkdb'
+        report_file = '/data/db_dumps/20160101/gp_dump_20160101010101.rpt'
+        result = check_cdatabase_exists(self.context, report_file)
         self.assertTrue(result)
 
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['--', '-- Database creation', '--', '', "CREATE DATABASE testdb WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = dcddev;"])
-    def test25_check_cdatabase_exists(self, mock):
-        dbname = 'bkdb'
-        report_file = '/tmp/foo/foo/gp_dump_20130104133924.rpt'
-        result = check_cdatabase_exists(dbname, report_file, self.dump_prefix)
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['--', '-- Database creation', '--', '', "CREATE DATABASE fullbkdb WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = dcddev;"])
+    def test_check_cdatabase_exists_bad_dbname(self, mock):
+        self.context.dump_database = 'bkdb'
+        report_file = '/data/db_dumps/20160101/gp_dump_20160101010101.rpt'
+        result = check_cdatabase_exists(self.context, report_file)
         self.assertFalse(result)
 
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['--', '-- Database creation', '--', '', "CREATE testdb WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = dcddev;"])
-    def test26_check_cdatabase_exists(self, mock):
-        dbname = 'bkdb'
-        report_file = '/tmp/foo/foo/gp_dump_20130104133924.rpt'
-        result = check_cdatabase_exists(dbname, report_file, self.dump_prefix)
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['--', '-- Database creation', '--', '', "CREATE bkdb WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = dcddev;"])
+    def test_check_cdatabase_exists_no_database(self, mock):
+        self.context.dump_database = 'bkdb'
+        report_file = '/data/db_dumps/20160101/gp_dump_20160101010101.rpt'
+        result = check_cdatabase_exists(self.context, report_file)
         self.assertFalse(result)
 
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=[])
-    def test27_check_cdatabase_exists(self, mock):
-        dbname = 'bkdb'
-        report_file = '/tmp/foo/foo/gp_dump_20130104133924.rpt'
-        result = check_cdatabase_exists(dbname, report_file, self.dump_prefix)
+    def test_check_cdatabase_exists_empty_file(self, mock):
+        self.context.dump_database = 'bkdb'
+        report_file = '/data/db_dumps/20160101/gp_dump_20160101010101.rpt'
+        result = check_cdatabase_exists(self.context, report_file)
         self.assertFalse(result)
 
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['--', '-- Database creation', '--', '', 'CREATE DATABASE'])
-    def test28_check_cdatabase_exists(self, mock):
-        dbname = 'bkdb'
-        report_file = '/tmp/foo/foo/gp_dump'
-        result = check_cdatabase_exists(dbname, report_file, self.dump_prefix)
+    def test_check_cdatabase_exists_no_dbname(self, mock):
+        self.context.dump_database = 'bkdb'
+        report_file = '/data/db_dumps/20160101/gp_dump_20160101010101.rpt'
+        result = check_cdatabase_exists(self.context, report_file)
         self.assertFalse(result)
-
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['--', '-- Database creation', '--', '', "CREATE DATABASE testdb WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = dcddev;"])
-    def test29_check_cdatabase_exists(self, mock):
-        dbname = 'testdb'
-        report_file = '/tmp/foo/foo/gp_dump_20130104133924.rpt'
-        result = check_cdatabase_exists(dbname, report_file, self.dump_prefix)
-        self.assertTrue(result)
 
     @patch('gppylib.operations.backup_utils.Command.run')
     @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "CREATE DATABASE", "", True, False))
-    def test31_check_cdatabase_exists(self, mock1, mock2):
-        dbname = 'bkdb'
-        report_file = '/tmp/foo/foo/gp_dump'
-        ddboost = True
-        result = check_cdatabase_exists(dbname, report_file, self.dump_prefix, ddboost)
+    def test_check_cdatabase_exists_command_result(self, mock1, mock2):
+        self.context.dump_database = 'bkdb'
+        report_file = '/data/db_dumps/20160101/gp_dump_20160101010101.rpt'
+        self.context.ddboost = True
+        result = check_cdatabase_exists(self.context, report_file)
         self.assertFalse(result)
 
-    def test30_get_backup_directory(self):
-        mdd = '/data'
-        timestamp = '20121204090000'
-        expected = '/data/db_dumps/20121204'
-        result = get_backup_directory(mdd, self.backup_dir, self.dump_dir, timestamp)
+    def test_get_backup_dir_default(self):
+        expected = '/data/db_dumps/20160101'
+        result = self.context.get_backup_dir()
         self.assertTrue(result, expected)
 
-    def test31_get_backup_directory(self):
-        mdd = '/data'
-        backup_dir = '/tmp/foo'
-        timestamp = '20121204090000'
-        expected = '/tmp/foo/db_dumps/20121204'
-        result = get_backup_directory(mdd, backup_dir, self.dump_dir, timestamp)
+    def test_get_backup_dir_different_backup_dir(self):
+        self.context.backup_dir = '/tmp/foo'
+        expected = '/tmp/foo/db_dumps/20160101'
+        result = self.context.get_backup_dir()
         self.assertTrue(result, expected)
 
-    def test32_get_backup_directory(self):
-        mdd = None
-        timestamp = '20121204090000'
-        expected = '/tmp/foo/db_dumps/20121204'
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory with existing parameters'):
-            result = get_backup_directory(mdd, self.backup_dir, self.dump_dir, timestamp)
+    def test_get_backup_dir_no_mdd(self):
+        self.context.master_datadir= None
+        with self.assertRaisesRegexp(Exception, 'Cannot locate backup directory with existing parameters'):
+            result = self.context.get_backup_dir()
 
-    def test33_get_backup_directory(self):
-        mdd = '/data'
-        timestamp = 'a0121204090000'
-        expected = '/tmp/foo/db_dumps/20121204'
+    def test_get_backup_dir_bad_timestamp(self):
+        timestamp = 'a0160101010101'
         with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            result = get_backup_directory(mdd, self.backup_dir, self.dump_dir, timestamp)
+            result = self.context.get_backup_dir(timestamp)
 
-    def test34_generate_dirtytable_filename(self):
-        mdd = '/data'
-        timestamp = '20121204090000'
-        expected = '/data/db_dumps/20121204/gp_dump_20121204090000_dirty_list'
-        result = generate_dirtytable_filename(mdd, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(expected, result)
-
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['t1', 't2'])
-    def test35_verify_lines_in_file(self, mock):
-        fname = 'foo'
-        expected = ['t1', 't2']
-
-        # failure will raise an exception
-        verify_lines_in_file(fname, expected)
-
-
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['t1 ', 't2'])
-    def test36_verify_lines_in_file(self, mock):
-        fname = 'foo'
-        expected = ['t1', 't2']
-
-        with self.assertRaisesRegexp(Exception, 'After writing file \'foo\' contents not as expected'):
-            verify_lines_in_file(fname, expected)
-
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=[' t1', 't2'])
-    def test37_verify_lines_in_file(self, mock):
-        fname = 'foo'
-        expected = ['t1', 't2']
-
-        with self.assertRaisesRegexp(Exception, 'After writing file \'foo\' contents not as expected'):
-            verify_lines_in_file(fname, expected)
-
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['t1'])
-    def test38_verify_lines_in_file(self, mock):
-        fname = 'foo'
-        expected = ['t1', 't2']
-
-        with self.assertRaisesRegexp(Exception, 'After writing file \'foo\' contents not as expected'):
-            verify_lines_in_file(fname, expected)
-
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['t1', 't2', 't3'])
-    def test39_verify_lines_in_file(self, mock):
-        fname = 'foo'
-        expected = ['t1', 't2']
-
-        with self.assertRaisesRegexp(Exception, 'After writing file \'foo\' contents not as expected'):
-            verify_lines_in_file(fname, expected)
-
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=[])
-    def test40_verify_lines_in_file(self, mock):
-        fname = 'foo'
-        expected = ['t1', 't2']
-
-        with self.assertRaisesRegexp(Exception, 'After writing file \'foo\' contents not as expected'):
-            verify_lines_in_file(fname, expected)
-
-    def test41_generate_plan_filename(self):
-        mdd = '/data'
-        timestamp = '20121204090000'
-        expected = '/data/db_dumps/20121204/gp_restore_20121204090000_plan'
-        result = generate_plan_filename(mdd, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(expected, result)
-
-    def test42_generate_partition_list_filename(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/gp_dump_20120731093030_table_list'
-        output = generate_partition_list_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test43_generate_metadata_filename(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/gp_dump_1_1_20120731093030.gz'
-        output = generate_metadata_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test44_generate_metadata_filename(self):
-        master_data_dir = None
-        timestamp = '20120731093030'
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory with existing parameters'):
-            generate_metadata_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test45_generate_metadata_filename(self):
-        master_data_dir = '/data'
-        timestamp = None
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory without timestamp'):
-            generate_metadata_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test46_generate_metadata_filename(self):
-        master_data_dir = '/data'
-        timestamp = 'xx120731093030'
-        with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_metadata_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test47_generate_metadata_filename(self):
-        master_data_dir = '/data'
-        timestamp = '2012'
-        with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_metadata_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test48_write_lines_to_file(self):
-        lines = ['Hello', 'World\n', '  Greenplum   ']
-        filename = os.path.join(os.getcwd(), 'abc')
-        write_lines_to_file(filename, lines)
-        self.assertTrue(os.path.isfile(filename))
-        content = get_lines_from_file(filename)
-        expected_output = [s.strip('\n') for s in lines]
-        self.assertEquals(expected_output, content)
-        os.remove(filename)
-
-    def test49_write_lines_to_file(self):
-        lines = []
-        filename = '/this_directory/doesnot/exist'
-        with self.assertRaises(IOError):
-            write_lines_to_file(filename, lines)
-
-    def test50_write_lines_to_file(self):
-        lines = []
-        filename = os.path.join(os.getcwd(), 'abc')
-        write_lines_to_file(filename, lines)
-        self.assertTrue(os.path.exists(filename))
-        content = get_lines_from_file(filename)
-        self.assertEquals(lines, content)
-        os.remove(filename)
-
-    def test51_write_lines_to_file(self):
-        lines = ['Hello', 'World', '', 'Greenplum']
-        filename = os.path.join(os.getcwd(), 'abc')
-        write_lines_to_file(filename, lines)
-        self.assertTrue(os.path.isfile(filename))
-        content = get_lines_from_file(filename)
-        self.assertEquals(lines, content)
-        os.remove(filename)
-
-    def test52_check_successful_dump(self):
+    def test_check_successful_dump_default(self):
         successful_dump = check_successful_dump(['gp_dump utility finished successfully.'])
         self.assertTrue(successful_dump)
 
-    def test53_check_successful_dump(self):
+    def test_check_successful_dump_failure(self):
         successful_dump = check_successful_dump(['gp_dump utility finished unsuccessfully.'])
         self.assertFalse(successful_dump)
 
-    def test54_check_successful_dump(self):
+    def test_check_successful_dump_no_result(self):
         successful_dump = check_successful_dump([])
         self.assertFalse(successful_dump)
 
-    def test55_check_successful_dump(self):
+    def test_check_successful_dump_with_whitespace(self):
         successful_dump = check_successful_dump(['gp_dump utility finished successfully.\n'])
         self.assertTrue(successful_dump)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Full', 'Timestamp Key: 01234567891234', 'gp_dump utility finished successfully.'])
-    def test56_get_full_ts_from_report_file(self, mock1, mock2):
+    def test_get_full_ts_from_report_file_default(self, mock1, mock2):
         expected_output = '01234567891234'
-        ts = get_full_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+        ts = get_full_ts_from_report_file(self.context, 'foo')
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=False)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Full', 'Timestamp Key: 01234567891234', 'gp_dump utility finished successfully.'])
-    def test57_get_full_ts_from_report_file(self, mock1, mock2):
+    def test_get_full_ts_from_report_file_no_database(self, mock1, mock2):
         expected_output = None
-        ts = get_full_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+        ts = get_full_ts_from_report_file(self.context, 'foo')
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Full', 'Timestamp Key: 01234567891234567', 'gp_dump utility finished successfully.'])
-    def test58_get_full_ts_from_report_file(self, mock1, mock2):
+    def test_get_full_ts_from_report_file_timestamp_too_long(self, mock1, mock2):
         with self.assertRaisesRegexp(Exception, 'Invalid timestamp value found in report_file'):
-            get_full_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+            get_full_ts_from_report_file(self.context, 'foo')
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Full', 'Timestamp Key: xxx34567891234', 'gp_dump utility finished successfully.'])
-    def test59_get_full_ts_from_report_file(self, mock1, mock2):
+    def test_get_full_ts_from_report_file_bad_timestamp(self, mock1, mock2):
         with self.assertRaisesRegexp(Exception, 'Invalid timestamp value found in report_file'):
-            get_full_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+            get_full_ts_from_report_file(self.context, 'foo')
 
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Full'])
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
-    def test60_get_full_ts_from_report_file(self, mock1, mock2):
+    def test_get_full_ts_from_report_file_missing_output(self, mock1, mock2):
         expected_output = None
-        ts = get_full_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+        ts = get_full_ts_from_report_file(self.context, 'foo')
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Full', 'gp_dump utility finished successfully.'])
-    def test61_get_full_ts_from_report_file(self, mock1, mock2):
+    def test_get_full_ts_from_report_file_missing_timestamp(self, mock1, mock2):
         expected_output = None
-        ts = get_full_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+        ts = get_full_ts_from_report_file(self.context, 'foo')
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Full', 'Timestamp Key: xxx34567891234', 'gp_dump utility finished successfully.'])
-    def test61_get_full_ts_from_report_file_with_ddboost_bad_ts(self, mock1, mock2):
-        ddboost = True
+    def test_get_full_ts_from_report_file_with_ddboost_bad_ts(self, mock1, mock2):
+        self.context.ddboost = True
         with self.assertRaisesRegexp(Exception, 'Invalid timestamp value found in report_file'):
-            ts = get_full_ts_from_report_file('testdb', 'foo', self.dump_prefix, ddboost)
+            ts = get_full_ts_from_report_file(self.context, 'foo')
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Full', 'Timestamp Key: 01234567891234', 'gp_dump utility finished successfully.'])
-    def test61_get_full_ts_from_report_file_with_ddboost_good_ts(self, mock1, mock2):
+    def test_get_full_ts_from_report_file_with_ddboost_good_ts(self, mock1, mock2):
         expected_output = '01234567891234'
-        ddboost = True
-        ts = get_full_ts_from_report_file('testdb', 'foo', self.dump_prefix, ddboost)
+        self.context.ddboost = True
+        ts = get_full_ts_from_report_file(self.context, 'foo')
+        self.assertEqual(ts, expected_output)
+
+    @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Incremental', 'Timestamp Key: 01234567891234', 'gp_dump utility finished successfully.'])
+    def test_get_incremental_ts_from_report_file_default(self, mock1, mock2):
+        expected_output = '01234567891234'
+        ts = get_incremental_ts_from_report_file(self.context, 'foo')
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Incremental'])
-    def test62_get_incremental_ts_from_report_file(self, mock1, mock2):
+    def test_get_incremental_ts_from_report_file_missing_output(self, mock1, mock2):
         expected_output = None
-        ts = get_incremental_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+        ts = get_incremental_ts_from_report_file(self.context, 'foo')
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Incremental', 'gp_dump utility finished successfully.'])
-    def test63_get_incremental_ts_from_report_file(self, mock1, mock2):
+    def test_get_incremental_ts_from_report_file_success(self, mock1, mock2):
         expected_output = None
-        ts = get_incremental_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+        ts = get_incremental_ts_from_report_file(self.context, 'foo')
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Full', 'Timestamp Key: 01234567891234', 'gp_dump utility finished successfully.'])
-    def test64_get_incremental_ts_from_report_file(self, mock1, mock2):
+    def test_get_incremental_ts_from_report_file_full(self, mock1, mock2):
         expected_output = None
-        ts = get_incremental_ts_from_report_file('testdb', 'foo', self.dump_prefix)
-        self.assertEqual(ts, expected_output)
-
-    @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Incremental', 'Timestamp Key: 01234567891234', 'gp_dump utility finished successfully.'])
-    def test65_get_incremental_ts_from_report_file(self, mock1, mock2):
-        expected_output = '01234567891234'
-        ts = get_incremental_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+        ts = get_incremental_ts_from_report_file(self.context, 'foo')
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=False)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Incremental', 'Timestamp Key: 01234567891234', 'gp_dump utility finished successfully.'])
-    def test66_get_incremental_ts_from_report_file(self, mock1, mock2):
+    def test_get_incremental_ts_from_report_file_no_database(self, mock1, mock2):
         expected_output = None
-        ts = get_incremental_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+        ts = get_incremental_ts_from_report_file(self.context, 'foo')
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Incremental', 'Timestamp Key: 01234567891234567', 'gp_dump utility finished successfully.'])
-    def test67_get_incremental_ts_from_report_file(self, mock1, mock2):
+    def test_get_incremental_ts_from_report_file_timestamp_too_long(self, mock1, mock2):
         with self.assertRaisesRegexp(Exception, 'Invalid timestamp value found in report_file'):
-            get_incremental_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+            get_incremental_ts_from_report_file(self.context, 'foo')
 
     @patch('gppylib.operations.backup_utils.check_cdatabase_exists', return_value=True)
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['Backup Type: Incremental', 'Timestamp Key: xxx34567891234', 'gp_dump utility finished successfully.'])
-    def test68_get_incremental_ts_from_report_file(self, mock1, mock2):
+    def test_get_incremental_ts_from_report_file_bad_timestamp(self, mock1, mock2):
         with self.assertRaisesRegexp(Exception, 'Invalid timestamp value found in report_file'):
-            get_incremental_ts_from_report_file('testdb', 'foo', self.dump_prefix)
+            get_incremental_ts_from_report_file(self.context, 'foo')
 
-    def test69_check_backup_type(self):
+    def test_check_backup_type_full(self):
         backup_type = check_backup_type(['Backup Type: Full'], 'Full')
         self.assertEqual(backup_type, True)
 
-    def test70_check_backup_type(self):
+    def test_check_backup_type_mismatch(self):
         backup_type = check_backup_type(['Backup Type: Incremental'], 'Full')
         self.assertEqual(backup_type, False)
 
-    def test71_check_backup_type(self):
+    def test_check_backup_type_invalid_type(self):
         backup_type = check_backup_type(['foo'], 'Full')
         self.assertEqual(backup_type, False)
 
-    def test72_check_backup_type(self):
+    def test_check_backup_type_type_too_long(self):
         backup_type = check_backup_type(['Backup Type: FullQ'], 'Full')
         self.assertEqual(backup_type, False)
 
-    def test73_get_timestamp_val(self):
+    def test_get_timestamp_val_default(self):
         ts_key = get_timestamp_val(['Timestamp Key: 01234567891234'])
         self.assertEqual(ts_key, '01234567891234')
 
-    def test74_get_timestamp_val(self):
+    def test_get_timestamp_val_timestamp_too_short(self):
         ts_key = get_timestamp_val(['Time: 00000'])
         self.assertEqual(ts_key, None)
 
-    def test75_get_timestamp_val(self):
+    def test_get_timestamp_val_bad_timestamp(self):
         with self.assertRaisesRegexp(Exception, 'Invalid timestamp value found in report_file'):
             get_timestamp_val(['Timestamp Key: '])
 
-    def test76_get_dump_dirs(self):
-        dump_dirs = ['20121212']
-        self.create_backup_dirs(dump_dirs=dump_dirs)
-        expected_output = [os.path.join(os.getcwd(), 'db_dumps', d) for d in dump_dirs]
-        try:
-            ddir = get_dump_dirs(os.getcwd(), self.dump_dir)
-            self.assertEqual(ddir, expected_output)
-        finally:
-            self.remove_backup_dirs(dump_dirs=dump_dirs)
+    @patch('os.path.isdir', return_value=True)
+    @patch('os.listdir', return_value=['20161212'])
+    def test_get_dump_dirs_single(self, mock, mock1):
+        self.context.backup_dir = '/tmp'
+        expected_output = ['/tmp/db_dumps/20161212']
+        ddir = get_dump_dirs(self.context)
+        self.assertEqual(ddir, expected_output)
 
-    def test77_get_dump_dirs(self):
-        dump_dir_list = ['20121212', '20121213', '20121214']
-        expected_output = [os.path.join(os.getcwd(), 'db_dumps', d) for d in dump_dir_list]
-        self.create_backup_dirs(dump_dirs=dump_dir_list)
-        try:
-            ddir = get_dump_dirs(os.getcwd(), self.dump_dir)
-            self.assertEqual(ddir.sort(), expected_output.sort())
-        finally:
-            self.remove_backup_dirs(dump_dirs=dump_dir_list)
+    @patch('os.path.isdir', return_value=True)
+    @patch('os.listdir', return_value=['20161212', '20161213', '20161214'])
+    def test_get_dump_dirs_multiple(self, mock, mock1):
+        self.context.backup_dir = '/tmp'
+        expected_output = ['20161212', '20161213', '20161214']
+        ddir = get_dump_dirs(self.context)
+        self.assertEqual(ddir.sort(), expected_output.sort())
 
-    def test78_get_dump_dirs(self):
-        dump_dir_list = []
-        self.create_backup_dirs(dump_dirs=dump_dir_list)
-        try:
-            self.assertEquals([], get_dump_dirs(os.getcwd(), self.dump_dir))
-        finally:
-            self.remove_backup_dirs(dump_dirs=dump_dir_list)
+    @patch('os.path.isdir', return_value=True)
+    @patch('os.listdir', return_value=[])
+    def test_get_dump_dirs_empty(self, mock, mock2):
+        self.context.backup_dir = '/tmp'
+        self.assertEquals([], get_dump_dirs(self.context))
 
-    def test79_get_dump_dirs(self):
-        dump_dir_list = ['2012120a', '201212121', 'abcde']
-        self.create_backup_dirs(dump_dirs=dump_dir_list)
-        try:
-            self.assertEquals([], get_dump_dirs(os.getcwd(), self.dump_dir))
-        finally:
-            self.remove_backup_dirs(dump_dirs=dump_dir_list)
+    @patch('os.path.isdir', return_value=True)
+    @patch('os.listdir', return_value=['2016120a', '201612121', 'abcde'])
+    def test_get_dump_dirs_bad_dirs(self, mock, mock2):
+        self.context.backup_dir = '/tmp'
+        self.assertEquals([], get_dump_dirs(self.context))
 
-    def test80_get_dump_dirs(self):
-        dump_dir_list = ['11111111']
-        expected_output = [os.path.join(os.getcwd(), 'db_dumps', d) for d in dump_dir_list]
-        self.create_backup_dirs(dump_dirs=dump_dir_list)
+    @patch('os.listdir', return_value=['11111111', '20161201']) # Second file shouldn't be picked up, pretend it's a file
+    @patch('os.path.isdir', side_effect=[True, True, False]) # First value verifies dump dir exists, second and third are for the respective date dirs above
+    def test_get_dump_dirs_file_not_dir(self, mock, mock2):
+        self.context.backup_dir = '/tmp'
+        expected_output = ['/tmp/db_dumps/11111111']
+        ddir = get_dump_dirs(self.context)
+        self.assertEqual(ddir, expected_output)
 
-        # this file should not get picked up
-        fn = os.path.join(os.getcwd(), 'db_dumps', '20121201')
-        with open(fn, 'w') as fd:
-            fd.write('hello world')
-
-        try:
-            ddir = get_dump_dirs(os.getcwd(), self.dump_dir)
-            self.assertEqual(ddir, expected_output)
-        finally:
-            self.remove_backup_dirs(dump_dirs=dump_dir_list)
-            os.remove(fn)
-
-    def test81_get_dump_dirs(self):
-        dump_dirs = None
-        self.create_backup_dirs(dump_dirs=None)
-        try:
-            self.assertEquals([], get_dump_dirs(os.getcwd(), self.dump_dir))
-        finally:
-            self.remove_backup_dirs(dump_dirs=None)
-
-    def test82_get_dump_dirs(self):
-        self.assertEquals([], get_dump_dirs('abcdef', self.dump_dir))
-
-    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20121212', '20121213', '20121214'])
-    @patch('os.listdir', return_value=['gp_cdatabase_1_1_20121212111111', 'gp_dump_20121212000000.rpt', 'gp_cdatabase_1_1_20121212000001'])
+    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20161212', '20161213', '20161214'])
+    @patch('os.listdir', return_value=['gp_cdatabase_1_1_20161212111111', 'gp_dump_20161212000000.rpt', 'gp_cdatabase_1_1_20161212000001'])
     @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value=['000000'])
-    def test83_get_latest_full_dump_timestamp(self, mock1, mock2, mock3):
+    def test_get_latest_full_dump_timestamp_default(self, mock1, mock2, mock3):
         expected_output = ['000000']
-        ts = get_latest_full_dump_timestamp('testdb', '/foo/db_dumps', self.dump_dir, self.dump_prefix)
+        ts = get_latest_full_dump_timestamp(self.context)
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=[])
-    def test84_get_latest_full_dump_timestamp(self, mock1):
+    def test_get_latest_full_dump_timestamp_no_full(self, mock1):
         with self.assertRaisesRegexp(Exception, 'No full backup found for incremental'):
-            get_latest_full_dump_timestamp('testdb', '/foo/db_dumps', self.dump_dir, self.dump_prefix)
+            get_latest_full_dump_timestamp(self.context)
 
-    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20121212', '20121213', '20121214'])
-    @patch('os.listdir', return_value=[])
-    def test85_get_latest_full_dump_timestamp(self, mock1, mock2):
-        with self.assertRaisesRegexp(Exception, 'Invalid None param to get_latest_full_dump_timestamp'):
-            get_latest_full_dump_timestamp('testdb', None, self.dump_dir, self.dump_prefix)
-
-    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20121212', '20121213', '20121214'])
-    @patch('os.listdir', return_value=['gp_cdatabase_1_1_2012121211111', 'gp_cdatabase_1_1_201212120000010', 'gp_cdatabase_1_1_2012121a111111'])
-    def test86_get_latest_full_dump_timestamp(self, mock1, mock2):
+    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20161212', '20161213', '20161214'])
+    @patch('os.listdir', return_value=['gp_cdatabase_1_1_2016121211111', 'gp_cdatabase_1_1_201612120000010', 'gp_cdatabase_1_1_2016121a111111'])
+    def test_get_latest_full_dump_timestamp_bad_timestamp(self, mock1, mock2):
         with self.assertRaisesRegexp(Exception, 'No full backup found for incremental'):
-            ts = get_latest_full_dump_timestamp('testdb', '/tmp/foo', self.dump_dir, self.dump_prefix)
+            ts = get_latest_full_dump_timestamp(self.context)
 
-    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20121212', '20121213', '20121214'])
-    @patch('os.listdir', return_value=['gp_cdatabase_1_1_20121212111111', 'gp_dump_20121212000000.rpt.bk', 'gp_cdatabase_1_1_20121212000001'])
-    def test87_get_latest_full_dump_timestamp(self, mock1, mock2):
+    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20161212', '20161213', '20161214'])
+    @patch('os.listdir', return_value=['gp_cdatabase_1_1_20161212111111', 'gp_dump_20161212000000.rpt.bk', 'gp_cdatabase_1_1_20161212000001'])
+    def test_get_latest_full_dump_timestamp_no_report_file(self, mock1, mock2):
         with self.assertRaisesRegexp(Exception, 'No full backup found for incremental'):
-            ts = get_latest_full_dump_timestamp('testdb', '/tmp/foo', self.dump_dir, self.dump_prefix)
+            ts = get_latest_full_dump_timestamp(self.context)
 
-    def test88_generate_pgstatlastoperation_filename(self):
-        master_data_dir = '/data'
-        backup_dir = None
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/gp_dump_20120731093030_last_operation'
-        output = generate_pgstatlastoperation_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_with_ddboost(self):
+        expected_output = '/data/backup/DCA-35/20160101/gp_dump_20160101010101_last_operation'
+        self.context.ddboost = True
+        self.context.dump_dir = 'backup/DCA-35'
+        output = self.context.generate_filename("last_operation")
         self.assertEquals(output, expected_output)
 
-    def test88_generate_pgstatlastoperation_filename_with_ddboost(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/backup/DCA-35/20120731/gp_dump_20120731093030_last_operation'
-        ddboost = True
-        dump_dir = 'backup/DCA-35'
-        output = generate_pgstatlastoperation_filename(master_data_dir, self.backup_dir, dump_dir, self.dump_prefix, timestamp, ddboost)
-        self.assertEquals(output, expected_output)
-
-    def test89_generate_ao_state_filename(self):
-        master_data_dir = os.environ.get('MASTER_DATA_DIRECTORY')
-        timestamp = '20120731093030'
-        expected_output = '%s/db_dumps/20120731/gp_dump_20120731093030_ao_state_file' % master_data_dir
-        output = generate_ao_state_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_with_env_mdd(self):
+        timestamp = '20160101010101'
+        expected_output = '%s/db_dumps/20160101/gp_dump_20160101010101_ao_state_file' % self.context.master_datadir
+        output = self.context.generate_filename("ao")
         self.assertEqual(output, expected_output)
 
-    def test90_generate_ao_state_filename(self):
-        master_data_dir = None
-        backup_dir = '/tmp'
-        timestamp = '20120731093030'
-        expected_output = '%s/db_dumps/20120731/gp_dump_20120731093030_ao_state_file' % backup_dir
-        output = generate_ao_state_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEqual(output, expected_output)
-
-    def test91_generate_ao_state_filename_with_ddboost(self):
-        master_data_dir = '/data'
-        backup_dir = '/tmp'
-        timestamp = '20120731093030'
-        expected_output = '/data/backup/DCA-35/20120731/gp_dump_20120731093030_ao_state_file'
-        ddboost = True
-        dump_dir = 'backup/DCA-35'
-        output = generate_ao_state_filename(master_data_dir, backup_dir, dump_dir, self.dump_prefix, timestamp, ddboost)
-        self.assertEqual(output, expected_output)
-
-    def test91_generate_co_state_filename(self):
-        master_data_dir = os.environ.get('MASTER_DATA_DIRECTORY')
-        timestamp = '20120731093030'
-        expected_output = '%s/db_dumps/20120731/gp_dump_20120731093030_co_state_file' % master_data_dir
-        output = generate_co_state_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEqual(output, expected_output)
-
-    def test92_generate_co_state_filename(self):
-        master_data_dir = None
-        backup_dir = '/tmp'
-        timestamp = '20120731093030'
-        expected_output = '%s/db_dumps/20120731/gp_dump_20120731093030_co_state_file' % backup_dir
-        output = generate_co_state_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEqual(output, expected_output)
-
-    def test93_generate_co_state_filename_with_ddboost(self):
-        master_data_dir = '/data'
-        backup_dir = '/tmp'
-        timestamp = '20120731093030'
-        expected_output = '/data/backup/DCA-35/20120731/gp_dump_20120731093030_co_state_file'
-        ddboost = True
-        dump_dir = 'backup/DCA-35'
-        output = generate_co_state_filename(master_data_dir, backup_dir, dump_dir, self.dump_prefix, timestamp, ddboost)
-        self.assertEqual(output, expected_output)
+    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20160930'])
+    @patch('gppylib.operations.backup_utils.get_latest_report_in_dir', return_value='20160930093000')
+    def test_get_latest_report_timestamp_default(self, mock1, mock2):
+        self.context.backup_dir = '/foo'
+        result = get_latest_report_timestamp(self.context)
+        self.assertEquals(result, '20160930093000')
 
     @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=[])
     @patch('gppylib.operations.backup_utils.get_latest_report_in_dir', return_value=[])
-    def test93_get_latest_report_timestamp(self, mock1, mock2):
-        bdir = '/foo'
-        result = get_latest_report_timestamp(bdir, self.dump_dir, self.dump_prefix)
+    def test_get_latest_report_timestamp_no_dirs(self, mock1, mock2):
+        self.context.backup_dir = '/foo'
+        result = get_latest_report_timestamp(self.context)
         self.assertEquals(result, None)
 
-    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20120930'])
+    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20160930'])
     @patch('gppylib.operations.backup_utils.get_latest_report_in_dir', return_value=None)
-    def test94_get_latest_report_timestamp(self, mock1, mock2):
-        bdir = '/foo'
-        result = get_latest_report_timestamp(bdir, self.dump_dir, self.dump_prefix)
+    def test_get_latest_report_timestamp_no_report_file(self, mock1, mock2):
+        self.context.backup_dir = '/foo'
+        result = get_latest_report_timestamp(self.context)
         self.assertEquals(result, None)
 
-    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20120930'])
-    @patch('gppylib.operations.backup_utils.get_latest_report_in_dir', return_value='20120930093000')
-    def test95_get_latest_report_timestamp(self, mock1, mock2):
-        bdir = '/foo'
-        result = get_latest_report_timestamp(bdir, self.dump_dir, self.dump_prefix)
-        self.assertEquals(result, '20120930093000')
-
-    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20120930', '20120929'])
-    @patch('gppylib.operations.backup_utils.get_latest_report_in_dir', side_effect=[None, '20120929093000'])
-    def test96_get_latest_report_timestamp(self, mock1, mock2):
-        bdir = '/foo'
-        result = get_latest_report_timestamp(bdir, self.dump_dir, self.dump_prefix)
-        self.assertEquals(result, '20120929093000')
+    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20160930', '20160929'])
+    @patch('gppylib.operations.backup_utils.get_latest_report_in_dir', side_effect=[None, '20160929093000'])
+    def test_get_latest_report_timestamp_multiple_dirs(self, mock1, mock2):
+        self.context.backup_dir = '/foo'
+        result = get_latest_report_timestamp(self.context)
+        self.assertEquals(result, '20160929093000')
 
     @patch('os.listdir', return_value=[])
-    def test97_get_latest_report_in_dir(self, mock1):
+    def test_get_latest_report_in_dir_no_dirs(self, mock1):
         bdir = '/foo'
-        result = get_latest_report_in_dir(bdir, self.dump_prefix)
+        result = get_latest_report_in_dir(bdir, self.context.dump_prefix)
         self.assertEquals(result, None)
 
-    @patch('os.listdir', return_value=['gp_dump_20130125140013.rpt', 'gp_dump_20140125140013.FOO'])
-    def test98_get_latest_report_in_dir(self, mock1):
+    @patch('os.listdir', return_value=['gp_dump_20130125140013.rpt', 'gp_dump_20160125140013.FOO'])
+    def test_get_latest_report_in_dir_bad_extension(self, mock1):
         bdir = '/foo'
-        result = get_latest_report_in_dir(bdir, self.dump_prefix)
+        result = get_latest_report_in_dir(bdir, self.context.dump_prefix)
         self.assertEquals(result, '20130125140013')
 
-    @patch('os.listdir', return_value=['gp_dump_20130125140013.rpt', 'gp_dump_20140125140013.rpt'])
-    def test99_get_latest_report_in_dir(self, mock1):
+    @patch('os.listdir', return_value=['gp_dump_20130125140013.rpt', 'gp_dump_20160125140013.rpt'])
+    def test_get_latest_report_in_dir_different_years(self, mock1):
         bdir = '/foo'
-        result = get_latest_report_in_dir(bdir, self.dump_prefix)
-        self.assertEquals(result, '20140125140013')
+        result = get_latest_report_in_dir(bdir, self.context.dump_prefix)
+        self.assertEquals(result, '20160125140013')
 
-    @patch('os.listdir', return_value=['gp_dump_20140125140013.rpt', 'gp_dump_20130125140013.rpt'])
-    def test100(self, mock1):
+    @patch('os.listdir', return_value=['gp_dump_20160125140013.rpt', 'gp_dump_20130125140013.rpt'])
+    def test_get_latest_report_in_dir_different_years_different_order(self, mock1):
         bdir = '/foo'
-        result = get_latest_report_in_dir(bdir, self.dump_prefix)
-        self.assertEquals(result, '20140125140013')
+        result = get_latest_report_in_dir(bdir, self.context.dump_prefix)
+        self.assertEquals(result, '20160125140013')
 
-    def test_create_temp_file_with_tables_00(self):
-        dirty_tables = ['public.t1', 'public.t2', 'pepper.t3']
+    def test_create_temp_file_with_tables_default(self):
+        dirty_tables = ['public.t1', 'public.t2', 'testschema.t3']
         dirty_file = create_temp_file_with_tables(dirty_tables)
         self.assertTrue(os.path.basename(dirty_file).startswith('table_list'))
         self.assertTrue(os.path.exists(dirty_file))
@@ -830,16 +576,7 @@ class BackupUtilsTestCase(unittest.TestCase):
         self.assertEqual(dirty_tables, content)
         os.remove(dirty_file)
 
-    def test_create_temp_file_with_tables_01(self):
-        dirty_tables = ['']
-        dirty_file = create_temp_file_with_tables(dirty_tables)
-        self.assertTrue(os.path.basename(dirty_file).startswith('table_list'))
-        self.assertTrue(os.path.exists(dirty_file))
-        content = get_lines_from_file(dirty_file)
-        self.assertEqual(dirty_tables, content)
-        os.remove(dirty_file)
-
-    def test_create_temp_file_with_tables_02(self):
+    def test_create_temp_file_with_tables_no_tables(self):
         dirty_tables = ['']
         dirty_file = create_temp_file_with_tables(dirty_tables)
         self.assertTrue(os.path.basename(dirty_file).startswith('table_list'))
@@ -848,8 +585,8 @@ class BackupUtilsTestCase(unittest.TestCase):
         self.assertEqual(dirty_tables, content)
         os.remove(dirty_file)
 
-    def test_create_temp_file_from_list_00(self):
-        dirty_tables = ['public.t1', 'public.t2', 'pepper.t3']
+    def test_create_temp_file_from_list_nonstandard_name(self):
+        dirty_tables = ['public.t1', 'public.t2', 'testschema.t3']
         dirty_file = create_temp_file_from_list(dirty_tables, 'dirty_hackup_list_')
         self.assertTrue(os.path.basename(dirty_file).startswith('dirty_hackup_list'))
         self.assertTrue(os.path.exists(dirty_file))
@@ -857,7 +594,7 @@ class BackupUtilsTestCase(unittest.TestCase):
         self.assertEqual(dirty_tables, content)
         os.remove(dirty_file)
 
-    def test_create_temp_file_from_list_01(self):
+    def test_create_temp_file_from_list_no_tables_different_name(self):
         dirty_tables = ['']
         dirty_file = create_temp_file_from_list(dirty_tables, 'dirty_hackup_list_')
         self.assertTrue(os.path.basename(dirty_file).startswith('dirty_hackup_list'))
@@ -866,69 +603,63 @@ class BackupUtilsTestCase(unittest.TestCase):
         self.assertEqual(dirty_tables, content)
         os.remove(dirty_file)
 
-    def test_create_temp_file_from_list_02(self):
-        dirty_tables = ['']
-        dirty_file = create_temp_file_from_list(dirty_tables, 'dirty_hackup_list_')
-        self.assertTrue(os.path.basename(dirty_file).startswith('dirty_hackup_list'))
-        self.assertTrue(os.path.exists(dirty_file))
-        content = get_lines_from_file(dirty_file)
-        self.assertEqual(dirty_tables, content)
-        os.remove(dirty_file)
-
-    def test_get_timestamp_from_increments_filename_00(self):
+    def test_get_timestamp_from_increments_filename_default(self):
         fname = '/data/foo/db_dumps/20130207/gp_dump_20130207133000_increments'
-        ts = get_timestamp_from_increments_filename(fname, self.dump_prefix)
+        ts = get_timestamp_from_increments_filename(fname, self.context.dump_prefix)
         self.assertEquals(ts, '20130207133000')
 
-    def test_get_timestamp_from_increments_filename_01(self):
+    def test_get_timestamp_from_increments_filename_bad_file(self):
         fname = '/data/foo/db_dumps/20130207/gpdump_20130207133000_increments'
         with self.assertRaisesRegexp(Exception, 'Invalid increments file'):
-            get_timestamp_from_increments_filename(fname, self.dump_prefix)
+            get_timestamp_from_increments_filename(fname, self.context.dump_prefix)
 
     @patch('glob.glob', return_value=[])
-    def test_get_full_timestamp_for_incremental_00(self, m1):
-        backup_dir = 'home'
-        ts = '20130207133000'
-        with self.assertRaisesRegexp(Exception, "Could not locate fullbackup associated with timestamp '20130207133000'. Either increments file or full backup is missing."):
-            get_full_timestamp_for_incremental(backup_dir, self.dump_dir, self.dump_prefix, ts)
+    def test_get_full_timestamp_for_incremental_no_backup(self, mock1):
+        self.context.backup_dir = 'home'
+        with self.assertRaisesRegexp(Exception, "Could not locate full backup associated with timestamp '20160101010101'. Either increments file or full backup is missing."):
+            get_full_timestamp_for_incremental(self.context)
 
     @patch('glob.glob', return_value=['foo'])
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=[])
-    def test_get_full_timestamp_for_incremental_01(self, m1, m2):
-        backup_dir = 'home'
-        ts = '20130207133000'
-        with self.assertRaisesRegexp(Exception, "Could not locate fullbackup associated with timestamp '20130207133000'. Either increments file or full backup is missing."):
-            get_full_timestamp_for_incremental(backup_dir, self.dump_dir, self.dump_prefix, ts)
+    def test_get_full_timestamp_for_incremental_bad_files(self, mock1, mock2):
+        self.context.backup_dir = 'home'
+        with self.assertRaisesRegexp(Exception, "Could not locate full backup associated with timestamp '20160101010101'. Either increments file or full backup is missing."):
+            get_full_timestamp_for_incremental(self.context)
 
     @patch('glob.glob', return_value=['/tmp/db_dumps/20130207/gp_dump_20130207093000_increments'])
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20130207133001', '20130207133000'])
-    def test_get_full_timestamp_for_incremental_02(self, m1, m2):
+    def test_get_full_timestamp_for_incremental_default(self, mock1, mock2):
         backup_dir = 'home'
-        ts = '20130207133000'
-        full_ts = get_full_timestamp_for_incremental(backup_dir, self.dump_dir, self.dump_prefix, ts)
+        self.context.timestamp = '20130207133000'
+        full_ts = get_full_timestamp_for_incremental(self.context)
         self.assertEquals(full_ts, '20130207093000')
 
-    def test_check_funny_chars_in_names_00(self):
+    def test_check_funny_chars_in_names_exclamation_mark(self):
         tablenames = ['hello! world', 'correct']
         with self.assertRaisesRegexp(Exception, 'Name has an invalid character'):
             check_funny_chars_in_names(tablenames)
 
-    def test_check_funny_chars_in_names_01(self):
+    def test_check_funny_chars_in_names_newline(self):
         tablenames = ['hello\nworld', 'propertablename']
         with self.assertRaisesRegexp(Exception, 'Name has an invalid character'):
             check_funny_chars_in_names(tablenames)
 
-    def test_check_funny_chars_in_names_02(self):
+    def test_check_funny_chars_in_names_default(self):
         tablenames = ['helloworld', 'propertablename']
         check_funny_chars_in_names(tablenames) #should not raise an exception
 
-    def test_expand_partition_tables_00(self):
+    def test_check_funny_chars_in_names_comma(self):
+        tablenames = ['hello, world', 'correct']
+        with self.assertRaisesRegexp(Exception, 'Name has an invalid character'):
+            check_funny_chars_in_names(tablenames)
+
+    def test_expand_partition_tables_do_nothing(self):
         self.assertEqual(expand_partition_tables('foo', None), None)
 
     @patch('gppylib.operations.backup_utils.dbconn.execSQL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[['public', 'tl1'], ['public', 'tl2']])
-    def test_expand_partition_tables_01(self, mock1, mock2, mock3):
+    def test_expand_partition_tables_default(self, mock1, mock2, mock3):
         dbname = 'foo'
         restore_tables = ['public.t1', 'public.t2']
         expected_output = ['public.tl1', 'public.tl2', 'public.t2']
@@ -938,14 +669,14 @@ class BackupUtilsTestCase(unittest.TestCase):
     @patch('gppylib.operations.backup_utils.dbconn.execSQL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[])
-    def test_expand_partition_tables_02(self, mock1, mock2, mock3):
+    def test_expand_partition_tables_no_change(self, mock1, mock2, mock3):
         dbname = 'foo'
         restore_tables = ['public.t1', 'public.t2']
         expected_output = ['public.t1', 'public.t2']
         result = expand_partition_tables(dbname, restore_tables)
         self.assertEqual(result.sort(), expected_output.sort())
 
-    def test_populate_filter_tables_00(self):
+    def test_populate_filter_tables_all_part_tables(self):
         table = 'public.t1'
         rows = [['public', 't1'], ['public', 't2'], ['public', 't3']]
         non_partition_tables = []
@@ -953,7 +684,7 @@ class BackupUtilsTestCase(unittest.TestCase):
         self.assertEqual(populate_filter_tables(table, rows, non_partition_tables, partition_leaves),
                             (([], ['public.t1', 'public.t2', 'public.t3'])))
 
-    def test_populate_filter_tables_01(self):
+    def test_populate_filter_tables_no_part_tables(self):
         table = 'public.t1'
         rows = []
         non_partition_tables = []
@@ -962,8 +693,8 @@ class BackupUtilsTestCase(unittest.TestCase):
                             ((['public.t1'], [])))
 
     @patch('gppylib.operations.backup_utils.expand_partition_tables', return_value=['public.t1_p1', 'public.t1_p2', 'public.t1_p3', 'public.t2', 'public.t3'])
-    def test_expand_partitions_and_populate_filter_file01(self, mock):
-        dbname = 'testdb'
+    def test_expand_partitions_and_populate_filter_file_part_tables(self, mock):
+        dbname = 'bkdb'
         partition_list = ['public.t1', 'public.t2', 'public.t3']
         file_prefix = 'include_dump_tables_file'
         expected_output = ['public.t2', 'public.t3', 'public.t1', 'public.t1_p1', 'public.t1_p2', 'public.t1_p3']
@@ -975,8 +706,8 @@ class BackupUtilsTestCase(unittest.TestCase):
         os.remove(result)
 
     @patch('gppylib.operations.backup_utils.expand_partition_tables', return_value=['public.t1', 'public.t2', 'public.t3'])
-    def test_expand_partitions_and_populate_filter_file02(self, mock):
-        dbname = 'testdb'
+    def test_expand_partitions_and_populate_filter_file_no_part_tables(self, mock):
+        dbname = 'bkdb'
         partition_list = ['public.t1', 'public.t2', 'public.t3']
         file_prefix = 'exclude_dump_tables_file'
         result = expand_partitions_and_populate_filter_file(dbname, partition_list, file_prefix)
@@ -987,8 +718,8 @@ class BackupUtilsTestCase(unittest.TestCase):
         os.remove(result)
 
     @patch('gppylib.operations.backup_utils.expand_partition_tables', return_value=[])
-    def test_expand_partitions_and_populate_filter_file03(self, mock):
-        dbname = 'testdb'
+    def test_expand_partitions_and_populate_filter_file_no_tables(self, mock):
+        dbname = 'bkdb'
         partition_list = ['part_table']
         file_prefix = 'exclude_dump_tables_file'
         result = expand_partitions_and_populate_filter_file(dbname, partition_list, file_prefix)
@@ -998,879 +729,414 @@ class BackupUtilsTestCase(unittest.TestCase):
         self.assertEqual(contents.sort(), partition_list.sort())
         os.remove(result)
 
-    def test_get_batch_from_list00(self):
+    def test_get_batch_from_list_default(self):
         batch = 1000
         length = 3033
         expected = [(0,1000), (1000,2000), (2000,3000), (3000,4000)]
         indices = get_batch_from_list(length, batch)
         self.assertEqual(expected, indices)
 
-    def test_get_batch_from_list01(self):
+    def test_get_batch_from_list_one_job(self):
         batch = 1000
         length = 1
         expected = [(0,1000)]
         indices = get_batch_from_list(length, batch)
         self.assertEqual(expected, indices)
 
-    def test_get_batch_from_list02(self):
+    def test_get_batch_from_list_matching_jobs(self):
         batch = 1000
         length = 1000
         expected = [(0,1000)]
         indices = get_batch_from_list(length, batch)
         self.assertEqual(expected, indices)
 
-    def test_get_batch_from_list03(self):
+    def test_get_batch_from_list_no_jobs(self):
         batch = 1000
         length = 0
         expected = []
         indices = get_batch_from_list(length, batch)
         self.assertEqual(expected, indices)
 
-    def test_get_batch_from_list04(self):
+    def test_get_batch_from_list_more_jobs(self):
         batch = 1000
         length = 2000
         expected = [(0,1000), (1000,2000)]
         indices = get_batch_from_list(length, batch)
         self.assertEqual(expected, indices)
 
-    def test_list_to_quoted_string00(self):
+    def test_list_to_quoted_string_default(self):
         input = ['public.ao_table', 'public.co_table']
         expected = "'public.ao_table', 'public.co_table'"
         output = list_to_quoted_string(input)
         self.assertEqual(expected, output)
 
-    def test_list_to_quoted_string01(self):
+    def test_list_to_quoted_string_whitespace(self):
         input = ['   public.ao_table', 'public.co_table   ']
         expected = "'   public.ao_table', 'public.co_table   '"
         output = list_to_quoted_string(input)
         self.assertEqual(expected, output)
 
-    def test_list_to_quoted_string02(self):
+    def test_list_to_quoted_string_one_table(self):
         input = ['public.ao_table']
         expected = "'public.ao_table'"
         output = list_to_quoted_string(input)
         self.assertEqual(expected, output)
 
-    def test_list_to_quoted_string03(self):
+    def test_list_to_quoted_string_no_tables(self):
         input = []
         expected = "''"
         output = list_to_quoted_string(input)
         self.assertEqual(expected, output)
 
-    def test01_generate_files_filename(self):
-        master_data_dir = '/data'
-        backup_dir = '/backup'
-        timestamp = '20120731093030'
-        expected_output = '/backup/db_dumps/20120731/gp_dump_20120731093030_regular_files'
-        output = generate_files_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_with_prefix(self):
+        self.context.dump_prefix = 'foo_'
+        expected_output = '/data/db_dumps/20160101/%sgp_dump_20160101010101.rpt' % self.context.dump_prefix
+        output = self.context.generate_filename("report")
         self.assertEquals(output, expected_output)
 
-    def test02_generate_files_filename(self):
-        master_data_dir = None
-        backup_dir = '/backup'
-        timestamp = '20120731093030'
-        expected_output = '/backup/db_dumps/20120731/gp_dump_20120731093030_regular_files'
-        output = generate_files_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+    def test_generate_filename_with_prefix_and_ddboost(self):
+        self.context.dump_prefix = 'foo_'
+        expected_output = '/data/backup/DCA-35/20160101/%sgp_dump_20160101010101.rpt' % self.context.dump_prefix
+        self.context.ddboost = True
+        self.context.dump_dir = 'backup/DCA-35'
+        output = self.context.generate_filename("report")
         self.assertEquals(output, expected_output)
 
-    def test03_generate_files_filename(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/gp_dump_20120731093030_regular_files'
-        output = generate_files_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test01_generate_pipes_filename(self):
-        master_data_dir = '/data'
-        backup_dir = '/backup'
-        timestamp = '20120731093030'
-        expected_output = '/backup/db_dumps/20120731/gp_dump_20120731093030_pipes'
-        output = generate_pipes_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test02_generate_pipes_filename(self):
-        master_data_dir = None
-        backup_dir = '/backup'
-        timestamp = '20120731093030'
-        expected_output = '/backup/db_dumps/20120731/gp_dump_20120731093030_pipes'
-        output = generate_pipes_filename(master_data_dir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test03_generate_pipes_filename(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/gp_dump_20120731093030_pipes'
-        output = generate_pipes_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test00_generate_report_filename_with_prefix(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '/data/db_dumps/20120731/%sgp_dump_20120731093030.rpt' % dump_prefix
-        output = generate_report_filename(master_data_dir, self.backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test01_generate_report_filename_with_prefix(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '/data/backup/DCA-35/20120731/%sgp_dump_20120731093030.rpt' % dump_prefix
-        ddboost = True
-        dump_dir = 'backup/DCA-35'
-        output = generate_report_filename(master_data_dir, self.backup_dir, dump_dir, dump_prefix, timestamp, ddboost)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_ao_state_filename_with_prefix(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        dump_dir = 'db_dumps'
-        dump_prefix = 'foo_'
-        expected_output = '%s/%s/20120731/%sgp_dump_20120731093030_ao_state_file' % (master_data_dir, dump_dir, dump_prefix)
-        output = generate_ao_state_filename(master_data_dir, self.backup_dir, dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_co_state_filename_with_prefix(self):
-        master_data_dir = os.environ.get('MASTER_DATA_DIRECTORY')
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '%s/db_dumps/20120731/%sgp_dump_20120731093030_co_state_file' % (master_data_dir, dump_prefix)
-        output = generate_co_state_filename(master_data_dir, self.backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEqual(output, expected_output)
-
-    def test00_generate_increments_filename_with_prefix(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '/data/db_dumps/20120731/%sgp_dump_20120731093030_increments' % dump_prefix
-        output = generate_increments_filename(master_data_dir, self.backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test01_generate_increments_filename_with_prefix(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '/data/backup/DCA-35/20120731/%sgp_dump_20120731093030_increments' % dump_prefix
-        ddboost = True
-        dump_dir = 'backup/DCA-35'
-        output = generate_increments_filename(master_data_dir, self.backup_dir, dump_dir, dump_prefix, timestamp, ddboost)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_pgstatlastoperation_filename_with_prefix(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '/data/db_dumps/20120731/%sgp_dump_20120731093030_last_operation' % dump_prefix
-        output = generate_pgstatlastoperation_filename(master_data_dir, self.backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_dirtytable_filename_with_prefix(self):
-        mdd = '/data'
-        timestamp = '20121204090000'
-        dump_prefix = 'foo_'
-        expected = '/data/db_dumps/20121204/%sgp_dump_20121204090000_dirty_list' % dump_prefix
-        result = generate_dirtytable_filename(mdd, self.backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(expected, result)
-
-    def test01_generate_dirtytable_filename_with_prefix(self):
-        mdd = '/data'
-        timestamp = '20121204090000'
-        dump_prefix = 'foo_'
-        ddboost = True
-        dump_dir = 'backup/DCA-35'
-        expected = '/data/backup/DCA-35/20121204/%sgp_dump_20121204090000_dirty_list' % dump_prefix
-        result = generate_dirtytable_filename(mdd, self.backup_dir, dump_dir, dump_prefix, timestamp, ddboost)
-        self.assertEquals(expected, result)
-
-    def test00_generate_plan_filename_with_prefix(self):
-        mdd = '/data'
-        timestamp = '20121204090000'
-        dump_prefix = 'foo_'
-        expected = '/data/db_dumps/20121204/%sgp_restore_20121204090000_plan' % dump_prefix
-        result = generate_plan_filename(mdd, self.backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(expected, result)
-
-    def test00_generate_metadata_filename_with_prefix(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '/data/db_dumps/20120731/%sgp_dump_1_1_20120731093030.gz' % dump_prefix
-        output = generate_metadata_filename(master_data_dir, self.backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_partition_list_filename_with_prefix(self):
-        master_data_dir = '/data'
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '/data/db_dumps/20120731/%sgp_dump_20120731093030_table_list' % dump_prefix
-        output = generate_partition_list_filename(master_data_dir, self.backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test01_generate_files_filename_with_prefix(self):
-        master_data_dir = '/data'
-        backup_dir = '/backup'
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '/backup/db_dumps/20120731/%sgp_dump_20120731093030_regular_files' % dump_prefix
-        output = generate_files_filename(master_data_dir, backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test01_generate_pipes_filename_with_prefix(self):
-        master_data_dir = '/data'
-        backup_dir = '/backup'
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '/backup/db_dumps/20120731/%sgp_dump_20120731093030_pipes' % dump_prefix
-        output = generate_pipes_filename(master_data_dir, backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    @patch('os.listdir', return_value=['bar_gp_dump_20140125140013.rpt', 'foo_gp_dump_20130125140013.rpt'])
-    def test00_get_latest_report_in_dir_with_prefix(self, mock1):
+    @patch('os.listdir', return_value=['bar_gp_dump_20160125140013.rpt', 'foo_gp_dump_20130125140013.rpt'])
+    def test_get_latest_report_in_dir_with_mixed_prefixes(self, mock1):
         bdir = '/foo'
-        dump_prefix = 'foo_'
-        result = get_latest_report_in_dir(bdir, dump_prefix)
+        self.context.dump_prefix = 'foo_'
+        result = get_latest_report_in_dir(bdir, self.context.dump_prefix)
         self.assertEquals(result, '20130125140013')
 
     @patch('os.listdir', return_value=['gp_dump_20130125140013.rpt'])
-    def test01_get_latest_report_in_dir_with_prefix(self, mock1):
+    def test_get_latest_report_in_dir_with_no_prefix(self, mock1):
         bdir = '/foo'
-        dump_prefix = 'foo_'
-        result = get_latest_report_in_dir(bdir, dump_prefix)
+        self.context.dump_prefix = 'foo_'
+        result = get_latest_report_in_dir(bdir, self.context.dump_prefix)
         self.assertEquals(result, None)
-
-    @patch('glob.glob', return_value=[])
-    def test_get_full_timestamp_for_incremental_with_prefix_00(self, m1):
-        backup_dir = 'home'
-        ts = '20130207133000'
-        dump_prefix = 'foo_'
-        with self.assertRaisesRegexp(Exception, "Could not locate fullbackup associated with timestamp '20130207133000'. Either increments file or full backup is missing."):
-            get_full_timestamp_for_incremental(backup_dir, self.dump_dir, self.dump_prefix, ts)
-
-    @patch('glob.glob', return_value=['foo'])
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=[])
-    def test_get_full_timestamp_for_incremental_with_prefix_01(self, m1, m2):
-        backup_dir = 'home'
-        ts = '20130207133000'
-        dump_prefix = 'foo_'
-        with self.assertRaisesRegexp(Exception, "Could not locate fullbackup associated with timestamp '20130207133000'. Either increments file or full backup is missing."):
-            get_full_timestamp_for_incremental(backup_dir, self.dump_dir, self.dump_prefix, ts)
 
     @patch('glob.glob', return_value=['/tmp/db_dumps/20130207/foo_gp_dump_20130207093000_increments'])
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20130207133001', '20130207133000'])
-    def test_get_full_timestamp_for_incremental_with_prefix_02(self, m1, m2):
-        backup_dir = 'home'
-        ts = '20130207133000'
-        dump_prefix = 'foo_'
-        full_ts = get_full_timestamp_for_incremental(backup_dir, self.dump_dir, dump_prefix, ts)
+    def test_get_full_timestamp_for_incremental_with_prefix_default(self, mock1, mock2):
+        self.context.backup_dir = 'home'
+        self.context.dump_prefix = 'foo_'
+        self.context.timestamp = '20130207133000'
+        full_ts = get_full_timestamp_for_incremental(self.context)
         self.assertEquals(full_ts, '20130207093000')
 
-    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20121212', '20121213', '20121214'])
-    @patch('os.listdir', return_value=['foo_gp_cdatabase_1_1_20121212111111', 'foo_gp_dump_20121212000000.rpt', 'foo_gp_cdatabase_1_1_20121212000001'])
+    @patch('glob.glob', return_value=[])
+    def test_get_full_timestamp_for_incremental_with_prefix_no_files(self, mock1):
+        self.context.backup_dir = 'home'
+        self.context.dump_prefix = 'foo_'
+        with self.assertRaisesRegexp(Exception, "Could not locate full backup associated with timestamp '20160101010101'. Either increments file or full backup is missing."):
+            get_full_timestamp_for_incremental(self.context)
+
+    @patch('glob.glob', return_value=['foo'])
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=[])
+    def test_get_full_timestamp_for_incremental_with_prefix_bad_files(self, mock1, mock2):
+        self.context.backup_dir = 'home'
+        self.context.dump_prefix = 'foo_'
+        with self.assertRaisesRegexp(Exception, "Could not locate full backup associated with timestamp '20160101010101'. Either increments file or full backup is missing."):
+            get_full_timestamp_for_incremental(self.context)
+
+    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20161212', '20161213', '20161214'])
+    @patch('os.listdir', return_value=['foo_gp_cdatabase_1_1_20161212111111', 'foo_gp_dump_20161212000000.rpt', 'foo_gp_cdatabase_1_1_20161212000001'])
     @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value=['000000'])
-    def test00_get_latest_full_dump_timestamp_with_prefix(self, mock1, mock2, mock3):
+    def test_get_latest_full_dump_timestamp_with_prefix_multiple_files(self, mock1, mock2, mock3):
         expected_output = ['000000']
-        dump_prefix = 'foo_'
-        ts = get_latest_full_dump_timestamp('testdb', '/foo/db_dumps', self.dump_dir, dump_prefix)
+        self.context.dump_prefix = 'foo_'
+        ts = get_latest_full_dump_timestamp(self.context)
         self.assertEqual(ts, expected_output)
 
     @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=[])
-    def test01_get_latest_full_dump_timestamp_with_prefix(self, mock1):
-        dump_prefix = 'foo_'
+    def test_get_latest_full_dump_timestamp_with_prefix_no_backup(self, mock1):
+        self.context.dump_prefix = 'foo_'
         with self.assertRaisesRegexp(Exception, 'No full backup found for incremental'):
-            get_latest_full_dump_timestamp('testdb', '/foo/db_dumps', self.dump_dir, dump_prefix)
+            get_latest_full_dump_timestamp(self.context)
 
-    @patch('gppylib.operations.backup_utils.get_dump_dirs', return_value=['20121212', '20121213', '20121214'])
-    @patch('os.listdir', return_value=[])
-    def test02_get_latest_full_dump_timestamp_with_prefix(self, mock1, mock2):
-        dump_prefix = 'foo_'
-        with self.assertRaisesRegexp(Exception, 'Invalid None param to get_latest_full_dump_timestamp'):
-            get_latest_full_dump_timestamp('testdb', None, self.dump_dir, dump_prefix)
-
-    def test00_convert_reportfilename_to_cdatabasefilename_with_prefix(self):
-        report_file = '/tmp/foo/foo/bar_gp_dump_20130104133924.rpt'
-        expected_output = '/tmp/foo/foo/bar_gp_cdatabase_1_1_20130104133924'
-        dump_prefix = 'bar_'
-        cdatabase_file = convert_reportfilename_to_cdatabasefilename(report_file, dump_prefix)
+    def test_convert_report_filename_to_cdatabase_filename_with_prefix_default(self):
+        report_file = '/data/db_dumps/20160101/bar_gp_dump_20160101010101.rpt'
+        expected_output = '/data/db_dumps/20160101/bar_gp_cdatabase_1_1_20160101010101'
+        self.context.dump_prefix = 'bar_'
+        cdatabase_file = convert_report_filename_to_cdatabase_filename(self.context, report_file)
         self.assertEquals(expected_output, cdatabase_file)
 
-    @patch('gppylib.operations.backup_utils.get_ddboost_backup_directory', return_value='backup/DCA-35')
-    def test01_convert_reportfilename_to_cdatabasefilename_with_prefix(self, mock1):
-        report_file = '/tmp/foo/foo/bar_gp_dump_20130104133924.rpt'
-        expected_output = 'backup/DCA-35/20130104/bar_gp_cdatabase_1_1_20130104133924'
-        dump_prefix = 'bar_'
-        ddboost = True
-        cdatabase_file = convert_reportfilename_to_cdatabasefilename(report_file, dump_prefix, ddboost)
-        self.assertEquals(expected_output, cdatabase_file)
-
-    def test00_generate_master_config_filename(self):
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        expected_output = '%sgp_master_config_files_%s.tar' % (dump_prefix, timestamp)
-        output = generate_master_config_filename(dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_segment_config_filename(self):
-        timestamp = '20120731093030'
-        dump_prefix = 'foo_'
-        segId = 2
-        expected_output = '%sgp_segment_config_files_0_%d_%s.tar' % (dump_prefix, segId, timestamp)
-        output = generate_segment_config_filename(dump_prefix, segId, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_global_prefix(self):
-        dump_prefix = 'foo_'
-        expected_output = '%sgp_global_1_1_' % (dump_prefix)
-        output = generate_global_prefix(dump_prefix)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_master_dbdump_prefix(self):
-        dump_prefix = 'foo_'
-        expected_output = '%sgp_dump_1_1_' % (dump_prefix)
-        output = generate_master_dbdump_prefix(dump_prefix)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_master_status_prefix(self):
-        dump_prefix = 'foo_'
-        expected_output = '%sgp_dump_status_1_1_' % (dump_prefix)
-        output = generate_master_status_prefix(dump_prefix)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_seg_status_prefix(self):
-        dump_prefix = 'foo_'
-        expected_output = '%sgp_dump_status_0_' % (dump_prefix)
-        output = generate_seg_status_prefix(dump_prefix)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_seg_dbdump_prefix(self):
-        dump_prefix = 'foo_'
-        expected_output = '%sgp_dump_0_' % (dump_prefix)
-        output = generate_seg_dbdump_prefix(dump_prefix)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_dbdump_prefix(self):
-        dump_prefix = 'foo_'
-        expected_output = '%sgp_dump_' % (dump_prefix)
-        output = generate_dbdump_prefix(dump_prefix)
-        self.assertEquals(output, expected_output)
-
-    def test00_generate_createdb_filename(self):
-        dump_prefix = 'foo_'
-        master_datadir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/%sgp_cdatabase_1_1_%s' % (dump_prefix, timestamp)
-        output = generate_createdb_filename(master_datadir, None, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test01_generate_createdb_filename(self):
-        master_datadir = '/data'
-        timestamp = '20120731093030'
-        ddboost = True
-        dump_dir = 'backup/DCA-35'
-        dump_prefix = 'foo_'
-        expected_output = '%s/%s/20120731/%sgp_cdatabase_1_1_%s' % (master_datadir, dump_dir, dump_prefix, timestamp)
-        output = generate_createdb_filename(master_datadir, self.backup_dir, dump_dir, dump_prefix, timestamp, ddboost)
-        self.assertEquals(output, expected_output)
-
-    def test_generate_filter_filename(self):
-        dump_prefix='foo_'
-        master_datadir = '/data'
-        timestamp = '20120731093030'
-        expected_output = '/data/db_dumps/20120731/%sgp_dump_%s_filter' % (dump_prefix, timestamp)
-        output = generate_filter_filename(master_datadir, self.backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
-
-    def test_generate_filter_filename_with_backupdir(self):
-        dump_prefix='foo_'
-        master_datadir = '/data'
-        backup_dir = '/bkup'
-        timestamp = '20120731093030'
-        expected_output = '/bkup/db_dumps/20120731/%sgp_dump_%s_filter' % (dump_prefix, timestamp)
-        output = generate_filter_filename(master_datadir, backup_dir, self.dump_dir, dump_prefix, timestamp)
-        self.assertEquals(output, expected_output)
+    @patch('gppylib.operations.backup_utils.Command.run')
+    def test_backup_file_with_nbu_default(self, mock1):
+        backup_file_with_nbu(self.context, path=self.netbackup_filepath)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    def test00_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath)
-
-    @patch('gppylib.operations.backup_utils.Command.run')
-    def test01_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = 100
-        netbackup_keyword = None
+    def test_backup_file_with_nbu_with_segment(self, mock1):
         segment_hostname = "sdw"
 
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath, segment_hostname)
+        backup_file_with_nbu(self.context, path=self.netbackup_filepath, hostname=segment_hostname)
 
     @patch('gppylib.operations.backup_utils.Command.run', side_effect=Exception('Error backing up file to NetBackup'))
-    def test02_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
+    def test_backup_file_with_nbu_with_Error(self, mock1):
         with self.assertRaisesRegexp(Exception, 'Error backing up file to NetBackup'):
-            backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath)
+            backup_file_with_nbu(self.context, path=self.netbackup_filepath)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    def test03_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = None
-        segment_hostname = "sdw"
-        netbackup_keyword = None
+    def test_backup_file_with_nbu_no_block_size(self, mock1):
+        self.context.netbackup_block_size = None
 
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath, segment_hostname)
-
-    @patch('gppylib.operations.backup_utils.Command.run')
-    def test04_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath)
+        backup_file_with_nbu(self.context, path=self.netbackup_filepath)
 
     @patch('gppylib.operations.backup_utils.Command.run', side_effect=Exception('Error backing up file to NetBackup'))
-    def test05_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = None
-        netbackup_keyword = None
+    def test_backup_file_with_nbu_no_block_size_with_error(self, mock1):
+        self.context.netbackup_block_size = None
 
         with self.assertRaisesRegexp(Exception, 'Error backing up file to NetBackup'):
-            backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath)
+            backup_file_with_nbu(self.context, path=self.netbackup_filepath)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    def test06_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = 100
+    def test_backup_file_with_nbu_with_keyword(self, mock1):
         netbackup_keyword = "hello"
 
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath)
+        backup_file_with_nbu(self.context, path=self.netbackup_filepath)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    def test07_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = 100
+    def test_backup_file_with_nbu_with_keyword_and_segment(self, mock1):
         netbackup_keyword = "hello"
         segment_hostname = "sdw"
 
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath, segment_hostname)
+        backup_file_with_nbu(self.context, path=self.netbackup_filepath, hostname=segment_hostname)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    def test08_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = None
+    def test_backup_file_with_nbu_no_block_size_with_keyword_and_segment(self, mock1):
+        self.context.netbackup_block_size = None
         segment_hostname = "sdw"
         netbackup_keyword = "hello"
 
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath, segment_hostname)
+        backup_file_with_nbu(self.context, path=self.netbackup_filepath, hostname=segment_hostname)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    def test09_backup_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = None
+    def test_backup_file_with_nbu_with_keyword_and_segment(self, mock1):
+        self.context.netbackup_block_size = None
         netbackup_keyword = "hello"
 
-        backup_file_with_nbu(netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, netbackup_filepath)
+        backup_file_with_nbu(self.context, path=self.netbackup_filepath)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    def test00_restore_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = None
-
-        restore_file_with_nbu(netbackup_service_host, netbackup_block_size, netbackup_filepath)
-
-    @patch('gppylib.operations.backup_utils.Command.run')
-    def test01_restore_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_filepath = "/tmp/db_dumps/foo"
+    def test_restore_file_with_nbu_no_block_size_with_segment(self, mock1):
         segment_hostname = "sdw"
-        netbackup_block_size = None
+        self.context.netbackup_block_size = None
 
-        restore_file_with_nbu(netbackup_service_host, netbackup_block_size, netbackup_filepath, segment_hostname)
+        backup_file_with_nbu(self.context, path=self.netbackup_filepath, hostname=segment_hostname)
 
     @patch('gppylib.operations.backup_utils.Command.run', side_effect=Exception('Error backing up file to NetBackup'))
-    def test02_restore_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_filepath = "/tmp/db_dumps/foo"
+    def test_restore_file_with_nbu_no_block_size_with_segment_and_error(self, mock1):
         segment_hostname = "sdw"
-        netbackup_block_size = None
+        self.context.netbackup_block_size = None
 
         with self.assertRaisesRegexp(Exception, 'Error backing up file to NetBackup'):
-            restore_file_with_nbu(netbackup_service_host, netbackup_block_size, netbackup_filepath, segment_hostname)
+            restore_file_with_nbu(self.context, path=self.netbackup_filepath, hostname=segment_hostname)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    def test03_restore_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_filepath = "/tmp/db_dumps/foo"
-        netbackup_block_size = 1024
+    def test_restore_file_with_nbu_big_block_size(self, mock1):
+        self.context.netbackup_block_size = 1024
 
-        restore_file_with_nbu(netbackup_service_host, netbackup_block_size, netbackup_filepath)
+        restore_file_with_nbu(self.context, path=self.netbackup_filepath)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    def test04_restore_file_with_nbu(self, mock1):
-        netbackup_service_host = "mdw"
-        netbackup_filepath = "/tmp/db_dumps/foo"
+    def test_restore_file_with_nbu_with_segment_and_big_block_size(self, mock1):
         segment_hostname = "sdw"
-        netbackup_block_size = 2048
-
-        restore_file_with_nbu(netbackup_service_host, netbackup_block_size, netbackup_filepath, segment_hostname)
-
-    def test00_generate_global_filename(self):
-        master_datadir = "/data"
-        dump_dir = "db_dumps"
-        dump_date = "20140101"
-        timestamp = "20140101000000"
-        expected_output = "/data/db_dumps/20140101/gp_global_1_1_20140101000000"
-
-        result = generate_global_filename(master_datadir, self.backup_dir, dump_dir, self.dump_prefix, dump_date, timestamp)
-        self.assertEquals(result, expected_output)
-
-    def test01_generate_global_filename(self):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        dump_dir = "db_dumps"
-        dump_date = "20140101"
-        timestamp = "20140101000000"
-        expected_output = "/datadomain/db_dumps/20140101/gp_global_1_1_20140101000000"
-
-        result = generate_global_filename(master_datadir, backup_dir, dump_dir, self.dump_prefix, dump_date, timestamp)
-        self.assertEquals(result, expected_output)
-
-    def test02_generate_global_filename(self):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        dump_dir = "db_dumps"
-        dump_date = "20140101"
-        timestamp = "20140101000000"
-        expected_output = "/datadomain/db_dumps/20140101/gp_global_1_1_20140101000000"
-
-        result = generate_global_filename(master_datadir, backup_dir, dump_dir, self.dump_prefix, dump_date, timestamp)
-        self.assertEquals(result, expected_output)
-
-    def test00_generate_cdatabase_filename(self):
-        master_datadir = "/data"
-        dump_dir = "db_dumps"
-        dump_prefix = ""
-        timestamp = "20140101000000"
-        expected_output = "/data/db_dumps/20140101/gp_cdatabase_1_1_20140101000000"
-
-        result = generate_cdatabase_filename(master_datadir, self.backup_dir, dump_dir, dump_prefix, timestamp)
-        self.assertEquals(result, expected_output)
-
-    def test01_generate_cdatabase_filename(self):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        timestamp = "20140101000000"
-        expected_output = "/datadomain/db_dumps/20140101/gp_cdatabase_1_1_20140101000000"
-
-        result = generate_cdatabase_filename(master_datadir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(result, expected_output)
-
-    def test02_generate_cdatabase_filename(self):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        timestamp = "20140101000000"
-        expected_output = "/datadomain/db_dumps/20140101/gp_cdatabase_1_1_20140101000000"
-
-        result = generate_cdatabase_filename(master_datadir, backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-        self.assertEquals(result, expected_output)
-
-    def test03_generate_cdatabase_filename(self):
-        master_datadir = None
-        timestamp = "20140101000000"
-
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory with existing parameters'):
-            generate_cdatabase_filename(master_datadir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test04_generate_cdatabase_filename(self):
-        master_data_dir = '/data'
-        timestamp = None
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory without timestamp'):
-            generate_cdatabase_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test05_generate_cdatabase_filename(self):
-        master_data_dir = '/data'
-        timestamp = 'xx120731093030'
-        with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_cdatabase_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
-
-    def test06_generate_cdatabase_filename(self):
-        master_data_dir = '/data'
-        timestamp = '2012'
-        with self.assertRaisesRegexp(Exception, 'Invalid timestamp'):
-            generate_cdatabase_filename(master_data_dir, self.backup_dir, self.dump_dir, self.dump_prefix, timestamp)
+        self.context.netbackup_block_size = 2048
+        
+        restore_file_with_nbu(self.context, path=self.netbackup_filepath, hostname=segment_hostname)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "/data/gp_dump_1_1_20141201000000", "", True, False))
-    def test00_check_file_dumped_with_nbu(self, mock1, mock2):
-        netbackup_service_host = "mdw"
-        netbackup_filepath = "/data/gp_dump_1_1_20141201000000"
-
-        self.assertTrue(check_file_dumped_with_nbu(netbackup_service_host, netbackup_filepath))
+    @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "/tmp/db_dumps/foo", "", True, False))
+    def test_check_file_dumped_with_nbu_default(self, mock1, mock2):
+        self.assertTrue(check_file_dumped_with_nbu(self.context, path=self.netbackup_filepath))
 
     @patch('gppylib.operations.backup_utils.Command.run')
     @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "", "", True, False))
-    def test01_check_file_dumped_with_nbu(self, mock1, mock2):
-        netbackup_service_host = "mdw"
-        netbackup_filepath = "/data/gp_dump_1_1_20141201000000"
-
-        self.assertFalse(check_file_dumped_with_nbu(netbackup_service_host, netbackup_filepath))
+    def test_check_file_dumped_with_nbu_no_return(self, mock1, mock2):
+        self.assertFalse(check_file_dumped_with_nbu(self.context, path=self.netbackup_filepath))
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "/data/gp_dump_1_1_20141201000000", "", True, False))
-    def test02_check_file_dumped_with_nbu(self, mock1, mock2):
-        netbackup_service_host = "mdw"
-        netbackup_filepath = "/data/gp_dump_1_1_20141201000000"
+    @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "/tmp/db_dumps/foo", "", True, False))
+    def test_check_file_dumped_with_nbu_with_segment(self, mock1, mock2):
         hostname = "sdw"
 
-        self.assertTrue(check_file_dumped_with_nbu(netbackup_service_host, netbackup_filepath, hostname))
+        self.assertTrue(check_file_dumped_with_nbu(self.context, path=self.netbackup_filepath, hostname=hostname))
 
     @patch('gppylib.operations.backup_utils.Command.run')
     @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "", "", True, False))
-    def test03_check_file_dumped_with_nbu(self, mock1, mock2):
-        netbackup_service_host = "mdw"
-        netbackup_filepath = "/data/gp_dump_1_1_20141201000000"
+    def test_check_file_dumped_with_nbu_with_segment_and_no_return(self, mock1, mock2):
         hostname = "sdw"
 
-        self.assertFalse(check_file_dumped_with_nbu(netbackup_service_host, netbackup_filepath, hostname))
+        self.assertFalse(check_file_dumped_with_nbu(self.context, path=self.netbackup_filepath, hostname=hostname))
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "Data Domain Hostname:qadd01\nData Domain Boost Username:metro\n \
-            Default Backup Directory:/backup/DCA-35\nData Domain default log level:WARNING", "", True, False))
-    def test00_get_ddboost_backup_directory(self, mock1, mock2):
-        expected_output = '/backup/DCA-35'
-        result = get_ddboost_backup_directory()
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20160701000000_increments\n", "", True, False))
+    @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20160701000000', '20160715000000', '20160804000000'])
+    def test_get_full_timestamp_for_incremental_with_nbu_default(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        self.context.timestamp = '20160804000000'
+        expected_output = '20160701000000'
+
+        result = get_full_timestamp_for_incremental_with_nbu(self.context)
         self.assertEquals(result, expected_output)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "Data Domain Hostname:qadd01\nData Domain Boost Username:metro\n \
-            Deffult Backup Directory:/backup/DCA-35\nData Domain default log level:WARNING", "", True, False))
-    def test01_get_ddboost_backup_directory(self, mock1, mock2):
-        with self.assertRaisesRegexp(Exception, 'from command gpddboost --show-config not in expected format'):
-            get_ddboost_backup_directory()
-
-    @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "Data Domain Hostname:qadd01\nData Domain Boost Username:metro\n \
-            Default Backup Directory:\nData Domain default log level:WARNING", "", True, False))
-    def test02_get_ddboost_backup_directory(self, mock1, mock2):
-        with self.assertRaisesRegexp(Exception, 'DDBOOST default backup directory is not configured. Or the format of the line has changed'):
-            get_ddboost_backup_directory()
-
-    @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20140701000000_increments\n", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20160701000000_increments\n", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20140701000000', '20140715000000', '20140804000000'])
-    def test00_get_full_timestamp_for_incremental_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        incremental_timestamp = '20140804000000'
-        expected_output = '20140701000000'
-
-        result = get_full_timestamp_for_incremental_with_nbu(self.dump_prefix, incremental_timestamp, netbackup_service_host, netbackup_block_size)
-        self.assertEquals(result, expected_output)
-
-    @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20140701000000_increments\n", "", True, False))
-    @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20140701000000', '20140715000000'])
-    def test01_get_full_timestamp_for_incremental_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        incremental_timestamp = '20140804000000'
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20160701000000', '20160715000000'])
+    def test_get_full_timestamp_for_incremental_with_nbu_no_full_timestamp(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        self.context.timestamp = '20160804000000'
         expected_output = None
 
-        result = get_full_timestamp_for_incremental_with_nbu(self.dump_prefix, incremental_timestamp, netbackup_service_host, netbackup_block_size)
+        result = get_full_timestamp_for_incremental_with_nbu(self.context)
         self.assertEquals(result, expected_output)
 
     @patch('gppylib.operations.backup_utils.Command.run')
     @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
     @patch('gppylib.operations.backup_utils.get_lines_from_file')
-    def test02_get_full_timestamp_for_incremental_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        incremental_timestamp = '20140804000000'
+    def test_get_full_timestamp_for_incremental_with_nbu_empty_file(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        self.context.timestamp = '20160804000000'
         expected_output = None
 
-        result = get_full_timestamp_for_incremental_with_nbu(self.dump_prefix, incremental_timestamp, netbackup_service_host, netbackup_block_size)
+        result = get_full_timestamp_for_incremental_with_nbu(self.context)
         self.assertEquals(result, expected_output)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20140701000000_increments\n/tmp/gp_dump_20140801000000_increments\n", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20160701000000_increments\n/tmp/gp_dump_20160801000000_increments\n", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20140701000000', '20140715000000'])
-    def test03_get_full_timestamp_for_incremental_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        incremental_timestamp = '20140804000000'
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20160701000000', '20160715000000'])
+    def test_get_full_timestamp_for_incremental_with_nbu_later_timestamp(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        self.context.timestamp = '20160804000000'
         expected_output = None
 
-        result = get_full_timestamp_for_incremental_with_nbu(self.dump_prefix, incremental_timestamp, netbackup_service_host, netbackup_block_size)
+        result = get_full_timestamp_for_incremental_with_nbu(self.context)
         self.assertEquals(result, expected_output)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20140701000000_increments\n/tmp/gp_dump_20140801000000_increments\n", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20160701000000_increments\n/tmp/gp_dump_20160801000000_increments\n", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20140710000000', '20140720000000', '20140804000000'])
-    def test04_get_full_timestamp_for_incremental_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        incremental_timestamp = '20140804000000'
-        expected_output = '20140701000000'
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20160710000000', '20160720000000', '20160804000000'])
+    def test_get_full_timestamp_for_incremental_with_nbu_multiple_increments(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        self.context.timestamp = '20160804000000'
+        expected_output = '20160701000000'
 
-        result = get_full_timestamp_for_incremental_with_nbu(self.dump_prefix, incremental_timestamp, netbackup_service_host, netbackup_block_size)
+        result = get_full_timestamp_for_incremental_with_nbu(self.context)
         self.assertEquals(result, expected_output)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/foo_gp_dump_20140701000000_increments\n/tmp/foo_gp_dump_20140801000000_increments\n", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/foo_gp_dump_20160701000000_increments\n/tmp/foo_gp_dump_20160801000000_increments\n", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20140710000000', '20140720000000', '20140804000000'])
-    def test05_get_full_timestamp_for_incremental_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        incremental_timestamp = '20140804000000'
-        dump_prefix = 'foo'
-        expected_output = '20140701000000'
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20160710000000', '20160720000000', '20160804000000'])
+    def test_get_full_timestamp_for_incremental_with_nbu_with_prefix(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        self.context.timestamp = '20160804000000'
+        self.context.dump_prefix = 'foo'
+        expected_output = '20160701000000'
 
-        result = get_full_timestamp_for_incremental_with_nbu(dump_prefix, incremental_timestamp, netbackup_service_host, netbackup_block_size)
+        result = get_full_timestamp_for_incremental_with_nbu(self.context)
         self.assertEquals(result, expected_output)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/foo_gp_dump_20140701000000_increments\n/tmp/foo_gp_dump_20140801000000_increments\n", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/foo_gp_dump_20160701000000_increments\n/tmp/foo_gp_dump_20160801000000_increments\n", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20140710000000', '20140720000000'])
-    def test06_get_full_timestamp_for_incremental_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        incremental_timestamp = '20140804000000'
-        dump_prefix = 'foo'
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20160710000000', '20160720000000'])
+    def test_get_full_timestamp_for_incremental_with_nbu_no_matching_increment(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        self.context.timestamp = '20160804000000'
+        self.context.dump_prefix = 'foo'
         expected_output = None
 
-        result = get_full_timestamp_for_incremental_with_nbu(self.dump_prefix, incremental_timestamp, netbackup_service_host, netbackup_block_size)
+        result = get_full_timestamp_for_incremental_with_nbu(self.context)
         self.assertEquals(result, expected_output)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/data/gp_dump_20140701000000.rpt\n", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/data/gp_dump_20160701000000.rpt\n", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
-    @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value='20140701000000')
-    def test00_get_latest_full_ts_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        dbname = "testdb"
-        backup_dir = "/data"
-        expected_output = '20140701000000'
+    @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value='20160701000000')
+    def test_get_latest_full_ts_with_nbu_default(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        expected_output = '20160701000000'
 
-        result = get_latest_full_ts_with_nbu(dbname, backup_dir, self.dump_prefix, netbackup_service_host, netbackup_block_size)
+        result = get_latest_full_ts_with_nbu(self.context)
         self.assertEquals(result, expected_output)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/data/gp_dump_20140701000000.rpt\n", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/data/gp_dump_20160701000000.rpt\n", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
     @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value=None)
-    def test01_get_latest_full_ts_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        dbname = "testdb"
-        backup_dir = "/data"
+    def test_get_latest_full_ts_with_nbu_no_full(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
 
         with self.assertRaisesRegexp(Exception, 'No full backup found for given incremental on the specified NetBackup server'):
-            get_latest_full_ts_with_nbu(dbname, backup_dir, self.dump_prefix, netbackup_service_host, netbackup_block_size)
+            get_latest_full_ts_with_nbu(self.context)
 
     @patch('gppylib.operations.backup_utils.Command.run')
     @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
     @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value=None)
-    def test02_get_latest_full_ts_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        dbname = "testdb"
-        backup_dir = "/data"
+    def test_get_latest_full_ts_with_nbu_no_report_file(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
 
         with self.assertRaisesRegexp(Exception, 'No full backup found for given incremental on the specified NetBackup server'):
-            get_latest_full_ts_with_nbu(dbname, backup_dir, self.dump_prefix, netbackup_service_host, netbackup_block_size)
+            get_latest_full_ts_with_nbu(self.context)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20140701000000.rpt\n/tmp/gp_dump_20140720000000.rpt", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20160701000000.rpt\n/tmp/gp_dump_20160720000000.rpt", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
     @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value=None)
-    def test03_get_latest_full_ts_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        dbname = "testdb"
-        backup_dir = "/data"
+    def test_get_latest_full_ts_with_nbu_empty_report_file(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
 
         with self.assertRaisesRegexp(Exception, 'No full backup found for given incremental on the specified NetBackup server'):
-            get_latest_full_ts_with_nbu(dbname, backup_dir, self.dump_prefix, netbackup_service_host, netbackup_block_size)
+            get_latest_full_ts_with_nbu(self.context)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20140701000000.rpt\n/tmp/gp_dump_20140720000000.rpt", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20160701000000.rpt\n/tmp/gp_dump_20160720000000.rpt", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
-    @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value='20140701000000')
-    def test04_get_latest_full_ts_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        dbname = "testdb"
-        backup_dir = "/tmp"
-        expected_output = '20140701000000'
+    @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value='20160701000000')
+    def test_get_latest_full_ts_with_nbu_default(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        expected_output = '20160701000000'
 
-        result = get_latest_full_ts_with_nbu(dbname, backup_dir, self.dump_prefix, netbackup_service_host, netbackup_block_size)
+        result = get_latest_full_ts_with_nbu(self.context)
         self.assertEquals(result, expected_output)
 
     @patch('gppylib.operations.backup_utils.Command.run')
-    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20140701000000.rpt\n", "", True, False))
+    @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "/tmp/gp_dump_20160701000000.rpt\n", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
     @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value=None)
-    def test05_get_latest_full_ts_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        dump_prefix = 'foo'
-        dbname = "testdb"
-        backup_dir = "/tmp"
+    def test_get_latest_full_ts_with_nbu_with_prefix(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        self.context.dump_prefix = 'foo'
         expected_output = None
 
         with self.assertRaisesRegexp(Exception, 'No full backup found for given incremental on the specified NetBackup server'):
-            get_latest_full_ts_with_nbu(dbname, backup_dir, self.dump_prefix, netbackup_service_host, netbackup_block_size)
+            get_latest_full_ts_with_nbu(self.context)
 
     @patch('gppylib.operations.backup_utils.Command.run')
     @patch('gppylib.operations.backup_utils.Command.get_results', return_value=CommandResult(0, "No object matched the specified predicate\n", "", True, False))
     @patch('gppylib.operations.backup_utils.restore_file_with_nbu')
     @patch('gppylib.operations.backup_utils.get_full_ts_from_report_file', return_value=None)
-    def test06_get_latest_full_ts_with_nbu(self, mock1, mock2, mock3, mock4):
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        dbname = "testdb"
-        backup_dir = "/tmp"
+    def test_get_latest_full_ts_with_nbu_no_object(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_block_size = 1024
+        expected_output = None
 
-        with self.assertRaisesRegexp(Exception, 'No full backup found for given incremental on the specified NetBackup server'):
-            get_latest_full_ts_with_nbu(dbname, backup_dir, self.dump_prefix, netbackup_service_host, netbackup_block_size)
+        output = get_latest_full_ts_with_nbu(self.context)
+        self.assertEquals(output, expected_output)
+
+    # Yes, this is hackish, but mocking os.environ.get doesn't work.
+    def test_init_context_with_no_mdd(self):
+        old_mdd = os.environ.get('MASTER_DATA_DIRECTORY')
+        try:
+            os.environ['MASTER_DATA_DIRECTORY'] = ""
+            with self.assertRaisesRegexp(Exception, 'Environment Variable MASTER_DATA_DIRECTORY not set!'):
+                context = Context()
+        finally:
+            os.environ['MASTER_DATA_DIRECTORY'] = old_mdd

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright (c) Greenplum Inc 2012. All Rights Reserved.
 #
@@ -8,353 +7,184 @@ import shutil
 import time
 import unittest2 as unittest
 from datetime import datetime
-from gppylib.commands.base import CommandResult
-from gppylib.operations.backup_utils import write_lines_to_file
-from gppylib.operations.dump import DumpDatabase, DumpGlobal, compare_dict, create_partition_dict, \
-                                    get_dirty_heap_tables, get_filename_from_filetype,\
-                                    get_partition_list, get_partition_state, get_last_dump_timestamp, get_lines_from_file,\
-                                    get_last_state, get_last_operation_data, get_dirty_partition_tables,\
-                                    write_dirty_file, write_partition_list_file, write_dirty_file_to_temp, write_state_file,\
-                                    get_pgstatlastoperations_dict, get_tables_with_dirty_metadata, compare_metadata,\
-                                    CreateIncrementsFile, PostDumpDatabase, get_dirty_tables, validate_current_timestamp, MailEvent,\
-                                    validate_modcount, generate_dump_timestamp, get_filter_file, filter_dirty_tables, get_backup_dir, \
-                                    update_filter_file, backup_state_files_with_nbu, backup_cdatabase_file_with_nbu, backup_report_file_with_nbu, \
-                                    backup_global_file_with_nbu, backup_config_files_with_nbu, backup_report_file_with_ddboost, \
-                                    backup_increments_file_with_ddboost, copy_file_to_dd, backup_dirty_file_with_nbu, backup_increments_file_with_nbu, \
-                                    backup_partition_list_file_with_nbu, get_include_schema_list_from_exclude_schema, backup_schema_file_with_ddboost, \
-                                    update_filter_file_with_dirty_list, TIMESTAMP, TIMESTAMP_KEY, DUMP_DATE, DeleteCurrentDump, DeleteOldestDumps
-from mock import patch, MagicMock, Mock
+from gppylib.commands.base import Command, CommandResult
+from gppylib.operations.backup_utils import *
+from gppylib.operations.dump import *
+from mock import patch, MagicMock, Mock, mock_open, call
 
 class DumpTestCase(unittest.TestCase):
 
-    def setUp(self):
-        self.dumper = DumpDatabase(dump_database='testdb',
-                                   dump_schema='testschema',
-                                   include_dump_tables=[],
-                                   exclude_dump_tables=[],
-                                   include_dump_tables_file='/tmp/table_list.txt',
-                                   exclude_dump_tables_file=None,
-                                   backup_dir='/data/master/p1',
-                                   free_space_percent=None,
-                                   compress=True,
-                                   clear_catalog_dumps=False,
-                                   encoding=None,
-                                   output_options=[],
-                                   batch_default=None,
-                                   master_datadir='/data/master/p1',
-                                   master_port=0,
-                                   dump_dir='db_dumps',
-                                   dump_prefix='',
-                                   include_schema_file=None,
-                                   ddboost=False,
-                                   netbackup_service_host=None,
-                                   netbackup_policy=None,
-                                   netbackup_schedule=None,
-                                   netbackup_block_size=None,
-                                   netbackup_keyword=None,
-                                   incremental=False)
+    @patch('gppylib.operations.backup_utils.Context.get_master_port', return_value = 5432)
+    def setUp(self, mock):
+        context = Context()
+        context.dump_database='testdb'
+        context.dump_schema='testschema'
+        context.include_dump_tables_file='/tmp/table_list.txt'
+        context.master_datadir=context.backup_dir='/data/master/p1'
+        context.batch_default=None
+        context.timestamp_key = '20160101010101'
+        context.generate_dump_timestamp()
+        context.schema_file = None
 
-    def create_backup_dirs(self, top_dir=os.getcwd(), dump_dirs=[]):
-        if dump_dirs is None:
-            return
+        self.context = context
+        self.dumper = DumpDatabase(self.context)
+        self.dump_globals = DumpGlobal(self.context)
+        self.mailEvent = MailEvent(subject="test", message="Hello", to_addrs="example@pivotal.io")
 
-        for dump_dir in dump_dirs:
-            backup_dir = os.path.join(top_dir, 'db_dumps', dump_dir)
-            if not os.path.isdir(backup_dir):
-                os.makedirs(backup_dir)
-                if not os.path.isdir(backup_dir):
-                    raise Exception('Failed to create directory %s' % backup_dir)
-
-    def remove_backup_dirs(self, top_dir=os.getcwd(), dump_dirs=[]):
-        if dump_dirs is None:
-            return
-
-        for dump_dir in dump_dirs:
-            backup_dir = os.path.join(top_dir, 'db_dumps', dump_dir)
-            shutil.rmtree(backup_dir)
-            if os.path.isdir(backup_dir):
-                raise Exception('Failed to remove directory %s' % backup_dir)
-
-    def test00_create_dump_line_without_incremental(self):
-        output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
-        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
-        self.assertEquals(output, expected_output)
-
-    @patch('gppylib.operations.dump.get_heap_partition_list', return_value=[['123', 'public', 't4'], ['123', 'public', 't5'], ['123', 'pepper', 't6']])
-    def test01_get_dirty_heap_tables(self, mock1):
-        expected_output = set(['public.t4', 'public.t5', 'pepper.t6'])
-        dirty_table_list = get_dirty_heap_tables(1234, 'testdb')
+    @patch('gppylib.operations.dump.get_heap_partition_list', return_value=[['123', 'public', 't4'], ['123', 'public', 't5'], ['123', 'testschema', 't6']])
+    def test_get_dirty_heap_tables_default(self, mock1):
+        expected_output = set(['public.t4', 'public.t5', 'testschema.t6'])
+        dirty_table_list = get_dirty_heap_tables(self.context)
         self.assertEqual(dirty_table_list, expected_output)
 
     @patch('gppylib.operations.dump.get_heap_partition_list', return_value=[[], ['123', 'public', 't5'], ['123', 'public', 't6']])
-    def test02_get_dirty_heap_tables(self, mock1):
+    def test_get_dirty_heap_tables_empty_arg(self, mock1):
         with self.assertRaisesRegexp(Exception, 'Heap tables query returned rows with unexpected number of columns 0'):
-            dirty_table_list = get_dirty_heap_tables(1234, 'testdb')
+            dirty_table_list = get_dirty_heap_tables(self.context)
 
-    def test02_write_dirty_file(self):
+    def test_write_dirty_file_default(self):
         dirty_tables = ['t1', 't2', 't3']
-        backup_dir = None
-        timestamp_key = '20121212010101'
-        self.create_backup_dirs(dump_dirs=['20121212'])
-        tmpfilename = write_dirty_file(os.getcwd(), dirty_tables, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, timestamp_key)
-        with open(tmpfilename) as tmpfile:
-            output = tmpfile.readlines()
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            tmpfilename = write_dirty_file(self.context, dirty_tables)
+            result = m()
+            self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
+            for i in range(len(dirty_tables)):
+                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
 
-        output = map(lambda x: x.strip(), output)
-        self.assertEqual(dirty_tables, output)
-        os.remove(tmpfilename)
-        self.remove_backup_dirs(dump_dirs=['20121212'])
-
-    def test02a_write_dirty_file(self):
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='test_dirty_filename')
+    def test_write_dirty_file_timestamp(self, mock1):
         dirty_tables = ['t1', 't2', 't3']
-        timestamp_key = '20121212010101'
-        backup_dir = '/tmp'
-        self.create_backup_dirs(top_dir=backup_dir, dump_dirs=['20121212'])
-        tmpfilename = write_dirty_file('/data', dirty_tables, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, timestamp_key)
-        with open(tmpfilename) as tmpfile:
-            output = tmpfile.readlines()
+        timestamp = '20160101010101'
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            tmpfilename = write_dirty_file(self.context, dirty_tables, timestamp)
+            mock1.assert_called_with("dirty_table", timestamp) 
+            result = m()
+            self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
+            for i in range(len(dirty_tables)):
+                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
 
-        output = map(lambda x: x.strip(), output)
-        self.assertEqual(dirty_tables, output)
-        os.remove(tmpfilename)
-        self.remove_backup_dirs(top_dir=backup_dir, dump_dirs=['20121212'])
-
-    def test03_write_dirty_file(self):
+    def test_write_dirty_file_no_list(self):
         dirty_tables = None
-        timestamp_key = '20121212010101'
-        backup_dir = None
-        self.create_backup_dirs(dump_dirs=['20121212'])
-        tmpfilename = write_dirty_file(dirty_tables, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, timestamp_key)
+        tmpfilename = write_dirty_file(self.context, dirty_tables)
         self.assertEqual(tmpfilename, None)
-        self.remove_backup_dirs(dump_dirs=['20121212'])
 
-    def test03a_write_dirty_file(self):
-        dirty_tables = None
-        timestamp_key = '20121212010101'
-        backup_dir = '/tmp'
-        self.create_backup_dirs(top_dir=backup_dir, dump_dirs=['20121212'])
-        tmpfilename = write_dirty_file('/data', dirty_tables, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, timestamp_key)
-        self.assertEqual(tmpfilename, None)
-        self.remove_backup_dirs(top_dir=backup_dir, dump_dirs=['20121212'])
-
-    def test04_write_dirty(self):
+    def test_write_dirty_file_empty_list(self):
         dirty_tables = []
-        timestamp_key = '20121212010101'
-        backup_dir = None
-        self.create_backup_dirs(dump_dirs=['20121212'])
-        tmpfilename = write_dirty_file(os.getcwd(), dirty_tables, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, timestamp_key)
-        with open(tmpfilename) as tmpfile:
-            output = tmpfile.readlines()
-
-        output = map(lambda x: x.strip(), output)
-        self.assertEqual(dirty_tables, output)
-        os.remove(tmpfilename)
-        self.remove_backup_dirs(dump_dirs=['20121212'])
-
-    def test04a_write_dirty(self):
-        dirty_tables = []
-        timestamp_key = '20121212010101'
-        backup_dir = '/tmp'
-        self.create_backup_dirs(top_dir=backup_dir, dump_dirs=['20121212'])
-        tmpfilename = write_dirty_file(os.getcwd(), dirty_tables, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix,  timestamp_key)
-        with open(tmpfilename) as tmpfile:
-            output = tmpfile.readlines()
-
-        output = map(lambda x: x.strip(), output)
-        self.assertEqual(dirty_tables, output)
-        os.remove(tmpfilename)
-        self.remove_backup_dirs(top_dir=backup_dir, dump_dirs=['20121212'])
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            tmpfilename = write_dirty_file(self.context, dirty_tables)
+            result = m()
+            self.assertEqual(len(result.write.call_args_list), 0)
 
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=['20120330120102', '20120330120103'])
     @patch('gppylib.operations.dump.get_incremental_ts_from_report_file', return_value='20120330120102')
-    def test05_validate_increments_file(self, mock1, mock2):
+    def test_validate_increments_file_default(self, mock1, mock2):
         # expect no exception to die out of this
-        CreateIncrementsFile.validate_increments_file('testdb', '/tmp/fn', '/data', None, None, None)
+        CreateIncrementsFile.validate_increments_file(self.context, '/tmp/fn')
 
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=['20120330120102', '20120330120103'])
     @patch('gppylib.operations.dump.get_incremental_ts_from_report_file', side_effect=Exception('invalid timestamp'))
-    def test06_validate_increments_file(self, mock1, mock2):
+    def test_validate_increments_file_bad_increment(self, mock1, mock2):
 
         with self.assertRaisesRegexp(Exception, "Timestamp '20120330120102' from increments file '/tmp/fn' is not a valid increment"):
-            CreateIncrementsFile.validate_increments_file('testdb', '/tmp/fn', '/data', None, None, None)
+            CreateIncrementsFile.validate_increments_file(self.context, '/tmp/fn')
 
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=['20120330120102', '20120330120103'])
     @patch('gppylib.operations.dump.get_incremental_ts_from_report_file', return_value=None)
-    def test07_validate_increments_file(self, mock1, mock2):
+    def test_validate_increments_file_empty_file(self, mock1, mock2):
 
         with self.assertRaisesRegexp(Exception, "Timestamp '20120330120102' from increments file '/tmp/fn' is not a valid increment"):
-            CreateIncrementsFile.validate_increments_file('testdb', '/tmp/fn', '/data', None, None, None)
+            CreateIncrementsFile.validate_increments_file(self.context, '/tmp/fn')
 
-    def test08_CreateIncrementsFile_init(self):
-        obj = CreateIncrementsFile('testdb', '20121225000000', '20121226000000', '/data', None, self.dumper.dump_dir, self.dumper.dump_prefix, False, None, None, None)
-        self.assertEquals(obj.increments_filename, '/data/db_dumps/20121225/gp_dump_20121225000000_increments')
+    @patch('os.path.isfile', return_value=True)
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    @patch('gppylib.operations.dump.CreateIncrementsFile.validate_increments_file')
+    def test_CreateIncrementsFile_init(self, mock1, mock2, mock3):
+        obj = CreateIncrementsFile(self.context)
+        self.assertEquals(obj.increments_filename, '/data/master/p1/db_dumps/20160101/gp_dump_20160101000000_increments')
 
-    def test09_CreateIncrementsFile_execute(self):
-        obj = CreateIncrementsFile('testdb', '20121225000000', '20121226000000', '/data', None, self.dumper.dump_dir, self.dumper.dump_prefix, False, None, None, None)
-        obj.increments_filename = os.path.join(os.getcwd(), 'test.increments')
-        if os.path.isfile(obj.increments_filename):
-            os.remove(obj.increments_filename)
-        result = obj.execute()
-        self.assertEquals(1, result)
-        os.remove(obj.increments_filename)
+    @patch('os.path.isfile', return_value=True)
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    @patch('gppylib.operations.dump.CreateIncrementsFile.validate_increments_file')
+    @patch('gppylib.operations.dump.get_lines_from_file', side_effect=[ [], ['20160101010101'] ])
+    def test_CreateIncrementsFile_execute_no_file(self, mock1, mock2, mock3, mock4):
+        obj = CreateIncrementsFile(self.context)
+        with patch('__builtin__.open', mock_open(), create=True):
+            result = obj.execute()
+            self.assertEquals(1, result)
 
-    def test10_CreateIncrementsFile_execute(self):
-        obj = CreateIncrementsFile('testdb', '20121225000000', '20121226000000', '/data', None, self.dumper.dump_dir, self.dumper.dump_prefix, False, None, None, None)
-        obj.increments_filename = os.path.join(os.getcwd(), 'test.increments')
-        with open(obj.increments_filename, 'w') as fd:
-            fd.write('20121225100000')
+    @patch('os.path.isfile', return_value=True)
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    @patch('gppylib.operations.dump.get_incremental_ts_from_report_file', return_value='')
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['20160101010101'])
+    def test_CreateIncrementsFile_execute_invalid_timestamp(self, mock1, mock2, mock3, mock4):
+        obj = CreateIncrementsFile(self.context)
         with self.assertRaisesRegexp(Exception, ".* is not a valid increment"):
             obj.execute()
-        os.remove(obj.increments_filename)
 
+    @patch('os.path.isfile', return_value=True)
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    @patch('gppylib.operations.dump.get_lines_from_file', side_effect=[ ['20160101010000'], ['20160101010000', '20160101010101'] ])
     @patch('gppylib.operations.dump.CreateIncrementsFile.validate_increments_file')
-    def test11_CreateIncrementsFile_execute(self, mock1):
-        obj = CreateIncrementsFile('testdb', '20121225000000', '20121226000000', '/data', None, self.dumper.dump_dir, self.dumper.dump_prefix, False, None, None, None)
-        obj.increments_filename = os.path.join(os.getcwd(), 'test.increments')
-        with open(obj.increments_filename, 'w') as fd:
-            fd.write('20121225100000\n')
-        result = obj.execute()
-        self.assertEquals(2, result)
-        os.remove(obj.increments_filename)
+    def test_CreateIncrementsFile_execute_append(self, mock1, mock2, mock3, mock4):
+        obj = CreateIncrementsFile(self.context)
+        with patch('__builtin__.open', mock_open(), create=True):
+            result = obj.execute()
+            self.assertEquals(2, result)
 
+    @patch('os.path.isfile', return_value=True)
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=[])
-    def test12_CreateIncrementsFile_execute(self, mock1):
-        obj = CreateIncrementsFile('testdb', '20121225000000', '20121226000000', '/data', None, self.dumper.dump_dir, self.dumper.dump_prefix, False, None, None, None)
-        obj.increments_filename = os.path.join(os.getcwd(), 'test.increments')
-        with self.assertRaisesRegexp(Exception, 'File not written to'):
-            result = obj.execute()
-        os.remove(obj.increments_filename)
-
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['20121225100000'])
     @patch('gppylib.operations.dump.CreateIncrementsFile.validate_increments_file')
-    def test13_CreateIncrementsFile_execute(self, mock1, mock2):
-        obj = CreateIncrementsFile('testdb', '20121225000000', '20121226000000', '/data', None, self.dumper.dump_dir, self.dumper.dump_prefix, False, None, None, None)
-        obj.increments_filename = os.path.join(os.getcwd(), 'test.increments')
-        with open(obj.increments_filename, 'w') as fd:
-            fd.write('20121225100000\n')
-        with self.assertRaisesRegexp(Exception, 'not written to'):
-            result = obj.execute()
-        os.remove(obj.increments_filename)
+    def test_CreateIncrementsFile_execute_no_output(self, mock1, mock2, mock3, mock4):
+        obj = CreateIncrementsFile(self.context)
+        with patch('__builtin__.open', mock_open(), create=True):
+            with self.assertRaisesRegexp(Exception, 'File not written to'):
+                result = obj.execute()
 
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['20121225100001', '20121226000000'])
+    @patch('os.path.isfile', return_value=True)
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['20160101000000'])
     @patch('gppylib.operations.dump.CreateIncrementsFile.validate_increments_file')
-    def test14_CreateIncrementsFile_execute(self, mock1, mock2):
-        obj = CreateIncrementsFile('testdb', '20121225000000', '20121226000000', '/data', None, self.dumper.dump_dir, self.dumper.dump_prefix, False, None, None, None)
-        obj.increments_filename = os.path.join(os.getcwd(), 'test.increments')
-        with open(obj.increments_filename, 'w') as fd:
-            fd.write('20121225100000\n')
-        with self.assertRaisesRegexp(Exception, 'trouble adding timestamp'):
-            result = obj.execute()
-        os.remove(obj.increments_filename)
+    def test_CreateIncrementsFile_execute_wrong_timestamp(self, mock1, mock2, mock3, mock4):
+        obj = CreateIncrementsFile(self.context)
+        with patch('__builtin__.open', mock_open(), create=True):
+            with self.assertRaisesRegexp(Exception, 'Timestamp .* not written to'):
+                result = obj.execute()
 
-    @patch('gppylib.operations.dump.get_partition_list', return_value=[[123, 'myschema', 't1'], [4444, 'otherschema', 't2'], [992313, 'public', 't3']])
-    @patch('gppylib.operations.dump.generate_partition_list_filename', return_value=os.path.join(os.getcwd(), 'test'))
-    @patch('gppylib.operations.dump.get_filter_file', return_value=None)
-    def test_write_partition_list_file_00(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp_key = '01234567891234'
-        dbname = 'bkdb'
-        port = '5432'
-        partition_list_file = os.path.join(os.getcwd(), 'test')
-        write_partition_list_file(master_datadir, backup_dir, timestamp_key, port, dbname, self.dumper.dump_dir, self.dumper.dump_prefix)
-        if not os.path.isfile(partition_list_file):
-            raise Exception('Partition list file %s not created' % partition_list_file)
-        with open(partition_list_file) as fd:
-            partition_list_file_contents = fd.read()
-        temp_list = partition_list_file_contents.splitlines()
-        self.assertEqual(temp_list, ['myschema.t1', 'otherschema.t2', 'public.t3'])
-        os.remove(partition_list_file)
+    @patch('os.path.isfile', return_value=True)
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    @patch('gppylib.operations.dump.get_lines_from_file', side_effect=[ ['20160101010000'], ['20160101010001', '20160101010101'] ])
+    @patch('gppylib.operations.dump.CreateIncrementsFile.validate_increments_file')
+    def test_CreateIncrementsFile_execute_modified_timestamp(self, mock1, mock2, mock3, mock4):
+        obj = CreateIncrementsFile(self.context)
+        with patch('__builtin__.open', mock_open(), create=True):
+            with self.assertRaisesRegexp(Exception, 'trouble adding timestamp'):
+                result = obj.execute()
 
-    @patch('gppylib.operations.dump.get_partition_list', return_value=[])
-    @patch('gppylib.operations.dump.generate_partition_list_filename', return_value=os.path.join(os.getcwd(), 'test'))
     @patch('gppylib.operations.dump.get_filter_file', return_value=None)
-    def test_write_partition_list_file_01(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp_key = '01234567891234'
-        dbname = 'bkdb'
-        port = '5432'
-        partition_list_file = os.path.join(os.getcwd(), 'test')
-        write_partition_list_file(master_datadir, backup_dir, timestamp_key, port, dbname, self.dumper.dump_dir, self.dumper.dump_prefix)
-        if not os.path.isfile(partition_list_file):
-            raise Exception('Partition list file %s not created' % partition_list_file)
-        with open(partition_list_file) as fd:
-            partition_list_file_contents = fd.read()
-        temp_list = partition_list_file_contents.splitlines()
-        self.assertEqual(temp_list, [])
-        os.remove(partition_list_file)
-
-    @patch('gppylib.operations.dump.get_partition_list', return_value=[['t1'], ['t2'], ['t3']])
-    @patch('gppylib.operations.dump.generate_partition_list_filename', return_value=os.path.join(os.getcwd(), 'test'))
-    @patch('gppylib.operations.dump.get_filter_file', return_value=None)
-    def test_write_partition_list_file_02(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp_key = '01234567891234'
-        dbname = 'bkdb'
-        port = '5432'
-        partition_list_file = os.path.join(os.getcwd(), 'test')
-        with self.assertRaisesRegexp(Exception, 'Invalid results from query to get all tables'):
-            write_partition_list_file(master_datadir, backup_dir, timestamp_key, port, dbname, self.dumper.dump_dir, self.dumper.dump_prefix)
+    def test_write_partition_list_file_no_filter_file(self, mock1):
+        with patch('gppylib.operations.dump.get_partition_list') as p:
+            part_list = [[123, 'myschema', 't1'], [4444, 'otherschema', 't2'], [992313, 'public', 't3']]
+            p.return_value = part_list
+            m = mock_open()
+            with patch('__builtin__.open', m, create=True):
+                write_partition_list_file(self.context)
+                result = m()
+                self.assertEqual(len(part_list), len(result.write.call_args_list))
+                for i in range(len(part_list)):
+                    expected = "%s.%s\n" % (part_list[i][1], part_list[i][2])
+                    self.assertEqual(call(expected), result.write.call_args_list[i])
 
     @patch('gppylib.operations.dump.get_partition_list', return_value=[['t1', 'foo', 'koo'], ['public', 't2'], ['public', 't3']])
-    @patch('gppylib.operations.dump.generate_partition_list_filename', return_value=os.path.join(os.getcwd(), 'test'))
     @patch('gppylib.operations.dump.get_filter_file', return_value=None)
-    def test_write_partition_list_file_03(self, mock1, mock2, mock3):
-        master_datadir =  'foo'
-        backup_dir = None
-        timestamp_key = '01234567891234'
-        dbname = 'bkdb'
-        port = '5432'
-        partition_list_file = os.path.join(os.getcwd(), 'test')
+    def test_write_partition_list_file_bad_query_return(self, mock1, mock2):
         with self.assertRaisesRegexp(Exception, 'Invalid results from query to get all tables'):
-            write_partition_list_file(master_datadir, backup_dir, timestamp_key, port, dbname, self.dumper.dump_dir, self.dumper.dump_prefix)
+            write_partition_list_file(self.context)
 
-    @patch('gppylib.operations.dump.get_partition_list', return_value=[['t1', 'foo', 'koo'], ['public', 't2'], ['public', 't3']])
-    @patch('gppylib.operations.dump.generate_partition_list_filename', return_value=os.path.join(os.getcwd(), 'test'))
-    @patch('gppylib.operations.dump.get_filter_file', return_value='/foo')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'public.t2'])
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['public.t3', 'public.t2'])
-    @patch('shutil.copyfile')
-    def test_write_partition_list_file_04(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir =  'foo'
-        backup_dir = None
-        timestamp_key = '01234567891234'
-        dbname = 'bkdb'
-        port = '5432'
-        partition_list_file = os.path.join(os.getcwd(), 'test')
-        with self.assertRaisesRegexp(Exception, 'contents not as expected'):
-            write_partition_list_file(master_datadir, backup_dir, timestamp_key, port, dbname, self.dumper.dump_dir, self.dumper.dump_prefix)
-
-    def test_dirty_file_to_temp_00(self):
-        dirty_tables = ['public.t1', 'public.t2', 'pepper.t3']
-        dirty_file = write_dirty_file_to_temp(dirty_tables)
-        self.assertTrue(os.path.basename(dirty_file).startswith('dirty_backup_list'))
-        self.assertTrue(os.path.isfile(dirty_file))
-        content = get_lines_from_file(dirty_file)
-        self.assertEqual(dirty_tables, content)
-        os.remove(dirty_file)
-
-    def test_dirty_file_to_temp_01(self):
-        dirty_tables = ['']
-        dirty_file = write_dirty_file_to_temp(dirty_tables)
-        self.assertTrue(os.path.basename(dirty_file).startswith('dirty_backup_list'))
-        self.assertTrue(os.path.isfile(dirty_file))
-        content = get_lines_from_file(dirty_file)
-        self.assertEqual(dirty_tables, content)
-        os.remove(dirty_file)
-
-    def test_dirty_file_to_temp_02(self):
-        dirty_tables = ['']
-        dirty_file = write_dirty_file_to_temp(dirty_tables)
-        self.assertTrue(os.path.basename(dirty_file).startswith('dirty_backup_list'))
-        self.assertTrue(os.path.isfile(dirty_file))
-        content = get_lines_from_file(dirty_file)
-        self.assertEqual(dirty_tables, content)
-        os.remove(dirty_file)
-
-    def test_create_dump_outcome_00(self):
+    def test_create_dump_outcome_default(self):
         start = datetime(2012, 7, 31, 9, 30, 00)
         end = datetime(2012, 8, 1, 12, 21, 11)
         rc = 5
@@ -365,2546 +195,851 @@ class DumpTestCase(unittest.TestCase):
         outcome = self.dumper.create_dump_outcome(start, end, rc)
         self.assertTrue(expected_outcome == outcome)
 
-    def test_get_report_dir00(self):
-        pdd = PostDumpDatabase(timestamp_start=None,
-                               compress=None,
-                               backup_dir='/tmp',
-                               batch_default=None,
-                               master_datadir='/master',
-                               master_port=None,
-                               dump_dir='db_dumps',
-                               dump_prefix='',
-                               ddboost=None,
-                               netbackup_service_host=None,
-                               incremental=False)
-        self.assertEquals(pdd.get_report_dir('20120930'), '/tmp/db_dumps/20120930')
-
-    def test_get_report_dir01(self):
-        pdd = PostDumpDatabase(timestamp_start=None,
-                               compress=None,
-                               backup_dir=None,
-                               batch_default=None,
-                               master_datadir='/master',
-                               master_port=None,
-                               dump_dir='db_dumps',
-                               dump_prefix='',
-                               ddboost=None,
-                               netbackup_service_host=None,
-                               incremental=False)
-        self.assertEquals(pdd.get_report_dir('20120930'), '/master/db_dumps/20120930')
-
     @patch('gppylib.operations.dump.ValidateDumpDatabase.run')
     @patch('gppylib.operations.dump.Command.run')
     @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "", "", True, False))
     @patch('gppylib.operations.dump.DumpDatabase.create_filter_file')
-    def test_execute_00(self, mock1, mock2, mock3, mock4):
+    def test_execute_default(self, mock1, mock2, mock3, mock4):
         self.dumper.execute()
         # should not raise any exceptions
 
     @patch('gppylib.operations.dump.dbconn.DbURL')
     @patch('gppylib.operations.dump.dbconn.connect')
     @patch('gppylib.operations.dump.execSQLForSingleton', return_value='100')
-    def test_get_partition_state_00(self, mock1, mock2, mock3):
-        master_port=5432
-        dbname='testdb'
-        partition_info = [(123, 'pepper', 't1', 4444), (234, 'pepper', 't2', 5555)]
-        expected_output = ['pepper,t1,100', 'pepper,t2,100']
-        result = get_partition_state(master_port, dbname, 'pg_aoseg', partition_info)
+    def test_get_partition_state_default(self, mock1, mock2, mock3):
+        partition_info = [(123, 'testschema', 't1', 4444), (234, 'testschema', 't2', 5555)]
+        expected_output = ['testschema, t1, 100', 'testschema, t2, 100']
+        result = get_partition_state(self.context, 'pg_aoseg', partition_info)
         self.assertEqual(result, expected_output)
 
     @patch('gppylib.operations.dump.dbconn.DbURL')
     @patch('gppylib.operations.dump.dbconn.connect')
-    def test_get_partition_state_01(self, mock1, mock2):
-        master_port=5432
-        dbname='testdb'
+    def test_get_partition_state_empty(self, mock1, mock2):
         partition_info = []
         expected_output = []
-        result = get_partition_state(master_port, dbname, 'pg_aoseg', partition_info)
+        result = get_partition_state(self.context, 'pg_aoseg', partition_info)
         self.assertEqual(result, expected_output)
 
     @patch('gppylib.operations.dump.dbconn.DbURL')
     @patch('gppylib.operations.dump.dbconn.connect')
     @patch('gppylib.operations.dump.execSQLForSingleton', return_value='10000000000000000')
-    def test_get_partition_state_02(self, mock1, mock2, mock3):
-        master_port=5432
-        dbname='testdb'
-        partition_info = [(123, 'pepper', 't1', 4444), (234, 'pepper', 't2', 5555)]
-        expected_output = ['pepper, t1, 10000000000000000', 'pepper, t2, 10000000000000000']
+    def test_get_partition_state_exceeded_count(self, mock1, mock2, mock3):
+        partition_info = [(123, 'testschema', 't1', 4444), (234, 'testschema', 't2', 5555)]
+        expected_output = ['testschema, t1, 10000000000000000', 'testschema, t2, 10000000000000000']
         with self.assertRaisesRegexp(Exception, 'Exceeded backup max tuple count of 1 quadrillion rows per table for:'):
-            get_partition_state(master_port, dbname, 'pg_aoseg', partition_info)
+            get_partition_state(self.context, 'pg_aoseg', partition_info)
 
     @patch('gppylib.operations.dump.dbconn.DbURL')
     @patch('gppylib.operations.dump.dbconn.connect')
     @patch('gppylib.operations.dump.execSQLForSingleton', return_value='100')
-    def test_get_partition_state_with_more_than_thousand_partition(self, mock1, mock2, mock3):
+    def test_get_partition_state_many_partition(self, mock1, mock2, mock3):
         master_port=5432
         dbname='testdb'
-        partition_info = [(123, 'pepper', 't1', 4444), (234, 'pepper', 't2', 5555)] * 1000
-        expected_output = ['pepper,t1,100', 'pepper,t2,100'] * 1000
-        result = get_partition_state(master_port, dbname, 'pg_aoseg', partition_info)
+        partition_info = [(123, 'testschema', 't1', 4444), (234, 'testschema', 't2', 5555)] * 1000
+        expected_output = ['testschema, t1, 100', 'testschema, t2, 100'] * 1000
+        result = get_partition_state(self.context, 'pg_aoseg', partition_info)
         self.assertEqual(result, expected_output)
 
-    def test_get_filename_from_filetype_00(self):
-        table_type = 'ao'
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp_key = '20121212010101'
-        self.create_backup_dirs(dump_dirs=['20121212'])
-        expected_output = '%s/db_dumps/20121212/gp_dump_%s_ao_state_file' % (master_datadir, timestamp_key)
-        result = get_filename_from_filetype(table_type, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, timestamp_key)
+    def test_get_filename_from_filetype_ao(self):
+        expected_output = '/data/master/p1/db_dumps/20160101/gp_dump_20160101010101_ao_state_file'
+        result = get_filename_from_filetype(self.context, "ao", self.context.timestamp)
         self.assertEqual(result, expected_output)
-        self.remove_backup_dirs(dump_dirs=['20121212'])
 
-    def test_get_filename_from_filetype_01(self):
-        table_type = 'co'
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp_key = '20121212010101'
-        self.create_backup_dirs(dump_dirs=['20121212'])
-        expected_output = '%s/db_dumps/20121212/gp_dump_%s_co_state_file' % (master_datadir, timestamp_key)
-        result = get_filename_from_filetype(table_type, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, timestamp_key)
+    def test_get_filename_from_filetype_co(self):
+        expected_output = '/data/master/p1/db_dumps/20160101/gp_dump_20160101010101_co_state_file'
+        result = get_filename_from_filetype(self.context, "co", self.context.timestamp)
         self.assertEqual(result, expected_output)
-        self.remove_backup_dirs(dump_dirs=['20121212'])
 
-    def test_get_filename_from_filetype_01_with_ddboost(self):
-        table_type = 'ao'
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp_key = '20121212010101'
-        self.create_backup_dirs(dump_dirs=['20121212'])
-        ddboost = True
-        dump_dir = 'backup/DCA-35'
-        expected_output = 'foo/backup/DCA-35/20121212/gp_dump_%s_ao_state_file' % (timestamp_key)
-        result = get_filename_from_filetype(table_type, master_datadir, backup_dir, dump_dir, self.dumper.dump_prefix, timestamp_key, ddboost)
-        self.assertEqual(result, expected_output)
-        self.remove_backup_dirs(dump_dirs=['20121212'])
-
-    def test_get_filename_from_filetype_02(self):
-        table_type = 'foo'
-        master_datadir = '/foo'
-        backup_dir = None
-        timestamp_key = '20121212010101'
+    def test_get_filename_from_filetype_bad_type(self):
         with self.assertRaisesRegexp(Exception, 'Invalid table type *'):
-            get_filename_from_filetype(table_type, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, timestamp_key)
+            result = get_filename_from_filetype(self.context, "schema", self.context.timestamp)
 
-    def test_get_filename_from_filetype_02_with_ddboost(self):
-        table_type = 'co'
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp_key = '20121212010101'
-        self.create_backup_dirs(dump_dirs=['20121212'])
-        ddboost = True
-        dump_dir = 'backup/DCA-35'
-        expected_output = 'foo/backup/DCA-35/20121212/gp_dump_%s_co_state_file' % (timestamp_key)
-        result = get_filename_from_filetype(table_type, master_datadir, backup_dir, dump_dir, self.dumper.dump_prefix, timestamp_key, ddboost)
-        self.assertEqual(result, expected_output)
-        self.remove_backup_dirs(dump_dirs=['20121212'])
-
-    def test_write_state_file_00(self):
+    def test_write_state_file_bad_type(self):
         table_type = 'foo'
-        master_datadir = '/foo'
-        backup_dir = None
-        timestamp_key = '20121212010101'
-        partition_list = ['pepper, t1, 100', 'pepper, t2, 100']
+        partition_list = ['testschema, t1, 100', 'testschema, t2, 100']
         with self.assertRaisesRegexp(Exception, 'Invalid table type *'):
-            write_state_file(table_type, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, partition_list)
+            write_state_file(self.context, table_type, partition_list)
 
-    @patch('gppylib.operations.dump.get_filename_from_filetype', return_value='/tmp/db_dumps/20121212/gp_dump_20121212010101_ao_state_file')
-    def test_write_state_file_01(self, mock1):
+    @patch('gppylib.operations.dump.get_filename_from_filetype', return_value='/tmp/db_dumps/20160101/gp_dump_20160101010101')
+    def test_write_state_file_default(self, mock1):
         table_type = 'ao'
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp_key = '20121212010101'
-        partition_list = ['pepper, t1, 100', 'pepper, t2, 100']
-        self.create_backup_dirs(top_dir='/tmp', dump_dirs=['20121212'])
-        write_state_file(table_type, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, partition_list)
-        if not os.path.isfile('/tmp/db_dumps/20121212/gp_dump_20121212010101_ao_state_file'):
-            raise Exception('AO state file was not created successfully')
-        self.remove_backup_dirs(top_dir='/tmp', dump_dirs=['20121212'])
+        part_list = ['testschema, t1, 100', 'testschema, t2, 100']
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            write_state_file(self.context, table_type, part_list)
+            result = m()
+            self.assertEqual(len(part_list), len(result.write.call_args_list))
+            for i in range(len(part_list)):
+                self.assertEqual(call(part_list[i]+'\n'), result.write.call_args_list[i])
 
-    @patch('gppylib.operations.dump.execute_sql', return_value=[['public', 'ao_table', 123, 'CREATE', 'table', '2012: 1'], ['pepper', 'co_table', 333, 'TRUNCATE', '', '2033 :1 - 111']])
-    def test_get_last_operation_data_00(self, mock):
-        output = get_last_operation_data(1, 'foodb')
-        expected = ['public,ao_table,123,CREATE,table,2012: 1', 'pepper,co_table,333,TRUNCATE,,2033 :1 - 111']
+    @patch('gppylib.operations.dump.execute_sql', return_value=[['public', 'ao_table', 123, 'CREATE', 'table', '2012: 1'], ['testschema', 'co_table', 333, 'TRUNCATE', '', '2033 :1 - 111']])
+    def test_get_last_operation_data_default(self, mock):
+        output = get_last_operation_data(self.context)
+        expected = ['public,ao_table,123,CREATE,table,2012: 1', 'testschema,co_table,333,TRUNCATE,,2033 :1 - 111']
         self.assertEquals(output, expected)
 
     @patch('gppylib.operations.dump.execute_sql', return_value=[])
-    def test_get_last_operation_data_01(self, mock):
-        output = get_last_operation_data(1, 'foodb')
+    def test_get_last_operation_data_empty(self, mock):
+        output = get_last_operation_data(self.context)
         expected = []
         self.assertEquals(output, expected)
 
     @patch('gppylib.operations.dump.execute_sql', return_value=[[123, 'table', '2012: 1'], [333, 'TRUNCATE', '', '2033 :1 - 111']])
-    def test_get_last_operation_data_02(self, mock):
+    def test_get_last_operation_data_invalid(self, mock):
         with self.assertRaisesRegexp(Exception, 'Invalid return from query'):
-            get_last_operation_data(1, 'foodb')
+            get_last_operation_data(self.context)
 
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212121212')
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101121212')
     @patch('gppylib.operations.dump.os.path.isfile', return_value=True)
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['pepper, t1, 100', 'pepper, t2, 100'])
-    def test_get_last_state_00(self, mock1, mock2, mock3):
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['testschema, t1, 100', 'testschema, t2, 100'])
+    def test_get_last_state_default(self, mock1, mock2, mock3):
         table_type = 'ao'
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        expected_output = ['pepper, t1, 100', 'pepper, t2, 100']
-        output = get_last_state(table_type, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp)
+        expected_output = ['testschema, t1, 100', 'testschema, t2, 100']
+        output = get_last_state(self.context, table_type)
         self.assertEqual(output, expected_output)
 
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212121212')
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101121212')
     @patch('gppylib.operations.dump.os.path.isfile', return_value=False)
-    @patch('gppylib.operations.dump.generate_ao_state_filename', return_value='foo')
-    def test_get_last_state_01(self, mock1, mock2, mock3):
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo')
+    def test_get_last_state_no_file(self, mock1, mock2, mock3):
         table_type = 'ao'
-        master_datadir = '/foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
         with self.assertRaisesRegexp(Exception, 'ao state file does not exist: foo'):
-            get_last_state(table_type, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp)
+            get_last_state(self.context, table_type)
 
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212121212')
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101121212')
     @patch('gppylib.operations.dump.os.path.isfile', return_value=True)
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=[])
-    def test_get_last_state_02(self, mock1, mock2, mock3):
+    def test_get_last_state_empty_file(self, mock1, mock2, mock3):
         table_type = 'ao'
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        expected_output = []
-        output = get_last_state(table_type, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp)
-        self.assertEqual(output, expected_output)
+        output = get_last_state(self.context, table_type)
+        self.assertEqual(output, [])
 
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212121212')
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101121212')
     @patch('gppylib.operations.dump.os.path.isfile', return_value=True)
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=[])
     @patch('gppylib.operations.dump.check_file_dumped_with_nbu', return_value=True)
     @patch('gppylib.operations.dump.restore_file_with_nbu')
-    def test_get_last_state_03(self, mock1, mock2, mock3, mock4, mock5):
+    def test_get_last_state_nbu(self, mock1, mock2, mock3, mock4, mock5):
         table_type = 'ao'
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        netbackup_service_host = "mdw"
-        netbackup_block_size = "1024"
-        expected_output = []
-        output = get_last_state(table_type, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_block_size)
-        self.assertEqual(output, expected_output)
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_block_size = "1024"
+        output = get_last_state(self.context, table_type)
+        self.assertEqual(output, [])
 
-    def test_compare_dict_00(self):
-        last_dict = {'pepper.t1':'100', 'pepper.t2':'200'}
-        curr_dict = {'pepper.t1':'200', 'pepper.t2':'200'}
-        expected_output = set(['pepper.t1'])
+    def test_compare_dict_different(self):
+        last_dict = {'testschema.t1':'100', 'testschema.t2':'200'}
+        curr_dict = {'testschema.t1':'200', 'testschema.t2':'200'}
+        expected_output = set(['testschema.t1'])
         result = compare_dict(last_dict, curr_dict)
         self.assertEqual(result, expected_output)
 
-    def test_compare_dict_01(self):
-        last_dict = {'pepper.t1':'100', 'pepper.t2':'200', 'pepper.t3':'300'}
-        curr_dict = {'pepper.t1':'100', 'pepper.t2':'100'}
-        expected_output = set(['pepper.t2'])
+    def test_compare_dict_extra(self):
+        last_dict = {'testschema.t1':'100', 'testschema.t2':'200', 'testschema.t3':'300'}
+        curr_dict = {'testschema.t1':'100', 'testschema.t2':'100'}
+        expected_output = set(['testschema.t2'])
         result = compare_dict(last_dict, curr_dict)
         self.assertEqual(result, expected_output)
 
-    def test_compare_dict_02(self):
-        last_dict = {'pepper.t1':'100', 'pepper.t2':'200'}
-        curr_dict = {'pepper.t1':'100', 'pepper.t2':'200', 'pepper.t3':'300'}
-        expected_output = set(['pepper.t3'])
+    def test_compare_dict_missing(self):
+        last_dict = {'testschema.t1':'100', 'testschema.t2':'200'}
+        curr_dict = {'testschema.t1':'100', 'testschema.t2':'200', 'testschema.t3':'300'}
+        expected_output = set(['testschema.t3'])
         result = compare_dict(last_dict, curr_dict)
         self.assertEqual(result, expected_output)
 
-    def test_compare_dict_03(self):
-        last_dict = {'pepper.t1':'100', 'pepper.t2':'200'}
-        curr_dict = {'pepper.t1':'100', 'pepper.t2':'200'}
+    def test_compare_dict_identical(self):
+        last_dict = {'testschema.t1':'100', 'testschema.t2':'200'}
+        curr_dict = {'testschema.t1':'100', 'testschema.t2':'200'}
         expected_output = set([])
         result = compare_dict(last_dict, curr_dict)
         self.assertEqual(result, expected_output)
 
-    def test_create_partition_dict_00(self):
-        partition_list = ['pepper,t1,100', 'pepper,t2,200']
-        expected_output = {'pepper.t1':'100', 'pepper.t2':'200'}
+    def test_create_partition_dict_default(self):
+        partition_list = ['testschema, t1, 100', 'testschema, t2, 200']
+        expected_output = {'testschema.t1':'100', 'testschema.t2':'200'}
         result = create_partition_dict(partition_list)
         self.assertEqual(result, expected_output)
 
-    def test_create_partition_dict_01(self):
+    def test_create_partition_dict_empty(self):
         partition_list = []
         expected_output = {}
         result = create_partition_dict(partition_list)
         self.assertEqual(result, expected_output)
 
-    def test_create_partition_dict_02(self):
-        partition_list = ['pepper t1 100']
+    def test_create_partition_dict_invalid_format(self):
+        partition_list = ['testschema t1 100']
         with self.assertRaisesRegexp(Exception, 'Invalid state file format *'):
             create_partition_dict(partition_list)
 
-    @patch('gppylib.operations.dump.generate_increments_filename')
+    @patch('gppylib.operations.backup_utils.Context.generate_filename')
     @patch('gppylib.operations.dump.os.path.isdir', return_value=False)
     @patch('gppylib.operations.dump.os.path.isfile', return_value=False)
-    def test_get_last_dump_timestamp_00(self, mock1, mock2, mock3):
-        master_datadir = '/foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        result = get_last_dump_timestamp(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp)
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    def test_get_last_dump_timestamp_default(self, mock1, mock2, mock3, mock4):
+        full_timestamp = '20160101000000'
+        result = get_last_dump_timestamp(self.context)
         self.assertEqual(result, full_timestamp)
 
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['20121212121210', '20121212121211'])
-    @patch('gppylib.operations.dump.generate_increments_filename')
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['20160101010000', '20160101010001'])
     @patch('gppylib.operations.dump.os.path.isdir', return_value=True)
     @patch('gppylib.operations.dump.os.path.isfile', return_value=True)
-    def test_get_last_dump_timestamp_01(self, mock1, mock2, mock3, mock4):
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    def test_get_last_dump_timestamp_one_previous(self, mock1, mock2, mock3, mock4):
         master_datadir = 'foo'
         backup_dir = None
-        full_timestamp = '20121212010101'
-        expected_output = '20121212121211'
-        result = get_last_dump_timestamp(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp)
+        full_timestamp = '20160101000000'
+        expected_output = '20160101010001'
+        result = get_last_dump_timestamp(self.context)
         self.assertEqual(result, expected_output)
 
-    @patch('gppylib.operations.dump.generate_increments_filename')
     @patch('gppylib.operations.dump.os.path.isdir', return_value=True)
     @patch('gppylib.operations.dump.os.path.isfile', return_value=True)
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=['2012093009300q'])
-    def test_get_last_dump_timestamp_02(self, mock1, mock2, mock3, mock4):
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        expected = '20120930093000'
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    def test_get_last_dump_timestamp_invalid_timestamp(self, mock1, mock2, mock3, mock4):
         with self.assertRaisesRegexp(Exception, 'get_last_dump_timestamp found invalid ts in file'):
-            get_last_dump_timestamp(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp)
+            get_last_dump_timestamp(self.context)
 
-    @patch('gppylib.operations.dump.generate_increments_filename')
     @patch('gppylib.operations.dump.os.path.isdir', return_value=True)
     @patch('gppylib.operations.dump.os.path.isfile', return_value=True)
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=[' 20120930093000 \n  \n  '])
-    def test_get_last_dump_timestamp_03(self, mock1, mock2, mock3, mock4):
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        expected = '20120930093000'
-        result = get_last_dump_timestamp(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp)
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=[' 20160101010101 \n  \n  '])
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    def test_get_last_dump_timestamp_extra_whitespace(self, mock1, mock2, mock3, mock4):
+        expected = '20160101010101'
+        result = get_last_dump_timestamp(self.context)
         self.assertEqual(result, expected)
 
-    @patch('gppylib.operations.dump.generate_increments_filename')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=[' 20120930093000 \n  \n  '])
-    @patch('gppylib.operations.dump.check_file_dumped_with_nbu', return_value=True)
-    @patch('gppylib.operations.dump.restore_file_with_nbu')
-    @patch('gppylib.operations.dump.os.path.exists', return_value=True)
-    def test_get_last_dump_timestamp_04(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        netbackup_service_host = "mdw"
-        netbackup_block_size = "1024"
-        expected = '20120930093000'
-        result = get_last_dump_timestamp(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_block_size)
-        self.assertEqual(result, expected)
-
-    @patch('gppylib.operations.dump.generate_increments_filename')
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
     @patch('gppylib.operations.dump.check_file_dumped_with_nbu', return_value=False)
-    def test_get_last_dump_timestamp_05(self, mock1, mock2):
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
+    def test_get_last_dump_timestamp_nbu(self, mock1, mock2):
         netbackup_service_host = "mdw"
         netbackup_block_size = "1024"
-        expected = '20121212010101'
-        result = get_last_dump_timestamp(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_block_size)
+        expected = '20160101000000'
+        result = get_last_dump_timestamp(self.context)
         self.assertEqual(result, expected)
 
-    def test_get_pgstatlastoperations_dict_00(self):
-        last_operations = ['public,t1,1234,ALTER,,201212121212:101010']
+    def test_get_pgstatlastoperations_dict_single_input(self):
+        last_operations = ['public,t1,1234,ALTER,,201601011212:101010']
         last_operations_dict = get_pgstatlastoperations_dict(last_operations)
-        expected_output = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201212121212:101010'}
+        expected_output = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
         self.assertEqual(last_operations_dict, expected_output)
 
-    def test_get_pgstatlastoperations_dict_01(self):
-        last_operations = ['public,t1,1234,ALTER,,201212121212:101010', 'public,t2,1234,VACCUM,TRUNCATE,201212121212:101015']
+    def test_get_pgstatlastoperations_dict_multiple_input(self):
+        last_operations = ['public,t1,1234,ALTER,,201601011212:101010', 'public,t2,1234,VACCUM,TRUNCATE,201601011212:101015']
         last_operations_dict = get_pgstatlastoperations_dict(last_operations)
-        expected_output = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201212121212:101010',
-                           ('1234', 'VACCUM'): 'public,t2,1234,VACCUM,TRUNCATE,201212121212:101015'}
+        expected_output = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010',
+                           ('1234', 'VACCUM'): 'public,t2,1234,VACCUM,TRUNCATE,201601011212:101015'}
         self.assertEqual(last_operations_dict, expected_output)
 
-    def test_get_pgstatlastoperations_dict_02(self):
+    def test_get_pgstatlastoperations_dict_empty(self):
         last_operations = []
         last_operations_dict = get_pgstatlastoperations_dict(last_operations)
         expected_output = {}
         self.assertEqual(last_operations_dict, expected_output)
 
-    def test_get_pgstatlastoperations_dict_03(self):
-        last_operations = ['public,t1,1234,ALTER,,201212121212:101010',  '2345,VACCUM,TRUNCATE,201212121212:101015']
+    def test_get_pgstatlastoperations_dict_invalid_input(self):
+        last_operations = ['public,t1,1234,ALTER,,201601011212:101010',  '2345,VACCUM,TRUNCATE,201601011212:101015']
         with self.assertRaisesRegexp(Exception, 'Wrong number of tokens in last_operation data for last backup'):
             get_pgstatlastoperations_dict(last_operations)
 
-    def test_compare_metadata_00(self):
-        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201212121212:101010'}
-        cur_metadata = ['public,t1,1234,ALTER,,201212121212:101010']
+    def test_compare_metadata_(self):
+        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
+        cur_metadata = ['public,t1,1234,ALTER,,201601011212:101010']
         dirty_tables = compare_metadata(old_metadata, cur_metadata)
         self.assertEquals(dirty_tables, set())
 
-    def test_compare_metadata_01(self):
-        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201212121212:101010'}
-        cur_metadata = ['public,t1,1234,TRUNCATE,,201212121212:101010']
+    def test_compare_metadata_different_keyword(self):
+        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
+        cur_metadata = ['public,t1,1234,TRUNCATE,,201601011212:101010']
         dirty_tables = compare_metadata(old_metadata, cur_metadata)
         self.assertEquals(dirty_tables, set(['public.t1']))
 
-    def test_compare_metadata_02(self):
-        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201212121212:101010'}
-        cur_metadata = ['public,t1,1234,ALTER,,201212121212:102510']
+    def test_compare_metadata_different_timestamp(self):
+        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
+        cur_metadata = ['public,t1,1234,ALTER,,201601011212:102510']
         dirty_tables = compare_metadata(old_metadata, cur_metadata)
         self.assertEquals(dirty_tables, set(['public.t1']))
 
-    def test_compare_metadata_03(self):
-        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201212121212:101010'}
-        cur_metadata = ['public,t1,1234,ALTER,,201212121212:101010','public,t1,1234,TRUNCATE,,201212121212:101010']
+    def test_compare_metadata_duplicate_input(self):
+        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
+        cur_metadata = ['public,t1,1234,ALTER,,201601011212:101010','public,t1,1234,TRUNCATE,,201601011212:101010']
         dirty_tables = compare_metadata(old_metadata, cur_metadata)
         self.assertEquals(dirty_tables, set(['public.t1']))
 
-    def test_compare_metadata_04(self):
-        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201212121212:101010'}
-        cur_metadata = ['public,t1,1234,ALTER,,201212121212:101010,']
+    def test_compare_metadata_invalid_input(self):
+        old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
+        cur_metadata = ['public,t1,1234,ALTER,,201601011212:101010,']
         with self.assertRaisesRegexp(Exception, 'Wrong number of tokens in last_operation data for current backup'):
             compare_metadata(old_metadata, cur_metadata)
 
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212010100')
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101010100')
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=[])
-    def test_get_tables_with_dirty_metadata_00(self, mock1, mock2):
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    def test_get_tables_with_dirty_metadata_empty(self, mock1, mock2, mock3):
         expected_output = set()
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
+        full_timestamp = '20160101010101'
         cur_pgstatoperations = []
-        dirty_tables = get_tables_with_dirty_metadata(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, cur_pgstatoperations)
+        dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
         self.assertEqual(dirty_tables, expected_output)
 
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212010100')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public,t1,1234,ALTER,CHANGE COLUMN,201212121212:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102510'])
-    def test_get_tables_with_dirty_metadata_01(self, mock1, mock2):
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101010100')
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510'])
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    def test_get_tables_with_dirty_metadata_default(self, mock1, mock2, mock3):
         expected_output = set()
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201212121212:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102510']
-        dirty_tables = get_tables_with_dirty_metadata(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, cur_pgstatoperations)
+        cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510']
+        dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
         self.assertEqual(dirty_tables, expected_output)
 
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212010100')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public,t1,1234,ALTER,CHANGE COLUMN,201212121212:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102511'])
-    def test_get_tables_with_dirty_metadata_02(self, mock1, mock2):
-        expected_output = set(['pepper.t2'])
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201212121212:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102510']
-        dirty_tables = get_tables_with_dirty_metadata(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, cur_pgstatoperations)
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101010100')
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102511'])
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    def test_get_tables_with_dirty_metadata_changed_table(self, mock1, mock2, mock3):
+        expected_output = set(['testschema.t2'])
+        cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510']
+        dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
         self.assertEqual(dirty_tables, expected_output)
 
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212010100')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['pepper,t2,2234,TRUNCATE,,201212121213:102510'])
-    def test_get_tables_with_dirty_metadata_03(self, mock1, mock2):
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101010100')
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['testschema,t1,2234,TRUNCATE,,201601011213:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510'])
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    def test_get_tables_with_dirty_metadata_extras(self, mock1, mock2, mock3):
+        expected_output = set(['testschema.t2', 'public.t3'])
+        full_timestamp = '20160101010101'
+        cur_pgstatoperations = ['testschema,t2,1234,ALTER,CHANGE COLUMN,201601011212:102510',
+                                'testschema,t2,2234,TRUNCATE,,201601011213:102510',
+                                'public,t3,2234,TRUNCATE,,201601011213:102510']
+        dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
+        self.assertEqual(dirty_tables, expected_output)
+
+
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101010100')
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['testschema,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510'])
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
+    def test_get_tables_with_dirty_metadata_different_schema(self, mock1, mock2, mock3):
         expected_output = set(['public.t1'])
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201212121212:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102510']
-        dirty_tables = get_tables_with_dirty_metadata(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, cur_pgstatoperations)
+        cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510']
+        dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
         self.assertEqual(dirty_tables, expected_output)
 
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212010100')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['pepper,t1,2234,TRUNCATE,,201212121213:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102510'])
-    def test_get_tables_with_dirty_metadata_04(self, mock1, mock2):
-        expected_output = set(['pepper.t2', 'public.t3'])
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        cur_pgstatoperations = ['pepper,t2,1234,ALTER,CHANGE COLUMN,201212121212:102510',
-                                'pepper,t2,2234,TRUNCATE,,201212121213:102510',
-                                'public,t3,2234,TRUNCATE,,201212121213:102510']
-        dirty_tables = get_tables_with_dirty_metadata(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, cur_pgstatoperations)
-        self.assertEqual(dirty_tables, expected_output)
-
-
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212010100')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['pepper,t1,1234,ALTER,CHANGE COLUMN,201212121212:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102510'])
-    def test_get_tables_with_dirty_metadata_05(self, mock1, mock2):
-        expected_output = set(['public.t1'])
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201212121212:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102510']
-        dirty_tables = get_tables_with_dirty_metadata(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, cur_pgstatoperations)
-        self.assertEqual(dirty_tables, expected_output)
-
-    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20121212010100')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['pepper,t1,1234,ALTER,CHANGE COLUMN,201212121212:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102510'])
+    @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101010100')
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['testschema,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510'])
     @patch('gppylib.operations.dump.restore_file_with_nbu')
-    def test_get_tables_with_dirty_metadata_06(self, mock1, mock2, mock3):
+    def test_get_tables_with_dirty_metadata_nbu(self, mock1, mock2, mock3):
         expected_output = set(['public.t1'])
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
-        cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201212121212:102510', 'pepper,t2,2234,TRUNCATE,,201212121213:102510']
-        netbackup_service_host = "mdw"
-        netbackup_block_size = "1024"
-        dirty_tables = get_tables_with_dirty_metadata(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, cur_pgstatoperations, netbackup_service_host, netbackup_block_size)
+        cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510']
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_block_size = "1024"
+        dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
         self.assertEqual(dirty_tables, expected_output)
 
-    @patch('gppylib.operations.dump.get_last_state', return_value=['pepper, t1, 100', 'pepper, t2, 200'])
-    def test_get_dirty_partition_tables_00(self, mock1):
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
+    @patch('gppylib.operations.dump.get_last_state', return_value=['testschema, t1, 100', 'testschema, t2, 200'])
+    def test_get_dirty_partition_tables_default(self, mock1):
         table_type = 'ao'
-        curr_state_partition_list = ['pepper,t3,300', 'pepper,t1,200']
-        expected_output = set(['pepper.t3', 'pepper.t1'])
-        result = get_dirty_partition_tables(table_type, curr_state_partition_list, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp)
+        curr_state_partition_list = ['testschema, t3, 300', 'testschema, t1, 200']
+        expected_output = set(['testschema.t3', 'testschema.t1'])
+        result = get_dirty_partition_tables(self.context, table_type, curr_state_partition_list)
         self.assertEqual(result, expected_output)
 
-    @patch('gppylib.operations.dump.get_last_state', return_value=['pepper, t1, 100', 'pepper, t2, 200'])
-    def test_get_dirty_partition_tables_01(self, mock1):
-        master_datadir = 'foo'
-        backup_dir = None
-        full_timestamp = '20121212010101'
+    @patch('gppylib.operations.dump.get_last_state', return_value=['testschema, t1, 100', 'testschema, t2, 200'])
+    def test_get_dirty_partition_tables_nbu(self, mock1):
         table_type = 'ao'
-        curr_state_partition_list = ['pepper,t3,300', 'pepper,t1,200']
-        netbackup_service_host = "mdw"
-        netbackup_block_size = "1024"
-        expected_output = set(['pepper.t3', 'pepper.t1'])
-        result = get_dirty_partition_tables(table_type, curr_state_partition_list, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_block_size)
+        curr_state_partition_list = ['testschema, t3, 300', 'testschema, t1, 200']
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_block_size = "1024"
+        expected_output = set(['testschema.t3', 'testschema.t1'])
+        result = get_dirty_partition_tables(self.context, table_type, curr_state_partition_list)
         self.assertEqual(result, expected_output)
 
     @patch('gppylib.operations.dump.get_dirty_heap_tables', return_value=set(['public.heap_table1']))
     @patch('gppylib.operations.dump.get_dirty_partition_tables', side_effect=[set(['public,ao_t1,100', 'public,ao_t2,100']), set(['public,co_t1,100', 'public,co_t2,100'])])
-    @patch('gppylib.operations.dump.get_tables_with_dirty_metadata', return_value=set(['public,ao_t3,1234,CREATE,,20121212101010', 'public,co_t3,2345,VACCUM,,20121212101010', 'public,ao_t1,1234,CREATE,,20121212101010']))
-    def test_get_dirty_tables_00(self, mock1, mock2, mock3):
-        master_port = '5432'
-        dbname = 'foo'
-        master_datadir = '/foo'
-        backup_dir = None
-        fulldump_ts = '20121212101010'
+    @patch('gppylib.operations.dump.get_tables_with_dirty_metadata', return_value=set(['public,ao_t3,1234,CREATE,,20160101101010', 'public,co_t3,2345,VACCUM,,20160101101010', 'public,ao_t1,1234,CREATE,,20160101101010']))
+    def test_get_dirty_tables(self, mock1, mock2, mock3):
         ao_partition_list = []
         co_partition_list = []
         last_operation_data = []
-        netbackup_service_host = None
-        netbackup_block_size = None
-        dirty_tables = get_dirty_tables(master_port, dbname, master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix,
-                                        fulldump_ts, ao_partition_list, co_partition_list, last_operation_data, netbackup_service_host, netbackup_block_size)
+        dirty_tables = get_dirty_tables(self.context, ao_partition_list, co_partition_list, last_operation_data)
         expected_output = ['public.heap_table1', 'public.ao_t1', 'public.ao_t2', 'public.co_t1', 'public.co_t2', 'public.ao_t3', 'public.co_t3']
         self.assertEqual(dirty_tables.sort(), expected_output.sort())
 
-    @patch('gppylib.operations.dump.get_latest_report_timestamp', return_value = '20130127150999')
-    def test_validate_current_timestamp_00(self, mock):
+    @patch('gppylib.operations.dump.get_latest_report_timestamp', return_value = '20160101010100')
+    def test_validate_current_timestamp_default(self, mock):
         directory = '/foo'
         #no exception
-        validate_current_timestamp(directory, self.dumper.dump_dir, self.dumper.dump_prefix, current='20130127151000')
+        validate_current_timestamp(self.context, current='20160101010101')
 
-    @patch('gppylib.operations.dump.get_latest_report_timestamp', return_value = '20130127151000')
-    def test_validate_current_timestamp_01(self, mock):
+    @patch('gppylib.operations.dump.get_latest_report_timestamp', return_value = '20160101010101')
+    def test_validate_current_timestamp_same_timestamp(self, mock):
         directory = '/foo'
         with self.assertRaisesRegexp(Exception, 'There is a future dated backup on the system preventing new backups'):
-            validate_current_timestamp(directory, self.dumper.dump_dir, self.dumper.dump_prefix, current='20130127151000')
+            validate_current_timestamp(self.context, current='20160101010101')
 
-    @patch('gppylib.operations.dump.get_latest_report_timestamp', return_value = '20130127151001')
-    def test_validate_current_timestamp_02(self, mock):
+    @patch('gppylib.operations.dump.get_latest_report_timestamp', return_value = '20170101010101')
+    def test_validate_current_timestamp_future_timestamp(self, mock):
         directory = '/foo'
         with self.assertRaisesRegexp(Exception, 'There is a future dated backup on the system preventing new backups'):
-            validate_current_timestamp(directory, self.dumper.dump_dir, self.dumper.dump_prefix, current='20130127151000')
+            validate_current_timestamp(self.context, current='20160101010101')
 
-    @patch('gppylib.operations.dump.get_latest_report_timestamp', return_value = '20140127151001')
-    def test_validate_current_timestamp_03(self, mock):
-        directory = '/foo'
-        with self.assertRaisesRegexp(Exception, 'There is a future dated backup on the system preventing new backups'):
-            validate_current_timestamp(directory, self.dumper.dump_dir, self.dumper.dump_prefix, current='20130127151000')
-
-    @patch('gppylib.operations.dump.get_latest_report_timestamp', return_value = '20120127150999')
-    def test_validate_current_timestamp_04(self, mock):
-        directory = '/foo'
-        #no exception
-        validate_current_timestamp(directory, self.dumper.dump_dir, self.dumper.dump_prefix, current='20130127151000')
-
-    def test_validate_modcount_00(self):
+    def test_validate_modcount_default(self):
         schemaname = 'public'
         partitionname = 't1'
         tuple_count = '999999999999999'
         validate_modcount(schemaname, partitionname, tuple_count)
 
-    def test_validate_modcount_01(self):
+    def test_validate_modcount_non_int(self):
         schemaname = 'public'
         partitionname = 't1'
         tuple_count = '#########'
         with self.assertRaisesRegexp(Exception, 'Can not convert modification count for table.'):
             validate_modcount(schemaname, partitionname, tuple_count)
 
-    def test_validate_modcount_02(self):
+    def test_validate_modcount_scientific_notation(self):
         schemaname = 'public'
         partitionname = 't1'
         tuple_count = '1+e15'
         with self.assertRaisesRegexp(Exception, 'Can not convert modification count for table.'):
             validate_modcount(schemaname, partitionname, tuple_count)
 
-    def test_validate_modcount_03(self):
+    def test_validate_modcount_exceeded_count(self):
         schemaname = 'public'
         partitionname = 't1'
         tuple_count = '1000000000000000'
         with self.assertRaisesRegexp(Exception, 'Exceeded backup max tuple count of 1 quadrillion rows per table for:'):
             validate_modcount(schemaname, partitionname, tuple_count)
 
-    def test_generate_dump_timestamp_00(self):
-        timestamp = datetime(2013, 02, 04, 10, 10, 10, 10000)
-        generate_dump_timestamp(timestamp)
-        from gppylib.operations.dump import DUMP_DATE, TIMESTAMP_KEY, TIMESTAMP
-        ts_key = timestamp.strftime("%Y%m%d%H%M%S")
-        self.assertEqual(timestamp, TIMESTAMP)
-        self.assertEqual(ts_key, TIMESTAMP_KEY)
-        self.assertEqual(ts_key[0:8], DUMP_DATE)
+    def test_generate_dump_timestamp_default(self):
+        ts_key = datetime(2013, 02, 04, 10, 10, 10, 10000).strftime("%Y%m%d%H%M%S")
+        self.context.timestamp_key = ts_key
+        self.context.generate_dump_timestamp()
+        self.assertEqual(ts_key, self.context.timestamp)
+        self.assertEqual(ts_key[0:8], self.context.db_date_dir)
 
-    def test_generate_dump_timestamp_01(self):
-        timestamp = None
-        generate_dump_timestamp(timestamp)
-        from gppylib.operations.dump import DUMP_DATE, TIMESTAMP_KEY, TIMESTAMP
-        self.assertNotEqual(None, TIMESTAMP)
-        self.assertNotEqual(None, TIMESTAMP_KEY)
-        self.assertNotEqual(None, DUMP_DATE)
+    def test_generate_dump_timestamp_no_timestamp(self):
+        self.context.timestamp_key = None
+        self.context.generate_dump_timestamp()
+        self.assertNotEqual(None, self.context.timestamp)
+        self.assertNotEqual(None, self.context.db_date_dir)
 
-    def test_generate_dump_timestamp_02(self):
-        timestamp1 = datetime(2013, 02, 04, 10, 10, 10, 10000)
-        generate_dump_timestamp(timestamp1)
-        timestamp2 = datetime(2013, 03, 04, 10, 10, 10, 10000)
-        generate_dump_timestamp(timestamp2)
-        from gppylib.operations.dump import DUMP_DATE, TIMESTAMP_KEY, TIMESTAMP
-        ts_key = timestamp2.strftime("%Y%m%d%H%M%S")
-        self.assertEqual(timestamp2, TIMESTAMP)
-        self.assertEqual(ts_key, TIMESTAMP_KEY)
-        self.assertEqual(ts_key[0:8], DUMP_DATE)
+    def test_generate_dump_timestamp_replace_timestamp(self):
+        ts1 = datetime(2013, 02, 04, 10, 10, 10, 10000)
+        ts2 = datetime(2013, 03, 04, 10, 10, 10, 10000)
+        self.context.timestamp_key = ts1.strftime("%Y%m%d%H%M%S")
+        self.context.generate_dump_timestamp()
+        self.context.timestamp_key = ts2.strftime("%Y%m%d%H%M%S")
+        self.context.generate_dump_timestamp()
+        ts_key = ts2.strftime("%Y%m%d%H%M%S")
+        self.assertEqual(ts_key, self.context.timestamp)
+        self.assertEqual(ts_key[0:8], self.context.db_date_dir)
 
-    def test_generate_dump_timestamp_03(self):
-        timestamp1 = datetime(2013, 02, 04, 10, 10, 10, 10000)
-        generate_dump_timestamp(timestamp1)
-        timestamp2 = datetime(2012, 03, 04, 10, 10, 10, 10000)
-        generate_dump_timestamp(timestamp2)
-        from gppylib.operations.dump import DUMP_DATE, TIMESTAMP_KEY, TIMESTAMP
-        ts_key = timestamp2.strftime("%Y%m%d%H%M%S")
-        self.assertEqual(timestamp2, TIMESTAMP)
-        self.assertEqual(ts_key, TIMESTAMP_KEY)
-        self.assertEqual(ts_key[0:8], DUMP_DATE)
+    def test_create_dump_string_with_prefix_schema_level_dump(self):
+        self.context.dump_prefix = 'foo_'
+        self.context.schema_file = '/tmp/schema_file '
+        with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
+            output = self.dumper.create_dump_string()
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file """
+            self.assertEquals(output, expected_output)
 
-    def test_create_dump_line_00(self):
-        self.dumper.include_schema_file = '/tmp/schema_file'
-        output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
-        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file"""
-        self.assertEquals(output, expected_output)
+    def test_create_dump_string_default(self):
+        self.context.schema_file = '/tmp/schema_file'
+        with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
+            output = self.dumper.create_dump_string()
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file"""
+            self.assertEquals(output, expected_output)
 
-    def test00_create_dump_line_with_prefix(self):
-        self.dumper.dump_prefix = 'foo_'
-        output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
-        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
-        self.assertEquals(output, expected_output)
+    def test_create_dump_string_without_incremental(self):
+        with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
+            output = self.dumper.create_dump_string()
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
+            self.assertEquals(output, expected_output)
 
-    def test_create_dump_line_with_include_file(self):
-        self.dumper.dump_prefix = 'metro_'
-        self.dumper.include_dump_tables_file = ('bar')
-        output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
-        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=%s""" % self.dumper.include_dump_tables_file
-        self.assertEquals(output, expected_output)
+    def test_create_dump_string_with_prefix(self):
+        self.context.dump_prefix = 'foo_'
+        with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
+            output = self.dumper.create_dump_string()
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
+            self.assertEquals(output, expected_output)
 
-    def test_create_dump_line_with_no_file_args(self):
-        self.dumper.dump_prefix = 'metro_'
-        self.dumper.include_dump_tables_file = None
-        output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
-        expected_output = '''gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb"'''
-        self.assertEquals(output, expected_output)
+    def test_create_dump_string_with_include_file(self):
+        self.context.dump_prefix = 'metro_'
+        self.context.include_dump_tables_file = 'bar'
+        with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
+            output = self.dumper.create_dump_string()
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=%s""" % self.context.include_dump_tables_file
+            self.assertEquals(output, expected_output)
 
-    def test_create_dump_line_with_netbackup_params(self):
-        self.dumper.include_dump_tables_file = None 
-        self.dumper.netbackup_service_host = "mdw"
-        self.dumper.netbackup_policy = "test_policy"
-        self.dumper.netbackup_schedule = "test_schedule"
-        output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
-        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --netbackup-service-host=mdw --netbackup-policy=test_policy --netbackup-schedule=test_schedule"""
-        self.assertEquals(output, expected_output)
+    def test_create_dump_string_with_no_file_args(self):
+        self.context.dump_prefix = 'metro_'
+        self.context.include_dump_tables_file = None
+        with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
+            output = self.dumper.create_dump_string()
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb\""""
+            self.assertEquals(output, expected_output)
 
-    def test_create_dump_line_with_prefix_schema_level_dump(self):
-        self.dumper.dump_prefix = 'foo_'
-        self.dumper.include_schema_file = '/tmp/schema_file '
-        output = self.dumper.create_dump_string('dcddev', '20121212', '01234567891234')
-        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file """
-        self.assertEquals(output, expected_output)
+    def test_create_dump_string_with_netbackup_params(self):
+        self.context.include_dump_tables_file = None
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_policy = "test_policy"
+        self.context.netbackup_schedule = "test_schedule"
+        with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
+            output = self.dumper.create_dump_string()
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --netbackup-service-host=mdw --netbackup-policy=test_policy --netbackup-schedule=test_schedule"""
+            self.assertEquals(output, expected_output)
 
     def test_get_backup_dir_with_master_data_dir(self):
-        master_datadir = '/foo'
-        backup_dir = None
-        self.assertEquals('/foo', get_backup_dir(master_datadir, backup_dir))
+        self.assertEquals('/data/master/p1/db_dumps/20160101', self.context.get_backup_dir())
 
     def test_get_backup_dir_with_backup_dir(self):
-        master_datadir = 'foo'
-        backup_dir = '/bkup'
-        self.assertEquals('/bkup', get_backup_dir(master_datadir, backup_dir))
+        self.context.backup_dir = '/tmp'
+        self.assertEquals('/tmp/db_dumps/20160101', self.context.get_backup_dir())
 
-    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20130101010101')
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101010101')
     @patch('os.path.isfile', return_value=True)
     def test_get_filter_file_file_exists(self, mock1, mock2):
-        dump_prefix = 'metro_'
-        master_datadir = '/foo'
-        backup_dir = None
-        dump_database = 'testdb'
-        expected_output = '/foo/db_dumps/20130101/metro_gp_dump_20130101010101_filter'
-        self.assertEquals(expected_output, get_filter_file(dump_database, master_datadir, backup_dir, self.dumper.dump_dir, dump_prefix))
+        self.context.dump_prefix = 'foo_'
+        expected_output = '/data/master/p1/db_dumps/20160101/foo_gp_dump_20160101010101_filter'
+        self.assertEquals(expected_output, get_filter_file(self.context))
 
     @patch('os.path.isfile', return_value=False)
-    @patch('gppylib.operations.dump.get_latest_full_ts_with_nbu', return_value='20130101010101')
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101010101')
+    @patch('gppylib.operations.dump.get_latest_full_ts_with_nbu', return_value='20160101010101')
     @patch('gppylib.operations.dump.check_file_dumped_with_nbu', return_value=True)
     @patch('gppylib.operations.dump.restore_file_with_nbu')
-    def test_get_filter_file_file_exists_on_nbu(self, mock1, mock2, mock3, mock4):
-        dump_prefix = 'metro_'
-        master_datadir = '/foo'
-        backup_dir = None
-        dump_database = 'testdb'
-        netbackup_service_host = "mdw"
-        netbackup_block_size = "1024"
-        ddboost = False
-        storage_unit = None
-        expected_output = '/foo/db_dumps/20130101/metro_gp_dump_20130101010101_filter'
-        self.assertEquals(expected_output, get_filter_file(dump_database, master_datadir, backup_dir, self.dumper.dump_dir, dump_prefix, ddboost, storage_unit, netbackup_service_host, netbackup_block_size))
+    def test_get_filter_file_file_exists_on_nbu(self, mock1, mock2, mock3, mock4, mock5):
+        self.context.dump_prefix = 'foo_'
+        self.context.netbackup_block_size = "1024"
+        self.context.netbackup_service_host = "mdw"
+        expected_output = '/data/master/p1/db_dumps/20160101/foo_gp_dump_20160101010101_filter'
+        self.assertEquals(expected_output, get_filter_file(self.context))
 
-    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20130101010101')
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101010101')
     @patch('os.path.isfile', return_value=False)
-    def test_get_filter_file_file_does_not_exists(self, mock1, mock2):
-        dump_prefix = 'metro_'
-        master_datadir = '/foo'
-        backup_dir = None
-        dump_database = 'testdb'
-        self.assertEquals(None, get_filter_file(dump_database, master_datadir, backup_dir, self.dumper.dump_dir, dump_prefix))
+    def test_get_filter_file_file_does_not_exist(self, mock1, mock2):
+        self.assertEquals(None, get_filter_file(self.context))
 
-    def test_update_filter_file_with_dirty_list_00(self):
+    def test_update_filter_file_with_dirty_list_default(self):
         filter_file = '/tmp/foo'
-        write_lines_to_file(filter_file, ['public.t1'])
         dirty_tables = ['public.t1', 'public.t2']
         expected_output = ['public.t1', 'public.t2']
-        update_filter_file_with_dirty_list(filter_file, dirty_tables)
-        output = get_lines_from_file(filter_file)
-        try:
-            self.assertEquals(expected_output, output)
-        finally:
-            if os.path.exists(filter_file):
-                os.remove(filter_file)
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            update_filter_file_with_dirty_list(filter_file, dirty_tables)
+            result = m()
+            self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
+            for i in range(len(dirty_tables)):
+                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
 
-    def test_update_filter_file_with_dirty_list_01(self):
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['public.t1', 'public.t2'])
+    def test_update_filter_file_with_dirty_list_duplicates(self, mock1):
         filter_file = '/tmp/foo'
-        write_lines_to_file(filter_file, ['public.t1'])
-        dirty_tables = ['public.t1']
-        expected_output = ['public.t1']
-        update_filter_file_with_dirty_list(filter_file, dirty_tables)
-        output = get_lines_from_file(filter_file)
-        try:
-            self.assertEquals(expected_output, output)
-        finally:
-            if os.path.exists(filter_file):
-                os.remove(filter_file)
-
-    def test_update_filter_file_with_dirty_list_02(self):
-        filter_file = '/tmp/foo'
-        write_lines_to_file(filter_file, ['public.t1', 'public.t2'])
         dirty_tables = ['public.t2']
         expected_output = ['public.t1', 'public.t2']
-        update_filter_file_with_dirty_list(filter_file, dirty_tables)
-        output = get_lines_from_file(filter_file)
-        try:
-            self.assertEquals(expected_output, output)
-        finally:
-            if os.path.exists(filter_file):
-                os.remove(filter_file)
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            update_filter_file_with_dirty_list(filter_file, dirty_tables)
+            result = m()
+            self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
+            for i in range(len(dirty_tables)):
+                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
 
-    def test_update_filter_file_with_dirty_list_03(self):
+    def test_update_filter_file_with_dirty_list_empty_file(self):
         filter_file = '/tmp/foo'
-        write_lines_to_file(filter_file, [])
         dirty_tables = ['public.t1', 'public.t2']
         expected_output = ['public.t1', 'public.t2']
-        update_filter_file_with_dirty_list(filter_file, dirty_tables)
-        output = get_lines_from_file(filter_file)
-        try:
-            self.assertEquals(expected_output, output)
-        finally:
-            if os.path.exists(filter_file):
-                os.remove(filter_file)
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            update_filter_file_with_dirty_list(filter_file, dirty_tables)
+            result = m()
+            self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
+            for i in range(len(dirty_tables)):
+                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
 
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'pepper.t2'])
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'testschema.t2'])
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20130101010101')
     @patch('gppylib.operations.dump.get_filter_file', return_value='/foo/metro_gp_dump_20130101010101_filter')
-    def test_filter_dirty_tables_with_filter(self, mock1, mock2, mock3):
-        dump_prefix = 'metro_'
-        master_datadir = '/foo'
-        backup_dir = None
-        dump_database = 'testdb'
-        dirty_tables = ['public.t1', 'public.t2', 'pepper.t1', 'pepper.t2']
-        expected_output = ['public.t1', 'pepper.t2']
-        self.assertEquals(sorted(expected_output), sorted(filter_dirty_tables(dirty_tables, dump_database, master_datadir, backup_dir, self.dumper.dump_dir, dump_prefix)))
+    @patch('gppylib.operations.dump.get_latest_full_ts_with_nbu', return_value='20130101010101')
+    def test_filter_dirty_tables_with_filter(self, mock1, mock2, mock3, mock4):
+        dirty_tables = ['public.t1', 'public.t2', 'testschema.t1', 'testschema.t2']
+        expected_output = ['public.t1', 'testschema.t2']
+        self.context.netbackup_service_host = 'mdw'
+        self.assertEquals(sorted(expected_output), sorted(filter_dirty_tables(self.context, dirty_tables)))
 
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'pepper.t2'])
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'testschema.t2'])
     @patch('gppylib.operations.dump.get_filter_file', return_value='/foo/metro_gp_dump_20130101010101_filter')
     @patch('gppylib.operations.dump.get_latest_full_ts_with_nbu', return_value='20130101010101')
-    def test_filter_dirty_tables_with_filter_with_nbu(self, mock1, mock2, mock3):
-        dump_prefix = 'metro_'
-        master_datadir = '/foo'
-        backup_dir = None
-        dump_database = 'testdb'
-        netbackup_service_host = "mdw"
-        netbackup_block_size = "1024"
-        ddboost = False
-        storage_unit = None
-        dirty_tables = ['public.t1', 'public.t2', 'pepper.t1', 'pepper.t2']
-        expected_output = ['public.t1', 'pepper.t2']
-        self.assertEquals(sorted(expected_output), sorted(filter_dirty_tables(dirty_tables, dump_database, master_datadir, backup_dir, self.dumper.dump_dir, dump_prefix, ddboost, storage_unit, netbackup_service_host, netbackup_block_size)))
+    @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20130101010101')
+    def test_filter_dirty_tables_with_filter_with_nbu(self, mock1, mock2, mock3, mock4):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_block_size = "1024"
+        dirty_tables = ['public.t1', 'public.t2', 'testschema.t1', 'testschema.t2']
+        expected_output = ['public.t1', 'testschema.t2']
+        self.assertEquals(sorted(expected_output), sorted(filter_dirty_tables(self.context, dirty_tables)))
 
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'pepper.t2'])
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'testschema.t2'])
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20130101010101')
     @patch('gppylib.operations.dump.get_filter_file', return_value=None)
     def test_filter_dirty_tables_without_filter(self, mock1, mock2, mock3):
-        dump_prefix = 'metro_'
-        master_datadir = '/foo'
-        backup_dir = None
-        dump_database = 'testdb'
-        dirty_tables = ['public.t1', 'public.t2', 'pepper.t1', 'pepper.t2']
-        self.assertEquals(sorted(dirty_tables), sorted(filter_dirty_tables(dirty_tables, dump_database, master_datadir, backup_dir, self.dumper.dump_dir, dump_prefix)))
+        dirty_tables = ['public.t1', 'public.t2', 'testschema.t1', 'testschema.t2']
+        self.assertEquals(sorted(dirty_tables), sorted(filter_dirty_tables(self.context, dirty_tables)))
 
-    @patch('gppylib.operations.dump.get_filter_file', return_value='/tmp/db_dumps/20121212/foo_gp_dump_01234567891234_filter')
+    @patch('gppylib.operations.dump.get_filter_file', return_value='/tmp/db_dumps/20160101/foo_gp_dump_01234567891234_filter')
     def test_create_filtered_dump_string(self, mock1):
-        self.dumper.dump_prefix = 'foo_'
-        output = self.dumper.create_filtered_dump_string('dcddev', '20121212', '01234567891234')
-        expected_output = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt --incremental-filter=/tmp/db_dumps/20121212/foo_gp_dump_01234567891234_filter"""
-        self.assertEquals(output, expected_output)
+        self.context.dump_prefix = 'foo_'
+        with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
+            output = self.dumper.create_filtered_dump_string()
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt --incremental-filter=/tmp/db_dumps/20160101/foo_gp_dump_01234567891234_filter"""
+            self.assertEquals(output, expected_output)
 
     @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "", "", True, False))
     @patch('gppylib.operations.dump.Command.run')
     def test_perform_dump_normal(self, mock1, mock2):
-        self.dumper.dump_prefix = 'foo_'
+        self.context.dump_prefix = 'foo_'
         title = 'Dump process'
-        dump_line = """gp_dump -p 0 -U dcddev --gp-d=/data/master/p1/db_dumps/20121212 --gp-r=/data/master/p1/db_dumps/20121212 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" testdb --table-file=/tmp/table_list.txt"""
+        dump_line = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
         (start, end, rc) = self.dumper.perform_dump(title, dump_line)
         self.assertNotEqual(start, None)
         self.assertNotEqual(end, None)
         self.assertEquals(rc, 0)
 
-class DumpGlobalTestCase(unittest.TestCase):
-
-    def setUp(self):
-        self.dumper = DumpGlobal(timestamp=None,
-                                 master_datadir='/foo',
-                                 master_port=0,
-                                 backup_dir='/foo',
-                                 dump_dir='db_dumps',
-                                 dump_prefix='',
-                                 ddboost=False,
-                                 ddboost_storage_unit=None)
-
     def test_create_pgdump_command_line(self):
-        self.dumper = DumpGlobal(timestamp=TIMESTAMP_KEY, master_datadir='/foo', master_port=9000, backup_dir='/foo', dump_dir='db_dumps', dump_prefix='', ddboost=False, ddboost_storage_unit=None)
-        global_file_name = '/foo/db_dumps/%s/gp_global_1_1_%s' % (DUMP_DATE, TIMESTAMP_KEY)
-
-        expected_output = "pg_dumpall -p 9000 -g --gp-syntax > %s" % global_file_name
-        output = self.dumper.create_pgdump_command_line()
+        global_file_name = '/data/master/p1/db_dumps/20160101/gp_global_1_1_20160101010101'
+        expected_output = "pg_dumpall -p 5432 -g --gp-syntax > %s" % global_file_name
+        output = self.dump_globals.create_pgdump_command_line()
         self.assertEquals(output, expected_output)
 
+    @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.dump.get_filter_file', return_value = '/tmp/update_test')
     @patch('gppylib.operations.dump.get_lines_from_file', return_value = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1'])
-    @patch('gppylib.operations.dump.execute_sql', return_value = [('public','ao_part_table','ao_part_table_1_prt_p1'), ('public','ao_part_table','ao_part_table_1_prt_p2')])
-    def test_update_filter_file_00(self, mock1, mock2, mock3):
-        master_datadir = '/tmp'
-        backup_dir = None
-        dump_database = 'testdb'
-        master_port = 5432
+    @patch('gppylib.operations.dump.execute_sql', side_effect = [ [['public.ao_part_table']], [['public.ao_part_table_1_prt_p1'], ['public.ao_part_table_1_prt_p2']] ])
+    def test_update_filter_file_default(self, mock1, mock2, mock3, mock4):
         filter_filename = '/tmp/update_test'
-
-        update_filter_file(dump_database, master_datadir, backup_dir, master_port, self.dumper.dump_dir, self.dumper.dump_prefix)
-        contents = get_lines_from_file(filter_filename)
+        contents = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1']
         expected_result = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1', 'public.ao_part_table_1_prt_p2']
-        self.assertEqual(expected_result.sort(), contents.sort())
-        os.remove(filter_filename)
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            update_filter_file(self.context)
+            result = m()
+            self.assertEqual(len(expected_result), len(result.write.call_args_list))
+            expected = sorted(expected_result)
+            output = sorted(result.write.call_args_list)
+            for i in range(len(expected)):
+                self.assertEqual(call(expected[i]+'\n'), output[i])
 
+    @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.dump.get_filter_file', return_value = '/tmp/update_test')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1', 'public.ao_part_table_1_prt_p2'])
-    @patch('gppylib.operations.dump.execute_sql', return_value = [('public','ao_part_table','ao_part_table_1_prt_p1')])
-    def test_update_filter_file_01(self, mock1, mock2, mock3):
-        master_datadir = '/tmp'
-        backup_dir = None
-        dump_database = 'testdb'
-        master_port = 5432
-        filter_filename = '/tmp/update_test'
-
-        update_filter_file(dump_database, master_datadir, backup_dir, master_port, self.dumper.dump_dir, self.dumper.dump_prefix)
-        contents = get_lines_from_file(filter_filename)
-        expected_result = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1', 'public.ao_part_table_1_prt_p2']
-        self.assertEqual(expected_result.sort(), contents.sort())
-        os.remove(filter_filename)
-
-    @patch('gppylib.operations.dump.get_filter_file', return_value='/tmp/update_test')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.heap_table1', 'public.ao_part_table', 'public.ao_part_table_1_prt_p1', 'public.ao_part_table_1_prt_p2'])
-    @patch('gppylib.operations.dump.execute_sql', return_value=[('public', 'ao_part_table', 'ao_part_table_1_prt_p1')])
+    @patch('gppylib.operations.dump.get_lines_from_file', return_value = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1'])
+    @patch('gppylib.operations.dump.execute_sql', side_effect = [ [['public.ao_part_table']], [['public.ao_part_table_1_prt_p1'], ['public.ao_part_table_1_prt_p2']] ])
     @patch('gppylib.operations.dump.restore_file_with_nbu')
     @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_update_filter_file_02(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = '/tmp'
-        backup_dir = None
-        dump_database = 'testdb'
-        master_port = 5432
+    def test_update_filter_file_default_with_nbu(self, mock1, mock2, mock3, mock4, mock5, mock6):
         filter_filename = '/tmp/update_test'
-        netbackup_service_host = "mdw"
-        netbackup_policy = "nbu_policy"
-        netbackup_schedule = "nbu_schedule"
-        netbackup_block_size = "1024"
-
-        update_filter_file(dump_database, master_datadir, backup_dir, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size)
-        contents = get_lines_from_file(filter_filename)
-        expected_result = ['public.heap_table1', 'public.ao_part_table', 'public.ao_part_table_1_prt_p1', 'public.ao_part_table_1_prt_p2']
-        self.assertEqual(expected_result.sort(), contents.sort())
-        os.remove(filter_filename)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_00(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_01(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_02(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_03(self, mock1):
-        master_datadir = None
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_04(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_05(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_06(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_07(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_08(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_09(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_10(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_11(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_backup_state_files_with_nbu_12(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = "foo"
-
-        backup_state_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_00(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_01(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_02(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_03(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_04(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, timestamp_key, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_05(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_06(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_07(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_08(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_09(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_10(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_11(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, timestamp_key, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_cdatabase_file_with_nbu_12(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = "foo"
-
-        backup_cdatabase_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_00(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_01(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_02(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_03(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_04(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_05(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_06(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_07(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_08(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_09(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_10(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_11(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_report_file_with_nbu_12(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = "foo"
-
-        backup_report_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_00(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_01(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_02(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_03(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_04(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-        
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-        
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_05(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_06(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_07(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_08(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_09(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_10(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_11(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_global_file_with_nbu_12(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = "foo"
-
-        backup_global_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_00(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_01(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = "/data"
-        backup_dir = None
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-        mock_segs = [Mock(), Mock()]
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_02(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-        mock_segs = [Mock(), Mock()]
-        netbackup_schedule = "test_schedule"
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_03(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = None
-        backup_dir = None
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-        mock_segs = [Mock(), Mock()]
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_04(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-        mock_segs = [Mock(), Mock()]
-        timestamp_key = "20140014000000"
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_05(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = "/data"
-        backup_dir = None
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-        mock_segs = [Mock(), Mock()]
-        timestamp_key = "20140014000000"
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_06(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-        mock_segs = [Mock(), Mock()]
-        timestamp_key = "20140014000000"
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_07(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = None
-        mock_segs = [Mock(), Mock()]
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_08(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = None
-        mock_segs = [Mock(), Mock()]
-        timestamp_key = "20140014000000"
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_09(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_10(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = "/data"
-        backup_dir = None
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-        mock_segs = [Mock(), Mock()]
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_11(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-        mock_segs = [Mock(), Mock()]
-        timestamp_key = "20140014000000"
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_master_config_filename')
-    @patch('gppylib.operations.dump.generate_segment_config_filename')
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    def test_backup_config_files_with_nbu_12(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = "foo"
-        mock_segs = [Mock(), Mock()]
-        timestamp_key = "20140014000000"
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-
-        backup_config_files_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, master_port, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.generate_schema_filename', result='foo_schema')
-    @patch('gppylib.operations.dump.copy_file_to_dd')
-    def backup_schema_file_with_ddboost_00(self, mock1, mock2):
-        master_datadir = '/data'
-        backup_dir = None
-        dump_dir = 'backup/DCA-35'
-        backup_schema_file_with_ddboost(master_datadir, backup_dir, dump_dir, self.dumper.dump_prefix)
-
-    @patch('gppylib.operations.dump.generate_report_filename', result='foo.rpt')
-    @patch('gppylib.operations.dump.copy_file_to_dd')
-    def test_backup_report_file_with_ddboost_00(self, mock1, mock2):
-        master_datadir = '/data'
-        backup_dir = None
-        dump_dir = 'backup/DCA-35'
-        backup_report_file_with_ddboost(master_datadir, backup_dir, dump_dir, self.dumper.dump_prefix)
-
-    @patch('gppylib.operations.dump.generate_increments_filename', result='foo.increments')
-    @patch('gppylib.operations.dump.copy_file_to_dd')
-    def test_backup_increments_file_with_ddboost_00(self, mock1, mock2):
-        master_datadir = '/data'
-        backup_dir = None
-        dump_dir = 'backup/DCA-35'
-
-        backup_increments_file_with_ddboost(master_datadir, backup_dir, dump_dir, self.dumper.dump_prefix, full_timestamp='20140101')
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_dirtytable_filename')
-    def test_backup_dirty_file_with_nbu_00(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_01(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_02(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_03(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_04(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_05(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_06(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_07(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_08(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_09(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_10(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_11(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_dirty_file_with_nbu_12(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = "foo"
-
-        backup_dirty_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_dirtytable_filename')
-    def test_backup_increments_file_with_nbu_00(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_01(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_02(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_03(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = None
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_04(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_05(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_06(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_07(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_08(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_09(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_10(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_11(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_increments_file_with_nbu_12(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        full_timestamp = "20130101000000"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = "foo"
-
-        backup_increments_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, full_timestamp, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_dirtytable_filename')
-    def test_backup_partition_list_file_with_nbu_00(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_01(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_02(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_03(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_04(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_05(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_06(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = None
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_07(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_08(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = None
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_09(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_10(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_11(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = 100
-        netbackup_keyword = "foo"
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.backup_file_with_nbu')
-    @patch('gppylib.operations.dump.generate_cdatabase_filename')
-    def test_backup_partition_list_file_with_nbu_12(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/tmp"
-        netbackup_service_host = "mdw"
-        netbackup_policy = "test_policy"
-        netbackup_schedule = "test_schedule"
-        timestamp_key = "20140014000000"
-        netbackup_block_size = None
-        netbackup_keyword = "foo"
-
-        backup_partition_list_file_with_nbu(master_datadir, backup_dir, self.dumper.dump_dir, self.dumper.dump_prefix, netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword, timestamp_key)
-
-    @patch('gppylib.operations.dump.execute_sql', return_value = [['gp_toolkit'], ['pg_toast'], ['pg_bitmapindex'], ['bar'], ['foo'], ['pg_catalog'], ['public'], ['information_schema']])
-    def test_get_include_schema_list_from_exclude_schema_00(self, mock1):
-        master_port = "5432"
-        dbname = 'testdb'
-        catalog_schema_list = ['gp_toolkit', 'information_schema']
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_policy = "nbu_policy"
+        self.context.netbackup_schedule = "nbu_schedule"
+        self.context.netbackup_block_size = "1024"
+        contents = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1']
+        expected_result = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1', 'public.ao_part_table_1_prt_p2']
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            update_filter_file(self.context)
+            result = m()
+            self.assertEqual(len(expected_result), len(result.write.call_args_list))
+            expected = sorted(expected_result)
+            output = sorted(result.write.call_args_list)
+            for i in range(len(expected)):
+                self.assertEqual(call(expected[i]+'\n'), output[i])
+
+    @patch('gppylib.operations.dump.backup_file_with_nbu')
+    def test_backup_state_files_with_nbu_default(self, mock):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_policy = "test_policy"
+        self.context.netbackup_schedule = "test_schedule"
+
+        backup_state_files_with_nbu(self.context)
+        self.assertEqual(mock.call_count, 3)
+
+    class MyMock(MagicMock):
+        def __init__(self, num_segs):
+            super(MagicMock, self).__init__()
+            self.mock_segs = []
+            for i in range(num_segs):
+                self.mock_segs.append(Mock())
+
+        def getSegmentList(self):
+            for id, seg in enumerate(self.mock_segs):
+                seg.get_active_primary.getSegmentHostName.return_value = Mock()
+                seg.get_primary_dbid.return_value = id + 2
+            return self.mock_segs
+
+    @patch('gppylib.operations.dump.GpArray.initFromCatalog', return_value=MyMock(1))
+    @patch('gppylib.gparray.GpDB.getSegmentHostName', return_value='sdw')
+    def test_backup_config_files_with_nbu_single_segment(self, mock1, mock2):
+        with patch('gppylib.operations.dump.backup_file_with_nbu', side_effect=my_counter) as nbu_mock:
+            global i
+            i = 0
+            self.context.netbackup_service_host = "mdw"
+            self.context.netbackup_policy = "test_policy"
+            self.context.netbackup_schedule = "test_schedule"
+
+            backup_config_files_with_nbu(self.context)
+            args, _ = nbu_mock.call_args_list[0]
+            self.assertEqual(args[1], "master_config")
+            for id, seg in enumerate(mock2.mock_segs):
+                self.assertEqual(seg.get_active_primary.call_count, 1)
+                self.assertEqual(seg.get_primary_dbid.call_count, 1)
+                args, _ = nbu_mock.call_args_list[id]
+                self.assertEqual(args, ("segment_config", id+2, "sdw"))
+            self.assertEqual(i, 2)
+
+    @patch('gppylib.operations.dump.GpArray.initFromCatalog', return_value=MyMock(3))
+    @patch('gppylib.gparray.GpDB.getSegmentHostName', return_value='sdw')
+    def test_backup_config_files_with_nbu_multiple_segments(self, mock1, mock2):
+        with patch('gppylib.operations.dump.backup_file_with_nbu', side_effect=my_counter) as nbu_mock:
+            global i
+            i = 0
+            self.context.netbackup_service_host = "mdw"
+            self.context.netbackup_policy = "test_policy"
+            self.context.netbackup_schedule = "test_schedule"
+
+            backup_config_files_with_nbu(self.context)
+            args, _ = nbu_mock.call_args_list[0]
+            self.assertEqual(args[1], "master_config")
+            for id, seg in enumerate(mock2.mock_segs):
+                self.assertEqual(seg.get_active_primary.call_count, 1)
+                self.assertEqual(seg.get_primary_dbid.call_count, 1)
+                args, _ = nbu_mock.call_args_list[id]
+                self.assertEqual(args, ("segment_config", id+2, "sdw"))
+            self.assertEqual(i, 4)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_ddboost_default(self, mock1, mock2):
+        self.context.backup_dir = None
+        self.context.dump_dir = 'backup/DCA-35'
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            backup_file_with_ddboost(self.context, "schema")
+            cmd.assert_called_with("copy file foo_schema to DD machine", "gpddboost --copyToDDBoost --from-file=foo_schema --to-file=backup/DCA-35/20160101/foo_schema")
+            self.assertEqual(mock2.call_count, 1)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_ddboost_no_filetype(self, mock1, mock2):
+        self.context.backup_dir = None
+        self.context.dump_dir = 'backup/DCA-35'
+        with self.assertRaisesRegexp(Exception, 'Cannot call backup_file_with_ddboost without a filetype argument'):
+            backup_file_with_ddboost(self.context)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_nbu_default(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_policy = "test_policy"
+        self.context.netbackup_schedule = "test_schedule"
+        self.context.netbackup_block_size = 100
+        cmdStr = "cat /tmp/foo_schema | gp_bsa_dump_agent --netbackup-service-host mdw --netbackup-policy test_policy --netbackup-schedule test_schedule --netbackup-filename /tmp/foo_schema --netbackup-block-size 100"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            backup_file_with_nbu(self.context, "schema")
+            cmd.assert_called_with("dumping metadata files from master", cmdStr)
+            self.assertEqual(mock2.call_count, 1)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_nbu_no_filetype(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_policy = "test_policy"
+        self.context.netbackup_schedule = "test_schedule"
+        self.context.netbackup_block_size = 100
+        cmdStr = "cat /tmp/foo_schema | gp_bsa_dump_agent --netbackup-service-host mdw --netbackup-policy test_policy --netbackup-schedule test_schedule --netbackup-filename /tmp/foo_schema --netbackup-block-size 100"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            backup_file_with_nbu(self.context, path="/tmp/foo_schema")
+            cmd.assert_called_with("dumping metadata files from master", cmdStr)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_nbu_no_path(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_policy = "test_policy"
+        self.context.netbackup_schedule = "test_schedule"
+        self.context.netbackup_block_size = 100
+        cmdStr = "cat /tmp/foo_schema | gp_bsa_dump_agent --netbackup-service-host mdw --netbackup-policy test_policy --netbackup-schedule test_schedule --netbackup-filename /tmp/foo_schema --netbackup-block-size 100"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            backup_file_with_nbu(self.context, "schema")
+            cmd.assert_called_with("dumping metadata files from master", cmdStr)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_nbu_both_args(self, mock1, mock2):
+        with self.assertRaisesRegexp(Exception, 'Cannot supply both a file type and a file path to backup_file_with_nbu'):
+            backup_file_with_nbu(self.context, "schema", "/tmp/foo_schema")
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_nbu_neither_arg(self, mock1, mock2):
+        with self.assertRaisesRegexp(Exception, 'Cannot call backup_file_with_nbu with no type or path argument'):
+            backup_file_with_nbu(self.context)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_nbu_block_size(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_policy = "test_policy"
+        self.context.netbackup_schedule = "test_schedule"
+        self.context.netbackup_block_size = 1024
+        cmdStr = "cat /tmp/foo_schema | gp_bsa_dump_agent --netbackup-service-host mdw --netbackup-policy test_policy --netbackup-schedule test_schedule --netbackup-filename /tmp/foo_schema --netbackup-block-size 1024"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            backup_file_with_nbu(self.context, "schema")
+            cmd.assert_called_with("dumping metadata files from master", cmdStr)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_nbu_keyword(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_policy = "test_policy"
+        self.context.netbackup_schedule = "test_schedule"
+        self.context.netbackup_block_size = 100
+        self.context.netbackup_keyword = "foo"
+        cmdStr = "cat /tmp/foo_schema | gp_bsa_dump_agent --netbackup-service-host mdw --netbackup-policy test_policy --netbackup-schedule test_schedule --netbackup-filename /tmp/foo_schema --netbackup-block-size 100 --netbackup-keyword foo"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            backup_file_with_nbu(self.context, "schema")
+            cmd.assert_called_with("dumping metadata files from master", cmdStr)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_backup_file_with_nbu_segment(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_policy = "test_policy"
+        self.context.netbackup_schedule = "test_schedule"
+        self.context.netbackup_block_size = 100
+        cmdStr = "cat /tmp/foo_schema | gp_bsa_dump_agent --netbackup-service-host mdw --netbackup-policy test_policy --netbackup-schedule test_schedule --netbackup-filename /tmp/foo_schema --netbackup-block-size 100"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            backup_file_with_nbu(self.context, "schema", hostname="sdw")
+            from gppylib.commands.base import REMOTE
+            cmd.assert_called_with("dumping metadata files from segment", cmdStr, ctxt=REMOTE, remoteHost="sdw")
+
+    @patch('gppylib.operations.dump.execute_sql', return_value = [['gp_toolkit'], ['pg_aoseg'], ['pg_toast'], ['pg_bitmapindex'], ['bar'], ['foo'], ['pg_catalog'], ['public'], ['information_schema']])
+    def test_get_include_schema_list_from_exclude_schema_default(self, mock1):
         exclude_schema_list = ['public', 'foo']
         expected_result = ['bar']
-        output = get_include_schema_list_from_exclude_schema(exclude_schema_list, catalog_schema_list, master_port, dbname)
+        output = get_include_schema_list_from_exclude_schema(self.context, exclude_schema_list)
         self.assertEqual(expected_result.sort(), output.sort())
 
-    @patch('gppylib.operations.dump.execute_sql', return_value = [['gp_toolkit'], ['pg_toast'], ['pg_bitmapindex'], ['bar'], ['foo'], ['pg_catalog'], ['public'], ['information_schema']])
-    def test_get_include_schema_list_from_exclude_schema_01(self, mock1):
-        master_port = "5432"
-        dbname = 'testdb'
-        catalog_schema_list = ['gp_toolkit', 'information_schema']
+    @patch('gppylib.operations.dump.execute_sql', return_value = [['gp_toolkit'], ['pg_aoseg'], ['pg_toast'], ['pg_bitmapindex'], ['bar'], ['foo'], ['pg_catalog'], ['public'], ['information_schema']])
+    def test_get_include_schema_list_from_exclude_schema_empty_list(self, mock1):
         exclude_schema_list = []
         expected_result = ['public', 'foo', 'bar']
-        output = get_include_schema_list_from_exclude_schema(exclude_schema_list, catalog_schema_list, master_port, dbname)
+        output = get_include_schema_list_from_exclude_schema(self.context, exclude_schema_list)
         self.assertEqual(expected_result.sort(), output.sort())
-
-class MailEventTestCase(unittest.TestCase):
-
-    def setUp(self):
-        self.mailEvent = MailEvent(subject="test", message="Hello", to_addrs="example@gopivotal.com")
 
     @patch('gppylib.operations.dump.Command.run')
     @patch('gppylib.operations.dump.findCmdInPath', return_value='/bin/mail')
-    def test_mail_execute_00(self, mock1, mock2):
-        m = MailEvent(subject="test", message="Hello", to_addrs="example@gopivotal.com")
+    def test_mail_execute_default(self, mock1, mock2):
+        m = MailEvent(subject="test", message="Hello", to_addrs="example@pivotal.io")
         m.execute()
-
-
-
-class DeleteCurrentDumpTestCase(unittest.TestCase):
-
-    @patch('gppylib.operations.dump.dbconn.DbURL')
-    @patch('gppylib.operations.dump.DeleteCurrentSegDump.run', return_value=None)
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList', return_value=[])
-    @patch('gppylib.commands.base.Command.__init__', return_value=None)
-    @patch('gppylib.commands.base.Command.run', return_value=None)
-    @patch('gppylib.commands.base.Command.get_results')
-    def test_delete_from_dynamic_ddboost_option(self, m1, m2, m3, m4, m5, m6, m7):
-            timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-            dump_file = 'gp_cdatabase_1_1_%s' % timestamp
-            m1.return_value.stdout = dump_file
-            port = 5432
-            dump_dir = 'MFR_TINC'
-            ddboost = True
-            storage_unit = 'TEMP'
-
-            DeleteCurrentDump(timestamp, None, port, dump_dir, ddboost, storage_unit).run()
-
-            m3.assert_any_call('DDBoost list dump files', 'gpddboost --listDirectory --dir=MFR_TINC/%s --ddboost-storage-unit=TEMP' % DUMP_DATE)
-            m3.assert_any_call('DDBoost delete of %s/%s/%s' % (dump_dir, DUMP_DATE, dump_file), 'gpddboost --del-file=%s/%s/%s --ddboost-storage-unit=TEMP' % (dump_dir, DUMP_DATE, dump_file))
-
-class DeleteOldestDumpsTestCase(unittest.TestCase):
-
-    @patch('gppylib.operations.dump.dbconn.DbURL')
-    @patch('gppylib.operations.dump.DeleteCurrentSegDump.run', return_value=None)
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList', return_value=[])
-    @patch('gppylib.commands.base.Command.__init__', return_value=None)
-    @patch('gppylib.commands.base.Command.run', return_value=None)
-    @patch('gppylib.commands.base.Command.get_results')
-    def test_delete_old_from_dynamic_ddboost_option(self, m1, m2, m3, m4, m5, m6, m7):
-            m1.return_value.stdout = '20160101'
-            m1.return_value.rc = 0
-            port = 5432
-            cleanup_date = '20160101'
-            cleanup_total = 1
-            dump_dir = 'MFR_TINC'
-            ddboost = True
-            storage_unit = 'TEMP'
-
-            DeleteOldestDumps(None, port, dump_dir,cleanup_date, cleanup_total, ddboost, storage_unit).run()
-
-            with open('/tmp/log', 'w') as fw:
-                fw.write(str(m3.call_args_list))
-            m3.assert_any_call('List directories in DDBoost db_dumps dir', 'gpddboost --ddboost-storage-unit %s --listDir --dir=MFR_TINC/ | grep ^[0-9] ' % (storage_unit))
-            m3.assert_any_call('DDBoost cleanup', 'gpddboost --del-dir=%s/%s --ddboost-storage-unit %s' % (dump_dir, cleanup_date, storage_unit))
 
 if __name__ == '__main__':
     unittest.main()
+
+i=0
+def my_counter(*args, **kwargs):
+    global i
+    i += 1
+    return Mock()

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -7,93 +7,31 @@
 import sys
 import unittest2 as unittest
 import tempfile, os, shutil
-from gppylib.commands.base import CommandResult
-from gppylib.operations.restore import RestoreDatabase, create_restore_plan, get_plan_file_contents, \
-        get_restore_tables_from_table_file, write_to_plan_file, check_table_name_format_and_duplicate, \
-        create_plan_file_contents, GetDbName, get_dirty_table_file_contents, \
-        get_incremental_restore_timestamps, get_partition_list, get_restore_dir, is_begin_incremental_run, \
-        is_incremental_restore, get_restore_table_list, validate_restore_tables_list, \
-        update_ao_stat_func, update_ao_statistics, _build_gpdbrestore_cmd_line, ValidateTimestamp, \
-        is_full_restore, restore_state_files_with_nbu, restore_report_file_with_nbu, restore_cdatabase_file_with_nbu, \
-        restore_global_file_with_nbu, restore_config_files_with_nbu, config_files_dumped, global_file_dumped, generate_restored_tables, \
-        restore_partition_list_file_with_nbu, restore_increments_file_with_nbu, GetDumpTables, validate_tablenames_exist_in_dump_file
-
-from gppylib.commands.base import ExecutionError
+from gppylib.commands.base import CommandResult, Command, ExecutionError
+from gppylib.operations.backup_utils import * 
+from gppylib.operations.restore import *
+from gppylib.operations.restore import _build_gpdbrestore_cmd_line
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
-from mock import mock_open, patch, MagicMock, Mock
-import __builtin__
+from mock import patch, MagicMock, Mock, mock_open, call
 
-class ValidateTimestampMock():
-    def __init__(self, compressed=None):
-        self.compress = compressed
-
-    def run(self):
-        restore_timestamp = "20121212121212"
-        return (restore_timestamp, None, self.compress)
-
-class OpenFileMock():
-    def __init__(self, lines):
-        self.lines = lines
-        self.max = len(lines)
-        self.counter = 0
-
-    def readlines(self):
-        return self.lines
-
-    def close(self):
-        pass
-
-    def open(self):
-        return self
-
-class restoreTestCase(unittest.TestCase):
+class RestoreTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.restore = RestoreDatabase(restore_timestamp = '20121212121212',
-                                       no_analyze = True,
-                                       drop_db = True,
-                                       restore_global = False,
-                                       master_datadir = 'foo',
-                                       backup_dir = None,
-                                       master_port = 1234,
-                                       dump_dir = "db_dumps",
-                                       dump_prefix = "",
-                                       no_plan = False,
-                                       restore_tables = None,
-                                       batch_default=64,
-                                       no_ao_stats = False,
-                                       redirected_restore_db = None,
-                                       report_status_dir = None,
-                                       restore_stats = None,
-                                       metadata_only = None,
-                                       ddboost = False,
-                                       netbackup_service_host = None,
-                                       netbackup_block_size = None,
-                                       change_schema = None,
-                                       schema_level_restore_list=None)
+        context = Context()
+        context.restore_db='testdb'
+        context.include_dump_tables_file='/tmp/table_list.txt'
+        context.master_datadir='/data/master/p1'
+        context.batch_default=None
+        context.timestamp = '20160101010101'
+        context.no_analyze = True
+        context.drop_db = True
+        context.master_port = 5432
+        
+        self.context = context
+        self.restore = RestoreDatabase(self.context)
+        self.validate_timestamp = ValidateTimestamp(self.context)
 
-    def create_backup_dirs(self, top_dir=os.getcwd(), dump_dirs=[]):
-        if dump_dirs is None:
-            return
-
-        for dump_dir in dump_dirs:
-            backup_dir = os.path.join(top_dir, 'db_dumps', dump_dir)
-            if not os.path.isdir(backup_dir):
-                os.makedirs(backup_dir)
-                if not os.path.isdir(backup_dir):
-                    raise Exception('Failed to create directory %s' % backup_dir)
-
-    def remove_backup_dirs(self, top_dir=os.getcwd(), dump_dirs=[]):
-        if dump_dirs is None:
-            return
-
-        for dump_dir in dump_dirs:
-            backup_dir = os.path.join(top_dir, 'db_dumps', dump_dir)
-            shutil.rmtree(backup_dir)
-            if os.path.isdir(backup_dir):
-                raise Exception('Failed to remove directory %s' % backup_dir)
-
-    def test_GetDbName_1(self):
+    def test_GetDbName_default(self):
         """ Basic test """
         with tempfile.NamedTemporaryFile() as f:
             f.write("""
@@ -106,7 +44,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
             f.flush()
             self.assertTrue(GetDbName(f.name).run() == "monkey")
 
-    def test_GetDbName_2(self):
+    def test_GetDbName_line_check(self):
         """ Verify that GetDbName looks no further than 50 lines. """
         with tempfile.NamedTemporaryFile() as f:
             for i in range(0, 50):
@@ -119,7 +57,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
                 return
             self.fail("DbNameGiveUp should have been raised.")
 
-    def test_GetDbName_3(self):
+    def test_GetDbName_no_name(self):
         """ Verify that GetDbName fails  when cdatabase file ends prematurely. """
         with tempfile.NamedTemporaryFile() as f:
             f.write("this is the whole file")
@@ -132,234 +70,145 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
 
     @patch('gppylib.operations.restore.RestoreDatabase._process_createdb', side_effect=ExceptionNoStackTraceNeeded('Failed to create database'))
     @patch('time.sleep')
-    def test_multitry_createdb_1(self, mock1, mock2):
-        self.assertRaises(ExceptionNoStackTraceNeeded, self.restore._multitry_createdb, '20121212121212', 'fullbkdb', None, 'foo', None, 1234)
+    def test_multitry_createdb_create_fails(self, mock1, mock2):
+        self.assertRaises(ExceptionNoStackTraceNeeded, self.restore._multitry_createdb)
 
     @patch('gppylib.operations.restore.RestoreDatabase._process_createdb')
-    def test_multitry_createdb_2(self, mock):
-        self.restore._multitry_createdb('20121212121212', 'fullbkdb', None, 'foo', None, 1234)
+    def test_multitry_createdb_default(self, mock):
+        self.restore._multitry_createdb()
 
     @patch('gppylib.operations.restore.get_partition_list', return_value=[('public', 't1'), ('public', 't2'), ('public', 't3')])
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental', return_value='123456789')
-    @patch('gppylib.operations.restore.get_incremental_restore_timestamps', return_value=['20121212121212', '20121212121211'])
+    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental', return_value='20160101000000')
+    @patch('gppylib.operations.restore.get_incremental_restore_timestamps', return_value=['20160101010101', '20160101010111'])
     @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=['public.t1', 'public.t2'])
-    def test_restore_plan_file_00(self, mock1, mock2, mock3, mock4):
-        master_datadir = 'foo'
-        db_timestamp = '01234567891234'
-        dbname = 'bkdb'
-        ddboost = False
-        backup_dir = None
-        netbackup_service_host = None
-        netbackup_block_size = None
-        self.create_backup_dirs(master_datadir, [db_timestamp[0:8]])
-        plan_file = create_restore_plan(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, db_timestamp, ddboost, netbackup_service_host, netbackup_block_size)
-        self.assertTrue(os.path.isfile(plan_file))
-        self.remove_backup_dirs(master_datadir, [db_timestamp[0:8]])
+    def test_create_restore_plan_default(self, mock1, mock2, mock3, mock4):
+        expected = ["20160101010111:", "20160101010101:public.t1,public.t2", "20160101000000:public.t3"]
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            plan_file = create_restore_plan(self.context)
+            result = m()
+            self.assertEqual(len(expected), len(result.write.call_args_list))
+            for i in range(len(expected)):
+                self.assertEqual(call(expected[i]+'\n'), result.write.call_args_list[i])
+
+    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental', return_value='20160101000000')
+    @patch('gppylib.operations.restore.get_incremental_restore_timestamps', return_value=['20160101010101', '20160101010111'])
+    @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=['public.t1', 'public.t2'])
+    def test_create_restore_plan_empty_list(self, mock1, mock2, mock3):
+        expected = ["20160101010111:", "20160101010101:", "20160101000000:"]
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            plan_file = create_restore_plan(self.context)
+            result = m()
+            self.assertEqual(len(expected), len(result.write.call_args_list))
+            for i in range(len(expected)):
+                self.assertEqual(call(expected[i]+'\n'), result.write.call_args_list[i])
 
     @patch('gppylib.operations.restore.get_partition_list', return_value=[])
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental', return_value='123456789')
-    @patch('gppylib.operations.restore.get_incremental_restore_timestamps', return_value=['20121212121212', '20121212121211'])
-    @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=['public.t1', 'public.t2'])
-    def test_restore_plan_file_01(self, mock1, mock2, mock3, mock4):
-        master_datadir = 'foo'
-        db_timestamp = '01234567891234'
-        dbname = 'bkdb'
-        ddboost = False
-        backup_dir = None
-        netbackup_service_host = None
-        netbackup_block_size = None
-        self.create_backup_dirs(master_datadir, [db_timestamp[0:8]])
-        plan_file = create_restore_plan(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, db_timestamp, ddboost, netbackup_service_host, netbackup_block_size)
-        self.assertTrue(os.path.isfile(plan_file))
-        self.remove_backup_dirs(master_datadir, [db_timestamp[0:8]])
-
-
-    @patch('gppylib.operations.restore.get_partition_list', return_value=[])
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental', return_value=None)
-    def test_restore_plan_file_02(self, mock1, mock2):
-        master_datadir = 'foo'
-        db_timestamp = '01234567891234'
-        dbname = 'bkdb'
-        ddboost = False
-        backup_dir = None
-        netbackup_service_host = None
-        netbackup_block_size = None
-
-        self.create_backup_dirs(master_datadir, [db_timestamp[0:8]])
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory without timestamp'):
-            create_restore_plan(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, db_timestamp, ddboost, netbackup_service_host, netbackup_block_size)
-        self.remove_backup_dirs(master_datadir, [db_timestamp[0:8]])
+    @patch('gppylib.operations.restore.get_timestamp_from_increments_filename', return_value=None)
+    def test_create_restore_plan_no_full_dump(self, mock1, mock2):
+        with patch('__builtin__.open', mock_open(), create=True):
+            with self.assertRaisesRegexp(Exception, 'Could not locate full backup associated with timestamp'):
+                create_restore_plan(self.context)
 
     @patch('gppylib.operations.restore.get_partition_list', return_value=[])
     @patch('gppylib.operations.restore.get_full_timestamp_for_incremental', return_value='20120101000000')
-    @patch('gppylib.operations.restore.get_incremental_restore_timestamps', return_value=['20121212121212', '20121212121211'])
+    @patch('gppylib.operations.restore.get_incremental_restore_timestamps', return_value=['20160101010101', '20160101010111'])
     @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=['public.t1', 'public.t2'])
     @patch('gppylib.operations.restore.create_plan_file_contents')
-    def test_restore_plan_file_03(self, mock1, mock2, mock3, mock4, mock5):
-        master_datadir = 'foo'
-        db_timestamp = '20140101000000'
-        dbname = 'bkdb'
-        ddboost = False
-        backup_dir = None
-        netbackup_service_host = 'mdw'
-        netbackup_block_size = '1024'
-        self.create_backup_dirs(master_datadir, [db_timestamp[0:8]])
-        plan_file = create_restore_plan(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, db_timestamp, ddboost, netbackup_service_host, netbackup_block_size)
-        self.assertTrue(os.path.isfile(plan_file))
-        self.remove_backup_dirs(master_datadir, [db_timestamp[0:8]])
+    def test_create_restore_plan_empty_list_with_nbu(self, mock1, mock2, mock3, mock4, mock5):
+        self.context.netbackup_service_host = 'mdw'
+        self.context.netbackup_block_size = '1024'
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            plan_file = create_restore_plan(self.context)
+            result = m()
+            self.assertEqual(len(result.write.call_args_list), 0)
 
     @patch('gppylib.operations.restore.get_partition_list', return_value=[])
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental', return_value=None)
-    def test_restore_plan_file_04(self, mock1, mock2):
-        master_datadir = 'foo'
-        db_timestamp = '01234567891234'
-        dbname = 'bkdb'
-        ddboost = False
-        backup_dir = None
-        netbackup_service_host = 'mdw'
-        netbackup_block_size = '1024'
-        self.create_backup_dirs(master_datadir, [db_timestamp[0:8]])
-        with self.assertRaisesRegexp(Exception, 'Can not locate backup directory without timestamp'):
-            create_restore_plan(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, db_timestamp, ddboost, netbackup_service_host, netbackup_block_size)
-        self.remove_backup_dirs(master_datadir, [db_timestamp[0:8]])
+    @patch('gppylib.operations.backup_utils.get_full_timestamp_for_incremental_with_nbu', return_value=None)
+    def test_create_restore_plan_no_full_dump_with_nbu(self, mock1, mock2):
+        self.context.netbackup_service_host = 'mdw'
+        self.context.netbackup_block_size = '1024'
+        with patch('__builtin__.open', mock_open(), create=True):
+            with self.assertRaisesRegexp(Exception, 'Could not locate full backup associated with timestamp'):
+                create_restore_plan(self.context)
 
-    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20121212121210', '20121212121209', '20121212121208', '20121212121207', '20121212121206', '20121212121205', '20121212121204', '20121212121203', '20121212121202', '20121212121201'])
-    def test_get_incremental_restore_timestamps_00(self, mock):
-        master_data_dir = 'foo'
-        latest_full_timestamp = '20121212121201'
-        restore_timestamp = '20121212121205'
-        backup_dir = None
-        increments = get_incremental_restore_timestamps(master_data_dir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, latest_full_timestamp, restore_timestamp)
-        self.assertEqual(increments, ['20121212121205', '20121212121204', '20121212121203', '20121212121202', '20121212121201'])
+    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20160101010110', '20160101010109', '20160101010108', '20160101010107', '20160101010106', '20160101010105', '20160101010104', '20160101010103', '20160101010102', '20160101010101'])
+    def test_get_incremental_restore_timestamps_midway(self, mock):
+        latest_full_timestamp = '20160101010101'
+        self.context.timestamp = '20160101010105'
+        increments = get_incremental_restore_timestamps(self.context, latest_full_timestamp)
+        self.assertEqual(increments, ['20160101010105', '20160101010104', '20160101010103', '20160101010102', '20160101010101'])
 
-    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20121212121210', '20121212121209', '20121212121208', '20121212121207', '20121212121206', '20121212121205', '20121212121204', '20121212121203', '20121212121202', '20121212121201'])
-    def test_get_incremental_restore_timestamps_01(self, mock):
-        master_data_dir = 'foo'
-        latest_full_timestamp = '20121212121201'
-        restore_timestamp = '20121212121210'
-        backup_dir = None
-        increments = get_incremental_restore_timestamps(master_data_dir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, latest_full_timestamp, restore_timestamp)
-        self.assertEqual(increments, ['20121212121210', '20121212121209', '20121212121208', '20121212121207', '20121212121206', '20121212121205', '20121212121204', '20121212121203', '20121212121202', '20121212121201'])
+    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20160101010110', '20160101010109', '20160101010108', '20160101010107', '20160101010106', '20160101010105', '20160101010104', '20160101010103', '20160101010102', '20160101010101'])
+    def test_get_incremental_restore_timestamps_latest(self, mock):
+        latest_full_timestamp = '20160101010101'
+        self.context.timestamp = '20160101010110'
+        increments = get_incremental_restore_timestamps(self.context, latest_full_timestamp)
+        self.assertEqual(increments, ['20160101010110', '20160101010109', '20160101010108', '20160101010107', '20160101010106', '20160101010105', '20160101010104', '20160101010103', '20160101010102', '20160101010101'])
 
     @patch('gppylib.operations.restore.get_lines_from_file', return_value=[])
-    def test_get_incremental_restore_timestamps_03(self, mock):
-        master_data_dir = 'foo'
-        latest_full_timestamp = '20121212121201'
-        restore_timestamp = '20121212121200'
-        backup_dir = None
-        increments = get_incremental_restore_timestamps(master_data_dir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, latest_full_timestamp, restore_timestamp)
+    def test_get_incremental_restore_timestamps_earliest(self, mock):
+        latest_full_timestamp = '20160101010101'
+        self.context.timestamp = '20160101010100'
+        increments = get_incremental_restore_timestamps(self.context, latest_full_timestamp)
         self.assertEqual(increments, [])
 
-    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['public.t1', 'public.t2', 'public.t3'])
-    def test_get_dirty_table_file_contents_00(self, mock):
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp_key = '20121212121212'
-        dirty_tables = get_dirty_table_file_contents(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp_key)
-        self.assertEqual(dirty_tables, ['public.t1', 'public.t2', 'public.t3'])
-
     @patch('gppylib.operations.restore.get_lines_from_file', side_effect=[['public.t1'], ['public.t1', 'public.t2', 'public.t3'], ['public.t2', 'public.t4']])
-    def test_create_plan_file_contents_00(self, mock):
-        master_datadir = 'foo'
+    def test_create_plan_file_contents_with_file(self, mock):
         table_set_from_metadata_file = ['public.t1', 'public.t2', 'public.t3', 'public.t4']
-        incremental_restore_timestamps = ['20121212121213', '20121212121212', '20121212121211']
-        latest_full_timestamp = '20121212121210'
-        backup_dir = None
-        netbackup_service_host = None
-        netbackup_block_size = None
-        expected_output = {'20121212121213': ['public.t1'], '20121212121212': ['public.t2', 'public.t3'], '20121212121211': ['public.t4'], '20121212121210': []}
-        file_contents = create_plan_file_contents(master_datadir,
-                                                  backup_dir,
-                                                  self.restore.dump_dir,
-                                                  self.restore.dump_prefix,
-                                                  table_set_from_metadata_file,
-                                                  incremental_restore_timestamps,
-                                                  latest_full_timestamp,
-                                                  netbackup_service_host,
-                                                  netbackup_block_size)
+        incremental_restore_timestamps = ['20160101010113', '20160101010101', '20160101010111']
+        latest_full_timestamp = '20160101010110'
+        expected_output = {'20160101010113': ['public.t1'], '20160101010101': ['public.t2', 'public.t3'], '20160101010111': ['public.t4'], '20160101010110': []}
+        file_contents = create_plan_file_contents(self.context, table_set_from_metadata_file, incremental_restore_timestamps, latest_full_timestamp)
         self.assertEqual(file_contents, expected_output)
 
-    def test_create_plan_file_contents_01(self):
-        master_datadir = 'foo'
+    def test_create_plan_file_contents_no_file(self):
         table_set_from_metadata_file = ['public.t1', 'public.t2', 'public.t3', 'public.t4']
         incremental_restore_timestamps = []
-        latest_full_timestamp = '20121212121210'
-        backup_dir = None
-        netbackup_service_host = None
-        netbackup_block_size = None
-        expected_output = {'20121212121210': ['public.t1', 'public.t2', 'public.t3', 'public.t4']}
-        file_contents = create_plan_file_contents(master_datadir,
-                                                  backup_dir,
-                                                  self.restore.dump_dir,
-                                                  self.restore.dump_prefix,
-                                                  table_set_from_metadata_file,
-                                                  incremental_restore_timestamps,
-                                                  latest_full_timestamp,
-                                                  netbackup_service_host,
-                                                  netbackup_block_size)
+        latest_full_timestamp = '20160101010110'
+        expected_output = {'20160101010110': ['public.t1', 'public.t2', 'public.t3', 'public.t4']}
+        file_contents = create_plan_file_contents(self.context, table_set_from_metadata_file, incremental_restore_timestamps, latest_full_timestamp)
         self.assertEqual(file_contents, expected_output)
 
     @patch('gppylib.operations.restore.get_lines_from_file', side_effect=[['public.t1'], ['public.t1', 'public.t2', 'public.t3'], ['public.t2', 'public.t4']])
-    def test_create_plan_file_contents_02(self, mock):
-        master_datadir = 'foo'
+    def test_create_plan_file_contents_no_metadata(self, mock):
         table_set_from_metadata_file = []
-        incremental_restore_timestamps = ['20121212121213', '20121212121212', '20121212121211']
-        latest_full_timestamp = '20121212121210'
-        backup_dir = None
-        netbackup_service_host = None
-        netbackup_block_size = None
-        expected_output = {'20121212121212': [], '20121212121213': [], '20121212121211': [], '20121212121210': []}
-        file_contents = create_plan_file_contents(master_datadir,
-                                                  backup_dir,
-                                                  self.restore.dump_dir,
-                                                  self.restore.dump_prefix,
-                                                  table_set_from_metadata_file,
-                                                  incremental_restore_timestamps,
-                                                  latest_full_timestamp,
-                                                  netbackup_service_host,
-                                                  netbackup_block_size)
+        incremental_restore_timestamps = ['20160101010113', '20160101010101', '20160101010111']
+        latest_full_timestamp = '20160101010110'
+        expected_output = {'20160101010101': [], '20160101010113': [], '20160101010111': [], '20160101010110': []}
+        file_contents = create_plan_file_contents(self.context, table_set_from_metadata_file, incremental_restore_timestamps, latest_full_timestamp)
         self.assertEqual(file_contents, expected_output)
 
     @patch('gppylib.operations.restore.get_lines_from_file', side_effect=[['public.t1'], ['public.t1', 'public.t2', 'public.t3'], ['public.t2', 'public.t4']])
     @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_create_plan_file_contents_03(self, mock1, mock2):
-        master_datadir = 'foo'
+    def test_create_plan_file_contents_with_nbu(self, mock1, mock2):
+        self.context.netbackup_service_host = 'mdw'
+        self.context.netbackup_block_size = '1024'
         table_set_from_metadata_file = []
-        incremental_restore_timestamps = ['20121212121213', '20121212121212', '20121212121211']
-        latest_full_timestamp = '20121212121210'
-        backup_dir = None
-        netbackup_service_host = 'mdw'
-        netbackup_block_size = '1024'
-        expected_output = {'20121212121212': [], '20121212121213': [], '20121212121211': [], '20121212121210': []}
-        file_contents = create_plan_file_contents(master_datadir,
-                                                  backup_dir,
-                                                  self.restore.dump_dir,
-                                                  self.restore.dump_prefix,
-                                                  table_set_from_metadata_file,
-                                                  incremental_restore_timestamps,
-                                                  latest_full_timestamp,
-                                                  netbackup_service_host,
-                                                  netbackup_block_size)
+        incremental_restore_timestamps = ['20160101010113', '20160101010101', '20160101010111']
+        latest_full_timestamp = '20160101010110'
+        expected_output = {'20160101010101': [], '20160101010113': [], '20160101010111': [], '20160101010110': []}
+        file_contents = create_plan_file_contents(self.context, table_set_from_metadata_file, incremental_restore_timestamps, latest_full_timestamp)
         self.assertEqual(file_contents, expected_output)
 
     @patch('gppylib.operations.restore.write_lines_to_file')
-    @patch('gppylib.operations.restore.verify_lines_in_file')
-    def test_write_to_plan_file_00(self, mock1, mock2):
+    def test_write_to_plan_file_default(self, mock1):
         plan_file = 'blah'
-        plan_file_contents = {'20121212121213': ['public.t1'],
-                              '20121212121212': ['public.t2', 'public.t3'],
-                              '20121212121211': ['public.t4']}
+        plan_file_contents = {'20160101010113': ['public.t1'],
+                              '20160101010101': ['public.t2', 'public.t3'],
+                              '20160101010111': ['public.t4']}
 
-        expected_output = ['20121212121213:public.t1',
-                           '20121212121212:public.t2,public.t3',
-                           '20121212121211:public.t4']
+        expected_output = ['20160101010113:public.t1',
+                           '20160101010111:public.t4',
+                           '20160101010101:public.t2,public.t3']
 
         file_contents = write_to_plan_file(plan_file_contents, plan_file)
         self.assertEqual(expected_output, file_contents)
 
     @patch('gppylib.operations.restore.write_lines_to_file')
-    @patch('gppylib.operations.restore.verify_lines_in_file')
-    def test_write_to_plan_file_01(self, mock1, mock2):
+    def test_write_to_plan_file_empty_list(self, mock1):
         plan_file = 'blah'
         plan_file_contents = {}
         expected_output = []
@@ -367,1141 +216,671 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         self.assertEqual(expected_output, file_contents)
 
     @patch('gppylib.operations.restore.write_lines_to_file')
-    @patch('gppylib.operations.restore.verify_lines_in_file')
-    def test_write_to_plan_file_02(self, mock1, mock2):
+    def test_write_to_plan_file_no_plan_file(self, mock1):
         plan_file = None
         plan_file_contents = {}
         with self.assertRaisesRegexp(Exception, 'Invalid plan file .*'):
             write_to_plan_file(plan_file_contents, plan_file)
 
     @patch('gppylib.operations.restore.get_lines_from_file', return_value=['public.t1', 'public.t2'])
-    def test_get_partition_list_00(self, mock):
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp = '20121212121212'
-        partition_list = get_partition_list(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp)
+    def test_get_partition_list_default(self, mock):
+        partition_list = get_partition_list(self.context)
         self.assertEqual(partition_list, [('public', 't1'), ('public', 't2')])
 
     @patch('gppylib.operations.restore.get_lines_from_file', return_value=[])
-    def test_get_partition_list_01(self, mock):
-        master_datadir = 'foo'
-        backup_dir = None
-        timestamp = '20121212121212'
-        partition_list = get_partition_list(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp)
+    def test_get_partition_list_no_partitions(self, mock):
+        partition_list = get_partition_list(self.context)
         self.assertEqual(partition_list, [])
 
     @patch('gppylib.operations.restore.get_lines_from_file', return_value=['Backup Type: Incremental'])
     @patch('os.path.isfile', return_value=True)
-    def test_is_incremental_restore_00(self, mock1, mock2):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
-        self.assertTrue(is_incremental_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp))
+    def test_is_incremental_restore_default(self, mock1, mock2):
+        self.assertTrue(is_incremental_restore(self.context))
 
     @patch('gppylib.operations.restore.get_lines_from_file')
     @patch('gppylib.operations.restore.check_backup_type', return_value=True)
     @patch('os.path.isfile', return_value=True)
-    def test_is_incremental_restore_01(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = '/foo'
-        self.assertTrue(is_incremental_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp))
+    def test_is_incremental_restore_bypass_file_incremental(self, mock1, mock2, mock3):
+        self.assertTrue(is_incremental_restore(self.context))
 
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.restore.get_lines_from_file', return_value=['Backup Type: Full'])
-    def test_is_incremental_restore_02(self, mock1, mock2):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
-        self.assertFalse(is_incremental_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp))
+    def test_is_incremental_restore_full_backup(self, mock1, mock2):
+        self.assertFalse(is_incremental_restore(self.context))
 
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.restore.get_lines_from_file')
     @patch('gppylib.operations.restore.check_backup_type', return_value=False)
-    def test_is_incremental_restore_03(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
-        self.assertFalse(is_incremental_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp))
+    def test_is_incremental_restore_bypass_file_full(self, mock1, mock2, mock3):
+        self.assertFalse(is_incremental_restore(self.context))
 
-    @patch('gppylib.operations.restore.generate_report_filename', return_value='foo')
     @patch('os.path.isfile', return_value=False)
-    def test_is_incremental_restore_04(self, mock1, mock2):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
-        self.assertFalse(is_incremental_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp))
+    def test_is_incremental_restore_no_file(self, mock1):
+        self.assertFalse(is_incremental_restore(self.context))
 
-    @patch('gppylib.operations.restore.generate_report_filename', return_value='foo')
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.restore.get_lines_from_file', return_value=['Backup Type: Full'])
     @patch('os.path.isfile', return_value=True)
-    def test_is_full_restore_00(self, mock1, mock2, mock3, mock4):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
-        self.assertTrue(is_full_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp))
+    def test_is_full_restore_default(self, mock1, mock2, mock3):
+        self.assertTrue(is_full_restore(self.context))
 
-    @patch('gppylib.operations.restore.generate_report_filename', return_value='foo')
     @patch('gppylib.operations.restore.get_lines_from_file')
     @patch('gppylib.operations.restore.check_backup_type', return_value=True)
     @patch('os.path.isfile', return_value=True)
-    def test_is_full_restore_01(self, mock1, mock2, mock3, mock4):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = '/foo'
-        self.assertTrue(is_full_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp))
+    def test_is_full_restore_bypass_file_full(self, mock1, mock2, mock3):
+        self.assertTrue(is_full_restore(self.context))
 
-    @patch('gppylib.operations.restore.generate_report_filename', return_value='foo')
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.restore.get_lines_from_file', return_value=['Backup Type: Incremental'])
-    def test_is_full_restore_02(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
-        self.assertFalse(is_full_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp))
+    def test_is_full_restore_incremental(self, mock1, mock2):
+        self.assertFalse(is_full_restore(self.context))
 
-    @patch('gppylib.operations.restore.generate_report_filename', return_value='foo')
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.restore.get_lines_from_file')
     @patch('gppylib.operations.restore.check_backup_type', return_value=False)
-    def test_is_full_restore_03(self, mock1, mock2, mock3, mock4):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
-        self.assertFalse(is_full_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp))
+    def test_is_full_restore_bypass_file_incremental(self, mock1, mock2, mock3):
+        self.assertFalse(is_full_restore(self.context))
 
-    @patch('gppylib.operations.restore.generate_report_filename', return_value='foo')
     @patch('os.path.isfile', return_value=False)
-    def test_is_full_restore_04(self, mock1, mock2):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
-        with self.assertRaisesRegexp(Exception, 'Report file foo does not exist'):
-            is_full_restore(master_datadir, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp)
+    def test_is_full_restore_no_file(self, mock1):
+        filename = self.context.generate_filename("report")
+        with self.assertRaisesRegexp(Exception, 'Report file %s does not exist' % filename):
+            is_full_restore(self.context)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_schema_only_restore_line_00(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = False
-        master_port = '5432'
+    def test_create_schema_only_restore_string_default(self, mock1, mock2):
+        self.context.backup_dir = None
         table_filter_file = None
         full_restore_with_filter = False
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-d=db_dumps/20121212 -d "bkdb"' % metadata_file
-
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        metadata_file = self.context.generate_filename("metadata")
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p -s %s --gp-d=db_dumps/20160101 --gp-c -d "testdb"' % metadata_file
+        
+        restore_line = self.restore.create_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_schema_only_restore_line_01(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
+    def test_create_schema_only_restore_string_no_compression(self, mock1, mock2):
+        self.context.backup_dir = None
+        self.context.compress = False
         table_filter_file = None
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-d=db_dumps/20121212 --gp-c -d "bkdb"' % metadata_file
+        metadata_file = self.context.generate_filename("metadata")
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p -s %s --gp-d=db_dumps/20160101 -d "testdb"' % metadata_file
 
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=True)
-    def test_build_schema_only_restore_line_02(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.backup_dir = '/foo'
+    @patch('gppylib.operations.backup_utils.Context.backup_dir_is_writable', return_value=True)
+    def test_create_schema_only_restore_string_backup_dir(self, mock1, mock2, mock3):
         table_filter_file = None
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-r=/foo/db_dumps/20121212 --status=/foo/db_dumps/20121212 --gp-d=/foo/db_dumps/20121212 --gp-c -d "bkdb"' % metadata_file
+        self.context.report_status_dir = "/data/master/p1/db_dumps/20160101"
+        metadata_file = self.context.generate_filename("metadata")
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p -s %s --gp-r=/data/master/p1/db_dumps/20160101 --status=/data/master/p1/db_dumps/20160101 --gp-d=db_dumps/20160101 --gp-c -d "testdb"' % metadata_file
 
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=False)
-    def test_build_schema_only_restore_line_03(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.backup_dir = '/foo'
-        self.restore.dump_prefix = 'bar_'
-        table_filter_file = None
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
-        full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-d=/foo/db_dumps/20121212 --prefix=bar_ --gp-c -d "bkdb"' % metadata_file
-
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
-        self.assertEqual(restore_line, expected_output)
-
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=False)
-    def test_build_schema_only_restore_line_04(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.backup_dir = '/foo'
-        self.restore.dump_prefix = 'bar_'
+    @patch('gppylib.operations.backup_utils.Context.backup_dir_is_writable', return_value=False)
+    def test_create_schema_only_restore_string_prefix(self, mock1, mock2, mock3):
+        self.context.dump_prefix = 'bar_'
         table_filter_file = 'filter_file1'
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
+        metadata_file = self.context.generate_filename("metadata")
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-d=/foo/db_dumps/20121212 --prefix=bar_ --gp-f=%s --gp-c -d "bkdb"' % (metadata_file, table_filter_file)
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p -s %s --gp-d=db_dumps/20160101 --prefix=bar_ --gp-f=%s --gp-c -d "testdb"' % (metadata_file, table_filter_file)
 
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=False)
-    def test_build_schema_only_restore_line_05(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.backup_dir = '/foo'
+    @patch('gppylib.operations.backup_utils.Context.backup_dir_is_writable', return_value=False)
+    def test_create_schema_only_restore_string_no_filter_file(self, mock1, mock2, mock3):
         table_filter_file = None
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
+        metadata_file = self.context.generate_filename("metadata")
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-d=/foo/db_dumps/20121212 --gp-c -d "bkdb"' % metadata_file
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p -s %s --gp-d=db_dumps/20160101 --gp-c -d "testdb"' % metadata_file
 
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_schema_only_restore_line_06(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
+    def test_create_schema_only_restore_string_different_status_dir(self, mock1, mock2):
+        self.context.report_status_dir = '/tmp'
         table_filter_file = None
         full_restore_with_filter = False
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-r=/tmp --status=/tmp --gp-d=/foo/db_dumps/20121212 --gp-c -d "bkdb"' % metadata_file
+        metadata_file = self.context.generate_filename("metadata")
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p -s %s --gp-r=/tmp --status=/tmp --gp-d=db_dumps/20160101 --gp-c -d "testdb"' % metadata_file
 
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_schema_only_restore_line_07(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
+    def test_create_schema_only_restore_string_status_dir_with_filter(self, mock1, mock2):
+        self.context.report_status_dir = '/tmp'
         table_filter_file = None
         full_restore_with_filter = True
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s -P --gp-r=/tmp --status=/tmp --gp-d=/foo/db_dumps/20121212 --gp-c -d "bkdb"' % metadata_file
+        metadata_file = self.context.generate_filename("metadata")
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p -s %s -P --gp-r=/tmp --status=/tmp --gp-d=db_dumps/20160101 --gp-c -d "testdb"' % metadata_file
 
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_schema_only_restore_line_08(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = False
-        master_port = '5432'
+    def test_create_schema_only_restore_string_with_nbu(self, mock1, mock2):
         table_filter_file = None
         full_restore_with_filter = False
-        self.restore.netbackup_service_host = "mdw"
-        self.restore.netbackup_block_size = None
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-d=db_dumps/20121212 -d "bkdb" --netbackup-service-host=mdw' % metadata_file
+        self.context.netbackup_service_host = "mdw"
+        metadata_file = self.context.generate_filename("metadata")
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p -s %s --gp-d=db_dumps/20160101 --gp-c -d "testdb" --netbackup-service-host=mdw' % metadata_file
 
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_schema_only_restore_line_09(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = False
-        master_port = '5432'
-        table_filter_file = None
-        full_restore_with_filter = False
-        self.restore.netbackup_service_host = "mdw"
-        self.restore.netbackup_block_size = 1024
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-d=db_dumps/20121212 -d "bkdb" --netbackup-service-host=mdw --netbackup-block-size=1024' % metadata_file
-
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
-        self.assertEqual(restore_line, expected_output)
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_schema_only_restore_line_10(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
+    def test_create_schema_only_restore_string_with_ddboost(self, mock1, mock2):
+        self.context.report_status_dir = '/tmp'
         table_filter_file = None
         full_restore_with_filter = True
-        self.restore.ddboost = True
-        self.restore.dump_dir = '/backup/DCA-35'
-        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s -P --gp-r=/tmp --status=/tmp --gp-d=/backup/DCA-35/20121212 --gp-c -d "bkdb" --ddboost' % metadata_file
+        self.context.ddboost = True
+        self.context.dump_dir = '/backup/DCA-35'
+        metadata_file = self.context.generate_filename("metadata")
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p -s %s -P --gp-r=/tmp --status=/tmp --gp-d=/backup/DCA-35/20160101 --gp-c -d "testdb" --ddboost' % metadata_file
 
-        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_post_data_schema_only_restore_line_00(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = False
-        master_port = '5432'
+    def test_create_post_data_schema_only_restore_string_default(self, mock1, mock2):
         table_filter_file = None
         full_restore_with_filter = True
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p -P -d "bkdb"'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20160101 --gp-i --gp-k=20160101010101 --gp-l=p -P --gp-c -d "testdb"'
 
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_post_data_schema_only_restore_line_01(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
+    @patch('gppylib.operations.backup_utils.Context.backup_dir_is_writable', return_value=True)
+    def test_create_post_data_schema_only_restore_string_no_filter(self, mock1, mock2, mock3):
         table_filter_file = None
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p --gp-c -d "bkdb"'
+        self.context.report_status_dir="/data/master/p1/db_dumps/20160101"
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20160101 --gp-i --gp-k=20160101010101 --gp-l=p --gp-r=/data/master/p1/db_dumps/20160101 --status=/data/master/p1/db_dumps/20160101 --gp-c -d "testdb"'
 
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=True)
-    def test_build_post_data_schema_only_restore_line_02(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.backup_dir = '/foo'
+    @patch('gppylib.operations.backup_utils.Context.backup_dir_is_writable', return_value=False)
+    def test_create_post_data_schema_only_restore_string_with_prefix(self, mock1, mock2, mock3):
+        self.context.dump_prefix = 'bar_'
         table_filter_file = None
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=/foo/db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p --gp-r=/foo/db_dumps/20121212 --status=/foo/db_dumps/20121212 --gp-c -d "bkdb"'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20160101 --gp-i --gp-k=20160101010101 --gp-l=p --prefix=bar_ --gp-c -d "testdb"'
 
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
-        self.assertEqual(restore_line, expected_output)
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=False)
-    def test_build_post_data_schema_only_restore_line_03(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.backup_dir = '/foo'
-        self.restore.dump_prefix = 'bar_'
-        table_filter_file = None
-        full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=/foo/db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p --prefix=bar_ --gp-c -d "bkdb"'
-
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=False)
-    def test_build_post_data_schema_only_restore_line_04(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.backup_dir = '/foo'
-        self.restore.dump_prefix = 'bar_'
+    @patch('gppylib.operations.backup_utils.Context.backup_dir_is_writable', return_value=False)
+    def test_create_post_data_schema_only_restore_string_with_prefix_and_filter(self, mock1, mock2, mock3):
+        self.context.dump_prefix = 'bar_'
         table_filter_file = 'filter_file1'
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=/foo/db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p --prefix=bar_ --gp-f=%s --gp-c -d "bkdb"' % (table_filter_file)
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20160101 --gp-i --gp-k=20160101010101 --gp-l=p --prefix=bar_ --gp-f=%s --gp-c -d "testdb"' % (table_filter_file)
 
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=False)
-    def test_build_post_data_schema_only_restore_line_05(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.backup_dir = '/foo'
+    @patch('gppylib.operations.backup_utils.Context.backup_dir_is_writable', return_value=False)
+    def test_create_post_data_schema_only_restore_string_no_backup_dir(self, mock1, mock2, mock3):
         table_filter_file = None
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=/foo/db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p --gp-c -d "bkdb"'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20160101 --gp-i --gp-k=20160101010101 --gp-l=p --gp-c -d "testdb"'
 
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_post_data_schema_only_restore_line_06(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
+    def test_create_post_data_schema_only_restore_string_different_status_dir(self, mock1, mock2):
+        self.context.report_status_dir = '/tmp'
         table_filter_file = None
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=/foo/db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p --gp-r=/tmp --status=/tmp --gp-c -d "bkdb"'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20160101 --gp-i --gp-k=20160101010101 --gp-l=p --gp-r=/tmp --status=/tmp --gp-c -d "testdb"'
 
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_post_data_schema_only_restore_line_07(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
+    def test_create_post_data_schema_only_restore_string_status_dir_and_filter(self, mock1, mock2):
+        self.context.report_status_dir = '/tmp'
         table_filter_file = None
         full_restore_with_filter = True
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=/foo/db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p -P --gp-r=/tmp --status=/tmp --gp-c -d "bkdb"'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20160101 --gp-i --gp-k=20160101010101 --gp-l=p -P --gp-r=/tmp --status=/tmp --gp-c -d "testdb"'
 
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_post_data_schema_only_restore_line_08(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
+    def test_create_post_data_schema_only_restore_string_with_ddboost(self, mock1, mock2):
+        self.context.report_status_dir = '/tmp'
         table_filter_file = None
         full_restore_with_filter = True
-        self.restore.ddboost = True
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=/foo/db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p -P --gp-r=/tmp --status=/tmp --gp-c -d "bkdb" --ddboost'
+        self.context.ddboost = True
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20160101 --gp-i --gp-k=20160101010101 --gp-l=p -P --gp-r=/tmp --status=/tmp --gp-c -d "testdb" --ddboost'
 
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_post_data_schema_only_restore_line_09(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
+    def test_create_post_data_schema_only_restore_string_with_nbu(self, mock1, mock2):
         table_filter_file = None
         full_restore_with_filter = True
-        self.restore.netbackup_service_host = "mdw"
-        self.restore.netbackup_block_size = None
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p -P --gp-c -d "bkdb" --netbackup-service-host=mdw'
+        self.context.backup_dir = None
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_block_size = 1024
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20160101 --gp-i --gp-k=20160101010101 --gp-l=p -P --gp-c -d "testdb" --netbackup-service-host=mdw --netbackup-block-size=1024'
 
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        restore_line = self.restore.create_post_data_schema_only_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_post_data_schema_only_restore_line_10(self, mock1, mock2):
-        master_datadir = 'foo'
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        table_filter_file = None
-        full_restore_with_filter = True
-        self.restore.netbackup_service_host = "mdw"
-        self.restore.netbackup_block_size = 1024
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p -P --gp-c -d "bkdb" --netbackup-service-host=mdw --netbackup-block-size=1024'
-
-        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+    def test_build_gpdbrestore_cmd_line_default(self, mock1, mock2):
+        ts = '20160101010101'
+        self.context.backup_dir = None
+        expected_output = 'gpdbrestore -t 20160101010101 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name'
+        restore_line = _build_gpdbrestore_cmd_line(self.context, ts, 'foo')
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_gpdbrestore_cmd_line_00(self, mock1, mock2):
-        ts = '20121212121212'
-        dump_prefix = 'bar_'
-        expected_output = 'gpdbrestore -t 20121212121212 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name --prefix=bar'
-        restore_line = _build_gpdbrestore_cmd_line(ts, 'foo', None, None, None, dump_prefix)
+    def test_build_gpdbrestore_cmd_line_backup_dir(self, mock1, mock2):
+        ts = '20160101010101'
+        self.context.backup_dir = '/tmp' 
+        expected_output = 'gpdbrestore -t 20160101010101 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name -u /tmp'
+        restore_line = _build_gpdbrestore_cmd_line(self.context, ts, 'foo')
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_redirected_restore_build_gpdbrestore_cmd_line_00(self, mock1, mock2):
-        ts = '20121212121212'
-        dump_prefix = 'bar_'
-        expected_output = 'gpdbrestore -t 20121212121212 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name --prefix=bar --redirect="redb"'
-        restore_line = _build_gpdbrestore_cmd_line(ts, 'foo', None, 'redb', None, dump_prefix)
+    def test_build_gpdbrestore_cmd_line_report_status_dir(self, mock1, mock2):
+        ts = '20160101010101'
+        self.context.backup_dir = None
+        self.context.report_status_dir = '/tmp'
+        expected_output = 'gpdbrestore -t 20160101010101 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name --report-status-dir=/tmp'
+        restore_line = _build_gpdbrestore_cmd_line(self.context, ts, 'foo')
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_gpdbrestore_cmd_line_01(self, mock1, mock2):
-        ts = '20121212121212'
-        dump_prefix = 'bar_'
-        expected_output = 'gpdbrestore -t 20121212121212 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name -u /tmp --prefix=bar'
-        restore_line = _build_gpdbrestore_cmd_line(ts, 'foo', '/tmp', None, None, dump_prefix)
+    def test_build_gpdbrestore_cmd_line_redirected_restore(self, mock1, mock2):
+        ts = '20160101010101'
+        self.context.backup_dir = None
+        self.context.redirected_restore_db = "redb"
+        expected_output = 'gpdbrestore -t 20160101010101 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name --redirect=redb'
+        restore_line = _build_gpdbrestore_cmd_line(self.context, ts, 'foo')
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_gpdbrestore_cmd_line_02(self, mock1, mock2):
-        ts = '20121212121212'
-        dump_prefix = 'bar_'
-        report_status_dir = '/tmp'
-        expected_output = 'gpdbrestore -t 20121212121212 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name --prefix=bar --report-status-dir=/tmp'
-        restore_line = _build_gpdbrestore_cmd_line(ts, 'foo', None, None, '/tmp', dump_prefix)
-        self.assertEqual(restore_line, expected_output)
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_gpdbrestore_cmd_line_03(self, mock1, mock2):
-        ts = '20121212121212'
-        dump_prefix = 'bar_'
-        expected_output = 'gpdbrestore -t 20121212121212 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name --prefix=bar --report-status-dir=/tmp --ddboost'
+    def test_build_gpdbrestore_cmd_line_with_ddboost(self, mock1, mock2):
+        ts = '20160101010101'
+        self.context.backup_dir = None
+        self.context.ddboost = True
+        self.context.report_status_dir = '/tmp'
+        expected_output = 'gpdbrestore -t 20160101010101 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name --report-status-dir=/tmp --ddboost'
         ddboost = True
-        restore_line = _build_gpdbrestore_cmd_line(ts, 'foo', None, None, '/tmp', dump_prefix, ddboost)
+        restore_line = _build_gpdbrestore_cmd_line(self.context, ts, 'foo')
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_redirected_restore_build_gpdbrestore_cmd_line_01(self, mock1, mock2):
-        ts = '20121212121212'
-        dump_prefix = 'bar_'
-        expected_output = 'gpdbrestore -t 20121212121212 --table-file foo -a -v --noplan --noanalyze --noaostats --no-validate-table-name -u /tmp --prefix=bar --redirect="redb"'
-        restore_line = _build_gpdbrestore_cmd_line(ts, 'foo', '/tmp', 'redb', None, dump_prefix)
-        self.assertEqual(restore_line, expected_output)
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_00(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = False
+    def test_create_restore_string_no_filter_file(self, mock1, mock2):
+        self.context.no_plan = True
         table_filter_file = None
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d "bkdb" -a'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=db_dumps/20160101 --gp-c -d "testdb" -a'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_01(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = False
-        no_ao_stats = False
+    def test_create_restore_string_default(self, mock1, mock2):
+        self.context.no_plan = True
         table_filter_file = '/tmp/foo'
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-f=/tmp/foo --gp-c -d "bkdb"'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=db_dumps/20160101 --gp-f=/tmp/foo --gp-c -d "testdb" -a'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_02(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = False
+    def test_create_restore_string_with_ddboost(self, mock1, mock2):
+        self.context.no_plan = True
         table_filter_file = None
         full_restore_with_filter = False
-        self.restore.ddboost = True
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d "bkdb" -a --ddboost'
+        self.context.ddboost = True
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=db_dumps/20160101 --gp-c -d "testdb" -a --ddboost'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_03(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
-        table_filter_file = None
-        self.restore.report_status_dir = '/tmp'
-        full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-r=/tmp --status=/tmp --gp-c -d "bkdb" -a --gp-nostats'
-
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
-        self.assertEqual(restore_line, expected_output)
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_04(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
+    def test_create_restore_string_different_status_dir(self, mock1, mock2):
+        self.context.no_plan = True
+        self.context.report_status_dir = '/tmp'
         table_filter_file = None
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d "bkdb" -a --gp-nostats'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=db_dumps/20160101 --gp-r=/tmp --status=/tmp --gp-c -d "testdb" -a'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_05(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = False
-        no_ao_stats = True
+    def test_create_restore_string_no_filter(self, mock1, mock2):
+        self.context.no_plan = True
+        table_filter_file = None
+        full_restore_with_filter = False
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=db_dumps/20160101 --gp-c -d "testdb" -a'
+
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
+        self.assertEqual(restore_line, expected_output)
+
+    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
+    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
+    def test_create_restore_string_no_filter_file(self, mock1, mock2):
+        self.context.no_plan = True
         table_filter_file = '/tmp/foo'
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-f=/tmp/foo --gp-c -d "bkdb" --gp-nostats'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=db_dumps/20160101 --gp-f=/tmp/foo --gp-c -d "testdb" -a'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_06(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
+    def test_create_restore_string_ddboost_and_prefix(self, mock1, mock2):
+        self.context.no_plan = True
         table_filter_file = None
+        self.context.dump_prefix = 'bar_'
         full_restore_with_filter = False
-        self.restore.ddboost = True
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d "bkdb" -a --gp-nostats --ddboost'
+        self.context.ddboost = True
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --prefix=bar_ --gp-k=20160101010101 --gp-l=p --gp-d=db_dumps/20160101 --gp-c -d "testdb" -a --ddboost'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_07(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
+    @patch('gppylib.operations.backup_utils.Context.backup_dir_is_writable', return_value=True)
+    def test_create_restore_string_backup_dir(self, mock1, mock2, mock3):
+        self.context.no_plan = True
         table_filter_file = None
-        self.restore.dump_prefix = 'bar_'
+        self.context.backup_dir = '/tmp'
         full_restore_with_filter = False
-        self.restore.ddboost = True
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --prefix=bar_ --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d "bkdb" -a --gp-nostats --ddboost'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=/tmp/db_dumps/20160101 --gp-r=/tmp/db_dumps/20160101 --status=/tmp/db_dumps/20160101 --gp-c -d "testdb" -a'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=True)
-    def test_build_restore_line_08(self, mock1, mock2, mock3):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
+    def test_create_restore_string_no_ao_stats(self, mock1, mock2):
+        self.context.no_plan = True
+        self.context.no_ao_stats = True
         table_filter_file = None
-        self.restore.backup_dir = '/tmp'
+        self.context.report_status_dir = '/tmp'
+        self.context.backup_dir = '/foo'
         full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/tmp/db_dumps/20121212 --gp-r=/tmp/db_dumps/20121212 --status=/tmp/db_dumps/20121212 --gp-c -d "bkdb" -a --gp-nostats'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=/foo/db_dumps/20160101 --gp-r=/tmp --status=/tmp --gp-c -d "testdb" -a --gp-nostats'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    @patch('gppylib.operations.restore.RestoreDatabase.backup_dir_is_writable', return_value=False)
-    def test_build_restore_line_09(self, mock1, mock2, mock3):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
+    def test_create_restore_string_with_plan(self, mock1, mock2):
         table_filter_file = None
-        self.restore.backup_dir = '/tmp'
-        full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/tmp/db_dumps/20121212 --gp-c -d "bkdb" -a --gp-nostats'
-
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
-        self.assertEqual(restore_line, expected_output)
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_10(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
-        table_filter_file = None
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
-        full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/foo/db_dumps/20121212 --gp-r=/tmp --status=/tmp --gp-c -d bkdb -a --gp-nostats'
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_11(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
-        table_filter_file = None
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
-        full_restore_with_filter = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/foo/db_dumps/20121212 --gp-r=/tmp --status=/tmp --gp-c -d "bkdb" -a --gp-nostats'
-
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
-        self.assertEqual(restore_line, expected_output)
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_12(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = False
-        no_ao_stats = True
-        table_filter_file = None
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
+        self.context.report_status_dir = '/tmp'
+        self.context.backup_dir = '/foo'
         full_restore_with_filter = True
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/foo/db_dumps/20121212 --gp-r=/tmp --status=/tmp --gp-c -d "bkdb" -a --gp-nostats'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=/foo/db_dumps/20160101 --gp-r=/tmp --status=/tmp --gp-c -d "testdb" -a'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_13(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
+    def test_create_restore_string_with_nbu(self, mock1, mock2):
+        self.context.no_plan = True
         table_filter_file = None
-        self.restore.report_status_dir = '/tmp'
-        self.restore.backup_dir = '/foo'
-        self.restore.netbackup_service_host = "mdw"
+        self.context.report_status_dir = '/tmp'
+        self.context.backup_dir = '/foo'
+        self.context.netbackup_service_host = "mdw"
         full_restore_with_filter = False
-        self.restore.ddboost = False
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=/foo/db_dumps/20121212 --gp-r=/tmp --status=/tmp --gp-c -d "bkdb" -a --gp-nostats --netbackup-service-host=mdw'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=/foo/db_dumps/20160101 --gp-r=/tmp --status=/tmp --gp-c -d "testdb" -a --netbackup-service-host=mdw'
 
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
-        self.assertEqual(restore_line, expected_output)
-
-    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
-    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_14(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        no_plan = True
-        no_ao_stats = True
-        table_filter_file = None
-        self.restore.ddboost = True
-        self.restore.report_status_dir = '/tmp'
-        self.restore.netbackup_service_host = "mdw"
-        full_restore_with_filter = False
-        self.restore.dump_dir = 'backup/DCA-35'
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=backup/DCA-35/20121212 --gp-r=/tmp --status=/tmp --gp-c -d "bkdb" -a --gp-nostats --ddboost --netbackup-service-host=mdw'
-
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, None)
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter)
         self.assertEqual(restore_line, expected_output)
 
     # Test to verify the command line for gp_restore
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
-    def test_build_restore_line_15(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        restore_db = 'bkdb'
-        compress = True
-        master_port = '5432'
-        ddboost = False
-        no_plan = True
-        no_ao_stats = False
+    def test_create_restore_string_change_schema(self, mock1, mock2):
+        self.context.no_plan = True
         table_filter_file = None
         full_restore_with_filter = False
-        change_schema = 'newschema'
-        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d "bkdb" -a --change-schema-file=newschema'
-        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
-                                                        full_restore_with_filter, change_schema)
+        change_schema_file = 'newschema'
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20160101010101 --gp-l=p --gp-d=db_dumps/20160101 --gp-c -d "testdb" -a --change-schema-file=newschema'
+        restore_line = self.restore.create_restore_string(table_filter_file, full_restore_with_filter, change_schema_file)
         self.assertEqual(restore_line, expected_output)
 
-    @patch('gppylib.operations.restore.generate_plan_filename', return_value='foo')
-    def test_get_plan_file_contents_00(self, mock1):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo')
+    def test_get_plan_file_contents_no_file(self, mock1):
         with self.assertRaisesRegexp(Exception, 'Plan file foo does not exist'):
-            get_plan_file_contents(master_datadir, backup_dir, timestamp, self.restore.dump_dir, self.restore.dump_prefix)
+            get_plan_file_contents(self.context)
 
-    @patch('gppylib.operations.restore.generate_plan_filename', return_value='foo')
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo')
     @patch('gppylib.operations.restore.get_lines_from_file', return_value=[])
     @patch('os.path.isfile', return_value=True)
-    def test_get_plan_file_contents_01(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
+    def test_get_plan_file_contents_empty_file(self, mock1, mock2, mock3):
         with self.assertRaisesRegexp(Exception, 'Plan file foo has no contents'):
-            get_plan_file_contents(master_datadir, backup_dir, timestamp, self.restore.dump_dir, self.restore.dump_prefix)
+            get_plan_file_contents(self.context)
 
-    @patch('gppylib.operations.restore.generate_plan_filename', return_value='foo')
-    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20121212121212:t1,t2', '20121212121211:t3,t4', '20121212121210:t5,t6,t7'])
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo')
+    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20160101010101:t1,t2', '20160101010111:t3,t4', '20160101121210:t5,t6,t7'])
     @patch('os.path.isfile', return_value=True)
-    def test_get_plan_file_contents_02(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
-        expected_output = [('20121212121212','t1,t2'), ('20121212121211','t3,t4'), ('20121212121210','t5,t6,t7')]
-        output = get_plan_file_contents(master_datadir, backup_dir, timestamp, self.restore.dump_dir, self.restore.dump_prefix)
+    def test_get_plan_file_contents_default(self, mock1, mock2, mock3):
+        expected_output = [('20160101010101','t1,t2'), ('20160101010111','t3,t4'), ('20160101121210','t5,t6,t7')]
+        output = get_plan_file_contents(self.context)
         self.assertEqual(output, expected_output)
 
-    @patch('gppylib.operations.restore.generate_plan_filename', return_value='foo')
-    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20121212121212:', '20121212121211', '20121212121210:'])
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo')
+    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20160101010101:', '20160101010111', '20160101121210:'])
     @patch('os.path.isfile', return_value=True)
-    def test_get_plan_file_contents_03(self, mock1, mock2, mock3):
-        master_datadir = 'foo'
-        timestamp = '20121212121212'
-        backup_dir = None
+    def test_get_plan_file_contents_invalid_format(self, mock1, mock2, mock3):
         with self.assertRaisesRegexp(Exception, 'Invalid plan file format'):
-            get_plan_file_contents(master_datadir, backup_dir, timestamp, self.restore.dump_dir, self.restore.dump_prefix)
+            get_plan_file_contents(self.context)
 
-    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20121212121212', 't1,t2'), ('20121212121211', 't3,t4'), ('20121212121210', 't5,t6,t7')])
+    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20160101010101', 't1,t2'), ('20160101010111', 't3,t4'), ('20160101121210', 't5,t6,t7')])
     @patch('gppylib.operations.restore.Command.run')
     @patch('gppylib.operations.restore.update_ao_statistics')
-    def test_restore_incremental_data_only_00(self, mock1, mock2, mock3):
-        restore_db = None
-        results = self.restore.restore_incremental_data_only(restore_db)
+    def test_restore_incremental_data_only_default(self, mock1, mock2, mock3):
+        results = self.restore.restore_incremental_data_only()
         self.assertTrue(results)
 
-    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20121212121212', 't1,t2'), ('20121212121211', 't3,t4'), ('20121212121210', 't5,t6,t7')])
-    @patch('gppylib.operations.restore.Command.run')
-    @patch('gppylib.operations.restore.update_ao_statistics')
-    def redirected_restore_test_restore_incremental_data_only_00(self, mock1, mock2, mock3):
-        restore_db = None
-        results = self.restore.restore_incremental_data_only(restore_db)
-        self.assertTrue(results)
-
-    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20121212121212', ''), ('20121212121211', ''), ('20121212121210', '')])
+    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20160101010101', ''), ('20160101010111', ''), ('20160101121210', '')])
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.restore.update_ao_statistics')
-    def test_restore_incremental_data_only_01(self, mock1, mock2, mock3):
-        restore_db = None
-        with self.assertRaisesRegexp(Exception, 'There were no tables to restore. Check the plan file contents for restore timestamp 20121212121212'):
-            self.restore.restore_incremental_data_only(restore_db)
+    def test_restore_incremental_data_only_no_tables(self, mock1, mock2, mock3):
+        with self.assertRaisesRegexp(Exception, 'There were no tables to restore. Check the plan file contents for restore timestamp 20160101010101'):
+            self.restore.restore_incremental_data_only()
 
-    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20121212121212', 't1,t2'), ('20121212121211', 't3,t4'), ('20121212121210', 't5,t6,t7')])
-    @patch('gppylib.operations.restore.Command.run')
-    @patch('gppylib.operations.restore.update_ao_statistics')
-    def test_restore_incremental_data_only_02(self, mock1, mock2, mock3):
-        restore_db = None
-        self.assertTrue(self.restore.restore_incremental_data_only(restore_db))
-
-    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20121212121212', 't1,t2'), ('20121212121211', 't3,t4'), ('20121212121210', 't5,t6,t7')])
+    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20160101010101', 't1,t2'), ('20160101010111', 't3,t4'), ('20160101121210', 't5,t6,t7')])
     @patch('gppylib.operations.restore.Command.run', side_effect=Exception('Error executing gpdbrestore'))
     @patch('gppylib.operations.restore.update_ao_statistics')
-    def test_restore_incremental_data_only_04(self, mock1, mock2, mock3):
-        restore_db = None
+    def test_restore_incremental_data_only_error(self, mock1, mock2, mock3):
         with self.assertRaisesRegexp(Exception, 'Error executing gpdbrestore'):
-            self.restore.restore_incremental_data_only(restore_db)
+            self.restore.restore_incremental_data_only()
 
-    def test_get_restore_dir_00(self):
-        master_datadir = '/foo'
-        backup_dir = None
-        self.assertEqual(get_restore_dir(master_datadir, backup_dir), '/foo')
-
-    def test_get_restore_dir_01(self):
-        master_datadir = None
-        backup_dir = '/foo'
-        self.assertEqual(get_restore_dir(master_datadir, backup_dir), '/foo')
-
-    def test_get_restore_dir_02(self):
-        master_datadir = None
-        backup_dir = None
-        self.assertEqual(get_restore_dir(master_datadir, backup_dir), None)
-
-    @patch('gppylib.operations.restore.is_incremental_restore', return_value=True)
-    def test_is_begin_incremental_run_00(self, m):
-        mdd = '/foo'
-        backup_dir = '/tmp'
-        timestamp = '20130204135500'
-        noplan = True
-        result = is_begin_incremental_run(mdd, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp, noplan)
-        self.assertFalse(result)
-
-    @patch('gppylib.operations.restore.is_incremental_restore', return_value=True)
-    def test_is_begin_incremental_run_01(self, m):
-        mdd = '/foo'
-        backup_dir = '/tmp'
-        timestamp = '20130204135500'
-        noplan = False
-        result = is_begin_incremental_run(mdd, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp, noplan)
-        self.assertTrue(result)
-
-    @patch('gppylib.operations.restore.is_incremental_restore', return_value=False)
-    def test_is_begin_incremental_run_02(self, m):
-        mdd = '/foo'
-        backup_dir = '/tmp'
-        timestamp = '20130204135500'
-        noplan = True
-        result = is_begin_incremental_run(mdd, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp, noplan)
-        self.assertFalse(result)
-
-    @patch('gppylib.operations.restore.is_incremental_restore', return_value=False)
-    def test_is_begin_incremental_run_03(self, m):
-        mdd = '/foo'
-        backup_dir = '/tmp'
-        timestamp = '20130204135500'
-        noplan = False
-        result = is_begin_incremental_run(mdd, backup_dir, self.restore.dump_dir, self.restore.dump_prefix, timestamp, noplan)
-        self.assertFalse(result)
-
-    def test_create_filter_file_00(self):
-        self.restore.restore_tables = None
-        fname = self.restore.create_filter_file()
-        self.assertEquals(fname, None)
+    def test_create_filter_file_no_tables(self):
+        self.context.restore_tables = None
+        self.assertEquals(self.restore.create_filter_file(), None)
 
     @patch('gppylib.operations.restore.get_all_segment_addresses', return_value=['host1'])
     @patch('gppylib.operations.restore.scp_file_to_hosts')
-    def test_create_filter_file_01(self, m1, m2):
-        self.restore.restore_tables = ['public.ao1', 'pepper.heap1']
-        fname = self.restore.create_filter_file()
-        tables = None
-        with open(fname) as fd:
-            contents = fd.read()
-            tables = contents.splitlines()
-        self.assertEquals(tables,self.restore.restore_tables)
-        os.remove(fname)
+    def test_create_filter_file_default(self, m1, m2):
+        self.context.restore_tables = ['public.ao1', 'testschema.heap1']
+        m = mock_open()
+        with patch('tempfile.NamedTemporaryFile', m, create=True):
+            fname = self.restore.create_filter_file()
+            result = m()
+            self.assertEqual(len(self.context.restore_tables), len(result.write.call_args_list))
+            for i in range(len(self.context.restore_tables)):
+                self.assertEqual(call(self.context.restore_tables[i]+'\n'), result.write.call_args_list[i])
 
     @patch('gppylib.operations.restore.get_lines_from_file', return_value = ['public.t1', 'public.t2', 'public.t3'])
     @patch('os.path.isfile', return_value = True)
-    def test_get_restore_tables_from_table_file_00(self, mock1, mock2):
+    def test_get_restore_tables_from_table_file_default(self, mock1, mock2):
         table_file = '/foo'
         expected_result = ['public.t1', 'public.t2', 'public.t3']
         result = get_restore_tables_from_table_file(table_file)
         self.assertEqual(expected_result, result)
 
     @patch('os.path.isfile', return_value = False)
-    def test_get_restore_tables_from_table_file_01(self, mock):
+    def test_get_restore_tables_from_table_file_no_file(self, mock):
         table_file = '/foo'
         expected_result = ['public.t1', 'public.t2', 'public.t3']
         with self.assertRaisesRegexp(Exception, 'Table file does not exist'):
             result = get_restore_tables_from_table_file(table_file)
 
-    def test_check_table_name_format_and_duplicate_00(self):
+    def test_check_table_name_format_and_duplicate_missing_schema(self):
         table_list = ['publicao1', 'public.ao2']
         with self.assertRaisesRegexp(Exception, 'No schema name supplied'):
             check_table_name_format_and_duplicate(table_list, None)
 
-    def test_check_table_name_format_and_duplicate_01(self):
+    def test_check_table_name_format_and_duplicate_default(self):
         table_list = ['public.ao1', 'public.ao2']
         check_table_name_format_and_duplicate(table_list, [])
 
-    def test_check_table_name_format_and_duplicate_02(self):
+    def test_check_table_name_format_and_duplicate_no_tables(self):
         table_list = []
         schema_list = []
         check_table_name_format_and_duplicate(table_list, schema_list)
 
-    def test_check_table_name_format_and_duplicate_03(self):
+    def test_check_table_name_format_and_duplicate_duplicate_tables(self):
         table_list = ['public.ao1', 'public.ao1']
         resolved_list, _ = check_table_name_format_and_duplicate(table_list, [])
         self.assertEqual(resolved_list, ['public.ao1'])
 
-    def test_check_table_name_format_and_duplicate_04(self):
+    def test_check_table_name_format_and_duplicate_funny_chars(self):
         table_list = [' `"@#$%^&( )_|:;<>?/-+={}[]*1Aa . `"@#$%^&( )_|:;<>?/-+={}[]*1Aa ', 'schema.ao1']
         schema_list = ['schema']
         resolved_table_list, resolved_schema_list = check_table_name_format_and_duplicate(table_list, schema_list)
         self.assertEqual(resolved_table_list, [' `"@#$%^&( )_|:;<>?/-+={}[]*1Aa . `"@#$%^&( )_|:;<>?/-+={}[]*1Aa '])
         self.assertEqual(resolved_schema_list, ['schema'])
 
-    def test_validate_tablenames_exist_in_dump_file_00(self):
+    def test_validate_tablenames_exist_in_dump_file_no_tables(self):
         dumped_tables = []
         table_list = ['schema.ao']
         with self.assertRaisesRegexp(Exception, 'No dumped tables to restore.'):
             validate_tablenames_exist_in_dump_file(table_list, dumped_tables)
 
-    def test_validate_tablenames_exist_in_dump_file_01(self):
+    def test_validate_tablenames_exist_in_dump_file_one_table(self):
         dumped_tables = [('schema', 'ao', 'gpadmin')]
         table_list = ['schema.ao']
         validate_tablenames_exist_in_dump_file(table_list, dumped_tables)
 
-    def test_validate_tablenames_exist_in_dump_file_02(self):
+    def test_validate_tablenames_exist_in_dump_file_nonexistent_table(self):
         dumped_tables = [('schema', 'ao', 'gpadmin')]
         table_list = ['schema.ao', 'schema.co']
         with self.assertRaisesRegexp(Exception, "Tables \['schema.co'\] not found in backup"):
             validate_tablenames_exist_in_dump_file(table_list, dumped_tables)
 
-    def test_get_restore_table_list_00(self):
+    def test_get_restore_table_list_default(self):
         table_list = ['public.ao_table', 'public.ao_table2', 'public.co_table', 'public.heap_table']
         restore_tables = ['public.ao_table2', 'public.co_table']
-        result = get_restore_table_list(table_list, restore_tables)
-        with open(result) as fd:
-            for line in fd:
-                self.assertTrue(line.strip() in restore_tables)
+        m = mock_open()
+        with patch('tempfile.NamedTemporaryFile', m, create=True):
+            result = get_restore_table_list(table_list, restore_tables)
+            result = m()
+            self.assertEqual(len(restore_tables), len(result.write.call_args_list))
+            for i in range(len(restore_tables)):
+                self.assertEqual(call(restore_tables[i]+'\n'), result.write.call_args_list[i])
 
-    def test_get_restore_table_list_01(self):
+    def test_get_restore_table_list_no_restore_tables(self):
         table_list = ['public.ao_table', 'public.ao_table2', 'public.co_table', 'public.heap_table']
-        restore_tables = []
-        result = get_restore_table_list(table_list, restore_tables)
-        with open(result) as fd:
-            for line in fd:
-                self.assertTrue(line.strip() in table_list)
+        restore_tables = None
+        m = mock_open()
+        with patch('tempfile.NamedTemporaryFile', m, create=True):
+            result = get_restore_table_list(table_list, restore_tables)
+            result = m()
+            self.assertEqual(len(table_list), len(result.write.call_args_list))
+            for i in range(len(table_list)):
+                self.assertEqual(call(table_list[i]+'\n'), result.write.call_args_list[i])
 
-    def test_get_restore_table_list_02(self):
+    def test_get_restore_table_list_extra_restore_tables(self):
         table_list = ['public.ao_table', 'public.ao_table2', 'public.co_table', 'public.heap_table']
         restore_tables = ['public.ao_table2', 'public.co_table', 'public.ao_table3']
-        result = get_restore_table_list(table_list, restore_tables)
-        with open(result) as fd:
-            for line in fd:
-                self.assertTrue(line.strip() in restore_tables)
+        expected = ['public.ao_table2', 'public.co_table']
+        m = mock_open()
+        with patch('tempfile.NamedTemporaryFile', m, create=True):
+            result = get_restore_table_list(table_list, restore_tables)
+            result = m()
+            self.assertEqual(len(expected), len(result.write.call_args_list))
+            for i in range(len(expected)):
+                self.assertEqual(call(expected[i]+'\n'), result.write.call_args_list[i])
 
-    def test_validate_restore_tables_list_00(self):
-        plan_file_contents = [('20121212121213', 'public.t1'), ('20121212121212', 'public.t2,public.t3'), ('20121212121212', 'public.t4')]
+    def test_validate_restore_tables_list_default(self):
+        plan_file_contents = [('20160101121213', 'public.t1'), ('20160101010101', 'public.t2,public.t3'), ('20160101010101', 'public.t4')]
         restore_tables = ['public.t1', 'public.t2']
         validate_restore_tables_list(plan_file_contents, restore_tables)
 
-    def test_validate_restore_tables_list_01(self):
-        plan_file_contents = [('20121212121213', 'public.t1'), ('20121212121212', 'public.t2,public.t3'), ('20121212121212', 'public.t4')]
+    def test_validate_restore_tables_list_invalid_tables(self):
+        plan_file_contents = [('20160101121213', 'public.t1'), ('20160101010101', 'public.t2,public.t3'), ('20160101010101', 'public.t4')]
         restore_tables = ['public.t5', 'public.t2']
         with self.assertRaisesRegexp(Exception, 'Invalid tables for -T option: The following tables were not found in plan file'):
             validate_restore_tables_list(plan_file_contents, restore_tables)
 
-    def test_validate_restore_tables_list_02(self):
-        plan_file_contents = [('20121212121213', 'public.t1'), ('20121212121212', 'public.t2,public.t3'), ('20121212121212', 'public.Ž')]
-        restore_tables = ['public.t1', 'public.Áá']
-        with self.assertRaisesRegexp(Exception, 'Invalid tables for -T option: The following tables were not found in plan file'):
-            validate_restore_tables_list(plan_file_contents, restore_tables)
-
-    def test_validate_restore_tables_list_03(self):
-        plan_file_contents = [('20121212121213', 'public.t1'), ('20121212121212', 'public.t2,public.t3'), ('20121212121212', 'public.测试')]
-        restore_tables = ['public.t1', 'public.测试']
-        validate_restore_tables_list(plan_file_contents, restore_tables)
-
-    def test_validate_restore_tables_list_04(self):
-        plan_file_contents = [('20121212121213', 'public.t1'), ('20121212121212', 'public.t2,public.t3'), ('20121212121212', 'public.Ž')]
-        restore_tables = ['public.t1', 'public.Ž']
-        validate_restore_tables_list(plan_file_contents, restore_tables)
-
-    def test_validate_restore_tables_list_05(self):
-        plan_file_contents = [('20121212121213', 'public.t1'), ('20121212121212', 'public.t2,schema.t3'), ('20121212121212', 'public.Áá')]
-        restore_tables = ['public.t1', 'public.Áá']
-        restore_schemas = ['schema']
-        validate_restore_tables_list(plan_file_contents, restore_tables)
-
-    def test_validate_restore_tables_list_06(self):
-        plan_file_contents = [('20121212121213', ' `\'"@#$%^&( )_|\\:;<>?/-+={}[]*1Aa . `\'"@#$%^&( )_|\\:;<>?/-+={}[]*1Aa ')]
-        restore_tables = [' `\'"@#$%^&( )_|\\:;<>?/-+={}[]*1Aa . `\'"@#$%^&( )_|\\:;<>?/-+={}[]*1Aa ']
-        validate_restore_tables_list(plan_file_contents, restore_tables)
-
-    @patch('gppylib.operations.unix.CheckFile.run', return_value=False)
-    def test_restore_global_00(self, mock):
-        restore_timestamp = '20121212121212'
-        master_datadir = 'foo'
-        backup_dir = None
-
-        with self.assertRaisesRegexp(Exception, 'Unable to locate global file gp_global_1_1_20121212121212 in dump set'):
-            self.restore._restore_global(restore_timestamp, master_datadir, backup_dir)
+    @patch('os.path.exists', return_value=False)
+    def test_restore_global_no_file(self, mock):
+        with self.assertRaisesRegexp(Exception, 'Unable to locate global file /data/master/p1/db_dumps/20160101/gp_global_1_1_20160101010101 in dump set'):
+            self.restore._restore_global(self.context)
 
     @patch('os.path.exists', return_value=True)
     @patch('gppylib.commands.gp.Psql.run')
-    def test_restore_global_01(self, mock1, mock2):
-        restore_timestamp = '20121212121212'
-        master_datadir = 'foo'
-        backup_dir = None
-
-        self.restore._restore_global(restore_timestamp, master_datadir, backup_dir) # should not error out
+    def test_restore_global_default(self, mock1, mock2):
+        self.restore._restore_global(self.context) # should not error out
 
     @patch('gppylib.operations.restore.execSQLForSingleton')
     @patch('pygresql.pgdb.pgdbCnx.commit')
-    def test_update_ao_stat_func_00(self, m1, m2):
+    def test_update_ao_stat_func_default(self, m1, m2):
         conn = None
         ao_schema = 'schema'
         ao_table = 'table'
@@ -1511,7 +890,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
 
     @patch('pygresql.pgdb.pgdbCnx.commit')
     @patch('gppylib.operations.restore.execSQLForSingleton')
-    def test_update_ao_stat_func_01(self, m1, m2):
+    def test_update_ao_stat_func_near_batch_size(self, m1, m2):
         conn = None
         ao_table = 'table'
         ao_schema = 'schema'
@@ -1521,7 +900,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
 
     @patch('gppylib.operations.restore.execSQLForSingleton')
     @patch('pygresql.pgdb.pgdbCnx.commit')
-    def test_update_ao_stat_func_02(self, m1, m2):
+    def test_update_ao_stat_func_equal_batch_size(self, m1, m2):
         conn = None
         ao_table = 'table'
         ao_schema = 'schema'
@@ -1532,7 +911,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
 
     @patch('gppylib.operations.restore.execSQLForSingleton')
     @patch('pygresql.pgdb.pgdbCnx.commit')
-    def test_update_ao_stat_func_03(self, m1, m2):
+    def test_update_ao_stat_func_over_batch_size(self, m1, m2):
         conn = None
         ao_table = 'table'
         ao_schema = 'schema'
@@ -1542,7 +921,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
 
     @patch('gppylib.operations.restore.execSQLForSingleton')
     @patch('pygresql.pgdb.pgdbCnx.commit')
-    def test_update_ao_stat_func_04(self, m1, m2):
+    def test_update_ao_stat_func_double_batch_size(self, m1, m2):
         conn = None
         ao_table = 'table'
         ao_schema = 'schema'
@@ -1554,15 +933,13 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.execute_sql', return_value=[['t1', 'public']])
     @patch('gppylib.operations.restore.dbconn.connect')
     @patch('gppylib.operations.restore.update_ao_stat_func')
-    def test_update_ao_statistics_00(self, m1, m2, m3):
-        port = 28888
-        db = 'testdb'
+    def test_update_ao_statistics_default(self, m1, m2, m3):
         restored_tables = []
-        update_ao_statistics(port, db, restored_tables)
+        update_ao_statistics(self.context, restored_tables)
 
-        update_ao_statistics(port, db, restored_tables=['public.t1'], restored_schema=[], restore_all=False)
-        update_ao_statistics(port, db, restored_tables=[], restored_schema=['public'], restore_all=False)
-        update_ao_statistics(port, db, restored_tables=[], restored_schema=[], restore_all=True)
+        update_ao_statistics(self.context, restored_tables=['public.t1'], restored_schema=[], restore_all=False)
+        update_ao_statistics(self.context, restored_tables=[], restored_schema=['public'], restore_all=False)
+        update_ao_statistics(self.context, restored_tables=[], restored_schema=[], restore_all=True)
 
     def test_generate_restored_tables_no_table(self):
         results = [['t1','public'], ['t2', 'public'], ['foo', 'bar']]
@@ -1591,1228 +968,213 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.dbconn.connect')
     @patch('gppylib.db.dbconn.execSQLForSingleton', return_value=5)
     def test_check_gp_toolkit_true(self, m1, m2):
-        restore_db = 'testdb'
-        self.assertTrue(self.restore.check_gp_toolkit(restore_db))
+        self.assertTrue(self.restore.check_gp_toolkit())
 
     @patch('gppylib.operations.restore.dbconn.connect')
     @patch('gppylib.db.dbconn.execSQLForSingleton', return_value=0)
     def test_check_gp_toolkit_false(self, m1, m2):
-        restore_db = 'testdb'
-        self.assertFalse(self.restore.check_gp_toolkit(restore_db))
+        self.assertFalse(self.restore.check_gp_toolkit())
 
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     @patch('gppylib.operations.restore.execSQL')
-    def test_analyze_restore_tables_00(self, mock1, mock2, mock3):
-        db_name = 'FOO'
-        port = 1234
-        restore_tables = ['public.t1', 'public.t2']
-        self.restore._analyze_restore_tables(db_name, restore_tables, None)
+    def test_analyze_restore_tables_default(self, mock1, mock2, mock3):
+        self.context.restore_tables = ['public.t1', 'public.t2']
+        self.restore._analyze_restore_tables()
 
     @patch('gppylib.operations.restore.execSQL', side_effect=Exception('analyze failed'))
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')
-    def test_analyze_restore_tables_01(self, mock1, mock2, mock3):
-        db_name = 'FOO'
-        port = 1234
-        restore_tables = ['public.t1', 'public.t2']
-        self.assertRaises(Exception, self.restore._analyze_restore_tables, db_name, restore_tables, None)
+    def test_analyze_restore_tables_analyze_failed(self, mock1, mock2, mock3):
+        self.context.restore_tables = ['public.t1', 'public.t2']
+        self.assertRaises(Exception, self.restore._analyze_restore_tables)
 
     @patch('gppylib.operations.backup_utils.execSQL')
     @patch('gppylib.operations.backup_utils.dbconn.DbURL', side_effect=Exception('Failed'))
     @patch('gppylib.operations.backup_utils.dbconn.connect')
-    def test_analyze_restore_tables_02(self, mock1, mock2, mock3):
-        db_name = 'FOO'
-        port = 1234
-        restore_tables = ['public.t1', 'public.t2']
-        self.assertRaises(Exception, self.restore._analyze_restore_tables, db_name, restore_tables, None)
-
-    @patch('gppylib.operations.backup_utils.execSQL')
-    @patch('gppylib.operations.backup_utils.dbconn.DbURL')
-    @patch('gppylib.operations.backup_utils.dbconn.connect', side_effect=Exception('Failed'))
-    def test_analyze_restore_tables_03(self, mock1, mock2, mock3):
-        db_name = 'FOO'
-        port = 1234
-        restore_tables = ['public.t1', 'public.t2']
-        self.assertRaises(Exception, self.restore._analyze_restore_tables, db_name, restore_tables, None)
+    def test_analyze_restore_tables_connection_failed(self, mock1, mock2, mock3):
+        self.context.restore_tables = ['public.t1', 'public.t2']
+        self.assertRaises(Exception, self.restore._analyze_restore_tables)
 
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     @patch('gppylib.operations.restore.execSQL')
-    def test_analyze_restore_tables_04(self, mock1, mock2, mock3):
-        db_name = 'FOO'
-        port = 1234
-        restore_tables = ['public.t%d' % i for i in range(3002)]
+    def test_analyze_restore_tables_three_batches(self, mock1, mock2, mock3):
+        self.context.restore_tables = ['public.t%d' % i for i in range(3002)]
         expected_batch_count = 3
-        batch_count = self.restore._analyze_restore_tables(db_name, restore_tables, None)
+        batch_count = self.restore._analyze_restore_tables()
         self.assertEqual(batch_count, expected_batch_count)
 
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     @patch('gppylib.operations.backup_utils.dbconn.execSQL')
-    def test_analyze_restore_tables_05(self, mock1, mock2, mock3):
-        db_name = 'FOO'
-        port = 1234
-        restore_tables = ['public.t1', 'public.t2']
-        change_schema = 'newschema'
-        self.restore._analyze_restore_tables(db_name, restore_tables, change_schema)
-
-    @patch('gppylib.operations.backup_utils.dbconn.DbURL')
-    @patch('gppylib.operations.backup_utils.dbconn.connect')
-    @patch('gppylib.operations.backup_utils.dbconn.execSQL')
-    def test_analyze_restore_tables_06(self, mock1, mock2, mock3):
-        db_name = 'FOO'
-        port = 1234
-        restore_tables = ['public.t1', 'public.t2']
-        change_schema = 'newschema'
-        self.restore._analyze_restore_tables(db_name, restore_tables, change_schema)
-
-    @patch('gppylib.operations.restore.ValidateTimestamp', return_value=ValidateTimestampMock())
-    @patch('os.path.join', return_value="")
-    @patch('__builtin__.open', return_value=OpenFileMock(["""-- Name:  ao_T`~@#$%^&*()-+[{]}|\;: \'"/?><1 ; Type: TABLE; Schema:  S`~@#$%^&*()-+[{]}|\;: \'"/?><1 ; Owner: gpadmin"""]))
-    def test_getdumptables_execute_when_no_tablespace_should_give_table_names_without_quotes(self, m1, m2, m3):
-        get = GetDumpTables(None, None, None, None, None, None, None, None)
-        result = get.get_dump_tables()
-        self.assertEqual(result, [(' S`~@#$%^&*()-+[{]}|\\;: \'"/?><1 ', ' ao_T`~@#$%^&*()-+[{]}|\\;: \'"/?><1 ', 'gpadmin')])
-
-    @patch('gppylib.operations.restore.ValidateTimestamp', return_value=ValidateTimestampMock())
-    @patch('os.path.join', return_value="")
-    @patch('__builtin__.open', return_value=OpenFileMock(["""-- Name:  ao_T`~@#$%^&*()-+[{]}|\;: \'"/?><1 ; Type: TABLE; Schema:  S`~@#$%^&*()-+[{]}|\;: \'"/?><1 ; Owner: gpadmin; Tablespace: """]))
-    def test_getdumptables_execute_should_give_table_names_without_quotes(self, m1, m2, m3):
-        get = GetDumpTables(None, None, None, None, None, None, None, None)
-        result = get.get_dump_tables()
-        self.assertEqual(result, [(' S`~@#$%^&*()-+[{]}|\\;: \'"/?><1 ', ' ao_T`~@#$%^&*()-+[{]}|\\;: \'"/?><1 ', 'gpadmin')])
-
-    @patch('gppylib.operations.restore.ValidateTimestamp', return_value=ValidateTimestampMock())
-    @patch('os.path.join', return_value="")
-    @patch('__builtin__.open', return_value=OpenFileMock(["""-- Name:  ao_T`~@#$%^&*()-+[{]}|\;: \'"/?><1 ; Type: COMMENT; Schema:  S`~@#$%^&*()-+[{]}|\;: \'"/?><1 ; Owner: gpadmin"""]))
-    def test_getdumptables_execute_when_not_table_should_return_none(self, m1, m2, m3):
-        get = GetDumpTables(None, None, None, None, None, None, None, None)
-        result = get.get_dump_tables()
-        self.assertEqual(result, [])
-
-    @patch('gppylib.operations.restore.ValidateTimestamp', return_value=ValidateTimestampMock())
-    @patch('os.path.join', return_value="")
-    @patch('__builtin__.open', return_value=OpenFileMock(["""-- Name: sales; Type: TABLE; Schema: public; Owner: gpadmin""", """START ('2011-01-01'::date) END ('2011-02-01'::date) EVERY ('1 mon'::interval) WITH (tablename='sales_1_prt_2', appendonly=false )"""]))
-    def test_getdumptables_execute_when_subpartition_table_exist(self, m1, m2, m3):
-        get = GetDumpTables(None, None, None, None, None, None, None, None)
-        result = get.get_dump_tables()
-        self.assertEqual(result, [('public', 'sales', 'gpadmin'), ('public', 'sales_1_prt_2', 'gpadmin')])
-
-    @patch('gppylib.operations.restore.ValidateTimestamp', return_value=ValidateTimestampMock())
-    @patch('os.path.join', return_value="")
-    @patch('__builtin__.open', return_value=OpenFileMock(["""-- Name:  ao_T`~@#$%^&*()-+[{]}|\;: \'"/?><1 ; Type: TABLE; Schema:  S`~@#$%^&*()-+[{]}|\;: \'"/?><1 ; Owner: gpadmin""", """START ('2011-01-01'::date) END ('2011-02-01'::date) EVERY ('1 mon'::interval) WITH (tablename=E' ao_T`~@#$%^&*()-+[{]}|\;: ''"/?><1 _1_prt_2', appendonly=false )"""]))
-    def test_getdumptables_execute_when_special_char_subpartition_table_exist(self, m1, m2, m3):
-        get = GetDumpTables(None, None, None, None, None, None, None, None)
-        result = get.get_dump_tables()
-        self.assertEqual(result, [(' S`~@#$%^&*()-+[{]}|\\;: \'"/?><1 ', ' ao_T`~@#$%^&*()-+[{]}|\\;: \'"/?><1 ', 'gpadmin'), (' S`~@#$%^&*()-+[{]}|\\;: \'"/?><1 ', ' ao_T`~@#$%^&*()-+[{]}|\\;: \'"/?><1 _1_prt_2', 'gpadmin')])
-
-    @patch('__builtin__.open', return_value=OpenFileMock(["""-- Name: sales; Type: TABLE; Schema: public; Owner: gpadmin""", """SUBPARTITION usa VALUES('usa') WITH (tablename='sales_1_prt_1', appendonly=false ),"""]))
-    def test_getdumptables_execute_when_multi_subpartition_table_exist(self, m1):
-        get = GetDumpTables(None, None, None, None, None, None, None, None)
-        result = get.get_dump_tables()
-        self.assertEqual(result, [('public', 'sales', 'gpadmin'), ('public', 'sales_1_prt_1', 'gpadmin')])
-
-    @patch('__builtin__.open', return_value=OpenFileMock(["""-- Name: sales; Type: TABLE; Schema: public; Owner: gpadmin""", """DEFAULT PARTITION outlying_dates  WITH (tablename='sales_1_prt_default', appendonly=false )"""]))
-    def test_getdumptables_execute_when_default_partition_table_exist(self, m1):
-        get = GetDumpTables(None, None, None, None, None, None, None, None)
-        result = get.get_dump_tables()
-        self.assertEqual(result, [('public', 'sales', 'gpadmin'), ('public', 'sales_1_prt_default', 'gpadmin')])
-
-    @patch('__builtin__.open', return_value=OpenFileMock(["""-- Name: sales; Type: TABLE; Schema: public; Owner: gpadmin""", """DEFAULT SUBPARTITION other_regions  WITH (tablename='sales_1_prt_13_2_prt_other_regions', appendonly=false )"""]))
-    def test_getdumptables_execute_when_default_subpartition_table_exist(self, m1):
-        get = GetDumpTables(None, None, None, None, None, None, None, None)
-        result = get.get_dump_tables()
-        self.assertEqual(result, [('public', 'sales', 'gpadmin'), ('public', 'sales_1_prt_13_2_prt_other_regions', 'gpadmin')])
-
-    @patch('gppylib.commands.base.Command.__init__', return_value=None)
-    @patch('gppylib.commands.base.Command.run', return_value=None)
-    @patch('gppylib.commands.base.Command.get_results')
-    def test_getdumptables_from_ddboost(self, m1, m2, mockCommand_init):
-            m1.stdout = ['my return']
-            get = GetDumpTables(None, None, None, None, None, None, 'ddboost', None, None, 'myfile')
-            result = get.get_dump_tables()
-            mockCommand_init.assert_called_once_with('DDBoost copy of master dump file', 'gpddboost --readFile --from-file=myfile | grep -e "-- Name: " -e "^\\W*START (" -e "^\\W*PARTITION " -e "^\\W*DEFAULT PARTITION " -e "^\\W*SUBPARTITION " -e "^\\W*DEFAULT SUBPARTITION "')
-
-
-    @patch('gppylib.commands.base.Command.__init__', return_value=None)
-    @patch('gppylib.commands.base.Command.run', return_value="myfile")
-    @patch('gppylib.commands.base.Command.get_results')
-    def test_getdumptables_from_ddboost_compressed_file(self, m1, m2, mockCommand_init):
-            m1.stdout = ['my return']
-            get = GetDumpTables(None, None, None, None, None, True, 'ddboost', None, None, 'myfile.gz')
-            result = get.get_dump_tables()
-            mockCommand_init.assert_called_once_with('DDBoost copy of master dump file', 'gpddboost --readFile --from-file=myfile.gz | gunzip | grep -e "-- Name: " -e "^\\W*START (" -e "^\\W*PARTITION " -e "^\\W*DEFAULT PARTITION " -e "^\\W*SUBPARTITION " -e "^\\W*DEFAULT SUBPARTITION "')
-
-
-    @patch('gppylib.commands.base.Command.__init__', return_value=None)
-    @patch('gppylib.commands.base.Command.run', return_value="myfile")
-    @patch('gppylib.commands.base.Command.get_results')
-    def test_getdumptables_from_netbackup(self, m1, m2, mockCommand_init):
-            m1.stdout = ['my return']
-            get = GetDumpTables(None, None, None, None, None, False, None, 'netbackup-host', None, 'myfile')
-            result = get.get_dump_tables()
-            mockCommand_init.assert_called_once_with('NetBackup copy of master dump file', 'gp_bsa_restore_agent --netbackup-service-host netbackup-host --netbackup-filename myfile | grep -e "-- Name: " -e "^\\W*START (" -e "^\\W*PARTITION " -e "^\\W*DEFAULT PARTITION " -e "^\\W*SUBPARTITION " -e "^\\W*DEFAULT SUBPARTITION "')
-
-
-    @patch('gppylib.commands.base.Command.__init__', return_value=None)
-    @patch('gppylib.commands.base.Command.run', return_value="myfile")
-    @patch('gppylib.commands.base.Command.get_results')
-    def test_getdumptables_from_netbackup_compressed_file(self, m1, m2, mockCommand_init):
-            m1.stdout = ['my return']
-            get = GetDumpTables(None, None, None, None, None, True, None, 'netbackup-host', None, 'myfile.gz')
-            result = get.get_dump_tables()
-            mockCommand_init.assert_called_once_with('NetBackup copy of master dump file', 'gp_bsa_restore_agent --netbackup-service-host netbackup-host --netbackup-filename myfile.gz | gunzip | grep -e "-- Name: " -e "^\\W*START (" -e "^\\W*PARTITION " -e "^\\W*DEFAULT PARTITION " -e "^\\W*SUBPARTITION " -e "^\\W*DEFAULT SUBPARTITION "')
-
-    @patch('gppylib.commands.base.Command.__init__', return_value=None)
-    @patch('gppylib.commands.base.Command.run', return_value="myfile")
-    @patch('gppylib.commands.base.Command.get_results')
-    def test_getdumptables_from_remote_host(self, m1, m2, mockCommand_init):
-            m1.stdout = ['my return']
-            get = GetDumpTables(None, None, None, None, None, False, None, None, 'remote_host', 'myfile')
-            result = get.get_dump_tables()
-            mockCommand_init.assert_called_once_with('Get remote copy of dumped tables', 'ssh remote_host cat myfile | grep -e "-- Name: " -e "^\\W*START (" -e "^\\W*PARTITION " -e "^\\W*DEFAULT PARTITION " -e "^\\W*SUBPARTITION " -e "^\\W*DEFAULT SUBPARTITION "')
-
-
-    @patch('gppylib.commands.base.Command.__init__', return_value=None)
-    @patch('gppylib.commands.base.Command.run', return_value="myfile")
-    @patch('gppylib.commands.base.Command.get_results')
-    def test_getdumptables_from_remote_host_compressed_file(self, m1, m2, mockCommand_init):
-            m1.stdout = ['my return']
-            get = GetDumpTables(None, None, None, None, None, True, None, None, 'remote_host', 'myfile.gz')
-            result = get.get_dump_tables()
-            mockCommand_init.assert_called_once_with('Get remote copy of dumped tables', 'ssh remote_host cat myfile.gz | gunzip | grep -e "-- Name: " -e "^\\W*START (" -e "^\\W*PARTITION " -e "^\\W*DEFAULT PARTITION " -e "^\\W*SUBPARTITION " -e "^\\W*DEFAULT SUBPARTITION "')
-
-class ValidateTimestampTestCase(unittest.TestCase):
-
-    def setUp(self):
-        self.validate_timestamp = ValidateTimestamp(candidate_timestamp='20140211111111',
-                                                    master_datadir='/mdd',
-                                                    backup_dir='/backup_dir',
-                                                    dump_dir='/db_dumps',
-                                                    dump_prefix='',
-                                                    netbackup_service_host=None,
-                                                    ddboost=False)
+    def test_analyze_restore_tables_change_schema(self, mock1, mock2, mock3):
+        self.context.restore_tables = ['public.t1', 'public.t2']
+        self.context.change_schema = 'newschema'
+        self.restore._analyze_restore_tables()
 
     @patch('os.path.exists', side_effect=[True, False])
-    def test_validate_compressed_file_with_compression_exists(self, mock):
+    def test_validate_metadata_file_with_compression_exists(self, mock):
         compressed_file = 'compressed_file.gz'
-        self.assertTrue(self.validate_timestamp.validate_compressed_file(compressed_file))
+        self.assertTrue(self.validate_timestamp.validate_metadata_file(compressed_file))
 
     @patch('os.path.exists', side_effect=[False, False])
-    def test_validate_compressed_file_with_compression_doesnt_exists(self, mock):
+    def test_validate_metadata_file_with_compression_doesnt_exists(self, mock):
         compressed_file = 'compressed_file.gz'
         with self.assertRaisesRegexp(ExceptionNoStackTraceNeeded, 'Unable to find compressed_file or compressed_file.gz'):
-            self.validate_timestamp.validate_compressed_file(compressed_file)
+            self.validate_timestamp.validate_metadata_file(compressed_file)
 
     @patch('os.path.exists', side_effect=[False, True])
-    def test_validate_compressed_file_without_compression_exists(self, mock):
+    def test_validate_metadata_file_without_compression_exists(self, mock):
         compressed_file = 'compressed_file.gz'
-        self.assertFalse(self.validate_timestamp.validate_compressed_file(compressed_file))
+        self.assertFalse(self.validate_timestamp.validate_metadata_file(compressed_file))
 
     @patch('os.path.exists', side_effect=[False, False])
-    def test_validate_compressed_file_without_compression_doesnt_exist(self, mock):
+    def test_validate_metadata_file_without_compression_doesnt_exist(self, mock):
         compressed_file = 'compressed_file.gz'
         with self.assertRaisesRegexp(ExceptionNoStackTraceNeeded, 'Unable to find compressed_file or compressed_file.gz'):
-            self.validate_timestamp.validate_compressed_file(compressed_file)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_state_files_with_nbu_00(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_state_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_state_files_with_nbu_01(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_state_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_state_files_with_nbu_02(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_state_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_state_files_with_nbu_03(self, mock1):
-        master_datadir = None
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            restore_state_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_state_files_with_nbu_04(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = None
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Restore timestamp is None.'):
-            restore_state_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_state_files_with_nbu_05(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = None
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Netbackup service hostname is None.'):
-            restore_state_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_state_files_with_nbu_06(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 2048
-
-        restore_state_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_state_files_with_nbu_07(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-
-        restore_state_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_state_files_with_nbu_08(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 4096
-
-        restore_state_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_report_file_with_nbu_00(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_report_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_report_file_with_nbu_01(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_report_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_report_file_with_nbu_02(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_report_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_report_file_with_nbu_03(self, mock1):
-        master_datadir = None
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            restore_report_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_report_file_with_nbu_04(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = None
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Restore timestamp is None.'):
-            restore_report_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_report_file_with_nbu_05(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = None
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Netbackup service hostname is None.'):
-            restore_report_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_report_file_with_nbu_06(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-
-        restore_report_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_report_file_with_nbu_07(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 2048
-
-        restore_report_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_report_file_with_nbu_08(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 4096
-
-        restore_report_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_cdatabase_file_with_nbu_00(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_cdatabase_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_cdatabase_file_with_nbu_01(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_cdatabase_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_cdatabase_file_with_nbu_02(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_cdatabase_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_cdatabase_file_with_nbu_03(self, mock1):
-        master_datadir = None
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            restore_cdatabase_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_cdatabase_file_with_nbu_04(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = None
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Restore timestamp is None.'):
-            restore_cdatabase_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_cdatabase_file_with_nbu_05(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = None
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Netbackup service hostname is None.'):
-            restore_cdatabase_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_cdatabase_file_with_nbu_06(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-
-        restore_cdatabase_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_cdatabase_file_with_nbu_07(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 2048
-
-        restore_cdatabase_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_cdatabase_file_with_nbu_08(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 4096
-
-        restore_cdatabase_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_global_file_with_nbu_00(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_global_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_global_file_with_nbu_01(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_global_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_global_file_with_nbu_02(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_global_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_global_file_with_nbu_03(self, mock1):
-        master_datadir = None
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            restore_global_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_global_file_with_nbu_04(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = None
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Restore timestamp is None.'):
-            restore_global_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_global_file_with_nbu_05(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = None
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Netbackup service hostname is None.'):
-            restore_global_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_global_file_with_nbu_06(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-
-        restore_global_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_global_file_with_nbu_07(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 2048
-
-        restore_global_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_global_file_with_nbu_08(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 4096
-
-        restore_global_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_00(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_01(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_02(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_03(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = None
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_04(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = None
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        with self.assertRaisesRegexp(Exception, 'Restore timestamp is None.'):
-            restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_05(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        master_port = "5432"
-        netbackup_service_host = None
-        netbackup_block_size = None
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        with self.assertRaisesRegexp(Exception, 'Netbackup service hostname is None.'):
-            restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_06(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        master_port = None
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        with self.assertRaisesRegexp(Exception, 'Master port is None.'):
-            restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_07(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_08(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 2048
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.GpArray.initFromCatalog')
-    @patch('gppylib.operations.dump.GpArray.getDbList')
-    @patch('gppylib.operations.restore.generate_segment_config_filename')
-    def test_restore_config_files_with_nbu_09(self, mock1, mock2, mock3, mock4, mock5, mock6):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        master_port = "5432"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 4096
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.isSegmentPrimary.return_value = True
-            seg.getSegmentDbId.return_value = id + 1
-            seg.getSegmentDataDirectory.return_value = "/data"
-            seg.getSegmentHostName.return_value = "sdw"
-
-        restore_config_files_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, master_port, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_partition_list_file_with_nbu_00(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_partition_list_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_partition_list_file_with_nbu_01(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_partition_list_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_partition_list_file_with_nbu_02(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_partition_list_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_partition_list_file_with_nbu_03(self, mock1):
-        master_datadir = None
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            restore_partition_list_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_partition_list_file_with_nbu_04(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = None
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Restore timestamp is None.'):
-            restore_partition_list_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_partition_list_file_with_nbu_05(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = None
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Netbackup service hostname is None.'):
-            restore_partition_list_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_partition_list_file_with_nbu_06(self, mock1):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-
-        restore_partition_list_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_partition_list_file_with_nbu_07(self, mock1):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 2048
-
-        restore_partition_list_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    def test_restore_partition_list_file_with_nbu_08(self, mock1):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141400002014"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 4096
-
-        restore_partition_list_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value='20140707000000')
-    def test_restore_increments_file_with_nbu_00(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20140808000000"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value='20140707000000')
-    def test_restore_increments_file_with_nbu_01(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20140808000000"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value='20140707000000')
-    def test_restore_increments_file_with_nbu_02(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20140808000000"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value='20140707000000')
-    def test_restore_increments_file_with_nbu_03(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = None
-        restore_timestamp = "20140808000000"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value='20140707000000')
-    def test_restore_increments_file_with_nbu_04(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = None
-        netbackup_service_host = "mdw"
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Restore timestamp is None.'):
-            restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value='20140707000000')
-    def test_restore_increments_file_with_nbu_05(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20140808000000"
-        netbackup_service_host = None
-        netbackup_block_size = None
-
-        with self.assertRaisesRegexp(Exception, 'Netbackup service hostname is None.'):
-            restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value='20140707000000')
-    def test_restore_increments_file_with_nbu_06(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20140808000000"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 1024
-
-        restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value='20140707000000')
-    def test_restore_increments_file_with_nbu_07(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20140808000000"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 2048
-
-        restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value='20140707000000')
-    def test_restore_increments_file_with_nbu_08(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20140808000000"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 4096
-
-        restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.restore_file_with_nbu')
-    @patch('gppylib.operations.restore.get_full_timestamp_for_incremental_with_nbu', return_value=None)
-    def test_restore_increments_file_with_nbu_09(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20140808000000"
-        netbackup_service_host = "mdw"
-        netbackup_block_size = 4096
-
-        with self.assertRaisesRegexp(Exception, 'Unable to locate full timestamp for given incremental timestamp "20140808000000" using NetBackup'):
-            restore_increments_file_with_nbu(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host, netbackup_block_size)
-
-    @patch('gppylib.operations.restore.get_backup_directory', return_value="/data")
-    @patch('gppylib.operations.restore.generate_master_config_filename', return_value="gp_master_config_20141200002014.tar")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=True)
-    def test_config_files_dumped_00(self, mock1, mock2, mock3):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertTrue(config_files_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.get_backup_directory', return_value="/data")
-    @patch('gppylib.operations.restore.generate_master_config_filename', return_value="gp_master_config_20141200002014.tar")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=True)
-    def test_config_files_dumped_01(self, mock1, mock2, mock3):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertTrue(config_files_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.get_backup_directory', return_value="/datadomain")
-    @patch('gppylib.operations.restore.generate_master_config_filename', return_value="gp_master_config_20141200002014.tar")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=True)
-    def test_config_files_dumped_02(self, mock1, mock2, mock3):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertTrue(config_files_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu')
-    def test_config_files_dumped_03(self, mock1, mock2, mock3):
-        master_datadir = None
-        backup_dir = None
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            config_files_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu')
-    def test_config_files_dumped_04(self, mock1, mock2, mock3):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = None
-        netbackup_service_host = "mdw"
-
-        with self.assertRaisesRegexp(Exception, 'Restore timestamp is None.'):
-            config_files_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host)
-
-    @patch('gppylib.operations.restore.get_backup_directory')
-    @patch('gppylib.operations.restore.generate_master_config_filename')
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu')
-    def test_config_files_dumped_05(self, mock1, mock2, mock3):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = None
-
-        with self.assertRaisesRegexp(Exception, 'Netbackup service hostname is None.'):
-            config_files_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host)
-
-    @patch('gppylib.operations.restore.get_backup_directory', return_value="/datadomain")
-    @patch('gppylib.operations.restore.generate_master_config_filename', return_value="gp_master_config_20141200002014.tar")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=False)
-    def test_config_files_dumped_06(self, mock1, mock2, mock3):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertFalse(config_files_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.get_backup_directory', return_value="/datadomain")
-    @patch('gppylib.operations.restore.generate_master_config_filename', return_value="gp_master_config_20141200002014.tar")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=False)
-    def test_config_files_dumped_07(self, mock1, mock2, mock3):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertFalse(config_files_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.get_backup_directory', return_value="/data")
-    @patch('gppylib.operations.restore.generate_master_config_filename', return_value="gp_master_config_20141200002014.tar")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=False)
-    def test_config_files_dumped_08(self, mock1, mock2, mock3):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertFalse(config_files_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.generate_global_filename', return_value="/data/gp_global_1_1_20141200002014")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=True)
-    def test_global_file_dumped_00(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertTrue(global_file_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.generate_global_filename', return_value="/data/gp_global_1_1_20141200002014")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=True)
-    def test_global_file_dumped_01(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertTrue(global_file_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.generate_global_filename', return_value="/datadomain/gp_global_1_1_20141200002014")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=True)
-    def test_global_file_dumped_02(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertTrue(global_file_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.generate_global_filename')
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu')
-    def test_global_file_dumped_03(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = None
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        with self.assertRaisesRegexp(Exception, 'Master data directory and backup directory are both none.'):
-            global_file_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host)
-
-    @patch('gppylib.operations.restore.generate_global_filename')
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu')
-    def test_global_file_dumped_04(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = None
-        netbackup_service_host = "mdw"
-
-        with self.assertRaisesRegexp(Exception, 'Restore timestamp is None.'):
-            global_file_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host)
-
-    @patch('gppylib.operations.restore.generate_global_filename')
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu')
-    def test_global_file_dumped_05(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = None
-
-        with self.assertRaisesRegexp(Exception, 'Netbackup service hostname is None.'):
-            global_file_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host)
-
-    @patch('gppylib.operations.restore.generate_global_filename', return_value="/datadomain/gp_global_1_1_20141200002014")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=False)
-    def test_global_file_dumped_06(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = None
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertFalse(global_file_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.generate_global_filename', return_value="/datadomain/gp_global_1_1_20141200002014")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=False)
-    def test_global_file_dumped_07(self, mock1, mock2):
-        master_datadir = None
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertFalse(global_file_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
-
-    @patch('gppylib.operations.restore.generate_global_filename', return_value="/data/gp_global_1_1_20141200002014")
-    @patch('gppylib.operations.restore.check_file_dumped_with_nbu', return_value=False)
-    def test_global_file_dumped_08(self, mock1, mock2):
-        master_datadir = "/data"
-        backup_dir = "/datadomain"
-        restore_timestamp = "20141200002014"
-        netbackup_service_host = "mdw"
-
-        self.assertFalse(global_file_dumped(master_datadir, backup_dir, self.validate_timestamp.dump_dir, self.validate_timestamp.dump_prefix, restore_timestamp, netbackup_service_host))
+            self.validate_timestamp.validate_metadata_file(compressed_file)
+
+    @patch('gppylib.operations.restore.restore_file_with_nbu')
+    def test_restore_state_files_with_nbu_default(self, mock1):
+        self.context.netbackup_service_host = "mdw"
+
+        restore_state_files_with_nbu(self.context)
+        self.assertEqual(mock1.call_count, 3)
+        calls = ["ao", "co", "last_operation"]
+        for i in range(len(mock1.call_args_list)):
+            self.assertEqual(mock1.call_args_list[i], call(self.context, calls[i]))
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_restore_file_with_nbu_default(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        cmdStr = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-filename /tmp/foo_schema > /tmp/foo_schema"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            restore_file_with_nbu(self.context, "schema")
+            cmd.assert_called_with("restoring metadata files to master", cmdStr)
+            self.assertEqual(mock2.call_count, 1)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='')
+    @patch('gppylib.commands.base.Command.run')
+    def test_restore_file_with_nbu_no_filetype(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_block_size = 100
+        cmdStr = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-block-size 100 --netbackup-filename /tmp/foo_schema > /tmp/foo_schema"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            restore_file_with_nbu(self.context, path="/tmp/foo_schema")
+            cmd.assert_called_with("restoring metadata files to master", cmdStr)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_restore_file_with_nbu_no_path(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_block_size = 100
+        cmdStr = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-block-size 100 --netbackup-filename /tmp/foo_schema > /tmp/foo_schema"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            restore_file_with_nbu(self.context, "schema")
+            cmd.assert_called_with("restoring metadata files to master", cmdStr)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_restore_file_with_nbu_both_args(self, mock1, mock2):
+        with self.assertRaisesRegexp(Exception, 'Cannot supply both a file type and a file path to restore_file_with_nbu'):
+            restore_file_with_nbu(self.context, "schema", "/tmp/foo_schema")
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_restore_file_with_nbu_neither_arg(self, mock1, mock2):
+        with self.assertRaisesRegexp(Exception, 'Cannot call restore_file_with_nbu with no type or path argument'):
+            restore_file_with_nbu(self.context)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_restore_file_with_nbu_block_size(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_block_size = 1024
+        cmdStr = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-block-size 1024 --netbackup-filename /tmp/foo_schema > /tmp/foo_schema"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            restore_file_with_nbu(self.context, "schema")
+            cmd.assert_called_with("restoring metadata files to master", cmdStr)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_restore_file_with_nbu_keyword(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        self.context.netbackup_keyword = "foo"
+        cmdStr = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-filename /tmp/foo_schema > /tmp/foo_schema"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            restore_file_with_nbu(self.context, "schema")
+            cmd.assert_called_with("restoring metadata files to master", cmdStr)
+
+    @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='/tmp/foo_schema')
+    @patch('gppylib.commands.base.Command.run')
+    def test_restore_file_with_nbu_segment(self, mock1, mock2):
+        self.context.netbackup_service_host = "mdw"
+        cmdStr = "gp_bsa_restore_agent --netbackup-service-host mdw --netbackup-filename /tmp/foo_schema > /tmp/foo_schema"
+        with patch.object(Command, '__init__', return_value=None) as cmd:
+            restore_file_with_nbu(self.context, "schema", hostname="sdw")
+            from gppylib.commands.base import REMOTE
+            cmd.assert_called_with("restoring metadata files to segment", cmdStr, ctxt=REMOTE, remoteHost="sdw")
+
+    class MyMock(MagicMock):
+        def __init__(self, num_segs):
+            super(MagicMock, self).__init__()
+            self.mock_segs = []
+            for i in range(num_segs):
+                self.mock_segs.append(Mock())
+
+        def getSegmentList(self):
+            for id, seg in enumerate(self.mock_segs):
+                seg.get_active_primary.getSegmentHostName.return_value = Mock()
+                seg.get_primary_dbid.return_value = id + 2
+            return self.mock_segs
+
+    @patch('gppylib.operations.dump.GpArray.initFromCatalog', return_value=MyMock(1))
+    @patch('gppylib.gparray.GpDB.getSegmentHostName', return_value='sdw')
+    def test_restore_config_files_with_nbu_single_segment(self, mock1, mock2):
+        with patch('gppylib.operations.restore.restore_file_with_nbu', side_effect=my_counter) as nbu_mock:
+            global i
+            i = 0
+            self.context.netbackup_service_host = "mdw"
+            self.context.netbackup_policy = "test_policy"
+            self.context.netbackup_schedule = "test_schedule"
+
+            restore_config_files_with_nbu(self.context)
+            args, _ = nbu_mock.call_args_list[0]
+            self.assertEqual(args[1], "master_config")
+            for id, seg in enumerate(mock2.mock_segs):
+                self.assertEqual(seg.get_active_primary.call_count, 1)
+                self.assertEqual(seg.get_primary_dbid.call_count, 1)
+                args, _ = nbu_mock.call_args_list[id]
+                self.assertEqual(args, ("segment_config", id+2, "sdw"))
+            self.assertEqual(i, 2)
+
+    @patch('gppylib.operations.dump.GpArray.initFromCatalog', return_value=MyMock(3))
+    @patch('gppylib.gparray.GpDB.getSegmentHostName', return_value='sdw')
+    def test_restore_config_files_with_nbu_multiple_segments(self, mock1, mock2):
+        with patch('gppylib.operations.restore.restore_file_with_nbu', side_effect=my_counter) as nbu_mock:
+            global i
+            i = 0
+            self.context.netbackup_service_host = "mdw"
+            self.context.netbackup_policy = "test_policy"
+            self.context.netbackup_schedule = "test_schedule"
+
+            restore_config_files_with_nbu(self.context)
+            args, _ = nbu_mock.call_args_list[0]
+            self.assertEqual(args[1], "master_config")
+            for id, seg in enumerate(mock2.mock_segs):
+                self.assertEqual(seg.get_active_primary.call_count, 1)
+                self.assertEqual(seg.get_primary_dbid.call_count, 1)
+                args, _ = nbu_mock.call_args_list[id]
+            self.assertEqual(i, 4)
 
 if __name__ == '__main__':
     unittest.main()
+
+i=0
+def my_counter(*args, **kwargs):
+    global i
+    i += 1
+    return Mock()
+

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_table.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_table.sql
@@ -10,7 +10,7 @@ Create table " co_T`~@#$%^&*()-+[{]}|\;: \'""/?><1 " (Column1 int, Column2 varch
     (Partition p1 values('backup') , Partition p2 values('restore')) ;
 
 Create table " ao_T`~@#$%^&*()-+[{]}|\;: \'""/?><1 " (Column1 int, Column2 varchar(20), Column3 date) 
-    WITH(appendonly = true, orientation = row, compresstype = quicklz)  
+    WITH(appendonly = true, orientation = row)  
     Distributed Randomly Partition by list(Column2) 
     Subpartition by range(Column3) Subpartition Template
         (start (date '2014-01-01') end (date '2016-01-01') every (interval '1 year'))

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -13,6 +13,7 @@ import yaml
 
 from gppylib.commands.gp import SegmentStart, GpStandbyStart
 from gppylib.commands.unix import findCmdInPath
+from gppylib.operations.backup_utils import Context
 from gppylib.operations.dump import get_partition_state
 from gppylib.operations.startSegments import MIRROR_MODE_MIRRORLESS
 from gppylib.operations.unix import ListRemoteFilesByPattern, CheckRemoteFile
@@ -1498,10 +1499,12 @@ def impl(context, table, dbname, ao_table):
     ao_sch, ao_tbl = ao_table.split('.') 
     part_info = [(1, ao_sch, ao_tbl, tbl)]
     try:
+        backup_utils = Context()
+        backup_utils.master_port = os.environ.get('PGPORT')
+        backup_utils.dump_database = dbname
         context.exception = None
         context.partition_list_res = None
-        context.partition_list_res = get_partition_state(master_port=os.environ.get('PGPORT'),
-                        dbname=dbname, catalog_schema=sch, partition_info=part_info)
+        context.partition_list_res = get_partition_state(backup_utils, sch, part_info)
     except Exception as e:
         context.exception = e
 

--- a/gpMgmt/bin/gppylib/test/behave_utils/utils.py
+++ b/gpMgmt/bin/gppylib/test/behave_utils/utils.py
@@ -346,7 +346,7 @@ def check_table_exists(context, dbname, table_name, table_type=None, host=None, 
         SQL = """
               select c.oid, c.relkind, c.relstorage, c.reloptions
               from pg_class c, pg_namespace n
-              where c.relname = E'%s' and n.nspname = E'%s' and c.relnamespace = n.oid;
+              where c.relname = '%s' and n.nspname = '%s' and c.relnamespace = n.oid;
               """ % (pg.escape_string(tablename), pg.escape_string(schemaname))
     else:
         SQL = """

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
@@ -9,16 +9,15 @@ from datetime import datetime
 from gppylib import gplog
 from gpcrondump import GpCronDump
 from gppylib.operations.utils import DEFAULT_NUM_WORKERS
-from mock import patch, Mock
-from gppylib.operations.dump import MailDumpEvent
+from mock import patch, Mock, MagicMock, mock_open
 from gppylib.commands.base import CommandResult
-from gppylib.operations.backup_utils import get_backup_directory, write_lines_to_file
-import mock
+from gppylib.operations.dump import MailDumpEvent
+from gppylib.operations.backup_utils import write_lines_to_file
 
 
 logger = gplog.get_unittest_logger()
 
-class GpCronDumpTestCase(unittest.TestCase):
+class GpcrondumpTestCase(unittest.TestCase):
 
     class Options:
         def __init__(self):
@@ -84,1126 +83,907 @@ class GpCronDumpTestCase(unittest.TestCase):
             self.netbackup_block_size = None
             self.netbackup_keyword = None
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
+    def setUp(self):
+        self.options = self.Options()
+        self.crondump = GpCronDump(self.options, None)
+        self.context = self.crondump.context
+
     @patch('gpcrondump.GpCronDump.validate_dump_schema')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_option_schema_filter_1(self, mock, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.include_schema_file = '/tmp/foo'
-        options.incremental = True
+    def test_schema_filter_1(self, mock, mock2):
+        self.options.include_schema_file = '/tmp/foo'
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--schema-file option can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.GpCronDump.validate_dump_schema')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_option_schema_filter_2(self, mock, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_schema_file = '/tmp/foo'
-        options.incremental = True
+    def test_schema_filter_2(self, mock, mock2):
+        self.options.exclude_schema_file = '/tmp/foo'
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--exclude-schema-file option can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_3(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_schema = 'foo'
-        options.incremental = True
+    def test_schema_filter_3(self, mock):
+        self.options.exclude_dump_schema = 'foo'
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '-S option can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_4(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = 'foo'
-        options.incremental = True
+    def test_schema_filter_4(self, mock):
+        self.options.dump_schema = 'foo'
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '-s option can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_5(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = 'foo'
-        options.exclude_schema_file = '/tmp/foo'
+    def test_schema_filter_5(self, mock):
+        self.options.dump_schema = 'foo'
+        self.options.exclude_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-s can not be selected with --exclude-schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_6(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = 'foo'
-        options.include_schema_file = '/tmp/foo'
+    def test_schema_filter_6(self, mock):
+        self.options.dump_schema = 'foo'
+        self.options.include_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-s can not be selected with --schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_7(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = 'foo'
-        options.exclude_dump_schema = 'foo'
+    def test_schema_filter_7(self, mock):
+        self.options.dump_schema = 'foo'
+        self.options.exclude_dump_schema = 'foo'
         with self.assertRaisesRegexp(Exception, '-s can not be selected with -S option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_8(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_schema = 'foo'
-        options.exclude_schema_file = '/tmp/foo'
+    def test_schema_filter_8(self, mock):
+        self.options.exclude_dump_schema = 'foo'
+        self.options.exclude_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-S can not be selected with --exclude-schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_9(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_schema = 'foo'
-        options.include_schema_file = '/tmp/foo'
+    def test_schema_filter_9(self, mock):
+        self.options.exclude_dump_schema = 'foo'
+        self.options.include_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-S can not be selected with --schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_10(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_schema_file = 'foo'
-        options.include_schema_file = '/tmp/foo'
+    def test_schema_filter_10(self, mock):
+        self.options.exclude_schema_file = 'foo'
+        self.options.include_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--exclude-schema-file can not be selected with --schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_11(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_schema_file = 'foo'
-        options.include_dump_tables_file = '/tmp/foo'
+    def test_schema_filter_11(self, mock):
+        self.options.exclude_schema_file = 'foo'
+        self.options.include_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with --exclude-schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_12(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_schema_file = 'foo'
-        options.exclude_dump_tables_file = '/tmp/foo'
+    def test_schema_filter_12(self, mock):
+        self.options.exclude_schema_file = 'foo'
+        self.options.exclude_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with --exclude-schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_13(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_schema_file = 'foo'
-        options.exclude_dump_tables_file = '/tmp/foo'
+    def test_schema_filter_13(self, mock):
+        self.options.include_schema_file = 'foo'
+        self.options.exclude_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with --schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_14(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_schema_file = 'foo'
-        options.include_dump_tables_file = '/tmp/foo'
+    def test_schema_filter_14(self, mock):
+        self.options.include_schema_file = 'foo'
+        self.options.include_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with --schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_15(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = 'foo'
-        options.include_dump_tables_file = '/tmp/foo'
+    def test_schema_filter_15(self, mock):
+        self.options.dump_schema = 'foo'
+        self.options.include_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with -s option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_16(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = 'foo'
-        options.exclude_dump_tables_file = '/tmp/foo'
+    def test_schema_filter_16(self, mock):
+        self.options.dump_schema = 'foo'
+        self.options.exclude_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with -s option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_17(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_schema = 'foo'
-        options.include_dump_tables_file = '/tmp/foo'
+    def test_schema_filter_17(self, mock):
+        self.options.exclude_dump_schema = 'foo'
+        self.options.include_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with -S option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_18(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_schema = 'foo'
-        options.exclude_dump_tables_file = '/tmp/foo'
+    def test_schema_filter_18(self, mock):
+        self.options.exclude_dump_schema = 'foo'
+        self.options.exclude_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with -S option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_19(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_schema_file = 'foo'
-        options.exclude_dump_tables = '/tmp/foo'
+    def test_schema_filter_19(self, mock):
+        self.options.exclude_schema_file = 'foo'
+        self.options.exclude_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with --exclude-schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_20(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_schema_file = 'foo'
-        options.include_dump_tables = '/tmp/foo'
+    def test_schema_filter_20(self, mock):
+        self.options.exclude_schema_file = 'foo'
+        self.options.include_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with --exclude-schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_21(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_schema_file = 'foo'
-        options.exclude_dump_tables = '/tmp/foo'
+    def test_schema_filter_21(self, mock):
+        self.options.include_schema_file = 'foo'
+        self.options.exclude_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with --schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_22(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_schema_file = 'foo'
-        options.include_dump_tables = '/tmp/foo'
+    def test_schema_filter_22(self, mock):
+        self.options.include_schema_file = 'foo'
+        self.options.include_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with --schema-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_23(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = 'foo'
-        options.exclude_dump_tables = '/tmp/foo'
+    def test_schema_filter_23(self, mock):
+        self.options.dump_schema = 'foo'
+        self.options.exclude_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with -s option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_24(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = 'foo'
-        options.include_dump_tables = '/tmp/foo'
+    def test_schema_filter_24(self, mock):
+        self.options.dump_schema = 'foo'
+        self.options.include_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with -s option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_25(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_schema = 'foo'
-        options.exclude_dump_tables = '/tmp/foo'
+    def test_schema_filter_25(self, mock):
+        self.options.exclude_dump_schema = 'foo'
+        self.options.exclude_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with -S option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_26(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_schema = 'foo'
-        options.include_dump_tables = '/tmp/foo'
+    def test_schema_filter_26(self, mock):
+        self.options.exclude_dump_schema = 'foo'
+        self.options.include_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with -S option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_27(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = ['information_schema']
+    def test_schema_filter_27(self, mock):
+        self.options.dump_schema = ['information_schema']
         with self.assertRaisesRegexp(Exception, "can not specify catalog schema 'information_schema' using -s option"):
-            GpCronDump(options, None)
+            GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_28(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_schema = ['information_schema']
+    def test_schema_filter_28(self, mock):
+        self.options.exclude_dump_schema = ['information_schema']
         with self.assertRaisesRegexp(Exception, "can not specify catalog schema 'information_schema' using -S option"):
-            GpCronDump(options, None)
+            GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_lines_from_file', return_value=['public', 'information_schema'])
-    def test_options_schema_filter_29(self, mock, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_schema_file = '/tmp/foo'
+    def test_schema_filter_29(self, mock, mock2):
+        self.options.exclude_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, "can not exclude catalog schema 'information_schema' in schema file '/tmp/foo'"):
-            GpCronDump(options, None)
+            GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_lines_from_file', return_value=['public', 'information_schema'])
-    def test_options_schema_filter_30(self, mock, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.include_schema_file = '/tmp/foo'
+    def test_schema_filter_30(self, mock, mock2):
+        self.options.include_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, "can not include catalog schema 'information_schema' in schema file '/tmp/foo'"):
-            GpCronDump(options, None)
+            GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_31(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.masterDataDirectory = '/tmp/foobar'
-        gpcd = GpCronDump(options, None)
-        dbname = 'foo'
-        timestamp = '20141016010101'
-        file = gpcd.get_schema_list_file(dbname)
-        self.assertEquals(file, None)
+    def test_schema_filter_31(self, mock, mock2):
+        self.options.masterDataDirectory = '/tmp/foobar'
+        gpcd = GpCronDump(self.options, None)
+        with patch('__builtin__.open', mock_open(), create=True):
+            gpcd.generate_schema_list_file()
+            self.assertEquals(gpcd.context.schema_file, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_32(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = ['public']
-        gpcd = GpCronDump(options, None)
-        dbname = 'foo'
-        timestamp = '20141016010101'
-        file = gpcd.get_schema_list_file(dbname)
-        self.assertTrue(file.startswith('/tmp/schema_list'))
+    def test_schema_filter_32(self, mock1):
+        self.options.dump_schema = ['public']
+        gpcd = GpCronDump(self.options, None)
+        with patch('__builtin__.open', mock_open(), create=True):
+            gpcd.generate_schema_list_file()
+            self.assertTrue(gpcd.context.schema_file.startswith('/tmp/schema_list'))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_schema_filter_33(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_schema_file = '/tmp/foo'
-        write_lines_to_file('/tmp/foo', ['public'])
-        gpcd = GpCronDump(options, None)
-        dbname = 'foo'
-        timestamp = '20141016010101'
-        file = gpcd.get_schema_list_file(dbname)
-        self.assertTrue(file.startswith('/tmp/schema_list'))
-        if os.path.exists('/tmp/foo'):
-            os.remove('/tmp/foo')
+    @patch('gpcrondump.get_lines_from_file', return_value=['public'])
+    def test_schema_filter_33(self, mock1, mock2):
+        self.options.include_schema_file = '/tmp/foo'
+        gpcd = GpCronDump(self.options, None)
+        with patch('__builtin__.open', mock_open(), create=True):
+            gpcd.generate_schema_list_file()
+            self.assertTrue(gpcd.context.schema_file.startswith('/tmp/schema_list'))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_include_schema_list_from_exclude_schema', return_value=['public'])
-    def test_options_schema_filter_34(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_schema_file = '/tmp/foo'
+    def test_schema_filter_34(self, mock1, mock2):
+        self.options.exclude_schema_file = '/tmp/foo'
         write_lines_to_file('/tmp/foo', ['public'])
-        gpcd = GpCronDump(options, None)
-        dbname = 'foo'
-        timestamp = '20141016010101'
-        file = gpcd.get_schema_list_file(dbname)
-        self.assertTrue(file.startswith('/tmp/schema_list'))
-        if os.path.exists('/tmp/foo'):
-            os.remove('/tmp/foo')
+        gpcd = GpCronDump(self.options, None)
+        with patch('__builtin__.open', mock_open(), create=True):
+            gpcd.generate_schema_list_file()
+            self.assertTrue(gpcd.context.schema_file.startswith('/tmp/schema_list'))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_include_schema_list_from_exclude_schema', return_value=['public'])
-    def test_options_schema_filter_35(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_schema = 'public'
-        gpcd = GpCronDump(options, None)
-        dbname = 'foo'
-        timestamp = '20141016010101'
-        file = gpcd.get_schema_list_file(dbname)
-        self.assertTrue(file.startswith('/tmp/schema_list'))
+    def test_schema_filter_35(self, mock1, mock2):
+        self.options.exclude_dump_schema = 'public'
+        gpcd = GpCronDump(self.options, None)
+        with patch('__builtin__.open', mock_open(), create=True):
+            gpcd.generate_schema_list_file()
+            self.assertTrue(gpcd.context.schema_file.startswith('/tmp/schema_list'))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_lines_from_file', return_value=['public'])
     @patch('gpcrondump.get_user_table_list_for_schema', return_value=['public', 'table1', 'public', 'table2'])
-    def test_options_schema_filter_36(self, mock1, mock2, mock3, mock4):
-        options = GpCronDumpTestCase.Options()
-        gpcd = GpCronDump(options, None)
-        dbname = 'foo'
-        schema_file = '/tmp/foo'
-        inc = gpcd.generate_include_table_list_from_schema_file(dbname, schema_file)
-        self.assertTrue(inc.startswith('/tmp/include_dump_tables_file'))
+    def test_schema_filter_36(self, mock1, mock2, mock3):
+        gpcd = GpCronDump(self.options, None)
+        with patch('__builtin__.open', mock_open(), create=True):
+            gpcd.generate_schema_list_file()
+            inc = gpcd.generate_include_table_list_from_schema_file()
+            self.assertTrue(inc.startswith('/tmp/include_dump_tables_file'))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options1(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_dump_tables = 'foo'
-        options.incremental = True
+    def test_options1(self, mock):
+        self.options.include_dump_tables = 'foo'
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'include table list can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options2(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_tables = 'foo'
-        options.incremental = True
+    def test_options2(self, mock):
+        self.options.exclude_dump_tables = 'foo'
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'exclude table list can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options3(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_dump_tables_file = 'foo'
-        options.incremental = True
+    def test_options3(self, mock):
+        self.options.include_dump_tables_file = 'foo'
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'include table file can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options4(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_tables_file = 'foo'
-        options.incremental = True
+    def test_options4(self, mock):
+        self.options.exclude_dump_tables_file = 'foo'
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'exclude table file can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options10(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.local_dump_prefix = 'foo'
-        options.incremental = False
-        options.list_filter_tables = True
+    def test_options10(self, mock):
+        self.options.local_dump_prefix = 'foo'
+        self.options.incremental = False
+        self.options.list_filter_tables = True
         try:
             with self.assertRaisesRegexp(Exception, 'list filter tables option requires --prefix and --incremental'):
-                cron = GpCronDump(options, None)
+                cron = GpCronDump(self.options, None)
         finally:
-            options.list_filter_tables = False
+            self.options.list_filter_tables = False
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20121225090000')
-    def test_options11(self, mock, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.incremental = True
-        cron = GpCronDump(options, None)
-        self.assertEquals(cron.full_dump_timestamp, '20121225090000')
+    def test_options11(self, mock, mock2):
+        self.options.incremental = True
+        cron = GpCronDump(self.options, None)
+        self.assertEquals(cron.context.full_dump_timestamp, '20121225090000')
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options12(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.incremental = True
-        options.dump_databases = 'bkdb,fulldb'
+    def test_options12(self, mock):
+        self.options.incremental = True
+        self.options.dump_databases = 'bkdb,fulldb'
         with self.assertRaisesRegexp(Exception, 'multi-database backup is not supported with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20120330090000')
     @patch('gpcrondump.validate_current_timestamp')
-    @patch('gpcrondump.GpCronDump._get_master_port')
-    def test_options13(self, mock, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.incremental = True
-        options.dump_databases = ['bkdb']
+    def test_options13(self, mock, mock2):
+        self.options.incremental = True
+        self.options.dump_databases = ['bkdb']
 
         #If this is successful then it should not raise an exception
-        GpCronDump(options, None)
+        GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options14(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_databases = 'bkdb'
-        options.incremental = False
+    def test_options14(self, mock):
+        self.options.dump_databases = 'bkdb'
+        self.options.incremental = False
 
         #If this is successful then it should not raise an exception
-        GpCronDump(options, None)
+        GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options15(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_databases = 'bkdb,fulldb'
-        options.incremental = False
+    def test_options15(self, mock):
+        self.options.dump_databases = 'bkdb,fulldb'
+        self.options.incremental = False
 
         #If this is successful then it should not raise an exception
-        GpCronDump(options, None)
+        GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options16(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.masterDataDirectory = '/tmp/foobar'
-        options.backup_dir = '/foo1'
-        gpcd = GpCronDump(options, None)
-        self.assertEquals(gpcd.getBackupDirectoryRoot(), '/foo1')
-
-    @patch('gpcrondump.GpCronDump._get_master_port')
-    @patch('gpcrondump.validate_current_timestamp')
-    def test_options17(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.masterDataDirectory = '/tmp/foobar'
-        options.backup_dir = None
-        gpcd = GpCronDump(options, None)
-        self.assertEquals(gpcd.getBackupDirectoryRoot(), '/tmp/foobar')
-
-    @patch('gpcrondump.GpCronDump._get_master_port')
-    @patch('gpcrondump.validate_current_timestamp')
-    def test_options18(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_schema = 'foo'
-        options.incremental = True
+    def test_options16(self, mock):
+        self.options.dump_schema = 'foo'
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '-s option can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options19(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.clear_dumps = True
-        options.incremental = True
+    def test_options17(self, mock):
+        self.options.clear_dumps = True
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '-c option can not be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options20(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_databases = []
-        options.incremental = True
+    def test_options18(self, mock):
+        self.options.dump_databases = []
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'Must supply -x <database name> with incremental option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options21(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.ddboost = True
-        options.replicate = False
-        options.max_streams = 20
+    def test_options19(self, mock):
+        self.options.ddboost = True
+        self.options.replicate = False
+        self.options.max_streams = 20
         with self.assertRaisesRegexp(Exception, '--max-streams must be specified along with --replicate'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options22(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.ddboost = True
-        options.replicate = True
-        options.max_streams = None
+    def test_options20(self, mock):
+        self.options.ddboost = True
+        self.options.replicate = True
+        self.options.max_streams = None
         with self.assertRaisesRegexp(Exception, '--max-streams must be specified along with --replicate'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options23(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.ddboost = True
-        options.replicate = True
-        options.max_streams = 0
+    def test_options21(self, mock):
+        self.options.ddboost = True
+        self.options.replicate = True
+        self.options.max_streams = 0
         with self.assertRaisesRegexp(Exception, '--max-streams must be a number greater than zero'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options24(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.ddboost = True
-        options.replicate = True
-        options.max_streams = "abc"
+    def test_options22(self, mock):
+        self.options.ddboost = True
+        self.options.replicate = True
+        self.options.max_streams = "abc"
         with self.assertRaisesRegexp(Exception, '--max-streams must be a number greater than zero'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options25(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.ddboost = False
-        options.replicate = False
-        options.max_streams = 20
+    def test_options23(self, mock):
+        self.options.ddboost = False
+        self.options.replicate = False
+        self.options.max_streams = 20
         with self.assertRaisesRegexp(Exception, '--replicate and --max-streams cannot be used without --ddboost'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options26(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.list_backup_files = True
-        options.timestamp_key = None
+    def test_options24(self, mock1):
+        self.options.list_backup_files = True
+        self.options.timestamp_key = None
         with self.assertRaisesRegexp(Exception, 'Must supply -K option when listing backup files'):
-            GpCronDump(options, None)
+            GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options27(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_databases = 'bkdb,fulldb'
-        options.timestamp_key = True
+    def test_options25(self, mock):
+        self.options.dump_databases = 'bkdb,fulldb'
+        self.options.timestamp_key = '20160101010101'
         with self.assertRaisesRegexp(Exception, 'multi-database backup is not supported with -K option'):
-            GpCronDump(options, None)
+            GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options28(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_databases = ['bkdb']
-        options.timestamp_key = True
-        options.ddboost = True
-        options.list_backup_files = True
+    def test_options27(self, mock):
+        self.options.ddboost = True
+        self.options.list_backup_files = True
+        self.options.timestamp_key = '20160101010101'
         with self.assertRaisesRegexp(Exception, 'list backup files not supported with ddboost option'):
-            GpCronDump(options, None)
+            GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options29(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.dump_databases = ['bkdb']
-        options.timestamp_key = True
-        options.ddboost = True
-        options.netbackup_service_host = "mdw"
-        options.netbackup_policy = "test_policy"
-        options.netbackup_schedule = "test_schedule"
+    def test_options28(self, mock):
+        self.options.ddboost = True
+        self.options.netbackup_service_host = "mdw"
+        self.options.netbackup_policy = "test_policy"
+        self.options.netbackup_schedule = "test_schedule"
         with self.assertRaisesRegexp(Exception, '--ddboost is not supported with NetBackup'):
-            GpCronDump(options, None)
+            GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
-    def test_options_ddboost_storage_unit_should_be_used_with_ddboost(self, mock):
+    def test_options_ddboost_storage_unit_should_be_used_with_ddboost(self):
         """
         --ddboost-storage-unit option must come with --ddboost option
         """
-        options = GpCronDumpTestCase.Options()
-        options.dump_databases = ['bkdb']
-        options.ddboost_storage_unit = "GPDB"
+        self.options.ddboost_storage_unit = "GPDB"
         with self.assertRaisesRegexp(Exception, 'Must specify --ddboost option together with the --ddboost-storage-unit'):
-            GpCronDump(options, None)
+            GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_include_exclude_for_dump_database00(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.masterDataDirectory = '/tmp/foobar'
-        gpcd = GpCronDump(options, None)
+        self.options.masterDataDirectory = '/tmp/foobar'
+        gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
         (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
         self.assertEquals(inc, None)
         self.assertEquals(exc, None)
  
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.expand_partitions_and_populate_filter_file', return_value='/tmp/include_dump_tables_file')
     @patch('gpcrondump.get_lines_from_file', return_value=['public.t1', 'public.t2'])
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_include_exclude_for_dump_database01(self, mock1, mock2, mock3, mock4):
-        options = GpCronDumpTestCase.Options()
-        options.masterDataDirectory = '/tmp/foobar'
-        options.include_dump_tables_file = '/mydir/incfile'
-        gpcd = GpCronDump(options, None)
+        self.options.masterDataDirectory = '/tmp/foobar'
+        self.options.include_dump_tables_file = '/mydir/incfile'
+        gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
         (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
         self.assertTrue(inc.startswith('/tmp/include_dump_tables_file'))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.expand_partitions_and_populate_filter_file', return_value='/tmp/include_dump_tables_file')
     @patch('gpcrondump.get_lines_from_file')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_include_exclude_for_dump_database02(self, mock1, mock2, mock3, mock4):
-        options = GpCronDumpTestCase.Options()
-        options.masterDataDirectory = '/tmp/foobar'
-        options.include_dump_tables = ['public.t1', 'public.t2', 'public.t3']
-        gpcd = GpCronDump(options, None)
+        self.options.masterDataDirectory = '/tmp/foobar'
+        self.options.include_dump_tables = ['public.t1', 'public.t2', 'public.t3']
+        gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
         (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
         self.assertTrue(inc.startswith('/tmp/include_dump_tables_file'))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20121225090000')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_include_exclude_for_dump_database03(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.masterDataDirectory = '/tmp/foobar'
-        options.incremental = True
-        gpcd = GpCronDump(options, None)
+        self.options.masterDataDirectory = '/tmp/foobar'
+        self.options.incremental = True
+        gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
         (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
         self.assertEquals(inc, '/tmp/dirty')
         self.assertEquals(exc, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.expand_partitions_and_populate_filter_file', return_value='/tmp/exclude_dump_tables_file')
     @patch('gpcrondump.get_lines_from_file', return_value=['public.t1', 'public.t2'])
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_include_exclude_for_dump_database04(self, mock1, mock2, mock3, mock4):
-        options = GpCronDumpTestCase.Options()
-        options.masterDataDirectory = '/tmp/foobar'
-        options.exclude_dump_tables_file = '/odir/exfile'
-        gpcd = GpCronDump(options, None)
+        self.options.masterDataDirectory = '/tmp/foobar'
+        self.options.exclude_dump_tables_file = '/odir/exfile'
+        gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
         (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
         self.assertTrue(exc.startswith('/tmp/exclude_dump_tables_file'))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.expand_partitions_and_populate_filter_file', return_value='/tmp/exclude_dump_tables_file')
     @patch('gpcrondump.get_lines_from_file')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_include_exclude_for_dump_database06(self, mock1, mock2, mock3, mock4):
-        options = GpCronDumpTestCase.Options()
-        options.masterDataDirectory = '/tmp/foobar'
-        options.exclude_dump_tables = ['public.t4', 'public.t5', 'public.t6']
-        gpcd = GpCronDump(options, None)
+        self.options.masterDataDirectory = '/tmp/foobar'
+        self.options.exclude_dump_tables = ['public.t4', 'public.t5', 'public.t6']
+        gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
         (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
         self.assertTrue(exc.startswith('/tmp/exclude_dump_tables_file'))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.GpCronDump._get_table_names_from_partition_list', side_effect = [['public.aot1', 'public.aot2'], ['public.cot1', 'public.cot2']])
-    def test_verify_tablenames_00(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        cron = GpCronDump(options, None)
+    def test_verify_tablenames_default(self, mock1, mock2):
+        cron = GpCronDump(self.options, None)
         ao_partition_list = ['public, aot1, 2190', 'public, aot2, 3190']
         co_partition_list = ['public, cot1, 2190', 'public, cot2, 3190']
         heap_partition_list = ['public.heapt1', 'public.heapt2']
         cron._verify_tablenames(ao_partition_list, co_partition_list, heap_partition_list) #Should not raise an exception
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.GpCronDump._get_table_names_from_partition_list', side_effect = [['public.aot1:asd', 'public.aot2'], ['public.cot1', 'public.cot2:asd']])
-    def test_verify_tablenames_00_bad(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        cron = GpCronDump(options, None)
+    def test_verify_tablenames_bad_chars(self, mock1, mock2):
+        cron = GpCronDump(self.options, None)
         ao_partition_list = ['public, aot1!asd, 2190', 'public, aot2, 3190']
         co_partition_list = ['public, cot1, 2190', 'public, cot2\nasd, 3190']
         heap_partition_list = ['public, heapt1, 2190', 'public, heapt2!asdasd , 3190']
         with self.assertRaisesRegexp(Exception, ''):
             cron._verify_tablenames(ao_partition_list, co_partition_list, heap_partition_list)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_inserts_with_incremental(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.output_options = ['--inserts']
-        options.incremental = True
+    def test_options_inserts_with_incremental(self, mock):
+        self.options.output_options = ['--inserts']
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--inserts, --column-inserts, --oids cannot be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_oids_with_incremental(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.output_options = ['--oids']
-        options.incremental = True
+    def test_options_oids_with_incremental(self, mock):
+        self.options.output_options = ['--oids']
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--inserts, --column-inserts, --oids cannot be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_column_inserts_with_incremental(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.output_options = ['--column-inserts']
-        options.incremental = True
+    def test_options_column_inserts_with_incremental(self, mock):
+        self.options.output_options = ['--column-inserts']
+        self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--inserts, --column-inserts, --oids cannot be selected with incremental backup'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_get_table_names_from_partition_list_00(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        cron = GpCronDump(options, None)
+    def test_get_table_names_from_partition_list_00(self, mock1):
+        cron = GpCronDump(self.options, None)
         partition_list = ['public, aot1, 2190', 'public, aot2:aot, 3190']
         expected_output = ['public.aot1', 'public.aot2:aot']
         result = cron._get_table_names_from_partition_list(partition_list)
         self.assertEqual(result, expected_output)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_get_table_names_from_partition_list_01(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        cron = GpCronDump(options, None)
+    def test_get_table_names_from_partition_list_01(self, mock1):
+        cron = GpCronDump(self.options, None)
         partition_list = ['public, aot1, 2190', 'public, aot2,aot, 3190']
         with self.assertRaisesRegexp(Exception, 'Invalid partition entry "public, aot2,aot, 3190"'):
             cron._get_table_names_from_partition_list(partition_list)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter1(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_dump_tables = 'foo'
-        options.include_dump_tables_file = 'foo'
+    def test_options_table_filter1(self, mock):
+        self.options.include_dump_tables = 'foo'
+        self.options.include_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '-t can not be selected with --table-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter2(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_dump_tables = 'foo'
-        options.exclude_dump_tables_file = 'foo'
+    def test_options_table_filter2(self, mock):
+        self.options.include_dump_tables = 'foo'
+        self.options.exclude_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '-t can not be selected with --exclude-table-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter3(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_tables = 'foo'
-        options.exclude_dump_tables_file = 'foo'
+    def test_options_table_filter3(self, mock):
+        self.options.exclude_dump_tables = 'foo'
+        self.options.exclude_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '-T can not be selected with --exclude-table-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter4(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.exclude_dump_tables = 'foo'
-        options.include_dump_tables_file = 'foo'
+    def test_options_table_filter4(self, mock):
+        self.options.exclude_dump_tables = 'foo'
+        self.options.include_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '-T can not be selected with --table-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter5(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_dump_tables = 'foo'
-        options.exclude_dump_tables = 'foo'
+    def test_options_table_filter5(self, mock):
+        self.options.include_dump_tables = 'foo'
+        self.options.exclude_dump_tables = 'foo'
         with self.assertRaisesRegexp(Exception, '-t can not be selected with -T option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter6(self, mock, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_dump_tables_file = 'foo'
-        options.exclude_dump_tables_file = 'foo'
+    def test_options_table_filter6(self, mock):
+        self.options.include_dump_tables_file = 'foo'
+        self.options.exclude_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '--table-file can not be selected with --exclude-table-file option'):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_get_timestamp_object1(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = '20130101010101'
-        gpcd = GpCronDump(options, None)
-        timestamp = gpcd._get_timestamp_object(options.timestamp_key)
-        self.assertEquals(timestamp, datetime(2013, 1, 1, 1, 1, 1))
-
-    @patch('gpcrondump.GpCronDump._get_master_port')
-    @patch('gpcrondump.validate_current_timestamp')
-    def test_get_timestamp_object2(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = '20130101010'
-        gpcd = GpCronDump(options, None)
-        with self.assertRaisesRegexp(Exception, 'Invalid timestamp key'):
-            gpcd._get_timestamp_object(options.timestamp_key)
-
-    @patch('gpcrondump.GpCronDump._get_master_port')
-    @patch('gpcrondump.validate_current_timestamp')
-    def test_get_timestamp_object3(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = None
-        gpcd = GpCronDump(options, None)
-        timestamp = gpcd._get_timestamp_object(options.timestamp_key)
-        self.assertTrue(isinstance(timestamp, datetime))
-
-    @patch('gpcrondump.GpCronDump._get_master_port')
-    @patch('gpcrondump.validate_current_timestamp')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_files_file_list1(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = None
-        options.masterDataDirectory = '/foo'
-        gpcd = GpCronDump(options, None)
+        self.options.timestamp_key = None
+        self.options.masterDataDirectory = '/foo'
+        gpcd = GpCronDump(self.options, None)
         master = Mock()
         master.getSegmentHostName.return_value = 'foo1'
-        timestamp = '20130101010101'
-        dump_dir = get_backup_directory(options.masterDataDirectory, options.backup_dir, gpcd.dump_dir, timestamp)
-        files_file_list = gpcd._get_files_file_list(master, dump_dir, timestamp)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_cdatabase_1_1_20130101010101' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_status_1_1_20130101010101' % options.masterDataDirectory]
+        gpcd.context.timestamp = '20130101010101'
+        dump_dir = gpcd.context.get_backup_dir()
+        files_file_list = gpcd._get_files_file_list(master)
+        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory]
         self.assertEqual(files_file_list, expected_files_list)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_files_file_list2(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = None
-        options.masterDataDirectory = '/foo'
-        gpcd = GpCronDump(options, None)
+        self.options.timestamp_key = None
+        self.options.masterDataDirectory = '/foo'
+        gpcd = GpCronDump(self.options, None)
         master = Mock()
         master.getSegmentHostName.return_value = 'foo2'
-        timestamp = '20130101010101'
-        dump_dir = get_backup_directory(options.masterDataDirectory, options.backup_dir, gpcd.dump_dir, timestamp)
-        files_file_list = gpcd._get_files_file_list(master, dump_dir, timestamp)
-        expected_files_list = ['foo2:%s/db_dumps/20130101/gp_cdatabase_1_1_20130101010101' % options.masterDataDirectory,
-                               'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % options.masterDataDirectory,
-                               'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % options.masterDataDirectory,
-                               'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % options.masterDataDirectory,
-                               'foo2:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % options.masterDataDirectory,
-                               'foo2:%s/db_dumps/20130101/gp_dump_status_1_1_20130101010101' % options.masterDataDirectory]
+        gpcd.context.timestamp = '20130101010101'
+        dump_dir = gpcd.context.get_backup_dir()
+        files_file_list = gpcd._get_files_file_list(master)
+        expected_files_list = ['foo2:%s/db_dumps/20130101/gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
+                               'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
+                               'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
+                               'foo2:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
+                               'foo2:%s/db_dumps/20130101/gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory]
         self.assertEqual(files_file_list, expected_files_list)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20130101000000')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_files_file_list3(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = '20130101010101'
-        options.incremental = True
-        options.masterDataDirectory = '/data/foo'
-        gpcd = GpCronDump(options, None)
+        self.options.timestamp_key = '20130101010101'
+        self.options.incremental = True
+        self.options.masterDataDirectory = '/data/foo'
+        gpcd = GpCronDump(self.options, None)
         master = Mock()
         master.getSegmentHostName.return_value = 'foo1'
-        timestamp = '20130101010101'
+        gpcd.context.timestamp = '20130101010101'
 
-        dump_dir = get_backup_directory(options.masterDataDirectory, None, gpcd.dump_dir, timestamp)
-        files_file_list = gpcd._get_files_file_list(master, dump_dir, timestamp)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_cdatabase_1_1_20130101010101' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_status_1_1_20130101010101' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_20130101000000_increments' % options.masterDataDirectory]
+        dump_dir = gpcd.context.get_backup_dir()
+        files_file_list = gpcd._get_files_file_list(master)
+        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_20130101000000_increments' % self.options.masterDataDirectory]
         self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gppylib.operations.backup_utils.get_latest_full_dump_timestamp', return_value='20130101000000')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_files_file_list_with_filter(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = '20130101010101'
-        options.local_dump_prefix = 'metro'
-        options.include_dump_tables_file = 'bar'
-        options.masterDataDirectory = '/data/foo'
-        gpcd = GpCronDump(options, None)
+        self.options.timestamp_key = '20130101010101'
+        self.options.local_dump_prefix = 'metro'
+        self.options.include_dump_tables_file = 'bar'
+        self.options.masterDataDirectory = '/data/foo'
+        gpcd = GpCronDump(self.options, None)
         master = Mock()
         master.getSegmentHostName.return_value = 'foo1'
-        timestamp = '20130101010101'
-        dump_dir = get_backup_directory(options.masterDataDirectory, options.backup_dir, gpcd.dump_dir, timestamp)
-        files_file_list = gpcd._get_files_file_list(master, dump_dir, timestamp)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/metro_gp_cdatabase_1_1_20130101010101' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_ao_state_file' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_co_state_file' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_last_operation' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101.rpt' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_status_1_1_20130101010101' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_filter' % options.masterDataDirectory]
+        gpcd.context.timestamp = '20130101010101'
+        dump_dir = gpcd.context.get_backup_dir()
+        files_file_list = gpcd._get_files_file_list(master)
+        expected_files_list = ['foo1:%s/db_dumps/20130101/metro_gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_filter' % self.options.masterDataDirectory]
         self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20130101000000')
-    @patch('gpcrondump.GpCronDump._get_master_port')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_files_file_list_with_prefix(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = '20130101010101'
-        options.incremental = True
-        options.local_dump_prefix = 'metro'
-        options.masterDataDirectory = '/data/foo'
-        gpcd = GpCronDump(options, None)
+        self.options.timestamp_key = '20130101010101'
+        self.options.incremental = True
+        self.options.local_dump_prefix = 'metro'
+        self.options.masterDataDirectory = '/data/foo'
+        gpcd = GpCronDump(self.options, None)
         master = Mock()
         master.getSegmentHostName.return_value = 'foo1'
-        timestamp = '20130101010101'
+        gpcd.context.timestamp = '20130101010101'
 
-        dump_dir = get_backup_directory(options.masterDataDirectory, None, gpcd.dump_dir, timestamp)
-        files_file_list = gpcd._get_files_file_list(master, dump_dir, timestamp)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/metro_gp_cdatabase_1_1_20130101010101' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_ao_state_file' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_co_state_file' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_last_operation' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101.rpt' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_status_1_1_20130101010101' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101000000_increments' % options.masterDataDirectory]
+        dump_dir = gpcd.context.get_backup_dir()
+        files_file_list = gpcd._get_files_file_list(master)
+        expected_files_list = ['foo1:%s/db_dumps/20130101/metro_gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101000000_increments' % self.options.masterDataDirectory]
 
         self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_pipes_file_list1(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = None
-        options.masterDataDirectory = '/foo'
-        gpcd = GpCronDump(options, None)
+        self.options.timestamp_key = None
+        self.options.masterDataDirectory = '/foo'
+        gpcd = GpCronDump(self.options, None)
         master = Mock()
         master.getSegmentHostName.return_value = 'foo2'
         mock_segs = []
-        timestamp = '20130101010101'
-        dump_dir = get_backup_directory(options.masterDataDirectory, options.backup_dir, gpcd.dump_dir, timestamp)
-        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs, dump_dir, timestamp)
-        expected_files_list = ['foo2:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % options.masterDataDirectory,
-                               'foo2:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % options.masterDataDirectory]
+        gpcd.context.timestamp = '20130101010101'
+        dump_dir = gpcd.context.get_backup_dir()
+        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs)
+        expected_files_list = ['foo2:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % self.options.masterDataDirectory,
+                               'foo2:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % self.options.masterDataDirectory]
         self.assertEqual(pipes_file_list, expected_files_list)
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_pipes_file_list2(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = None
-        options.masterDataDirectory = '/foo'
-        gpcd = GpCronDump(options, None)
+        self.options.timestamp_key = None
+        self.options.masterDataDirectory = '/foo'
+        gpcd = GpCronDump(self.options, None)
         master = Mock()
         master.getSegmentHostName.return_value = 'foo1'
         mock_segs = [Mock(), Mock()]
         for id, seg in enumerate(mock_segs):
             seg.getSegmentDataDirectory.return_value = '/bar'
             seg.getSegmentHostName.return_value = 'foo1'
-            seg.getSegmentDbId.return_value = id + 1
-        timestamp = '20130101010101'
-        dump_dir = get_backup_directory(options.masterDataDirectory, options.backup_dir, gpcd.dump_dir, timestamp)
-        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs, dump_dir, timestamp)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % options.masterDataDirectory,
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_1_20130101010101.gz',
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_2_20130101010101.gz']
+            seg.getSegmentDbId.return_value = id + 2
+        gpcd.context.timestamp = '20130101010101'
+        dump_dir = gpcd.context.get_backup_dir()
+        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs)
+        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % self.options.masterDataDirectory,
+                               'foo1:/bar/db_dumps/20130101/gp_dump_0_2_20130101010101.gz',
+                               'foo1:/bar/db_dumps/20130101/gp_dump_0_3_20130101010101.gz']
         self.assertEqual(sorted(pipes_file_list), sorted(expected_files_list))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_pipes_file_list3(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = None
-        options.dump_global = True
-        options.masterDataDirectory = '/foo'
-        gpcd = GpCronDump(options, None)
+        self.options.timestamp_key = None
+        self.options.dump_global = True
+        self.options.masterDataDirectory = '/foo'
+        gpcd = GpCronDump(self.options, None)
         master = Mock()
         master.getSegmentHostName.return_value = 'foo1'
         mock_segs = [Mock(), Mock()]
         for id, seg in enumerate(mock_segs):
             seg.getSegmentDataDirectory.return_value = '/bar'
             seg.getSegmentHostName.return_value = 'foo1'
-            seg.getSegmentDbId.return_value = id + 1
-        timestamp = '20130101010101'
-        dump_dir = get_backup_directory(options.masterDataDirectory, options.backup_dir, gpcd.dump_dir, timestamp)
-        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs, dump_dir, timestamp)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_global_1_1_20130101010101' % options.masterDataDirectory,
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_1_20130101010101.gz',
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_2_20130101010101.gz']
+            seg.getSegmentDbId.return_value = id + 2
+        gpcd.context.timestamp = '20130101010101'
+        dump_dir = gpcd.context.get_backup_dir()
+        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs)
+        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_global_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:/bar/db_dumps/20130101/gp_dump_0_2_20130101010101.gz',
+                               'foo1:/bar/db_dumps/20130101/gp_dump_0_3_20130101010101.gz']
         self.assertEqual(sorted(pipes_file_list), sorted(expected_files_list))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_pipes_file_list4(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = None
-        options.masterDataDirectory = '/foo'
-        options.dump_config = True
-        gpcd = GpCronDump(options, None)
+        self.options.timestamp_key = None
+        self.options.masterDataDirectory = '/foo'
+        self.options.dump_config = True
+        gpcd = GpCronDump(self.options, None)
         master = Mock()
         master.getSegmentHostName.return_value = 'foo1'
         mock_segs = [Mock(), Mock()]
         for id, seg in enumerate(mock_segs):
             seg.getSegmentDataDirectory.return_value = '/bar'
             seg.getSegmentHostName.return_value = 'foo1'
-            seg.getSegmentDbId.return_value = id + 1
-        timestamp = '20130101010101'
-        dump_dir = get_backup_directory(options.masterDataDirectory, options.backup_dir, gpcd.dump_dir, timestamp)
-        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs, dump_dir, timestamp)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_master_config_files_20130101010101.tar' % options.masterDataDirectory,
-                               'foo1:/bar/db_dumps/20130101/gp_segment_config_files_0_1_20130101010101.tar',
+            seg.getSegmentDbId.return_value = id + 2
+        gpcd.context.timestamp = '20130101010101'
+        dump_dir = gpcd.context.get_backup_dir()
+        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs)
+        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_master_config_files_20130101010101.tar' % self.options.masterDataDirectory,
                                'foo1:/bar/db_dumps/20130101/gp_segment_config_files_0_2_20130101010101.tar',
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_1_20130101010101.gz',
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_2_20130101010101.gz']
+                               'foo1:/bar/db_dumps/20130101/gp_segment_config_files_0_3_20130101010101.tar',
+                               'foo1:/bar/db_dumps/20130101/gp_dump_0_2_20130101010101.gz',
+                               'foo1:/bar/db_dumps/20130101/gp_dump_0_3_20130101010101.gz']
         self.assertEqual(sorted(pipes_file_list), sorted(expected_files_list))
 
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_gpcrondump_init0(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.timestamp_key = None
-        options.local_dump_prefix = 'foo'
-        options.ddboost = False
-        options.ddboost_verify = False
-        options.ddboost_config_remove = False
-        options.ddboost_user = False
-        options.ddboost_host = False
-        options.max_streams = None
-        options.list_backup_files = False
-        gpcd = GpCronDump(options, None)
-        self.assertEqual(gpcd.dump_prefix, 'foo_')
+        self.options.timestamp_key = None
+        self.options.local_dump_prefix = 'foo'
+        self.options.ddboost = False
+        self.options.ddboost_verify = False
+        self.options.ddboost_config_remove = False
+        self.options.ddboost_user = False
+        self.options.ddboost_host = False
+        self.options.max_streams = None
+        self.options.list_backup_files = False
+        gpcd = GpCronDump(self.options, None)
+        self.assertEqual(gpcd.context.dump_prefix, 'foo_')
 
     @patch('gpcrondump.os.path.isfile', return_value=True)
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.os.path.getsize', return_value=111)
     @patch('gpcrondump.yaml.load', return_value={'EMAIL_DETAILS': [{'FROM': 'RRP_MPE2_DCA_1', 'DBNAME': 'testdb100', 'SUBJECT': "backup completed for Database 'testdb100'"}]})
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_validate_parse_email_File00(self, mock1, mock2, mock3, mock4):
-        options = GpCronDumpTestCase.Options()
-        options.include_email_file = "/tmp/abc.yaml"
-        m = mock.MagicMock()
+        self.options.include_email_file = "/tmp/abc.yaml"
+        m = MagicMock()
         with patch('__builtin__.open', m, create=True):
-            cron = GpCronDump(options, None)
+            cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.os.path.isfile', return_value=False)
-    @patch('gpcrondump.GpCronDump._get_master_port')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_validate_parse_email_File01(self, mock1, mock2):
-        options = GpCronDumpTestCase.Options()
-        options.include_email_file = "/tmp/abc.yaml"
-        with self.assertRaisesRegexp(Exception, "\'%s\' file does not exist." % options.include_email_file):
-            cron = GpCronDump(options, None)
+        self.options.include_email_file = "/tmp/abc.yaml"
+        with self.assertRaisesRegexp(Exception, "\'%s\' file does not exist." % self.options.include_email_file):
+            cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.os.path.isfile', return_value=True)
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.os.path.getsize', return_value=111)
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_validate_parse_email_File02(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.include_email_file = "/tmp/abc"
-        with self.assertRaisesRegexp(Exception, "'%s' is not '.yaml' file. File containing email details should be '.yaml' file." %  options.include_email_file):
-            cron = GpCronDump(options, None)
+        self.options.include_email_file = "/tmp/abc"
+        with self.assertRaisesRegexp(Exception, "'%s' is not '.yaml' file. File containing email details should be '.yaml' file." %  self.options.include_email_file):
+            cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.os.path.isfile', return_value=True)
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.os.path.getsize', return_value=0)
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_validate_parse_email_File03(self, mock1, mock2, mock3):
-        options = GpCronDumpTestCase.Options()
-        options.include_email_file = "/tmp/abc.yaml"
-        with self.assertRaisesRegexp(Exception, "'%s' file is empty." % options.include_email_file):
-            cron = GpCronDump(options, None)
+        self.options.include_email_file = "/tmp/abc.yaml"
+        with self.assertRaisesRegexp(Exception, "'%s' file is empty." % self.options.include_email_file):
+            cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.os.path.isfile', return_value=True)
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.os.path.getsize', return_value=111)
     @patch('gpcrondump.yaml.load', return_value={'EMAIL_DETAILS': [{'FROM': 'RRP_MPE2_DCA_1', 'NAME': 'testdb100', 'SUBJECT': "backup completed for Database 'testdb100'"}]})
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_validate_parse_email_File04(self, mock1, mock2, mock3, mock4):
-        options = GpCronDumpTestCase.Options()
-        options.include_email_file = "/tmp/abc.yaml"
-        m = mock.MagicMock()
-        with self.assertRaisesRegexp(Exception, "\'%s\' file is not formatted properly." % options.include_email_file):
+        self.options.include_email_file = "/tmp/abc.yaml"
+        m = MagicMock()
+        with self.assertRaisesRegexp(Exception, "\'%s\' file is not formatted properly." % self.options.include_email_file):
             with patch('__builtin__.open', m, create=True):
-                cron = GpCronDump(options, None)
+                cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.os.path.isfile', return_value=True)
-    @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.os.path.getsize', return_value=111)
     @patch('gpcrondump.yaml.load', return_value={'EMAIL_DETAILS': [{'FROM': 'RRP_MPE2_DCA_1', 'DBNAME': None, 'SUBJECT': "backup completed for Database 'testdb100'"}]})
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_validate_parse_email_File05(self, mock1, mock2, mock3, mock4):
-        options = GpCronDumpTestCase.Options()
-        options.include_email_file = "/tmp/abc.yaml"
-        m = mock.MagicMock()
-        with self.assertRaisesRegexp(Exception, "\'%s\' file is not formatted properly." % options.include_email_file):
+        self.options.include_email_file = "/tmp/abc.yaml"
+        m = MagicMock()
+        with self.assertRaisesRegexp(Exception, "\'%s\' file is not formatted properly." % self.options.include_email_file):
             with patch('__builtin__.open', m, create=True):
-                cron = GpCronDump(options, None)
+                cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.MailDumpEvent')
-    @patch('gpcrondump.GpCronDump._get_master_port')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_send_email00(self, mock1, MailDumpEvent):
-        options = GpCronDumpTestCase.Options()
         dump_database = 'testdb1'
         current_exit_status = 0
         time_start = '12:07:09'
         time_end = '12:08:18'
-        cron = GpCronDump(options, None)
+        cron = GpCronDump(self.options, None)
         cron._send_email(dump_database, current_exit_status, time_start, time_end)
 
     @patch('gppylib.commands.base.Command.run')
     @patch('gppylib.commands.base.Command.get_results')
-    @patch('gpcrondump.GpCronDump._get_master_port')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_show_ddboost_config_local_DDServer(self, mock_get_pgport, mock_result, mock_run):
         mock_result.return_value = CommandResult(0, '''20160510:15:45:01|ddboost-[DEBUG]:-Libraries were loaded successfully
 20160510:15:45:01|ddboost-[INFO]:-opening LB on /home/gpadmin/DDBOOST_CONFIG
@@ -1212,13 +992,10 @@ Data Domain Boost Username:metro
 Default Backup Directory:MY_MFR
 Data Domain default log level:WARNING
 Data Domain Storage Unit:GPDB''', '', False, True)
-
-        options = GpCronDumpTestCase.Options()
-        options.ddboost_show_config = True
-
-        cron = GpCronDump(options, None)
+        self.options.ddboost_show_config = True
+        gpcd = GpCronDump(self.options, None)
         logger.info = Mock()
-        cron.show_ddboost_config()
+        gpcd.show_ddboost_config()
         logger.info.assert_any_call('Data Domain Hostname:qadd01')
         logger.info.assert_any_call('Data Domain Boost Username:metro')
         logger.info.assert_any_call('Default Backup Directory:MY_MFR')
@@ -1228,7 +1005,7 @@ Data Domain Storage Unit:GPDB''', '', False, True)
 
     @patch('gppylib.commands.base.Command.run')
     @patch('gppylib.commands.base.Command.get_results')
-    @patch('gpcrondump.GpCronDump._get_master_port')
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_show_ddboost_config_remote_DDServer(self, mock_get_pgport, mock_result, mock_run):
         mock_result.return_value = CommandResult(0, '''20160511:10:28:06|ddboost-[DEBUG]:-Libraries were loaded successfully
 20160511:10:28:06|ddboost-[INFO]:-opening LB on /home/gpadmin/DDBOOST_MFR_CONFIG
@@ -1236,13 +1013,10 @@ Data Domain Hostname:dd1
 Data Domain Boost Username:gpadmin
 Data Domain default log level:WARNING
 Data Domain default log size:50''', '', False, True)
-
-        options = GpCronDumpTestCase.Options()
-        options.ddboost_show_config = True
-
-        cron = GpCronDump(options, None)
+        self.options.ddboost_show_config = True
+        gpcd = GpCronDump(self.options, None)
         logger.info = Mock()
-        cron.show_ddboost_config()
+        gpcd.show_ddboost_config()
         logger.info.assert_any_call('Data Domain Hostname:dd1')
         logger.info.assert_any_call('Data Domain Boost Username:gpadmin')
         logger.info.assert_any_call('Data Domain default log level:WARNING')

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
@@ -18,15 +18,16 @@ class MyTestCase(unittest.TestCase):
     def test_spreadmirror_layout(self):
         """ Basic spread mirroring """
         mirror_type = 'spread'
-        interface_list = [1]
         primary_portbase = 5000
         mirror_portbase = 6000
+        interface_list = [1]
         primary_replication_portbase = 7000
         mirror_replication_portbase = 8000
+        dir_prefix = 'gpseg'
+
         hostlist = ['host1']
         primary_list = ['/db1']
         mirror_list = ['/mir1']
-        dir_prefix = 'gpseg'
         
         #need to have enough hosts otherwise we get exceptions
         with self.assertRaises(Exception):
@@ -44,31 +45,31 @@ class MyTestCase(unittest.TestCase):
         
         #now we have enough
         hostlist.append('host3')
-        self.mirrorlayout_test(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)
+        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
         
         
         #enough
         hostlist = ['host1', 'host2', 'host3']
         primary_list = ['/db1', '/db2']
         mirror_list = ['/mir1', '/mir2']
-        self.mirrorlayout_test(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)
+        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
 
         #typical thumper
         hostlist = ['sdw1', 'sdw2', 'sdw3', 'sdw4', 'sdw5']
         primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4']
         mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror']
-        self.mirrorlayout_test(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)
+        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
 
         #typical Thor
         hostlist = ['sdw1', 'sdw2', 'sdw3', 'sdw4', 'sdw5', 'sdw6', 'sdw7', 'sdw8', 'sdw9']
         primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4', '/dbfast5', '/dbfast6', '/dbfast7', '/dbfast8']
         mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror',
                        '/dbfast5/mirror', '/dbfast6/mirror', '/dbfast7/mirror', '/dbfast8/mirror']
-        self.mirrorlayout_test(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)
+        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
 
     def test_groupmirror_layout(self):
         """ Basic group mirroring """
@@ -78,10 +79,11 @@ class MyTestCase(unittest.TestCase):
         interface_list = [1]
         primary_replication_portbase = 7000
         mirror_replication_portbase = 8000
+        dir_prefix = 'gpseg'
+
         hostlist = ['host1']
         primary_list = ['/db1']
         mirror_list = ['/mir1']
-        dir_prefix = 'gpseg'
         
         #not enough
         with self.assertRaises(Exception):
@@ -103,20 +105,50 @@ class MyTestCase(unittest.TestCase):
         hostlist = ['sdw1', 'sdw2', 'sdw3', 'sdw4', 'sdw5']
         primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4']
         mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror']
-        self.mirrorlayout_test(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)
+        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
 
         #typical Thor
         hostlist = ['sdw1', 'sdw2', 'sdw3', 'sdw4', 'sdw5', 'sdw6', 'sdw7', 'sdw8', 'sdw9']
         primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4', '/dbfast5', '/dbfast6', '/dbfast7', '/dbfast8']
         mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror',
                        '/dbfast5/mirror', '/dbfast6/mirror', '/dbfast7/mirror', '/dbfast8/mirror']
-        self.mirrorlayout_test(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)        
+        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
 
+    def test_get_segment_list(self):
+        mirror_type = 'grouped'
+        primary_portbase = 5000
+        mirror_portbase = 6000
+        interface_list = [1]
+        primary_replication_portbase = 7000
+        mirror_replication_portbase = 8000
+        dir_prefix = 'gpseg'
 
-#------------------------------- non-test helper --------------------------------
-    def mirrorlayout_test(self, hostlist, interface_list, primary_list, primary_portbase, mirror_type, 
+        hostlist = ['sdw1', 'sdw2', 'sdw3', 'sdw4', 'sdw5']
+        primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4']
+        mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror']
+
+        gparray = self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)
+        self._validate_array(gparray)
+
+        # test without expansion segments
+        expansion_hosts = []
+        self._validate_get_segment_list(gparray, hostlist, expansion_hosts, primary_list)
+
+        # test with expansion segments
+        expansion_hosts = ['sdw6', 'sdw7']
+        rows =  createSegmentRows(expansion_hosts, interface_list, primary_list, primary_portbase, mirror_type,
+                                  mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)
+        offset = len(hostlist) * len(primary_list) # need to continue numbering where the last createSegmentRows left off
+        for row in rows:
+            gparray.addExpansionSeg(row.content+offset, 'p' if convert_bool(row.isprimary) else 'm', row.dbid+offset,
+                                    'p' if convert_bool(row.isprimary) else 'm', row.host, row.address, row.port, row.fulldir, row.prPort)
+        self._validate_get_segment_list(gparray, hostlist, expansion_hosts, primary_list)
+
+#------------------------------- non-test helpers --------------------------------
+    def setup_gparray(self, hostlist, interface_list, primary_list, primary_portbase, mirror_type, 
                           mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase):
         master = GpDB(content = -1,
                     preferred_role = 'p',
@@ -150,9 +182,7 @@ class MyTestCase(unittest.TestCase):
             allrows.append(newrow)
         
         gparray = GpArray(allrows)
-                
-        self._validate_array(gparray)
-    
+        return gparray
         
     def _validate_array(self, gparray): 
         portdict = {}
@@ -171,7 +201,27 @@ class MyTestCase(unittest.TestCase):
             
         for count in portdict.values():
             self.assertEquals(expected_count, count)
-            
+
+    def _validate_get_segment_list(self, gparray, hostlist, expansion_hosts, primary_list):
+        hostlist.extend(expansion_hosts)
+        expected = []
+        for host in hostlist:
+            for primary in primary_list:
+                expected.append("host %s, primary %s" % (host, primary))
+
+        has_expansion_hosts = (len(expansion_hosts) > 0)
+        segments = gparray.getSegmentList(has_expansion_hosts)
+        actual = []
+        for segment in segments:
+            primary = segment.primaryDB
+            datadir = primary.datadir[0:primary.datadir.rindex("/")] # strip off the "/gpseg##" portion of the primary name for comparison
+            actual.append("host %s, primary %s" % (primary.hostname, datadir))
+        self.assertEquals(len(expected), len(actual))
+
+        expected = sorted(expected)
+        actual = sorted(actual)
+        for i in range(len(expected)):
+            self.assertEquals(expected[i], actual[i])
     
 def convert_bool(val):
     if val == 't':


### PR DESCRIPTION
Previously, the functions and helper classes in gpcrondump, gpdbrestore, dump.py,
and restore.py all required long lists of arguments to be passed around and
required many helper functions.  This made adding new command-line options
or new features quite time-consuming to implement and to test.

Now, a Context class has been added to backup_utils.py that holds all of the
variables used for command-line options, as well as other variables used in
many places during backup and restore; additionally, many helper functions
have been condensed into a few functions within Context, and in the future
more such functions can be moved to Context as needed.  This will make it
much easier to expand dump and restore functionality going forward.