### PR TITLE
s3ext: add a standalone config checking app [v2]

### DIFF
--- a/gpAux/extensions/Makefile
+++ b/gpAux/extensions/Makefile
@@ -52,7 +52,8 @@ mkgphdfs:
 
 .PHONY:
 mks3ext:
-	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gps3ext USE_PGXS=1 install
+	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -B -C gps3ext USE_PGXS=1 install
+	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -B -C gps3ext -f Makefile.chkcfg USE_PGXS=1 install
 
 # Only include include these files when running enterprise build
 ENTERPRISE_TARGETS="mkdbgen mkgphdfs mkorafce mkplr mkpljava"

--- a/gpAux/extensions/gps3ext/.gitignore
+++ b/gpAux/extensions/gps3ext/.gitignore
@@ -49,5 +49,6 @@ core
 *.gcda
 *.gcno
 s3test
+s3chkcfg
 
 s3.conf

--- a/gpAux/extensions/gps3ext/Makefile
+++ b/gpAux/extensions/gps3ext/Makefile
@@ -4,8 +4,8 @@ DEBUG_S3_CURL = n
 DEBUG_S3_SYMBOL = y
 
 # Flags
-SHLIB_LINK = -lstdc++ -lxml2 -lpthread -lcrypto -lcurl -lz
-PG_CPPFLAGS = -O2 -std=c++98 -Wall -fPIC -I$(libpq_srcdir) -Isrc -Ilib -I/usr/include/libxml2 -I$(libpq_srcdir)/postgresql/server/utils
+SHLIB_LINK += -lstdc++ -lxml2 -lpthread -lcrypto -lcurl -lz
+PG_CPPFLAGS += -O2 -std=c++98 -Wall -fPIC -I$(libpq_srcdir) -Isrc -Ilib -I/usr/include/libxml2 -I$(libpq_srcdir)/postgresql/server/utils
 
 ifeq ($(DEBUG_S3),y)
 	PG_CPPFLAGS += -DDEBUG_S3

--- a/gpAux/extensions/gps3ext/Makefile.chkcfg
+++ b/gpAux/extensions/gps3ext/Makefile.chkcfg
@@ -1,0 +1,28 @@
+# Options
+DEBUG_S3 = y
+DEBUG_S3_CURL = n
+DEBUG_S3_SYMBOL = y
+
+# Flags
+PG_LIBS += -lstdc++ -lxml2 -lpthread -lcrypto -lcurl -lz
+PG_CPPFLAGS += -O2 -std=c++98 -Wall -fPIC -DS3_CHK_CFG -Isrc -Ilib -I/usr/include/libxml2
+
+ifeq ($(DEBUG_S3),y)
+	PG_CPPFLAGS += -DDEBUG_S3
+endif
+
+ifeq ($(DEBUG_S3_CURL),y)
+	PG_CPPFLAGS += -DDEBUG_S3_CURL
+endif
+
+ifeq ($(DEBUG_S3_SYMBOL),y)
+	PG_CPPFLAGS += -g
+endif
+
+# Targets
+PROGRAM = s3chkcfg
+OBJS = src/s3chkcfg.o src/s3conf.o src/s3downloader.o src/s3wrapper.o src/s3utils.o src/s3log.o src/s3common.o lib/http_parser.o lib/ini.o
+
+# Launch
+PGXS := $(shell pg_config --pgxs)
+include $(PGXS)

--- a/gpAux/extensions/gps3ext/Makefile.others
+++ b/gpAux/extensions/gps3ext/Makefile.others
@@ -9,7 +9,7 @@ BIG_FILE_TEST = n
 CPP = g++
 INCLUDES = -Isrc -Ilib -I/usr/include/libxml2
 LDFLAGS = -lpthread -lcrypto -lcurl -lxml2 -lgcov -lz
-CFLAGS = -O2 -g3 -std=c++98 -Wall -fPIC -fprofile-arcs -ftest-coverage
+CPPFLAGS = -O2 -g3 -std=c++98 -Wall -fPIC -fprofile-arcs -ftest-coverage
 
 ifeq ($(DEBUG_S3),y)
 	CPPFLAGS += -DDEBUG_S3
@@ -55,13 +55,13 @@ gtest_main.o : $(GTEST_SRCS_)
 gtest_main.a : gtest-all.o gtest_main.o
 	$(AR) $(ARFLAGS) $@ $^
 
-%.o: %.cpp
-	$(CPP) $(CPPFLAGS) $(INCLUDES) -MMD -MP -c $< -o $@
+buildtest: $(TEST_APP)
 
 $(TEST_APP): gtest_main.a $(TEST_OBJS)
 	$(CPP) $^ -o $(TEST_APP) $(LDFLAGS)
 
-buildtest: $(TEST_APP)
+%.o: %.cpp
+	$(CPP) $(CPPFLAGS) $(INCLUDES) -MMD -MP -c $< -o $@
 
 test: $(TEST_APP)
 	-@./$(TEST_APP)

--- a/gpAux/extensions/gps3ext/README.md
+++ b/gpAux/extensions/gps3ext/README.md
@@ -6,10 +6,10 @@
 
 ### Run Unit Tests
 
-`make -f Makefile.test test`
+`make -f Makefile.others test`
 
 Some tests need [unite](https://github.com/lij55/unite) to serve the test contents and recevie log.
 
 ### Test Code Coverage
 
-`make -f Makefile.test coverage`
+`make -f Makefile.others coverage`

--- a/gpAux/extensions/gps3ext/src/gps3ext.cpp
+++ b/gpAux/extensions/gps3ext/src/gps3ext.cpp
@@ -1,22 +1,20 @@
 #define PGDLLIMPORT "C"
 
+#include <signal.h>
 #include <cstdlib>
 
+#include <openssl/err.h>
 #include <pthread.h>
-#include <signal.h>
 
 #include "postgres.h"
-
-#include "funcapi.h"
 
 #include "access/extprotocol.h"
 #include "catalog/pg_proc.h"
 #include "fmgr.h"
+#include "funcapi.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/memutils.h"
-
-#include <openssl/err.h>
 
 #include "gps3ext.h"
 #include "s3common.h"
@@ -30,55 +28,24 @@
 PG_MODULE_MAGIC;
 PG_FUNCTION_INFO_V1(s3_export);
 PG_FUNCTION_INFO_V1(s3_import);
-PG_FUNCTION_INFO_V1(s3_validate_urls);
 
 extern "C" {
 Datum s3_export(PG_FUNCTION_ARGS);
 Datum s3_import(PG_FUNCTION_ARGS);
-Datum s3_validate_urls(PG_FUNCTION_ARGS);
 }
 
-#define MUTEX_TYPE pthread_mutex_t
-#define MUTEX_SETUP(x) pthread_mutex_init(&(x), NULL)
-#define MUTEX_CLEANUP(x) pthread_mutex_destroy(&(x))
-#define MUTEX_LOCK(x) pthread_mutex_lock(&(x))
-#define MUTEX_UNLOCK(x) pthread_mutex_unlock(&(x))
-#define THREAD_ID pthread_self()
+void check_essential_config() {
+    if (s3ext_accessid == "") {
+        ereport(ERROR, (0, errmsg("ERROR: access id is empty")));
+    }
 
-/* This array will store all of the mutexes available to OpenSSL. */
-static MUTEX_TYPE *mutex_buf = NULL;
+    if (s3ext_secret == "") {
+        ereport(ERROR, (0, errmsg("ERROR: secret is empty")));
+    }
 
-static void locking_function(int mode, int n, const char *file, int line) {
-    if (mode & CRYPTO_LOCK)
-        MUTEX_LOCK(mutex_buf[n]);
-    else
-        MUTEX_UNLOCK(mutex_buf[n]);
-}
-
-static unsigned long id_function(void) { return ((unsigned long)THREAD_ID); }
-
-int thread_setup(void) {
-    int i;
-
-    mutex_buf =
-        (pthread_mutex_t *)palloc(CRYPTO_num_locks() * sizeof(MUTEX_TYPE));
-    if (!mutex_buf) return 0;
-    for (i = 0; i < CRYPTO_num_locks(); i++) MUTEX_SETUP(mutex_buf[i]);
-    CRYPTO_set_id_callback(id_function);
-    CRYPTO_set_locking_callback(locking_function);
-    return 1;
-}
-
-int thread_cleanup(void) {
-    int i;
-
-    if (!mutex_buf) return 0;
-    CRYPTO_set_id_callback(NULL);
-    CRYPTO_set_locking_callback(NULL);
-    for (i = 0; i < CRYPTO_num_locks(); i++) MUTEX_CLEANUP(mutex_buf[i]);
-    pfree(mutex_buf);
-    mutex_buf = NULL;
-    return 1;
+    if ((s3ext_segnum == -1) || (s3ext_segid == -1)) {
+        ereport(ERROR, (0, errmsg("ERROR: segment id is invalid")));
+    }
 }
 
 /*
@@ -86,10 +53,7 @@ int thread_cleanup(void) {
  * invoked by GPDB, be careful with C++ exceptions.
  */
 Datum s3_import(PG_FUNCTION_ARGS) {
-    S3ExtBase *myData;
-    char *data;
-    int data_len;
-    size_t nread = 0;
+    S3Reader *s3reader = NULL;
 
     /* Must be called via the external table format manager */
     if (!CALLED_AS_EXTPROTOCOL(fcinfo))
@@ -97,96 +61,44 @@ Datum s3_import(PG_FUNCTION_ARGS) {
              "extprotocol_import: not called by external protocol manager");
 
     /* Get our internal description of the protocol */
-    myData = (S3ExtBase *)EXTPROTOCOL_GET_USER_CTX(fcinfo);
+    s3reader = (S3Reader *)EXTPROTOCOL_GET_USER_CTX(fcinfo);
 
+    /* last call. destroy reader */
     if (EXTPROTOCOL_IS_LAST_CALL(fcinfo)) {
-        if (myData) {
-            thread_cleanup();
-            if (!myData->Destroy()) {
-                ereport(ERROR, (0, errmsg("Failed to cleanup S3 extention")));
-            }
-            delete myData;
+        thread_cleanup();
+
+        if (!reader_cleanup(&s3reader)) {
+            ereport(ERROR, (0, errmsg("Failed to cleanup S3 extention")));
         }
-
-        /*
-         * Cleanup function for the XML library.
-         */
-        xmlCleanupParser();
-
         PG_RETURN_INT32(0);
     }
 
-    if (myData == NULL) {
-        /* first call. do any desired init */
-        curl_global_init(CURL_GLOBAL_ALL);
+    /* first call. do any desired init */
+    if (s3reader == NULL) {
+        const char *url_with_options = EXTPROTOCOL_GET_URL(fcinfo);
+
         thread_setup();
 
-        char *url_with_options = EXTPROTOCOL_GET_URL(fcinfo);
-        char *url = truncate_options(url_with_options);
-
-        char *config_path = get_opt_s3(url_with_options, "config");
-        if (!config_path) {
-            // no config path in url, use default value
-            // data_folder/gpseg0/s3/s3.conf
-            config_path = strdup("s3/s3.conf");
-        }
-
-        bool result = InitConfig(config_path, "");
-        if (!result) {
-            free(config_path);
-            ereport(ERROR, (0, errmsg("Can't find config file, please check")));
-        } else {
-            ClearConfig();
-            free(config_path);
-        }
-
-        InitLog();
-
-        if (s3ext_accessid == "") {
-            ereport(ERROR, (0, errmsg("ERROR: access id is empty")));
-        }
-
-        if (s3ext_secret == "") {
-            ereport(ERROR, (0, errmsg("ERROR: secret is empty")));
-        }
-
-        if ((s3ext_segnum == -1) || (s3ext_segid == -1)) {
-            ereport(ERROR, (0, errmsg("ERROR: segment id is invalid")));
-        }
-
-        myData = CreateExtWrapper(url);
-
-        if (!myData ||
-            !myData->Init(s3ext_segid, s3ext_segnum, s3ext_chunksize)) {
-            if (myData) delete myData;
+        s3reader = reader_init(url_with_options);
+        if (!s3reader) {
             ereport(ERROR, (0, errmsg("Failed to init S3 extension, segid = "
                                       "%d, segnum = %d, please check your "
                                       "configurations and net connection",
                                       s3ext_segid, s3ext_segnum)));
         }
 
-        EXTPROTOCOL_SET_USER_CTX(fcinfo, myData);
+        check_essential_config();
 
-        free(url);
+        EXTPROTOCOL_SET_USER_CTX(fcinfo, s3reader);
     }
 
-    /* =======================================================================
-     *                            DO THE IMPORT
-     * =======================================================================
-     */
-
-    data = EXTPROTOCOL_GET_DATABUF(fcinfo);
-    data_len = EXTPROTOCOL_GET_DATALEN(fcinfo);
-    uint64_t readlen = 0;
-    if (data_len > 0) {
-        readlen = data_len;
-        if (!myData->TransferData(data, readlen))
-            ereport(ERROR, (0, errmsg("s3_import: could not read data")));
-        nread = (size_t)readlen;
-        // S3DEBUG("read %d data from S3", nread);
+    char *data_buf = EXTPROTOCOL_GET_DATABUF(fcinfo);
+    int data_len = EXTPROTOCOL_GET_DATALEN(fcinfo);
+    if (!reader_transfer_data(s3reader, data_buf, data_len)) {
+        ereport(ERROR, (0, errmsg("s3_import: could not read data")));
     }
 
-    PG_RETURN_INT32((int)nread);
+    PG_RETURN_INT32(data_len);
 }
 
 /*
@@ -194,5 +106,3 @@ Datum s3_import(PG_FUNCTION_ARGS) {
  * invoked by GPDB, be careful with C++ exceptions.
  */
 Datum s3_export(PG_FUNCTION_ARGS) { PG_RETURN_INT32(0); }
-
-Datum s3_validate_urls(PG_FUNCTION_ARGS) { PG_RETURN_VOID(); }

--- a/gpAux/extensions/gps3ext/src/s3chkcfg.cpp
+++ b/gpAux/extensions/gps3ext/src/s3chkcfg.cpp
@@ -1,7 +1,3 @@
-#include <unistd.h>
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
-
 #include "s3chkcfg.h"
 
 volatile bool QueryCancelPending = false;
@@ -11,7 +7,6 @@ int main(int argc, char *argv[]) {
     int ret = 0;
 
     s3ext_logtype = STDERR_LOG;
-    s3ext_loglevel = EXT_ERROR;
 
     if (argc == 1) {
         print_usage(stderr);
@@ -68,7 +63,6 @@ bool read_config(const char *config) {
 
     ret = InitConfig(config, "default");
     s3ext_logtype = STDERR_LOG;
-    s3ext_loglevel = EXT_ERROR;
 
     return ret;
 }
@@ -89,7 +83,7 @@ uint8_t print_contents(ListBucketResult *r) {
     vector<BucketContent *>::iterator i;
 
     for (i = r->contents.begin(); i != r->contents.end(); i++) {
-        if (count > 8) {
+        if ((s3ext_loglevel <= EXT_WARNING) && count > 8) {
             printf("... ...\n");
             break;
         }
@@ -115,6 +109,8 @@ bool check_config(const char *url_with_options) {
         free(url_str);
         return false;
     }
+
+    curl_global_init(CURL_GLOBAL_ALL);
 
     S3Reader *wrapper = NULL;
     ListBucketResult *result = NULL;
@@ -177,8 +173,7 @@ bool s3_download(const char *url_with_options) {
         goto FAIL;
     }
 
-    s3ext_logtype = REMOTE_LOG;
-    s3ext_loglevel = EXT_ERROR;
+    s3ext_logtype = STDERR_LOG;
 
     wrapper = reader_init(url_with_options);
     if (!wrapper) {
@@ -208,7 +203,6 @@ bool s3_download(const char *url_with_options) {
     }
 
     free(data_buf);
-    // delete wrapper;
 
     return true;
 

--- a/gpAux/extensions/gps3ext/src/s3chkcfg.cpp
+++ b/gpAux/extensions/gps3ext/src/s3chkcfg.cpp
@@ -7,6 +7,7 @@ int main(int argc, char *argv[]) {
     int ret = 0;
 
     s3ext_logtype = STDERR_LOG;
+    s3ext_loglevel = EXT_ERROR;
 
     if (argc == 1) {
         print_usage(stderr);

--- a/gpAux/extensions/gps3ext/src/s3chkcfg.cpp
+++ b/gpAux/extensions/gps3ext/src/s3chkcfg.cpp
@@ -1,0 +1,225 @@
+#include <unistd.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
+#include "s3chkcfg.h"
+
+volatile bool QueryCancelPending = false;
+
+int main(int argc, char *argv[]) {
+    int opt = 0;
+    int ret = 0;
+
+    s3ext_logtype = STDERR_LOG;
+    s3ext_loglevel = EXT_ERROR;
+
+    if (argc == 1) {
+        print_usage(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    while ((opt = getopt(argc, argv, "c:d:ht")) != -1) {
+        switch (opt) {
+            case 'c':
+                ret = check_config(optarg);
+                break;
+            case 'd':
+                ret = s3_download(optarg);
+                break;
+            case 'h':
+                print_usage(stdout);
+                break;
+            case 't':
+                print_template();
+                break;
+            default:
+                print_usage(stderr);
+                exit(EXIT_FAILURE);
+        }
+    }
+
+    return ret;
+}
+
+void print_template() {
+    printf(
+        "[default]\n"
+        "secret = \"aws secret\"\n"
+        "accessid = \"aws access id\"\n"
+        "threadnum = 4\n"
+        "chunksize = 67108864\n"
+        "low_speed_limit = 10240\n"
+        "low_speed_time = 60\n"
+        "encryption = true\n");
+}
+
+void print_usage(FILE *stream) {
+    fprintf(stream,
+            "Usage: s3chkcfg -c \"s3://endpoint/bucket/prefix "
+            "config=path_to_config_file\", to check the configuration.\n"
+            "       s3chkcfg -d \"s3://endpoint/bucket/prefix "
+            "config=path_to_config_file\", to download and output to stdout.\n"
+            "       s3chkcfg -t, to show the config template.\n"
+            "       s3chkcfg -h, to show this help.\n");
+}
+
+bool read_config(const char *config) {
+    bool ret = false;
+
+    ret = InitConfig(config, "default");
+    s3ext_logtype = STDERR_LOG;
+    s3ext_loglevel = EXT_ERROR;
+
+    return ret;
+}
+
+ListBucketResult *list_bucket(S3Reader *wrapper) {
+    S3Credential g_cred = {s3ext_accessid, s3ext_secret};
+
+    ListBucketResult *r =
+        ListBucket("https", wrapper->get_region(), wrapper->get_bucket(),
+                   wrapper->get_prefix(), g_cred);
+
+    return r;
+}
+
+uint8_t print_contents(ListBucketResult *r) {
+    char urlbuf[256];
+    uint8_t count = 0;
+    vector<BucketContent *>::iterator i;
+
+    for (i = r->contents.begin(); i != r->contents.end(); i++) {
+        if (count > 8) {
+            printf("... ...\n");
+            break;
+        }
+
+        BucketContent *p = *i;
+        snprintf(urlbuf, 256, "%s", p->Key().c_str());
+        printf("File: %s, Size: %" PRIu64 "\n", urlbuf, p->Size());
+
+        count++;
+    }
+
+    return count;
+}
+
+bool check_config(const char *url_with_options) {
+    char *url_str = truncate_options(url_with_options);
+    if (!url_str) {
+        return false;
+    }
+
+    char *config_path = get_opt_s3(url_with_options, "config");
+    if (!config_path) {
+        free(url_str);
+        return false;
+    }
+
+    S3Reader *wrapper = NULL;
+    ListBucketResult *result = NULL;
+    bool ret = false;
+
+    if (!read_config(config_path)) {
+        goto FAIL;
+    }
+
+    wrapper = new S3Reader(url_str);
+    if (!wrapper) {
+        fprintf(stderr, "Failed to allocate wrapper\n");
+        goto FAIL;
+    }
+
+    if (!wrapper->ValidateURL()) {
+        fprintf(stderr, "Failed: URL is not valid.\n");
+        goto FAIL;
+    }
+
+    result = list_bucket(wrapper);
+    if (!result) {
+        goto FAIL;
+    } else {
+        if (print_contents(result)) {
+            printf("Yea! Your configuration works well.\n");
+        } else {
+            printf(
+                "Your configuration works well, however there is no file "
+                "matching your prefix.\n");
+        }
+        delete result;
+    }
+
+    ret = true;
+
+FAIL:
+    free(url_str);
+    free(config_path);
+
+    if (wrapper) {
+        delete wrapper;
+    }
+
+    return ret;
+}
+
+bool s3_download(const char *url_with_options) {
+    if (!url_with_options) {
+        return false;
+    }
+
+    S3Reader *wrapper = NULL;
+    int data_len = BUF_SIZE;
+
+    thread_setup();
+
+    char *data_buf = (char *)malloc(BUF_SIZE);
+    if (!data_buf) {
+        goto FAIL;
+    }
+
+    s3ext_logtype = REMOTE_LOG;
+    s3ext_loglevel = EXT_ERROR;
+
+    wrapper = reader_init(url_with_options);
+    if (!wrapper) {
+        fprintf(stderr, "Failed to init wrapper\n");
+        goto FAIL;
+    }
+
+    s3ext_segid = 0;
+    s3ext_segnum = 1;
+
+    do {
+        data_len = BUF_SIZE;
+
+        if (!reader_transfer_data(wrapper, data_buf, data_len)) {
+            fprintf(stderr, "Failed to read data\n");
+            goto FAIL;
+        }
+
+        fwrite(data_buf, data_len, 1, stdout);
+    } while (data_len);
+
+    thread_cleanup();
+
+    if (!reader_cleanup(&wrapper)) {
+        fprintf(stderr, "Failed to cleanup wrapper\n");
+        goto FAIL;
+    }
+
+    free(data_buf);
+    // delete wrapper;
+
+    return true;
+
+FAIL:
+    if (data_buf) {
+        free(data_buf);
+    }
+
+    if (wrapper) {
+        delete wrapper;
+    }
+
+    return false;
+}

--- a/gpAux/extensions/gps3ext/src/s3chkcfg.h
+++ b/gpAux/extensions/gps3ext/src/s3chkcfg.h
@@ -1,6 +1,10 @@
 #ifndef __S3_CHK_CFG__
 #define __S3_CHK_CFG__
 
+#include <unistd.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
 #include "s3common.h"
 #include "s3conf.h"
 #include "s3downloader.h"

--- a/gpAux/extensions/gps3ext/src/s3chkcfg.h
+++ b/gpAux/extensions/gps3ext/src/s3chkcfg.h
@@ -1,0 +1,30 @@
+#ifndef __S3_CHK_CFG__
+#define __S3_CHK_CFG__
+
+#include "s3common.h"
+#include "s3conf.h"
+#include "s3downloader.h"
+#include "s3log.h"
+#include "s3wrapper.h"
+
+#define BUF_SIZE 64 * 1024
+
+extern volatile bool QueryCancelPending;
+
+extern S3Reader *wrapper;
+
+void print_template();
+
+void print_usage(FILE *stream);
+
+bool read_config(const char *config);
+
+ListBucketResult *list_bucket(S3Reader *wrapper);
+
+uint8_t print_contents(ListBucketResult *r);
+
+bool check_config(const char *url_with_options);
+
+bool s3_download(const char *url_with_options);
+
+#endif

--- a/gpAux/extensions/gps3ext/src/s3common.h
+++ b/gpAux/extensions/gps3ext/src/s3common.h
@@ -10,6 +10,7 @@
 
 #include "http_parser.h"
 #include "s3log.h"
+
 using std::string;
 
 struct S3Credential {
@@ -35,13 +36,16 @@ enum Method { GET, PUT, POST, DELETE, HEAD };
 
 class HeaderContent {
    public:
-    HeaderContent(){};
-    ~HeaderContent(){};
+    HeaderContent();
+    ~HeaderContent();
     bool Add(HeaderField f, const string& value);
     const char* Get(HeaderField f);
+    void CreateList();
     struct curl_slist* GetList();
+    void FreeList();
 
    private:
+    struct curl_slist* header_list;
     std::map<HeaderField, string> fields;
 };
 
@@ -80,5 +84,9 @@ uint64_t ParserCallback(void* contents, uint64_t size, uint64_t nmemb,
 char* get_opt_s3(const char* url, const char* key);
 
 char* truncate_options(const char* url_with_options);
+
+int thread_setup(void);
+
+int thread_cleanup(void);
 
 #endif  // __S3_COMMON_H__

--- a/gpAux/extensions/gps3ext/src/s3common_test.cpp
+++ b/gpAux/extensions/gps3ext/src/s3common_test.cpp
@@ -52,11 +52,10 @@ TEST(Common, HeaderContent) {
     }
 
     if (h) {
+        h->CreateList();
         curl_slist *l = h->GetList();
         ASSERT_NE((void *)NULL, l);
-        if (l) {
-            curl_slist_free_all(l);
-        }
+        h->FreeList();
     }
 
     if (h) delete h;

--- a/gpAux/extensions/gps3ext/src/s3conf.cpp
+++ b/gpAux/extensions/gps3ext/src/s3conf.cpp
@@ -65,6 +65,8 @@ bool InitConfig(const string& conf_path,
         if (conf_path == "") {
 #ifndef DEBUG_S3
             write_log("Config file is not specified\n");
+#else
+            S3ERROR("Config file is not specified");
 #endif
             return false;
         }
@@ -75,6 +77,8 @@ bool InitConfig(const string& conf_path,
         if (!s3cfg || !s3cfg->Handle()) {
 #ifndef DEBUG_S3
             write_log("Failed to parse config file\n");
+#else
+            S3ERROR("Failed to parse config file");
 #endif
             if (s3cfg) {
                 delete s3cfg;
@@ -86,11 +90,24 @@ bool InitConfig(const string& conf_path,
         Config* cfg = s3cfg;
         bool ret = false;
         string content;
-        content = cfg->Get("default", "loglevel", "INFO");
+
+#ifdef S3_CHK_CFG
+        if (s3ext_loglevel == -1) {
+            content = cfg->Get("default", "loglevel", "WARNING");
+            s3ext_loglevel = getLogLevel(content.c_str());
+        }
+
+        if (s3ext_logtype == -1) {
+            content = cfg->Get("default", "logtype", "INTERNAL");
+            s3ext_logtype = getLogType(content.c_str());
+        }
+#else
+        content = cfg->Get("default", "loglevel", "WARNING");
         s3ext_loglevel = getLogLevel(content.c_str());
 
         content = cfg->Get("default", "logtype", "INTERNAL");
         s3ext_logtype = getLogType(content.c_str());
+#endif
 
         s3ext_accessid = cfg->Get("default", "accessid", "");
         s3ext_secret = cfg->Get("default", "secret", "");

--- a/gpAux/extensions/gps3ext/src/s3conf.cpp
+++ b/gpAux/extensions/gps3ext/src/s3conf.cpp
@@ -76,9 +76,9 @@ bool InitConfig(const string& conf_path,
         s3cfg = new Config(conf_path);
         if (!s3cfg || !s3cfg->Handle()) {
 #ifndef DEBUG_S3
-            write_log("Failed to parse config file, or it doesn't exist\n");
+            write_log("Failed to parse config file \"%s\", or it doesn't exist\n", conf_path.c_str());
 #else
-            S3ERROR("Failed to parse config file, or it doesn't exist");
+            S3ERROR("Failed to parse config file \"%s\", or it doesn't exist", conf_path.c_str());
 #endif
             if (s3cfg) {
                 delete s3cfg;

--- a/gpAux/extensions/gps3ext/src/s3conf.cpp
+++ b/gpAux/extensions/gps3ext/src/s3conf.cpp
@@ -76,9 +76,9 @@ bool InitConfig(const string& conf_path,
         s3cfg = new Config(conf_path);
         if (!s3cfg || !s3cfg->Handle()) {
 #ifndef DEBUG_S3
-            write_log("Failed to parse config file\n");
+            write_log("Failed to parse config file, or it doesn't exist\n");
 #else
-            S3ERROR("Failed to parse config file");
+            S3ERROR("Failed to parse config file, or it doesn't exist");
 #endif
             if (s3cfg) {
                 delete s3cfg;
@@ -91,20 +91,17 @@ bool InitConfig(const string& conf_path,
         bool ret = false;
         string content;
 
-#ifdef S3_CHK_CFG
         if (s3ext_loglevel == -1) {
             content = cfg->Get("default", "loglevel", "WARNING");
             s3ext_loglevel = getLogLevel(content.c_str());
         }
 
+#ifdef S3_CHK_CFG
         if (s3ext_logtype == -1) {
             content = cfg->Get("default", "logtype", "INTERNAL");
             s3ext_logtype = getLogType(content.c_str());
         }
 #else
-        content = cfg->Get("default", "loglevel", "WARNING");
-        s3ext_loglevel = getLogLevel(content.c_str());
-
         content = cfg->Get("default", "logtype", "INTERNAL");
         s3ext_logtype = getLogType(content.c_str());
 #endif

--- a/gpAux/extensions/gps3ext/src/s3downloader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3downloader.cpp
@@ -84,6 +84,9 @@ bool BlockingBuffer::Init() {
 }
 
 // ret < len means EMPTY
+// that's why it checks if left_data_lentgh is larger than *or equal to* len
+// below[1], provides a chance ret is 0, which is smaller than len. Otherwise,
+// other funcs won't know when to read next buffer.
 uint64_t BlockingBuffer::Read(char *buf, uint64_t len) {
     // QueryCancelPending stops s3_import(), this check is not needed if
     // s3_import() every time calls BlockingBuffer->Read() only once,
@@ -105,7 +108,7 @@ uint64_t BlockingBuffer::Read(char *buf, uint64_t len) {
     uint64_t length_to_read = std::min(len, left_data_length);
 
     memcpy(buf, this->bufferdata + this->readpos, length_to_read);
-    if (left_data_length >= len) {
+    if (left_data_length >= len) { // [1]
         this->readpos += len;  // not empty
     } else {                   // empty, reset everything
         this->readpos = 0;
@@ -318,7 +321,7 @@ bool Downloader::plain_get(char *data, uint64_t &len) {
 
 RETRY:
     // confirm there is no more available data, done with this file
-    if (this->readlen == filelen) {
+    if (this->readlen >= filelen) {
         len = 0;
         return true;
     }
@@ -331,11 +334,14 @@ RETRY:
             memcpy(data, this->magic_bytes + this->readlen, len);
             tmplen = len;
         } else {
-            memcpy(data, this->magic_bytes + this->readlen,
-                   this->magic_bytes_num - this->readlen);
-            tmplen = this->magic_bytes_num - this->readlen +
-                     buf->Read(data + this->magic_bytes_num - this->readlen,
-                               this->readlen + len - this->magic_bytes_num);
+            uint64_t rest_magic_num = this->magic_bytes_num - this->readlen;
+            memcpy(data, this->magic_bytes + this->readlen, rest_magic_num);
+            tmplen = rest_magic_num;
+
+            // whether we need to buf->Read()
+            if (this->magic_bytes_num < filelen) {
+                tmplen += buf->Read(data + rest_magic_num, len - rest_magic_num);
+            }
         }
     } else {
         tmplen = buf->Read(data, len);
@@ -385,7 +391,7 @@ RETRY:
     }
 
     // no more available data to read, decompress or copy, done with this file
-    if (this->readlen == filelen && !(zinfo->have_out - zinfo->done_out) &&
+    if ((this->readlen >= filelen) && !(zinfo->have_out - zinfo->done_out) &&
         !strm->avail_in) {
         if (zinfo->inited) {
             inflateEnd(strm);
@@ -457,14 +463,15 @@ RETRY:
         // from magic_bytes, or buf->Read(), or both
         if (!zinfo->have_out) {
             if (this->readlen < this->magic_bytes_num) {
-                memcpy(zinfo->in, this->magic_bytes + this->readlen,
-                       this->magic_bytes_num - this->readlen);
-                strm->avail_in =
-                    this->magic_bytes_num - this->readlen +
-                    buf->Read((char *)zinfo->in + this->magic_bytes_num -
-                                  this->readlen,
-                              S3_ZIP_CHUNKSIZE - this->magic_bytes_num +
-                                  this->readlen);
+                uint64_t rest_magic_num = this->magic_bytes_num - this->readlen;
+                memcpy(zinfo->in, this->magic_bytes + this->readlen, rest_magic_num);
+                strm->avail_in = rest_magic_num;
+
+                // whether we need to buf->Read()
+                if (this->magic_bytes_num < filelen) {
+                    strm->avail_in += buf->Read((char *)zinfo->in + rest_magic_num,
+                                                S3_ZIP_CHUNKSIZE - rest_magic_num);
+                }
             } else {
                 strm->avail_in = buf->Read((char *)zinfo->in, S3_ZIP_CHUNKSIZE);
             }
@@ -481,7 +488,7 @@ RETRY:
 
             // done with *reading* this compressed file, still need to confirm
             // it's all decompressed and transferred/get()
-            if (strm->avail_in == 0) {
+            if (strm->avail_in < S3_ZIP_CHUNKSIZE) {
                 this->chunkcount++;
                 goto RETRY;
             }
@@ -493,16 +500,27 @@ RETRY:
 
 void Downloader::destroy() {
     for (int i = 0; i < this->num; i++) {
-        if (this->threads && this->threads[i]) pthread_cancel(this->threads[i]);
+        if (this->threads && this->threads[i]) {
+            pthread_cancel(this->threads[i]);
+        }
     }
 
     for (int i = 0; i < this->num; i++) {
-        if (this->threads && this->threads[i])
+        if (this->threads && this->threads[i]) {
             pthread_join(this->threads[i], NULL);
-        if (this->buffers && this->buffers[i]) delete this->buffers[i];
+            this->threads[i] = 0;
+        }
+
+        if (this->buffers && this->buffers[i]) {
+            delete this->buffers[i];
+            this->buffers[i] = NULL;
+        }
     }
 
-    if (this->o) delete this->o;
+    if (this->o) {
+        delete this->o;
+        this->o = NULL;
+    }
 }
 
 Downloader::~Downloader() {
@@ -620,6 +638,8 @@ uint64_t HTTPFetcher::fetchdata(uint64_t offset, char *data, uint64_t len) {
             continue;
         }
 
+        this->headers.FreeList();
+        this->headers.CreateList();
         chunk = this->headers.GetList();
         if (!chunk) {
             S3ERROR("Failed to construct curl header");
@@ -665,9 +685,7 @@ uint64_t HTTPFetcher::fetchdata(uint64_t offset, char *data, uint64_t len) {
         this->curl = curl_handle;
     }
 
-    if (chunk) {
-        curl_slist_free_all(chunk);
-    }
+    this->headers.FreeList();
 
     return bi.len;
 }
@@ -751,6 +769,7 @@ xmlParserCtxtPtr DoGetXML(const string &region, const string &url,
         return NULL;
     }
 
+    header->CreateList();
     struct curl_slist *chunk = header->GetList();
 
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
@@ -772,9 +791,12 @@ xmlParserCtxtPtr DoGetXML(const string &region, const string &url,
             S3ERROR("XML is downloaded but failed to be parsed");
         }
     }
-    curl_slist_free_all(chunk);
+
     curl_easy_cleanup(curl);
+
+    header->FreeList();
     delete header;
+
     return xml.ctxt;
 }
 
@@ -928,13 +950,20 @@ ListBucketResult *ListBucket(const string &schema, const string &region,
 
         xmlNodePtr cur = root_element->xmlChildrenNode;
         while (cur != NULL) {
+#ifdef S3_CHK_CFG
+            if (!xmlStrcmp(cur->name, (const xmlChar *)"Message")) {
+#else
             if (!xmlStrcmp(cur->name, (const xmlChar *)"Code")) {
+#endif
                 char *content = (char *)xmlNodeGetContent(cur);
                 if (content) {
-                    S3ERROR("Server returns error \"%s\"", content);
+                    S3ERROR("Amazon S3 returns error \"%s\"", content);
                     xmlFree(content);
                 }
-                break;
+                delete result;
+                xmlFreeParserCtxt(xmlcontext);
+                xmlFreeDoc(doc);
+                return NULL;
             }
 
             cur = cur->next;

--- a/gpAux/extensions/gps3ext/src/s3downloader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3downloader.cpp
@@ -950,11 +950,7 @@ ListBucketResult *ListBucket(const string &schema, const string &region,
 
         xmlNodePtr cur = root_element->xmlChildrenNode;
         while (cur != NULL) {
-#ifdef S3_CHK_CFG
             if (!xmlStrcmp(cur->name, (const xmlChar *)"Message")) {
-#else
-            if (!xmlStrcmp(cur->name, (const xmlChar *)"Code")) {
-#endif
                 char *content = (char *)xmlNodeGetContent(cur);
                 if (content) {
                     S3ERROR("Amazon S3 returns error \"%s\"", content);

--- a/gpAux/extensions/gps3ext/src/s3downloader.h
+++ b/gpAux/extensions/gps3ext/src/s3downloader.h
@@ -112,7 +112,7 @@ class Downloader {
     uint64_t readlen;
 
     unsigned char magic_bytes[4];
-    uint8_t magic_bytes_num;
+    uint64_t magic_bytes_num;
     compression_type_t compression;
     bool set_compression();
 

--- a/gpAux/extensions/gps3ext/src/s3log.h
+++ b/gpAux/extensions/gps3ext/src/s3log.h
@@ -43,9 +43,15 @@ LOGLEVEL getLogLevel(const char* v);
     if (EXT_WARNING <= s3ext_loglevel) \
     PRINTFUNCTION(EXT_WARNING, LOG_FMT message NEWLINE, LOG_ARGS("W"), ##args)
 
+#ifdef S3_CHK_CFG
+#define S3ERROR(message, args...)    \
+    if (EXT_ERROR <= s3ext_loglevel) \
+    PRINTFUNCTION(EXT_ERROR, "%s " message NEWLINE, "Failed:", ##args)
+#else
 #define S3ERROR(message, args...)    \
     if (EXT_ERROR <= s3ext_loglevel) \
     PRINTFUNCTION(EXT_ERROR, LOG_FMT message NEWLINE, LOG_ARGS("E"), ##args)
+#endif
 
 void InitLog();
 

--- a/gpAux/extensions/gps3ext/src/s3uploader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3uploader.cpp
@@ -213,6 +213,7 @@ const char *GetUploadId(const char *host, const char *bucket,
         return NULL;
     }
 
+    header->CreateList();
     struct curl_slist *chunk = header->GetList();
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
 
@@ -223,7 +224,7 @@ const char *GetUploadId(const char *host, const char *bucket,
                 curl_easy_strerror(res));
 
     xmlParseChunk(xml.ctxt, "", 0, 1);
-    curl_slist_free_all(chunk);
+    header->FreeList();
     curl_easy_cleanup(curl);
 
     if (!xml.ctxt) {
@@ -248,6 +249,7 @@ const char *GetUploadId(const char *host, const char *bucket,
     xmlDocPtr doc = xml.ctxt->myDoc;
     xmlFreeParserCtxt(xml.ctxt);
     xmlFreeDoc(doc);
+    delete header;
 
     return upload_id;
 }
@@ -335,6 +337,7 @@ const char *PartPutS3Object(const char *host, const char *bucket,
         return NULL;
     }
 
+    header->CreateList();
     struct curl_slist *chunk = header->GetList();
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
 
@@ -371,8 +374,10 @@ const char *PartPutS3Object(const char *host, const char *bucket,
     const char *etag = etag_to_end.substr(0, etag_len).c_str();
 
     if (etag) {
-        curl_slist_free_all(chunk);
+        header->FreeList();
+        delete header;
         curl_easy_cleanup(curl);
+
         return strdup(etag);
     }
 
@@ -410,8 +415,10 @@ const char *PartPutS3Object(const char *host, const char *bucket,
     xmlFreeParserCtxt(xml.ctxt);
     xmlFreeDoc(doc);
 
-    curl_slist_free_all(chunk);
     curl_easy_cleanup(curl);
+
+    header->FreeList();
+    delete header;
 
     return NULL;
 }
@@ -519,6 +526,7 @@ bool CompleteMultiPutS3(const char *host, const char *bucket,
         return false;
     }
 
+    header->CreateList();
     struct curl_slist *chunk = header->GetList();
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
 
@@ -573,7 +581,7 @@ bool CompleteMultiPutS3(const char *host, const char *bucket,
         std::cout << "Error: " << response_code << std::endl;
     }
 
-    curl_slist_free_all(chunk);
+    delete header;
     curl_easy_cleanup(curl);
     free(body_data);
 

--- a/gpAux/extensions/gps3ext/src/s3wrapper.cpp
+++ b/gpAux/extensions/gps3ext/src/s3wrapper.cpp
@@ -86,6 +86,8 @@ bool S3Reader::Init(int segid, int segnum, int chunksize) {
                 S3INFO("Keylist of bucket is empty");
                 if (initretry) {
                     S3INFO("Retry listing bucket");
+                    delete this->keylist;
+                    this->keylist = NULL;
                     continue;
                 } else {
                     S3ERROR("Quit initialization because keylist is empty");
@@ -194,10 +196,12 @@ bool S3Reader::Destroy() {
         if (this->filedownloader) {
             this->filedownloader->destroy();
             delete this->filedownloader;
+            this->filedownloader = NULL;
         }
 
         if (this->keylist) {
             delete this->keylist;
+            this->keylist = NULL;
         }
     } catch (...) {
         S3ERROR("Caught an exception, aborting");
@@ -211,8 +215,8 @@ bool S3ExtBase::ValidateURL() {
     // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
     const char *awsdomain = ".amazonaws.com";
-    unsigned int ibegin = 0;
-    unsigned int iend = url.find("://");
+    size_t ibegin = 0;
+    size_t iend = url.find("://");
     if (iend == string::npos) {  // Error
         return false;
     }
@@ -268,3 +272,112 @@ bool S3Protocol_t::Write(char *data, size_t &len) {
     return true;
 }
 */
+
+// invoked by s3_import(), need to be exception safe
+S3Reader *reader_init(const char *url_with_options) {
+    try {
+        if (!url_with_options) {
+            return NULL;
+        }
+
+        /* first call. do any desired init */
+        curl_global_init(CURL_GLOBAL_ALL);
+
+        char *url = truncate_options(url_with_options);
+        if (!url) {
+            return NULL;
+        }
+
+        char *config_path = get_opt_s3(url_with_options, "config");
+        if (!config_path) {
+            // no config path in url, use default value
+            // data_folder/gpseg0/s3/s3.conf
+            config_path = strdup("s3/s3.conf");
+        }
+
+        bool result = InitConfig(config_path, "");
+        if (!result) {
+            free(url);
+            free(config_path);
+            return NULL;
+        } else {
+            ClearConfig();
+            free(config_path);
+        }
+
+        InitLog();
+
+        S3Reader *reader = (S3Reader *)CreateExtWrapper(url);
+
+        free(url);
+
+        if (!reader) {
+            return NULL;
+        }
+
+        if (!reader->Init(s3ext_segid, s3ext_segnum, s3ext_chunksize)) {
+            reader->Destroy();
+            delete reader;
+            return NULL;
+        }
+
+        return reader;
+    } catch (...) {
+        S3ERROR("Caught an exception, aborting");
+        return NULL;
+    }
+}
+
+// invoked by s3_import(), need to be exception safe
+bool reader_transfer_data(S3Reader *reader, char *data_buf, int &data_len) {
+    try {
+        if (!reader || !data_buf || (data_len < 0)) {
+            return false;
+        }
+
+        if (data_len == 0) {
+            return true;
+        }
+
+        uint64_t read_len = data_len;
+        if (!reader->TransferData(data_buf, read_len)) {
+            return false;
+        }
+
+        // sure read_len <= data_len here, hence truncation will never happen
+        data_len = (int)read_len;
+    } catch (...) {
+        S3ERROR("Caught an exception, aborting");
+        return false;
+    }
+
+    return true;
+}
+
+// invoked by s3_import(), need to be exception safe
+bool reader_cleanup(S3Reader **reader) {
+    try {
+        if (*reader) {
+            if (!(*reader)->Destroy()) {
+                delete *reader;
+                *reader = NULL;
+                return false;
+            }
+
+            delete *reader;
+            *reader = NULL;
+        } else {
+            return false;
+        }
+
+        /*
+         * Cleanup function for the XML library.
+         */
+        xmlCleanupParser();
+    } catch (...) {
+        S3ERROR("Caught an exception, aborting");
+        return false;
+    }
+
+    return true;
+}

--- a/gpAux/extensions/gps3ext/src/s3wrapper.cpp
+++ b/gpAux/extensions/gps3ext/src/s3wrapper.cpp
@@ -280,7 +280,6 @@ S3Reader *reader_init(const char *url_with_options) {
             return NULL;
         }
 
-        /* first call. do any desired init */
         curl_global_init(CURL_GLOBAL_ALL);
 
         char *url = truncate_options(url_with_options);

--- a/gpAux/extensions/gps3ext/src/s3wrapper.h
+++ b/gpAux/extensions/gps3ext/src/s3wrapper.h
@@ -18,15 +18,17 @@ class S3ExtBase {
     virtual bool ValidateURL();
 
     string get_region() { return this->region; }
+    string get_bucket() { return this->bucket; }
+    string get_prefix() { return this->prefix; }
 
    protected:
     S3Credential cred;
 
     string url;
     string schema;
+    string region;
     string bucket;
     string prefix;
-    string region;
 
     int segid;
     int segnum;
@@ -56,5 +58,11 @@ class S3Reader : public S3ExtBase {
 class S3Writer : public S3ExtBase {};
 
 extern "C" S3ExtBase* CreateExtWrapper(const char* url);
+
+S3Reader* reader_init(const char* url_with_options);
+
+bool reader_transfer_data(S3Reader* reader, char* data_buf, int& data_len);
+
+bool reader_cleanup(S3Reader** reader);
 
 #endif


### PR DESCRIPTION
Usage: s3chkcfg -c "s3://endpoint/bucket/prefix config=path_to_config_file", to check the configuration.
       s3chkcfg -d "s3://endpoint/bucket/prefix config=path_to_config_file", to download and output to stdout.
       s3chkcfg -t, to show the config template.
       s3chkcfg -h, to show this help.

Also did refactoring to reuse functions common with s3ext module.