### PR TITLE
Fix the naming of output columns of append node

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3588,7 +3588,7 @@ CTranslatorDXLToPlStmt::PappendFromDXLAppend
 
 		TargetEntry *pte = MakeNode(TargetEntry);
 		pte->expr = (Expr *) pvar;
-		pte->resname = CTranslatorUtils::SzFromWsz(pdxlopScIdent->Pdxlcr()->Pmdname()->Pstr()->Wsz());
+		pte->resname = CTranslatorUtils::SzFromWsz(pdxlopPrel->PmdnameAlias()->Pstr()->Wsz());
 		pte->resno = attno;
 
 		// add column mapping to output translation context

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -9934,6 +9934,14 @@ explain select * from orca.index_test where a = 5 and c = 5;
  Optimizer status: PQO version 1.602
 (5 rows)
 
+-- renaming columns
+select * from (values (2),(null)) v(k);
+ k
+---
+ 2
+
+(2 rows)
+
 -- clean up
 drop schema orca cascade;
 NOTICE:  drop cascades to table orca.index_test

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -1277,6 +1277,9 @@ explain select * from orca.index_test where c = 5;
 -- force_explain
 explain select * from orca.index_test where a = 5 and c = 5;
 
+-- renaming columns
+select * from (values (2),(null)) v(k);
+
 -- clean up
 drop schema orca cascade;
 reset optimizer_segments;


### PR DESCRIPTION
@danielgustafsson @d @xinzweb @oarap @hsyuan 

In the DXL to PlStmt translator, we do not respect the renaming of the columns of the append node.

@danielgustafsson this was one of the failures in the postgres merge.