### PR TITLE
Enable assigning database owner containing special characters.

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/backup_mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/backup_mgmt_utils.py
@@ -449,3 +449,10 @@ def impl(context, filename, table_type, tablename, dbname):
         raise Exception("Table '%s' does not exist when it should" % tablename)
     validate_restore_data_in_file(context, tablename, dbname, filename)
 
+@then('verify that the owner of "{dbname}" is "{expected_owner}"')
+def impl(context, dbname, owner):
+    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+        query = "SELECT pg_catalog.pg_get_userbyid(d.datdba) FROM pg_catalog.pg_database d WHERE d.datname = '%s';" % dbname
+        actual_owner = dbconn.execSQLForSingleton(conn, query)
+    if actual_owner != expected_owner:
+        raise Exception("Database %s has owner %s when it should have owner %s" % (dbname, actual_owner, expected_owner))

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1066,6 +1066,8 @@ def verify_file_contents(context, file_type, file_dir, text_find, should_contain
         fn = '%sgp_statistics_1_1_%s' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == 'schema':
         fn = '%sgp_dump_%s_schema' % (context.dump_prefix, context.backup_timestamp)
+    elif file_type == 'cdatabase':
+        fn = '%sgp_dump_1_1_cdatabase_%s' % (context.dump_prefix, context.backup_timestamp)
 
     subdirectory = context.backup_timestamp[0:8]
     

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -7885,7 +7885,7 @@ dumpDatabaseDefinition()
 	}
 	if (strlen(dba) > 0)
 	{
-		appendPQExpBuffer(creaQry, " OWNER = %s", dba);
+		appendPQExpBuffer(creaQry, " OWNER = %s", fmtId(dba));
 	}
 
 	if (strlen(tablespace) > 0 && strcmp(tablespace, "pg_default") != 0)


### PR DESCRIPTION
Previously, the cdatabase file created by gpcrondump did not correctly quote a role containing special characters in its CREATE DATABASE statement.  Such roles are now handled correctly.

Authors: Jamie McAtamney and Chumki Roy