### PR TITLE
Add dockerfile with consistent environment for development on GPDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM pivotaldata/gpdb-devel
+
+WORKDIR /workspace
+
+ADD . gpdb/
+
+WORKDIR gpdb
+
+RUN ./configure --with-python --with-perl --enable-mapreduce --with-libxml --prefix=/usr/local/gpdb
+RUN time make -j4
+RUN make install
+
+RUN chown -R gpadmin:gpadmin /workspace/gpdb
+RUN chown -R gpadmin:gpadmin /usr/local/gpdb

--- a/README.md
+++ b/README.md
@@ -204,6 +204,63 @@ make installcheck-bugbuster
   some tests are known to fail with Greenplum. The
   __installcheck-good__ schedule excludes those tests.
 
+## Development with Docker (alpha)
+
+We provide a docker image with all dependencies required to compile and test
+GPDB. You can view the dependency dockerfile at `./docker/base/Dockerfile`.
+The image is hosted on docker hub at `pivotaldata/gpdb-devel`. This docker
+image is currently under heavy development.
+
+Known issues:
+* The `installcheck-good` make target has at least 4 failures, some of which
+  are non-deterministic
+
+### Running regression tests with Docker
+
+1. Create a docker host with 8gb RAM and 4 cores
+    ```bash
+    docker-machine create -d virtualbox --virtualbox-cpu-count 4 --virtualbox-disk-size 50000 --virtualbox-memory 8192 gpdb
+    eval $(docker-machine env gpdb)
+    ```
+
+1. Build your code on gpdb-devel rootfs
+    ```bash
+    cd [path/to/gpdb]
+    docker build .
+    # image beefc4f3 built
+    ```
+    The top level Dockerfile will automatically sync your current working
+    directory into the docker image. This means that any code you are working
+    on will automatically be built and ready for testing in the docker context
+
+1. Log into docker image
+    ```bash
+    docker run -it beefc4f3
+    ```
+
+1. As `gpadmin` user run `installcheck-good`
+    ```bash
+    su gpadmin
+    cd /workspace/gpdb
+    make installcheck-good
+    ```
+
+### Caveats
+
+* No Space Left On Device
+    On macOS the docker-machine vm can periodically become full with unused images.
+    You can clear these images with a combination of docker commands.
+    ```bash
+    # assuming no currently running containers
+    # remove all stopped containers from cache
+    docker ps -aq | xargs -n 1 docker rm
+    # remove all untagged images
+    docker images -aq --filter dangling=true | xargs -n 1 docker rmi
+    ```
+
+    Alternatively you can use the (beta) Native macOS docker client now available
+    in docker 1.12.
+
 ## Glossary
 
 * __QD__

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,64 @@
+FROM centos:6
+
+RUN yum -y update
+RUN yum -y groupinstall "Development tools"
+RUN yum -y install ed
+RUN yum -y install readline-devel
+RUN yum -y install zlib-devel
+RUN yum -y install curl-devel
+RUN yum -y install bzip2-devel
+RUN yum -y install python-devel
+RUN yum -y install apr-devel
+RUN yum -y install libevent-devel
+RUN yum -y install openssl-libs openssl-devel
+RUN yum -y install libyaml libyaml-devel
+RUN yum -y install epel-release
+RUN yum -y install htop
+RUN yum -y install ccache
+RUN yum -y install libffi-devel
+RUN yum -y install iproute
+RUN yum -y install net-tools
+RUN yum -y install openssh-server
+RUN yum -y install perl-devel
+RUN yum -y install perl-CPAN
+RUN yum -y install perl-ExtUtils-Embed
+RUN yum -y install libxml2-devel
+
+ADD https://bootstrap.pypa.io/get-pip.py /
+RUN python /get-pip.py
+RUN pip install psutil lockfile paramiko setuptools epydoc
+RUN rm /get-pip.py
+
+# Misc
+RUN yum -y install vim mc psmisc
+
+# cmake 3.0
+WORKDIR /root
+
+ADD http://www.cmake.org/files/v3.0/cmake-3.0.0.tar.gz ./
+RUN tar -zxvf cmake-3.0.0.tar.gz
+WORKDIR cmake-3.0.0
+RUN ./bootstrap
+RUN make
+RUN make install
+ENV PATH=/usr/local/bin:$PATH
+
+# compile GPDB
+
+WORKDIR /workspace
+
+ADD . gpdb/
+ADD ./docker/dotfiles/root.bashrc /root/.bashrc
+ADD ./docker/dotfiles/gpadmin.bashrc /home/gpadmin/.bashrc
+
+WORKDIR gpdb
+
+RUN ./configure --with-python --with-perl --enable-mapreduce --with-libxml --prefix=/usr/local/gpdb
+RUN time make -j4
+RUN make install
+
+RUN ./docker/prep_for_ssh.bash
+
+RUN chown -R gpadmin:gpadmin /home/gpadmin
+
+RUN chmod u+s `which ping`

--- a/docker/dotfiles/gpadmin.bashrc
+++ b/docker/dotfiles/gpadmin.bashrc
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source /usr/local/gpdb/greenplum_path.sh
+
+if [ ! -e /tmp/demo_sem ]; then
+  touch /tmp/demo_sem
+
+  pushd /workspace/gpdb/gpAux/gpdemo
+    make cluster
+  popd
+fi
+
+source /workspace/gpdb/gpAux/gpdemo/gpdemo-env.sh

--- a/docker/dotfiles/root.bashrc
+++ b/docker/dotfiles/root.bashrc
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ ! -e /tmp/ssh_sem ]; then
+  touch /tmp/ssh_sem
+  /workspace/gpdb/docker/start_ssh.bash
+fi

--- a/docker/prep_for_ssh.bash
+++ b/docker/prep_for_ssh.bash
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Based on install_hawq_toolchain.bash in Pivotal-DataFabric/ci-infrastructure repo
+
+setup_ssh_for_user() {
+  local user="${1}"
+  local home_dir
+  home_dir=$(eval echo "~${user}")
+
+  mkdir -p "${home_dir}"/.ssh
+  touch "${home_dir}/.ssh/authorized_keys" "${home_dir}/.ssh/known_hosts" "${home_dir}/.ssh/config"
+  ssh-keygen -t rsa -N "" -f "${home_dir}/.ssh/id_rsa"
+  cat "${home_dir}/.ssh/id_rsa.pub" >> "${home_dir}/.ssh/authorized_keys"
+  chmod 0600 "${home_dir}/.ssh/authorized_keys"
+  cat << 'NOROAMING' >> "${home_dir}/.ssh/config"
+Host *
+  UseRoaming no
+NOROAMING
+  chown -R "${user}" "${home_dir}/.ssh"
+}
+
+transfer_ownership() {
+  chown -R gpadmin:gpadmin /workspace/gpdb
+  chown -R gpadmin:gpadmin /usr/local/gpdb
+}
+
+setup_gpadmin_user() {
+  /usr/sbin/useradd gpadmin
+  echo -e "password\npassword" | passwd gpadmin
+  groupadd supergroup
+  usermod -a -G supergroup gpadmin
+  setup_ssh_for_user gpadmin
+  transfer_ownership
+}
+
+setup_sshd() {
+  test -e /etc/ssh/ssh_host_key || ssh-keygen -f /etc/ssh/ssh_host_key -N '' -t rsa1
+  test -e /etc/ssh/ssh_host_rsa_key || ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
+  test -e /etc/ssh/ssh_host_dsa_key || ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa
+
+  # See https://gist.github.com/gasi/5691565
+  sed -ri 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+  # Disable password authentication so builds never hang given bad keys
+  sed -ri 's/PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config
+
+  setup_ssh_for_user root
+}
+
+_main() {
+  setup_gpadmin_user
+  setup_sshd
+}
+
+_main "$@"
+

--- a/docker/start_ssh.bash
+++ b/docker/start_ssh.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -ex
+
+ssh_keyscan_for_user() {
+  local user="${1}"
+  local home_dir
+  home_dir=$(eval echo "~${user}")
+
+  {
+    ssh-keyscan localhost
+    ssh-keyscan 0.0.0.0
+    ssh-keyscan github.com
+  } >> "${home_dir}/.ssh/known_hosts"
+}
+
+/usr/sbin/sshd -D &
+
+ssh_keyscan_for_user gpadmin
+ssh_keyscan_for_user root
+


### PR DESCRIPTION
# GPDB Dockerfile
Development on GPDB requires a significant investment in preparing a development environment. This requirement can be off-putting to a possible new community member wishing to contribute to OSS development. Similarly, it makes ramping very difficult for new core-contributors.

## Goals of this pull request
* provide a reproducible environment with all dependencies required to compile GPDB, run regression tests, and run integration tests.
* provide a consistent process for compiling, running, and testing new code on any platform using Docker as an abstraction. For example: A contributor can use these docker images to develop on Mac OS X but compile and run on Centos6.
* collaborate with the community on defining a guaranteed environment upon which GPDB can compile, run, and be tested.

## How to review this pull request
This PR adds two Dockerfiles. A top-level Dockerfile with logic for compiling GPDB, and an internal base-image Dockerfile with dependency installation and Centos rootfs (available on [dockerhub](https://hub.docker.com/r/pivotaldata/gpdb-devel/)). Additionally, two utility scripts have been added to prepare the docker environment for running a colocated GPDB cluster.

The `prep_for_ssh` utility file creates the `gpadmin` user and prepares the docker environment for `gpstart`. The `start_ssh` utility file runs an ssh daemon (`gpstart` uses ssh to bootstrap the colocated cluster) and adds all possible ssh targets to `known_hosts` so `make cluster` can be run without user interaction.

The updates to the readme contain instructions for how a contributor can consume this docker workflow.

Finally, this should be considered a feature under active development. Not all regression tests pass, and compilation time could be significantly improved. I'd like to get the current state of this workflow committed to receive community feedback and dogfood this workflow among core-contributors to GPDB. 

#### Things planned for the future:
* CI to automatically build a new base-image on changes to the `docker/base` directory
* ccache or alternative to improve first-time build time of top-level Dockerfile