### PR TITLE
Change retry condition of creating gang.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -135,6 +135,7 @@ static CdbComponentDatabaseInfo *findDatabaseInfoBySegIndex(
 		CdbComponentDatabases *cdbs, int segIndex);
 static void addGangToAllocated(Gang *gp);
 static Gang *getAvailableGang(GangType type, int size, int content);
+static bool readerGangsExist(void);
 
 /*
  * Create a reader gang.
@@ -466,27 +467,26 @@ create_gang_retry:
 		goto exit;
 	}
 
-	disconnectAndDestroyGang(newGangDefinition);
-	newGangDefinition = NULL;
-
 	/* Writer gang is created before reader gangs. */
 	if (type == GANGTYPE_PRIMARY_WRITER)
 		Insist(!gangsExist());
 
-	/* We could do some retry here */
-	if (successful_connections + in_recovery_mode_count == size &&
-		gp_gang_creation_retry_count &&
-		create_gang_retry_counter++ < gp_gang_creation_retry_count)
+	/*
+	 * Retry when:
+	 * 1) It's the writer gang.
+	 * 2) It's the first reader gang.
+	 * 3) All failed segment are in recovery mode.
+	 */
+	if(gp_gang_creation_retry_count &&
+	   create_gang_retry_counter++ < gp_gang_creation_retry_count &&
+	   (type == GANGTYPE_PRIMARY_WRITER ||
+	    !readerGangsExist() ||
+	    successful_connections + in_recovery_mode_count == size))
 	{
-		LOG_GANG_DEBUG(LOG, "createGang: gang creation failed, but retryable.");
+		disconnectAndDestroyGang(newGangDefinition);
+		newGangDefinition = NULL;
 
-		/*
-		 * On the first retry, we want to verify that we are
-		 * using the most current version of the
-		 * configuration.
-		 */
-		if (create_gang_retry_counter == 0)
-			FtsNotifyProber();
+		LOG_GANG_DEBUG(LOG, "createGang: gang creation failed, but retryable.");
 
 		CHECK_FOR_INTERRUPTS();
 		pg_usleep(gp_gang_creation_retry_timer * 1000);
@@ -2204,6 +2204,14 @@ bool gangsExist(void)
 {
 	return (primaryWriterGang != NULL ||
 			allocatedReaderGangsN != NIL ||
+			availableReaderGangsN != NIL ||
+			allocatedReaderGangs1 != NIL||
+			availableReaderGangs1 != NIL);
+}
+
+static bool readerGangsExist(void)
+{
+	return (allocatedReaderGangsN != NIL ||
 			availableReaderGangsN != NIL ||
 			allocatedReaderGangs1 != NIL||
 			availableReaderGangs1 != NIL);


### PR DESCRIPTION
When create gang failed and all segment DB are alive,
we could retry when any of the following conditions is meet:
1) It's the writer gang.
2) It's the first reader gang and the writer gang is healthy.
3) All failed connections are due to segment recovery.