### PR TITLE
Remove documentation about deprecated -i option from pg_dump

### DIFF
--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -296,20 +296,9 @@ PostgreSQL documentation
       <term><option>--ignore-version</></term>
       <listitem>
        <para>
-        Ignore version mismatch between
-        <application>pg_dump</application> and the database server.
+        This option has been deprecated.
        </para>
 
-       <para>
-        <application>pg_dump</application> can dump from servers running
-        previous releases of <productname>PostgreSQL</>, but very old
-        versions are not supported anymore (currently, those prior to 7.0).
-        Dumping from a server newer than <application>pg_dump</application>
-        is likely not to work at all.
-        Use this option if you need to override the version check (and
-        if <application>pg_dump</application> then fails, don't say
-        you weren't warned).
-       </para>
       </listitem>
      </varlistentry>
 

--- a/doc/src/sgml/ref/pg_dumpall.sgml
+++ b/doc/src/sgml/ref/pg_dumpall.sgml
@@ -155,17 +155,7 @@ PostgreSQL documentation
       <term><option>--ignore-version</></term>
       <listitem>
        <para>
-        Ignore version mismatch between
-        <application>pg_dumpall</application> and the database server.
-       </para>
-
-       <para>
-        <application>pg_dumpall</application> can handle databases
-        from previous releases of <productname>PostgreSQL</>, but very
-        old versions are not supported anymore (currently prior to
-        7.0).  Use this option if you need to override the version
-        check (and if <application>pg_dumpall</application> then
-        fails, don't say you weren't warned).
+	    This option has been deprecated.
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
As noted in #770, the -i option is a noop in `pg_dump` and `pg_dumpall` so remove documentation from reference page. What to do when a user invokes -i is left to decide but getting the documentation removed is a first step.