### PR TITLE
Remove dead support for multiple hash algorithms

### DIFF
--- a/contrib/gp_distribution_policy/gp_distribution_policy.c
+++ b/contrib/gp_distribution_policy/gp_distribution_policy.c
@@ -181,7 +181,7 @@ gp_distribution_policy_heap_table_check(PG_FUNCTION_ARGS)
 		CHECK_FOR_INTERRUPTS();
 
 		/* Initialize hash function and structure */
-		CdbHash *hash = makeCdbHash(GpIdentity.numsegments, HASH_FNV_1);
+		CdbHash *hash = makeCdbHash(GpIdentity.numsegments);
 		cdbhashinit(hash);
 		
 		for(int i = 0; i < policy->nattrs; i++)

--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -1,7 +1,8 @@
 /*--------------------------------------------------------------------------
  *
  * cdbhash.c
- *	  Provides hashing routines to support consistant data distribution/location within Greenplum Database.
+ *	  Provides hashing routines to support consistant data distribution/location
+ *    within Greenplum Database.
  *
  * Copyright (c) 2005-2008, Greenplum inc
  *
@@ -470,7 +471,7 @@ hashDatum(Datum datum, Oid type, datumHashFunction hashFn, void *clientData)
 			 * nabstime.c. We use the actual value instead
 			 * of defining it again here.
 			 */
-			if(tinterval->status == 0 ||
+			if (tinterval->status == 0 ||
 			   tinterval->data[0] == INVALID_ABSTIME ||
 			   tinterval->data[1] == INVALID_ABSTIME)
 			{
@@ -610,7 +611,7 @@ cdbhashnull(CdbHash *h)
 	hashNullDatum(addToCdbHash, (void*)h);
 }
 
-/**
+/*
  * Update the hash value for a null Datum
  *
  * @param hashFn called to update the hash value.
@@ -643,7 +644,6 @@ cdbhashnokey(CdbHash *h)
 	
 	h->rrindex++; /* increment for next time around */
 }
-
 
 
 /*
@@ -713,7 +713,8 @@ typeIsEnumType(Oid typeoid)
 	return res;
 }
 
-bool isGreenplumDbHashable(Oid typid)
+bool
+isGreenplumDbHashable(Oid typid)
 {
 	/* we can hash all arrays */
 	if (typeIsArrayType(typid))
@@ -803,7 +804,6 @@ fnv1_32_buf(void *buf, size_t len, uint32 hval)
 	 */
 	while (bp < be)
 	{
-
 		/* multiply by the 32 bit FNV magic prime mod 2^32 */
 #if defined(NO_FNV_GCC_OPTIMIZATION)
 		hval *= FNV_32_PRIME;
@@ -860,27 +860,28 @@ inet_getkey(inet *addr, unsigned char *inet_key, int key_size)
 /*
  * Given the original length of the data array this function is
  * recalculating the length after ignoring any trailing blanks. The
- * actual data is remained unmodified.
+ * actual data remains unmodified.
  */
 static int
 ignoreblanks(char *data, int len)
 {
-
 	/* look for trailing blanks and skip them in the hash calculation */
 	while (data[len - 1] == ' ')
 	{
 		len--;
-		if (len == 1)			/* if only 1 char is left, leave it alone!
-								 * (the string is either empty or has 1 char) */
+		/*
+		 * If only 1 char is left, leave it alone! The string is either empty
+		 * or has 1 char
+		 */
+		if (len == 1)
 			break;
 	}
 
 	return len;
-
 }
 
 /*
- * returns 1 is the input int is a power of 2 and 0 otherwize.
+ * returns 1 is the input int is a power of 2 and 0 otherwise.
  */
 static int
 ispowof2(int numsegs)

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -165,7 +165,7 @@ directDispatchCalculateHash(Plan *plan, GpPolicy *targetPolicy)
 	ListCell *cell=NULL;
 	bool directDispatch;
 
-	h = makeCdbHash(GpIdentity.numsegments, HASH_FNV_1);
+	h = makeCdbHash(GpIdentity.numsegments);
 	cdbhashinit(h);
 
 	/*
@@ -2593,7 +2593,7 @@ Plan *zap_trivial_result(PlannerInfo *root, Plan *plan)
 int32 
 cdbhash_const(Const *pconst, int iSegments)
 {
-	CdbHash *pcdbhash = makeCdbHash(iSegments, HASH_FNV_1);
+	CdbHash *pcdbhash = makeCdbHash(iSegments);
 	cdbhashinit(pcdbhash);
 			
 	if (pconst->constisnull)
@@ -2622,7 +2622,7 @@ cdbhash_const_list(List *plConsts, int iSegments)
 {
 	Assert(0 < list_length(plConsts));
 	
-	CdbHash *pcdbhash = makeCdbHash(iSegments, HASH_FNV_1);
+	CdbHash *pcdbhash = makeCdbHash(iSegments);
 	cdbhashinit(pcdbhash);
 
 	ListCell   *lc = NULL;

--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -249,7 +249,7 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 				/* don't bother for ones which will likely hash to many segments */
 				totalCombinations < GpIdentity.numsegments * 3 )
 		{
-			CdbHash *h = makeCdbHash(GpIdentity.numsegments, HASH_FNV_1);
+			CdbHash *h = makeCdbHash(GpIdentity.numsegments);
 			long index = 0;
 
 			result.dd.isDirectDispatch = true;

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2788,7 +2788,7 @@ CopyFromDispatch(CopyState cstate)
 		else
 			p_nattrs = 0;
 		/* Create hash API reference */
-		cdbHash = makeCdbHash(cdbCopy->total_segs, HASH_FNV_1);
+		cdbHash = makeCdbHash(cdbCopy->total_segs);
 	}
 
 
@@ -3343,7 +3343,7 @@ CopyFromDispatch(CopyState cstate)
 								save_cxt = MemoryContextSwitchTo(oldcontext);
 								d->relid = relid;
 								part_hash = d->cdbHash =
-									makeCdbHash(cdbCopy->total_segs, HASH_FNV_1);
+									makeCdbHash(cdbCopy->total_segs);
 								part_policy = d->policy =
 									GpPolicyCopy(oldcontext,
 												 rel->rd_cdbpolicy);

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -1053,7 +1053,7 @@ ExecInitMotion(Motion * node, EState *estate, int eflags)
 		/*
 		 * Create hash API reference
 		 */
-		motionstate->cdbhash = makeCdbHash(node->numOutputSegs, HASH_FNV_1);
+		motionstate->cdbhash = makeCdbHash(node->numOutputSegs);
     }
 
 	/* Merge Receive: Set up the key comparator and priority queue. */

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -268,7 +268,7 @@ static bool TupleMatchesHashFilter(Result *resultNode, TupleTableSlot *resultSlo
 
 		Assert(list_length(resultNode->hashList) <= resultSlot->tts_tupleDescriptor->natts);
 
-		CdbHash *hash = makeCdbHash(GpIdentity.numsegments, HASH_FNV_1);
+		CdbHash *hash = makeCdbHash(GpIdentity.numsegments);
 		cdbhashinit(hash);
 		foreach(cell, resultNode->hashList)
 		{

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -28,8 +28,6 @@ typedef enum
 	REDUCE_BITMASK
 } CdbHashReduce;
 
-typedef uint32 CdbHashFn (void *, size_t, uint32);
-
 /*
  * Structure that holds Greenplum Database hashing information.
  */
@@ -38,9 +36,6 @@ typedef struct CdbHash
 	uint32		hash;			/* The result hash value							*/
 	int			numsegs;		/* number of segments in Greenplum Database used for
 								 * partitioning  */
-	CdbHashAlg	hashalg;		/* the hashing algorithm							*/
-	CdbHashFn  *hashfn;			/* hashing function for the selected hash
-								 * algorithm */
 	CdbHashReduce reducealg;	/* the algorithm used for reducing to buckets		*/
 	uint32		rrindex;		/* round robin index for empty policy tables		*/
 
@@ -55,9 +50,8 @@ extern void hashNullDatum(datumHashFunction hashFn, void *clientData);
 /*
  * Create and initialize a CdbHash in the current memory context.
  * Parameter numsegs - number of segments in Greenplum Database.
- * Parameter algorithm - the hash algorithm, either HASH_FNV_1 or HASH_FNV_1A
  */
-extern CdbHash *makeCdbHash(int numsegs, CdbHashAlg algorithm);
+extern CdbHash *makeCdbHash(int numsegs);
 
 /*
  * Initialize CdbHash for hashing the next tuple values.


### PR DESCRIPTION
The support for having multiple hashing algorithms for the table distribution was short circuited over 10 years ago (relevant commit for those with access to the pre-OSS repo is 72c718ce) when support for more generic hashing was introduced together with NULL hashing policies. Seems a bit pointless to carry around the algorithm info and function pointer when they are in reality hardcoded. Simplify and remove the dead code and avoid passing around a parameter with a single possible value.

While in there, did some cleanups on style and spelling to make the file more or less internally consistent style wise.