### PR TITLE
Remove inaccurate icg test that injects QueryFinishPending

### DIFF
--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -103,32 +103,3 @@ LIMIT 2;
 (2 rows)
 
 reset gp_enable_mk_sort;
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
--- where the child is a Materialize node
-set statement_mem="5MB";
-set gp_cte_sharing=on;
---start_ignore
-\! gpfaultinjector -f execshare_input_next -y reset --seg_dbid 2
-20160613:16:17:13:089857 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f execshare_input_next -y reset --seg_dbid 2
-20160613:16:17:13:089857 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20160613:16:17:13:089857 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
-20160613:16:17:13:089857 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
-20160613:16:17:13:089857 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20160613:16:17:13:089857 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
-\! gpfaultinjector -f execshare_input_next -y finish_pending --seg_dbid 2
-20160613:16:17:14:089869 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f execshare_input_next -y finish_pending --seg_dbid 2
-20160613:16:17:14:089869 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20160613:16:17:14:089869 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
-20160613:16:17:14:089869 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
-20160613:16:17:14:089869 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20160613:16:17:14:089869 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
---end_ignore 
- 
-with ctesisc as (select i1 as c1,i3 as c2 from testsisc) select count(*) > 0 from ctesisc as t1, ctesisc as t2 where t1.c1 = t2.c2;
- ?column? 
-----------
- t
-(1 row)
-

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -59,16 +59,3 @@ LIMIT 2;
 
 reset gp_enable_mk_sort;
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
--- where the child is a Materialize node
-set statement_mem="5MB";
-set gp_cte_sharing=on;
-
---start_ignore
-\! gpfaultinjector -f execshare_input_next -y reset --seg_dbid 2
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
-\! gpfaultinjector -f execshare_input_next -y finish_pending --seg_dbid 2
---end_ignore 
- 
-with ctesisc as (select i1 as c1,i3 as c2 from testsisc) select count(*) > 0 from ctesisc as t1, ctesisc as t2 where t1.c1 = t2.c2;


### PR DESCRIPTION
This test was introduced in commit c36ecd6f6fafa64840aac793590988ecfe329751.
It does not actually test the changes of that commit, instead it was aiming to test some other scenarios.
It seems that the test does not have a deterministic behavior.
We remove it for now, and we will investigate if the scenarios that we were aiming to test are possible and write deterministic tests.