### PR TITLE
Typo in gp_read_backup_file__()

### DIFF
--- a/src/backend/cdb/cdbbackup.c
+++ b/src/backend/cdb/cdbbackup.c
@@ -1507,7 +1507,7 @@ gp_read_backup_file__(PG_FUNCTION_ARGS)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
-				 errmsg("Backup File %s Type %d could not be be found", pszFileName, fileType)));
+				 errmsg("Backup File %s Type %d could not be found", pszFileName, fileType)));
 	}
 
 	/* Read file */


### PR DESCRIPTION
Minor typo in gp_read_backup_file__() - "could not be be found" -> "could not be found".

