### PR TITLE
Make InitPlan Param mechanism cope with InitPlans that are never executed

### DIFF
--- a/src/backend/cdb/cdbsubplan.c
+++ b/src/backend/cdb/cdbsubplan.c
@@ -278,6 +278,7 @@ addRemoteExecParamsToParamList(PlannedStmt *stmt, ParamListInfo extPrm, ParamExe
 		{
 			// param of id i not found. Likely have been removed because of
 			// constant folding
+			j++;
 			continue;
 		}
 

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -356,6 +356,9 @@ cdbdisp_dispatchPlan(struct QueryDesc *queryDesc,
 			pli = (ParamListInfoData *) (parambuf.data + plioff);
 			pxd = &pli->params[iparam];
 
+			if (pxd->ptype == InvalidOid)
+				continue;
+
 			/*
 			 * Does pxd->value contain the value itself, or a pointer?
 			 */

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -762,12 +762,19 @@ ExecInitSubPlan(SubPlanState *node, EState *estate, int eflags)
 				prmExt = &paramInfo->params[extParamIndex];
 
 				/* Make sure the types are valid */
-				Assert(OidIsValid(prmExt->ptype) && "Invalid Oid for pre-evaluated parameter.");				
-
-				/** Hurray! Copy value from external parameter and don't bother setting up execPlan. */
-				prmExec->execPlan = NULL;
-				prmExec->isnull = prmExt->isnull;
-				prmExec->value = prmExt->value;
+				if (!OidIsValid(prmExt->ptype))
+				{
+					prmExec->execPlan = NULL;
+					prmExec->isnull = true;
+					prmExec->value = (Datum) 0;
+				}
+				else
+				{
+					/** Hurray! Copy value from external parameter and don't bother setting up execPlan. */
+					prmExec->execPlan = NULL;
+					prmExec->isnull = prmExt->isnull;
+					prmExec->value = prmExt->value;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
If there are two InitPlan nodes inside each other, and the outer InitPlan
never executes the inner InitPlan (because the value of the outer InitPlan
was determined without it), don't get confused when some of the params
are not set (= won't even have a valid type OID)

bfv_subquery regression tests exercised this. It failed with
--enable-cassert. Fixes github issue #500.