### PR TITLE
Support Memory accounting allocators for external libraries

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -15,6 +15,7 @@
 
 #include "gpopt/CGPOptimizer.h"
 #include "gpopt/utils/COptTasks.h"
+#include "gpopt/gpdbwrappers.h"
 
 // the following headers are needed to reference optimizer library initializers
 #include "naucrates/init.h"
@@ -86,7 +87,7 @@ void
 CGPOptimizer::InitGPOPT ()
 {
   // Use GPORCA's default allocators
-  struct gpos_init_params params = { NULL, NULL };
+  struct gpos_init_params params = { gpdb::GPMalloc, gpdb::GPFree };
   gpos_init(&params);
   gpdxl_init();
   gpopt_init();

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -84,10 +84,15 @@ CGPOptimizer::SzDXLPlan
 //
 //---------------------------------------------------------------------------
 void
-CGPOptimizer::InitGPOPT ()
+CGPOptimizer::InitGPOPT (bool use_gpdb_allocators)
 {
   // Use GPORCA's default allocators
-  struct gpos_init_params params = { gpdb::GPMalloc, gpdb::GPFree };
+  struct gpos_init_params params = { NULL, NULL };
+  if ( use_gpdb_allocators ) {
+    params.alloc = gpdb::GPMalloc;
+    params.free = gpdb::GPFree;
+  }
+
   gpos_init(&params);
   gpdxl_init();
   gpopt_init();
@@ -158,9 +163,9 @@ char *SzDXLPlan
 //---------------------------------------------------------------------------
 extern "C"
 {
-void InitGPOPT ()
+void InitGPOPT (bool use_gpdb_allocators)
 {
-	return CGPOptimizer::InitGPOPT();
+	return CGPOptimizer::InitGPOPT(use_gpdb_allocators);
 }
 }
 

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2224,6 +2224,20 @@ gpdb::GPDBFree
 	GP_WRAP_END;
 }
 
+void *
+gpdb::GPMalloc
+	(
+	Size size
+	)
+{
+	GP_WRAP_START;
+	{
+		return gp_malloc(size);
+	}
+	GP_WRAP_END;
+	return NULL;
+}
+
 struct varlena *
 gpdb::PvlenDetoastDatum
 	(
@@ -2236,6 +2250,20 @@ gpdb::PvlenDetoastDatum
 	}
 	GP_WRAP_END;
 	return NULL;
+}
+
+void
+gpdb::GPFree
+	(
+	void *ptr
+	)
+{
+	GP_WRAP_START;
+	{
+		gp_free(ptr);
+		return;
+	}
+	GP_WRAP_END;
 }
 
 bool

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2232,7 +2232,7 @@ gpdb::GPMalloc
 {
 	GP_WRAP_START;
 	{
-		return gp_malloc(size);
+		return gp_accounted_malloc(size);
 	}
 	GP_WRAP_END;
 	return NULL;
@@ -2260,7 +2260,7 @@ gpdb::GPFree
 {
 	GP_WRAP_START;
 	{
-		gp_free(ptr);
+		gp_accounted_free(ptr);
 		return;
 	}
 	GP_WRAP_END;

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -71,7 +71,7 @@ static bool ThereIsAtLeastOneRole(void);
 static void process_startup_options(Port *port, bool am_superuser);
 
 #ifdef USE_ORCA
-extern void InitGPOPT();
+extern void InitGPOPT(bool use_gpdb_allocators);
 extern void TerminateGPOPT();
 #endif
 
@@ -594,7 +594,7 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 
 #ifdef USE_ORCA
 	/* Initialize GPOPT */
-	InitGPOPT();
+	InitGPOPT(optimizer_use_gpdb_allocators);
 #endif
 
 	/*

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -571,6 +571,7 @@ bool		optimizer_multilevel_partitioning;
 bool		optimizer_enable_derive_stats_all_groups;
 bool		optimizer_explain_show_status;
 bool		optimizer_prefer_scalar_dqa_multistage_agg;
+bool		optimizer_use_gpdb_allocators;
 
 /**
  * GUCs related to code generation.
@@ -3398,6 +3399,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_prefer_scalar_dqa_multistage_agg,
 		true, NULL, NULL
+	},
+
+	{
+		{"optimizer_use_gpdb_allocators", PGC_POSTMASTER, DEVELOPER_OPTIONS,
+			gettext_noop("Use GPDB based memory allocators instead of GPOS defaults."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_use_gpdb_allocators,
+		false, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -526,7 +526,6 @@ void *gp_accounted_realloc(void *ptr, int64 newSize)
 	Assert(!MySessionState || gp_mp_inited);
 	Assert(NULL != ptr);
 
-
 	AccountedAllocHeader* header = UserPtrToAccountedAllocPtr(ptr);
 	int64 oldAllocSize = UserPtr_GetVmemPtrSize(header);
 

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -501,7 +501,7 @@ void gp_free(void *user_pointer)
 	VmemTracker_ReleaseVmem(UserPtrSize_GetVmemPtrSize(usable_size));
 }
 
-void *gp_accounted_alloc(int64 size)
+void *gp_accounted_malloc(int64 size)
 {
 	Assert(gp_mp_inited);
 

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -554,7 +554,9 @@ void gp_accounted_free(void* ptr)
 	Assert(NULL != ptr);
 
 	AccountedAllocHeader* header = UserPtrToAccountedAllocPtr(ptr);
-	uint16 totalSize = UserPtr_GetVmemPtrSize(header);
+	size_t totalSize = UserPtr_GetVmemPtrSize(header);
+
+	Assert(UserPtr_GetUserPtrSize(header) - sizeof(AccountedAllocHeader) > 0);
 
 	MemoryAccounting_Free(AccountedAllocPtr_GetMemoryAccount(header),
 			AccountedAllocPtr_GetMemoryAccountGeneration(header), totalSize);

--- a/src/backend/utils/mmgr/test/Makefile
+++ b/src/backend/utils/mmgr/test/Makefile
@@ -24,6 +24,8 @@ vmem_tracker.t: \
 
 memprot.t: \
 	$(MOCK_DIR)/backend/utils/mmgr/vmem_tracker_mock.o \
+	$(MOCK_DIR)/backend/utils/mmgr/memaccounting_mock.o \
+	$(MOCK_DIR)/backend/utils/mmgr/aset_mock.o \
 	$(MOCK_DIR)/backend/utils/error/assert_mock.o \
 	$(MOCK_DIR)/backend/utils/error/elog_mock.o \
 	$(MOCK_DIR)/backend/utils/mmgr/event_version_mock.o 

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -1562,6 +1562,10 @@ test__MemoryAccounting_SaveToFile__GeneratesCorrectString(void **state)
     pfree(newAccount);
 }
 
+/*
+ * Tests basic functionality of accounting allocators to record and
+ * retrieve allocation information from the active memory account.
+ */
 void
 test__MemoryAccounting__AccountedAllocators(void **state)
 {
@@ -1569,15 +1573,19 @@ test__MemoryAccounting__AccountedAllocators(void **state)
 	size_t allocated = 0;
 	void *ptr1, *ptr2;
 
+	/* Switch to a new memory account */
 	START_MEMORY_ACCOUNT(MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Optimizer));
 
+	/* Reset the account for calculations */
 	MemoryAccounting_Reset();
 	assert_true(MemoryAccounting_GetBalance(ActiveMemoryAccount) == 0);
 
+	/* Check if we account for allocation in the account balance */
 	ptr1 = gp_accounted_malloc(allocation_size);
 	allocated += UserPtr_GetVmemPtrSize(UserPtrToAccountedAllocPtr(ptr1));
 	assert_true(MemoryAccounting_GetBalance(ActiveMemoryAccount) == allocated);
 
+	/* Allocate some more */
 	ptr2 = gp_accounted_malloc(2 * allocation_size);
 	allocated += UserPtr_GetVmemPtrSize(UserPtrToAccountedAllocPtr(ptr2));
 	assert_true(MemoryAccounting_GetBalance(ActiveMemoryAccount) == allocated);
@@ -1585,7 +1593,9 @@ test__MemoryAccounting__AccountedAllocators(void **state)
 	gp_accounted_free(ptr1);
 	gp_accounted_free(ptr2);
 
+	/* Check if we accounted for all allocated memory freed in account balance */
 	assert_true(MemoryAccounting_GetBalance(ActiveMemoryAccount) == 0);
+	/* Check if we accounted peak allocation in the account peak */
 	assert_true(MemoryAccounting_GetPeak(ActiveMemoryAccount) == allocated);
 
 	END_MEMORY_ACCOUNT();

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -1560,6 +1560,13 @@ test__MemoryAccounting_SaveToFile__GeneratesCorrectString(void **state)
     pfree(newAccount);
 }
 
+void
+test__MemoryAccounting__AccountedAllocators(void **state)
+{
+
+	assert_true(true);
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -1598,6 +1605,7 @@ main(int argc, char* argv[])
 		unit_test_setup_teardown(test__MemoryAccounting_ToString__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_SaveToLog__GeneratesCorrectString, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_SaveToFile__GeneratesCorrectString, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__MemoryAccounting__AccountedAllocators, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 	};
 
 	return run_tests(tests);

--- a/src/backend/utils/mmgr/test/memprot_test.c
+++ b/src/backend/utils/mmgr/test/memprot_test.c
@@ -619,7 +619,8 @@ main(int argc, char* argv[])
 		unit_test_setup_teardown(test__gp_malloc_calls_vmem_tracker_when_mp_init_true, MemProtTestSetup, MemProtTestTeardown),
 		unit_test_setup_teardown(test__gp_malloc_and_free__basic_tests, MemProtTestSetup, MemProtTestTeardown),
 		unit_test_setup_teardown(test__gp_realloc__basic_tests, MemProtTestSetup, MemProtTestTeardown),
-		unit_test_setup_teardown(test__gp_accounted_malloc__basic_tests, MemProtTestSetup, MemProtTestTeardown),
+
+		unit_test_setup_teardown(test__gp_accounted_malloc_and_free__basic_tests, MemProtTestSetup, MemProtTestTeardown),
 		unit_test_setup_teardown(test__gp_accounted_realloc__basic_tests, MemProtTestSetup, MemProtTestTeardown),
 	};
 

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -44,7 +44,7 @@ class CGPOptimizer
 
     // gpopt initialize and terminate
     static
-    void InitGPOPT();
+    void InitGPOPT(bool use_gpdb_allocators);
 
     static
     void TerminateGPOPT();

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -408,6 +408,8 @@ namespace gpdb {
 	void *PvMemoryContextReallocImpl(void *pointer, Size size, const char* file, const char * func, int line);
 	void *GPDBAlloc(Size size);
 	void GPDBFree(void *ptr);
+	void *GPMalloc(Size size);
+	void GPFree(void *ptr);
 
 	// create a duplicate of the given string in the given memory context
 	char *SzMemoryContextStrdup(MemoryContext context, const char *string);

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -64,6 +64,7 @@ extern "C" {
 #include "parser/parse_coerce.h"
 #include "utils/selfuncs.h"
 #include "utils/faultinjector.h"
+#include "utils/gp_alloc.h"
 
 extern
 Query *preprocess_query_optimizer(Query *pquery, ParamListInfo boundParams);

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -64,7 +64,7 @@ extern "C" {
 #include "parser/parse_coerce.h"
 #include "utils/selfuncs.h"
 #include "utils/faultinjector.h"
-#include "utils/gp_alloc.h"
+#include "utils/gp_accounted_alloc.h"
 
 extern
 Query *preprocess_query_optimizer(Query *pquery, ParamListInfo boundParams);

--- a/src/include/utils/gp_accounted_alloc.h
+++ b/src/include/utils/gp_accounted_alloc.h
@@ -12,11 +12,13 @@
 #include "memaccounting.h"
 
 extern bool
-MemoryAccounting_Allocate(struct MemoryAccount* memoryAccount, Size allocatedSize);
+MemoryAccounting_Allocate(struct MemoryAccount* memoryAccount,
+		Size allocatedSize);
+
 extern bool
-MemoryAccounting_Free(MemoryAccount* memoryAccount, uint16 memoryAccountGeneration, Size allocatedSize);
-
-
+MemoryAccounting_Free(MemoryAccount* memoryAccount,
+		uint16 memoryAccountGeneration,
+		Size allocatedSize);
 
 #ifdef USE_ASSERT_CHECKING
 #define GP_ALLOC_DEBUG
@@ -37,12 +39,26 @@ typedef int64 AccountedAllocHeaderChecksumType;
 
 #endif
 
+/*
+ * The AccountedAllocHeader sits between the usable memory and any Vmem headers.
+ * This provides a "light-weight" allocation API that can track memory
+ * allocations and frees using GPDB's memory accounting mechanism without the
+ * overhead of explicitly managing block and check allocations. In this way, we
+ * can account for memory usage of external libraries to maintain a more accurate
+ * account of memory consumed by GPDB.
+ */
 typedef struct AccountedAllocHeader
 {
 #ifdef GP_ALLOC_DEBUG
+	/*
+	 * Checksum to verify we are correctly using gp_accounted_malloc with
+	 * gp_accounted_free
+	 */
 	AccountedAllocHeaderChecksumType checksum;
 #endif
+	/* Memory account where to this allocation is recorded */
 	struct MemoryAccount *memoryAccount;
+	/* Track account validity */
 	uint16 memoryAccountGeneration;
 } AccountedAllocHeader;
 
@@ -50,12 +66,14 @@ extern void *gp_accounted_malloc(int64 sz);
 extern void *gp_accounted_realloc(void *ptr, int64 newsz);
 extern void gp_accounted_free(void *ptr);
 
+/* Get the actual usable payload address from the header */
 static inline
 void *AccountedAllocPtrToUserPtr(AccountedAllocHeader *ptr)
 {
 	return (void *)(((char*)ptr) + sizeof(AccountedAllocHeader));
 }
 
+/* Get address of the header from a user pointer */
 static inline
 AccountedAllocHeader *UserPtrToAccountedAllocPtr(void *ptr)
 {
@@ -63,12 +81,14 @@ AccountedAllocHeader *UserPtrToAccountedAllocPtr(void *ptr)
 }
 
 #ifdef GP_ALLOC_DEBUG
-static inline
-AccountedAllocHeaderChecksumType AccountedAllocPtr_GetChecksum(AccountedAllocHeader *ptr)
+/* Retrieve the checksum from the header */
+static inline AccountedAllocHeaderChecksumType
+AccountedAllocPtr_GetChecksum(AccountedAllocHeader *ptr)
 {
 	return ptr->checksum;
 }
 
+/* Stores a checksum in the header for debugging purpose */
 static inline
 void AccountedAllocPtr_SetChecksum(AccountedAllocHeader *ptr)
 {
@@ -76,13 +96,16 @@ void AccountedAllocPtr_SetChecksum(AccountedAllocHeader *ptr)
 }
 #endif   /* GP_ALLOC_DEBUG */
 
+/* Extract the memory account stored in the AccountedHeader */
 static inline
-struct MemoryAccount* AccountedAllocPtr_GetMemoryAccount(AccountedAllocHeader *ptr)
+struct MemoryAccount*
+AccountedAllocPtr_GetMemoryAccount(AccountedAllocHeader *ptr)
 {
 	AccountedAllocPtr_VerifyChecksum(ptr);
 	return ptr->memoryAccount;
 }
 
+/* Extract the memory account generation stored in the AccountedHeader */
 static inline
 uint16 AccountedAllocPtr_GetMemoryAccountGeneration(AccountedAllocHeader *ptr)
 {
@@ -90,23 +113,32 @@ uint16 AccountedAllocPtr_GetMemoryAccountGeneration(AccountedAllocHeader *ptr)
 	return ptr->memoryAccountGeneration;
 }
 
+/* Set the memory account stored in the AccountedHeader */
 static inline
-struct MemoryAccount* AccountedAllocPtr_SetMemoryAccount(AccountedAllocHeader *ptr, struct MemoryAccount* memoryAccount)
+struct MemoryAccount* AccountedAllocPtr_SetMemoryAccount(
+		AccountedAllocHeader *ptr, struct MemoryAccount* memoryAccount)
 {
 	return ptr->memoryAccount = memoryAccount;
 }
 
+/* Set the memory account generation stored in the AccountedHeader */
 static inline
-uint16 AccountedAllocPtr_SetMemoryAccountGeneration(AccountedAllocHeader *ptr, uint16 memoryAccountGeneration)
+uint16 AccountedAllocPtr_SetMemoryAccountGeneration(
+		AccountedAllocHeader *ptr, uint16 memoryAccountGeneration)
 {
 	return ptr->memoryAccountGeneration = memoryAccountGeneration;
 }
 
+/*
+ * Initialize the AccountedAlloc header with current memory account and account
+ * generation
+ */
 static inline
 void AccountedAllocPtr_Initialize(AccountedAllocHeader *ptr)
 {
 	AccountedAllocPtr_SetMemoryAccount(ptr, ActiveMemoryAccount);
-	AccountedAllocPtr_SetMemoryAccountGeneration(ptr, MemoryAccountingCurrentGeneration);
+	AccountedAllocPtr_SetMemoryAccountGeneration(ptr,
+			MemoryAccountingCurrentGeneration);
 #ifdef GP_ALLOC_DEBUG
 	AccountedAllocPtr_SetChecksum(ptr);
 #endif

--- a/src/include/utils/gp_accounted_alloc.h
+++ b/src/include/utils/gp_accounted_alloc.h
@@ -1,0 +1,67 @@
+/*-------------------------------------------------------------------------
+ *
+ * gp_alloc.h
+ *	  This file contains declarations for an allocator that works with vmem quota.
+ *
+ * Copyright (c) 2016, Pivotal Inc.
+ */
+#ifndef GP_ACCOUNTED_ALLOC_H
+#define GP_ACCOUNTED_ALLOC_H
+
+#include "nodes/nodes.h"
+#include "memaccounting.h"
+
+typedef struct AccountedAllocHeader
+{
+	struct MemoryAccount *memoryAccount;
+	uint16 memoryAccountGeneration;
+} AccountedAllocHeader;
+
+extern void *gp_accounted_malloc(int64 sz);
+extern void *gp_accounted_realloc(void *ptr, int64 newsz);
+extern void gp_accounted_free(void *ptr);
+
+static inline
+void *AccountedAllocPtrToUserPtr(AccountedAllocHeader *ptr)
+{
+	return (void *)(((char*)ptr) + sizeof(AccountedAllocHeader));
+}
+
+static inline
+AccountedAllocHeader *UserPtrToAccountedAllocPtr(void *ptr)
+{
+	return (AccountedAllocHeader *)(((char*)ptr) - sizeof(AccountedAllocHeader));
+}
+
+static inline
+struct MemoryAccount* AccountedAllocPtr_GetMemoryAccount(AccountedAllocHeader *ptr)
+{
+	return ptr->memoryAccount;
+}
+
+static inline
+uint16 AccountedAllocPtr_GetMemoryAccountGeneration(AccountedAllocHeader *ptr)
+{
+	return ptr->memoryAccountGeneration;
+}
+
+static inline
+struct MemoryAccount* AccountedAllocPtr_SetMemoryAccount(AccountedAllocHeader *ptr, struct MemoryAccount* memoryAccount)
+{
+	return ptr->memoryAccount = memoryAccount;
+}
+
+static inline
+uint16 AccountedAllocPtr_SetMemoryAccountGeneration(AccountedAllocHeader *ptr, uint16 memoryAccountGeneration)
+{
+	return ptr->memoryAccountGeneration = memoryAccountGeneration;
+}
+
+static inline
+void AccountedAllocPtr_Initialize(AccountedAllocHeader *ptr)
+{
+	AccountedAllocPtr_SetMemoryAccount(ptr, ActiveMemoryAccount);
+	AccountedAllocPtr_SetMemoryAccountGeneration(ptr, MemoryAccountingCurrentGeneration);
+}
+
+#endif   /* GP_ACCOUNTED_ALLOC_H */

--- a/src/include/utils/gp_accounted_alloc.h
+++ b/src/include/utils/gp_accounted_alloc.h
@@ -11,8 +11,37 @@
 #include "nodes/nodes.h"
 #include "memaccounting.h"
 
+extern bool
+MemoryAccounting_Allocate(struct MemoryAccount* memoryAccount, Size allocatedSize);
+extern bool
+MemoryAccounting_Free(MemoryAccount* memoryAccount, uint16 memoryAccountGeneration, Size allocatedSize);
+
+
+
+#ifdef USE_ASSERT_CHECKING
+#define GP_ALLOC_DEBUG
+#endif
+
+#ifdef GP_ALLOC_DEBUG
+
+#define ACCOUNTED_ALLOC_HEADER_CHECKSUM 0xacacacacac
+
+typedef int64 AccountedAllocHeaderChecksumType;
+
+#define AccountedAllocPtr_VerifyChecksum(ptr) \
+	Assert(AccountedAllocPtr_GetChecksum(ptr) == ACCOUNTED_ALLOC_HEADER_CHECKSUM)
+
+#else
+
+#define AccountedAllocPtr_VerifyChecksum(ptr)
+
+#endif
+
 typedef struct AccountedAllocHeader
 {
+#ifdef GP_ALLOC_DEBUG
+	AccountedAllocHeaderChecksumType checksum;
+#endif
 	struct MemoryAccount *memoryAccount;
 	uint16 memoryAccountGeneration;
 } AccountedAllocHeader;
@@ -33,15 +62,31 @@ AccountedAllocHeader *UserPtrToAccountedAllocPtr(void *ptr)
 	return (AccountedAllocHeader *)(((char*)ptr) - sizeof(AccountedAllocHeader));
 }
 
+#ifdef GP_ALLOC_DEBUG
+static inline
+AccountedAllocHeaderChecksumType AccountedAllocPtr_GetChecksum(AccountedAllocHeader *ptr)
+{
+	return ptr->checksum;
+}
+
+static inline
+void AccountedAllocPtr_SetChecksum(AccountedAllocHeader *ptr)
+{
+	ptr->checksum = ACCOUNTED_ALLOC_HEADER_CHECKSUM;
+}
+#endif   /* GP_ALLOC_DEBUG */
+
 static inline
 struct MemoryAccount* AccountedAllocPtr_GetMemoryAccount(AccountedAllocHeader *ptr)
 {
+	AccountedAllocPtr_VerifyChecksum(ptr);
 	return ptr->memoryAccount;
 }
 
 static inline
 uint16 AccountedAllocPtr_GetMemoryAccountGeneration(AccountedAllocHeader *ptr)
 {
+	AccountedAllocPtr_VerifyChecksum(ptr);
 	return ptr->memoryAccountGeneration;
 }
 
@@ -62,6 +107,9 @@ void AccountedAllocPtr_Initialize(AccountedAllocHeader *ptr)
 {
 	AccountedAllocPtr_SetMemoryAccount(ptr, ActiveMemoryAccount);
 	AccountedAllocPtr_SetMemoryAccountGeneration(ptr, MemoryAccountingCurrentGeneration);
+#ifdef GP_ALLOC_DEBUG
+	AccountedAllocPtr_SetChecksum(ptr);
+#endif
 }
 
 #endif   /* GP_ACCOUNTED_ALLOC_H */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -451,6 +451,7 @@ extern bool optimizer_multilevel_partitioning;
 extern bool optimizer_enable_derive_stats_all_groups;
 extern bool optimizer_explain_show_status;
 extern bool optimizer_prefer_scalar_dqa_multistage_agg;
+extern bool optimizer_use_gpdb_allocators;
 
 /**
  * GUCs related to code generation.

--- a/src/test/unit/mock/gpopt_mock.c
+++ b/src/test/unit/mock/gpopt_mock.c
@@ -47,7 +47,7 @@ OptVersion(void)
 }
 
 void
-InitGPOPT ()
+InitGPOPT (bool use_gpdb_allocators)
 {
 	elog(ERROR, "mock implementation of InitGPOPT called");
 }


### PR DESCRIPTION
For background on related Vmem changes in GPDB, refer to the related PR (https://github.com/greenplum-db/gpdb/pull/825).

This PR aims to export a new allocation API that can be used by external libraries such as ORCA. Since we cannot make any assumptions on the memory allocation models and methodology of the external libraries, we need a very light-weight API to account for the memory consumed.
The new allocation API defines 3 functions - gp_accounted_malloc, gp_accounted_realloc, gp_accounted_free. These will server as a light wrapper on top of GPDB’s Vmem allocators (gp_malloc, gp_realloc, gp_free).

These functions depend on another header (AccountedAllocHeader) that stores the memory account and generation under which this memory was allocated. This header is needed to know the correct account to subtract from when memory is realloc’ed or free’d. It uses the size information stored in the Vmem header to update appropriate memory accounts. This inter-dependency of the two subsystems is similar to the AsetAllocInfo API already present in GPDB to update account information (which is called by palloc and pfree). This new accounted allocators API is necessary to prevent the overheads involved in the chunk and block allocation process generally used in GPDB via palloc/pfree.

ICG passes with GUC optimizer_use_gpdb_allocators enabled.