### PR TITLE
Remove Debug_check_for_invalid_persistent_tid option.

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -393,8 +393,7 @@ heap_create(const char *relname,
 		}
 		
 
-		if (Debug_check_for_invalid_persistent_tid &&
-			!Persistent_BeforePersistenceWork() &&
+		if (!Persistent_BeforePersistenceWork() &&
 			PersistentStore_IsZeroTid(&rel->rd_segfile0_relationnodeinfo.persistentTid))
 		{	
 			elog(ERROR, 
@@ -1201,8 +1200,7 @@ InsertGpRelationNodeTuple(
 //	cqContext	cqc;
 //	cqContext  *pcqCtx;
 
-	if (Debug_check_for_invalid_persistent_tid &&
-		!Persistent_BeforePersistenceWork() &&
+	if (!Persistent_BeforePersistenceWork() &&
 		PersistentStore_IsZeroTid(persistentTid))
 	{	
 		elog(ERROR, 
@@ -1271,8 +1269,7 @@ UpdateGpRelationNodeTuple(
 	bool		repl_repl[Natts_gp_relation_node];
 	HeapTuple	newtuple;
 
-	if (Debug_check_for_invalid_persistent_tid &&
-		!Persistent_BeforePersistenceWork() &&
+	if (!Persistent_BeforePersistenceWork() &&
 		PersistentStore_IsZeroTid(persistentTid))
 	{	
 		elog(ERROR, 
@@ -2416,28 +2413,8 @@ StoreAttrDefault(Relation rel, AttrNumber attnum, Node *expr, Oid attrdefOid)
 			cql("INSERT INTO pg_attrdef ", 
 				NULL));
 
-	elogif(Debug_check_for_invalid_persistent_tid, LOG,
-			 "StoreAttrDefault[1] relation %u/%u/%u '%s', isPresent %s, serial number " INT64_FORMAT ", TID %s",
-			 adrel->rd_node.spcNode,
-			 adrel->rd_node.dbNode,
-			 adrel->rd_node.relNode,
-			 NameStr(adrel->rd_rel->relname),
-			 (adrel->rd_segfile0_relationnodeinfo.isPresent ? "true" : "false"),
-			 adrel->rd_segfile0_relationnodeinfo.persistentSerialNum,
-			 ItemPointerToString(&adrel->rd_segfile0_relationnodeinfo.persistentTid));
-
 	// Fetch gp_persistent_relation_node information that will be added to XLOG record.
 	RelationFetchGpRelationNodeForXLog(adrel);
-
-	elogif(Debug_check_for_invalid_persistent_tid, LOG,
-			 "StoreAttrDefault[2] relation %u/%u/%u '%s', isPresent %s, serial number " INT64_FORMAT ", TID %s",
-			 adrel->rd_node.spcNode,
-			 adrel->rd_node.dbNode,
-			 adrel->rd_node.relNode,
-			 NameStr(adrel->rd_rel->relname),
-			 (adrel->rd_segfile0_relationnodeinfo.isPresent ? "true" : "false"),
-			 adrel->rd_segfile0_relationnodeinfo.persistentSerialNum,
-			 ItemPointerToString(&adrel->rd_segfile0_relationnodeinfo.persistentTid));
 
 	tuple = caql_form_tuple(adrcqCtx, values, nulls);
 

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1511,8 +1511,7 @@ setNewRelfilenodeToOid(Relation relation, Oid newrelfilenode)
 											&relation->rd_segfile0_relationnodeinfo.persistentSerialNum);
 	}
 
-	if (Debug_check_for_invalid_persistent_tid &&
-		!Persistent_BeforePersistenceWork() &&
+	if (!Persistent_BeforePersistenceWork() &&
 		PersistentStore_IsZeroTid(&relation->rd_segfile0_relationnodeinfo.persistentTid))
 	{
 		elog(ERROR,

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -343,8 +343,7 @@ Sequence_FetchGpRelationNodeForXLog(Relation rel)
 				 ItemPointerToString(&rel->rd_segfile0_relationnodeinfo.persistentTid));
 	}
 
-	if (Debug_check_for_invalid_persistent_tid &&
-		!Persistent_BeforePersistenceWork() &&
+	if (!Persistent_BeforePersistenceWork() &&
 		PersistentStore_IsZeroTid(&rel->rd_segfile0_relationnodeinfo.persistentTid))
 	{	
 		elog(ERROR, 

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -654,8 +654,7 @@ RelationFetchSegFile0GpRelationNode(
 		}
 
 		Assert(!Persistent_BeforePersistenceWork());
-		if (Debug_check_for_invalid_persistent_tid &&
-			PersistentStore_IsZeroTid(&relation->rd_segfile0_relationnodeinfo.persistentTid))
+		if (PersistentStore_IsZeroTid(&relation->rd_segfile0_relationnodeinfo.persistentTid))
 		{	
 			elog(ERROR, 
 				 "RelationFetchSegFile0GpRelationNode has invalid TID (0,0) into relation %u/%u/%u '%s', serial number " INT64_FORMAT,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -255,7 +255,6 @@ bool		gp_persistent_repair_global_sequence = false;
 bool		Debug_print_xlog_relation_change_info = false;
 bool		Debug_print_xlog_relation_change_info_skip_issues_only = false;
 bool		Debug_print_xlog_relation_change_info_backtrace_skip_issues = false;
-bool		Debug_check_for_invalid_persistent_tid = false;
 
 bool		Debug_filerep_crc_on = true;
 bool		Debug_filerep_print = false;
@@ -2049,16 +2048,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Debug_print_xlog_relation_change_info_backtrace_skip_issues,
-		false, NULL, NULL
-	},
-
-	{
-		{"debug_check_for_invalid_persistent_tid", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Check for invalid persistent TID"),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_check_for_invalid_persistent_tid,
 		false, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -230,7 +230,6 @@ extern bool filerep_inject_change_tracking_recovery_fault;
 extern bool filerep_mirrorvalidation_during_resync;
 extern bool log_filerep_to_syslogger;
 extern bool gp_crash_recovery_suppress_ao_eof;
-extern bool Debug_check_for_invalid_persistent_tid;
 extern bool gp_create_table_random_default_distribution;
 extern bool gp_allow_non_uniform_partitioning_ddl;
 extern bool gp_enable_exchange_default_partition;


### PR DESCRIPTION
The checks for invalid TIDs are very cheap, a few CPU instructions. It's
better to catch bugs involving invalid TID early, so let's always check
for them.

The LOGs in storeAttrDefault() that were also tied to this GUC seemed
oddly specific. They were probably added long time ago to hunt for some
particular bug, and don't seem generally useful, so I just removed them.