### PR TITLE
s3ext: complete warnings and set returning values

### DIFF
--- a/gpAux/extensions/gps3ext/src/s3chkcfg.cpp
+++ b/gpAux/extensions/gps3ext/src/s3chkcfg.cpp
@@ -32,9 +32,17 @@ int main(int argc, char *argv[]) {
                 print_usage(stderr);
                 exit(EXIT_FAILURE);
         }
+
+        break;
     }
 
-    return ret;
+    if (!ret) {
+        fprintf(stderr, "Failed. Please check the arguments.\n\n");
+        print_usage(stderr);
+        exit(EXIT_FAILURE);
+    } else {
+        exit(EXIT_SUCCESS);
+    }
 }
 
 void print_template() {


### PR DESCRIPTION
Display better error messages and quit with proper exit code.