### PR TITLE
Fix potential overflow in mpp_err_msg_cache()

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_dump_util.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.c
@@ -619,6 +619,7 @@ mpp_err_msg_cache(const char *loglevel, const char *prog, const char *fmt,...)
 {
 	va_list		ap;
 	char		szTimeNow[18];
+	int			len;
 
 	va_start(ap, fmt);
 	fprintf(stderr, "%s|%s-[%s]:-", GetTimeNow(szTimeNow), prog, loglevel);
@@ -627,8 +628,19 @@ mpp_err_msg_cache(const char *loglevel, const char *prog, const char *fmt,...)
 
 	/* cache a copy of the message - we may need it for a report */
 	va_start(ap, fmt);
-	vsprintf(predump_errmsg, gettext(fmt), ap);
+	len = vsnprintf(predump_errmsg, sizeof(predump_errmsg), gettext(fmt), ap);
 	va_end(ap);
+
+	/*
+	 * If the passed error string exceeds the size of the buffer, indicate that
+	 * by suffixing the string with ".."
+	 */
+	if (len > sizeof(predump_errmsg))
+	{
+		int		i;
+		for (i = sizeof(predump_errmsg) - 3; predump_errmsg[i]; i++)
+			predump_errmsg[i] = '.';
+	}
 }
 
 /* Simple error logging to stdout  */

--- a/src/bin/pg_dump/cdb/cdb_dump_util.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.c
@@ -28,7 +28,9 @@
 
 static char predump_errmsg[1024];
 
-bool shouldDumpSchemaOnly(int g_role, bool incrementalBackup, void *list) {
+bool
+shouldDumpSchemaOnly(int g_role, bool incrementalBackup, void *list)
+{
     if (g_role != ROLE_SEGDB || !incrementalBackup)
         return false;
 
@@ -1680,7 +1682,8 @@ parseDDBoostCredential(char *hostname, char *user, char *password, const char *p
 }
 
 /* if the file too long this will rotate the files_name to file_name_0 - .._10 . the last file is deleted*/
-void rotate_dd_logs(const char *file_name, unsigned int num_of_files, unsigned int log_size)
+void
+rotate_dd_logs(const char *file_name, unsigned int num_of_files, unsigned int log_size)
 {
     struct stat st;
 
@@ -1713,6 +1716,7 @@ void rotate_dd_logs(const char *file_name, unsigned int num_of_files, unsigned i
     else
         mpp_err_msg("INFO","rotate_dd_logs","failed to find size");
 }
+
 /* Initialize the file for logging DDboost related information */
 void
 _ddp_test_log(const void *session_ptr, const ddp_char_t *log_msg, ddp_severity_t severity)
@@ -1935,12 +1939,14 @@ insertIntoHashTable(Oid o, char t)
     return 0;
 }
 
-int hashFunc(Oid k)
+int
+hashFunc(Oid k)
 {
     return k % HASH_TABLE_SIZE;
 }
 
-char getTypstorage(Oid o)
+char
+getTypstorage(Oid o)
 {
     int index  = hashFunc(o);
     Node *temp = hash_table[index];
@@ -1955,7 +1961,8 @@ char getTypstorage(Oid o)
     return EMPTY_TYPSTORAGE;
 }
 
-int removeNode(Oid o)
+int
+removeNode(Oid o)
 {
     int index = hashFunc(o);
 
@@ -1987,7 +1994,8 @@ int removeNode(Oid o)
     return -1;
 }
 
-void cleanUpTable()
+void
+cleanUpTable()
 {
 
     int i = 0;


### PR DESCRIPTION
Saving the error message into the static buffer in `mpp_err_msg_cache()` can lead to overflow since the string copy isn't bounded. Move to using a bounded copy and also indicate truncated messages by ending them with ".."

Considering that this doesn't seem to have happened indicates that it's not worth dynamically extending/shrinking the buffer to cope with the input, simply ensuring to not overflow is probably enough.

Also did some return value declaration cleanup while in there to make the file consistent in that regard (separate commit of course).