### PR TITLE
Add a safe version of to_date(), which validates the input date

### DIFF
--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -3317,7 +3317,6 @@ to_date_valid(PG_FUNCTION_ARGS)
 	Datum		validate;
 	Datum		result_out;
 	Datum		validate_in;
-	//FunctionCallInfoData fcinfo2;
 
 	/* call the original to_date() function and receive the result */
 	result = DirectFunctionCall2(to_date, PointerGetDatum(date_txt), PointerGetDatum(fmt));
@@ -3327,26 +3326,13 @@ to_date_valid(PG_FUNCTION_ARGS)
 	validate_in = DirectFunctionCall3(timestamp_in, result_out, ObjectIdGetDatum(InvalidOid), Int32GetDatum(-1));
 
 	/* compare the two dates */
-	/* DirectFunctionCallX will throw an error if the result is NULL */
-	//InitFunctionCallInfoData(fcinfo2, NULL, 2, NULL, NULL);
 
-
-
-	// same check as in timestamp_to_char(), except that DirectFunctionCall2() will raise an error if NULL
+	/* same check as in timestamp_to_char(), except that DirectFunctionCall2() will raise an error if NULL */
 	if ((VARSIZE(fmt) - VARHDRSZ) <= 0 || TIMESTAMP_NOT_FINITE(DatumGetTimestamp(validate_in)))
 		PG_RETURN_NULL();
 
-
-
-
-	//fcinfo2.arg[0] = validate_in;
-	//fcinfo2.arg[1] = PG_GETARG_DATUM(1);
-	//fcinfo2.argnull[0] = false;
-	//fcinfo2.argnull[1] = false;
-
-	//validate = timestamp_to_char(&fcinfo2);
 	validate = DirectFunctionCall2(timestamp_to_char, validate_in, PointerGetDatum(fmt));
-	// DirectFunctionCall2() will raise an error if the result is NULL, no need to handle it here
+	/* DirectFunctionCall2() will raise an error if the result is NULL, no need to handle it here */
 	if (DatumGetBool(DirectFunctionCall2(textne, PointerGetDatum((text *)validate), PointerGetDatum(date_txt))))
 	{
 		ereport(ERROR,

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -2753,7 +2753,7 @@ DESCR("convert text to timestamp with time zone");
 DATA(insert OID = 1780 ( to_date			PGNSP PGUID 12 1 0 f f t f s 2	1082 "25 25" _null_ _null_ _null_  to_date - _null_ _null_ ));
 DESCR("convert text to date");
 DATA(insert OID = 3399 ( to_date_valid			PGNSP PGUID 12 1 0 f f t f s 2	1082 "25 25" _null_ _null_ _null_  to_date_valid - _null_ _null_ ));
-DESCR("convert text to date");
+DESCR("convert text to date, validate the date");
 DATA(insert OID = 1768 ( to_char			PGNSP PGUID 12 1 0 f f t f s 2	25 "1186 25" _null_ _null_ _null_  interval_to_char - _null_ _null_ ));
 DESCR("format interval to text");
 

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -2752,6 +2752,8 @@ DATA(insert OID = 1778 ( to_timestamp		PGNSP PGUID 12 1 0 f f t f s 2	1184 "25 2
 DESCR("convert text to timestamp with time zone");
 DATA(insert OID = 1780 ( to_date			PGNSP PGUID 12 1 0 f f t f s 2	1082 "25 25" _null_ _null_ _null_  to_date - _null_ _null_ ));
 DESCR("convert text to date");
+DATA(insert OID = 3399 ( to_date_valid			PGNSP PGUID 12 1 0 f f t f s 2	1082 "25 25" _null_ _null_ _null_  to_date_valid - _null_ _null_ ));
+DESCR("convert text to date");
 DATA(insert OID = 1768 ( to_char			PGNSP PGUID 12 1 0 f f t f s 2	25 "1186 25" _null_ _null_ _null_  interval_to_char - _null_ _null_ ));
 DESCR("format interval to text");
 

--- a/src/include/utils/formatting.h
+++ b/src/include/utils/formatting.h
@@ -33,6 +33,7 @@ extern Datum timestamptz_to_char(PG_FUNCTION_ARGS);
 extern Datum interval_to_char(PG_FUNCTION_ARGS);
 extern Datum to_timestamp(PG_FUNCTION_ARGS);
 extern Datum to_date(PG_FUNCTION_ARGS);
+extern Datum to_date_valid(PG_FUNCTION_ARGS);
 extern Datum numeric_to_number(PG_FUNCTION_ARGS);
 extern Datum numeric_to_char(PG_FUNCTION_ARGS);
 extern Datum int4_to_char(PG_FUNCTION_ARGS);

--- a/src/test/regress/expected/to_date.out
+++ b/src/test/regress/expected/to_date.out
@@ -57,6 +57,30 @@ select to_date('2016/02/29', 'YYYY/MM/DD');
  02-29-2016
 (1 row)
 
+select to_date('2016/02/27', NULL);
+ to_date 
+---------
+ 
+(1 row)
+
+select to_date('2016/02/31', NULL);
+ to_date 
+---------
+ 
+(1 row)
+
+select to_date(NULL, 'YYYY/MM/DD');
+ to_date 
+---------
+ 
+(1 row)
+
+select to_date(NULL, NULL);
+ to_date 
+---------
+ 
+(1 row)
+
 -- test to_date_valid()
 select to_date_valid('2016/01/15', 'YYYY/MM/DD');
  to_date_valid 
@@ -92,5 +116,29 @@ select to_date_valid('2016/02/29', 'YYYY/MM/DD');
  to_date_valid 
 ---------------
  02-29-2016
+(1 row)
+
+select to_date_valid('2016/02/27', NULL);
+ to_date_valid 
+---------------
+ 
+(1 row)
+
+select to_date_valid('2016/02/31', NULL);
+ to_date_valid 
+---------------
+ 
+(1 row)
+
+select to_date_valid(NULL, 'YYYY/MM/DD');
+ to_date_valid 
+---------------
+ 
+(1 row)
+
+select to_date_valid(NULL, NULL);
+ to_date_valid 
+---------------
+ 
 (1 row)
 

--- a/src/test/regress/expected/to_date.out
+++ b/src/test/regress/expected/to_date.out
@@ -1,0 +1,96 @@
+-- -----------------------------------------------------------------
+-- Test to_date() and to_date_valid()
+-- -----------------------------------------------------------------
+show datestyle;
+   DateStyle   
+---------------
+ Postgres, MDY
+(1 row)
+
+-- test to_date() first
+-- also make sure that it still returns invalid results 
+select to_date('2016/01/15', 'YYYY/MM/DD');
+  to_date   
+------------
+ 01-15-2016
+(1 row)
+
+select to_date('2016/01/31', 'YYYY/MM/DD');
+  to_date   
+------------
+ 01-31-2016
+(1 row)
+
+select to_date('2016/02/31', 'YYYY/MM/DD');
+  to_date   
+------------
+ 03-02-2016
+(1 row)
+
+select to_date('2016-01-15', 'YYYY-MM-DD');
+  to_date   
+------------
+ 01-15-2016
+(1 row)
+
+select to_date('2016-02-31', 'YYYY-MM-DD');
+  to_date   
+------------
+ 03-02-2016
+(1 row)
+
+select to_date('15-01-2016', 'DD-MM-YYYY');
+  to_date   
+------------
+ 01-15-2016
+(1 row)
+
+select to_date('31-02-2016', 'DD-MM-YYYY');
+  to_date   
+------------
+ 03-02-2016
+(1 row)
+
+select to_date('2016/02/29', 'YYYY/MM/DD');
+  to_date   
+------------
+ 02-29-2016
+(1 row)
+
+-- test to_date_valid()
+select to_date_valid('2016/01/15', 'YYYY/MM/DD');
+ to_date_valid 
+---------------
+ 01-15-2016
+(1 row)
+
+select to_date_valid('2016/01/31', 'YYYY/MM/DD');
+ to_date_valid 
+---------------
+ 01-31-2016
+(1 row)
+
+select to_date_valid('2016/02/31', 'YYYY/MM/DD');
+ERROR:  date out of range: "2016/02/31"
+select to_date_valid('2016-01-15', 'YYYY-MM-DD');
+ to_date_valid 
+---------------
+ 01-15-2016
+(1 row)
+
+select to_date_valid('2016-02-31', 'YYYY-MM-DD');
+ERROR:  date out of range: "2016-02-31"
+select to_date_valid('15-01-2016', 'DD-MM-YYYY');
+ to_date_valid 
+---------------
+ 01-15-2016
+(1 row)
+
+select to_date_valid('31-02-2016', 'DD-MM-YYYY');
+ERROR:  date out of range: "31-02-2016"
+select to_date_valid('2016/02/29', 'YYYY/MM/DD');
+ to_date_valid 
+---------------
+ 02-29-2016
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -131,4 +131,8 @@ test: uaocs_compaction/threshold
 test: uaocs_compaction/index_stats
 test: uaocs_compaction/index
 test: uaocs_compaction/drop_column
+
+# test to_date() and to_date_valid()
+test: to_date
+
 # end of tests

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -149,3 +149,6 @@ test: default_parameters
 # test workfiles compressed using zlib
 # 'zlib' utilizes fault injectors so it needs to be in a group by itself
 test: zlib
+
+# test to_date() and to_date_valid()
+test: to_date

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -149,6 +149,3 @@ test: default_parameters
 # test workfiles compressed using zlib
 # 'zlib' utilizes fault injectors so it needs to be in a group by itself
 test: zlib
-
-# test to_date() and to_date_valid()
-test: to_date

--- a/src/test/regress/sql/to_date.sql
+++ b/src/test/regress/sql/to_date.sql
@@ -12,6 +12,10 @@ select to_date('2016-02-31', 'YYYY-MM-DD');
 select to_date('15-01-2016', 'DD-MM-YYYY');
 select to_date('31-02-2016', 'DD-MM-YYYY');
 select to_date('2016/02/29', 'YYYY/MM/DD');
+select to_date('2016/02/27', NULL);
+select to_date('2016/02/31', NULL);
+select to_date(NULL, 'YYYY/MM/DD');
+select to_date(NULL, NULL);
 
 -- test to_date_valid()
 select to_date_valid('2016/01/15', 'YYYY/MM/DD');
@@ -22,3 +26,7 @@ select to_date_valid('2016-02-31', 'YYYY-MM-DD');
 select to_date_valid('15-01-2016', 'DD-MM-YYYY');
 select to_date_valid('31-02-2016', 'DD-MM-YYYY');
 select to_date_valid('2016/02/29', 'YYYY/MM/DD');
+select to_date_valid('2016/02/27', NULL);
+select to_date_valid('2016/02/31', NULL);
+select to_date_valid(NULL, 'YYYY/MM/DD');
+select to_date_valid(NULL, NULL);

--- a/src/test/regress/sql/to_date.sql
+++ b/src/test/regress/sql/to_date.sql
@@ -1,0 +1,24 @@
+-- -----------------------------------------------------------------
+-- Test to_date() and to_date_valid()
+-- -----------------------------------------------------------------
+show datestyle;
+-- test to_date() first
+-- also make sure that it still returns invalid results 
+select to_date('2016/01/15', 'YYYY/MM/DD');
+select to_date('2016/01/31', 'YYYY/MM/DD');
+select to_date('2016/02/31', 'YYYY/MM/DD');
+select to_date('2016-01-15', 'YYYY-MM-DD');
+select to_date('2016-02-31', 'YYYY-MM-DD');
+select to_date('15-01-2016', 'DD-MM-YYYY');
+select to_date('31-02-2016', 'DD-MM-YYYY');
+select to_date('2016/02/29', 'YYYY/MM/DD');
+
+-- test to_date_valid()
+select to_date_valid('2016/01/15', 'YYYY/MM/DD');
+select to_date_valid('2016/01/31', 'YYYY/MM/DD');
+select to_date_valid('2016/02/31', 'YYYY/MM/DD');
+select to_date_valid('2016-01-15', 'YYYY-MM-DD');
+select to_date_valid('2016-02-31', 'YYYY-MM-DD');
+select to_date_valid('15-01-2016', 'DD-MM-YYYY');
+select to_date_valid('31-02-2016', 'DD-MM-YYYY');
+select to_date_valid('2016/02/29', 'YYYY/MM/DD');


### PR DESCRIPTION
The regular to_date() function accepts invalid dates and uses
the input to calculate a valid date based on the difference in
the input. 2016-02-31 becomes 2016-03-02.

The new function verifies that the output and the input date
are the same, using the format string provides as second
parameter. A difference raises an error.

Solves Tracker #119368939
