### PR TITLE
Avoiding ERROR loglevel during transaction abort

### DIFF
--- a/src/backend/executor/execWorkfile.c
+++ b/src/backend/executor/execWorkfile.c
@@ -450,7 +450,7 @@ ExecWorkFile_Close(ExecWorkFile *workfile)
 				ExecWorkFile_AdjustBFZSize(workfile, file_size);
 			}
 
-			bfz_close(bfz_file, true);
+			bfz_close(bfz_file, true, true);
 			break;
 		default:
 			insist_log(false, "invalid work file type: %d", workfile->fileType);

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -494,7 +494,7 @@ void ExecShareInputScanReScan(ShareInputScanState *node, ExprContext *exprCtxt)
 
 /*************************************************************************
  * XXX 
- * we need some IPC mechanism for shareinptu_read_wait/writer_notify.  Semaphore is
+ * we need some IPC mechanism for shareinput_read_wait/writer_notify.  Semaphore is
  * the first thing come to mind but it turns out postgres is very picky about
  * how to use semaphore and we do not want to mess up with it.
  *
@@ -825,8 +825,8 @@ shareinput_writer_notifyready(int share_id, int xslice, PlanGenerator planGen)
 	pctxt->del_ready = true;
 	pctxt->readyfd = open(pctxt->lkname_ready, O_RDWR, 0600); 
 	if(pctxt->readyfd < 0)
-	
 		elog(ERROR, "could not open fifo \"%s\": %m", pctxt->lkname_ready);
+
 	sisc_lockname(pctxt->lkname_done, MAXPGPATH, share_id, "done");
 	create_tmp_fifo(pctxt->lkname_done);
 	pctxt->del_done = true;

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -549,40 +549,43 @@ static void sisc_lockname(char* p, int size, int share_id, const char* name)
 
 static void shareinput_clean_lk_ctxt(ShareInput_Lk_Context *lk_ctxt)
 {
-	int err;
-
 	elog(DEBUG1, "shareinput_clean_lk_ctxt cleanup lk ctxt %p", lk_ctxt);
 
-	if(lk_ctxt->readyfd >= 0)
-	{
-		err = gp_retry_close(lk_ctxt->readyfd);
-		insist_log(!err, "shareinput_clean_lk_ctxt cannot close readyfd: %m");
+	if (!lk_ctxt)
+		return;
 
-		lk_ctxt->readyfd = -1;
+	if (lk_ctxt->readyfd >= 0)
+	{
+		if (gp_retry_close(lk_ctxt->readyfd))
+			ereport(WARNING,
+				(errcode(ERRCODE_IO_ERROR),
+				errmsg("shareinput_clean_lk_ctxt cannot close readyfd: %m")));
 	}
 
-	if(lk_ctxt->donefd >= 0)
+	if (lk_ctxt->donefd >= 0)
 	{
-		err = gp_retry_close(lk_ctxt->donefd);
-		insist_log(!err, "shareinput_clean_lk_ctxt cannot close donefd: %m");
-
-		lk_ctxt->donefd = -1;
+		if (gp_retry_close(lk_ctxt->donefd))
+			ereport(WARNING,
+				(errcode(ERRCODE_IO_ERROR),
+				errmsg("shareinput_clean_lk_ctxt cannot close donefd: %m")));
 	}
 
-	if(lk_ctxt->del_ready && lk_ctxt->lkname_ready[0])
+	if (lk_ctxt->del_ready && lk_ctxt->lkname_ready[0])
 	{
-		err = unlink(lk_ctxt->lkname_ready);
-		insist_log(!err, "shareinput_clean_lk_ctxt cannot unlink \"%s\": %m", lk_ctxt->lkname_ready);
-
-		lk_ctxt->del_ready = false;
+		if (unlink(lk_ctxt->lkname_ready))
+			ereport(WARNING,
+				(errcode(ERRCODE_IO_ERROR),
+				errmsg("shareinput_clean_lk_ctxt cannot unlink \"%s\": %m",
+					lk_ctxt->lkname_ready)));
 	}
 
-	if(lk_ctxt->del_done && lk_ctxt->lkname_done[0])
+	if (lk_ctxt->del_done && lk_ctxt->lkname_done[0])
 	{
-		err = unlink(lk_ctxt->lkname_done);
-		insist_log(!err, "shareinput_clean_lk_ctxt cannot unline \"%s\": %m", lk_ctxt->lkname_done);
-
-		lk_ctxt->del_done = false;
+		if (unlink(lk_ctxt->lkname_done))
+			ereport(WARNING,
+				(errcode(ERRCODE_IO_ERROR),
+				errmsg("shareinput_clean_lk_ctxt cannot unlink \"%s\": %m",
+					lk_ctxt->lkname_done)));
 	}
 
 	gp_free(lk_ctxt);

--- a/src/backend/storage/file/bfz.c
+++ b/src/backend/storage/file/bfz.c
@@ -60,10 +60,22 @@ bfz_string_to_compression(const char *string)
 	return -1;
 }
 
+/*
+ * bfz_close_callback
+ *		Callback for register for transaction end cleanups
+ *
+ * If the callback is called during transaction abort we want to avoid throwing
+ * another ereport().
+ */
 static void
 bfz_close_callback(XactEvent event, void *arg)
 {
-	bfz_close(arg, false);
+	bool unlink_error = true;
+
+	if (event == XACT_EVENT_ABORT)
+		unlink_error = false;
+
+	bfz_close(arg, false, unlink_error);
 }
 
 #define BFZ_CHECKSUM_EQ(c1, c2) EQ_CRC32C(c1, c2)
@@ -413,8 +425,19 @@ bfz_create_internal(bfz_t *bfz_handle, const char *fileName, bool open_existing,
 	return bfz_handle;
 }
 
+/*
+ * bfz_close
+ *		Close and free used resources
+ *
+ * When unreg is set to true the callback for removing the file during end of
+ * transaction will be removed to avoid attempting to delete a removed file.
+ * If the file is missing and can't be deleted an error will be thrown, this
+ * can be avoided by setting error_on_unlink to false when running bfz_close()
+ * as part of a transaction abortion for example were throwing additional
+ * errors should be avoided.
+ */
 void
-bfz_close(bfz_t * thiz, bool unreg)
+bfz_close(bfz_t * thiz, bool unreg, bool error_on_unlink)
 {
 	if (unreg)
 		UnregisterXactCallbackOnce(bfz_close_callback, thiz);
@@ -437,7 +460,7 @@ bfz_close(bfz_t * thiz, bool unreg)
 	if (thiz->del_on_close && thiz->filename != NULL)
 	{
 		if (unlink(thiz->filename))
-			ereport(ERROR,
+			ereport((error_on_unlink ? ERROR : WARNING),
 					(errcode(ERRCODE_IO_ERROR),
 					errmsg("could not close temporary file %s: %m", thiz->filename)));
 		pfree(thiz->filename);

--- a/src/include/storage/bfz.h
+++ b/src/include/storage/bfz.h
@@ -76,7 +76,7 @@ extern bfz_t *bfz_create(const char *filePrefix, bool delOnClose, int compress);
 extern bfz_t *bfz_open(const char *fileName, bool delOnClose, int compress);
 extern int64 bfz_append_end(bfz_t * thiz);
 extern void bfz_scan_begin(bfz_t * thiz);
-extern void bfz_close(bfz_t * thiz, bool unreg);
+extern void bfz_close(bfz_t * thiz, bool unreg, bool error_on_unlink);
 extern ssize_t readAndRetry(int fd, void *buffer, size_t size);
 extern ssize_t writeAndRetry(int fd, const void *buffer, size_t size);
 

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -86,6 +86,8 @@ s/^NOTICE:.*Table has no attributes to distribute on.//
 m/^NOTICE:.*ANALYZE detected all empty sample pages for table .*, please run VACUUM FULL for accurate estimation/
 s/^NOTICE:.*ANALYZE detected all empty sample pages for table .*, please run VACUUM FULL for accurate estimation//
 
+m/^WARNING:  could not close temporary file .*: No such file or directory/
+s/^WARNING:  could not close temporary file .*: No such file or directory//
 -- end_matchignore
 
 -- start_matchsubs


### PR DESCRIPTION
Avoid throwing an error in bfz_close() during aborting a transaction. When bfz_close() is called in the codepath during the abortion of a transaction we must avoid throwing even more errors unless the situation calls for it. For bfz_close() it's fine to lower the ereport level to WARNING in this case. Longer term we should move this, and other, codepaths away from calling unlink() directly and instead use the API provided but this closes a current issue in ICG so better to close this immediately and refactor all callsites when having a clean ICG.

Also reduce log severity in shareinput_clean_lk_ctxt(). If we are unable to unlink the temporary files in the shareinput cleanup it seems quite aggressive to insist_log() and forcibly exit. While definately something to warn it doesn't seem worth breaking hard for (unless I'm missing something).

Also see discussion on [-dev](https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/GimV-ChJ61o) around this. ICG was previously breaking for me but runs with these commits.

Includes a minor cleanup commit in code surrounding the patch.