### PR TITLE
Support null attributes in code generated ExecVariableList

### DIFF
--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -741,6 +741,22 @@ class TypeMaker<ReferentType&> {
   }
 };
 
+// Partial specialization for C/C++ array types, which are converted to their
+// corresponding llvm array types
+template <typename ArrayElementType, size_t N>
+class TypeMaker<ArrayElementType[N]>{
+  public:
+    static llvm::Type* Get(llvm::LLVMContext* context) {
+      llvm::Type* unit_type = codegen_utils_detail::TypeMaker<ArrayElementType>::Get(context);
+      return llvm::ArrayType::get(unit_type, N);
+    }
+
+    static llvm::Type* GetAnnotated(llvm::LLVMContext* context) {
+      llvm::Type* unit_type = codegen_utils_detail::TypeMaker<ArrayElementType>::Get(context);
+      return llvm::ArrayType::get(unit_type, N);
+    }
+};
+
 }  // namespace codegen_utils_detail
 
 template <typename CppType>


### PR DESCRIPTION
This PR enhances code generated ExecVariableList with support of null attributes. Also, it removes redundant checks, e.g., we do not need to check if tuple is a MemTuple, since the code generated ExecVariableList is called only from a Scan operator. 

Also, there are some formatting changes based on Google C++ style.

@hardikar @foyzur @gcaragea @karthijrk Please take a look if you have time. 