### PR TITLE
Simplify counting of tupletable slots, by getting rid of the counting.

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -271,7 +271,7 @@ InternalCreateExecutorState(MemoryContext qcontext, bool is_subquery)
 
 	estate->es_query_cxt = qcontext;
 
-	estate->es_tupleTable = NULL;
+	estate->es_tupleTable = NIL;
 
 	estate->es_processed = 0;
 	estate->es_lastoid = InvalidOid;

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -195,8 +195,7 @@ ExecInitSubqueryScan(SubqueryScan *node, EState *estate, int eflags)
 	sp_estate->es_range_table = estate->es_range_table;
 	sp_estate->es_param_list_info = estate->es_param_list_info;
 	sp_estate->es_param_exec_vals = estate->es_param_exec_vals;
-	sp_estate->es_tupleTable =
-		ExecCreateTupleTable(ExecCountSlotsNode(node->subplan) + 10);
+	sp_estate->es_tupleTable = NIL;
 	sp_estate->es_snapshot = estate->es_snapshot;
 	sp_estate->es_crosscheck_snapshot = estate->es_crosscheck_snapshot;
 	sp_estate->es_instrument = estate->es_instrument;

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -22,7 +22,7 @@
 #include "codegen/codegen_wrapper.h"
 
 /*----------
- * The executor stores tuples in a "tuple table" which is composed of
+ * The executor stores tuples in a "tuple table" which is a List of
  * independent TupleTableSlots.  There are several cases we need to handle:
  *		1. physical tuple in a disk buffer page
  *		2. physical tuple constructed in palloc'ed memory
@@ -113,7 +113,7 @@
 
 typedef struct TupleTableSlot
 {
-	NodeTag		type;		/* vestigial ... allows IsA tests */
+	NodeTag		type;
 	int         PRIVATE_tts_flags;      /* TTS_xxx flags */
 
 	/* Heap tuple stuff */
@@ -357,26 +357,14 @@ static inline bool slot_attisnull(TupleTableSlot *slot, int attnum)
 	return memtuple_attisnull(slot->PRIVATE_tts_memtuple, slot->tts_mt_bind, attnum);
 }
 
-/*
- * Tuple table data structure: an array of TupleTableSlots.
- */
-typedef struct TupleTableData
-{
-	int			size;			/* size of the table (number of slots) */
-	int			next;			/* next available slot number */
-	TupleTableSlot array[1];	/* VARIABLE LENGTH ARRAY - must be last */
-} TupleTableData;				/* VARIABLE LENGTH STRUCT */
-
-typedef TupleTableData *TupleTable;
-
 /* in executor/execTuples.c */
 extern void init_slot(TupleTableSlot *slot, TupleDesc tupdesc);
 
-extern TupleTable ExecCreateTupleTable(int tableSize);
-extern void ExecDropTupleTable(TupleTable table, bool shouldFree);
+extern TupleTableSlot *MakeTupleTableSlot(void);
+extern TupleTableSlot *ExecAllocTableSlot(List **tupleTable);
+extern void ExecResetTupleTable(List *tupleTable, bool shouldFree);
 extern TupleTableSlot *MakeSingleTupleTableSlot(TupleDesc tupdesc);
 extern void ExecDropSingleTupleTableSlot(TupleTableSlot *slot);
-extern TupleTableSlot *ExecAllocTableSlot(TupleTable table);
 extern void ExecSetSlotDescriptor(TupleTableSlot *slot, TupleDesc tupdesc); 
 
 extern TupleTableSlot *ExecStoreHeapTuple(HeapTuple tuple,

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -575,7 +575,7 @@ typedef struct EState
 	/* Other working state: */
 	MemoryContext es_query_cxt; /* per-query context in which EState lives */
 
-	TupleTable	es_tupleTable;	/* Array of TupleTableSlots */
+	List	   *es_tupleTable;	/* List of TupleTableSlots */
 
 	uint64		es_processed;	/* # of tuples processed */
 	Oid			es_lastoid;		/* last oid processed (by INSERT) */


### PR DESCRIPTION
Backport this patch from PostgreSQL 9.0, which replaces the tuple table
array with a linked list of individually palloc'd slots. With that, we
don't need to know the size of the array beforehand, and don't need to
count the slots. The counting was especially funky for subplans in GPDB,
and it was about to change with the upcoming PostgreSQL 8.3 merge again.
This makes it a lot simpler.

I don't plan to backport the follow-up patch to remove the ExecCountSlots
infrastructure. We'll get that later, when we merge with PostgreSQL 9.0.

commit f92e8a4b5ee6a22252cbba012d629f5cefef913f
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Sun Sep 27 20:09:58 2009 +0000

    Replace the array-style TupleTable data structure with a simple List of
    TupleTableSlot nodes.  This eliminates the need to count in advance
    how many Slots will be needed, which seems more than worth the small
    increase in the amount of palloc traffic during executor startup.

    The ExecCountSlots infrastructure is now all dead code, but I'll remove it
    in a separate commit for clarity.

    Per a comment from Robert Haas.