### PR TITLE
Reconnect PostgreSQL 8.3 specific code in xlogdump

### DIFF
--- a/contrib/xlogdump/xlogdump_oid2name.c
+++ b/contrib/xlogdump/xlogdump_oid2name.c
@@ -259,7 +259,7 @@ oid2name_get_name(uint32 oid, char *buf, size_t buflen, const char *query)
 }
 
 /*
- * Atempt to read the name of tablespace into lastSpcName
+ * Attempt to read the name of tablespace into lastSpcName
  * (if there's a database connection and the oid changed since lastSpcOid)
  */
 char *
@@ -276,7 +276,7 @@ getSpaceName(uint32 spcid, char *buf, size_t buflen)
 
 
 /*
- * Atempt to get the name of database (if there's a database connection)
+ * Attempt to get the name of database (if there's a database connection)
  */
 char *
 getDbName(uint32 dbid, char *buf, size_t buflen)
@@ -299,7 +299,7 @@ getDbName(uint32 dbid, char *buf, size_t buflen)
 }
 
 /*
- * Atempt to get the name of relation and copy to relName 
+ * Attempt to get the name of relation and copy to relName
  * (if there's a database connection and the reloid changed)
  * Copy a string with oid if not found
  */
@@ -321,7 +321,7 @@ getRelName(uint32 relid, char *buf, size_t buflen)
 	/*
 	 * If the xlog record has some information about rmgr operation on
 	 * a different database, it needs to establish a new connection
-	 * to the different database in order to retreive a object name
+	 * to the different database in order to retrieve a object name
 	 * from the system catalog.
 	 */
 	if (conn && strcmp(PQdb(conn), dbName) != 0)

--- a/contrib/xlogdump/xlogdump_rmgr.c
+++ b/contrib/xlogdump/xlogdump_rmgr.c
@@ -294,8 +294,7 @@ print_rmgr_xact(XLogRecPtr cur, XLogRecord *record, uint8 info, bool hideTimesta
 		snprintf(buf, sizeof(buf), "d/s:%d/%d commit at %s",
 			 xlrec.dbId, xlrec.tsId,
 			 str_time(_timestamptz_to_time_t(xlrec.xact_time)));
-/* 83MERGE_FIXME_HL: re-enable this after merging the relevant change */ */
-#elif PG_VERSION_NUM >= 80300 && 0
+#elif PG_VERSION_NUM >= 80300
 		snprintf(buf, sizeof(buf), "commit at %s",
 			 str_time(_timestamptz_to_time_t(xlrec.xact_time)));
 #else
@@ -315,8 +314,7 @@ print_rmgr_xact(XLogRecPtr cur, XLogRecord *record, uint8 info, bool hideTimesta
 		xl_xact_abort	xlrec;
 		memcpy(&xlrec, XLogRecGetData(record), sizeof(xlrec));
 		snprintf(buf, sizeof(buf), "abort at %s",
-/* 83MERGE_FIXME_HL: re-enable this after merging the relevant change */
-#if PG_VERSION_NUM >= 80300 && 0
+#if PG_VERSION_NUM >= 80300
 			 str_time(_timestamptz_to_time_t(xlrec.xact_time)));
 #else
 			 str_time(_timestamptz_to_time_t(xlrec.xtime)));
@@ -335,8 +333,7 @@ print_rmgr_xact(XLogRecPtr cur, XLogRecord *record, uint8 info, bool hideTimesta
 			 xlrec.xid,
 			 xlrec.crec.dbId, xlrec.crec.tsId,
 			 str_time(_timestamptz_to_time_t(xlrec.crec.xact_time)));
-/* 83MERGE_FIXME_HL: re-enable this after merging the relevant change */
-#elif PG_VERSION_NUM >= 80300 && 0
+#elif PG_VERSION_NUM >= 80300
 		snprintf(buf, sizeof(buf), "commit prepared xid:%d, commit at %s",
 			 xlrec.xid,
 			 str_time(_timestamptz_to_time_t(xlrec.crec.xact_time)));
@@ -358,8 +355,7 @@ print_rmgr_xact(XLogRecPtr cur, XLogRecord *record, uint8 info, bool hideTimesta
 			 xlrec.xid,
 			 xlrec.crec.dbId, xlrec.crec.tsId,
 			 str_time(_timestamptz_to_time_t(xlrec.crec.xact_time)));
-/* 83MERGE_FIXME_HL: re-enable this after merging the relevant change */
-#elif PG_VERSION_NUM >= 80300 && 0
+#elif PG_VERSION_NUM >= 80300
 		snprintf(buf, sizeof(buf), "abort prepared xid:%d, commit at %s",
 			 xlrec.xid,
 			 str_time(_timestamptz_to_time_t(xlrec.crec.xact_time)));
@@ -607,14 +603,11 @@ print_rmgr_standby(XLogRecPtr cur, XLogRecord *record, uint8 info)
 void
 print_rmgr_heap2(XLogRecPtr cur, XLogRecord *record, uint8 info)
 {
-	/*
-	 * 83MERGE_FIXME: re-enable the declaration of these variables when the
-	 * relevant changes are merged (see below).
-	 *
-	 * char spaceName[NAMEDATALEN];
-	 * char dbName[NAMEDATALEN];
-	 * char relName[NAMEDATALEN];
-	 */
+#if PG_VERSION_NUM >= 90000
+	char spaceName[NAMEDATALEN];
+	char dbName[NAMEDATALEN];
+	char relName[NAMEDATALEN];
+#endif
 	char buf[1024];
 
 	switch (info)
@@ -632,8 +625,7 @@ print_rmgr_heap2(XLogRecPtr cur, XLogRecord *record, uint8 info)
 		}
 		break;
 
-/* 83MERGE_FIXME_HL: re-enable this after merging the relevant change */
-#if PG_VERSION_NUM >= 80300 && 0
+#if PG_VERSION_NUM >= 80300
 		case XLOG_HEAP2_CLEAN:
 #if PG_VERSION_NUM < 90000
 		case XLOG_HEAP2_CLEAN_MOVE:
@@ -643,10 +635,12 @@ print_rmgr_heap2(XLogRecPtr cur, XLogRecord *record, uint8 info)
 			int total_off;
 			int nunused = 0;
 
+#if PG_VERSION_NUM >= 90000
 			memcpy(&xlrec, XLogRecGetData(record), sizeof(xlrec));
 			getSpaceName(xlrec.node.spcNode, spaceName, sizeof(spaceName));
 			getDbName(xlrec.node.dbNode, dbName, sizeof(dbName));
 			getRelName(xlrec.node.relNode, relName, sizeof(relName));
+#endif
 
 			total_off = (record->xl_len - SizeOfHeapClean) / sizeof(OffsetNumber);
 
@@ -656,11 +650,11 @@ print_rmgr_heap2(XLogRecPtr cur, XLogRecord *record, uint8 info)
 #if PG_VERSION_NUM >= 90000
 			snprintf(buf, sizeof(buf), "clean%s: s/d/r:%s/%s/%s block:%u redirected/dead/unused:%d/%d/%d removed xid:%d",
 			       "",
+			       spaceName, dbName, relName,
 #else
-			snprintf(buf, sizeof(buf), "clean%s: s/d/r:%s/%s/%s block:%u redirected/dead/unused:%d/%d/%d",
+			snprintf(buf, sizeof(buf), "clean%s: block:%u redirected/dead/unused:%d/%d/%d",
 			       info == XLOG_HEAP2_CLEAN_MOVE ? "_move" : "",
 #endif
-			       spaceName, dbName, relName,
 			       xlrec.block,
 			       xlrec.nredirected, xlrec.ndead, nunused
 #if PG_VERSION_NUM >= 90000
@@ -788,8 +782,7 @@ print_rmgr_heap(XLogRecPtr cur, XLogRecord *record, uint8 info, bool statements)
 			break;
 		}
 		case XLOG_HEAP_UPDATE:
-/* 83MERGE_FIXME_HL: re-enable this after merging the relevant change */
-#if PG_VERSION_NUM >= 80300 && 0
+#if PG_VERSION_NUM >= 80300
 		case XLOG_HEAP_HOT_UPDATE:
 #endif
 		{
@@ -804,8 +797,7 @@ print_rmgr_heap(XLogRecPtr cur, XLogRecord *record, uint8 info, bool statements)
 				printUpdate((xl_heap_update *) XLogRecGetData(record), record->xl_len - SizeOfHeapUpdate - SizeOfHeapHeader, relName);
 
 			snprintf(buf, sizeof(buf), "%supdate%s: s/d/r:%s/%s/%s block %u off %u to block %u off %u",
-/* 83MERGE_FIXME_HL: re-enable this after merging the relevant change */
-#if PG_VERSION_NUM >= 80300 && 0
+#if PG_VERSION_NUM >= 80300
 				   (info & XLOG_HEAP_HOT_UPDATE) ? "hot_" : "",
 #else
 				   "",


### PR DESCRIPTION
Now that PostgreSQL 8.3 has been merged we can enable the 8.3 specific parts of xlogdump. There was a bug in the upstream code however that included calls using struct members not available until 9.0 (coming in commit 375369a), disconnect this in the typical if/endif way. Since xlogdump is abandonware due to the inclusion of pg_xlogdump in 9.3 theres not much use in submitting this upstream since we effectively maintain this code.

Also fixes some minor typos.