### PR TITLE
fix gpexpand Worker-thread hang problem

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -3151,5 +3151,8 @@ finally:
     except NameError:
         pass
     
+    if gp_expand is not None:
+        gp_expand.shutdown()
+
     coverage.stop()
     coverage.generate_report()

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2315,6 +2315,14 @@ UPDATE gp_distribution_policy
             # schema doesn't exist.  Cancel or error during setup
             pass
 
+    def halt_work(self):
+        if self.pool:
+            self.pool.haltWork()
+            self.pool.joinWorkers()
+
+        if self.queue:
+            self.queue.haltWork()
+            self.queue.joinWorkers()
 
     def cleanup_schema(self, gpexpand_db_status):
         """Removes the gpexpand schema"""
@@ -3152,7 +3160,7 @@ finally:
         pass
     
     if gp_expand is not None:
-        gp_expand.shutdown()
+        gp_expand.halt_work()
 
     coverage.stop()
     coverage.generate_report()

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -197,7 +197,6 @@ class Worker(Thread):
                 if try_count == 5:
                     self.logger.debug("[%s] try and get work from queue..." % self.name)
                     try_count = 0
-                    #self.shouldStop = True
                 
                 if self.shouldStop:
                     self.logger.debug('[%s] stopping' % self.name)
@@ -223,7 +222,6 @@ class Worker(Thread):
                         return
                       
             except Empty:                
-                try_count += 1
                 if self.shouldStop:
                     self.logger.debug("[%s] stopping" % self.name)
                     return

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -197,6 +197,7 @@ class Worker(Thread):
                 if try_count == 5:
                     self.logger.debug("[%s] try and get work from queue..." % self.name)
                     try_count = 0
+                    #self.shouldStop = True
                 
                 if self.shouldStop:
                     self.logger.debug('[%s] stopping' % self.name)
@@ -222,6 +223,7 @@ class Worker(Thread):
                         return
                       
             except Empty:                
+                try_count += 1
                 if self.shouldStop:
                     self.logger.debug("[%s] stopping" % self.name)
                     return


### PR DESCRIPTION
When using python 2.7, gpexpand will hang when the command "gpexpand -D gpadmin" is done.
The sub-thread Worker will still do getting from WorkerPool Queue, because the run() function's no stopping logical.

however, when using python 2.6.2, it's OK. Maybe the Python threading module changed somehow.