### PR TITLE
Fix gpexpand: let it disconnect from the database

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -705,6 +705,11 @@ class SegmentTemplate:
 
         self.oldSegCount = self.gparray.get_segment_count()
 
+        try:
+            self.conn.close()
+        except:
+            pass
+
         GpStop.local('gpexpand _create_template stop gpdb', masterOnly=True, fast=True)
 
         # Verify that we actually stopped
@@ -999,6 +1004,27 @@ class gpexpand:
         self.segTemplate = None
         pass
 
+    def __del__(self):
+        """ Cleanup the environment after the script has finished """
+        logger.info('Cleaning up...')
+        if hasattr(self, 'pool'):
+            try:
+                self.pool.haltWork()
+                self.pool.joinWorkers()
+            except:
+                pass
+        if hasattr(self, 'queue'):
+            try:
+                self.queue.haltWork()
+                self.queue.joinWorkers()
+            except:
+                pass
+        if hasattr(self, 'conn'):
+            try:
+                self.conn.close()
+            except:
+                pass
+
     @staticmethod
     def prepare_gpdb_state(logger, dburl):
         """ Gets GPDB in the appropriate state for an expansion.
@@ -1254,6 +1280,11 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
                 cleanSchema = True
             else:
                 self.logger.debug('Skipping %s' % status[0])
+
+        try:
+            conn.close()
+        except:
+            pass
 
         GpStop.local('gpexpand rollback', masterOnly=True, fast=True)
 
@@ -1970,6 +2001,7 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
 
         self.conn.commit()
 
+        self.conn.close()
 
         self.statusLogger.set_status('PREPARE_EXPANSION_SCHEMA_DONE')
         self.statusLogger.set_status('EXPANSION_PREPARE_DONE')
@@ -3151,5 +3183,8 @@ finally:
     except NameError:
         pass
     
+    if gp_expand is not None:
+        del gp_expand
+
     coverage.stop()
     coverage.generate_report()

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -705,6 +705,8 @@ class SegmentTemplate:
 
         self.oldSegCount = self.gparray.get_segment_count()
 
+        self.conn.close()
+
         GpStop.local('gpexpand _create_template stop gpdb', masterOnly=True, fast=True)
 
         # Verify that we actually stopped
@@ -1254,6 +1256,8 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
                 cleanSchema = True
             else:
                 self.logger.debug('Skipping %s' % status[0])
+
+        self.conn.close()
 
         GpStop.local('gpexpand rollback', masterOnly=True, fast=True)
 
@@ -1970,6 +1974,7 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
 
         self.conn.commit()
 
+        self.conn.close()
 
         self.statusLogger.set_status('PREPARE_EXPANSION_SCHEMA_DONE')
         self.statusLogger.set_status('EXPANSION_PREPARE_DONE')

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -705,11 +705,6 @@ class SegmentTemplate:
 
         self.oldSegCount = self.gparray.get_segment_count()
 
-        try:
-            self.conn.close()
-        except:
-            pass
-
         GpStop.local('gpexpand _create_template stop gpdb', masterOnly=True, fast=True)
 
         # Verify that we actually stopped
@@ -1004,27 +999,6 @@ class gpexpand:
         self.segTemplate = None
         pass
 
-    def __del__(self):
-        """ Cleanup the environment after the script has finished """
-        logger.info('Cleaning up...')
-        if hasattr(self, 'pool'):
-            try:
-                self.pool.haltWork()
-                self.pool.joinWorkers()
-            except:
-                pass
-        if hasattr(self, 'queue'):
-            try:
-                self.queue.haltWork()
-                self.queue.joinWorkers()
-            except:
-                pass
-        if hasattr(self, 'conn'):
-            try:
-                self.conn.close()
-            except:
-                pass
-
     @staticmethod
     def prepare_gpdb_state(logger, dburl):
         """ Gets GPDB in the appropriate state for an expansion.
@@ -1280,11 +1254,6 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
                 cleanSchema = True
             else:
                 self.logger.debug('Skipping %s' % status[0])
-
-        try:
-            conn.close()
-        except:
-            pass
 
         GpStop.local('gpexpand rollback', masterOnly=True, fast=True)
 
@@ -2001,7 +1970,6 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
 
         self.conn.commit()
 
-        self.conn.close()
 
         self.statusLogger.set_status('PREPARE_EXPANSION_SCHEMA_DONE')
         self.statusLogger.set_status('EXPANSION_PREPARE_DONE')
@@ -3183,8 +3151,5 @@ finally:
     except NameError:
         pass
     
-    if gp_expand is not None:
-        del gp_expand
-
     coverage.stop()
     coverage.generate_report()

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -31,6 +31,7 @@ MASTER_ONLY_TABLES = [
     'gp_fault_strategy',
     'gp_san_configuration',
     'gp_segment_configuration',
+    'gp_verification_history',
     'pg_description',
     'pg_listener',  # ???
     'pg_partition',

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -31,7 +31,6 @@ MASTER_ONLY_TABLES = [
     'gp_fault_strategy',
     'gp_san_configuration',
     'gp_segment_configuration',
-    'gp_verification_history',
     'pg_description',
     'pg_listener',  # ???
     'pg_partition',


### PR DESCRIPTION
The problem is the following: If you try to expand an existing cluster with _gpexpand_ it will connect to the database to analyse the configuration of the cluster and make the changes. But it does not close the session before trying to stop the database. The gpstop will initiate a smart shutdown process, wait 120 seconds and then kill the database with SIGQUIT. After that _pgcontroldata_ returns the state of the cluster "In production" therefore _gpexpand_ thinks it has failed to stop the database and exits.

Another related problem is that when the connection to the database is not closed the script does not return to the command line when it finishes. I don't know the exact reason for this but explicit disconnecting helps.