### PR TITLE
s3ext: fix a regression bug of decompress reader

### DIFF
--- a/gpAux/extensions/gps3ext/include/decompress_reader.h
+++ b/gpAux/extensions/gps3ext/include/decompress_reader.h
@@ -29,13 +29,17 @@ class DecompressReader : public Reader {
    private:
     void decompress();
 
+    uint64_t getDecompressedBytesNum() {
+        return S3_ZIP_CHUNKSIZE - this->zstream.avail_out;
+    }
+
     Reader *reader;
 
     // zlib related variables.
     z_stream zstream;
-    char *in;       // Input buffer for decompression.
-    char *out;      // Output buffer for decompression.
-    int outOffset;  // Next position to read in out buffer.
+    char *in;            // Input buffer for decompression.
+    char *out;           // Output buffer for decompression.
+    uint64_t outOffset;  // Next position to read in out buffer.
 };
 
 #endif /* INCLUDE_DECOMPRESS_READER_H_ */

--- a/gpAux/extensions/gps3ext/include/reader.h
+++ b/gpAux/extensions/gps3ext/include/reader.h
@@ -12,7 +12,8 @@ class Reader {
 
     // read() attempts to read up to count bytes into the buffer starting at
     // buffer.
-    // Return 0 if EOF. Throw exception if encounters errors.
+    // Always return 0 if EOF, no matter how many times it's invoked. Throw exception if encounters
+    // errors.
     virtual uint64_t read(char *buf, uint64_t count) = 0;
 
     // This should be reentrant, has no side effects when called multiple times.

--- a/gpAux/extensions/gps3ext/include/s3common_reader.h
+++ b/gpAux/extensions/gps3ext/include/s3common_reader.h
@@ -6,8 +6,11 @@
 
 class S3CommonReader : public Reader {
    public:
-    S3CommonReader();
-    virtual ~S3CommonReader();
+    S3CommonReader() {
+    }
+
+    virtual ~S3CommonReader() {
+    }
 
     virtual void open(const ReaderParams& params);
 

--- a/gpAux/extensions/gps3ext/src/decompress_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/decompress_reader.cpp
@@ -1,10 +1,11 @@
 #include <algorithm>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <string.h>
 
 #include "decompress_reader.h"
 #include "s3log.h"
 #include "s3macros.h"
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
 
 unsigned int S3_ZIP_CHUNKSIZE = 1024 * 1024 * 2;
 
@@ -44,6 +45,7 @@ void DecompressReader::open(const ReaderParams &params) {
 
     zstream.avail_in = 0;
     zstream.avail_out = S3_ZIP_CHUNKSIZE;
+
     this->outOffset = 0;
 
     // 47 is the number of windows bits, to make sure zlib could recognize and decode gzip stream.
@@ -54,44 +56,23 @@ void DecompressReader::open(const ReaderParams &params) {
 }
 
 uint64_t DecompressReader::read(char *buf, uint64_t bufSize) {
-    uint64_t ret = 0;
-    uint64_t remainingBufLen = bufSize;
-    uint64_t remainingOutLen = S3_ZIP_CHUNKSIZE - this->zstream.avail_out - this->outOffset;
-    bool readFinished = false;
+    uint64_t remainingOutLen = this->getDecompressedBytesNum() - this->outOffset;
 
-    do {
-        // S3DEBUG("has = %" PRIu64 ", offset = %d, chunksize = %u, avail_out = %u, count = %"
-        // PRIu64,
-        //     remainingOutLen, outOffset, S3_ZIP_CHUNKSIZE, this->zstream.avail_out, bufSize);
+    // S3DEBUG("has = %" PRIu64 ", offset = %d, chunksize = %u, avail_out = %u, count = %"
+    // PRIu64,
+    //     remainingOutLen, outOffset, S3_ZIP_CHUNKSIZE, this->zstream.avail_out, bufSize);
+    if (remainingOutLen == 0) {
+        this->decompress();
+        this->outOffset = 0;  // reset cursor for out buffer to read from beginning.
+        remainingOutLen = this->getDecompressedBytesNum();
+    }
 
-        if (this->outOffset < (S3_ZIP_CHUNKSIZE - this->zstream.avail_out)) {
-            // Read remaining data in out buffer decompressed last time.
-        } else {
-            this->decompress();
-            this->outOffset = 0;  // reset cursor for out buffer to read from beginning.
-            remainingOutLen = S3_ZIP_CHUNKSIZE - this->zstream.avail_out;
-        }
+    uint64_t count = std::min(remainingOutLen, bufSize);
+    memcpy(buf, this->out + outOffset, count);
 
-        int count = std::min(remainingOutLen, remainingBufLen);
-        memcpy(buf + ret, this->out + outOffset, count);
-        this->outOffset += count;
-        remainingBufLen -= count;
-        ret += count;
+    this->outOffset += count;
 
-        // When to break?
-        //  1) Decompress is done, no more data in 'in' buf. Or
-        //  2) We have no enough free-space in 'buf' to hold next entire 'out' buf.
-        //      maybe next decompressed size < S3_ZIP_CHUNKSIZE, but we have no chance
-        //      to predict it, so use the max value 'S3_ZIP_CHUNKSIZE' instead.
-        //      We can improve it in future by optimizing this conditions.
-        if ((this->zstream.avail_in == 0 && this->zstream.avail_out == S3_ZIP_CHUNKSIZE) ||
-            remainingBufLen < S3_ZIP_CHUNKSIZE) {
-            readFinished = true;
-        }
-
-    } while (!readFinished);
-
-    return ret;
+    return count;
 }
 
 // Read compressed data from underlying reader and decompress to this->out buffer.
@@ -103,12 +84,26 @@ void DecompressReader::decompress() {
 
         // reader S3_ZIP_CHUNKSIZE data from underlying reader and put into this->in buffer.
         uint64_t hasRead = this->reader->read(this->in, S3_ZIP_CHUNKSIZE);
+
+        // EOF, no more data to decompress.
         if (hasRead == 0) {
             S3DEBUG(
                 "No more data to decompress: avail_in = %u, avail_out = %u, total_in = %u, "
                 "total_out = %u",
                 zstream.avail_in, zstream.avail_out, zstream.total_in, zstream.total_out);
-            return;  // EOF
+            return;
+        }
+
+        // Fill this->in as possible as it could, otherwise data in this->in might not be able to be
+        // inflated.
+        while (hasRead < S3_ZIP_CHUNKSIZE) {
+            uint64_t count = this->reader->read(this->in + hasRead, S3_ZIP_CHUNKSIZE - hasRead);
+
+            if (count == 0) {
+                break;
+            }
+
+            hasRead += count;
         }
 
         this->zstream.next_in = (Byte *)this->in;
@@ -124,10 +119,10 @@ void DecompressReader::decompress() {
 
     int status = inflate(&this->zstream, Z_NO_FLUSH);
     if (status == Z_STREAM_END) {
-        S3DEBUG("compression finished: Z_STREAM_END.");
+        S3DEBUG("Compression finished: Z_STREAM_END.");
     } else if (status < 0 || status == Z_NEED_DICT) {
         inflateEnd(&this->zstream);
-        CHECK_OR_DIE_MSG(false, "failed to decompress data: %d", status);
+        CHECK_OR_DIE_MSG(false, "Failed to decompress data: %d", status);
     }
 
     // S3DEBUG("After decompress: avail_in = %u, avail_out = %u, total_in = %u, total_out = %u",

--- a/gpAux/extensions/gps3ext/src/decompress_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/decompress_reader.cpp
@@ -83,6 +83,8 @@ void DecompressReader::decompress() {
         this->zstream.next_out = (Byte *)this->out;
 
         // reader S3_ZIP_CHUNKSIZE data from underlying reader and put into this->in buffer.
+        // read() might happen more than one time when it's EOF, make sure every time read() will
+        // return 0.
         uint64_t hasRead = this->reader->read(this->in, S3_ZIP_CHUNKSIZE);
 
         // EOF, no more data to decompress.

--- a/gpAux/extensions/gps3ext/src/s3common_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3common_reader.cpp
@@ -1,12 +1,6 @@
 #include "s3common_reader.h"
 #include "s3macros.h"
 
-S3CommonReader::S3CommonReader() {
-}
-
-S3CommonReader::~S3CommonReader() {
-}
-
 void S3CommonReader::open(const ReaderParams &params) {
     this->keyReader.setS3interface(s3service);
     S3CompressionType compressionType =

--- a/gpAux/extensions/gps3ext/src/s3key_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3key_reader.cpp
@@ -1,5 +1,6 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+#include <string.h>
 
 #include "s3common.h"
 #include "s3interface.h"

--- a/gpAux/extensions/gps3ext/test/decompress_reader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/decompress_reader_test.cpp
@@ -114,15 +114,20 @@ TEST_F(DecompressReaderTest, AbleToDecompressSmallCompressedData) {
 }
 
 TEST_F(DecompressReaderTest, AbleToDecompressFragmentalCompressedData) {
+    // Fragmental data might not be decompressed, this case makes sure following data will be read
+    // to compose a decompressable unit.
+
     // compressed data to decompress
     const char hello[] = "The quick brown fox jumps over the lazy dog";
     setBufReaderByRawData(hello, sizeof(hello));
 
+    // set chunk size large enough to bypass gzip header.
     this->bufReader.setChunkSize(10);
 
     char buf[100];
     uint64_t offset = decompressReader.read(buf, sizeof(buf));
 
+    // set chunk size to 1 byte, which could not be decompressed by itself.
     this->bufReader.setChunkSize(1);
     while (offset < sizeof(hello)) {
         uint64_t count = decompressReader.read(buf + offset, sizeof(buf));
@@ -262,6 +267,7 @@ TEST_F(DecompressReaderTest, AbleToDecompressWithLargeReadBufferWithDecompressab
     char outputBuffer[30] = {0};
     int outOffset = 0;
 
+    // read and compose all chunks.
     while (outOffset < sizeof(hello)) {
         uint64_t count =
             decompressReader.read(outputBuffer + outOffset, sizeof(outputBuffer) - outOffset);

--- a/gpAux/extensions/gps3ext/test/decompress_reader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/decompress_reader_test.cpp
@@ -9,6 +9,7 @@ class MockBufferReader : public Reader {
    public:
     MockBufferReader() {
         this->offset = 0;
+        this->chunkSize = 0;
     }
 
     void open(const ReaderParams &params) {
@@ -30,7 +31,7 @@ class MockBufferReader : public Reader {
         }
 
         uint64_t size = (remaining > count) ? count : remaining;
-
+        size = size < this->chunkSize ? size : this->chunkSize;
         for (int i = 0; i < size; i++) {
             buf[i] = this->data[offset + i];
         }
@@ -44,9 +45,14 @@ class MockBufferReader : public Reader {
         this->offset = 0;
     }
 
+    void setChunkSize(uint64_t size) {
+        this->chunkSize = size;
+    }
+
    private:
     std::vector<uint8_t> data;
     uint64_t offset;
+    uint64_t chunkSize;
 };
 
 class DecompressReaderTest : public testing::Test {
@@ -54,6 +60,7 @@ class DecompressReaderTest : public testing::Test {
     // Remember that SetUp() is run immediately before a test starts.
     virtual void SetUp() {
         // need to setup upstreamReader before open.
+        this->bufReader.setChunkSize(1024 * 1024 * 64);
         decompressReader.setReader(&bufReader);
         decompressReader.open(params);
     }
@@ -106,6 +113,30 @@ TEST_F(DecompressReaderTest, AbleToDecompressSmallCompressedData) {
     EXPECT_EQ(0, strncmp(hello, buf, count));
 }
 
+TEST_F(DecompressReaderTest, AbleToDecompressFragmentalCompressedData) {
+    // compressed data to decompress
+    const char hello[] = "The quick brown fox jumps over the lazy dog";
+    setBufReaderByRawData(hello, sizeof(hello));
+
+    this->bufReader.setChunkSize(10);
+
+    char buf[100];
+    uint64_t offset = decompressReader.read(buf, sizeof(buf));
+
+    this->bufReader.setChunkSize(1);
+    while (offset < sizeof(hello)) {
+        uint64_t count = decompressReader.read(buf + offset, sizeof(buf));
+
+        ASSERT_NE(count, 0);
+        offset += count;
+    }
+
+    uint64_t count = decompressReader.read(buf + offset, sizeof(buf));
+
+    EXPECT_EQ(0, count);
+    EXPECT_EQ(0, strncmp(hello, buf, count));
+}
+
 TEST_F(DecompressReaderTest, AbleToDecompressWithSmallReadBuffer) {
     // Test case for: caller uses buffer smaller than internal chunk.
     //      total compressed data is small (12 bytes),
@@ -151,8 +182,7 @@ TEST_F(DecompressReaderTest, AbleToDecompressWithSmallInternalReaderBuffer) {
 
     int expectedLen[] = {9, 1, 9, 1, 9, 1, 4, 0};
     for (int i = 0; i < sizeof(expectedLen) / sizeof(int); i++) {
-        uint64_t count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-        ASSERT_EQ(expectedLen[i], count);
+        ASSERT_EQ(expectedLen[i], decompressReader.read(outputBuffer, sizeof(outputBuffer)));
     }
 }
 
@@ -194,17 +224,10 @@ TEST_F(DecompressReaderTest, AbleToDecompressWithAlignedLargeReadBuffer) {
 
     char outputBuffer[16] = {0};
 
-    // read 1st 16 bytes
-    uint64_t count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-    EXPECT_EQ(sizeof(outputBuffer), count);
-
-    // read 2nd 2 bytes
-    count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-    EXPECT_EQ(2, count);
-
-    // read 3rd 0 byte
-    count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-    EXPECT_EQ(0, count);
+    int expectedLen[] = {8, 8, 2, 0};
+    for (int i = 0; i < sizeof(expectedLen) / sizeof(int); i++) {
+        ASSERT_EQ(expectedLen[i], decompressReader.read(outputBuffer, sizeof(outputBuffer)));
+    }
 }
 
 TEST_F(DecompressReaderTest, AbleToDecompressWithUnalignedLargeReadBuffer) {
@@ -222,33 +245,10 @@ TEST_F(DecompressReaderTest, AbleToDecompressWithUnalignedLargeReadBuffer) {
 
     char outputBuffer[S3_ZIP_CHUNKSIZE * 6 + 4];
 
-    // read once, decompress 6 times
-    uint64_t count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-    EXPECT_EQ(48, count);
-
-    // read the last 2 bytes
-    count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-    EXPECT_EQ(2, count);
-}
-
-TEST_F(DecompressReaderTest, AbleToDecompressWithEnoughSizeReadBuffer) {
-    // Test case for: optimal buffer size fill after decompression
-    // We need to make sure that we are filling the decompression
-    // buffer fully before asking for a new chunck from the read buffer
-    S3_ZIP_CHUNKSIZE = 8;
-    decompressReader.resizeDecompressReaderBuffer(S3_ZIP_CHUNKSIZE);
-
-    char hello[S3_ZIP_CHUNKSIZE * 6 + 2];
-    memset((void *)hello, 'A', sizeof(hello));
-    hello[sizeof(hello) - 1] = '\0';
-
-    setBufReaderByRawData(hello, sizeof(hello));
-
-    char outputBuffer[S3_ZIP_CHUNKSIZE * 8];
-
-    // read once, decompress 6 times
-    uint64_t count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-    EXPECT_EQ(sizeof(hello), count);
+    int expectedLen[] = {8, 8, 8, 8, 8, 8, 2, 0};
+    for (int i = 0; i < sizeof(expectedLen) / sizeof(int); i++) {
+        ASSERT_EQ(expectedLen[i], decompressReader.read(outputBuffer, sizeof(outputBuffer)));
+    }
 }
 
 TEST_F(DecompressReaderTest, AbleToDecompressWithLargeReadBufferWithDecompressableString) {
@@ -259,36 +259,16 @@ TEST_F(DecompressReaderTest, AbleToDecompressWithLargeReadBufferWithDecompressab
     char hello[] = "abcdefghigklmnopqrstuvwxyz";  // 26+1 bytes
     setBufReaderByRawData(hello, sizeof(hello));
 
-    // for chunksize = 8, upper string will be decompressed in four steps: 5, 8, 8, 6
+    char outputBuffer[30] = {0};
+    int outOffset = 0;
 
-    char outputBuffer[20] = {0};
+    while (outOffset < sizeof(hello)) {
+        uint64_t count =
+            decompressReader.read(outputBuffer + outOffset, sizeof(outputBuffer) - outOffset);
+        outOffset += count;
+    }
 
-    uint64_t count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-    EXPECT_TRUE(strncmp("abcdefghigklmnopqrstuvwxyz", outputBuffer, 5 + 8) == 0);
-    EXPECT_EQ(5 + 8, count);
-
-    count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-    EXPECT_EQ(8 + 6, count);
-}
-
-TEST_F(DecompressReaderTest, AbleToDecompressWithEnoughLargeReadBufferWithDecompressableString) {
-    // Test case for: the input data is decompressable, hence the size of "compressed" data is
-    // larger than original size of data.
-    S3_ZIP_CHUNKSIZE = 8;
-    decompressReader.resizeDecompressReaderBuffer(S3_ZIP_CHUNKSIZE);
-
-    // Smaller chunk size, bigger read buffer from caller. Need composite multiple chunks.
-    char hello[] = "abcdefghigklmnopqrstuvwxyz";  // 26+1 bytes
-    setBufReaderByRawData(hello, sizeof(hello));
-
-    // for chunksize = 8, upper string will be decompressed in four steps: 5, 8, 8, 6
-
-    char outputBuffer[40] = {0};
-
-    // read 26+1 bytes
-    uint64_t count = decompressReader.read(outputBuffer, sizeof(outputBuffer));
-    EXPECT_EQ(sizeof(hello), count);
-    EXPECT_TRUE(strncmp("abcdefghigklmnopqrstuvwxyz", outputBuffer, count) == 0);
+    EXPECT_TRUE(strncmp(hello, outputBuffer, sizeof(hello)) == 0);
 }
 
 TEST_F(DecompressReaderTest, AbleToDecompressWithSmartLargeReadBufferWithDecompressableString) {


### PR DESCRIPTION
Root cause: DecompressReader requests data from upstream reader, which
might return a very small amount of data, zlib inflate() may not be able
to decompress it.

Fix: fill zlib's chunk as possible as it could.

Test case: DecompressReaderTest.AbleToDecompressFragmentalCompressedData

Also refactor DecompressReader::read().

Signed-off-by: Peifeng Qiu <pqiu@pivotal.io>
Signed-off-by: Adam Lee <ali@pivotal.io>