### PR TITLE
Disable foreign key constraints from after row triggers.

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -1727,7 +1727,9 @@ ExecARInsertTriggers(EState *estate, ResultRelInfo *relinfo,
 {
 	TriggerDesc *trigdesc = relinfo->ri_TrigDesc;
 
-	if (trigdesc && trigdesc->n_after_row[TRIGGER_EVENT_INSERT] > 0)
+	if (trigdesc &&
+		trigdesc->n_after_row[TRIGGER_EVENT_INSERT] > 0 &&
+		RI_FKey_trigger_type(trigdesc->triggers->tgfoid) == RI_TRIGGER_NONE)
 	{
 		if(RelationIsAoCols(relinfo->ri_RelationDesc))
 			elog(ERROR, "Trigger is not supported on AOCS yet");
@@ -1874,7 +1876,9 @@ ExecARDeleteTriggers(EState *estate, ResultRelInfo *relinfo,
 {
 	TriggerDesc *trigdesc = relinfo->ri_TrigDesc;
 
-	if (trigdesc && trigdesc->n_after_row[TRIGGER_EVENT_DELETE] > 0)
+	if (trigdesc &&
+		trigdesc->n_after_row[TRIGGER_EVENT_DELETE] > 0 &&
+		RI_FKey_trigger_type(trigdesc->triggers->tgfoid) == RI_TRIGGER_NONE)
 	{
 		HeapTuple	trigtuple = GetTupleForTrigger(estate, relinfo,
 												   tupleid, NULL);
@@ -2057,7 +2061,9 @@ ExecARUpdateTriggers(EState *estate, ResultRelInfo *relinfo,
 {
 	TriggerDesc *trigdesc = relinfo->ri_TrigDesc;
 
-	if (trigdesc && trigdesc->n_after_row[TRIGGER_EVENT_UPDATE] > 0)
+	if (trigdesc &&
+		trigdesc->n_after_row[TRIGGER_EVENT_UPDATE] > 0 &&
+		RI_FKey_trigger_type(trigdesc->triggers->tgfoid) == RI_TRIGGER_NONE)
 	{
 		HeapTuple	trigtuple = GetTupleForTrigger(estate, relinfo,
 												   tupleid, NULL);

--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -258,3 +258,28 @@ SELECT '' AS five, * FROM UNIQUE_TBL;
 
 DROP TABLE UNIQUE_TBL;
 
+--
+-- Test foreign key constraints
+--
+CREATE TABLE fkc_table1(a text, b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
+CREATE TABLE fkc_table2(a text, b text) DISTRIBUTED BY (a);
+
+ALTER TABLE fkc_table2 ADD CONSTRAINT fkc_table2_pkey PRIMARY KEY (a);
+ALTER TABLE fkc_table1 ADD CONSTRAINT fkc_table1_fkey FOREIGN KEY (a) REFERENCES fkc_table2 (a) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+INSERT INTO fkc_table2 VALUES ('foobar', 'barbar');
+INSERT INTO fkc_table1 VALUES ('foobar', 'barbar');
+UPDATE fkc_table1 SET b = 'asdf';
+
+CREATE TABLE fkc_table3(a text, b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (b);
+CREATE TABLE fkc_table4(a text, b text) DISTRIBUTED BY (b);
+
+ALTER TABLE fkc_table4 ADD CONSTRAINT fkc_table2_pkey PRIMARY KEY (a);
+ALTER TABLE fkc_table3 ADD CONSTRAINT fkc_table1_fkey FOREIGN KEY (a) REFERENCES fkc_table2 (a) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO fkc_table4 VALUES ('foobar', 'barbar');
+INSERT INTO fkc_table3 VALUES ('foobar', 'barbar');
+UPDATE fkc_table4 SET a = 'bar';
+INSERT INTO fkc_table3 VALUES ('asdf', 'fdsa');
+INSERT INTO fkc_table4 VALUES ('asdf', 'fdsa');
+DELETE FROM fkc_table4 WHERE a = 'asdf';

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -365,3 +365,27 @@ SELECT '' AS five, * FROM UNIQUE_TBL;
 (5 rows)
 
 DROP TABLE UNIQUE_TBL;
+--
+-- Test foreign key constraints
+--
+CREATE TABLE fkc_table1(a text, b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
+CREATE TABLE fkc_table2(a text, b text) DISTRIBUTED BY (a);
+ALTER TABLE fkc_table2 ADD CONSTRAINT fkc_table2_pkey PRIMARY KEY (a);
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "fkc_table2_pkey" for table "fkc_table2"
+ALTER TABLE fkc_table1 ADD CONSTRAINT fkc_table1_fkey FOREIGN KEY (a) REFERENCES fkc_table2 (a) ON DELETE NO ACTION ON UPDATE NO ACTION;
+INSERT INTO fkc_table2 VALUES ('foobar', 'barbar');
+INSERT INTO fkc_table1 VALUES ('foobar', 'barbar');
+UPDATE fkc_table1 SET b = 'asdf';
+CREATE TABLE fkc_table3(a text, b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (b);
+CREATE TABLE fkc_table4(a text, b text) DISTRIBUTED BY (b);
+ALTER TABLE fkc_table4 ADD CONSTRAINT fkc_table2_pkey PRIMARY KEY (a);
+NOTICE:  updating distribution policy to match new primary key
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "fkc_table4_pkey" for table "fkc_table4"
+ALTER TABLE fkc_table3 ADD CONSTRAINT fkc_table1_fkey FOREIGN KEY (a) REFERENCES fkc_table2 (a) ON DELETE RESTRICT ON UPDATE RESTRICT;
+INSERT INTO fkc_table4 VALUES ('foobar', 'barbar');
+INSERT INTO fkc_table3 VALUES ('foobar', 'barbar');
+UPDATE fkc_table4 SET a = 'bar';
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+INSERT INTO fkc_table3 VALUES ('asdf', 'fdsa');
+INSERT INTO fkc_table4 VALUES ('asdf', 'fdsa');
+DELETE FROM fkc_table4 WHERE a = 'asdf';

--- a/src/test/regress/output/constraints_optimizer.source
+++ b/src/test/regress/output/constraints_optimizer.source
@@ -397,3 +397,26 @@ SELECT '' AS five, * FROM UNIQUE_TBL;
 (5 rows)
 
 DROP TABLE UNIQUE_TBL;
+--
+-- Test foreign key constraints
+--
+CREATE TABLE fkc_table1(a text, b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
+CREATE TABLE fkc_table2(a text, b text) DISTRIBUTED BY (a);
+ALTER TABLE fkc_table2 ADD CONSTRAINT fkc_table2_pkey PRIMARY KEY (a);
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "fkc_table2_pkey" for table "fkc_table2"
+ALTER TABLE fkc_table1 ADD CONSTRAINT fkc_table1_fkey FOREIGN KEY (a) REFERENCES fkc_table2 (a) ON DELETE NO ACTION ON UPDATE NO ACTION;
+INSERT INTO fkc_table2 VALUES ('foobar', 'barbar');
+INSERT INTO fkc_table1 VALUES ('foobar', 'barbar');
+UPDATE fkc_table1 SET b = 'asdf';
+CREATE TABLE fkc_table3(a text, b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (b);
+CREATE TABLE fkc_table4(a text, b text) DISTRIBUTED BY (b);
+ALTER TABLE fkc_table4 ADD CONSTRAINT fkc_table2_pkey PRIMARY KEY (a);
+NOTICE:  updating distribution policy to match new primary key
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "fkc_table4_pkey" for table "fkc_table4"
+ALTER TABLE fkc_table3 ADD CONSTRAINT fkc_table1_fkey FOREIGN KEY (a) REFERENCES fkc_table2 (a) ON DELETE RESTRICT ON UPDATE RESTRICT;
+INSERT INTO fkc_table4 VALUES ('foobar', 'barbar');
+INSERT INTO fkc_table3 VALUES ('foobar', 'barbar');
+UPDATE fkc_table4 SET a = 'bar';
+INSERT INTO fkc_table3 VALUES ('asdf', 'fdsa');
+INSERT INTO fkc_table4 VALUES ('asdf', 'fdsa');
+DELETE FROM fkc_table4 WHERE a = 'asdf';

--- a/src/test/regress/output/misc.source
+++ b/src/test/regress/output/misc.source
@@ -549,6 +549,10 @@ SELECT user_relns() AS user_relns
  equipment_r
  f_star
  fast_emp4000
+ fkc_table1
+ fkc_table2
+ fkc_table3
+ fkc_table4
  float4_tbl
  float8_tbl
  floats
@@ -651,7 +655,7 @@ SELECT user_relns() AS user_relns
  toyemp
  usr_define_type
  varchar_tbl
-(147 rows)
+(151 rows)
 
 SELECT name(equipment(hobby_construct(text 'skywalking', text 'mer')));
  name 


### PR DESCRIPTION
Greenplum does not support foreign keys but users can still declare them and
store the constraints in the catalog. It was found that foreign key constraints
were being called in after row triggers at the end of ExecInsert, ExecDelete,
and ExecUpdate. ExecDelete's call to ExecARDeleteTriggers and ExecUpdate's call
to ExecARUpdateTriggers would result in a faulty tuple lookup and an ERROR. The
expected result is a noop trigger after the DML. Actually, we don't really
support triggers much either...