### PR TITLE
Don't modfiy PlannedStmt during execution

### DIFF
--- a/src/backend/cdb/cdbexplain.c
+++ b/src/backend/cdb/cdbexplain.c
@@ -802,7 +802,7 @@ cdbexplain_collectStatsFromNode(PlanState *planstate, CdbExplain_SendStatCtx *ct
     si->workmemused     = instr->workmemused;
     si->workmemwanted   = instr->workmemwanted;
     si->workfileCreated  = instr->workfileCreated;
-	si->peakMemBalance	 = MemoryAccounting_GetPeak(planstate->plan->memoryAccount);
+	si->peakMemBalance	 = MemoryAccounting_GetPeak(planstate->memoryAccount);
 	si->firststart      = instr->firststart;
 	si->numPartScanned = instr->numPartScanned;
 }                               /* cdbexplain_collectStatsFromNode */

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -2875,10 +2875,15 @@ remove_subquery_in_RTEs(Node *node)
 
         if (RTE_SUBQUERY == rte->rtekind && NULL != rte->subquery)
         {
-            /*
-             * replace subquery with a dummy subquery
-             */
-            rte->subquery = makeNode(Query);
+			/*
+			 * Replace subquery with a dummy subquery.
+			 *
+			 * XXX: We could save a lot more memory by deep-freeing the many
+			 * fields in the Query too. But I'm not sure which of them might
+			 * be shared by other objects in the tree.
+			 */
+			pfree(rte->subquery);
+			rte->subquery = makeNode(Query);
         }
 
         return;

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -58,10 +58,10 @@ typedef struct DispatchCommandQueryParms
 	int serializedQuerytreelen;
 	char *serializedPlantree;
 	int serializedPlantreelen;
+	char *serializedQueryDispatchDesc;
+	int serializedQueryDispatchDesclen;
 	char *serializedParams;
 	int serializedParamslen;
-	char *serializedSliceInfo;
-	int serializedSliceInfolen;
 
 	/*
 	 * serialized DTX context string
@@ -168,12 +168,12 @@ cdbdisp_dispatchPlan(struct QueryDesc *queryDesc,
 					 bool cancelOnError, struct CdbDispatcherState *ds)
 {
 	char *splan,
-		 *ssliceinfo,
+		 *sddesc,
 		 *sparams;
 
 	int	splan_len,
 		splan_len_uncompressed,
-		ssliceinfo_len,
+		sddesc_len,
 		sparams_len;
 
 	SliceTable *sliceTbl;
@@ -396,8 +396,8 @@ cdbdisp_dispatchPlan(struct QueryDesc *queryDesc,
 		sparams_len = 0;
 	}
 
-	ssliceinfo =
-		serializeNode((Node *) sliceTbl, &ssliceinfo_len,
+	sddesc =
+		serializeNode((Node *) queryDesc->ddesc, &sddesc_len,
 					  NULL /*uncompressed_size */ );
 
 	MemSet(&queryParms, 0, sizeof(queryParms));
@@ -408,8 +408,8 @@ cdbdisp_dispatchPlan(struct QueryDesc *queryDesc,
 	queryParms.serializedPlantreelen = splan_len;
 	queryParms.serializedParams = sparams;
 	queryParms.serializedParamslen = sparams_len;
-	queryParms.serializedSliceInfo = ssliceinfo;
-	queryParms.serializedSliceInfolen = ssliceinfo_len;
+	queryParms.serializedQueryDispatchDesc = sddesc;
+	queryParms.serializedQueryDispatchDesclen = sddesc_len;
 	queryParms.rootIdx = rootIdx;
 
 	/*
@@ -833,10 +833,10 @@ cdbdisp_queryParmsInit(struct CdbDispatcherState *ds,
 		pQueryParms->serializedParams = NULL;
 	}
 
-	if (pQueryParms->serializedSliceInfo != NULL)
+	if (pQueryParms->serializedQueryDispatchDesc != NULL)
 	{
-		pfree(pQueryParms->serializedSliceInfo);
-		pQueryParms->serializedSliceInfo = NULL;
+		pfree(pQueryParms->serializedQueryDispatchDesc);
+		pQueryParms->serializedQueryDispatchDesc = NULL;
 	}
 
 	if (pQueryParms->serializedDtxContextInfo != NULL)
@@ -1027,8 +1027,8 @@ PQbuildGpQueryString(MemoryContext cxt, DispatchCommandParms * pParms,
 	int	plantree_len = pQueryParms->serializedPlantreelen;
 	const char *params = pQueryParms->serializedParams;
 	int	params_len = pQueryParms->serializedParamslen;
-	const char *sliceinfo = pQueryParms->serializedSliceInfo;
-	int	sliceinfo_len = pQueryParms->serializedSliceInfolen;
+	const char *sddesc = pQueryParms->serializedQueryDispatchDesc;
+	int	sddesc_len = pQueryParms->serializedQueryDispatchDesclen;
 	const char *snapshotInfo = pQueryParms->serializedDtxContextInfo;
 	int	snapshotInfo_len = pQueryParms->serializedDtxContextInfolen;
 	int	flags = 0; /* unused flags */
@@ -1068,7 +1068,7 @@ PQbuildGpQueryString(MemoryContext cxt, DispatchCommandParms * pParms,
 		sizeof(querytree_len) +
 		sizeof(plantree_len) +
 		sizeof(params_len) +
-		sizeof(sliceinfo_len) +
+		sizeof(sddesc_len) +
 		sizeof(snapshotInfo_len) +
 		snapshotInfo_len +
 		sizeof(flags) +
@@ -1076,7 +1076,7 @@ PQbuildGpQueryString(MemoryContext cxt, DispatchCommandParms * pParms,
 		sizeof(seqServerPort) +
 		command_len +
 		querytree_len +
-		plantree_len + params_len + sliceinfo_len + seqServerHostlen;
+		plantree_len + params_len + sddesc_len + seqServerHostlen;
 
 	shared_query = MemoryContextAlloc(cxt, total_query_len);
 
@@ -1157,7 +1157,7 @@ PQbuildGpQueryString(MemoryContext cxt, DispatchCommandParms * pParms,
 	memcpy(pos, &tmp, sizeof(params_len));
 	pos += sizeof(params_len);
 
-	tmp = htonl(sliceinfo_len);
+	tmp = htonl(sddesc_len);
 	memcpy(pos, &tmp, sizeof(tmp));
 	pos += sizeof(tmp);
 
@@ -1207,10 +1207,10 @@ PQbuildGpQueryString(MemoryContext cxt, DispatchCommandParms * pParms,
 		pos += params_len;
 	}
 
-	if (sliceinfo_len > 0)
+	if (sddesc_len > 0)
 	{
-		memcpy(pos, sliceinfo, sliceinfo_len);
-		pos += sliceinfo_len;
+		memcpy(pos, sddesc, sddesc_len);
+		pos += sddesc_len;
 	}
 
 	if (seqServerHostlen > 0)

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -84,8 +84,6 @@ typedef struct DispatchCommandQueryParms
 	int primary_gang_id;
 } DispatchCommandQueryParms;
 
-static void stripPlanBeforeDispatch(PlannedStmt *plan);
-
 static void
 CdbDispatchUtilityStatement_Internal(struct Node *stmt,
 									 bool needTwoPhase,
@@ -284,8 +282,6 @@ cdbdisp_dispatchPlan(struct QueryDesc *queryDesc,
 	{
 		verify_shared_snapshot_ready();
 	}
-
-	stripPlanBeforeDispatch(queryDesc->plannedstmt);
 
 	/*
 	 * serialized plan tree. Note that we're called for a single
@@ -776,16 +772,6 @@ CdbDispatchUtilityStatement_NoTwoPhase(struct Node *stmt,
 	CdbDispatchUtilityStatement_Internal(stmt,
 										 false,
 										 "CdbDispatchUtilityStatement_NoTwoPhase");
-}
-
-/*
- * Remove subquery field in RTE's with subquery kind. This is an optimization used
- * to reduce plan size before serialization for dispatching.
- */
-static void
-stripPlanBeforeDispatch(PlannedStmt *plan)
-{
-	remove_subquery_in_RTEs((Node *) plan->rtable);
 }
 
 /*

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -164,7 +164,7 @@ PerformCursorOpen(PlannedStmt *stmt, ParamListInfo params,
 	 * Start execution, inserting parameters if any.
 	 */
 	PortalStart(portal, params, ActiveSnapshot,
-				savedSeqServerHost, savedSeqServerPort);
+				savedSeqServerHost, savedSeqServerPort, NULL);
 
 	Assert(portal->strategy == PORTAL_ONE_SELECT);
 

--- a/src/backend/commands/prepare.c
+++ b/src/backend/commands/prepare.c
@@ -242,7 +242,7 @@ ExecuteQuery(ExecuteStmt *stmt, const char *queryString,
 	 * Run the portal to completion.
 	 */
 	PortalStart(portal, paramLI, ActiveSnapshot,
-				savedSeqServerHost, savedSeqServerPort);
+				savedSeqServerHost, savedSeqServerPort, NULL);
 
 	(void) PortalRun(portal, 
 					FETCH_ALL, 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -251,14 +251,12 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 	Assert(queryDesc->estate == NULL);
 	Assert(queryDesc->plannedstmt != NULL);
 
-	PlannedStmt *plannedStmt = queryDesc->plannedstmt;
-
-	if (NULL == plannedStmt->memoryAccount)
+	if (NULL == queryDesc->memoryAccount)
 	{
-		plannedStmt->memoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
+		queryDesc->memoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
 	}
 
-	START_MEMORY_ACCOUNT(plannedStmt->memoryAccount);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccount);
 
 	Assert(queryDesc->plannedstmt->intoPolicy == NULL
 		   || queryDesc->plannedstmt->intoPolicy->ptype == POLICYTYPE_PARTITIONED);
@@ -784,9 +782,9 @@ ExecutorRun(QueryDesc *queryDesc,
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->plannedstmt && NULL != queryDesc->plannedstmt->memoryAccount);
+	Assert(NULL != queryDesc->memoryAccount);
 
-	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccount);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccount);
 
 	/*
 	 * Set dynamicTableScanInfo to the one in estate, and reset its value at
@@ -984,9 +982,9 @@ ExecutorEnd(QueryDesc *queryDesc)
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->plannedstmt && NULL != queryDesc->plannedstmt->memoryAccount);
+	Assert(queryDesc->memoryAccount);
 
-	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccount);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccount);
 
 	if (DEBUG1 >= log_min_messages)
 	{
@@ -1146,9 +1144,9 @@ ExecutorRewind(QueryDesc *queryDesc)
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->plannedstmt && NULL != queryDesc->plannedstmt->memoryAccount);
+	Assert(NULL != queryDesc->memoryAccount);
 
-	START_MEMORY_ACCOUNT(queryDesc->plannedstmt->memoryAccount);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccount);
 
 	/* It's probably not sensible to rescan updating queries */
 	Assert(queryDesc->operation == CMD_SELECT);

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -822,7 +822,7 @@ ExecProcNode(PlanState *node)
 
 	START_CODE_GENERATOR_MANAGER(node->CodegenManager);
 	{
-	START_MEMORY_ACCOUNT(node->plan->memoryAccount);
+	START_MEMORY_ACCOUNT(node->memoryAccount);
 	{
 
 #ifndef WIN32
@@ -1269,7 +1269,7 @@ MultiExecProcNode(PlanState *node)
 
 	Assert(NULL != node->plan);
 
-	START_MEMORY_ACCOUNT(node->plan->memoryAccount);
+	START_MEMORY_ACCOUNT(node->memoryAccount);
 	{
 		PG_TRACE5(execprocnode__enter, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id, node->plan->plan_parent_node_id);
 

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -573,7 +573,7 @@ postquel_end(execution_state *es)
 			{
 				Oid			relationOid = InvalidOid; 					/* relation that is modified */
 				AutoStatsCmdType cmdType = AUTOSTATS_CMDTYPE_SENTINEL; 	/* command type */
-				autostats_get_cmdtype(es->qd->plannedstmt, &cmdType, &relationOid);
+				autostats_get_cmdtype(es->qd, &cmdType, &relationOid);
 				auto_stats(cmdType, relationOid, es->qd->es_processed, true /* inFunction */);
 			}
 		}

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -284,7 +284,7 @@ ExecHashTableCreate(HashState *hashState, HashJoinState *hjstate, List *hashOper
 	ListCell   *ho;
 	MemoryContext oldcxt;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
 	{
 
 	Hash *node = (Hash *) hashState->ps.plan;
@@ -657,7 +657,7 @@ ExecHashTableDestroy(HashState *hashState, HashJoinTable hashtable)
 	Assert(hashtable);
 	Assert(!hashtable->eagerlyReleased);
 	
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
 	{
 
 	/*
@@ -927,7 +927,7 @@ ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
 	int			batchno;
 	int			hashTupleSize;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
 	{
 	PlanState *ps = &hashState->ps;
 
@@ -1021,7 +1021,7 @@ ExecHashGetHashValue(HashState *hashState, HashJoinTable hashtable,
 	MemoryContext oldContext;
 	bool		result = true;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
 	{
 
 	Assert(hashkeys_null);
@@ -1157,7 +1157,7 @@ ExecScanHashBucket(HashState *hashState, HashJoinState *hjstate,
 	HashJoinTuple hashTuple = hjstate->hj_CurTuple;
 	uint32		hashvalue = hjstate->hj_CurHashValue;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
 	{
 	/*
 	 * hj_CurTuple is NULL to start scanning a new bucket, or the address of
@@ -1215,7 +1215,7 @@ ExecHashTableReset(HashState *hashState, HashJoinTable hashtable)
 	MemoryContext oldcxt;
 	int			nbuckets = 0;
 
-	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
 	{
 	Assert(hashtable);
 	Assert(!hashtable->eagerlyReleased);
@@ -1268,7 +1268,7 @@ ExecHashTableExplainInit(HashState *hashState, HashJoinState *hjstate,
     MemoryContext   oldcxt;
     int             nbatch = Max(hashtable->nbatch, 1);
 
-    START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccount);
+    START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
     {
     /* Switch to a memory context that survives until ExecutorEnd. */
     oldcxt = MemoryContextSwitchTo(hjstate->js.ps.state->es_query_cxt);
@@ -1556,7 +1556,7 @@ ExecHashTableExplainBatchEnd(HashState *hashState, HashJoinTable hashtable)
     HashJoinBatchData  *batch = NULL;
     int                 i;
     
-    START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccount);
+    START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
     {
     Assert(!hashtable->eagerlyReleased);
     Assert(hashtable->batches);

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1031,6 +1031,7 @@ SubplanQueryDesc(QueryDesc * qd)
 							NULL,		/* Null destination for the QE */
 							qd->params,
 							qd->doInstrument);
+	subqd->ddesc = qd->ddesc;
 
 	return subqd;
 }

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1258,7 +1258,7 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	 * Start portal execution.
 	 */
 	PortalStart(portal, paramLI, snapshot,
-				savedSeqServerHost, savedSeqServerPort);
+				savedSeqServerHost, savedSeqServerPort, NULL);
 
 	Assert(portal->strategy != PORTAL_MULTI_QUERY);
 
@@ -2132,6 +2132,9 @@ _SPI_pquery(QueryDesc * queryDesc, bool fire_triggers, long tcount)
 
 	PG_TRY();
 	{
+		Oid			relationOid = InvalidOid; 	/* relation that is modified */
+		AutoStatsCmdType cmdType = AUTOSTATS_CMDTYPE_SENTINEL; 	/* command type */
+
 		/*
 		 * Temporarily disable gpperfmon since we don't send information for internal queries in
 		 * most cases, except when the debugging level is set to DEBUG4 or DEBUG5.
@@ -2160,18 +2163,16 @@ _SPI_pquery(QueryDesc * queryDesc, bool fire_triggers, long tcount)
 			if (fire_triggers)
 				AfterTriggerEndQuery(queryDesc->estate);
 
+		if (Gp_role == GP_ROLE_DISPATCH)
+			autostats_get_cmdtype(queryDesc, &cmdType, &relationOid);
+
 		ExecutorEnd(queryDesc);
 
 		gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
 
 		/* MPP-14001: Running auto_stats */
 		if (Gp_role == GP_ROLE_DISPATCH)
-		{
-			Oid	relationOid = InvalidOid; 	/* relation that is modified */
-			AutoStatsCmdType cmdType = AUTOSTATS_CMDTYPE_SENTINEL; 	/* command type */
-			autostats_get_cmdtype(queryDesc->plannedstmt, &cmdType, &relationOid);
 			auto_stats(cmdType, relationOid, queryDesc->es_processed, true /* inFunction */);
-		}
 	}
 	PG_CATCH();
 	{

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -188,9 +188,20 @@ _copyPlannedStmt(PlannedStmt *from)
 	}
 	else
 		newnode->intoPolicy = NULL;
-	COPY_NODE_FIELD(sliceTable);
 
 	COPY_SCALAR_FIELD(query_mem);
+
+	return newnode;
+}
+
+static QueryDispatchDesc *
+_copyQueryDispatchDesc(QueryDispatchDesc *from)
+{
+	QueryDispatchDesc *newnode = makeNode(QueryDispatchDesc);
+
+	COPY_NODE_FIELD(intoOidInfo);
+	COPY_NODE_FIELD(intoTableSpaceName);
+	COPY_NODE_FIELD(sliceTable);
 
 	return newnode;
 }
@@ -1271,15 +1282,31 @@ _copyIntoClause(IntoClause *from)
 	COPY_NODE_FIELD(options);
 	COPY_SCALAR_FIELD(onCommit);
 	COPY_STRING_FIELD(tableSpaceName);
-	COPY_SCALAR_FIELD(oidInfo.relOid);
-	COPY_SCALAR_FIELD(oidInfo.comptypeOid);
-	COPY_SCALAR_FIELD(oidInfo.toastOid);
-	COPY_SCALAR_FIELD(oidInfo.toastIndexOid);
-	COPY_SCALAR_FIELD(oidInfo.toastComptypeOid);
-	COPY_SCALAR_FIELD(oidInfo.aosegOid);
-	COPY_SCALAR_FIELD(oidInfo.aosegIndexOid);
-	COPY_SCALAR_FIELD(oidInfo.aosegComptypeOid);
-	
+
+	return newnode;
+}
+
+static TableOidInfo *
+_copyTableOidInfo(TableOidInfo *from)
+{
+	TableOidInfo *newnode = makeNode(TableOidInfo);
+
+	COPY_SCALAR_FIELD(relOid);
+	COPY_SCALAR_FIELD(comptypeOid);
+	COPY_SCALAR_FIELD(comptypeArrayOid);
+	COPY_SCALAR_FIELD(toastOid);
+	COPY_SCALAR_FIELD(toastIndexOid);
+	COPY_SCALAR_FIELD(toastComptypeOid);
+	COPY_SCALAR_FIELD(aosegOid);
+	COPY_SCALAR_FIELD(aosegIndexOid);
+	COPY_SCALAR_FIELD(aosegComptypeOid);
+	COPY_SCALAR_FIELD(aovisimapOid);
+	COPY_SCALAR_FIELD(aovisimapIndexOid);
+	COPY_SCALAR_FIELD(aovisimapComptypeOid);
+	COPY_SCALAR_FIELD(aoblkdirOid);
+	COPY_SCALAR_FIELD(aoblkdirIndexOid);
+	COPY_SCALAR_FIELD(aoblkdirComptypeOid);
+
 	return newnode;
 }
 
@@ -4400,6 +4427,9 @@ copyObject(void *from)
 		case T_PlannedStmt:
 			retval = _copyPlannedStmt(from);
 			break;
+		case T_QueryDispatchDesc:
+			retval = _copyQueryDispatchDesc(from);
+			break;
 		case T_Plan:
 			retval = _copyPlan(from);
 			break;
@@ -4547,6 +4577,9 @@ copyObject(void *from)
 			break;
 		case T_IntoClause:
 			retval = _copyIntoClause(from);
+			break;
+		case T_TableOidInfo:
+			retval = _copyTableOidInfo(from);
 			break;
 		case T_Var:
 			retval = _copyVar(from);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -132,11 +132,6 @@ _equalRangeVar(RangeVar *a, RangeVar *b)
 
 /* 
  * Records information about the target of a CTAS (SELECT ... INTO). 
- * This node type first appears in 3.4 as part of the preparation for 
- * PlannedStmt support.
- *
- * NB Prior to introducting the IntoClause, only relOid, comptypeOid were
- *    tested for equality
  */
 static bool
 _equalIntoClause(IntoClause *a, IntoClause *b)
@@ -146,8 +141,28 @@ _equalIntoClause(IntoClause *a, IntoClause *b)
 	COMPARE_NODE_FIELD(options);
 	COMPARE_SCALAR_FIELD(onCommit);
 	COMPARE_STRING_FIELD(tableSpaceName);
-	COMPARE_SCALAR_FIELD(oidInfo.relOid);
-	COMPARE_SCALAR_FIELD(oidInfo.comptypeOid);
+
+	return true;
+}
+
+static bool
+_equalTableOidInfo(TableOidInfo *a, TableOidInfo *b)
+{
+	COMPARE_SCALAR_FIELD(relOid);
+	COMPARE_SCALAR_FIELD(comptypeOid);
+	COMPARE_SCALAR_FIELD(comptypeArrayOid);
+	COMPARE_SCALAR_FIELD(toastOid);
+	COMPARE_SCALAR_FIELD(toastIndexOid);
+	COMPARE_SCALAR_FIELD(toastComptypeOid);
+	COMPARE_SCALAR_FIELD(aosegOid);
+	COMPARE_SCALAR_FIELD(aosegIndexOid);
+	COMPARE_SCALAR_FIELD(aosegComptypeOid);
+	COMPARE_SCALAR_FIELD(aovisimapOid);
+	COMPARE_SCALAR_FIELD(aovisimapIndexOid);
+	COMPARE_SCALAR_FIELD(aovisimapComptypeOid);
+	COMPARE_SCALAR_FIELD(aoblkdirOid);
+	COMPARE_SCALAR_FIELD(aoblkdirIndexOid);
+	COMPARE_SCALAR_FIELD(aoblkdirComptypeOid);
 	
 	return true;
 }
@@ -2535,6 +2550,9 @@ equal(void *a, void *b)
 			break;
 		case T_IntoClause:
 			retval = _equalIntoClause(a, b);
+			break;
+		case T_TableOidInfo:
+			retval = _equalTableOidInfo(a, b);
 			break;
 		case T_Var:
 			retval = _equalVar(a, b);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -352,10 +352,19 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_INT_FIELD(nInitPlans);
 
 	/* Don't serialize policy */
-	WRITE_NODE_FIELD(sliceTable);
 
 	WRITE_UINT64_FIELD(query_mem);
+}
+
+static void
+_outQueryDispatchDesc(StringInfo str, QueryDispatchDesc *node)
+{
+	WRITE_NODE_TYPE("QUERYDISPATCHDESC");
+
 	WRITE_NODE_FIELD(transientTypeRecords);
+	WRITE_NODE_FIELD(intoOidInfo);
+	WRITE_STRING_FIELD(intoTableSpaceName);
+	WRITE_NODE_FIELD(sliceTable);
 }
 
 static void
@@ -1199,6 +1208,9 @@ _outNode(StringInfo str, void *obj)
 			case T_PlannedStmt:
 				_outPlannedStmt(str,obj);
 				break;
+			case T_QueryDispatchDesc:
+				_outQueryDispatchDesc(str,obj);
+				break;
 			case T_Plan:
 				_outPlan(str, obj);
 				break;
@@ -1342,6 +1354,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_IntoClause:
 				_outIntoClause(str, obj);
+				break;
+			case T_TableOidInfo:
+				_outTableOidInfo(str, obj);
 				break;
 			case T_Var:
 				_outVar(str, obj);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -317,10 +317,8 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_INT_FIELD(nInitPlans);
 
 	/* Don't serialize policy */
-	WRITE_NODE_FIELD(sliceTable);
 
 	WRITE_UINT64_FIELD(query_mem);
-	WRITE_NODE_FIELD(transientTypeRecords);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
@@ -1118,21 +1116,28 @@ _outIntoClause(StringInfo str, IntoClause *node)
 	WRITE_NODE_FIELD(options);
 	WRITE_ENUM_FIELD(onCommit, OnCommitAction);
 	WRITE_STRING_FIELD(tableSpaceName);
-	WRITE_OID_FIELD(oidInfo.relOid);
-	WRITE_OID_FIELD(oidInfo.comptypeOid);
-	WRITE_OID_FIELD(oidInfo.comptypeArrayOid);
-	WRITE_OID_FIELD(oidInfo.toastOid);
-	WRITE_OID_FIELD(oidInfo.toastIndexOid);
-	WRITE_OID_FIELD(oidInfo.toastComptypeOid);
-	WRITE_OID_FIELD(oidInfo.aosegOid);
-	WRITE_OID_FIELD(oidInfo.aosegIndexOid);
-	WRITE_OID_FIELD(oidInfo.aosegComptypeOid);
-	WRITE_OID_FIELD(oidInfo.aovisimapOid);
-	WRITE_OID_FIELD(oidInfo.aovisimapIndexOid);
-	WRITE_OID_FIELD(oidInfo.aovisimapComptypeOid);
-	WRITE_OID_FIELD(oidInfo.aoblkdirOid);
-	WRITE_OID_FIELD(oidInfo.aoblkdirIndexOid);
-	WRITE_OID_FIELD(oidInfo.aoblkdirComptypeOid);
+}
+
+static void
+_outTableOidInfo(StringInfo str, TableOidInfo *node)
+{
+	WRITE_NODE_TYPE("TABLEOIDINFO");
+
+	WRITE_OID_FIELD(relOid);
+	WRITE_OID_FIELD(comptypeOid);
+	WRITE_OID_FIELD(comptypeArrayOid);
+	WRITE_OID_FIELD(toastOid);
+	WRITE_OID_FIELD(toastIndexOid);
+	WRITE_OID_FIELD(toastComptypeOid);
+	WRITE_OID_FIELD(aosegOid);
+	WRITE_OID_FIELD(aosegIndexOid);
+	WRITE_OID_FIELD(aosegComptypeOid);
+	WRITE_OID_FIELD(aovisimapOid);
+	WRITE_OID_FIELD(aovisimapIndexOid);
+	WRITE_OID_FIELD(aovisimapComptypeOid);
+	WRITE_OID_FIELD(aoblkdirOid);
+	WRITE_OID_FIELD(aoblkdirIndexOid);
+	WRITE_OID_FIELD(aoblkdirComptypeOid);
 }
 
 static void
@@ -4377,6 +4382,9 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_IntoClause:
 				_outIntoClause(str, obj);
+				break;
+			case T_TableOidInfo:
+				_outTableOidInfo(str, obj);
 				break;
 			case T_Var:
 				_outVar(str, obj);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -368,34 +368,6 @@ _readRangeVar(void)
 	READ_DONE();
 }
 
-static IntoClause *
-_readIntoClause(void)
-{
-	READ_LOCALS(IntoClause);
-
-	READ_NODE_FIELD(rel);
-	READ_NODE_FIELD(colNames);
-	READ_NODE_FIELD(options);
-	READ_ENUM_FIELD(onCommit, OnCommitAction);
-	READ_STRING_FIELD(tableSpaceName);
-	READ_OID_FIELD(oidInfo.relOid);
-	READ_OID_FIELD(oidInfo.comptypeOid);
-	READ_OID_FIELD(oidInfo.comptypeArrayOid);
-	READ_OID_FIELD(oidInfo.toastOid);
-	READ_OID_FIELD(oidInfo.toastIndexOid);
-	READ_OID_FIELD(oidInfo.toastComptypeOid);
-	READ_OID_FIELD(oidInfo.aosegOid);
-	READ_OID_FIELD(oidInfo.aosegIndexOid);
-	READ_OID_FIELD(oidInfo.aosegComptypeOid);
-	READ_OID_FIELD(oidInfo.aovisimapOid);
-	READ_OID_FIELD(oidInfo.aovisimapIndexOid);
-	READ_OID_FIELD(oidInfo.aovisimapComptypeOid);
-	READ_OID_FIELD(oidInfo.aoblkdirOid);
-	READ_OID_FIELD(oidInfo.aoblkdirIndexOid);
-	READ_OID_FIELD(oidInfo.aoblkdirComptypeOid);
-	READ_DONE();
-}
-
 /*
  * _readConst
  */
@@ -1466,13 +1438,22 @@ _readPlannedStmt(void)
 	READ_INT_FIELD(nMotionNodes);
 	READ_INT_FIELD(nInitPlans);
 	/* intoPolicy not serialized in outfast.c */
-	READ_NODE_FIELD(sliceTable);
 
 	READ_UINT64_FIELD(query_mem);
-	READ_NODE_FIELD(transientTypeRecords);
 	READ_DONE();
 }
 
+static QueryDispatchDesc *
+_readQueryDispatchDesc(void)
+{
+	READ_LOCALS(QueryDispatchDesc);
+
+	READ_NODE_FIELD(transientTypeRecords);
+	READ_NODE_FIELD(intoOidInfo);
+	READ_STRING_FIELD(intoTableSpaceName);
+	READ_NODE_FIELD(sliceTable);
+	READ_DONE();
+}
 
 /*
  * _readPlan
@@ -2639,6 +2620,9 @@ readNodeBinary(void)
 			case T_PlannedStmt:
 				return_value = _readPlannedStmt();
 				break;
+			case T_QueryDispatchDesc:
+				return_value = _readQueryDispatchDesc();
+				break;
 			case T_Plan:
 					return_value = _readPlan();
 					break;
@@ -2785,6 +2769,9 @@ readNodeBinary(void)
 				break;
 			case T_IntoClause:
 				return_value = _readIntoClause();
+				break;
+			case T_TableOidInfo:
+				return_value = _readTableOidInfo();
 				break;
 			case T_Var:
 				return_value = _readVar();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -653,7 +653,6 @@ _readRangeVar(void)
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
-#ifndef COMPILING_BINARY_FUNCS
 static IntoClause *
 _readIntoClause(void)
 {
@@ -664,52 +663,33 @@ _readIntoClause(void)
 	READ_NODE_FIELD(options);
 	READ_ENUM_FIELD(onCommit, OnCommitAction);
 	READ_STRING_FIELD(tableSpaceName);
-	READ_OID_FIELD(oidInfo.relOid);
-    READ_OID_FIELD(oidInfo.comptypeOid);
-	READ_OID_FIELD(oidInfo.comptypeArrayOid);
-    READ_OID_FIELD(oidInfo.toastOid);
-    READ_OID_FIELD(oidInfo.toastIndexOid);
-    READ_OID_FIELD(oidInfo.toastComptypeOid);
-    READ_OID_FIELD(oidInfo.aosegOid);
-    READ_OID_FIELD(oidInfo.aosegIndexOid);
-    READ_OID_FIELD(oidInfo.aosegComptypeOid);
-	READ_OID_FIELD(oidInfo.aovisimapOid);
-	READ_OID_FIELD(oidInfo.aovisimapIndexOid);
-	READ_OID_FIELD(oidInfo.aovisimapComptypeOid);
-	READ_OID_FIELD(oidInfo.aoblkdirOid);
-	READ_OID_FIELD(oidInfo.aoblkdirIndexOid);
-	READ_OID_FIELD(oidInfo.aoblkdirComptypeOid);
-	/* policy not serialized */
-
-	/* Is this code, carried over from 3.3, actually needed?
-	 *
-	 * If the Query was a CTAS, and the CTAS was stored in the catalog
-	 * as part of a rule, we don't want to remember the OIDs assigned
-	 * in the past.  Not sure we can ever have that happen.
-	 */
-	Assert(local_node->oidInfo.relOid == InvalidOid);
-
-	local_node->oidInfo.relOid = InvalidOid;
-	local_node->oidInfo.comptypeOid = InvalidOid;
-	local_node->oidInfo.comptypeArrayOid = InvalidOid;
-	local_node->oidInfo.toastOid = InvalidOid;
-	local_node->oidInfo.toastIndexOid = InvalidOid;
-	local_node->oidInfo.toastComptypeOid = InvalidOid;
-	local_node->oidInfo.aosegOid = InvalidOid;
-	local_node->oidInfo.aosegIndexOid = InvalidOid;
-	local_node->oidInfo.aosegComptypeOid = InvalidOid;
-	local_node->oidInfo.aoblkdirOid = InvalidOid;
-	local_node->oidInfo.aoblkdirIndexOid = InvalidOid;
-	local_node->oidInfo.aoblkdirComptypeOid = InvalidOid;
-	local_node->oidInfo.aovisimapOid = InvalidOid;
-	local_node->oidInfo.aovisimapIndexOid = InvalidOid;
-	local_node->oidInfo.aovisimapComptypeOid = InvalidOid;
-
-	/* policy not serialized */
 
 	READ_DONE();
 }
-#endif /* COMPILING_BINARY_FUNCS */
+
+static TableOidInfo *
+_readTableOidInfo(void)
+{
+	READ_LOCALS(TableOidInfo);
+
+	READ_OID_FIELD(relOid);
+	READ_OID_FIELD(comptypeOid);
+	READ_OID_FIELD(comptypeArrayOid);
+	READ_OID_FIELD(toastOid);
+	READ_OID_FIELD(toastIndexOid);
+	READ_OID_FIELD(toastComptypeOid);
+	READ_OID_FIELD(aosegOid);
+	READ_OID_FIELD(aosegIndexOid);
+	READ_OID_FIELD(aosegComptypeOid);
+	READ_OID_FIELD(aovisimapOid);
+	READ_OID_FIELD(aovisimapIndexOid);
+	READ_OID_FIELD(aovisimapComptypeOid);
+	READ_OID_FIELD(aoblkdirOid);
+	READ_OID_FIELD(aoblkdirIndexOid);
+	READ_OID_FIELD(aoblkdirComptypeOid);
+
+	READ_DONE();
+}
 
 /*
  * _readVar
@@ -3122,6 +3102,7 @@ static ParseNodeInfo infoAr[] =
 	{"SLICETABLE", (ReadFn)_readSliceTable},
 	{"SORTCLAUSE", (ReadFn)_readSortClause},
 	{"SUBLINK", (ReadFn)_readSubLink},
+	{"TABLEOIDINFO", (ReadFn)_readTableOidInfo},
 	{"TABLEVALUEEXPR", (ReadFn)_readTableValueExpr},
 	{"TARGETENTRY", (ReadFn)_readTargetEntry},
 	{"TRUNCATESTMT", (ReadFn)_readTruncateStmt},

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -192,6 +192,12 @@ static void postprocess_plan(PlannedStmt *plan)
 	globNew->share.nextPlanId = 0;
 	globNew->subplans = plan->subplans;
 	(void) apply_shareinput_xslice(plan->planTree, globNew);
+
+	/*
+	 * To save on memory, and on the network bandwidth when the plan is dispatched
+	 * QEs, strip all subquery RTEs of the original Query objects.
+	 */
+	remove_subquery_in_RTEs((Node *) plan->rtable);
 }
 #endif
 
@@ -462,7 +468,12 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 
 	top_plan = zap_trivial_result(root, top_plan);
 
-	
+	/*
+	 * To save on memory, and on the network bandwidth when the plan is dispatched
+	 * QEs, strip all subquery RTEs of the original Query objects.
+	 */
+	remove_subquery_in_RTEs((Node *) glob->finalrtable);
+
 	/* build the PlannedStmt result */
 	result = makeNode(PlannedStmt);
 	

--- a/src/backend/postmaster/autostats.c
+++ b/src/backend/postmaster/autostats.c
@@ -21,6 +21,7 @@
 #include "cdb/cdbvars.h"
 #include "cdb/cdbpartition.h"
 #include "commands/vacuum.h"
+#include "executor/execdesc.h"
 #include "nodes/makefuncs.h"
 #include "nodes/plannodes.h"
 #include "parser/parsetree.h"
@@ -188,8 +189,9 @@ autostats_cmdtype_to_string(AutoStatsCmdType cmdType)
  * a PlannedStmt. This is done in preparation to call auto_stats()
  */
 void
-autostats_get_cmdtype(PlannedStmt *stmt, AutoStatsCmdType * pcmdType, Oid *prelationOid)
+autostats_get_cmdtype(QueryDesc *queryDesc, AutoStatsCmdType * pcmdType, Oid *prelationOid)
 {
+	PlannedStmt *stmt = queryDesc->plannedstmt;
 	Oid			relationOid = InvalidOid;		/* relation that is modified */
 	AutoStatsCmdType cmdType = AUTOSTATS_CMDTYPE_SENTINEL;		/* command type */
 	RangeTblEntry *rte = NULL;
@@ -200,7 +202,7 @@ autostats_get_cmdtype(PlannedStmt *stmt, AutoStatsCmdType * pcmdType, Oid *prela
 			if (stmt->intoClause != NULL)
 			{
 				/* CTAS */
-				relationOid = stmt->intoClause->oidInfo.relOid;
+				relationOid = queryDesc->ddesc->intoOidInfo->relOid;
 				cmdType = AUTOSTATS_CMDTYPE_CTAS;
 			}
 			break;

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -61,6 +61,9 @@ typedef struct QueryDesc
 	bool		extended_query;   /* simple or extended query protocol? */
 	char		*portal_name;	/* NULL for unnamed portal */
 	
+	/* The overall memory consumption account (i.e., outside of an operator) */
+	MemoryAccount *memoryAccount;
+
 	/* CDB: EXPLAIN ANALYZE statistics */
 	struct CdbExplain_ShowStatCtx  *showstatctx;
 	

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1388,6 +1388,9 @@ typedef struct PlanState
 	void      (*cdbexplainfun)(struct PlanState *planstate, struct StringInfoData *buf);
 	/* callback before ExecutorEnd */
 
+	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
+	MemoryAccount* memoryAccount;
+
 	/*
 	 * GpMon packet
 	 */

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -43,7 +43,8 @@ typedef enum NodeTag
 	T_SliceTable,
 	T_ShareNodeEntry,
 	T_PartitionState,
-	
+	T_QueryDispatchDesc,
+
 	/*
 	 * TAGS FOR PLAN NODES (plannodes.h)
 	 */
@@ -219,6 +220,7 @@ typedef enum NodeTag
 	T_PartBoundExpr,
 	T_PartBoundInclusionExpr,
 	T_PartBoundOpenExpr,
+	T_TableOidInfo,
 
 	/*
 	 * TAGS FOR EXPRESSION STATE NODES (execnodes.h)

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -283,9 +283,6 @@ typedef struct Plan
 	 * How much memory (in KB) should be used to execute this plan node?
 	 */
 	uint64 operatorMemKB;
-
-	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
-	MemoryAccount* memoryAccount;
 } Plan;
 
 /* ----------------

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -163,9 +163,6 @@ typedef struct PlannedStmt
 	/* What is the memory reserved for this query's execution? */
 	uint64		query_mem;
 
-	/* The overall memory consumption account (i.e., outside of an operator) */
-	MemoryAccount *memoryAccount;
-
 	/*
 	 * List of TupleDescNodes, one for each transient record type, when a
 	 * PlannedStmt is transferred from QD to QEs

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -149,25 +149,8 @@ typedef struct PlannedStmt
 	 */
 	struct GpPolicy  *intoPolicy;
 
-	/*
-	 * GPDB: This allows the slice table to accompany the plan as it
-	 * moves around the executor.
-	 *
-	 * Currently, the slice table should not be installed on the QD.
-	 * Rather is it shipped to QEs as a separate parameter to MPPEXEC.
-	 * The implementation of MPPEXEC, which runs on the QEs, installs
-	 * the slice table in the plan as required there.
-	 */
-	Node	   *sliceTable;
-
 	/* What is the memory reserved for this query's execution? */
 	uint64		query_mem;
-
-	/*
-	 * List of TupleDescNodes, one for each transient record type, when a
-	 * PlannedStmt is transferred from QD to QEs
-	 */
-	List	   *transientTypeRecords;
 } PlannedStmt;
 
 

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -85,6 +85,7 @@ typedef struct RangeVar
 
 typedef struct TableOidInfo
 {
+	NodeTag		type;
 	Oid         relOid;			/* If the heap is (re-)created, create  with this relOid */
 	Oid         comptypeOid;
 	Oid         comptypeArrayOid;
@@ -114,9 +115,6 @@ typedef struct IntoClause
 	List	   *options;		/* options from WITH clause */
 	OnCommitAction onCommit;	/* what do we do at COMMIT? */
 	char	   *tableSpaceName; /* table space to use, or NULL */
-	
-	/* MPP */
-	TableOidInfo oidInfo;
 } IntoClause;
 
 

--- a/src/include/postmaster/autostats.h
+++ b/src/include/postmaster/autostats.h
@@ -15,6 +15,8 @@
 #ifndef AUTOSTATS_H
 #define AUTOSTATS_H
 
+#include "executor/execdesc.h"
+
 /**
  * AutoStatsCmdType - an enumeration of type of statements known to auto-stats
  * module. 
@@ -37,7 +39,7 @@ typedef enum AutoStatsCmdType
 } AutoStatsCmdType;
 
 extern const char *autostats_cmdtype_to_string(AutoStatsCmdType cmdType);
-extern void autostats_get_cmdtype(PlannedStmt *stmt,
+extern void autostats_get_cmdtype(QueryDesc *queryDesc,
 					  AutoStatsCmdType *pcmdType, Oid *prelationOid);
 extern void auto_stats(AutoStatsCmdType cmdType, Oid relationOid,
 		   uint64 ntuples, bool inFunction);

--- a/src/include/tcop/pquery.h
+++ b/src/include/tcop/pquery.h
@@ -28,7 +28,8 @@ extern List *FetchStatementTargetList(Node *stmt);
 
 extern void PortalStart(Portal portal, ParamListInfo params,
 						Snapshot snapshot,
-						const char *seqServerHost, int seqServerPort);
+						const char *seqServerHost, int seqServerPort,
+						QueryDispatchDesc *ddesc);
 
 extern void PortalSetResultFormat(Portal portal, int nFormats,
 					  int16 *formats);

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -226,21 +226,21 @@ typedef struct SerializedMemoryAccount {
  * that will not be executed in current slice
  */
 #define CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, planNode, NodeType) \
-		(NULL != planNode->memoryAccount && MEMORY_OWNER_TYPE_Exec_##NodeType == planNode->memoryAccount->ownerType) ?\
-			planNode->memoryAccount : \
-			(isAlienPlanNode ? AlienExecutorMemoryAccount : \
-				MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
-				work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType));
+	(isAlienPlanNode ? AlienExecutorMemoryAccount :						\
+	 MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
+									work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType))
 
 /*
  * SAVE_EXECUTOR_MEMORY_ACCOUNT saves an operator specific memory account
  * into the PlanState of that operator
  */
 #define SAVE_EXECUTOR_MEMORY_ACCOUNT(execState, curMemoryAccount)\
-		Assert(NULL == ((PlanState *)execState)->plan->memoryAccount || \
-		AlienExecutorMemoryAccount == ((PlanState *)execState)->plan->memoryAccount || \
-		curMemoryAccount == ((PlanState *)execState)->plan->memoryAccount);\
-		((PlanState *)execState)->plan->memoryAccount = curMemoryAccount;
+	do { \
+		Assert(NULL == ((PlanState *)execState)->memoryAccount || \
+			   AlienExecutorMemoryAccount == ((PlanState *)execState)->memoryAccount || \
+			   curMemoryAccount == ((PlanState *)execState)->memoryAccount); \
+		((PlanState *)execState)->memoryAccount = curMemoryAccount; \
+	} while(0)
 
 extern struct MemoryAccount*
 MemoryAccounting_CreateAccount(long maxLimit, enum MemoryOwnerType ownerType);

--- a/src/include/utils/portal.h
+++ b/src/include/utils/portal.h
@@ -162,6 +162,8 @@ typedef struct PortalData
 	/* If not NULL, Executor is active; call ExecutorEnd eventually: */
 	QueryDesc  *queryDesc;		/* info needed for executor invocation */
 
+	QueryDispatchDesc *ddesc;	/* extra info dispatched from QD to QEs */
+
 	/* If portal returns tuples, this is their tupdesc: */
 	TupleDesc	tupDesc;		/* descriptor for result tuples */
 	/* and these are the format codes to use for the columns: */


### PR DESCRIPTION
With the upcoming PostgreSQL 8.3 merge, a PlannedStmt will be cached across multiple executions of a statement. In preparation for that, move things that modified during execution out of PlannedStmt.