### PR TITLE
Remove OS check for Darwin and Sparc during mirror creation in gpdemo.

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -280,19 +280,17 @@ cat >> $CLUSTER_CONFIG <<-EOF
 	ENCODING=UNICODE
 EOF
 
-if [ `uname -p` != "sparc" ] && [ `uname -s` != "Darwin" ]; then
-	cat >> $CLUSTER_CONFIG <<-EOF
+cat >> $CLUSTER_CONFIG <<-EOF
+
+	# Array of mirror data locations for each hosts Segment Instances, the number of directories in this array will
+	# set the number of segment instances per host
+	declare -a MIRROR_DATA_DIRECTORY=(${DIRVEC_MIRROR[@]})
 	
-		# Array of mirror data locations for each hosts Segment Instances, the number of directories in this array will
-		# set the number of segment instances per host
-		declare -a MIRROR_DATA_DIRECTORY=(${DIRVEC_MIRROR[@]})
-		
-		MIRROR_PORT_BASE=`expr $DEMO_PORT_BASE + 3`
-	
-		REPLICATION_PORT_BASE=`expr $DEMO_PORT_BASE + 6`
-		MIRROR_REPLICATION_PORT_BASE=`expr $DEMO_PORT_BASE + 9`
-	EOF
-fi
+	MIRROR_PORT_BASE=`expr $DEMO_PORT_BASE + 3`
+
+	REPLICATION_PORT_BASE=`expr $DEMO_PORT_BASE + 6`
+	MIRROR_REPLICATION_PORT_BASE=`expr $DEMO_PORT_BASE + 9`
+EOF
 
 cat >> $CLUSTER_CONFIG <<-EOF
 


### PR DESCRIPTION
Currently, gpdemo does not build mirrors for Darwin and Sparc. This was a
restriction from the early 2010s and should not be an issue today with
modern systems.