### PR TITLE
Remove unnecessary debug-logging of tuple counts.

### DIFF
--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -424,20 +424,6 @@ ProcessQuery(Portal portal,
 				ExecuteTruncate(truncStmt);
 			}
 		}
-
-		/* MPP-4407. Logging number of tuples modified. */
-		if (relationOid != InvalidOid)
-		{
-			if (cmdType < AUTOSTATS_CMDTYPE_SENTINEL &&			
-				GetPlannedStmtLogLevel(stmt) <= log_statement)
-			{
-				elog(DEBUG1, "type_of_statement = %s dboid = %d tableoid = %d num_tuples_modified = %u", 
-					 autostats_cmdtype_to_string(cmdType), 
-					 MyDatabaseId, 
-					 relationOid, 
-					 (unsigned int) queryDesc->es_processed);
-			}
-		}
 		
 		/* MPP-4082. Issue automatic ANALYZE if conditions are satisfied. */
 		bool inFunction = false;

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -29,9 +29,6 @@ extern const char *CreateCommandTag(Node *parsetree);
 
 extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
-/* GPDB_83MERGE_FIXME Function is deprecated upstream but used in MPP code, replace */
-extern LogStmtLevel GetPlannedStmtLogLevel(PlannedStmt * stmt);
-
 extern bool CommandIsReadOnly(Node *parsetree);
 
 extern void CheckRelationOwnership(RangeVar *rel, bool noCatalogs);


### PR DESCRIPTION
It doesn't seem too useful, to hae a DEBUG1 of tuple counts. I doubt
anyone has taken advantage of that in years. Removing it allows us
to refactor the code inside GetPlannedStmtLogLevel() back into
GetCommandLogLevel(), like it is in the upstream.