### PR TITLE
Avoid postmaster infinite loop upon a backend crash

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2505,8 +2505,9 @@ ServerLoop(void)
 						 (long)BgWriterPID);
 			}
 
-			if (CheckpointPID == 0 && pmState > PM_STARTUP_PASS4 &&
-				Shutdown == NoShutdown)
+			if (CheckpointPID == 0 &&
+			    pmState > PM_STARTUP_PASS4 &&
+			    pmState < PM_CHILD_STOP_BEGIN)
 			{
 				CheckpointPID = StartCheckpointServer();
 				if (Debug_print_server_processes)
@@ -2535,9 +2536,11 @@ ServerLoop(void)
 				if (AutoVacPID != 0)
 					start_autovac_launcher = false; /* signal processed */
 			}
-			
+
 			/* If we have lost the stats collector, try to start a new one */
-			if (PgStatPID == 0 && pmState > PM_STARTUP_PASS4)
+			if (PgStatPID == 0 &&
+			    pmState > PM_STARTUP_PASS4 &&
+			    pmState < PM_CHILD_STOP_BEGIN)
 			{
 				PgStatPID = pgstat_start();
 				if (Debug_print_server_processes)


### PR DESCRIPTION
Backend crash due to PANIC causes postmaster ServerLoop to shutdown all
subprocesses and then restart them.  During 8.3 merge, the condition to restart
was weakened, causing ServerLoop to incorrectly initiate restart of
subprocesses before all existing subprocesses are shutdown.  This led to an
infinite loop in the event of PANIC.

This is a paired effort by @amilkh and Asim