### PR TITLE
Refactor gpcheckcat to modularize the repair code and add repair for the missing_extraneous module.

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -19,14 +19,9 @@ Usage: gpcheckcat [<option>] [dbname]
 '''
 import getopt
 import re
-import stat
 import sys
+import time
 from datetime import datetime
-from time import localtime, strftime
-
-
-TIMESTAMP = datetime.now().strftime("%Y%m%d%H%M%S")
-REPAIR_SCRIPT = 'runsql_%s.sh' % TIMESTAMP
 
 try:
     from gppylib.db import dbconn
@@ -38,6 +33,8 @@ try:
     from pygresql import pg
     from gpcheckcat_modules.unique_index_violation_check import UniqueIndexViolationCheck
     from gpcheckcat_modules.leaked_schema_dropper import LeakedSchemaDropper
+    from gpcheckcat_modules.repair import Repair
+
 except ImportError, e:
     sys.exit('Error: unable to import module: ' + str(e))
 
@@ -103,7 +100,7 @@ class Global():
         self.opt['-V'] = False
         self.opt['-t'] = False
 
-        self.opt['-g'] = 'gpcheckcat.repair.' + strftime('%Y-%m-%d.%H.%M.%S', localtime())
+        self.opt['-g'] = 'gpcheckcat.repair.' + Repair.TIMESTAMP
         self.opt['-B'] = parallelism
         self.opt['-T'] = None
 
@@ -149,9 +146,6 @@ class Global():
         # array of SQL statements. Key is dbid
         self.ReSync = {}
 
-        # Indexes to rebuild
-        self.Reindex = []
-
         # constraints which are actually unenforcable
         self.Constraints = []
 
@@ -160,6 +154,9 @@ class Global():
 
         # fix distribution policies
         self.Policies = []
+
+        # Indexes to rebuild
+        self.Reindex = []
 
         self.missingEntryStatus = None
         self.inconsistentEntryStatus = None
@@ -187,7 +184,6 @@ def usage(exitarg=None):
 ###############################
 
 def getversion():
-    versions = ["3.2", "3.3", "4.0", "4.1", "main"]
     db = connect()
     curs = db.query('''
     select regexp_replace(version(),
@@ -529,6 +525,7 @@ def checkDistribPolicy():
         myprint('[ERROR] executing test: checkDistribPolicy')
         myprint('  Execution error: ' + str(e))
 
+    checkConstraintsRepair()
 
 #############
 def checkPartitionIntegrity():
@@ -726,6 +723,7 @@ def checkPartitionIntegrity():
 
     db.close()
 
+    checkPoliciesRepair()
 
 #############
 # A dictionary of SQL statements for checkPartitionRegularity()
@@ -1931,7 +1929,8 @@ def removeFastSequence(db):
                               union
                               select oid from gp_dist_random('pg_class')) AS c
                         ON (fs.objid = c.oid)
-                     WHERE c.oid IS NULL) AS r
+                        WHERE c.oid IS NULL
+                        ) AS r
                   ON r.gp_segment_id = cfg.content
                WHERE cfg.role = 'p';
               """
@@ -2233,6 +2232,8 @@ def checkOwners():
         # Check owners in pg_operator
         # Check owners in pg_opclass
         # ...
+
+    checkOwnersRepair()
 
 
 def checkPersistentTables():
@@ -2928,7 +2929,7 @@ def fkQuery(catname, pkcatname, fkeystr, pkeystr, pkeys, cat1pkeys):
 # -------------------------------------------------------------------------------
 def checkMissingEntry():
     logger.info('-----------------------------------')
-    logger.info('Performing cross consistency tests: check for missing or extraneous entries')
+    logger.info('Performing cross consistency tests: check for missing or extraneous issues')
 
     if GV.missingEntryStatus == None:
         GV.missingEntryStatus = True
@@ -2936,8 +2937,18 @@ def checkMissingEntry():
     # looks up information in the catalog:
     tables = GV.catalog.getCatalogTables()
 
-    for cat in sorted(tables):
-        checkTableMissingEntry(cat)
+    catalog_issues = {}
+
+    for catalog_table_obj in sorted(tables):
+        issues = checkTableMissingEntry(catalog_table_obj)
+        if not issues:
+            continue
+
+        catalog_name = catalog_table_obj.getTableName()
+        _, pk_name = getPrimaryKeyColumn(catalog_name, catalog_table_obj.getPrimaryKey())
+        catalog_issues[(catalog_name, pk_name)] = issues
+
+    do_repair_for_extra(catalog_issues)
 
 
 # -------------------------------------------------------------------------------
@@ -2987,7 +2998,6 @@ def checkTableMissingEntry(cat):
                 log_level = logging.WARNING
             else:
                 GV.checkStatus = False
-                setError(ERROR_NOREPAIR)
                 GV.missingEntryStatus = False
                 logger_with_level = logger.error
                 log_level = logging.ERROR
@@ -3003,6 +3013,9 @@ def checkTableMissingEntry(cat):
             processMissingDuplicateEntryResult(catname, fields, results, "missing")
             if catname == 'pg_type':
                 generateVerifyFile(catname, fields, results, 'missing_extraneous')
+
+            return results
+
     except Exception, e:
         setError(ERROR_NOREPAIR)
         GV.missingEntryStatus = False
@@ -3452,26 +3465,6 @@ name_repair = {
             "description": "Check if needs repairing segment",
             "fn": lambda maybeRemove, catmod_guc, seg: checkSegmentRepair(maybeRemove, catmod_guc, seg)
         },
-    "reindex":
-        {
-            "description": "Check if needs repair file for reindex",
-            "fn": lambda: checkReindexRepair()
-        },
-    "constraints":
-        {
-            "description": "Check if needs repair file to fix constraints",
-            "fn": lambda: checkConstraintsRepair()
-        },
-    "owners":
-        {
-            "description": "Check if needs repair file to fix messed up ownership",
-            "fn": lambda: checkOwnersRepair()
-        },
-    "policies":
-        {
-            "description": "Check if needs repair file to fix distribution policy",
-            "fn": lambda: checkPoliciesRepair()
-        }
 }
 
 ############################################################################
@@ -3660,7 +3653,6 @@ def runOneCheck(name):
             GV.failedChecks.append(name)
 
 
-
 #-------------------------------------------------------------------------------
 def runAllChecks():
     '''
@@ -3675,25 +3667,13 @@ def runAllChecks():
     fixes = (len(GV.Remove) > 0 or
              len(GV.AdjustConname) > 0 or
              len(GV.DemoteConstraint) > 0 or
-             len(GV.ReSync) > 0 or
-             len(GV.Reindex) > 0 or
-             len(GV.Constraints) > 0 or
-             len(GV.Owners) > 0 or
-             len(GV.Policies) > 0)
+             len(GV.ReSync) > 0)
     if GV.opt['-g'] != None and fixes:
-        try:
-            if not os.path.exists(GV.opt['-g']):
-                os.mkdir(GV.opt['-g'])
-        except Exception, e:
-            logger.fatal('Unable to create directory "%s": %s' % (GV.opt['-g'], str(e)))
-            sys.exit(1)
-
+        repair_obj = Repair(context=GV)
+        repair_dir_path = repair_obj.create_repair_dir()
         logger.debug('Building catalog repair scripts')
         # build a script to run these files
         script = ''
-        # if repair script already exist, do not have to add extra script type to head
-        if not os.path.isfile(os.path.join(GV.opt['-g'], REPAIR_SCRIPT)):
-            script = '#!/bin/bash\ncd $(dirname $0)\n'
         # set allow_system_table_mods GUC for gpdb >= 4.2
         catmod_guc = ""
         if GV.version >= "4.2":
@@ -3717,43 +3697,55 @@ def runAllChecks():
             segment_repair_script = name_repair["segment"]["fn"](maybeRemove, catmod_guc, seg)
             script += segment_repair_script
 
-        c = GV.cfg[1]
-        for name in name_repair:
-            # skip checking on the segment repeatedly
-            if name in ['segment']:
-                continue
-            description, repair_filename = name_repair[name]["fn"]()
-            if repair_filename != None:
-                script += description
-                script += 'psql -X -a -h %s -p %i -f %s "%s" > %s.out 2>&1\n' % \
-                          (c['hostname'], c['port'], repair_filename, GV.dbname, repair_filename)
+        repair_obj.append_content_to_bash_script(repair_dir_path, script)
 
-        generate_repair_script(script)
+        print_repair_issues(repair_dir_path)
 
     if GV.retcode >= ERROR_NOREPAIR:
         logger.warn('[WARN]: unable to generate repairs for some issues')
     logger.info("Check complete")
 
 
-def generate_repair_script(script):
-    try:
-        path = '%s/%s' % (GV.opt['-g'], REPAIR_SCRIPT)
-        file = open(path, 'a')
-        file.write(script)
-        file.close()
-        os.chmod(path, stat.S_IXUSR | stat.S_IRUSR | stat.S_IWUSR)
-    except Exception, e:
-        logger.fatal('Could not write script: %s' % str(e))
-        sys.exit(1)
+def do_repair(sql_repair_contents, issue_type, description):
+    if len(sql_repair_contents) == 0:
+        return
 
+    repair_dir_path = ""
+    try:
+        repair_obj = Repair(context=GV, issue_type=issue_type, desc=description)
+        repair_dir_path = repair_obj.create_repair(sql_repair_contents=sql_repair_contents)
+    except Exception, ex:
+        logger.fatal(str(ex))
+
+    print_repair_issues(repair_dir_path)
+
+
+def do_repair_for_extra(catalog_issues):
+    if len(catalog_issues) == 0:
+        return
+
+    setError(ERROR_REMOVE)
+    repair_dir_path = ""
+    for (catalog_name, pk_name), issues in catalog_issues.iteritems():
+        try:
+            repair_obj = Repair(context=GV, issue_type="extra", desc="Removing extra entries")
+            repair_dir_path = repair_obj.create_repair_for_extra_missing(catalog_name=catalog_name, issues=issues, pk_name=pk_name)
+        except Exception, ex:
+            logger.fatal(str(ex))
+
+    print_repair_issues(repair_dir_path)
+
+
+def print_repair_issues(repair_dir_path):
     myprint('')
-    myprint('[INFO]: repair scripts generated: %s' % path)
+    myprint("catalog issue(s) found , repair script(s) generated in dir {0}".format(repair_dir_path))
+    myprint('')
 
 
 def checkReindexRepair():
     if len(GV.Reindex) > 0:
         # dbname.type.timestamp.sql
-        filename = '%s.%s.%s.sql' % (GV.dbname, "reindex", TIMESTAMP)
+        filename = '%s.%s.%s.sql' % (GV.dbname, "reindex", Repair.TIMESTAMP)
         fullpath = '%s/%s' % (GV.opt['-g'], filename)
         try:
             file = open(fullpath, 'w')
@@ -3769,76 +3761,23 @@ def checkReindexRepair():
     else:
         return None, None
 
-
 def checkConstraintsRepair():
-    if len(GV.Constraints) > 0:
-        # dbname.type.timestamp.sql
-        filename = '%s.%s.%s.sql' % (GV.dbname, "removeconstraints", TIMESTAMP)
-        fullpath = '%s/%s' % (GV.opt['-g'], filename)
-        try:
-            file = open(fullpath, 'w')
-        except Exception, e:
-            logger.fatal('Unable to create file "%s": %s' % (fullpath, str(e)))
-            sys.exit(1)
-
-        description = '\necho "Dropping invalid unique constraints"\n'
-        GV.Constraints = list(set(GV.Constraints))
-        for r in GV.Constraints:
-            file.write('%s\n' % r)
-        file.close()
-        return description, filename
-    else:
-        return None, None
-
+    do_repair(GV.Constraints, issue_type="removeconstraints", description='Dropping invalid unique constraints')
 
 def checkOwnersRepair():
-    if len(GV.Owners) > 0:
-        # Previously we removed duplicate statements from the "Owners" list
-        # by casting it through a "list(set(...))", however this does not work
-        # since the order of items in the list is important for correct results.
-
-        # dbname.type.timestamp.sql
-        filename = '%s.%s.%s.sql' % (GV.dbname, "fixowners", TIMESTAMP)
-        fullpath = '%s/%s' % (GV.opt['-g'], filename)
-        try:
-            file = open(fullpath, 'w')
-        except Exception, e:
-            logger.fatal('Unable to create file "%s": %s' % (fullpath, str(e)))
-            sys.exit(1)
-
-        description = '\necho "Correcting table ownership"\n'
-        for r in GV.Owners:
-            file.write('%s\n' % r)
-        file.close()
-        return description, filename
-    else:
-        return None, None
+    # Previously we removed duplicate statements from the "Owners" list
+    # by casting it through a "list(set(...))", however this does not work
+    # since the order of items in the list is important for correct results.
+    do_repair(GV.Owners, issue_type="fixowner", description='Correcting table ownership')
 
 def checkPoliciesRepair():
     # changes to distribution policies
-    if len(GV.Policies) > 0:
-        # dbname.type.timestamp.sql
-        filename = '%s.%s.%s.sql' % (GV.dbname, "fixdistribution", TIMESTAMP)
-        fullpath = '%s/%s' % (GV.opt['-g'], filename)
-        try:
-            file = open(fullpath, 'w')
-        except Exception, e:
-            logger.fatal('Unable to create file "%s": %s' % (fullpath, str(e)))
-            sys.exit(1)
-
-        description = '\necho "Fixing distribution policies"\n'
-        for r in GV.Policies:
-            file.write('%s\n' % r)
-        file.close()
-        return description, filename
-    else:
-        return None, None
-
+    do_repair(GV.Policies, issue_type="fixdistribution", description='Fixing distribution policies')
 
 def checkSegmentRepair(maybeRemove, catmod_guc, seg):
     # dbid.host.port.dbname.timestamp.sql
     c = GV.cfg[seg]
-    filename = '%i.%s.%i.%s.%s.sql' % (seg, c['hostname'], c['port'], GV.dbname, TIMESTAMP)
+    filename = '%i.%s.%i.%s.%s.sql' % (seg, c['hostname'], c['port'], GV.dbname, Repair.TIMESTAMP)
     filename = filename.replace(' ', '_')
     fullpath = '%s/%s' % (GV.opt['-g'], filename)
     try:
@@ -3849,9 +3788,9 @@ def checkSegmentRepair(maybeRemove, catmod_guc, seg):
 
     # unique
     lines = set()
-    if GV.Remove.has_key(seg):
+    if GV.Remove.has_key(seg):#foreign_key check
         lines = lines.union(GV.Remove[seg])
-    if GV.AdjustConname.has_key(seg):
+    if GV.AdjustConname.has_key(seg):#part_constraint
         lines = lines.union(GV.AdjustConname[seg])
     if GV.DemoteConstraint.has_key(seg):
         lines = lines.union(GV.DemoteConstraint[seg])
@@ -4196,6 +4135,17 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
         gpObj.addForeignKeyIssue(issue)
 
 
+def getPrimaryKeyColumn(catname, pknames):
+    # We have to look up key to report (pg_pltemplate)
+    gpObjName = catname
+    gpColName = None
+    if catname in TableMainColumn:
+        gpColName = TableMainColumn[catname][0]
+        gpObjName = TableMainColumn[catname][1]
+    elif 'oid' in pknames:
+        gpColName = 'oid'
+    return gpObjName, gpColName
+
 # -------------------------------------------------------------------------------
 def processACLResult(catname, colname, allValues):
     '''
@@ -4204,16 +4154,9 @@ def processACLResult(catname, colname, allValues):
     				1 | gptest | None | {=Tc/nmiller,nmiller=CTc/nmiller,person2=CTc/nmiller}
     '''
 
-    gpObjName = catname
-    gpColName = None
     pknames = [i for i in colname[1:-2]]
 
-    # We have to look up key to report (pg_pltemplate)
-    if catname in TableMainColumn:
-        gpColName = TableMainColumn[catname][0]
-        gpObjName = TableMainColumn[catname][1]
-    elif 'oid' in pknames:
-        gpColName = 'oid'
+    gpObjName, gpColName = getPrimaryKeyColumn(catname, pknames)
 
     # Process entries
     for row in allValues:
@@ -4825,7 +4768,7 @@ def generateVerifyFile(catname, fields, results, checkname):
           ) alltyprelids
           GROUP BY relname, oid ORDER BY count(*) desc
     '''.format(in_clause=in_clause)
-    filename = 'gpcheckcat.verify.%s.%s.%s.%s.sql' % (GV.dbname, catname, checkname, TIMESTAMP)
+    filename = 'gpcheckcat.verify.%s.%s.%s.%s.sql' % (GV.dbname, catname, checkname, Repair.TIMESTAMP)
     try:
         with open(filename, 'w') as fp:
             fp.write(verify_sql + '\n')

--- a/gpMgmt/bin/gpcheckcat_modules/repair.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+import os
+import stat
+from datetime import datetime
+from gpcheckcat_modules.repair_missing_extraneous import RepairMissingExtraneous
+
+
+class Repair:
+
+    TIMESTAMP = datetime.now().strftime("%Y%m%d%H%M%S")
+
+    def __init__(self, context=None, issue_type=None, desc=None):
+        self._context = context
+        self._issue_type = issue_type
+        self._desc = desc
+        self._repair_script = 'runsql_%s.sh' % self.TIMESTAMP
+
+    def create_repair(self, sql_repair_contents):
+        repair_dir = self.create_repair_dir()
+
+        sql_file_name = self.__create_sql_file_in_repair_dir(repair_dir, sql_repair_contents)
+
+        self.__create_bash_script_in_repair_dir(repair_dir, sql_file_name, segment_id=-1)
+
+        return repair_dir
+
+    def create_repair_for_extra_missing(self, catalog_name, issues, pk_name):
+
+        extra_missing_repair_obj = RepairMissingExtraneous(catalog_name=catalog_name,
+                                                           issues=issues, pk_name=pk_name)
+        repair_dir = self.create_repair_dir()
+        all_seg_ids = self._context.report_cfg.keys()
+        segment_to_oid_map = extra_missing_repair_obj.get_segment_to_oid_mapping(all_seg_ids)
+
+        for segment_id, oids in segment_to_oid_map.iteritems():
+            sql_content = extra_missing_repair_obj.get_delete_sql(oids)
+            self.__create_bash_script_in_repair_dir(repair_dir, sql_content,
+                                                    segment_id=segment_id, catalog_name=catalog_name)
+
+        return repair_dir
+
+    def create_repair_dir(self):
+        repair_dir = self._context.opt['-g']
+        if not os.path.exists(repair_dir):
+            os.mkdir(repair_dir)
+
+        return repair_dir
+
+    def append_content_to_bash_script(self, repair_dir_path, script, catalog_name=None):
+        bash_file_path = self.__get_bash_filepath(repair_dir_path, catalog_name)
+        if not os.path.isfile(bash_file_path):
+            script = '#!/bin/bash\ncd $(dirname $0)\n' + script
+
+        with open(bash_file_path, 'a') as bash_file:
+            bash_file.write(script)
+
+        os.chmod(bash_file_path, stat.S_IXUSR | stat.S_IRUSR | stat.S_IWUSR)
+
+    def __create_sql_file_in_repair_dir(self, repair_dir, sql_repair_contents):
+        sql_file_name = self.__get_sql_filename()
+        sql_file_path = os.path.join(repair_dir, sql_file_name)
+
+        with open(sql_file_path, 'w') as sql_file:
+            for content in sql_repair_contents:
+                sql_file.write(content + "\n")
+
+        return sql_file_name
+
+    def __create_bash_script_in_repair_dir(self, repair_dir, sql, segment_id, catalog_name=None):
+        if not sql:
+            return
+
+        bash_script_content = self.__get_bash_script_content(sql, segment_id)
+        self.append_content_to_bash_script(repair_dir, bash_script_content, catalog_name)
+
+    def __get_sql_filename(self):
+        return '%s_%s_%s.sql' % (self._context.dbname, self._issue_type, self.TIMESTAMP)
+
+    def __get_bash_filepath(self, repair_dir, catalog_name):
+        bash_file_name = self._repair_script
+
+        if self._issue_type and catalog_name:
+            bash_file_name = 'run_{0}_{1}_{2}_{3}.sh'.format(self._context.dbname, self._issue_type,
+                                                             catalog_name, self.TIMESTAMP)
+
+        return os.path.join(repair_dir, bash_file_name)
+
+    def __get_bash_script_content(self, filename, segment_id):
+        c = self._context.report_cfg[segment_id]
+        out_filename = "{0}_{1}_{2}".format(self._context.dbname, self._issue_type, self.TIMESTAMP)
+        bash_script_content = '\necho "{0}"\n'.format(self._desc)
+        bash_script_content += self.__get_psql_command(segment_id).format(hostname=c['hostname'],
+                                                                                      port=c['port'], sql=filename,
+                                                                                      dbname=self._context.dbname,
+                                                                                      filename=out_filename)
+        return bash_script_content
+
+    def __get_psql_command(self, segment_id):
+        """
+        cases to consider
+        self._issue_type : extra/missing vs everything else(policies, owner, constraint)
+        master vs segment
+        """
+        psql_cmd = ""
+
+        if segment_id > -1:  # segment node
+            psql_cmd += 'PGOPTIONS=\'-c gp_session_role=utility\' '
+
+        psql_cmd += 'psql -X -a -h {hostname} -p {port} '
+
+        if self._issue_type == 'extra' or self._issue_type == 'missing':
+            psql_cmd += '-c '
+        else:
+            psql_cmd += '-f '
+
+        psql_cmd += '"{sql}" "{dbname}" >> {filename}.out 2>&1\n'
+
+        return psql_cmd
+
+

--- a/gpMgmt/bin/gpcheckcat_modules/repair.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair.py
@@ -90,9 +90,9 @@ class Repair:
         out_filename = "{0}_{1}_{2}".format(self._context.dbname, self._issue_type, self.TIMESTAMP)
         bash_script_content = '\necho "{0}"\n'.format(self._desc)
         bash_script_content += self.__get_psql_command(segment_id).format(hostname=c['hostname'],
-                                                                                      port=c['port'], sql=filename,
-                                                                                      dbname=self._context.dbname,
-                                                                                      filename=out_filename)
+                                                                          port=c['port'], sql=filename,
+                                                                          dbname=self._context.dbname,
+                                                                          filename=out_filename)
         return bash_script_content
 
     def __get_psql_command(self, segment_id):

--- a/gpMgmt/bin/gpcheckcat_modules/repair.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair.py
@@ -1,4 +1,16 @@
 #!/usr/bin/env python
+"""
+Purpose : Creates the repair dir and the corresponding sql/bash scripts for
+          repairing some of the catalog issues(see the list below) reported by gpcheckcat.
+          Not responsible for generating the repair contents.
+
+Creates repair for the following gpcheckcat checks
+       * missing_extraneous
+       * owner
+       * part_integrity
+       * distribution_policy
+"""
+
 import os
 import stat
 from datetime import datetime

--- a/gpMgmt/bin/gpcheckcat_modules/repair_missing_extraneous.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair_missing_extraneous.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+from gppylib.operations.backup_utils import escapeDoubleQuoteInSQLString
+
+
+class RepairMissingExtraneous:
+
+    def __init__(self, catalog_name,  issues, pk_name):
+        self._catalog_name = catalog_name
+        self._issues = issues
+        if pk_name is None:
+            pk_name = 'oid'
+        self._pk_name = pk_name
+
+    def get_delete_sql(self, oids):
+        escaped_catalog_name = escapeDoubleQuoteInSQLString(self._catalog_name)
+        escaped_pk_name = escapeDoubleQuoteInSQLString(self._pk_name)
+
+        delete_sql = 'BEGIN;set allow_system_table_mods="dml";delete from {0} where {1} in ({2});COMMIT;'
+
+        return delete_sql.format(escaped_catalog_name, escaped_pk_name, ','.join(str(oid) for oid in oids))
+
+    def get_segment_to_oid_mapping(self, all_seg_ids):
+        if not self._issues:
+            return
+
+        #   issues look like this
+        #   [(49401, "extra", '{1,2}'),
+        #    (49401, "extra", '{1,2}')]
+        #               OR
+        #   [(49401, 'cmax', "extra", '{1,2}'),
+        #    (49401, 'cmax', "extra", '{1,2}')]
+
+        all_seg_ids = set([str(seg_id) for seg_id in all_seg_ids])
+        oids_to_segment_mapping = {}
+        for issue in self._issues:
+
+            oid = issue[0]
+
+            issue_type = issue[-2]
+            seg_ids = issue[-1].strip('{}').split(',')
+
+            # if an oid is missing from a segment(s) , then it is considered to be extra
+            # on all the other segments/master
+            if issue_type == "missing":
+                seg_ids = all_seg_ids - set(seg_ids)
+
+            for seg_id in seg_ids:
+                seg_id = int(seg_id)
+
+                if not oids_to_segment_mapping.has_key(seg_id):
+                    oids_to_segment_mapping[seg_id] = set()
+
+                oids_to_segment_mapping[seg_id].add(oid)
+
+        return oids_to_segment_mapping
+

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_aoco_table.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_aoco_table.sql
@@ -1,0 +1,15 @@
+drop table if exists aoco;
+
+CREATE TABLE aoco (col1 int) WITH (appendonly=true) distributed randomly;
+
+insert into aoco values(1);
+insert into aoco values(2);
+insert into aoco values(3);
+insert into aoco values(4);
+insert into aoco values(5);
+insert into aoco values(6);
+insert into aoco values(7);
+insert into aoco values(8);
+insert into aoco values(9);
+insert into aoco values(10);
+insert into aoco values(11);

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_inconsistent_gpfastsequence.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_inconsistent_gpfastsequence.sql
@@ -1,0 +1,3 @@
+set allow_system_table_mods='dml';
+set allow_segment_dml=true;
+delete from pg_class where oid in (select objid from gp_fastsequence);

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_inconsistent_policy.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_inconsistent_policy.sql
@@ -1,0 +1,16 @@
+set allow_system_table_mods='dml';
+CREATE TABLE sales (trans_id int, date date, amount 
+decimal(9,2), region text) 
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'), 
+  SUBPARTITION asia VALUES ('asia'), 
+  SUBPARTITION europe VALUES ('europe'), 
+  DEFAULT SUBPARTITION other_regions)
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2012-01-01') EXCLUSIVE
+   EVERY (INTERVAL '1 month'), 
+   DEFAULT PARTITION outlying_dates );
+update gp_distribution_policy set attrnums = '{2}' where localoid in (select localoid from gp_distribution_policy order by random() limit 3);

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_invalid_constraint.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_invalid_constraint.sql
@@ -1,0 +1,3 @@
+set allow_system_table_mods='dml';
+create table foo(i int primary key);
+update gp_distribution_policy  set attrnums=NULL where localoid='foo'::regclass::oid;

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
@@ -1,0 +1,107 @@
+from mock import *
+import os
+from gp_unittest import *
+from gpcheckcat_modules.repair import Repair
+import tempfile
+import shutil
+
+class RepairTestCase(GpTestCase):
+    def setUp(self):
+        self.repair_dir_path = tempfile.mkdtemp()
+
+        self.context = Mock()
+        self.context.opt = dict()
+        self.context.opt["-g"] = self.repair_dir_path
+        self.context.report_cfg = {0: {'segname': 'seg1', 'hostname': 'somehost', 'port': 25432},
+                                   1: {'segname': 'seg2', 'hostname': 'somehost', 'port': 25433},
+                                   2: {'segname': 'seg3', 'hostname': 'somehost', 'port': 25434},
+                                   -1: {'segname': 'master', 'hostname': 'somehost', 'port': 15432}}
+        self.context.dbname = "somedb"
+
+        self.subject = Repair(self.context, "issuetype", "some desc")
+        self.subject.TIMESTAMP = "timestamp"
+        self.subject._repair_script = "runsql_timestamp.sh"
+        self.repair_sql_contents = ["some sql1", "some sql2"]
+        extra_missing_repair_obj = Mock(spec=['get_segment_to_oid_mapping', 'get_delete_sql'])
+        extra_missing_repair_obj.get_segment_to_oid_mapping.return_value = {
+            -1: set([49401, 49402]),
+             0: set([49403]),
+             1: set([49403, 49404])
+        }
+
+        extra_missing_repair_obj.get_delete_sql.return_value = "delete_sql"
+        self.apply_patches([
+            patch("gpcheckcat_modules.repair.RepairMissingExtraneous", return_value=extra_missing_repair_obj)
+        ])
+
+    def test_create_repair__normal(self):
+        repair_dir = self.subject.create_repair(self.repair_sql_contents)
+        self.assertEqual(repair_dir, self.repair_dir_path)
+        sql_contents = ["some sql1\n",
+                        "some sql2\n"]
+
+        bash_contents = ['#!/bin/bash\n',
+                         'cd $(dirname $0)\n',
+                         '\n',
+                         'echo "some desc"\n',
+                         'psql -X -a -h somehost -p 15432 -f "somedb_issuetype_timestamp.sql" '
+                         '"somedb" >> somedb_issuetype_timestamp.out 2>&1\n']
+
+        self.verify_repair_dir_contents(os.path.join(repair_dir, "somedb_issuetype_timestamp.sql"), sql_contents)
+        self.verify_repair_dir_contents(os.path.join(repair_dir, "runsql_timestamp.sh"), bash_contents)
+
+    def test_create_repair_extra__normal(self):
+        self.subject = Repair(self.context, "extra", "some desc")
+        self.subject.TIMESTAMP = "timestamp"
+        catalog_table_name = "catalog"
+        repair_dir = self.subject.create_repair_for_extra_missing(catalog_table_name, issues=None, pk_name=None)
+        self.assertEqual(repair_dir, self.repair_dir_path)
+        bash_contents =[
+                    "#!/bin/bash\n",
+                    "cd $(dirname $0)\n",
+                    "\n",
+                    "echo \"some desc\"\n",
+                    "PGOPTIONS='-c gp_session_role=utility' psql -X -a -h somehost -p 25432 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n",
+                    "\n",
+                    "echo \"some desc\"\n",
+                    "PGOPTIONS='-c gp_session_role=utility' psql -X -a -h somehost -p 25433 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n",
+                    "\n",
+                    "echo \"some desc\"\n",
+                    "psql -X -a -h somehost -p 15432 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n"]
+
+        self.verify_repair_dir_contents(os.path.join(repair_dir, "run_somedb_extra_{0}_timestamp.sh".
+                                                         format(catalog_table_name)), bash_contents)
+
+    def test_append_content_to_bash_script__with_catalog_table(self):
+        catalog_table_name = "catalog"
+        script = "some script here"
+        self.subject.append_content_to_bash_script(self.repair_dir_path, script, catalog_table_name)
+        bash_contents =[
+            "#!/bin/bash\n",
+            "cd $(dirname $0)\n",
+            "some script here"]
+
+        self.verify_repair_dir_contents(os.path.join(self.repair_dir_path, "run_somedb_issuetype_catalog_timestamp.sh".
+                                                     format(catalog_table_name)), bash_contents)
+
+    def test_append_content_to_bash_script__without_catalog_table(self):
+        script = "some script here"
+        self.subject.append_content_to_bash_script(self.repair_dir_path, script)
+        bash_contents =[
+            "#!/bin/bash\n",
+            "cd $(dirname $0)\n",
+            "some script here"]
+
+        self.verify_repair_dir_contents(os.path.join(self.repair_dir_path, "runsql_timestamp.sh"), bash_contents)
+
+    def verify_repair_dir_contents(self, file_path, contents):
+        with open(file_path) as f:
+            file_contents = f.readlines()
+
+        self.assertEqual(file_contents, contents)
+
+    def tearDown(self):
+        shutil.rmtree(self.repair_dir_path)
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair_missing_extraneous.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair_missing_extraneous.py
@@ -1,0 +1,74 @@
+from mock import *
+from gp_unittest import *
+from gpcheckcat_modules.repair_missing_extraneous import RepairMissingExtraneous
+
+class RepairMissingExtraneousTestCase(GpTestCase):
+    def setUp(self):
+        self.all_seg_ids = [-1,0,1,2,3]
+
+        self.table_name = 'pg_attribut"e'
+
+    def test_get_segment_to_oid_mapping_with_both_extra_and_missing(self):
+        issues = [(49401, "extra", '{1,2}'),
+                  (49401, "extra", '{1,2}'),
+                  (49402, "missing", '{2,3}'),
+                  (49403, "extra", '{2,3}'),
+                  (49404, "missing", '{1}'),
+                  (49405, "extra", '{2,3}'),
+                  (49406, "missing", '{2}')]
+
+        self.subject = RepairMissingExtraneous(self.table_name, issues, "attrelid")
+        repair_sql_contents = self.subject.get_segment_to_oid_mapping(self.all_seg_ids)
+
+        self.assertEqual(len(repair_sql_contents), 5)
+        self.assertEqual(repair_sql_contents[-1], set([49402, 49404, 49406]))
+        self.assertEqual(repair_sql_contents[0], set([49402, 49404, 49406]))
+        self.assertEqual(repair_sql_contents[1], set([49401, 49402,  49406]))
+        self.assertEqual(repair_sql_contents[2], set([49401, 49403, 49404, 49405]))
+        self.assertEqual(repair_sql_contents[3], set([49403, 49404, 49405, 49406]))
+
+    def test_get_segment_to_oid_mappin_with_only_extra(self):
+        issues = [(49401, 'cmax', "extra", '{1,2}'),
+                  (49401, 'cmax', "extra", '{1,2}'),
+                  (49403, 'cmax', "extra", '{2,3}'),
+                  (49405, 'cmax', "extra", '{2,3}')]
+
+        self.subject = RepairMissingExtraneous(self.table_name, issues, "attrelid")
+        repair_sql_contents = self.subject.get_segment_to_oid_mapping(self.all_seg_ids)
+
+        self.assertEqual(len(repair_sql_contents), 3)
+        self.assertEqual(repair_sql_contents[1], set([49401]))
+        self.assertEqual(repair_sql_contents[2], set([49401, 49403, 49405]))
+        self.assertEqual(repair_sql_contents[3], set([49403, 49405]))
+
+    def test_get_segment_to_oid_mappin_with_only_missing(self):
+        issues = [(49401, 'cmax', "missing", '{1,2}'),
+                  (49401, 'cmax', "missing", '{1,2}'),
+                  (49403, 'cmax', "missing", '{2,3}'),
+                  (49405, 'cmax', "missing", '{2,3}')]
+
+        self.subject = RepairMissingExtraneous(self.table_name, issues, "attrelid")
+        repair_sql_contents = self.subject.get_segment_to_oid_mapping(self.all_seg_ids)
+
+        self.assertEqual(len(repair_sql_contents), 4)
+        self.assertEqual(repair_sql_contents[-1], set([49401, 49403, 49405]))
+        self.assertEqual(repair_sql_contents[0], set([49401, 49403, 49405]))
+        self.assertEqual(repair_sql_contents[1], set([49403, 49405]))
+        self.assertEqual(repair_sql_contents[3], set([49401]))
+
+    def test_get_delelte_sql__with_multiple_oids(self):
+        self.subject = RepairMissingExtraneous(self.table_name, None, "attrelid")
+        oids = [1,3,4]
+        delete_sql = self.subject.get_delete_sql(oids)
+        self.assertEqual(delete_sql, 'BEGIN;set allow_system_table_mods="dml";'
+                                      'delete from "pg_attribut""e" where "attrelid" in (1,3,4);COMMIT;')
+
+    def test_get_delelte_sql__with_one_oid(self):
+        self.subject = RepairMissingExtraneous(self.table_name, None, "attrelid")
+        oids = [5]
+        delete_sql = self.subject.get_delete_sql(oids)
+        self.assertEqual(delete_sql, 'BEGIN;set allow_system_table_mods="dml";'
+                                     'delete from "pg_attribut""e" where "attrelid" in (5);COMMIT;')
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION

1. Moved all the generic repair code to its own module.
2. New module for missing_extraneous repair.
3. Make gpcheckcat do repairs per check instead of doing it after all
the checks have finished
4. Fix gpcheckcat so that it now creates a repair dir with -R option.
5. Unit and behave tests for the above mentioned modules.
6. Update gpcheckcat behave to use consistent db names
7. Behave tests for a few other checks like foreign_key, constraint_db,
part_integrity and also for the -g option
