### PR TITLE
First Cut at fixing XLOG Redo Issues

### DIFF
--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -821,6 +821,7 @@ _bitmap_log_newpage(Relation rel, uint8 info, Buffer buf)
 
 	xlNewPage.bm_node = rel->rd_node;
 	xlNewPage.bm_persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
+	xlNewPage.bm_tidAllowedToBeZero = rel->rd_segfile0_relationnodeinfo.tidAllowedToBeZero;
 	xlNewPage.bm_persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
 	xlNewPage.bm_new_blkno = BufferGetBlockNumber(buf);
 

--- a/src/backend/cdb/cdbresynchronizechangetracking.c
+++ b/src/backend/cdb/cdbresynchronizechangetracking.c
@@ -534,6 +534,7 @@ static void ChangeTracking_AddRelationChangeInfo(
 									  RelFileNode *relFileNode,
 									  BlockNumber blockNumber,
 									  ItemPointer persistentTid,
+										bool	tidAllowedToBeZero,
 									  int64	  	  persistentSerialNum)
 {
 	RelationChangeInfo	*relationChangeInfo;
@@ -545,6 +546,7 @@ static void ChangeTracking_AddRelationChangeInfo(
 	relationChangeInfo->relFileNode = 			*relFileNode;
 	relationChangeInfo->blockNumber = 			blockNumber;
 	relationChangeInfo->persistentTid = 		*persistentTid;
+	relationChangeInfo->tidAllowedToBeZero = tidAllowedToBeZero;
 	relationChangeInfo->persistentSerialNum = 	persistentSerialNum;
 
 	(*relationChangeInfoArrayCount)++;
@@ -613,6 +615,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->heapnode.node),
 													   xlrec->block,
 													   &xlrec->heapnode.persistentTid,
+														 xlrec->heapnode.tidAllowedToBeZero,
 													   xlrec->heapnode.persistentSerialNum);
 					break;
 				}
@@ -635,6 +638,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->target.node),
 													   ItemPointerGetBlockNumber(&(xlrec->target.tid)),
 													   &xlrec->target.persistentTid,
+														 xlrec->target.tidAllowedToBeZero,
 													   xlrec->target.persistentSerialNum);
 					break;
 				}
@@ -649,6 +653,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->target.node),
 													   ItemPointerGetBlockNumber(&(xlrec->target.tid)),
 													   &xlrec->target.persistentTid,
+														 xlrec->target.tidAllowedToBeZero,
 													   xlrec->target.persistentSerialNum);
 					break;
 				}
@@ -669,6 +674,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->target.node),
 													   newblock,
 													   &xlrec->target.persistentTid,
+														 xlrec->target.tidAllowedToBeZero,
 													   xlrec->target.persistentSerialNum);
 					if(!samepage)
 						ChangeTracking_AddRelationChangeInfo(
@@ -678,6 +684,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->target.node),
 														   oldblock,
 														   &xlrec->target.persistentTid,
+															 xlrec->target.tidAllowedToBeZero,
 														   xlrec->target.persistentSerialNum);
 						
 					break;
@@ -693,6 +700,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->heapnode.node),
 													   xlrec->block,
 													   &xlrec->heapnode.persistentTid,
+														 xlrec->heapnode.tidAllowedToBeZero,
 													   xlrec->heapnode.persistentSerialNum);
 					break;
 				}
@@ -707,6 +715,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->heapnode.node),
 													   xlrec->blkno,
 													   &xlrec->heapnode.persistentTid,
+														 xlrec->heapnode.tidAllowedToBeZero,
 													   xlrec->heapnode.persistentSerialNum);
 					break;
 				}
@@ -722,6 +731,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->target.node),
 													   block,
 													   &xlrec->target.persistentTid,
+														 xlrec->target.tidAllowedToBeZero,
 													   xlrec->target.persistentSerialNum);
 					break;
 				}
@@ -737,6 +747,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->target.node),
 													   block,
 													   &xlrec->target.persistentTid,
+														 xlrec->target.tidAllowedToBeZero,
 													   xlrec->target.persistentSerialNum);
 					break;
 				}
@@ -763,6 +774,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->target.node),
 													   BlockIdGetBlockNumber(&blkid),
 													   &xlrec->target.persistentTid,
+														 xlrec->target.tidAllowedToBeZero,
 													   xlrec->target.persistentSerialNum);
 					
 					if(info == XLOG_BTREE_INSERT_META)
@@ -773,6 +785,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->target.node),
 														   BTREE_METAPAGE,
 														   &xlrec->target.persistentTid,
+															 xlrec->target.tidAllowedToBeZero,
 														   xlrec->target.persistentSerialNum);
 
 					break;
@@ -791,6 +804,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 						relationChangeInfoMaxSize, &(xlrec->node),
 						xlrec->leftsib,
 						&xlrec->persistentTid,
+						xlrec->tidAllowedToBeZero,
 						xlrec->persistentSerialNum);
 
 					/* new right page */
@@ -800,6 +814,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 						relationChangeInfoMaxSize, &(xlrec->node),
 						xlrec->rightsib,
 						&xlrec->persistentTid,
+						xlrec->tidAllowedToBeZero,
 						xlrec->persistentSerialNum);
 
 					/* next block (orig page's rightlink) */
@@ -811,6 +826,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 							relationChangeInfoMaxSize, &(xlrec->node),
 							xlrec->rnext,
 							&xlrec->persistentTid,
+							xlrec->tidAllowedToBeZero,
 							xlrec->persistentSerialNum);
 					}
 					break;
@@ -826,6 +842,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->btreenode.node),
 													   xlrec->block,
 													   &xlrec->btreenode.persistentTid,
+														 xlrec->btreenode.tidAllowedToBeZero,
 													   xlrec->btreenode.persistentSerialNum);
 					break;
 				}
@@ -845,6 +862,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->target.node),
 														   block,
 														   &xlrec->target.persistentTid,
+															 xlrec->target.tidAllowedToBeZero,
 														   xlrec->target.persistentSerialNum);
 					
 					if (xlrec->rightblk != P_NONE)
@@ -855,6 +873,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->target.node),
 														   xlrec->rightblk,
 														   &xlrec->target.persistentTid,
+															 xlrec->target.tidAllowedToBeZero,
 														   xlrec->target.persistentSerialNum);
 
 					if (xlrec->leftblk != P_NONE)
@@ -865,6 +884,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->target.node),
 														   xlrec->leftblk,
 														   &xlrec->target.persistentTid,
+															 xlrec->target.tidAllowedToBeZero,
 														   xlrec->target.persistentSerialNum);
 					
 					if (xlrec->deadblk != P_NONE)
@@ -875,6 +895,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->target.node),
 														   xlrec->deadblk,
 														   &xlrec->target.persistentTid,
+															 xlrec->target.tidAllowedToBeZero,
 														   xlrec->target.persistentSerialNum);						
 					
 					if (info == XLOG_BTREE_DELETE_PAGE_META)
@@ -885,6 +906,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->target.node),
 														   BTREE_METAPAGE,
 														   &xlrec->target.persistentTid,
+															 xlrec->target.tidAllowedToBeZero,
 														   xlrec->target.persistentSerialNum);
 					break;
 				}
@@ -899,6 +921,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->btreenode.node),
 													   xlrec->rootblk,
 													   &xlrec->btreenode.persistentTid,
+														 xlrec->btreenode.tidAllowedToBeZero,
 													   xlrec->btreenode.persistentSerialNum);	
 					 
 					/* newroot always updates the meta page */
@@ -909,6 +932,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->btreenode.node),
 													   BTREE_METAPAGE,
 													   &xlrec->btreenode.persistentTid,
+														 xlrec->btreenode.tidAllowedToBeZero,
 													   xlrec->btreenode.persistentSerialNum);	
 					
 					break;
@@ -932,6 +956,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->bm_node),
 													   xlrec->bm_new_blkno,
 													   &xlrec->bm_persistentTid,
+														 xlrec->bm_tidAllowedToBeZero,
 													   xlrec->bm_persistentSerialNum);
 					break;
 				}
@@ -946,6 +971,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->bm_node),
 													   xlrec->bm_lov_blkno,
 													   &xlrec->bm_persistentTid,
+														 xlrec->bm_tidAllowedToBeZero,
 													   xlrec->bm_persistentSerialNum);
 					
 					if (xlrec->bm_is_new_lov_blkno)
@@ -956,6 +982,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->bm_node),
 														   BM_METAPAGE,
 														   &xlrec->bm_persistentTid,
+															 xlrec->bm_tidAllowedToBeZero,
 														   xlrec->bm_persistentSerialNum);
 					break;
 				}
@@ -970,6 +997,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->bm_node),
 													   BM_METAPAGE,
 													   &xlrec->bm_persistentTid,
+														 xlrec->bm_tidAllowedToBeZero,
 													   xlrec->bm_persistentSerialNum);
 					break;
 				}
@@ -984,6 +1012,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->bm_node),
 													   xlrec->bm_lov_blkno,
 													   &xlrec->bm_persistentTid,
+														 xlrec->bm_tidAllowedToBeZero,
 													   xlrec->bm_persistentSerialNum);
 					break;
 				}
@@ -998,6 +1027,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->bm_node),
 													   xlrec->bm_lov_blkno,
 													   &xlrec->bm_persistentTid,
+														 xlrec->bm_tidAllowedToBeZero,
 													   xlrec->bm_persistentSerialNum);
 
 					ChangeTracking_AddRelationChangeInfo(
@@ -1007,6 +1037,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->bm_node),
 													   xlrec->bm_blkno,
 													   &xlrec->bm_persistentTid,
+														 xlrec->bm_tidAllowedToBeZero,
 													   xlrec->bm_persistentSerialNum);
 					
 					if (!xlrec->bm_is_last)
@@ -1017,6 +1048,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->bm_node),
 														   xlrec->bm_next_blkno,
 														   &xlrec->bm_persistentTid,
+															 xlrec->bm_tidAllowedToBeZero,
 														   xlrec->bm_persistentSerialNum);
 					break;
 				}
@@ -1031,6 +1063,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->bm_node),
 													   xlrec->bm_blkno,
 													   &xlrec->bm_persistentTid,
+														 xlrec->bm_tidAllowedToBeZero,
 													   xlrec->bm_persistentSerialNum);
 					break;
 				}
@@ -1045,6 +1078,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->bm_node),
 													   xlrec->bm_first_blkno,
 													   &xlrec->bm_persistentTid,
+														 xlrec->bm_tidAllowedToBeZero,
 													   xlrec->bm_persistentSerialNum);
 					
 					if (xlrec->bm_two_pages)
@@ -1055,6 +1089,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->bm_node),
 														   xlrec->bm_second_blkno,
 														   &xlrec->bm_persistentTid,
+															 xlrec->bm_tidAllowedToBeZero,
 														   xlrec->bm_persistentSerialNum);
 					
 					if (xlrec->bm_new_lastpage)
@@ -1065,6 +1100,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xlrec->bm_node),
 														   xlrec->bm_lov_blkno,
 														   &xlrec->bm_persistentTid,
+															 xlrec->bm_tidAllowedToBeZero,
 														   xlrec->bm_persistentSerialNum);
 						
 					break;
@@ -1087,6 +1123,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xlrec->node),
 													   0, /* seq_redo touches block 0 only */
 													   &xlrec->persistentTid,
+														 xlrec->tidAllowedToBeZero,
 													   xlrec->persistentSerialNum);
 
 					break;
@@ -1111,6 +1148,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xldata->node),
 													   xldata->blkno,
 													   &xldata->persistentTid,
+														 xldata->tidAllowedToBeZero,
 													   xldata->persistentSerialNum);
 					break;
 				}
@@ -1125,6 +1163,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xldata->node),
 													   xldata->blkno,
 													   &xldata->persistentTid,
+														 xldata->tidAllowedToBeZero,
 													   xldata->persistentSerialNum);
 					break;
 				}
@@ -1143,6 +1182,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xldata->node),
 													   xldata->origblkno,
 													   &xldata->persistentTid,
+														 xldata->tidAllowedToBeZero,
 													   xldata->persistentSerialNum);
 
 					/* now log all the pages that we split into */					
@@ -1163,6 +1203,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 														   &(xldata->node),
 														   gistp->blkno,
 														   &xldata->persistentTid,
+															 xldata->tidAllowedToBeZero,
 														   xldata->persistentSerialNum);
 						
 						/* skip over all index tuples. we only care about block numbers */
@@ -1187,6 +1228,7 @@ void ChangeTracking_GetRelationChangeInfoFromXlog(
 													   &(xldata->node),
 													   GIST_ROOT_BLKNO,
 													   &xldata->persistentTid,
+														 xldata->tidAllowedToBeZero,
 													   xldata->persistentSerialNum);
 					break;
 				}

--- a/src/include/access/bitmap.h
+++ b/src/include/access/bitmap.h
@@ -579,6 +579,7 @@ typedef struct xl_bm_bitmapwords
 {
 	RelFileNode 	bm_node;
 	ItemPointerData bm_persistentTid;
+	bool bm_tidAllowedToBeZero;
 	int64 			bm_persistentSerialNum;
 
 	/* The block number for the bitmap page */
@@ -637,6 +638,7 @@ typedef struct xl_bm_updatewords
 {
 	RelFileNode		bm_node;
 	ItemPointerData bm_persistentTid;
+	bool	bm_tidAllowedToBeZero;
 	int64 			bm_persistentSerialNum;
 
 	BlockNumber		bm_lov_blkno;
@@ -668,6 +670,7 @@ typedef struct xl_bm_updateword
 {
 	RelFileNode		bm_node;
 	ItemPointerData bm_persistentTid;
+	bool bm_tidAllowedToBeZero;
 	int64 			bm_persistentSerialNum;
 
 	BlockNumber		bm_blkno;
@@ -681,6 +684,7 @@ typedef struct xl_bm_lovitem
 {
 	RelFileNode 	bm_node;
 	ItemPointerData bm_persistentTid;
+	bool	bm_tidAllowedToBeZero;
 	int64 			bm_persistentSerialNum;
 
 	BlockNumber		bm_lov_blkno;
@@ -694,6 +698,7 @@ typedef struct xl_bm_newpage
 {
 	RelFileNode 	bm_node;
 	ItemPointerData bm_persistentTid;
+	bool	bm_tidAllowedToBeZero;
 	int64 			bm_persistentSerialNum;
 
 	BlockNumber		bm_new_blkno;
@@ -707,6 +712,7 @@ typedef struct xl_bm_bitmappage
 {
 	RelFileNode 	bm_node;
 	ItemPointerData bm_persistentTid;
+	bool	bm_tidAllowedToBeZero;
 	int64 			bm_persistentSerialNum;
 
 	BlockNumber		bm_bitmap_blkno;
@@ -727,6 +733,7 @@ typedef struct xl_bm_bitmap_lastwords
 {
 	RelFileNode 	bm_node;
 	ItemPointerData bm_persistentTid;
+	bool	bm_tidAllowedToBeZero;
 	int64 			bm_persistentSerialNum;
 
 	BM_HRL_WORD		bm_last_compword;
@@ -744,6 +751,7 @@ typedef struct xl_bm_metapage
 {
 	RelFileNode 	bm_node;
 	ItemPointerData bm_persistentTid;
+	bool	bm_tidAllowedToBeZero;
 	int64 			bm_persistentSerialNum;
 
 	Oid				bm_lov_heapId;		/* the relation id for the heap */

--- a/src/include/access/filerepdefs.h
+++ b/src/include/access/filerepdefs.h
@@ -34,6 +34,8 @@ typedef struct MirroredBufferPoolBulkLoadInfo
 
 	ItemPointerData				persistentTid;
 
+	bool tidAllowedToBeZero;
+
 	int64						persistentSerialNum;
 
 } MirroredBufferPoolBulkLoadInfo;

--- a/src/include/access/gist_private.h
+++ b/src/include/access/gist_private.h
@@ -106,6 +106,7 @@ typedef struct gistxlogPageUpdate
 {
 	RelFileNode 	node;
 	ItemPointerData persistentTid;
+	bool tidAllowedToBeZero;
 	int64 			persistentSerialNum;
 	BlockNumber 	blkno;
 
@@ -126,6 +127,7 @@ typedef struct gistxlogPageSplit
 {
 	RelFileNode 	node;
 	ItemPointerData persistentTid;
+	bool tidAllowedToBeZero;
 	int64 			persistentSerialNum;
 
 	BlockNumber  origblkno;		/* splitted page */
@@ -144,6 +146,7 @@ typedef struct gistxlogCreateIndex
 {
 	RelFileNode 	node;
 	ItemPointerData persistentTid;
+	bool tidAllowedToBeZero;
 	int64 			persistentSerialNum;
 
 } gistxlogCreateIndex;
@@ -164,6 +167,7 @@ typedef struct gistxlogPageDelete
 {
 	RelFileNode 	node;
 	ItemPointerData persistentTid;
+	bool tidAllowedToBeZero;
 	int64 			persistentSerialNum;
 	BlockNumber 	blkno;
 } gistxlogPageDelete;

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -176,6 +176,8 @@ inline static void xl_heaptid_set(
 {
 	heaptid->node = rel->rd_node;
 	heaptid->persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
+  heaptid->tidAllowedToBeZero = rel->rd_segfile0_relationnodeinfo.tidAllowedToBeZero;
+
 	heaptid->persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
 	heaptid->tid = *tid;
 }

--- a/src/include/access/htup.h
+++ b/src/include/access/htup.h
@@ -501,6 +501,7 @@ typedef struct xl_heaptid
 	RelFileNode node;
 	ItemPointerData persistentTid;
 	int64 persistentSerialNum;
+	bool tidAllowedToBeZero;
 	ItemPointerData tid;		/* changed tuple id */
 } xl_heaptid;
 
@@ -511,6 +512,7 @@ typedef struct xl_heapnode
 	RelFileNode node;
 	ItemPointerData persistentTid;
 	int64 persistentSerialNum;
+	bool	tidAllowedToBeZero;
 } xl_heapnode;
 
 /* This is what we need to know about delete */

--- a/src/include/access/nbtree.h
+++ b/src/include/access/nbtree.h
@@ -221,6 +221,7 @@ typedef struct xl_btreetid
 {
 	RelFileNode node;
 	ItemPointerData persistentTid;
+	bool tidAllowedToBeZero;
 	int64 persistentSerialNum;
 	ItemPointerData tid;		/* changed tuple id */
 } xl_btreetid;
@@ -236,6 +237,7 @@ inline static void xl_btreetid_set(
 {
 	btreeid->node = rel->rd_node;
 	btreeid->persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
+	btreeid->tidAllowedToBeZero = rel->rd_segfile0_relationnodeinfo.tidAllowedToBeZero;
 	btreeid->persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
 	ItemPointerSet(&(btreeid->tid), itup_blkno, itup_off);
 }
@@ -244,6 +246,7 @@ typedef struct xl_btreenode
 {
 	RelFileNode node;
 	ItemPointerData persistentTid;
+	bool tidAllowedToBeZero;
 	int64 persistentSerialNum;
 } xl_btreenode;
 
@@ -254,6 +257,7 @@ inline static void xl_btreenode_set(
 {
 	btreenode->node = rel->rd_node;
 	btreenode->persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
+	btreenode->tidAllowedToBeZero = rel->rd_segfile0_relationnodeinfo.tidAllowedToBeZero;
 	btreenode->persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
 }
 
@@ -311,6 +315,7 @@ typedef struct xl_btree_split
 	OffsetNumber firstright;	/* first item moved to right page */
 
 	ItemPointerData persistentTid;
+	bool tidAllowedToBeZero;
 	int64		persistentSerialNum;
 
 	/*

--- a/src/include/access/persistentendxactrec.h
+++ b/src/include/access/persistentendxactrec.h
@@ -71,6 +71,8 @@ typedef struct PersistentEndXactFileSysActionInfo
 
 	ItemPointerData			persistentTid;
 
+	bool tidAllowedToBeZero;
+
 	int64					persistentSerialNum;
 
 } PersistentEndXactFileSysActionInfo;
@@ -197,4 +199,3 @@ extern void PersistentEndXactRec_Deserialize(
 	uint8						**nextData);
 
 #endif   /* PERSISTENTENDXACTREC_H */
-

--- a/src/include/cdb/cdbappendonlystoragewrite.h
+++ b/src/include/cdb/cdbappendonlystoragewrite.h
@@ -93,6 +93,7 @@ typedef struct AppendOnlyStorageWrite
 	int32		segmentFileNum;
 
 	ItemPointerData 	persistentTid;
+	bool tidAllowedToBeZero;
 	int64				persistentSerialNum;
 			/*
 			 * Persistence information for current write open.
@@ -518,4 +519,3 @@ extern char *AppendOnlyStorageWrite_ContextStr(
 	AppendOnlyStorageWrite		*storageWrite);
 
 #endif   /* CDBAPPENDONLYSTORAGEWRITE_H */
-

--- a/src/include/cdb/cdbresynchronizechangetracking.h
+++ b/src/include/cdb/cdbresynchronizechangetracking.h
@@ -165,6 +165,7 @@ typedef struct RelationChangeInfo
 	BlockNumber 	blockNumber;
 	ItemPointerData persistentTid;
 	int64	  		persistentSerialNum;
+	bool	tidAllowedToBeZero;
 } RelationChangeInfo;
 
 extern void ChangeTracking_GetRelationChangeInfoFromXlog(
@@ -408,4 +409,3 @@ extern void ChangeTracking_DoFullCompactingRoundIfNeeded(void);
 extern void ChangeTracking_CreateTransientLog(void);
 
 #endif   /* CDBRESYNCHRONIZECHANGETRACKING_H */
-

--- a/src/include/commands/sequence.h
+++ b/src/include/commands/sequence.h
@@ -81,6 +81,7 @@ typedef struct xl_seq_rec
 {
 	RelFileNode 	node;
 	ItemPointerData persistentTid;
+	bool	tidAllowedToBeZero;
 	int64 			persistentSerialNum;
 
 	/* SEQUENCE TUPLE DATA FOLLOWS AT THE END */


### PR DESCRIPTION
If you force kill make install check-good, recovery can error out with error "Not enough space on page" which is not correct. @hlinnaka identified this issue and added fixes. This is a deeper issue where we don't check if persistentTid is valid or not and if it can be zero or not.

This fix uses unused bool value for the same and uses it for checking the condition