### PR TITLE
Gang leak

### DIFF
--- a/src/backend/cdb/cdbgang.c
+++ b/src/backend/cdb/cdbgang.c
@@ -2799,6 +2799,10 @@ disconnectAndDestroyAllGangs(void)
 	if (gp_log_gang >= GPVARS_VERBOSITY_DEBUG)
 		elog(LOG, "disconnectAndDestroyAllGangs done");
 
+	/*
+	 * As all the reader and writer gangs are destroyed, reset the
+	 * corresponding GangContext to prevent leaks
+	 */
 	if (NULL != GangContext)
 	{
 		MemoryContextReset(GangContext);

--- a/src/backend/cdb/cdbgang.c
+++ b/src/backend/cdb/cdbgang.c
@@ -2798,6 +2798,11 @@ disconnectAndDestroyAllGangs(void)
 
 	if (gp_log_gang >= GPVARS_VERBOSITY_DEBUG)
 		elog(LOG, "disconnectAndDestroyAllGangs done");
+
+	if (NULL != GangContext)
+	{
+		MemoryContextReset(GangContext);
+	}
 }
 
 bool


### PR DESCRIPTION
As part of stability improvement effort, we have been working to detect leaking memory in GPDB sessions. We found that GangContext leaks 576 bytes per gang destruction, including idle session cleanup, which happens every 18 seconds in release build (by default).

In this PR we are resetting the GangContext whenever we destroy the writer and the reader gangs. This fixes the above described 576 bytes leaks per destruction.