### PR TITLE
Remove dead code in the Algebrizer #121649987

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -417,22 +417,6 @@ CTranslatorQueryToDXL::CheckSupportedCmdType
 		return;
 	}
 
-	if (CMD_INSERT == pquery->commandType || CMD_DELETE == pquery->commandType || CMD_UPDATE == pquery->commandType)
-	{
-	  // GPDB_83_MERGE_FIXME: resultRelations was moved from Query to PlannedStmt. But
-	  // we're supposed to do the planning, so I assume we don't have easy access to
-	  // PlannedStmt here. I'm actually confused how this ever worked; I would've expected
-	  // resultRelations to not be filled in before planning. Or maybe it's filled in
-	  // at rewrite phase; not sure.
-#if 0
-		if (NULL != pquery->resultRelations)
-		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("DML on partitioned tables"));
-		}
-#endif
-		return;
-	}
-
 	SCmdNameElem rgStrMap[] =
 		{
 		{CMD_UTILITY, GPOS_WSZ_LIT("UTILITY command")}


### PR DESCRIPTION
8.3 merge discovered some dead code in the Orca related Query 2 DXL translator (a.k.a Algebrizer).

Orca supports DML on partitioned table, this was some deadcode that was not being exercised. 

Thanks @hlinnaka.

@oarap @danielgustafsson @d @xinzweb @hsyuan please take a look. Will also port it to 4.3 after the PR.