### PR TITLE
Reduce memory consumption by using move semantics instead of copy.

### DIFF
--- a/gpAux/extensions/gps3ext/include/makefile.inc
+++ b/gpAux/extensions/gps3ext/include/makefile.inc
@@ -2,6 +2,6 @@ COMMON_OBJS = s3conf.o s3common.o s3utils.o s3log.o s3url_parser.o s3http_header
 
 COMMON_LINK_OPTIONS = -lstdc++ -lxml2 -lpthread -lcrypto -lcurl -lz
 
-COMMON_CPP_FLAGS = -O2 -std=c++98 -Wall -fPIC -I/usr/include/libxml2
+COMMON_CPP_FLAGS = -O2 -std=c++0x -Wall -fPIC -I/usr/include/libxml2
 
 TEST_OBJS = $(patsubst %.o,%_test.o,$(COMMON_OBJS))

--- a/gpAux/extensions/gps3ext/include/restful_service.h
+++ b/gpAux/extensions/gps3ext/include/restful_service.h
@@ -60,10 +60,7 @@ class Response {
     }
 
     void clearBuffer() {
-        buffer.clear();
-
-        // shrink to fit is added in C++11
-        // buffer.shrink_to_fit();
+        buffer = vector<uint8_t>();
     }
 
    private:

--- a/gpAux/extensions/gps3ext/include/restful_service.h
+++ b/gpAux/extensions/gps3ext/include/restful_service.h
@@ -34,6 +34,10 @@ class Response {
         return buffer;
     }
 
+    vector<uint8_t>&& moveDataBuffer() {
+        return std::move(buffer);
+    }
+
     const string& getMessage() const {
         return message;
     }

--- a/gpAux/extensions/gps3ext/include/s3interface.h
+++ b/gpAux/extensions/gps3ext/include/s3interface.h
@@ -60,8 +60,9 @@ class S3Interface {
         throw std::runtime_error("Default implementation must not be called.");
     }
 
-    virtual uint64_t fetchData(uint64_t offset, char* data, uint64_t len, const string& sourceUrl,
-                               const string& region, const S3Credential& cred) {
+    virtual uint64_t fetchData(uint64_t offset, vector<uint8_t>& data, uint64_t len,
+                               const string& sourceUrl, const string& region,
+                               const S3Credential& cred) {
         throw std::runtime_error("Default implementation must not be called.");
     }
 
@@ -78,8 +79,8 @@ class S3Service : public S3Interface {
     ListBucketResult* listBucket(const string& schema, const string& region, const string& bucket,
                                  const string& prefix, const S3Credential& cred);
 
-    uint64_t fetchData(uint64_t offset, char* data, uint64_t len, const string& sourceUrl,
-                       const string& region, const S3Credential& cred);
+    uint64_t fetchData(uint64_t offset, vector<uint8_t>& data, uint64_t len,
+                       const string& sourceUrl, const string& region, const S3Credential& cred);
 
     S3CompressionType checkCompressionType(const string& keyUrl, const string& region,
                                            const S3Credential& cred);
@@ -102,7 +103,7 @@ class S3Service : public S3Interface {
     HTTPHeaders composeHTTPHeaders(const string& url, const string& marker, const string& prefix,
                                    const string& region, const S3Credential& cred);
 
-    xmlParserCtxtPtr getXMLContext(Response response);
+    xmlParserCtxtPtr getXMLContext(Response& response);
 
     RESTfulService* service;
 };

--- a/gpAux/extensions/gps3ext/include/s3key_reader.h
+++ b/gpAux/extensions/gps3ext/include/s3key_reader.h
@@ -137,7 +137,7 @@ class S3KeyReader : public Reader {
         return region;
     }
 
-   private:
+   protected:
     pthread_mutex_t mutexErrorMessage;
 
     bool sharedError;
@@ -164,8 +164,9 @@ class ChunkBuffer {
 
     ~ChunkBuffer();
 
-    // In C++98, if a class has reference member,
-    // then it can't be copy assigned by default, we need to implement operator= explicitly.
+    // if a class has reference member, then it can't be
+    // copy assigned by default, we need to implement operator= explicitly.
+    // it's needed for vector.
     ChunkBuffer& operator=(const ChunkBuffer& other);
 
     bool isEOF() {
@@ -183,9 +184,6 @@ class ChunkBuffer {
     void setS3interface(S3Interface* s3) {
         this->s3interface = s3;
     }
-
-    void init();
-    void destroy();
 
     pthread_cond_t* getStatCond() {
         return &statusCondVar;
@@ -213,7 +211,8 @@ class ChunkBuffer {
     uint64_t curFileOffset;
     uint64_t curChunkOffset;
     uint64_t chunkDataSize;
-    char* chunkData;
+
+    vector<uint8_t> chunkData;
     OffsetMgr& offsetMgr;
 
     S3Interface* s3interface;

--- a/gpAux/extensions/gps3ext/include/s3key_reader.h
+++ b/gpAux/extensions/gps3ext/include/s3key_reader.h
@@ -137,7 +137,7 @@ class S3KeyReader : public Reader {
         return region;
     }
 
-   protected:
+   private:
     pthread_mutex_t mutexErrorMessage;
 
     bool sharedError;

--- a/gpAux/extensions/gps3ext/src/s3common.cpp
+++ b/gpAux/extensions/gps3ext/src/s3common.cpp
@@ -62,13 +62,10 @@ void SignRequestV4(const string &method, HTTPHeaders *h, const string &orig_regi
     string query_encoded = encode_query_str(query);
     stringstream canonical_str;
 
-    canonical_str << method << "\n"
-                  << path << "\n"
-                  << query_encoded << "\nhost:" << h->Get(HOST)
+    canonical_str << method << "\n" << path << "\n" << query_encoded << "\nhost:" << h->Get(HOST)
                   << "\nx-amz-content-sha256:" << h->Get(X_AMZ_CONTENT_SHA256)
                   << "\nx-amz-date:" << h->Get(X_AMZ_DATE) << "\n\n"
-                  << "host;x-amz-content-sha256;x-amz-date\n"
-                  << h->Get(X_AMZ_CONTENT_SHA256);
+                  << "host;x-amz-content-sha256;x-amz-date\n" << h->Get(X_AMZ_CONTENT_SHA256);
     string signed_headers = "host;x-amz-content-sha256;x-amz-date";
 
     sha256_hex(canonical_str.str().c_str(), canonical_hex);
@@ -78,10 +75,8 @@ void SignRequestV4(const string &method, HTTPHeaders *h, const string &orig_regi
     find_replace(region, "external-1", "us-east-1");
 
     stringstream string2sign_str;
-    string2sign_str << "AWS4-HMAC-SHA256\n"
-                    << h->Get(X_AMZ_DATE) << "\n"
-                    << date_str << "/" << region << "/s3/aws4_request\n"
-                    << canonical_hex;
+    string2sign_str << "AWS4-HMAC-SHA256\n" << h->Get(X_AMZ_DATE) << "\n" << date_str << "/"
+                    << region << "/s3/aws4_request\n" << canonical_hex;
 
     stringstream kSecret;
     kSecret << "AWS4" << cred.secret;

--- a/gpAux/extensions/gps3ext/src/s3common.cpp
+++ b/gpAux/extensions/gps3ext/src/s3common.cpp
@@ -62,10 +62,13 @@ void SignRequestV4(const string &method, HTTPHeaders *h, const string &orig_regi
     string query_encoded = encode_query_str(query);
     stringstream canonical_str;
 
-    canonical_str << method << "\n" << path << "\n" << query_encoded << "\nhost:" << h->Get(HOST)
+    canonical_str << method << "\n"
+                  << path << "\n"
+                  << query_encoded << "\nhost:" << h->Get(HOST)
                   << "\nx-amz-content-sha256:" << h->Get(X_AMZ_CONTENT_SHA256)
                   << "\nx-amz-date:" << h->Get(X_AMZ_DATE) << "\n\n"
-                  << "host;x-amz-content-sha256;x-amz-date\n" << h->Get(X_AMZ_CONTENT_SHA256);
+                  << "host;x-amz-content-sha256;x-amz-date\n"
+                  << h->Get(X_AMZ_CONTENT_SHA256);
     string signed_headers = "host;x-amz-content-sha256;x-amz-date";
 
     sha256_hex(canonical_str.str().c_str(), canonical_hex);
@@ -75,8 +78,10 @@ void SignRequestV4(const string &method, HTTPHeaders *h, const string &orig_regi
     find_replace(region, "external-1", "us-east-1");
 
     stringstream string2sign_str;
-    string2sign_str << "AWS4-HMAC-SHA256\n" << h->Get(X_AMZ_DATE) << "\n" << date_str << "/"
-                    << region << "/s3/aws4_request\n" << canonical_hex;
+    string2sign_str << "AWS4-HMAC-SHA256\n"
+                    << h->Get(X_AMZ_DATE) << "\n"
+                    << date_str << "/" << region << "/s3/aws4_request\n"
+                    << canonical_hex;
 
     stringstream kSecret;
     kSecret << "AWS4" << cred.secret;

--- a/gpAux/extensions/gps3ext/src/s3interface.cpp
+++ b/gpAux/extensions/gps3ext/src/s3interface.cpp
@@ -300,10 +300,10 @@ uint64_t S3Service::fetchData(uint64_t offset, vector<uint8_t> &data, uint64_t l
         data = resp.moveDataBuffer();
         if (data.size() != len) {
             S3ERROR("%s", "Response is not fully received.");
-            return 0;
+            CHECK_OR_DIE_MSG(false, "%s", "Response is not fully received.");
         }
 
-        return len;
+        return data.size();
     } else if (resp.getStatus() == RESPONSE_ERROR) {
         xmlParserCtxtPtr xmlContext = getXMLContext(resp);
         if (xmlContext != NULL) {

--- a/gpAux/extensions/gps3ext/src/s3interface.cpp
+++ b/gpAux/extensions/gps3ext/src/s3interface.cpp
@@ -86,7 +86,7 @@ HTTPHeaders S3Service::composeHTTPHeaders(const string &url, const string &marke
     return header;
 }
 
-xmlParserCtxtPtr S3Service::getXMLContext(Response response) {
+xmlParserCtxtPtr S3Service::getXMLContext(Response &response) {
     xmlParserCtxtPtr xmlptr =
         xmlCreatePushParserCtxt(NULL, NULL, (const char *)(response.getRawData().data()),
                                 response.getRawData().size(), "resp.xml");
@@ -279,10 +279,9 @@ ListBucketResult *S3Service::listBucket(const string &schema, const string &regi
     return result;
 }
 
-uint64_t S3Service::fetchData(uint64_t offset, char *data, uint64_t len, const string &sourceUrl,
-                              const string &region, const S3Credential &cred) {
-    CHECK_OR_DIE(data != NULL);
-
+uint64_t S3Service::fetchData(uint64_t offset, vector<uint8_t> &data, uint64_t len,
+                              const string &sourceUrl, const string &region,
+                              const S3Credential &cred) {
     HTTPHeaders headers;
     map<string, string> params;
     UrlParser parser(sourceUrl.c_str());
@@ -297,14 +296,14 @@ uint64_t S3Service::fetchData(uint64_t offset, char *data, uint64_t len, const s
 
     Response resp = service->get(sourceUrl, headers, params);
     if (resp.getStatus() == RESPONSE_OK) {
-        vector<uint8_t> &responseData = resp.getRawData();
-        if (responseData.size() != len) {
+        // move response data buffer
+        data = resp.moveDataBuffer();
+        if (data.size() != len) {
             S3ERROR("%s", "Response is not fully received.");
             return 0;
         }
 
-        std::copy(responseData.begin(), responseData.end(), data);
-        return responseData.size();
+        return len;
     } else if (resp.getStatus() == RESPONSE_ERROR) {
         xmlParserCtxtPtr xmlContext = getXMLContext(resp);
         if (xmlContext != NULL) {

--- a/gpAux/extensions/gps3ext/src/s3key_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3key_reader.cpp
@@ -92,8 +92,7 @@ uint64_t ChunkBuffer::read(char* buf, uint64_t len) {
 
         if (!this->isEOF()) {
             // Release chunkData memory to reduce consumption.
-            this->chunkData.clear();
-            this->chunkData.shrink_to_fit();
+            this->chunkData = vector<uint8_t>();
 
             this->status = ReadyToFill;
 

--- a/gpAux/extensions/gps3ext/src/s3key_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3key_reader.cpp
@@ -29,17 +29,19 @@ Range OffsetMgr::getNextOffset() {
 ChunkBuffer::ChunkBuffer(const string& url, S3KeyReader& reader)
     : sourceUrl(url), offsetMgr(reader.getOffsetMgr()), sharedKeyReader(reader) {
     s3interface = NULL;
-    chunkData = NULL;
     Range range = offsetMgr.getNextOffset();
     curFileOffset = range.offset;
     chunkDataSize = range.length;
     status = ReadyToFill;
     eof = false;
     curChunkOffset = 0;
+    pthread_mutex_init(&this->statusMutex, NULL);
+    pthread_cond_init(&this->statusCondVar, NULL);
 }
 
 ChunkBuffer::~ChunkBuffer() {
-    this->destroy();
+    pthread_mutex_destroy(&this->statusMutex);
+    pthread_cond_destroy(&this->statusCondVar);
 }
 
 ChunkBuffer& ChunkBuffer::operator=(const ChunkBuffer& other) {
@@ -51,28 +53,6 @@ ChunkBuffer& ChunkBuffer::operator=(const ChunkBuffer& other) {
     this->chunkDataSize = other.chunkDataSize;
 
     return *this;
-}
-
-// Copy constructor will copy members, but chunkData must not be initialized before copy.
-// otherwise when worked with vector it will be freed twice.
-void ChunkBuffer::init() {
-    CHECK_OR_DIE_MSG(chunkData == NULL, "%s", "Error: reinitializing chunkBuffer.");
-
-    chunkData = new char[offsetMgr.getChunkSize()];
-    CHECK_OR_DIE_MSG(chunkData != NULL, "%s", "Failed to allocate Buffer, no enough memory?");
-
-    pthread_mutex_init(&this->statusMutex, NULL);
-    pthread_cond_init(&this->statusCondVar, NULL);
-}
-
-void ChunkBuffer::destroy() {
-    if (this->chunkData != NULL) {
-        delete this->chunkData;
-        this->chunkData = NULL;
-
-        pthread_mutex_destroy(&this->statusMutex);
-        pthread_cond_destroy(&this->statusCondVar);
-    }
 }
 
 // ret < len means EMPTY
@@ -102,7 +82,7 @@ uint64_t ChunkBuffer::read(char* buf, uint64_t len) {
     uint64_t lenToRead = std::min(len, leftLen);
 
     if (lenToRead != 0) {
-        memcpy(buf, this->chunkData + this->curChunkOffset, lenToRead);
+        memcpy(buf, this->chunkData.data() + this->curChunkOffset, lenToRead);
     }
 
     if (len <= leftLen) {                   // [1]
@@ -111,6 +91,10 @@ uint64_t ChunkBuffer::read(char* buf, uint64_t len) {
         this->curChunkOffset = 0;
 
         if (!this->isEOF()) {
+            // Release chunkData memory to reduce consumption.
+            this->chunkData.clear();
+            this->chunkData.shrink_to_fit();
+
             this->status = ReadyToFill;
 
             Range range = this->offsetMgr.getNextOffset();
@@ -219,14 +203,13 @@ void S3KeyReader::open(const ReaderParams& params) {
 
     CHECK_OR_DIE_MSG(params.getChunkSize() > 0, "%s", "chunk size must be greater than zero");
 
+    this->chunkBuffers.reserve(this->numOfChunks);
+
     for (uint64_t i = 0; i < this->numOfChunks; i++) {
-        // when vector reallocate memory, it will copy object.
-        // chunkData must be initialized after all copy.
-        this->chunkBuffers.push_back(ChunkBuffer(params.getKeyUrl(), *this));
+        this->chunkBuffers.emplace_back(params.getKeyUrl(), *this);
     }
 
     for (uint64_t i = 0; i < this->numOfChunks; i++) {
-        this->chunkBuffers[i].init();
         this->chunkBuffers[i].setS3interface(this->s3interface);
 
         pthread_t thread;

--- a/gpAux/extensions/gps3ext/test/gpreader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/gpreader_test.cpp
@@ -264,7 +264,7 @@ TEST_F(GPReaderTest, ReadAndGetFailedListBucketResponse) {
     listBucketResponse.setMessage(
         "Mocked error in test 'GPReader.ReadAndGetFailedListBucketResponse'");
 
-    EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(listBucketResponse));
+    EXPECT_CALL(mockRestfulService, get(_, _, _)).WillRepeatedly(Return(listBucketResponse));
 
     ReaderParams params;
     EXPECT_THROW(gpreader.open(params), std::runtime_error);

--- a/gpAux/extensions/gps3ext/test/mock_classes.h
+++ b/gpAux/extensions/gps3ext/test/mock_classes.h
@@ -19,7 +19,7 @@ class MockS3Interface : public S3Interface {
                                    const string& prefix, const S3Credential& cred));
 
     MOCK_METHOD6(fetchData,
-                 uint64_t(uint64_t offset, char *data, uint64_t len, const string &sourceUrl,
+                 uint64_t(uint64_t offset, vector<uint8_t>& data, uint64_t len, const string &sourceUrl,
                           const string &region, const S3Credential &cred));
 
     MOCK_METHOD3(checkCompressionType, S3CompressionType(const string& keyUrl, const string& region,

--- a/gpAux/extensions/gps3ext/test/s3common_reader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3common_reader_test.cpp
@@ -16,10 +16,11 @@ class MockS3InterfaceForCompressionRead : public MockS3Interface {
     void setData(Byte *rawData, uLong len) {
         data.insert(data.begin(), rawData, rawData + len);
     }
-    uint64_t mockFetchData(uint64_t offset, char *data, uint64_t len, const string &sourceUrl,
-                           const string &region, const S3Credential &cred) {
-        memcpy(data, this->data.data(), this->data.size());
-        return this->data.size();
+    uint64_t mockFetchData(uint64_t offset, vector<uint8_t> &data, uint64_t len,
+                           const string &sourceUrl, const string &region,
+                           const S3Credential &cred) {
+        data = std::move(this->data);
+        return data.size();
     }
 
     vector<uint8_t> data;

--- a/gpAux/extensions/gps3ext/test/s3interface_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3interface_test.cpp
@@ -245,7 +245,7 @@ TEST_F(S3ServiceTest, fetchDataFailedResponse) {
     vector<uint8_t> raw;
     raw.resize(100);
     Response response(RESPONSE_FAIL, raw);
-    EXPECT_CALL(mockRestfulService, get(_, _, _)).WillRepeatedly(Return(response));
+    EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
 
     vector<uint8_t> buffer;
 

--- a/gpAux/extensions/gps3ext/test/s3interface_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3interface_test.cpp
@@ -229,28 +229,25 @@ TEST_F(S3ServiceTest, fetchDataRoutine) {
 
     Response response(RESPONSE_OK, raw);
     EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
-    char buffer[100];
+
+    vector<uint8_t> buffer;
+
     uint64_t len = s3service->fetchData(
         0, buffer, 100, "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever", region,
         cred);
 
-    EXPECT_EQ(0, memcmp(buffer, raw.data(), 100));
+    EXPECT_EQ(buffer.size(), raw.size());
+    EXPECT_EQ(0, memcmp(buffer.data(), raw.data(), 100));
     EXPECT_EQ(100, len);
-}
-
-TEST_F(S3ServiceTest, fetchDataNULLBuffer) {
-    EXPECT_THROW(s3service->fetchData(
-                     0, NULL, 100, "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever",
-                     region, cred),
-                 std::runtime_error);
 }
 
 TEST_F(S3ServiceTest, fetchDataFailedResponse) {
     vector<uint8_t> raw;
     raw.resize(100);
     Response response(RESPONSE_FAIL, raw);
-    EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
-    char buffer[100];
+    EXPECT_CALL(mockRestfulService, get(_, _, _)).WillRepeatedly(Return(response));
+
+    vector<uint8_t> buffer;
 
     EXPECT_THROW(s3service->fetchData(
                      0, buffer, 100,
@@ -263,7 +260,7 @@ TEST_F(S3ServiceTest, fetchDataPartialResponse) {
     raw.resize(80);
     Response response(RESPONSE_OK, raw);
     EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
-    char buffer[100];
+    vector<uint8_t> buffer;
 
     EXPECT_EQ(0,
               s3service->fetchData(0, buffer, 100,
@@ -348,12 +345,12 @@ TEST_F(S3ServiceTest, fetchDataWithResponseError) {
         "</Error>";
     vector<uint8_t> raw(xml, xml + sizeof(xml) - 1);
     Response response(RESPONSE_ERROR, raw);
-    char buf[128] = {0};
+    vector<uint8_t> buffer;
 
     EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
 
     EXPECT_THROW(s3service->fetchData(
-                     0, buf, 128, "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever",
-                     region, cred),
+                     0, buffer, 128,
+                     "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever", region, cred),
                  std::runtime_error);
 }

--- a/gpAux/extensions/gps3ext/test/s3interface_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3interface_test.cpp
@@ -262,10 +262,10 @@ TEST_F(S3ServiceTest, fetchDataPartialResponse) {
     EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
     vector<uint8_t> buffer;
 
-    EXPECT_EQ(0,
-              s3service->fetchData(0, buffer, 100,
-                                   "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever",
-                                   region, cred));
+    EXPECT_THROW(s3service->fetchData(
+                     0, buffer, 100,
+                     "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever", region, cred),
+                 std::runtime_error);
 }
 
 TEST_F(S3ServiceTest, checkSmallFile) {

--- a/gpAux/extensions/gps3ext/test/s3restful_service_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3restful_service_test.cpp
@@ -35,7 +35,7 @@ TEST(S3RESTfulService, DISABLED_GetWithEmptyHeader) {
 
     EXPECT_EQ(RESPONSE_OK, resp.getStatus());
     EXPECT_EQ("Success", resp.getMessage());
-    EXPECT_EQ(true, resp.getRawData().size() > 10000);
+    EXPECT_EQ(true, resp.moveDataBuffer().size() > 10000);
 }
 
 TEST(S3RESTfulService, GetWithoutURL) {


### PR DESCRIPTION
1. Enable C++0x features in gcc.
2. Replace ChunkBuffer::chunkData with vector<uint8_t>. Remove init()
   and destroy().
3. Modify S3Service::fetchData, move buffer from Response object
   to data.
4. Modify S3Service::getXMLContext, use reference to avoid copy.
5. Fix unit tests in s3key_reader_test.

Signed-off-by: Peifeng Qiu <pqiu@pivotal.io>