### PR TITLE
Remove CDB README

### DIFF
--- a/src/backend/cdb/README
+++ b/src/backend/cdb/README
@@ -1,9 +1,0 @@
-
-
-CDB2 Additions to PostgreSQL
-----------------------------
-
-OVERVIEW
-
-Directory cdb-pg/src/backend/cdb/ contains CDB2 additions to PostgreSQL.  Corresponding external declarations are in cdb-pg/src/include/cdb/.  
-


### PR DESCRIPTION
Came across this README file while reading some code and rather than fixing the incorrect path specifications (cdb-pg/ is a leftover from pre-OSS days) it seemed equally useful to just remove it since it carries very little information.