### PR TITLE
Modernize and split out lookup code from autoconf

### DIFF
--- a/config/c-library.m4
+++ b/config/c-library.m4
@@ -325,28 +325,3 @@ if test "$pgac_cv_type_locale_t" = 'yes (in xlocale.h)'; then
   AC_DEFINE(LOCALE_T_IN_XLOCALE, 1,
             [Define to 1 if `locale_t' requires <xlocale.h>.])
 fi])])# PGAC_HEADER_XLOCALE
-
-# backport from Autoconf 2.61a
-# http://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commitdiff;h=f0c325537a22105536ac8c4e88656e50f9946486
-
-# AC_FUNC_FSEEKO
-# --------------
-AN_FUNCTION([ftello], [AC_FUNC_FSEEKO])
-AN_FUNCTION([fseeko], [AC_FUNC_FSEEKO])
-AC_DEFUN([AC_FUNC_FSEEKO],
-[_AC_SYS_LARGEFILE_MACRO_VALUE(_LARGEFILE_SOURCE, 1,
-   [ac_cv_sys_largefile_source],
-   [Define to 1 to make fseeko visible on some hosts (e.g. glibc 2.2).],
-   [[#include <sys/types.h> /* for off_t */
-     #include <stdio.h>]],
-   [[int (*fp) (FILE *, off_t, int) = fseeko;
-     return fseeko (stdin, 0, 0) && fp (stdin, 0, 0);]])
-
-# We used to try defining _XOPEN_SOURCE=500 too, to work around a bug
-# in glibc 2.1.3, but that breaks too many other things.
-# If you want fseeko and ftello with glibc, upgrade to a fixed glibc.
-if test $ac_cv_sys_largefile_source != unknown; then
-  AC_DEFINE(HAVE_FSEEKO, 1,
-    [Define to 1 if fseeko (and presumably ftello) exists and is declared.])
-fi
-])# AC_FUNC_FSEEKO

--- a/config/general.m4
+++ b/config/general.m4
@@ -69,22 +69,6 @@ AC_ARG_WITH([$2], [$3], [
 )
 ])# PGAC_ARG
 
-# PGAC_ARG_CHECK()
-# ----------------
-# Checks if the user passed any --with/without/enable/disable
-# arguments that were not defined. Just prints out a warning message,
-# so this should be called near the end, so the user will see it.
-
-AC_DEFUN([PGAC_ARG_CHECK],
-[for pgac_var in `set | sed 's/=.*//' | $EGREP 'with_|enable_'`; do
-  for pgac_arg in $pgac_args with_gnu_ld; do
-    if test "$pgac_var" = "$pgac_arg"; then
-      continue 2
-    fi
-  done
-  pgac_txt=`echo $pgac_var | sed 's/_/-/g'`
-  AC_MSG_WARN([option ignored: --$pgac_txt])
-done])# PGAC_ARG_CHECK
 
 # PGAC_ARG_BOOL(TYPE, NAME, DEFAULT, HELP-STRING, 
 #               [ACTION-IF-YES], [ACTION-IF-NO])

--- a/config/programs.m4
+++ b/config/programs.m4
@@ -225,3 +225,57 @@ AC_DEFUN([PGAC_CHECK_STRIP],
   AC_SUBST(STRIP_STATIC_LIB)
   AC_SUBST(STRIP_SHARED_LIB)
 ])# PGAC_CHECK_STRIP
+
+
+# GPAC_PATH_CMAKE
+# ---------------
+# Check for the 'cmake' program which is required for compiling
+# Greenplum with Code Generation
+AC_DEFUN([GPAC_PATH_CMAKE],
+[
+if test -z "$CMAKE"; then
+  AC_PATH_PROGS(CMAKE, cmake)
+fi
+
+if test -n "$CMAKE"; then
+  gpac_cmake_version=`$CMAKE --version 2>/dev/null | sed q`
+  if test -z "$gpac_cmake_version"; then
+    AC_MSG_ERROR([cmake is required for codegen, unable to identify version])
+  fi
+  AC_MSG_NOTICE([using $gpac_cmake_version])
+else
+  AC_MSG_ERROR([cmake is required for codegen, unable to find binary])
+fi
+]) # GPAC_PATH_CMAKE
+
+
+# GPAC_PATH_APR_1_CONFIG
+# ----------------------
+# Check for apr-1-config, used by gpfdist
+AC_DEFUN([GPAC_PATH_APR_1_CONFIG],
+[
+if test x"$with_apr_config" != x; then
+  APR_1_CONFIG=$with_apr_config
+fi
+if test -z "$APR_1_CONFIG"; then
+  AC_PATH_PROGS(APR_1_CONFIG, apr-1-config)
+fi
+
+if test -n "$APR_1_CONFIG"; then
+  gpac_apr_1_config_version=`$APR_1_CONFIG --version 2>/dev/null | sed q`
+  if test -z "$gpac_apr_1_config_version"; then
+    AC_MSG_ERROR([apr-1-config is required for gpfdist, unable to identify version])
+  fi
+  AC_MSG_NOTICE([using apr-1-config $gpac_apr_1_config_version])
+  apr_includes=`"$APR_1_CONFIG" --includes`
+  apr_link_ld_libs=`"$APR_1_CONFIG" --link-ld --libs`
+  apr_cflags=`"$APR_1_CONFIG" --cflags`
+  apr_cppflags=`"$APR_1_CONFIG" --cppflags`
+  AC_SUBST(apr_includes)
+  AC_SUBST(apr_link_ld_libs)
+  AC_SUBST(apr_cflags)
+  AC_SUBST(apr_cppflags)
+else
+  AC_MSG_ERROR([apr-1-config is required for gpfdist, unable to find binary])
+fi
+]) # GPAC_PATH_APR_1_CONFIG

--- a/configure
+++ b/configure
@@ -658,6 +658,11 @@ CURL_LIBS
 CURL_CFLAGS
 CURL_CONFIG
 have_yaml
+apr_cppflags
+apr_cflags
+apr_link_ld_libs
+apr_includes
+APR_1_CONFIG
 ADDON_DIR
 ZIC
 python_additional_libs
@@ -698,7 +703,6 @@ ELF_SYS
 EGREP
 GREP
 with_apr_config
-APR_1_CONFIG
 with_libcurl
 with_rt
 with_zlib
@@ -1502,7 +1506,7 @@ Optional Features:
   --enable-ntuplestore    enable debug_ntuplestore (for debugging)
   --enable-testutils      enable testing utilities
   --enable-orca           enable ORCA optimizer
-  --enable-codegen       enable code generation
+  --enable-codegen        enable code generation
   --enable-snmp           enable snmp for MIB and alerts via TRAP/INFORM
   --enable-connectemc     enable connect emc support
   --enable-ddboost        enable DD Boost support
@@ -1522,7 +1526,7 @@ Optional Packages:
   --with-libraries=DIRS   look for additional libraries in DIRS
   --with-libs=DIRS        alternative spelling of --with-libraries
   --with-pgport=PORTNUM   change default port number [5432]
-  --with-codegen-prefix   semicolon separated prefix search path for LLVM and Clang
+  --with-codegen-prefix="PATH;PATH"  semicolon separated prefix search path for LLVM and Clang
   --with-tcl              build Tcl modules (PL/Tcl)
   --with-tclconfig=DIR    tclConfig.sh is in DIR
   --with-perl             build Perl modules (PL/Perl)
@@ -1541,7 +1545,7 @@ Optional Packages:
   --without-zlib          do not use Zlib
   --without-rt            do not use Realtime Library
   --without-libcurl       do not use libcurl
-  --with-apr-config=PATH  path to apr-1-config
+  --with-apr-config=PATH  path to apr-1-config utility
   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
 
 Some influential environment variables:
@@ -5350,26 +5354,57 @@ $as_echo "checking whether to build with codegen... $enable_codegen" >&6; }
 
 
 
+pgac_args="$pgac_args with_codegen_prefix"
+
+
+# Check whether --with-codegen-prefix was given.
+if test "${with_codegen_prefix+set}" = set; then :
+  withval=$with_codegen_prefix;
+  case $withval in
+    yes)
+      as_fn_error $? "argument required for --with-codegen-prefix option" "$LINENO" 5
+      ;;
+    no)
+      as_fn_error $? "argument required for --with-codegen-prefix option" "$LINENO" 5
+      ;;
+    *)
+      if test "${enable_codegen}" = no; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: --with-codegen-prefix used without --enable-codegen" >&5
+$as_echo "$as_me: WARNING: --with-codegen-prefix used without --enable-codegen" >&2;}
+fi
+      ;;
+  esac
+
+fi
+
+
+
 if test "$enable_codegen" = yes; then :
    # then
-   # Extract the first word of "cmake", so it can be a program name with args.
-set dummy cmake; ac_word=$2
+
+if test -z "$CMAKE"; then
+  for ac_prog in cmake
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CMAKE+:} false; then :
+if ${ac_cv_path_CMAKE+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  if test -n "$CMAKE"; then
-  ac_cv_prog_CMAKE="$CMAKE" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+  case $CMAKE in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_CMAKE="$CMAKE" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
   test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CMAKE="yes"
+    ac_cv_path_CMAKE="$as_dir/$ac_word$ac_exec_ext"
     $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -5377,9 +5412,10 @@ done
   done
 IFS=$as_save_IFS
 
+  ;;
+esac
 fi
-fi
-CMAKE=$ac_cv_prog_CMAKE
+CMAKE=$ac_cv_path_CMAKE
 if test -n "$CMAKE"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CMAKE" >&5
 $as_echo "$CMAKE" >&6; }
@@ -5389,38 +5425,20 @@ $as_echo "no" >&6; }
 fi
 
 
-   if test "${CMAKE}" != yes; then :
-  as_fn_error $? "'cmake is required for building GPDB with codegen enabled'" "$LINENO" 5
+  test -n "$CMAKE" && break
+done
+
 fi
 
-
-pgac_args="$pgac_args with_codegen_prefix"
-
-
-# Check whether --with-codegen-prefix was given.
-if test "${with_codegen_prefix+set}" = set; then :
-  withval=$with_codegen_prefix;
-  case $withval in
-    yes)
-      codegen_prefix=
-      ;;
-    no)
-      :
-      ;;
-    *)
-      with_codegen_prefix=yes
-codegen_prefix=$withval
-      ;;
-  esac
-
+if test -n "$CMAKE"; then
+  gpac_cmake_version=`$CMAKE --version 2>/dev/null | sed q`
+  if test -z "$gpac_cmake_version"; then
+    as_fn_error $? "cmake is required for codegen, unable to identify version" "$LINENO" 5
+  fi
+  { $as_echo "$as_me:${as_lineno-$LINENO}: using $gpac_cmake_version" >&5
+$as_echo "$as_me: using $gpac_cmake_version" >&6;}
 else
-  with_codegen_prefix=no
-fi
-
-
-
-if test "$with_codegen_prefix" = yes; then
-  :
+  as_fn_error $? "cmake is required for codegen, unable to find binary" "$LINENO" 5
 fi
 
 
@@ -5434,7 +5452,7 @@ else
   build_type="Release"
 fi
 
-   CMAKE_CMD="cmake -DCMAKE_PREFIX_PATH="${codegen_prefix}" -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=${build_type} ."
+   CMAKE_CMD="${CMAKE} -DCMAKE_PREFIX_PATH="${with_codegen_prefix}" -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=${build_type} ."
    echo "Executing cmake command : ${CMAKE_CMD}"
    if ${CMAKE_CMD}; then :
 
@@ -6387,63 +6405,27 @@ fi
 # libapr. Used for gpfdist.
 #
 
+pgac_args="$pgac_args with_apr_config"
+
+
 # Check whether --with-apr-config was given.
 if test "${with_apr_config+set}" = set; then :
   withval=$with_apr_config;
-else
-  with_apr_config=yes
+  case $withval in
+    yes)
+      as_fn_error $? "argument required for --with-apr-config option" "$LINENO" 5
+      ;;
+    no)
+      as_fn_error $? "argument required for --with-apr-config option" "$LINENO" 5
+      ;;
+    *)
+
+      ;;
+  esac
+
 fi
 
 
-if test "$with_apr_config" = yes; then
-  for ac_prog in apr-1-config
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_APR_1_CONFIG+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $APR_1_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_APR_1_CONFIG="$APR_1_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_APR_1_CONFIG="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  ;;
-esac
-fi
-APR_1_CONFIG=$ac_cv_path_APR_1_CONFIG
-if test -n "$APR_1_CONFIG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $APR_1_CONFIG" >&5
-$as_echo "$APR_1_CONFIG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$APR_1_CONFIG" && break
-done
-
-else
-  APR_1_CONFIG=$with_apr_config
-fi
 
 
 #
@@ -8950,20 +8932,78 @@ fi
   fi
 fi
 
-#
-# Find APR headers and libraries
-#
+if test "$enable_gpfdist" = yes ; then
+
+if test x"$with_apr_config" != x; then
+  APR_1_CONFIG=$with_apr_config
+fi
+if test -z "$APR_1_CONFIG"; then
+  for ac_prog in apr-1-config
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_APR_1_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $APR_1_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_APR_1_CONFIG="$APR_1_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_APR_1_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+APR_1_CONFIG=$ac_cv_path_APR_1_CONFIG
+if test -n "$APR_1_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $APR_1_CONFIG" >&5
+$as_echo "$APR_1_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$APR_1_CONFIG" && break
+done
+
+fi
 
 if test -n "$APR_1_CONFIG"; then
+  gpac_apr_1_config_version=`$APR_1_CONFIG --version 2>/dev/null | sed q`
+  if test -z "$gpac_apr_1_config_version"; then
+    as_fn_error $? "apr-1-config is required for gpfdist, unable to identify version" "$LINENO" 5
+  fi
+  { $as_echo "$as_me:${as_lineno-$LINENO}: using apr-1-config $gpac_apr_1_config_version" >&5
+$as_echo "$as_me: using apr-1-config $gpac_apr_1_config_version" >&6;}
   apr_includes=`"$APR_1_CONFIG" --includes`
   apr_link_ld_libs=`"$APR_1_CONFIG" --link-ld --libs`
   apr_cflags=`"$APR_1_CONFIG" --cflags`
   apr_cppflags=`"$APR_1_CONFIG" --cppflags`
-  CPPFLAGS="$CPPFLAGS $apr_includes $apr_cppflags"
-  CFLAGS="$CFLAGS $apr_cflags"
+
+
+
+
+else
+  as_fn_error $? "apr-1-config is required for gpfdist, unable to find binary" "$LINENO" 5
 fi
 
-if test "$enable_gpfdist" = yes ; then
   # If the 'apr-1-config --link-ld' produced correct output, -lapr-1 is already
   # in LIBS, hence AC_SEARCH_LIBS rather than AC_CHECK_LIB. (and the autoconf
   # manual recommends always using AC_SEARCH_LIBS rather than AC_CHECK_LIB
@@ -10228,31 +10268,53 @@ done
 
   fi
 
+  for ac_header in yaml.h
+do :
   ac_fn_c_check_header_mongrel "$LINENO" "yaml.h" "ac_cv_header_yaml_h" "$ac_includes_default"
 if test "x$ac_cv_header_yaml_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_YAML_H 1
+_ACEOF
 
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: header file <yaml.h> is not found. disabling transformations for gpfdist." >&5
 $as_echo "$as_me: WARNING: header file <yaml.h> is not found. disabling transformations for gpfdist." >&2;}
 fi
 
+done
 
-  ac_fn_c_check_header_mongrel "$LINENO" "apr_getopt.h" "ac_cv_header_apr_getopt_h" "$ac_includes_default"
-if test "x$ac_cv_header_apr_getopt_h" = xyes; then :
-
-else
-  as_fn_error $? "header file <apr_getopt.h> is required" "$LINENO" 5
-fi
-
-
+  for ac_header in event.h
+do :
   ac_fn_c_check_header_mongrel "$LINENO" "event.h" "ac_cv_header_event_h" "$ac_includes_default"
 if test "x$ac_cv_header_event_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EVENT_H 1
+_ACEOF
 
 else
-  as_fn_error $? "header file <event.h> is required" "$LINENO" 5
+  as_fn_error $? "header file <event.h> is required for gpfdist" "$LINENO" 5
 fi
 
+done
 
+
+  ac_save_CPPFLAGS=$CPPFLAGS
+  CPPFLAGS="$apr_includes $CPPFLAGS"
+  for ac_header in apr_getopt.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "apr_getopt.h" "ac_cv_header_apr_getopt_h" "$ac_includes_default"
+if test "x$ac_cv_header_apr_getopt_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_APR_GETOPT_H 1
+_ACEOF
+
+else
+  as_fn_error $? "'header file <apr_getopt.h> is required for gpfdist'" "$LINENO" 5
+fi
+
+done
+
+  CPPFLAGS=$ac_save_CPPFLAGS
 fi
 
 if test "$with_zlib" = yes; then
@@ -14692,11 +14754,11 @@ rm -rf conftest*
 
 fi
 
-
+enable_largefile=yes
 else
 enable_largefile=no
-
 fi
+
 
 # Check for largefile support (must be after AC_SYS_LARGEFILE)
 # The cast to long int works around a bug in the HP C Compiler
@@ -17030,15 +17092,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
 
-
-# Warn about unknown options
-for pgac_var in `set | sed 's/=.*//' | $EGREP 'with_|enable_'`; do
-  for pgac_arg in $pgac_args with_gnu_ld; do
-    if test "$pgac_var" = "$pgac_arg"; then
-      continue 2
-    fi
-  done
-  pgac_txt=`echo $pgac_var | sed 's/_/-/g'`
-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: option ignored: --$pgac_txt" >&5
-$as_echo "$as_me: WARNING: option ignored: --$pgac_txt" >&2;}
-done

--- a/configure.in
+++ b/configure.in
@@ -628,26 +628,26 @@ AC_SUBST(enable_orca)
 #
 # Enable code generation
 #
-PGAC_ARG_BOOL(enable, codegen, no, [  --enable-codegen       enable code generation],
+PGAC_ARG_BOOL(enable, codegen, no, [  --enable-codegen        enable code generation],
               [AC_DEFINE([USE_CODEGEN], 1,
                          [Define to 1 to enable code generation. (--enable-codegen)])])
 AC_MSG_RESULT([checking whether to build with codegen... $enable_codegen])
 AC_SUBST(enable_codegen)
 
+PGAC_ARG_REQ(with, codegen-prefix,
+             [  --with-codegen-prefix="PATH;PATH"  semicolon separated prefix search path for LLVM and Clang],
+             [AS_IF([test "${enable_codegen}" = no],
+					[AC_MSG_WARN([--with-codegen-prefix used without --enable-codegen])])])
 
 AS_IF([test "$enable_codegen" = yes],
 [ # then
-   AC_CHECK_PROG(CMAKE, cmake, yes)
-   AS_IF([test "${CMAKE}" != yes], [AC_MSG_ERROR(['cmake is required for building GPDB with codegen enabled'])])
-
-   PGAC_ARG_OPTARG(with, codegen-prefix, [  --with-codegen-prefix   semicolon separated prefix search path for LLVM and Clang],
-                   [codegen_prefix=], [codegen_prefix=$withval])
+   GPAC_PATH_CMAKE
 
    cd src/backend/codegen
    AS_IF([test "${prefix}" = NONE], [prefix=${ac_default_prefix}])
    AS_IF([test "${enable_debug}" = yes], [build_type="Debug"], [build_type="Release"])
 
-   CMAKE_CMD="cmake -DCMAKE_PREFIX_PATH="${codegen_prefix}" -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=${build_type} ."
+   CMAKE_CMD="${CMAKE} -DCMAKE_PREFIX_PATH="${with_codegen_prefix}" -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_BUILD_TYPE=${build_type} ."
    echo "Executing cmake command : ${CMAKE_CMD}"
    AS_IF([${CMAKE_CMD}], [], [AC_MSG_ERROR(['error while configuring codegen.'])])
    cd -
@@ -940,15 +940,8 @@ AC_SUBST(with_libcurl)
 #
 # libapr. Used for gpfdist.
 #
-AC_ARG_WITH(apr-config,
-[AS_HELP_STRING([--with-apr-config=PATH],[path to apr-1-config])],
-[], [with_apr_config=yes])
-
-if test "$with_apr_config" = yes; then
-  AC_PATH_PROGS(APR_1_CONFIG, apr-1-config)
-else
-  APR_1_CONFIG=$with_apr_config
-fi
+PGAC_ARG_REQ(with, apr-config,
+             [  --with-apr-config=PATH  path to apr-1-config utility])
 AC_SUBST(with_apr_config)
 
 #
@@ -1147,20 +1140,8 @@ if test "$with_krb5" = yes ; then
   fi
 fi
 
-#
-# Find APR headers and libraries
-#
-
-if test -n "$APR_1_CONFIG"; then
-  apr_includes=`"$APR_1_CONFIG" --includes`
-  apr_link_ld_libs=`"$APR_1_CONFIG" --link-ld --libs`
-  apr_cflags=`"$APR_1_CONFIG" --cflags`
-  apr_cppflags=`"$APR_1_CONFIG" --cppflags`
-  CPPFLAGS="$CPPFLAGS $apr_includes $apr_cppflags"
-  CFLAGS="$CFLAGS $apr_cflags"
-fi
-
 if test "$enable_gpfdist" = yes ; then
+  GPAC_PATH_APR_1_CONFIG
   # If the 'apr-1-config --link-ld' produced correct output, -lapr-1 is already
   # in LIBS, hence AC_SEARCH_LIBS rather than AC_CHECK_LIB. (and the autoconf
   # manual recommends always using AC_SEARCH_LIBS rather than AC_CHECK_LIB
@@ -1312,9 +1293,13 @@ if test "$enable_gpfdist" = yes; then
     AC_CHECK_HEADERS([winsock2.h])
   fi
 
-  AC_CHECK_HEADER(yaml.h, [], [AC_MSG_WARN([header file <yaml.h> is not found. disabling transformations for gpfdist.])])
-  AC_CHECK_HEADER(apr_getopt.h, [], [AC_MSG_ERROR([header file <apr_getopt.h> is required])])
-  AC_CHECK_HEADER(event.h, [], [AC_MSG_ERROR([header file <event.h> is required])])
+  AC_CHECK_HEADERS(yaml.h, [], [AC_MSG_WARN([header file <yaml.h> is not found. disabling transformations for gpfdist.])])
+  AC_CHECK_HEADERS(event.h, [], [AC_MSG_ERROR([header file <event.h> is required for gpfdist])])
+
+  ac_save_CPPFLAGS=$CPPFLAGS
+  CPPFLAGS="$apr_includes $CPPFLAGS"
+  AC_CHECK_HEADERS(apr_getopt.h, [], [AC_MSG_ERROR(['header file <apr_getopt.h> is required for gpfdist'])])
+  CPPFLAGS=$ac_save_CPPFLAGS
 fi
 
 if test "$with_zlib" = yes; then
@@ -1974,11 +1959,11 @@ fi
 
 if test $ac_cv_func_fseeko = yes; then
 AC_SYS_LARGEFILE
-AC_SUBST(enable_largefile)
+enable_largefile=yes
 else
 enable_largefile=no
-AC_SUBST(enable_largefile)
 fi
+AC_SUBST(enable_largefile)
 
 # Check for largefile support (must be after AC_SYS_LARGEFILE)
 AC_CHECK_SIZEOF([off_t])
@@ -2193,6 +2178,3 @@ AC_CONFIG_HEADERS([src/interfaces/ecpg/include/ecpg_config.h],
                   [echo >src/interfaces/ecpg/include/stamp-h])
 
 AC_OUTPUT
-
-# Warn about unknown options
-PGAC_ARG_CHECK

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -297,6 +297,14 @@ perl_privlibexp		= @perl_privlibexp@
 perl_useshrplib		= @perl_useshrplib@
 perl_embed_ldflags	= @perl_embed_ldflags@
 
+# apr-1-config
+
+APR_1_CONFIG		= @APR_1_CONFIG@
+apr_includes		= @apr_includes@
+apr_link_ld_libs	= @apr_link_ld_libs@
+apr_cflags			= @apr_cflags@
+apr_cppflags		= @apr_cppflags@
+
 # Miscellaneous
 
 AWK	= @AWK@
@@ -306,7 +314,6 @@ MSGMERGE = @MSGMERGE@
 PYTHON	= @PYTHON@
 TAR	= @TAR@
 XGETTEXT = @XGETTEXT@
-APR_1_CONFIG = @APR_1_CONFIG@
 
 GZIP	= gzip
 BZIP2	= bzip2

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -6,7 +6,8 @@ ifeq ($(PORTNAME),win32)
   include $(top_builddir)/gpAux/Makefile.windows
 endif
 
-override CPPFLAGS := -I. $(CPPFLAGS)
+override CPPFLAGS := -I. $(CPPFLAGS) $(apr_includes) $(apr_cppflags)
+override CLAGS := $(CFLAGS) $(apr_cflags)
 
 OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o
 # configure should have been run by this point.
@@ -28,7 +29,7 @@ ifeq ($(PORTNAME),win32)
   OBJS += $(top_builddir)/src/port/glob.o
 endif
 
-LDLIBS += $(LIBS) $(GPFDIST_LIBS) $(shell $(APR_1_CONFIG) --link-ld --libs)
+LDLIBS += $(LIBS) $(GPFDIST_LIBS) $(apr_link_ld_libs)
 
 all: gpfdist$(EXE_EXT)
 


### PR DESCRIPTION
While waiting for an installcheck-good run I decided to fix the annoying `configure: WARNING: option ignored: --enable-largefile` warnings that are emitted on every autoconf run. In doing this I did some more cleanups and general fixing.

This attempts to clean up the autoconf script a bit and follow the upstream division of generic code in config/ with the actual lookup configuration in configure.in. Also updated our installation to rely on a more modern version of autoconf (at least version 2.63 which was released in 2008; 2.69 is the latest version, works great with our `configure.in`, and was released in 2012) by backporting parts of upstream commit 7cc514ac. This commit consist of:

- Decouple `--enable-codegen` and `--with-codegen-prefix` to not silently ignore prefixes if the enable flag isn't passed. Emit a warning if configuring prefixes without codegen. Also moves `--with-codegen-prefix` to require an argument since `--with-codegen-prefix` without an argument is likely to hide either a scripting bug or a misunderstanding from the user
- Move program checks for cmake and apr-1-config to `config/programs.m4` and allow for path overrides and ensure to use the resolved path when invoking (relates to the use of cmake)
- Propagate the apr-1-config flags and objects to where used via `Makefile.global` rather than performing another lookup in the local makefile
- Remove check for unused arguments since autoconf does that automatically since 2.63
- Remove backported `fseeko` handling since that isn't relevant for modern autoconf versions
- Help output and spelling fixes

@hardikar @gcaragea this should not change anything for codegen except it adds a warning when using `--with-codegen-prefix` without `--enable-codegen`, can you please have a look and see what you think?