### PR TITLE
Disable faultinjectors at the end of icg tests

### DIFF
--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -103,3 +103,20 @@ LIMIT 2;
 (2 rows)
 
 reset gp_enable_mk_sort;
+-- Disable faultinjectors
+--start_ignore
+\! gpfaultinjector -f execsort_mksort_mergeruns -y reset --seg_dbid 2
+20160621:08:58:20:039567 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f execsort_mksort_mergeruns -y reset --seg_dbid 2
+20160621:08:58:20:039567 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
+20160621:08:58:20:039567 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
+20160621:08:58:20:039567 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
+20160621:08:58:20:039567 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
+20160621:08:58:20:039567 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
+\! gpfaultinjector -f execshare_input_next -y reset --seg_dbid 2
+20160621:08:58:20:039579 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f execshare_input_next -y reset --seg_dbid 2
+20160621:08:58:20:039579 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
+20160621:08:58:20:039579 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
+20160621:08:58:20:039579 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
+20160621:08:58:20:039579 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
+20160621:08:58:20:039579 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
+--end_ignore

--- a/src/test/regress/expected/segspace.out
+++ b/src/test/regress/expected/segspace.out
@@ -175,3 +175,13 @@ select max(size) from segspace_view_gp_workfile_segspace;
    0
 (1 row)
 
+-- Disable faultinjectors
+--start_ignore
+\! gpfaultinjector -f exec_hashjoin_new_batch -y reset --seg_dbid 2
+20160621:09:04:08:041223 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y reset --seg_dbid 2
+20160621:09:04:08:041223 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
+20160621:09:04:08:041223 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
+20160621:09:04:08:041223 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
+20160621:09:04:08:041223 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
+20160621:09:04:08:041223 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
+--end_ignore

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -55,3 +55,13 @@ SET statement_mem=2000;
 --end_ignore
 SELECT MAX(i1) FROM test_zlib_hagg GROUP BY i2;
 ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error' (faultinjector.c:673)  (seg0 slice2 127.0.0.1:25432 pid=34971)
+-- Reset faultinjectors
+--start_ignore
+\! gpfaultinjector -f workfile_creation_failure -y reset --seg_dbid 2
+20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y reset --seg_dbid 2
+20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
+20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
+20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
+20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
+20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
+--end_ignore

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -58,4 +58,8 @@ from testsisc
 LIMIT 2;
 
 reset gp_enable_mk_sort;
-
+-- Disable faultinjectors
+--start_ignore
+\! gpfaultinjector -f execsort_mksort_mergeruns -y reset --seg_dbid 2
+\! gpfaultinjector -f execshare_input_next -y reset --seg_dbid 2
+--end_ignore

--- a/src/test/regress/sql/segspace.sql
+++ b/src/test/regress/sql/segspace.sql
@@ -148,3 +148,8 @@ rollback;
 -- check used segspace after test
 reset statement_mem;
 select max(size) from segspace_view_gp_workfile_segspace;
+
+-- Disable faultinjectors
+--start_ignore
+\! gpfaultinjector -f exec_hashjoin_new_batch -y reset --seg_dbid 2
+--end_ignore

--- a/src/test/regress/sql/zlib.sql
+++ b/src/test/regress/sql/zlib.sql
@@ -32,3 +32,8 @@ SET statement_mem=2000;
 --end_ignore
 
 SELECT MAX(i1) FROM test_zlib_hagg GROUP BY i2;
+
+-- Reset faultinjectors
+--start_ignore
+\! gpfaultinjector -f workfile_creation_failure -y reset --seg_dbid 2
+--end_ignore


### PR DESCRIPTION
There might be a case where the faultinjectors used in an icg test were not triggered as expected, e.g., the code path has changed. We need to disable all faultinjectors at the end of the tests to avoid triggering them later in another test. 

@edespino @gcaragea Please take a look if you have some time.