### PR TITLE
Reset g_dataSourceCtx variable at the end of transaction

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -1815,6 +1815,14 @@ void AtAbort_ExtTables(void)
 	g_dataSource = NULL;
 }
 
+/*
+ * Reset g_dataSourceCtx variable on EOX.
+ */
+void AtEOXact_ResetDataSourceCtx(void)
+{
+	g_dataSourceCtx = NULL;
+}
+
 void
 gfile_printf_then_putc_newline(const char*format,...)
 {

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -1813,12 +1813,6 @@ void AtAbort_ExtTables(void)
 {
 	close_external_source(g_dataSource, false, NULL);
 	g_dataSource = NULL;
-
-	/*
-	 * g_dataSourceCtx is allocated in TopTransactionContext, so
-	 * it's going away.
-	 */
-	g_dataSourceCtx = NULL;
 }
 
 void

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -1807,12 +1807,20 @@ void readHeaderLine(CopyState pstate)
 }
 
 /*
- * Free external resources on Abort.
- */
-void AtAbort_ExtTables(void)
+* Free external resources on end of transaction.
+*/
+void AtEOXact_ExtTables(bool isCommit)
 {
-	close_external_source(g_dataSource, false, NULL);
-	g_dataSource = NULL;
+	if (g_dataSource)
+	{
+		if (isCommit)
+		{
+			/* There shouldn't be any external tables still open at commit*/
+			elog(WARNING, "external table reference leak");
+		}
+		close_external_source(g_dataSource, false, NULL);
+		g_dataSource = NULL;
+	}
 }
 
 /*
@@ -1820,6 +1828,7 @@ void AtAbort_ExtTables(void)
  */
 void AtEOXact_ResetDataSourceCtx(void)
 {
+	/* g_dataSourceCtx is allocated in TopTransactionContext, so it's going away.*/
 	g_dataSourceCtx = NULL;
 }
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3354,7 +3354,12 @@ CommitTransaction(void)
 	 */
 	AtEOXact_UpdateFlatFiles(true);
 
-	/* reset g_dataSourceCtx
+	/*
+	 * Free external resources
+	 */
+	AtEOXact_ExtTables(true);
+
+	/* Reset g_dataSourceCtx
 	 * g_dataSourceCtx is allocated in TopTransactionContext, so it's going away.
 	 */
 	AtEOXact_ResetDataSourceCtx();
@@ -4005,7 +4010,7 @@ AbortTransaction(void)
 	 */
 	AfterTriggerEndXact(false);
 	AtAbort_Portals();
-	AtAbort_ExtTables();
+	AtEOXact_ExtTables(false);
 
 	/* reset g_dataSourceCtx
 	 * g_dataSourceCtx is allocated in TopTransactionContext, so it's going away.

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3354,6 +3354,11 @@ CommitTransaction(void)
 	 */
 	AtEOXact_UpdateFlatFiles(true);
 
+	/* reset g_dataSourceCtx
+	 * g_dataSourceCtx is allocated in TopTransactionContext, so it's going away.
+	 */
+	AtEOXact_ResetDataSourceCtx();
+
 	/*
 	 * Prepare all QE.
 	 */
@@ -4001,6 +4006,11 @@ AbortTransaction(void)
 	AfterTriggerEndXact(false);
 	AtAbort_Portals();
 	AtAbort_ExtTables();
+
+	/* reset g_dataSourceCtx
+	 * g_dataSourceCtx is allocated in TopTransactionContext, so it's going away.
+	 */
+	AtEOXact_ResetDataSourceCtx();
 
 	/* Perform any Resource Scheduler abort procesing. */
 	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)

--- a/src/include/access/fileam.h
+++ b/src/include/access/fileam.h
@@ -70,6 +70,7 @@ extern Oid external_insert(ExternalInsertDesc extInsertDesc, HeapTuple instup);
 extern void external_insert_finish(ExternalInsertDesc extInsertDesc);
 extern void external_set_env_vars(extvar_t *extvar, char* uri, bool csv, char* escape, char* quote, bool header, uint32 scancounter);
 extern void AtAbort_ExtTables(void);
+extern void AtEOXact_ResetDataSourceCtx(void);
 char*	linenumber_atoi(char buffer[20],int64 linenumber);
 
 

--- a/src/include/access/fileam.h
+++ b/src/include/access/fileam.h
@@ -69,7 +69,7 @@ extern ExternalInsertDesc external_insert_init(Relation rel);
 extern Oid external_insert(ExternalInsertDesc extInsertDesc, HeapTuple instup);
 extern void external_insert_finish(ExternalInsertDesc extInsertDesc);
 extern void external_set_env_vars(extvar_t *extvar, char* uri, bool csv, char* escape, char* quote, bool header, uint32 scancounter);
-extern void AtAbort_ExtTables(void);
+extern void AtEOXact_ExtTables(bool isCommit);
 extern void AtEOXact_ResetDataSourceCtx(void);
 char*	linenumber_atoi(char buffer[20],int64 linenumber);
 


### PR DESCRIPTION
This PR reverts commit d9edb869 (i.e., reset g_dataSourceCtx in AtAbort_ExtTables) and creates a function AtEOX_dataSourceCtx, which sets g_dataSourceCtx pointer to NULL.  AtEOX_dataSourceCtx is called in both commit and abort transaction.

Note that g_dataSourceCtx is used by both ExtTables and zlib. Thus,  we should not reset g_dataSourceCtx in AtAbort_ExtTable, since ExtTable is not the only owner. 

@gcaragea @hlinnaka Please take a look. Thanks 