### PR TITLE
GPHDFS insert or select query hangs indefinitely

### DIFF
--- a/gpAux/extensions/gphdfs/hadoop_env.sh
+++ b/gpAux/extensions/gphdfs/hadoop_env.sh
@@ -1,4 +1,4 @@
-export GP_JAVA_OPT='-Xmx1000m -XX:+DisplayVMOutputToStderr'
+export GP_JAVA_OPT='-Xmx1000m -XX:+DisplayVMOutputToStderr -Dhadoop.root.logger=INFO,console, -Dhadoop.security.logger=INFO,NullAppender'
 export PATH=$JAVA_HOME/bin:$PATH
 JAVA=$JAVA_HOME/bin/java
 CLASSPATH="$GPHOME"/"$GP_HADOOP_CONN_JARDIR"/$GP_HADOOP_CONN_VERSION.jar


### PR DESCRIPTION
I was able to reproduce this bug by bypassing loginSecureHadoop() that sets up the principals for the global login context. DFSClient then travels down the code path where hadoop.security.logger sends debug messages to the console resulting in a deadlock.

to work around this in my repo i simply override the $HADOOP_CONF/log4j.properties by adding options to GP_JAVA_OPT in $GPHOME/lib/hadoop/hadoop_env.sh.  We don't want debug logs going to stdout so if users modify their hadoop log4j we override to the settings to protect from deadlock. 

```
Thread 247741: (state = IN_NATIVE)
 - java.io.FileOutputStream.writeBytes(byte[], int, int, boolean) @bci=0 (Interpreted frame)
 - java.io.FileOutputStream.write(byte[], int, int) @bci=20, line=345 (Interpreted frame)
 - java.io.BufferedOutputStream.write(byte[], int, int) @bci=20, line=122 (Interpreted frame)
 - java.io.PrintStream.write(byte[], int, int) @bci=16, line=480 (Interpreted frame)
 - sun.nio.cs.StreamEncoder.writeBytes() @bci=120, line=221 (Interpreted frame)
 - sun.nio.cs.StreamEncoder.implFlushBuffer() @bci=11, line=291 (Interpreted frame)
 - sun.nio.cs.StreamEncoder.implFlush() @bci=1, line=295 (Interpreted frame)
 - sun.nio.cs.StreamEncoder.flush() @bci=12, line=141 (Interpreted frame)
 - java.io.OutputStreamWriter.flush() @bci=4, line=229 (Interpreted frame)
 - org.apache.log4j.helpers.QuietWriter.flush() @bci=4, line=59 (Interpreted frame)
 - org.apache.log4j.WriterAppender.subAppend(org.apache.log4j.spi.LoggingEvent) @bci=85, line=324 (Interpreted frame)
 - org.apache.log4j.WriterAppender.append(org.apache.log4j.spi.LoggingEvent) @bci=10, line=162 (Interpreted frame)
 - org.apache.log4j.AppenderSkeleton.doAppend(org.apache.log4j.spi.LoggingEvent) @bci=106, line=251 (Interpreted frame)
 - org.apache.log4j.helpers.AppenderAttachableImpl.appendLoopOnAppenders(org.apache.log4j.spi.LoggingEvent) @bci=41, line=66 (Interpreted frame)
 - org.apache.log4j.Category.callAppenders(org.apache.log4j.spi.LoggingEvent) @bci=26, line=206 (Interpreted frame)
 - org.apache.log4j.Category.forcedLog(java.lang.String, org.apache.log4j.Priority, java.lang.Object, java.lang.Throwable) @bci=14, line=391 (Interpreted frame)
 - org.apache.log4j.Category.log(java.lang.String, org.apache.log4j.Priority, java.lang.Object, java.lang.Throwable) @bci=34, line=856 (Interpreted frame)
 - org.apache.commons.logging.impl.Log4JLogger.debug(java.lang.Object, java.lang.Throwable) @bci=12, line=188 (Interpreted frame)
 - org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(java.lang.Object, java.lang.reflect.Method, java.lang.Object[]) @bci=458, line=139 (Interpreted frame)
 - com.sun.proxy.$Proxy10.getDelegationToken(org.apache.hadoop.io.Text) @bci=16 (Interpreted frame)
 - org.apache.hadoop.hdfs.DFSClient.getDelegationToken(org.apache.hadoop.io.Text) @bci=26, line=850 (Interpreted frame)
 - org.apache.hadoop.hdfs.DistributedFileSystem.getDelegationToken(java.lang.String) @bci=20, line=1328 (Interpreted frame)
 - org.apache.hadoop.fs.FileSystem.collectDelegationTokens(java.lang.String, org.apache.hadoop.security.Credentials, java.util.List) @bci=37, line=526 (Interpreted frame)
 - org.apache.hadoop.fs.FileSystem.addDelegationTokens(java.lang.String, org.apache.hadoop.security.Credentials) @bci=24, line=504 (Interpreted frame)
 - org.apache.hadoop.mapreduce.security.TokenCache.obtainTokensForNamenodesInternal(org.apache.hadoop.fs.FileSystem, org.apache.hadoop.security.Credentials, org.apache.hadoop.conf.Configuration) @bci=34, line=121 (Interpreted frame)
 - org.apache.hadoop.mapreduce.security.TokenCache.obtainTokensForNamenodesInternal(org.apache.hadoop.security.Credentials, org.apache.hadoop.fs.Path[], org.apache.hadoop.conf.Configuration) @bci=86, line=100 (Interpreted frame)
 - org.apache.hadoop.mapreduce.security.TokenCache.obtainTokensForNamenodes(org.apache.hadoop.security.Credentials, org.apache.hadoop.fs.Path[], org.apache.hadoop.conf.Configuration) @bci=10, line=80 (Interpreted frame)
 - org.apache.hadoop.mapreduce.lib.input.FileInputFormat.listStatus(org.apache.hadoop.mapreduce.JobContext) @bci=41, line=235 (Interpreted frame)
 - org.apache.hadoop.mapreduce.lib.input.FileInputFormat.getSplits(org.apache.hadoop.mapreduce.JobContext) @bci=29, line=340 (Interpreted frame)
 - com.emc.greenplum.gpdb.hdfsconnector.HDFSReader.assignSplits() @bci=61, line=245 (Interpreted frame)
 - com.emc.greenplum.gpdb.hdfsconnector.HDFSReader.doRead() @bci=15, line=157 (Interpreted frame)
 - com.emc.greenplum.gpdb.hdfsconnector.HDFSReader.main(java.lang.String[]) @bci=10, line=258 (Interpreted frame)

```
