### PR TITLE
Change the way temp schemas are created.

### DIFF
--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -39,8 +39,6 @@
 
 static void AlterSchemaOwner_internal(cqContext  *pcqCtx, 
 									  HeapTuple tup, Relation rel, Oid newOwnerId);
-static void RemoveSchema_internal(const char *namespaceName, DropBehavior behavior,
-								  bool missing_ok, bool is_internal);
 
 
 /*
@@ -51,8 +49,7 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 {
 	const char *schemaName = stmt->schemaname;
 	const char *authId = stmt->authid;
-	const bool  istemp = stmt->istemp;
-	Oid			namespaceId = 0;
+	Oid			namespaceId;
 	List	   *parsetree_list;
 	ListCell   *parsetree_item;
 	Oid			owner_uid;
@@ -61,6 +58,26 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 	AclResult	aclresult;
 	bool		shouldDispatch = (Gp_role == GP_ROLE_DISPATCH && 
 								  !IsBootstrapProcessingMode());
+
+	/*
+	 * GPDB: Creation of temporary namespaces is a special case. This statement
+	 * is dispatched by the dispatcher node the first time a temporary table is
+	 * created. It bypasses all the normal checks and logic of schema creation,
+	 * and is routed to the internal routine for creating temporary namespaces,
+	 * instead.
+	 */
+	if (stmt->istemp)
+	{
+		Assert(Gp_role == GP_ROLE_EXECUTE);
+
+		Assert(stmt->schemaname == InvalidOid);
+		Assert(stmt->authid == NULL);
+		Assert(stmt->schemaElts == NIL);
+		Assert(stmt->schemaOid != InvalidOid);
+
+		InitTempTableNamespaceWithOids(stmt->schemaOid);
+		return;
+	}
 
 	GetUserIdAndSecContext(&saved_uid, &save_sec_context);
 
@@ -72,52 +89,28 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 	else
 		owner_uid = saved_uid;
 
-	/* 
-	 * If we are creating a temporary schema then we can skip a 
-	 * bunch of checks that we would otherwise make.
+	/*
+	 * To create a schema, must have schema-create privilege on the current
+	 * database and must be able to become the target role (this does not
+	 * imply that the target role itself must have create-schema privilege).
+	 * The latter provision guards against "giveaway" attacks.	Note that a
+	 * superuser will always have both of these privileges a fortiori.
 	 */
-	if (istemp)
-	{
-		/*
-		 * CDB: Delete old temp schema.
-		 *
-		 * Remove any vestigages of old temporary schema, if any.  This can
-		 * happen when an old session crashes and doesn't run normal session
-		 * shutdown.  
-		 *
-		 * In postgres they try to reuse existing schemas in this case, 
-		 * however that does not work well for us since the schemas may exist 
-		 * on a segment by segment basis and we want to keep them syncronized
-		 * on oid.  The best way of dealing with this is to just delete the
-		 * old schemas.
-		 */
-		RemoveSchema_internal(schemaName, DROP_CASCADE, true, true);
-	}
-	else
-	{
-		/*
-		 * To create a schema, must have schema-create privilege on the current
-		 * database and must be able to become the target role (this does not
-		 * imply that the target role itself must have create-schema privilege).
-		 * The latter provision guards against "giveaway" attacks. Note that a
-		 * superuser will always have both of these privileges a fortiori.
-		 */
-		aclresult = pg_database_aclcheck(MyDatabaseId, saved_uid, ACL_CREATE);
-		if (aclresult != ACLCHECK_OK)
-			aclcheck_error(aclresult, ACL_KIND_DATABASE,
-						   get_database_name(MyDatabaseId));
+	aclresult = pg_database_aclcheck(MyDatabaseId, saved_uid, ACL_CREATE);
+	if (aclresult != ACLCHECK_OK)
+		aclcheck_error(aclresult, ACL_KIND_DATABASE,
+					   get_database_name(MyDatabaseId));
 
-		check_is_member_of_role(saved_uid, owner_uid);
+	check_is_member_of_role(saved_uid, owner_uid);
 
-		/* Additional check to protect reserved schema names */
-		if (!allowSystemTableModsDDL && IsReservedName(schemaName))
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_RESERVED_NAME),
-					 errmsg("unacceptable schema name \"%s\"", schemaName),
-					 errdetail("The prefix \"%s\" is reserved for system schemas.",
-							   GetReservedPrefix(schemaName))));
-		}
+	/* Additional check to protect reserved schema names */
+	if (!allowSystemTableModsDDL && IsReservedName(schemaName))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_RESERVED_NAME),
+				 errmsg("unacceptable schema name \"%s\"", schemaName),
+				 errdetail("The prefix \"%s\" is reserved for system schemas.",
+						   GetReservedPrefix(schemaName))));
 	}
 
 	/*
@@ -153,7 +146,7 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 		}
 
 		/* MPP-6929: metadata tracking */
-		if (Gp_role == GP_ROLE_DISPATCH && !istemp)
+		if (Gp_role == GP_ROLE_DISPATCH)
 			MetaTrackAddObject(NamespaceRelationId,
 							   namespaceId,
 							   saved_uid,
@@ -167,10 +160,6 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 
 	/* Advance cmd counter to make the namespace visible */
 	CommandCounterIncrement();
-
-	/* If this is the temporary namespace we must mark it specially */
-	if (istemp)
-		SetTempNamespace(namespaceId);
 
 	/*
 	 * Temporarily make the new namespace be the front of the search path, as
@@ -233,6 +222,8 @@ void
 RemoveSchema(List *names, DropBehavior behavior, bool missing_ok)
 {
 	char	   *namespaceName;
+	Oid			namespaceId;
+	ObjectAddress object;
 
 	if (list_length(names) != 1)
 		ereport(ERROR,
@@ -240,21 +231,9 @@ RemoveSchema(List *names, DropBehavior behavior, bool missing_ok)
 				 errmsg("schema name cannot be qualified")));
 	namespaceName = strVal(linitial(names));
 
-	RemoveSchema_internal(namespaceName, behavior, missing_ok, false);
-}
-
-static void
-RemoveSchema_internal(const char *namespaceName, DropBehavior behavior,
-					  bool missing_ok, bool is_internal)
-{
-	Oid			namespaceId;
-	ObjectAddress object;
-
-	namespaceId = caql_getoid(
-			NULL,
-			cql("SELECT oid FROM pg_namespace "
-				" WHERE nspname = :1 ",
-				CStringGetDatum(namespaceName)));
+	namespaceId = GetSysCacheOid(NAMESPACENAME,
+								 CStringGetDatum(namespaceName),
+								 0, 0, 0);
 	if (!OidIsValid(namespaceId))
 	{
 		if (!missing_ok)
@@ -263,7 +242,7 @@ RemoveSchema_internal(const char *namespaceName, DropBehavior behavior,
 					(errcode(ERRCODE_UNDEFINED_SCHEMA),
 					 errmsg("schema \"%s\" does not exist", namespaceName)));
 		}
-		if (!is_internal && Gp_role != GP_ROLE_EXECUTE)
+		if (Gp_role != GP_ROLE_EXECUTE)
 		{
 			ereport(NOTICE,
 					(errcode(ERRCODE_UNDEFINED_SCHEMA),
@@ -275,13 +254,12 @@ RemoveSchema_internal(const char *namespaceName, DropBehavior behavior,
 	}
 
 	/* Permission check */
-	if (!is_internal && !pg_namespace_ownercheck(namespaceId, GetUserId()))
+	if (!pg_namespace_ownercheck(namespaceId, GetUserId()))
 		aclcheck_error(ACLCHECK_NOT_OWNER, ACL_KIND_NAMESPACE,
 					   namespaceName);
 
 	/* Additional check to protect reserved schema names, exclude temp schema */
-	if (!is_internal && !allowSystemTableModsDDL &&
-		IsReservedName(namespaceName) &&
+	if (!allowSystemTableModsDDL &&	IsReservedName(namespaceName) &&
         (strlen(namespaceName)>=7 && strncmp(namespaceName, "pg_temp", 7)!=0))
 	{
 		ereport(ERROR,
@@ -301,7 +279,7 @@ RemoveSchema_internal(const char *namespaceName, DropBehavior behavior,
 	performDeletion(&object, behavior);
 
 	/* MPP-6929: metadata tracking */
-	if (!is_internal && Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role == GP_ROLE_DISPATCH)
 		MetaTrackDropObject(NamespaceRelationId, namespaceId);
 }
 
@@ -574,7 +552,6 @@ AlterSchemaOwner_internal(cqContext  *pcqCtx,
 		/* Update owner dependency reference */
 		changeDependencyOnOwner(NamespaceRelationId, HeapTupleGetOid(tup),
 								newOwnerId);
-		
 	}
 
 }

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4043,6 +4043,7 @@ _copyCreateSchemaStmt(CreateSchemaStmt *from)
 	COPY_NODE_FIELD(schemaElts);
 	COPY_SCALAR_FIELD(istemp);
 	COPY_SCALAR_FIELD(schemaOid);
+	COPY_SCALAR_FIELD(toastSchemaOid);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1869,6 +1869,7 @@ _equalCreateSchemaStmt(CreateSchemaStmt *a, CreateSchemaStmt *b)
 	COMPARE_NODE_FIELD(schemaElts);
 	COMPARE_SCALAR_FIELD(istemp);
 	COMPARE_SCALAR_FIELD(schemaOid);
+	COMPARE_SCALAR_FIELD(toastSchemaOid);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3978,6 +3978,7 @@ _outCreateSchemaStmt(StringInfo str, CreateSchemaStmt *node)
 	WRITE_STRING_FIELD(authid);
 	WRITE_BOOL_FIELD(istemp);
 	WRITE_OID_FIELD(schemaOid);
+	WRITE_OID_FIELD(toastSchemaOid);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2375,6 +2375,7 @@ _readCreateSchemaStmt(void)
 	local_node->schemaElts = 0;
 	READ_BOOL_FIELD(istemp);
 	READ_OID_FIELD(schemaOid);
+	READ_OID_FIELD(toastSchemaOid);
 
 	READ_DONE();
 }

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -74,6 +74,7 @@ extern void DropTempTableNamespaceForResetSession(Oid namespaceOid);
 extern void SetTempNamespace(Oid namespaceOid);
 extern Oid  ResetTempNamespace(void);
 extern bool TempNamespaceOidIsValid(void);  /* GPDB only:  used by cdbgang.c */
+extern void InitTempTableNamespaceWithOids(Oid tempSchema);
 
 extern Oid	LookupCreationNamespace(const char *nspname);
 extern Oid	QualifiedNameGetCreationNamespace(List *names, char **objname_p);

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1114,8 +1114,20 @@ typedef struct CreateSchemaStmt
 	char	   *schemaname;		/* the name of the schema to create */
 	char	   *authid;			/* the owner of the created schema */
 	List	   *schemaElts;		/* schema components (list of parsenodes) */
+
+	/*
+	 * In GPDB, when a CreateSchemaStmt is dispatched to executor nodes, the
+	 * following fields are set. schemaOid is the OID of the new schema.
+	 *
+	 * There's a special case for when the temporary namespace is created,
+	 * on the first use in the session. There are actually two temporary
+	 * namespaces, the regular one, and a temporary toast namespace. They are
+	 * both created in the same command, with istemp='true', schemaOid the
+	 * temp namespace's OID, and toastSchemaOid the temp toast namespace's OID.
+	 */
 	bool        istemp;         /* true for temp schemas (internal only) */
 	Oid			schemaOid;
+	Oid			toastSchemaOid;
 } CreateSchemaStmt;
 
 typedef enum DropBehavior


### PR DESCRIPTION
This reverts much of the changes vs. upstream, related to temp schema
creation. Instead of using the normal CREATE SCHEMA processing to also
create the temporary schema, let InitTempTableNameSpace() to do that
like in the upstream. But in addition to creating the the temp schema
locally, it dispatches a special CreateSchemaStmt command to the
executor nodes, which instructs the executor nodes to also call
InitTempTableNameSpace().