### PR TITLE
Backport 8.4 changes to text search pg_*_is_visible() functions.

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -3845,6 +3845,11 @@ pg_ts_parser_is_visible(PG_FUNCTION_ARGS)
 {
 	Oid			oid = PG_GETARG_OID(0);
 
+	if (!SearchSysCacheExists(TSPARSEROID,
+							  ObjectIdGetDatum(oid),
+							  0, 0, 0))
+		PG_RETURN_NULL();
+
 	PG_RETURN_BOOL(TSParserIsVisible(oid));
 }
 
@@ -3852,6 +3857,11 @@ Datum
 pg_ts_dict_is_visible(PG_FUNCTION_ARGS)
 {
 	Oid			oid = PG_GETARG_OID(0);
+
+	if (!SearchSysCacheExists(TSDICTOID,
+							  ObjectIdGetDatum(oid),
+							  0, 0, 0))
+		PG_RETURN_NULL();
 
 	PG_RETURN_BOOL(TSDictionaryIsVisible(oid));
 }
@@ -3861,6 +3871,11 @@ pg_ts_template_is_visible(PG_FUNCTION_ARGS)
 {
 	Oid			oid = PG_GETARG_OID(0);
 
+	if (!SearchSysCacheExists(TSTEMPLATEOID,
+							  ObjectIdGetDatum(oid),
+							  0, 0, 0))
+		PG_RETURN_NULL();
+
 	PG_RETURN_BOOL(TSTemplateIsVisible(oid));
 }
 
@@ -3868,6 +3883,11 @@ Datum
 pg_ts_config_is_visible(PG_FUNCTION_ARGS)
 {
 	Oid			oid = PG_GETARG_OID(0);
+
+	if (!SearchSysCacheExists(TSCONFIGOID,
+							  ObjectIdGetDatum(oid),
+							  0, 0, 0))
+		PG_RETURN_NULL();
 
 	PG_RETURN_BOOL(TSConfigIsVisible(oid));
 }


### PR DESCRIPTION
We had backported similar changes to the other pg_*_is_visible()
functions earlier, so for consistency, do the same for the new functions
we got from the 8.3 merge.

The related upstream commit was:

commit 66bb74dbe8206a35433d7cb0c47d82248a019802
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Mon Dec 15 18:09:41 2008 +0000

    Arrange for the pg_foo_is_visible and has_foo_privilege families of functions
    to return NULL, instead of erroring out, if the target object is specified by
    OID and we can't find that OID in the catalogs.  Since these functions operate
    internally on SnapshotNow rules, there is a race condition when using them
    in user queries: the query's MVCC snapshot might "see" a catalog row that's
    already committed dead, leading to a failure when the inquiry function is
    applied.  Returning NULL should generally provide more convenient behavior.
    This issue has been complained of before, and in particular we are now seeing
    it in the regression tests due to another recent patch.