### PR TITLE
Fix non-deterministic test suites

### DIFF
--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -486,7 +486,7 @@ delete from s where b = (select min(a) from r where b = s.b);
 -- end_ignore
 update p set c = c + 1;
 ERROR:  moving tuple from partition "p_1_prt_extra" to partition "p_1_prt_2" not supported  (seg2 rhel62-vm1:25434 pid=19030)
-update p set c = c + 1 where b in (select b from s);
+update p set c = c + 1 where b in (select b from s where b = 36);
 ERROR:  moving tuple from partition "p_1_prt_extra" to partition "p_1_prt_2" not supported  (seg2 rhel62-vm1:25434 pid=19030)
 -- ----------------------------------------------------------------------
 -- Test: unsupported_cases3.sql

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -484,7 +484,7 @@ delete from s where b = (select min(a) from r where b = s.b);
 ------------------------------------------------------------
 -- end_ignore
 update p set c = c + 1;
-update p set c = c + 1 where b in (select b from s);
+update p set c = c + 1 where b in (select b from s where b = 36);
 -- ----------------------------------------------------------------------
 -- Test: unsupported_cases3.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/sql/DML_over_joins.sql
+++ b/src/test/regress/sql/DML_over_joins.sql
@@ -619,7 +619,7 @@ delete from s where b = (select min(a) from r where b = s.b);
 
 update p set c = c + 1;
 
-update p set c = c + 1 where b in (select b from s);
+update p set c = c + 1 where b in (select b from s where b = 36);
 -- ----------------------------------------------------------------------
 -- Test: unsupported_cases3.sql
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
DML_over_join tests in non-deterministics since it depends which partition constraint is violated and was reported by @kuien https://github.com/greenplum-db/gpdb/issues/716

I changed the tests to be more targeted and avoid non-deterministic behavior.

@kuien @danielgustafsson @xinzweb @d @oarap @hsyuan please let me know this looks ok.