### PR TITLE
Backport isolationtester

### DIFF
--- a/src/test/isolation/.gitignore
+++ b/src/test/isolation/.gitignore
@@ -1,0 +1,12 @@
+# Local binaries
+/isolationtester
+/pg_isolation_regress
+
+# Local generated source files
+/specparse.c
+/specscanner.c
+
+# Generated subdirectories
+/results/
+/log/
+/tmp_check/

--- a/src/test/isolation/Makefile
+++ b/src/test/isolation/Makefile
@@ -24,11 +24,19 @@ pg_regress.o:
 	$(MAKE) -C $(top_builddir)/src/test/regress pg_regress.o
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/pg_regress.o .
 
-pqsignal.o:
-	$(MAKE) -C $(top_builddir)/src/test/regress pqsignal.o
-	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/pqsignal.o .
+gpstringsubs.pl: gpstringsubs.pl
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpstringsubs.pl
 
-pg_isolation_regress$(X): isolation_main.o pg_regress.o pqsignal.o
+gpdiff.pl: atmsort.pm explain.pm
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpdiff.pl
+
+atmsort.pm:
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/atmsort.pm
+
+explain.pm:
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/explain.pm
+
+pg_isolation_regress$(X): isolation_main.o pg_regress.o
 	$(CC) $(CFLAGS) $^ $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
 
 isolationtester$(X): $(OBJS) | submake-libpq submake-libpgport
@@ -66,13 +74,14 @@ endif
 # so do not clean them here
 clean distclean:
 	rm -f isolationtester$(X) pg_isolation_regress$(X) $(OBJS) isolation_main.o
-	rm -f pg_regress.o pqsignal.o
+	rm -f pg_regress.o
+	rm -f gpstringsubs.pl gpdiff.pl atmsort.pm explain.pm
 	rm -rf $(pg_regress_clean_files)
 
 maintainer-clean: distclean
 	rm -f specparse.c specscanner.c
 
-installcheck: all
+installcheck: all gpdiff.pl gpstringsubs.pl
 	./pg_isolation_regress --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --schedule=$(srcdir)/isolation_schedule
 
 # Version of the install check test that includes the prepared_transactions test

--- a/src/test/isolation/Makefile
+++ b/src/test/isolation/Makefile
@@ -1,0 +1,91 @@
+#
+# Makefile for isolation tests
+#
+
+subdir = src/test/isolation
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+
+# where to find psql for testing an existing installation
+PSQLDIR = $(bindir)
+
+ifeq ($(PORTNAME), win32)
+LDLIBS += -lws2_32
+endif
+
+override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPFLAGS)
+override LDLIBS := $(libpq_pgport) $(LDLIBS)
+
+OBJS =  specparse.o isolationtester.o
+
+all: isolationtester$(X) pg_isolation_regress$(X)
+
+pg_regress.o:
+	$(MAKE) -C $(top_builddir)/src/test/regress pg_regress.o
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/pg_regress.o .
+
+pqsignal.o:
+	$(MAKE) -C $(top_builddir)/src/test/regress pqsignal.o
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/pqsignal.o .
+
+pg_isolation_regress$(X): isolation_main.o pg_regress.o pqsignal.o
+	$(CC) $(CFLAGS) $^ $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
+
+isolationtester$(X): $(OBJS) | submake-libpq submake-libpgport
+	$(CC) $(CFLAGS) $(OBJS) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
+
+distprep: specparse.c specscanner.c
+
+# There is no correct way to write a rule that generates two files.
+# Rules with two targets don't have that meaning, they are merely
+# shorthand for two otherwise separate rules.  To be safe for parallel
+# make, we must chain the dependencies like this.  The semicolon is
+# important, otherwise make will choose the built-in rule for
+# gram.y=>gram.c.
+
+specparse.h: specparse.c ;
+
+# specscanner is compiled as part of specparse
+specparse.o: specscanner.c
+
+specparse.c: specparse.y
+ifdef BISON
+	$(BISON) $(BISONFLAGS) -o $@ $<
+else
+	@$(missing) bison $< $@
+endif
+
+specscanner.c: specscanner.l
+ifdef FLEX
+	$(FLEX) $(FLEXFLAGS) -o'$@' $<
+else
+	@$(missing) flex $< $@
+endif
+
+# specparse.c and specscanner.c are in the distribution tarball,
+# so do not clean them here
+clean distclean:
+	rm -f isolationtester$(X) pg_isolation_regress$(X) $(OBJS) isolation_main.o
+	rm -f pg_regress.o pqsignal.o
+	rm -rf $(pg_regress_clean_files)
+
+maintainer-clean: distclean
+	rm -f specparse.c specscanner.c
+
+installcheck: all
+	./pg_isolation_regress --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --schedule=$(srcdir)/isolation_schedule
+
+# Version of the install check test that includes the prepared_transactions test
+# It only makes sense to run this if set up to use prepared transactions,
+# via the postgresql.conf.
+installcheck-prepared-txns: all
+	./pg_isolation_regress --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --schedule=$(srcdir)/isolation_schedule prepared-transactions
+
+
+# We can't support "make check" because isolationtester requires libpq, and
+# in fact (on typical platforms using shared libraries) requires libpq to
+# already be installed.  You could run "make install" and then run a check
+# using a temp installation, but there seems little point in that.
+check:
+	@echo "'make check' is not supported."
+	@echo "Install PostgreSQL, then 'make installcheck' instead."

--- a/src/test/isolation/README
+++ b/src/test/isolation/README
@@ -1,0 +1,113 @@
+src/test/isolation/README
+
+Isolation tests
+===============
+
+This directory contains a set of tests for concurrent behaviors in
+PostgreSQL.  These tests require running multiple interacting transactions,
+which requires management of multiple concurrent connections, and therefore
+can't be tested using the normal pg_regress program.  The name "isolation"
+comes from the fact that the original motivation was to test the
+serializable isolation level; but tests for other sorts of concurrent
+behaviors have been added as well.
+
+To run the tests, you need to have a server running at the default port
+expected by libpq.  (You can set PGPORT and so forth in your environment
+to control this.)  Then run
+    gmake installcheck
+To run just specific test(s), you can do something like
+    ./pg_isolation_regress fk-contention fk-deadlock
+(look into the specs/ subdirectory to see the available tests).
+
+The prepared-transactions test requires the server's
+max_prepared_transactions parameter to be set to at least 3; therefore it
+is not run by default.  To include it in the test run, use
+    gmake installcheck-prepared-txns
+
+To define tests with overlapping transactions, we use test specification
+files with a custom syntax, which is described in the next section.  To add
+a new test, place a spec file in the specs/ subdirectory, add the expected
+output in the expected/ subdirectory, and add the test's name to the
+isolation_schedule file.
+
+isolationtester is a program that uses libpq to open multiple connections,
+and executes a test specified by a spec file. A libpq connection string
+specifies the server and database to connect to; defaults derived from
+environment variables are used otherwise.
+
+pg_isolation_regress is a tool similar to pg_regress, but instead of using
+psql to execute a test, it uses isolationtester.  It accepts all the same
+command-line arguments as pg_regress.
+
+
+Test specification
+==================
+
+Each isolation test is defined by a specification file, stored in the specs
+subdirectory. A test specification consists of four parts, in this order:
+
+setup { <SQL> }
+
+  The given SQL block is executed once, in one session only, before running
+  the test. Create any test tables or other required objects here. This
+  part is optional.
+
+teardown { <SQL> }
+
+  The teardown SQL block is executed once after the test is finished. Use
+  this to clean up in preparation for the next permutation, e.g dropping
+  any test tables created by setup. This part is optional.
+
+session "<name>"
+
+  There are normally several "session" parts in a spec file. Each
+  session is executed in its own connection. A session part consists
+  of three parts: setup, teardown and one or more "steps". The per-session
+  setup and teardown parts have the same syntax as the per-test setup and
+  teardown described above, but they are executed in each session. The
+  setup part typically contains a "BEGIN" command to begin a transaction.
+
+  Each step has the syntax
+
+  step "<name>" { <SQL> }
+
+  where <name> is a name identifying this step, and SQL is a SQL statement
+  (or statements, separated by semicolons) that is executed in the step.
+  Step names must be unique across the whole spec file.
+
+permutation "<step name>" ...
+
+  A permutation line specifies a list of steps that are run in that order.
+  Any number of permutation lines can appear.  If no permutation lines are
+  given, the test program automatically generates all possible orderings
+  of the steps from each session (running the steps of any one session in
+  order).  Note that the list of steps in a manually specified
+  "permutation" line doesn't actually have to be a permutation of the
+  available steps; it could for instance repeat some steps more than once,
+  or leave others out.
+
+Lines beginning with a # are considered comments.
+
+For each permutation of the session steps (whether these are manually
+specified in the spec file, or automatically generated), the isolation
+tester runs the main setup part, then per-session setup parts, then
+the selected session steps, then per-session teardown, then the main
+teardown script.  Each selected step is sent to the connection associated
+with its session.
+
+
+Support for blocking commands
+=============================
+
+Each step may contain commands that block until further action has been taken
+(most likely, some other session runs a step that unblocks it or causes a
+deadlock).  A test that uses this ability must manually specify valid
+permutations, i.e. those that would not expect a blocked session to execute a
+command.  If the test fails to follow that rule, the test is aborted.
+
+Currently, at most one step can be waiting at a time.  As long as one
+step is waiting, subsequent steps are run to completion synchronously.
+
+Note that isolationtester recognizes that a command has blocked by looking
+to see if it is shown as waiting in the pg_locks view; therefore, only
+blocks on heavyweight locks will be detected.

--- a/src/test/isolation/expected/ao-serializable-read.out
+++ b/src/test/isolation/expected/ao-serializable-read.out
@@ -1,0 +1,22 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2begin s2select s1insert s1select s2select s2insert s2select
+step s2begin: BEGIN ISOLATION LEVEL SERIALIZABLE;
+step s2select: select count(*) from ao;
+count          
+
+0              
+step s1insert: insert into ao select i, i from generate_series(0, 99) i;
+step s1select: select count(*) from ao;
+count          
+
+100            
+step s2select: select count(*) from ao;
+count          
+
+0              
+step s2insert: insert into ao select i, i from generate_series(0, 99) i;
+step s2select: select count(*) from ao;
+count          
+
+100            

--- a/src/test/isolation/expected/ao-serializable-vacuum.out
+++ b/src/test/isolation/expected/ao-serializable-vacuum.out
@@ -1,0 +1,19 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2begin s1delete s1vacuum s2select s2insert s2select
+step s2begin: BEGIN ISOLATION LEVEL SERIALIZABLE;
+		  select 123 as "establish snapshot";
+establish snapshot
+
+123            
+step s1delete: delete from ao;
+step s1vacuum: vacuum ao;
+step s2select: select count(*) from ao;
+count          
+
+100            
+step s2insert: insert into ao select i, i from generate_series(0, 99) i;
+step s2select: select count(*) from ao;
+count          
+
+200            

--- a/src/test/isolation/isolation_main.c
+++ b/src/test/isolation/isolation_main.c
@@ -1,0 +1,89 @@
+/*-------------------------------------------------------------------------
+ *
+ * isolation_main --- pg_regress test launcher for isolation tests
+ *
+ * Portions Copyright (c) 1996-2011, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/test/isolation/isolation_main.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "pg_regress.h"
+
+/*
+ * start an isolation tester process for specified file (including
+ * redirection), and return process ID
+ */
+static PID_TYPE
+isolation_start_test(const char *testname,
+					 _stringlist ** resultfiles,
+					 _stringlist ** expectfiles,
+					 _stringlist ** tags)
+{
+	PID_TYPE	pid;
+	char		infile[MAXPGPATH];
+	char		outfile[MAXPGPATH];
+	char		expectfile[MAXPGPATH];
+	char		psql_cmd[MAXPGPATH * 3];
+	size_t		offset = 0;
+
+	/*
+	 * Look for files in the output dir first, consistent with a vpath search.
+	 * This is mainly to create more reasonable error messages if the file is
+	 * not found.  It also allows local test overrides when running pg_regress
+	 * outside of the source tree.
+	 */
+	snprintf(infile, sizeof(infile), "%s/specs/%s.spec",
+			 outputdir, testname);
+	if (!file_exists(infile))
+		snprintf(infile, sizeof(infile), "%s/specs/%s.spec",
+				 inputdir, testname);
+
+	snprintf(outfile, sizeof(outfile), "%s/results/%s.out",
+			 outputdir, testname);
+
+	snprintf(expectfile, sizeof(expectfile), "%s/expected/%s.out",
+			 outputdir, testname);
+	if (!file_exists(expectfile))
+		snprintf(expectfile, sizeof(expectfile), "%s/expected/%s.out",
+				 inputdir, testname);
+
+	add_stringlist_item(resultfiles, outfile);
+	add_stringlist_item(expectfiles, expectfile);
+
+	if (launcher)
+		offset += snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
+						   "%s ", launcher);
+
+	snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
+			 SYSTEMQUOTE "\"./isolationtester\" \"dbname=%s\" < \"%s\" > \"%s\" 2>&1" SYSTEMQUOTE,
+			 dblist->str,
+			 infile,
+			 outfile);
+
+	pid = spawn_process(psql_cmd);
+
+	if (pid == INVALID_PID)
+	{
+		fprintf(stderr, _("could not start process for test %s\n"),
+				testname);
+		exit_nicely(2);
+	}
+
+	return pid;
+}
+
+static void
+isolation_init(void)
+{
+	/* set default regression database name */
+	add_stringlist_item(&dblist, "isolationtest");
+}
+
+int
+main(int argc, char *argv[])
+{
+	return regression_main(argc, argv, isolation_init, isolation_start_test);
+}

--- a/src/test/isolation/isolation_main.c
+++ b/src/test/isolation/isolation_main.c
@@ -53,9 +53,15 @@ isolation_start_test(const char *testname,
 	add_stringlist_item(resultfiles, outfile);
 	add_stringlist_item(expectfiles, expectfile);
 
+	/*
+	 * GPDB_91_MERGE_FIXME: pg_regress --launcher argument was added in PostgreSQL 9.1.
+	 * We don't have it in GPDB yet. Re-enable this when we merge with 9.1.
+	 */
+#if PG_VERSION_NUM >= 90100
 	if (launcher)
 		offset += snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
 						   "%s ", launcher);
+#endif
 
 	snprintf(psql_cmd + offset, sizeof(psql_cmd) - offset,
 			 SYSTEMQUOTE "\"./isolationtester\" \"dbname=%s\" < \"%s\" > \"%s\" 2>&1" SYSTEMQUOTE,

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -1,0 +1,4 @@
+
+# GPDB-specific tests
+
+test: ao-serializable-read

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -2,3 +2,4 @@
 # GPDB-specific tests
 
 test: ao-serializable-read
+test: ao-serializable-vacuum

--- a/src/test/isolation/isolationtester.c
+++ b/src/test/isolation/isolationtester.c
@@ -1,0 +1,395 @@
+/*
+ * src/test/isolation/isolationtester.c
+ *
+ * isolationtester.c
+ *		Runs an isolation test specified by a spec file.
+ */
+
+#include "postgres_fe.h"
+
+#ifdef WIN32
+#include <windows.h>
+#endif
+
+#include "libpq-fe.h"
+
+#include "isolationtester.h"
+
+static PGconn **conns = NULL;
+static int	nconns = 0;
+
+static void run_all_permutations(TestSpec * testspec);
+static void run_all_permutations_recurse(TestSpec * testspec, int nsteps, Step ** steps);
+static void run_named_permutations(TestSpec * testspec);
+static void run_permutation(TestSpec * testspec, int nsteps, Step ** steps);
+
+static int	step_qsort_cmp(const void *a, const void *b);
+static int	step_bsearch_cmp(const void *a, const void *b);
+
+static void printResultSet(PGresult *res);
+
+/* close all connections and exit */
+static void
+exit_nicely(void)
+{
+	int			i;
+
+	for (i = 0; i < nconns; i++)
+		PQfinish(conns[i]);
+	exit(1);
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *conninfo;
+	TestSpec   *testspec;
+	int			i;
+
+	/*
+	 * If the user supplies a parameter on the command line, use it as the
+	 * conninfo string; otherwise default to setting dbname=postgres and using
+	 * environment variables or defaults for all other connection parameters.
+	 */
+	if (argc > 1)
+		conninfo = argv[1];
+	else
+		conninfo = "dbname = postgres";
+
+	/* Read the test spec from stdin */
+	spec_yyparse();
+	testspec = &parseresult;
+	printf("Parsed test spec with %d sessions\n", testspec->nsessions);
+
+	/* Establish connections to the database, one for each session */
+	nconns = testspec->nsessions;
+	conns = calloc(nconns, sizeof(PGconn *));
+	for (i = 0; i < testspec->nsessions; i++)
+	{
+		PGresult   *res;
+
+		conns[i] = PQconnectdb(conninfo);
+		if (PQstatus(conns[i]) != CONNECTION_OK)
+		{
+			fprintf(stderr, "Connection %d to database failed: %s",
+					i, PQerrorMessage(conns[i]));
+			exit_nicely();
+		}
+
+		/*
+		 * Suppress NOTIFY messages, which otherwise pop into results at odd
+		 * places.
+		 */
+		res = PQexec(conns[i], "SET client_min_messages = warning;");
+		if (PQresultStatus(res) != PGRES_COMMAND_OK)
+		{
+			fprintf(stderr, "message level setup failed: %s", PQerrorMessage(conns[i]));
+			exit_nicely();
+		}
+		PQclear(res);
+	}
+
+	/* Set the session index fields in steps. */
+	for (i = 0; i < testspec->nsessions; i++)
+	{
+		Session    *session = testspec->sessions[i];
+		int			stepindex;
+
+		for (stepindex = 0; stepindex < session->nsteps; stepindex++)
+			session->steps[stepindex]->session = i;
+	}
+
+	/*
+	 * Run the permutations specified in the spec, or all if none were
+	 * explicitly specified.
+	 */
+	if (testspec->permutations)
+		run_named_permutations(testspec);
+	else
+		run_all_permutations(testspec);
+
+	/* Clean up and exit */
+	for (i = 0; i < nconns; i++)
+		PQfinish(conns[i]);
+	return 0;
+}
+
+static int *piles;
+
+/*
+ * Run all permutations of the steps and sessions.
+ */
+static void
+run_all_permutations(TestSpec * testspec)
+{
+	int			nsteps;
+	int			i;
+	Step	  **steps;
+
+	/* Count the total number of steps in all sessions */
+	nsteps = 0;
+	for (i = 0; i < testspec->nsessions; i++)
+		nsteps += testspec->sessions[i]->nsteps;
+
+	steps = malloc(sizeof(Step *) * nsteps);
+
+	/*
+	 * To generate the permutations, we conceptually put the steps of each
+	 * session on a pile. To generate a permuation, we pick steps from the
+	 * piles until all piles are empty. By picking steps from piles in
+	 * different order, we get different permutations.
+	 *
+	 * A pile is actually just an integer which tells how many steps we've
+	 * already picked from this pile.
+	 */
+	piles = malloc(sizeof(int) * testspec->nsessions);
+	for (i = 0; i < testspec->nsessions; i++)
+		piles[i] = 0;
+
+	run_all_permutations_recurse(testspec, 0, steps);
+}
+
+static void
+run_all_permutations_recurse(TestSpec * testspec, int nsteps, Step ** steps)
+{
+	int			i;
+	int			found = 0;
+
+	for (i = 0; i < testspec->nsessions; i++)
+	{
+		/* If there's any more steps in this pile, pick it and recurse */
+		if (piles[i] < testspec->sessions[i]->nsteps)
+		{
+			steps[nsteps] = testspec->sessions[i]->steps[piles[i]];
+			piles[i]++;
+
+			run_all_permutations_recurse(testspec, nsteps + 1, steps);
+
+			piles[i]--;
+
+			found = 1;
+		}
+	}
+
+	/* If all the piles were empty, this permutation is completed. Run it */
+	if (!found)
+		run_permutation(testspec, nsteps, steps);
+}
+
+/*
+ * Run permutations given in the test spec
+ */
+static void
+run_named_permutations(TestSpec * testspec)
+{
+	int			i,
+				j;
+	int			n;
+	int			nallsteps;
+	Step	  **allsteps;
+
+	/* First create a lookup table of all steps */
+	nallsteps = 0;
+	for (i = 0; i < testspec->nsessions; i++)
+		nallsteps += testspec->sessions[i]->nsteps;
+
+	allsteps = malloc(nallsteps * sizeof(Step *));
+
+	n = 0;
+	for (i = 0; i < testspec->nsessions; i++)
+	{
+		for (j = 0; j < testspec->sessions[i]->nsteps; j++)
+			allsteps[n++] = testspec->sessions[i]->steps[j];
+	}
+
+	qsort(allsteps, nallsteps, sizeof(Step *), &step_qsort_cmp);
+
+	for (i = 0; i < testspec->npermutations; i++)
+	{
+		Permutation *p = testspec->permutations[i];
+		Step	  **steps;
+
+		steps = malloc(p->nsteps * sizeof(Step *));
+
+		/* Find all the named steps from the lookup table */
+		for (j = 0; j < p->nsteps; j++)
+		{
+			steps[j] = *((Step **) bsearch(p->stepnames[j], allsteps, nallsteps,
+										 sizeof(Step *), &step_bsearch_cmp));
+			if (steps[j] == NULL)
+			{
+				fprintf(stderr, "undefined step \"%s\" specified in permutation\n", p->stepnames[j]);
+				exit_nicely();
+			}
+		}
+
+		run_permutation(testspec, p->nsteps, steps);
+		free(steps);
+	}
+}
+
+static int
+step_qsort_cmp(const void *a, const void *b)
+{
+	Step	   *stepa = *((Step **) a);
+	Step	   *stepb = *((Step **) b);
+
+	return strcmp(stepa->name, stepb->name);
+}
+
+static int
+step_bsearch_cmp(const void *a, const void *b)
+{
+	char	   *stepname = (char *) a;
+	Step	   *step = *((Step **) b);
+
+	return strcmp(stepname, step->name);
+}
+
+/*
+ * Run one permutation
+ */
+static void
+run_permutation(TestSpec * testspec, int nsteps, Step ** steps)
+{
+	PGresult   *res;
+	int			i;
+
+	printf("\nstarting permutation:");
+	for (i = 0; i < nsteps; i++)
+		printf(" %s", steps[i]->name);
+	printf("\n");
+
+	/* Perform setup */
+	if (testspec->setupsql)
+	{
+		res = PQexec(conns[0], testspec->setupsql);
+		if (PQresultStatus(res) != PGRES_COMMAND_OK)
+		{
+			fprintf(stderr, "setup failed: %s", PQerrorMessage(conns[0]));
+			exit_nicely();
+		}
+		PQclear(res);
+	}
+
+	/* Perform per-session setup */
+	for (i = 0; i < testspec->nsessions; i++)
+	{
+		if (testspec->sessions[i]->setupsql)
+		{
+			res = PQexec(conns[i], testspec->sessions[i]->setupsql);
+			if (PQresultStatus(res) == PGRES_TUPLES_OK)
+			{
+				printResultSet(res);
+			}
+			else if (PQresultStatus(res) != PGRES_COMMAND_OK)
+			{
+				fprintf(stderr, "setup of session %s failed: %s",
+						testspec->sessions[i]->name,
+						PQerrorMessage(conns[i]));
+				exit_nicely();
+			}
+			PQclear(res);
+		}
+	}
+
+	/* Perform steps */
+	for (i = 0; i < nsteps; i++)
+	{
+		Step	   *step = steps[i];
+
+		printf("step %s: %s\n", step->name, step->sql);
+		res = PQexec(conns[step->session], step->sql);
+
+		switch (PQresultStatus(res))
+		{
+			case PGRES_COMMAND_OK:
+				break;
+
+			case PGRES_TUPLES_OK:
+				printResultSet(res);
+				break;
+
+			case PGRES_FATAL_ERROR:
+				/*
+				 * Detail may contain XID values, so we want to just show
+				 * primary.  Beware however that libpq-generated error results
+				 * may not contain subfields, only an old-style message.
+				 */
+				{
+					const char *sev = PQresultErrorField(res,
+														 PG_DIAG_SEVERITY);
+					const char *msg = PQresultErrorField(res,
+													PG_DIAG_MESSAGE_PRIMARY);
+
+					if (sev && msg)
+						printf("%s:  %s\n", sev, msg);
+					else
+						printf("%s", PQresultErrorMessage(res));
+				}
+				break;
+
+			default:
+				printf("unexpected result status: %s\n",
+					   PQresStatus(PQresultStatus(res)));
+		}
+		PQclear(res);
+	}
+
+	/* Perform per-session teardown */
+	for (i = 0; i < testspec->nsessions; i++)
+	{
+		if (testspec->sessions[i]->teardownsql)
+		{
+			res = PQexec(conns[i], testspec->sessions[i]->teardownsql);
+			if (PQresultStatus(res) != PGRES_COMMAND_OK)
+			{
+				fprintf(stderr, "teardown of session %s failed: %s",
+						testspec->sessions[i]->name,
+						PQerrorMessage(conns[i]));
+				/* don't exit on teardown failure */
+			}
+			PQclear(res);
+		}
+	}
+
+	/* Perform teardown */
+	if (testspec->teardownsql)
+	{
+		res = PQexec(conns[0], testspec->teardownsql);
+		if (PQresultStatus(res) == PGRES_TUPLES_OK)
+		{
+			printResultSet(res);
+		}
+		else if (PQresultStatus(res) != PGRES_COMMAND_OK)
+		{
+			fprintf(stderr, "teardown failed: %s",
+					PQerrorMessage(conns[0]));
+			/* don't exit on teardown failure */
+
+		}
+		PQclear(res);
+	}
+}
+
+static void
+printResultSet(PGresult *res)
+{
+	int			nFields;
+	int			i,
+				j;
+
+	/* first, print out the attribute names */
+	nFields = PQnfields(res);
+	for (i = 0; i < nFields; i++)
+		printf("%-15s", PQfname(res, i));
+	printf("\n\n");
+
+	/* next, print out the rows */
+	for (i = 0; i < PQntuples(res); i++)
+	{
+		for (j = 0; j < nFields; j++)
+			printf("%-15s", PQgetvalue(res, i, j));
+		printf("\n");
+	}
+}

--- a/src/test/isolation/isolationtester.h
+++ b/src/test/isolation/isolationtester.h
@@ -1,0 +1,59 @@
+/*-------------------------------------------------------------------------
+ *
+ * isolationtester.h
+ *	  include file for isolation tests
+ *
+ * Portions Copyright (c) 1996-2011, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *		src/test/isolation/isolationtester.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef ISOLATIONTESTER_H
+#define ISOLATIONTESTER_H
+
+typedef struct Session Session;
+typedef struct Step Step;
+
+struct Session
+{
+	char	   *name;
+	char	   *setupsql;
+	char	   *teardownsql;
+	Step	  **steps;
+	int			nsteps;
+};
+
+struct Step
+{
+	int			session;
+	char	   *name;
+	char	   *sql;
+};
+
+typedef struct
+{
+	int			nsteps;
+	char	  **stepnames;
+}	Permutation;
+
+typedef struct
+{
+	char	   *setupsql;
+	char	   *teardownsql;
+	Session   **sessions;
+	int			nsessions;
+	Permutation **permutations;
+	int			npermutations;
+}	TestSpec;
+
+extern TestSpec parseresult;
+
+extern int	spec_yyparse(void);
+
+extern int	spec_yylex(void);
+extern void spec_yyerror(const char *str);
+
+#endif   /* ISOLATIONTESTER_H */

--- a/src/test/isolation/specparse.y
+++ b/src/test/isolation/specparse.y
@@ -1,0 +1,185 @@
+%{
+/*-------------------------------------------------------------------------
+ *
+ * specparse.y
+ *	  bison grammar for the isolation test file format
+ *
+ * Portions Copyright (c) 1996-2011, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres_fe.h"
+
+#include "isolationtester.h"
+
+
+TestSpec		parseresult;			/* result of parsing is left here */
+
+%}
+
+%expect 0
+%name-prefix="spec_yy"
+
+%union
+{
+	char	   *str;
+	Session	   *session;
+	Step	   *step;
+	Permutation *permutation;
+	struct
+	{
+		void  **elements;
+		int		nelements;
+	}			ptr_list;
+}
+
+%type <str>  opt_setup opt_teardown
+%type <ptr_list> step_list session_list permutation_list opt_permutation_list
+%type <ptr_list> string_literal_list
+%type <session> session
+%type <step> step
+%type <permutation> permutation
+
+%token <str> sqlblock string_literal
+%token PERMUTATION SESSION SETUP STEP TEARDOWN TEST
+
+%%
+
+TestSpec:
+			opt_setup
+			opt_teardown
+			session_list
+			opt_permutation_list
+			{
+				parseresult.setupsql = $1;
+				parseresult.teardownsql = $2;
+				parseresult.sessions = (Session **) $3.elements;
+				parseresult.nsessions = $3.nelements;
+				parseresult.permutations = (Permutation **) $4.elements;
+				parseresult.npermutations = $4.nelements;
+			}
+		;
+
+opt_setup:
+			/* EMPTY */			{ $$ = NULL; }
+			| SETUP sqlblock	{ $$ = $2; }
+		;
+
+opt_teardown:
+			/* EMPTY */			{ $$ = NULL; }
+			| TEARDOWN sqlblock	{ $$ = $2; }
+		;
+
+session_list:
+			session_list session
+			{
+				$$.elements = realloc($1.elements,
+									  ($1.nelements + 1) * sizeof(void *));
+				$$.elements[$1.nelements] = $2;
+				$$.nelements = $1.nelements + 1;
+			}
+			| session
+			{
+				$$.nelements = 1;
+				$$.elements = malloc(sizeof(void *));
+				$$.elements[0] = $1;
+			}
+		;
+
+session:
+			SESSION string_literal opt_setup step_list opt_teardown
+			{
+				$$ = malloc(sizeof(Session));
+				$$->name = $2;
+				$$->setupsql = $3;
+				$$->steps = (Step **) $4.elements;
+				$$->nsteps = $4.nelements;
+				$$->teardownsql = $5;
+			}
+		;
+
+step_list:
+			step_list step
+			{
+				$$.elements = realloc($1.elements,
+									  ($1.nelements + 1) * sizeof(void *));
+				$$.elements[$1.nelements] = $2;
+				$$.nelements = $1.nelements + 1;
+			}
+			| step
+			{
+				$$.nelements = 1;
+				$$.elements = malloc(sizeof(void *));
+				$$.elements[0] = $1;
+			}
+		;
+
+
+step:
+			STEP string_literal sqlblock
+			{
+				$$ = malloc(sizeof(Step));
+				$$->name = $2;
+				$$->sql = $3;
+			}
+		;
+
+
+opt_permutation_list:
+			permutation_list
+			{
+				$$ = $1;
+			}
+			| /* EMPTY */
+			{
+				$$.elements = NULL;
+				$$.nelements = 0;
+			}
+
+permutation_list:
+			permutation_list permutation
+			{
+				$$.elements = realloc($1.elements,
+									  ($1.nelements + 1) * sizeof(void *));
+				$$.elements[$1.nelements] = $2;
+				$$.nelements = $1.nelements + 1;
+			}
+			| permutation
+			{
+				$$.nelements = 1;
+				$$.elements = malloc(sizeof(void *));
+				$$.elements[0] = $1;
+			}
+		;
+
+
+permutation:
+			PERMUTATION string_literal_list
+			{
+				$$ = malloc(sizeof(Permutation));
+				$$->stepnames = (char **) $2.elements;
+				$$->nsteps = $2.nelements;
+			}
+		;
+
+string_literal_list:
+			string_literal_list string_literal
+			{
+				$$.elements = realloc($1.elements,
+									  ($1.nelements + 1) * sizeof(void *));
+				$$.elements[$1.nelements] = $2;
+				$$.nelements = $1.nelements + 1;
+			}
+			| string_literal
+			{
+				$$.nelements = 1;
+				$$.elements = malloc(sizeof(void *));
+				$$.elements[0] = $1;
+			}
+		;
+
+%%
+
+#include "specscanner.c"

--- a/src/test/isolation/specs/ao-serializable-read.spec
+++ b/src/test/isolation/specs/ao-serializable-read.spec
@@ -1,0 +1,68 @@
+# Test reading an AO-table in SERIALIZABLE mode.
+#
+#
+# This is an old repro script for a GPDB bug that was fixed in GPDB 4.1.0.0.
+# Explanation from the original bug report follows:
+#
+# -----
+# Try to repro this by running the following steps in two psql sessions:
+#
+# (1) In session 1,
+#
+# drop table if exists ao;
+# create table ao (i int, j int) with (appendonly=true);
+#
+# (2) In session 2:
+#
+# begin TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+# select * from ao;
+#  i | j
+# ---+---
+# (0 rows)
+#
+# (3) In session 1:
+#
+# insert into ao select i, i from generate_series(0, 99) i;
+# select count(*) from ao;
+#  count
+# -------
+#    100
+# (1 row)
+#
+# (4) In session 2:
+#
+# select * from ao;
+#  i | j
+# ---+---
+# (0 rows)
+#
+# insert into ao select i, i from generate_series(0, 99) i;
+# -- This select used to return '200', i.e. the rows inserted by session 1
+# erroneously became visible to us.
+# select count(*) from ao;
+#  count
+# -------
+#    200
+# (1 row)
+#
+setup
+{
+    create table ao (i int, j int) with (appendonly=true);
+}
+
+teardown
+{
+    drop table if exists ao;
+}
+
+session "s1"
+step "s1insert"	{ insert into ao select i, i from generate_series(0, 99) i; }
+step "s1select"	{ select count(*) from ao; }
+
+session "s2"
+step "s2begin"	{ BEGIN ISOLATION LEVEL SERIALIZABLE; }
+step "s2select"	{ select count(*) from ao; }
+step "s2insert"	{ insert into ao select i, i from generate_series(0, 99) i; }
+teardown	{ abort; }
+
+permutation "s2begin" "s2select" "s1insert" "s1select" "s2select" "s2insert" "s2select"

--- a/src/test/isolation/specs/ao-serializable-vacuum.spec
+++ b/src/test/isolation/specs/ao-serializable-vacuum.spec
@@ -1,0 +1,28 @@
+# Test reading an AO-table in SERIALIZABLE mode, with concurrent VACUUM.
+#
+setup
+{
+    create table ao (i int, j int) with (appendonly=true);
+    insert into ao select i, i from generate_series(0, 99) i;
+}
+
+teardown
+{
+    drop table if exists ao;
+}
+
+session "s1"
+step "s1delete"	{ delete from ao; }
+step "s1vacuum"	{ vacuum ao; }
+
+session "s2"
+step "s2begin"	{ BEGIN ISOLATION LEVEL SERIALIZABLE;
+		  select 123 as "establish snapshot"; }
+step "s2select"	{ select count(*) from ao; }
+step "s2insert"	{ insert into ao select i, i from generate_series(0, 99) i; }
+teardown	{ abort; }
+
+# 1. Begin serializable transaction in session 2.
+# 2. Delete all rows and vacuum the table in session 1.
+# 3. Select in session 2. This should still see the rows deleted by session 1.
+permutation "s2begin" "s1delete" "s1vacuum" "s2select" "s2insert" "s2select"

--- a/src/test/isolation/specscanner.l
+++ b/src/test/isolation/specscanner.l
@@ -1,0 +1,111 @@
+%{
+/*-------------------------------------------------------------------------
+ *
+ * specscanner.l
+ *	  a lexical scanner for an isolation test specification
+ *
+ * Portions Copyright (c) 1996-2011, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *-------------------------------------------------------------------------
+ */
+
+static int	yyline = 1;			/* line number for error reporting */
+
+static char litbuf[1024];
+static int litbufpos = 0;
+
+static void addlitchar(const char c);
+
+%}
+
+%option 8bit
+%option never-interactive
+%option nodefault
+%option noinput
+%option nounput
+%option noyywrap
+%option prefix="spec_yy"
+
+
+%x sql
+%x qstr
+
+non_newline		[^\n\r]
+space			[ \t\r\f]
+
+comment			("#"{non_newline}*)
+
+%%
+
+permutation		{ return(PERMUTATION); }
+session			{ return(SESSION); }
+setup			{ return(SETUP); }
+step			{ return(STEP); }
+teardown		{ return(TEARDOWN); }
+
+[\n]			{ yyline++; }
+{comment}		{ /* ignore */ }
+{space}			{ /* ignore */ }
+
+ /* Quoted strings: "foo" */
+\"				{
+					litbufpos = 0;
+					BEGIN(qstr);
+				}
+<qstr>\"		{
+					litbuf[litbufpos] = '\0';
+					yylval.str = strdup(litbuf);
+					BEGIN(INITIAL);
+					return(string_literal);
+				}
+<qstr>.			{ addlitchar(yytext[0]); }
+<qstr>\n		{ yyerror("unexpected newline in quoted string"); }
+<qstr><<EOF>>	{ yyerror("unterminated quoted string"); }
+
+ /* SQL blocks: { UPDATE ... } */
+"{"{space}*		{
+
+					litbufpos = 0;
+					BEGIN(sql);
+				}
+<sql>{space}*"}" {
+					litbuf[litbufpos] = '\0';
+					yylval.str = strdup(litbuf);
+					BEGIN(INITIAL);
+					return(sqlblock);
+				}
+<sql>.			{
+					addlitchar(yytext[0]);
+				}
+<sql>\n			{
+					yyline++;
+					addlitchar(yytext[0]);
+				}
+<sql><<EOF>>	{
+					yyerror("unterminated sql block");
+				}
+
+.				{
+					fprintf(stderr, "syntax error at line %d: unexpected character \"%s\"\n", yyline, yytext);
+					exit(1);
+				}
+%%
+
+static void
+addlitchar(const char c)
+{
+  if (litbufpos >= sizeof(litbuf) - 1)
+  {
+    fprintf(stderr, "SQL step too long\n");
+    exit(1);
+  }
+  litbuf[litbufpos++] = c;
+}
+
+void
+yyerror(const char *message)
+{
+	fprintf(stderr, "%s at line %d\n", message, yyline);
+	exit(1);
+}


### PR DESCRIPTION
We desperately need regression tests involving distributed transactions. This PR backports the "isolationtester" from PostgreSQL master, and adds one GPDB test case that uses it, mostly as a demonstration of how to use it. The test case it adds is the repro script from MPP-10963, which is being discussed on gpdb-dev at the moment (https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/JrXnNap84tw/P7_glyDpDgAJ). This PR isn't otherwise related to that discussion, except that having isolationtester available will be very helpful in developing that feature, among other things.