### PR TITLE
fix_malloc_errmsg: Fix error message for record length too long.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -4284,10 +4284,9 @@ retry:
 		if (!readRecordBuf)
 		{
 			readRecordBufSize = 0;
-			/* We treat this as a "bogus data" condition */
 			ereport(emode,
-					(errmsg("record length %u at %X/%X too long",
-							total_len, RecPtr->xlogid, RecPtr->xrecoff)));
+					(errmsg("cannot allocate %u bytes for record at %X/%X",
+							newSize, RecPtr->xlogid, RecPtr->xrecoff)));
 			goto next_record_is_invalid;
 		}
 		readRecordBufSize = newSize;


### PR DESCRIPTION
Make the error message more descriptive when cannot enlarge readRecordBuf.