### PR TITLE
Drop tables and roles after the test [#122775301]

### DIFF
--- a/src/test/regress/expected/role.out
+++ b/src/test/regress/expected/role.out
@@ -84,12 +84,6 @@ NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- OpenSSL SHA2 returning a different SHA2 to RSA BSAFE!
 --select rolname, rolpassword from pg_authid where rolname = 'sha256';
 drop role sha256;
-drop view if exists t1_view;
-NOTICE:  view "t1_view" does not exist, skipping
-drop table if exists t1;
-NOTICE:  table "t1" does not exist, skipping
-drop role if exists u1;
-drop role if exists superuser;
 create role superuser;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 create role u1;
@@ -105,3 +99,8 @@ revoke all privileges on TABLE t1, t1_view FROM u1;
 set role u1;
 select * from t1_view order by 1;
 ERROR:  permission denied for relation t1_view
+reset role;
+drop view t1_view;
+drop table t1;
+drop role u1;
+drop role superuser;

--- a/src/test/regress/sql/role.sql
+++ b/src/test/regress/sql/role.sql
@@ -58,12 +58,6 @@ create role sha256 password 'abc';
 --select rolname, rolpassword from pg_authid where rolname = 'sha256';
 drop role sha256;
 
-drop view if exists t1_view;
-drop table if exists t1;
-
-drop role if exists u1;
-drop role if exists superuser;
-
 create role superuser;
 create role u1;
 set role superuser;
@@ -75,3 +69,8 @@ set role superuser;
 revoke all privileges on TABLE t1, t1_view FROM u1;
 set role u1;
 select * from t1_view order by 1;
+reset role;
+drop view t1_view;
+drop table t1;
+drop role u1;
+drop role superuser;


### PR DESCRIPTION
In https://github.com/greenplum-db/gpdb/commit/93b0e47ac05dbdaa373bdc6cb4b798c34ce3da39 I added a test suite that tests the role. This affects other install check good tests. In this fix, I am cleaning the roles and objects added in that test suites before exiting. 