### PR TITLE
Correct spelling in pgcrypto gppkg definition

### DIFF
--- a/contrib/pgcrypto/package/pgcrypto.spec
+++ b/contrib/pgcrypto/package/pgcrypto.spec
@@ -10,7 +10,7 @@ AutoProv:       no
 Provides:       pgcrypto = %{pgcrypto_ver} 
 
 %description
-The Pgcrypto package provides cryptographic package for the Greenplum Database.
+The Pgcrypto package provides cryptographic functions for the Greenplum Database.
 
 %install
 mkdir -p %{buildroot}/temp


### PR DESCRIPTION
Update the spelling in the description text of the RPM specification to make the description text match the summary which IMHO reads better. I assume this can be pushed since the description field is non-functional but since I'm not very familiar with the gppkg packaging I opted for opening a PR. Ping @edespino.