### PR TITLE
Lower minimum work_mem to 64kB, also on non-assert-enabled builds.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1257,11 +1257,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_UNIT_KB | GUC_GPDB_ADDOPT
 		},
 		&work_mem,
-#ifdef USE_ASSERT_CHECKING      /* allow executor testing with low memory */
-        32768, 2 * BLCKSZ / 1024, MAX_KILOBYTES, NULL, NULL
-#else
-		32768, 8 * BLCKSZ / 1024, MAX_KILOBYTES, NULL, NULL
-#endif
+        32768, 64, MAX_KILOBYTES, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
A new regression test was added in the upstream that does work_mem='64kB',
which used to fail without --enable-cassert. There's little reason to not
allow a small value here, so let's just allow it. It doesn't mean that
anyone should use such a small value in production, but that's just a
matter of "don't do that then".