### PR TITLE
Fix broken zlib unittests

### DIFF
--- a/src/backend/storage/file/test/compress_zlib_test.c
+++ b/src/backend/storage/file/test/compress_zlib_test.c
@@ -80,11 +80,11 @@ test__bfz_zlib_init__palloc_write(void **state)
 	bfz.mode = BFZ_MODE_APPEND;
 	bfz.fd = -1;
 
-	Size beforeAlloc = MemoryContextGetPeakSpace(TopMemoryContext);
+	Size beforeAlloc = MemoryContextGetPeakSpace(TopTransactionContext);
 
 	bfz_zlib_init(&bfz);
 
-	Size afterAlloc = MemoryContextGetPeakSpace(TopMemoryContext);
+	Size afterAlloc = MemoryContextGetPeakSpace(TopTransactionContext);
 
 	int memZlib = zlib_memory_needed(true /* isWrite */);
 
@@ -100,11 +100,11 @@ test__bfz_zlib_init__palloc_read(void **state)
 	bfz.mode = BFZ_MODE_SCAN;
 	bfz.fd = -1;
 
-	Size beforeAlloc = MemoryContextGetPeakSpace(TopMemoryContext);
+	Size beforeAlloc = MemoryContextGetPeakSpace(TopTransactionContext);
 
 	bfz_zlib_init(&bfz);
 
-	Size afterAlloc = MemoryContextGetPeakSpace(TopMemoryContext);
+	Size afterAlloc = MemoryContextGetPeakSpace(TopTransactionContext);
 
 	int memZlib = zlib_memory_needed(false /* isWrite */);
 
@@ -115,6 +115,13 @@ int
 main(int argc, char* argv[])
 {
 	cmockery_parse_arguments(argc, argv);
+
+	TopTransactionContext =
+		AllocSetContextCreate(TopMemoryContext,
+							  "TopTransactionContext",
+							  ALLOCSET_DEFAULT_MINSIZE,
+							  ALLOCSET_DEFAULT_INITSIZE,
+							  ALLOCSET_DEFAULT_MAXSIZE);
 
 	const UnitTest tests[] = {
 		unit_test(test__bfz_zlib_init__palloc_write),

--- a/src/backend/storage/file/test/compress_zlib_test.c
+++ b/src/backend/storage/file/test/compress_zlib_test.c
@@ -81,10 +81,12 @@ test__bfz_zlib_init__palloc_write(void **state)
 	bfz.fd = -1;
 
 	Size beforeAlloc = MemoryContextGetPeakSpace(TopTransactionContext);
+	assert_true(TopTransactionContext != CurrentMemoryContext);
 
 	bfz_zlib_init(&bfz);
 
 	Size afterAlloc = MemoryContextGetPeakSpace(TopTransactionContext);
+	assert_true(TopTransactionContext != CurrentMemoryContext);
 
 	int memZlib = zlib_memory_needed(true /* isWrite */);
 
@@ -101,10 +103,12 @@ test__bfz_zlib_init__palloc_read(void **state)
 	bfz.fd = -1;
 
 	Size beforeAlloc = MemoryContextGetPeakSpace(TopTransactionContext);
+	assert_true(TopTransactionContext != CurrentMemoryContext);
 
 	bfz_zlib_init(&bfz);
 
 	Size afterAlloc = MemoryContextGetPeakSpace(TopTransactionContext);
+	assert_true(TopTransactionContext != CurrentMemoryContext);
 
 	int memZlib = zlib_memory_needed(false /* isWrite */);
 


### PR DESCRIPTION
Previous commit broke two unit-tests on workfile's compression using zlib. The broken unit-tests assume that g_datasourceCtx is allocated under TopMemoryContext, but in the previous commit we changed that to TopTransactionContext. This PR updates the unit-tests accordingly.

@foyzur @gcaragea Please take a look.