### PR TITLE
Fix bugs when a SET command is executed within init plan

### DIFF
--- a/src/backend/cdb/cdbgang.c
+++ b/src/backend/cdb/cdbgang.c
@@ -1926,6 +1926,7 @@ void freeGangsForPortal(char *portal_name)
 	}
 
 	cur_item = list_head(allocatedReaderGangs1);
+	prev_item = NULL;
 	while (cur_item != NULL)
 	{
 		Gang *gp = (Gang *) lfirst(cur_item);

--- a/src/backend/cdb/cdbgang.c
+++ b/src/backend/cdb/cdbgang.c
@@ -1199,7 +1199,7 @@ getAllIdleReaderGangs()
 }
 
 List *
-getAllBusyReaderGangs()
+getAllAllocatedReaderGangs()
 {
 	List *res = NIL;
 	ListCell *le;

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1548,7 +1548,7 @@ cdbdisp_dispatchSetCommandToAllGangs(const char *strCommand,
 
 	Gang *primaryGang;
 	List *idleReaderGangs;
-	List *busyReaderGangs;
+	List *allocatedReaderGangs;
 	ListCell *le;
 
 	int nsegdb = getgpsegmentCount();
@@ -1581,12 +1581,12 @@ cdbdisp_dispatchSetCommandToAllGangs(const char *strCommand,
 								  "cdbdisp_dispatchSetCommandToAllGangs");
 
 	idleReaderGangs = getAllIdleReaderGangs();
-	busyReaderGangs = getAllBusyReaderGangs();
+	allocatedReaderGangs = getAllAllocatedReaderGangs();
 
 	/*
 	 * Dispatch the command.
 	 */
-	gangCount = 1 + list_length(idleReaderGangs);
+	gangCount = 1 + list_length(idleReaderGangs) + list_length(allocatedReaderGangs);
 
 	ds->primaryResults = NULL;
 	ds->dispatchThreads = NULL;
@@ -1607,11 +1607,22 @@ cdbdisp_dispatchSetCommandToAllGangs(const char *strCommand,
 	 *Can not send set command to busy gangs, so those gangs
 	 *can not be reused because their GUC is not set.
 	 */
-	foreach(le, busyReaderGangs)
+	foreach(le, allocatedReaderGangs)
 	{
 		Gang *rg = lfirst(le);
 
-		rg->noReuse = true;
+		if (rg->portal_name != NULL)
+		{
+			/*
+			 * For named portal (like CURSOR), SET command will not be dispatched.
+			 * Meanwhile such gang should not be reused because it's guc was not set.
+			 */
+			rg->noReuse = true;
+		}
+		else
+		{
+			cdbdisp_dispatchToGang(ds, rg, -1, DEFAULT_DISP_DIRECT);
+		}
 	}
 }
 	

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -81,7 +81,7 @@ extern void CheckForResetSession(void);
 
 extern List * getAllIdleReaderGangs(void);
 
-extern List * getAllBusyReaderGangs(void);
+extern List * getAllAllocatedReaderGangs(void);
 
 
 extern CdbComponentDatabases *getComponentDatabases(void);

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -470,12 +470,29 @@ BEGIN
 END;
 $$
     LANGUAGE plpgsql NO SQL;
-select * from test_set_in_loop();
- test_set_in_loop
+SELECT * from test_set_in_loop();
+ test_set_in_loop 
 ------------------
               100
 (1 row)
 
-drop table if exists test_cursor_set_table;
-drop function if exists test_set_in_loop();
-drop function if exists test_call_set_command();
+CREATE FUNCTION test_set_within_initplan () RETURNS numeric
+AS $$
+DECLARE
+	result numeric;
+	tmp RECORD;
+BEGIN
+	result = 1;
+	execute 'SET gp_workfile_limit_per_query=524;';
+	select into tmp * from test_cursor_set_table limit 100;
+	return result;
+END;
+$$
+	LANGUAGE plpgsql NO SQL;
+CREATE TABLE test_initplan_set_table as select * from test_set_within_initplan();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'test_set_within_initplan' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+DROP TABLE if exists test_initplan_set_table;
+DROP TABLE if exists test_cursor_set_table;
+DROP FUNCTION if exists test_set_in_loop();
+DROP FUNCTION if exists test_call_set_command();

--- a/src/test/regress/sql/guc.sql
+++ b/src/test/regress/sql/guc.sql
@@ -165,9 +165,28 @@ END;
 $$
     LANGUAGE plpgsql NO SQL;
 
+SELECT * from test_set_in_loop();
 
-select * from test_set_in_loop();
 
-drop table if exists test_cursor_set_table;
-drop function if exists test_set_in_loop();
-drop function if exists test_call_set_command();
+CREATE FUNCTION test_set_within_initplan () RETURNS numeric
+AS $$
+DECLARE
+	result numeric;
+	tmp RECORD;
+BEGIN
+	result = 1;
+	execute 'SET gp_workfile_limit_per_query=524;';
+	select into tmp * from test_cursor_set_table limit 100;
+	return result;
+END;
+$$
+	LANGUAGE plpgsql NO SQL;
+
+
+CREATE TABLE test_initplan_set_table as select * from test_set_within_initplan();
+
+
+DROP TABLE if exists test_initplan_set_table;
+DROP TABLE if exists test_cursor_set_table;
+DROP FUNCTION if exists test_set_in_loop();
+DROP FUNCTION if exists test_call_set_command();


### PR DESCRIPTION
In commit d272592981b3c, GPDB marked all allocatedReaderGangs with noReuse flag. When plan contains
init plan and a SET command executed within it, GPDB will mark pre-assigned gangs to noReuse and
destroy them which make query crash