### PR TITLE
Fixing unit tests to make them green on Mac OS X with clang

### DIFF
--- a/src/backend/cdb/dispatcher/test/Makefile
+++ b/src/backend/cdb/dispatcher/test/Makefile
@@ -6,3 +6,15 @@ TARGETS=cdbdisp_query \
 		cdbdispatchresult
 
 include $(top_builddir)/src/backend/mock.mk
+
+cdbdisp_query.t: \
+	$(MOCK_DIR)/backend/executor/execUtils_mock.o \
+	$(MOCK_DIR)/backend/cdb/cdbrelsize_mock.o \
+	$(MOCK_DIR)/backend/cdb/cdbsrlz_mock.o \
+
+cdbdispatchresult.t: \
+	$(MOCK_DIR)/backend/gp_libpq_fe/pqexpbuffer_mock.o \
+	$(MOCK_DIR)/backend/cdb/cdbrelsize_mock.o \
+	$(MOCK_DIR)/backend/cdb/cdbsrlz_mock.o \
+
+include $(top_builddir)/src/backend/mock.mk

--- a/src/backend/cdb/dispatcher/test/cdbdispatchresult_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbdispatchresult_test.c
@@ -19,17 +19,6 @@ _init_cdbdisp_makeResult()
 	return results;
 }
 
-PQExpBuffer __wrap_createPQExpBuffer(void)
-{
-	return (PQExpBuffer) mock();
-}
-
-void
-__wrap_destroyPQExpBuffer(PQExpBuffer str)
-{
-	mock();
-}
-
 /*
  * Test cdbdisp_makeResult would return NULL if OOM happens
  */
@@ -45,8 +34,9 @@ test__cdbdisp_makeResult__oom(void **state)
 	/*
 	 * createPQExpBuffer is supposed to return NULL in OOM cases
 	 */
-	will_return(__wrap_createPQExpBuffer, NULL);
-	will_be_called(__wrap_destroyPQExpBuffer);
+	will_return(createPQExpBuffer, NULL);
+	expect_any(destroyPQExpBuffer, str);
+	will_be_called(destroyPQExpBuffer);
 	result = cdbdisp_makeResult(results, segdbDesc, 0);
 	assert_true(result == NULL);
 }

--- a/src/backend/executor/test/execHHashagg_test.c
+++ b/src/backend/executor/test/execHHashagg_test.c
@@ -94,7 +94,7 @@ test__getSpillFile__Initialize_wfile_exception(void **state)
 	workfile_set *work_set = (workfile_set *) palloc0(sizeof(workfile_set));
 	SpillSet *spill_set = (SpillSet *) palloc0(sizeof(SpillSet) + (branching_factor-1) * sizeof (SpillFile));
 
-	SpillFile *spill_file = &spill_set->spill_files[0];
+	volatile SpillFile *spill_file = &spill_set->spill_files[0];
 	spill_file->file_info = NULL;
 
 	/* Make workfile_mgr_create_file throw an exception, using the side effect function */

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -42,6 +42,13 @@ static StringInfoData outputBuffer;
 
 #include "../memaccounting.c"
 
+#define EXPECT_EXCEPTION()     \
+	expect_any(ExceptionalCondition,conditionName); \
+	expect_any(ExceptionalCondition,errorType); \
+	expect_any(ExceptionalCondition,fileName); \
+	expect_any(ExceptionalCondition,lineNumber); \
+    will_be_called_with_sideeffect(ExceptionalCondition, &_ExceptionalCondition, NULL);\
+
 /*
  * Mocks the function write_stderr and captures the output in
  * the global outputBuffer
@@ -1281,19 +1288,12 @@ test__MemoryAccounting_GetAccountName__Validate(void **state)
 	}
 
 #ifdef USE_ASSERT_CHECKING
-    expect_any(ExceptionalCondition,conditionName);
-    expect_any(ExceptionalCondition,errorType);
-    expect_any(ExceptionalCondition,fileName);
-    expect_any(ExceptionalCondition,lineNumber);
-
-    will_be_called_with_sideeffect(ExceptionalCondition, &_ExceptionalCondition, NULL);
-
-    MemoryAccount *newAccount = NULL;
+    MemoryAccount *newAccount = CreateMemoryAccountImpl(0, 0, ActiveMemoryAccount);
     /* Test if within memory-limit strings cause assertion failure */
 	PG_TRY();
 	{
 		/* 0 is an invalid memory owner type, so it should fail an assertion */
-		newAccount = CreateMemoryAccountImpl(0, 0, ActiveMemoryAccount);
+		EXPECT_EXCEPTION();
 		char *accountName = MemoryAccounting_GetAccountName(newAccount);
 		assert_true(false);
 	}
@@ -1303,6 +1303,7 @@ test__MemoryAccounting_GetAccountName__Validate(void **state)
 	PG_END_TRY();
 
 	pfree(newAccount);
+	newAccount = NULL;
 #endif
 }
 

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -40,6 +40,8 @@ static StringInfoData outputBuffer;
 #undef fclose
 #define fclose(fileHandle)
 
+void write_stderr_mock(const char *fmt,...);
+
 #include "../memaccounting.c"
 
 #define EXPECT_EXCEPTION()     \


### PR DESCRIPTION
Looks like clang has a different behavior compared to gcc and it breaks several things, mostly in the presence of PG_TRY and PG_CATCH. This PR fixes the following:

1. Instead of relying on --wrap of gcc to override mocked function, we cange makefile to make the object mocked
2. Declare a pointer volatile so that we can access it inside PG_CATCH() to assert on it without crashing. The pointer becomes corrupted otherwise.

