### PR TITLE
Update behave config to use new netbackup values

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/netbackup_behave_config.yaml
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/netbackup_behave_config.yaml
@@ -1,4 +1,10 @@
 NETBACKUP_PARAMS:
-    NETBACKUP_SERVICE_HOST: rhel64-1
-    NETBACKUP_POLICY: test
-    NETBACKUP_SCHEDULE: app_schedule
+    # IMPORTANT: during testing, we found that if we used a dns name for
+    # the netbackup host, that dns name should NOT be the same as the
+    # internal name used by that host itself. In other words, on the
+    # netbackup host itself, we gave localhost an alias in /etc/hosts of
+    # 'netbackup-server', but thing failed if we used that same name
+    # in clients also.
+    NETBACKUP_SERVICE_HOST: netbackup-service
+    NETBACKUP_POLICY: gpdb
+    NETBACKUP_SCHEDULE: gpdb_schedule


### PR DESCRIPTION
Renaming hostname to something more generic to be used in our behave test.