### PR TITLE
After Row Triggers: disable for AO tables and fix for Heap tables.

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2152,10 +2152,7 @@ ltrmark:;
 		MIRROREDLOCK_BUFMGR_LOCK;
 		
 		buffer = ReadBuffer(relation, ItemPointerGetBlockNumber(tid));
-		
-		MIRROREDLOCK_BUFMGR_UNLOCK;
-		// -------- MirroredLock ----------
-		
+
 		/*
 		 * Although we already know this tuple is valid, we must lock the
 		 * buffer to ensure that no one has a buffer cleanup lock; otherwise
@@ -2176,6 +2173,9 @@ ltrmark:;
 		tuple.t_self = *tid;
 
 		LockBuffer(buffer, BUFFER_LOCK_UNLOCK);
+
+		MIRROREDLOCK_BUFMGR_UNLOCK;
+		// -------- MirroredLock ----------
 	}
 
 	result = heap_copytuple(&tuple);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3308,12 +3308,11 @@ ExecInsert(TupleTableSlot *slot,
 		if (resultRelInfo->ri_NumIndices > 0)
 			ExecInsertIndexTuples(xslot, &(((HeapTuple) xtuple)->t_self), estate, false);
 
-	}
-
-	if (planGen == PLANGEN_PLANNER)
-	{
-		/* AFTER ROW INSERT Triggers */
-		ExecARInsertTriggers(estate, resultRelInfo, tuple);
+		if (planGen == PLANGEN_PLANNER)
+		{
+			/* AFTER ROW INSERT Triggers */
+			ExecARInsertTriggers(estate, resultRelInfo, tuple);
+		}
 	}
 }
 
@@ -3549,7 +3548,7 @@ ldelete:;
 	 */
 
 
-	if (planGen == PLANGEN_PLANNER)
+	if (!(isAORowsTable || isAOColsTable) && planGen == PLANGEN_PLANNER)
 	{
 		/* AFTER ROW DELETE Triggers */
 		ExecARDeleteTriggers(estate, resultRelInfo, tupleid);
@@ -4002,11 +4001,10 @@ lreplace:;
 	{
 		if (resultRelInfo->ri_NumIndices > 0 && !HeapTupleIsHeapOnly((HeapTuple) tuple))
 			ExecInsertIndexTuples(partslot, &(((HeapTuple) tuple)->t_self), estate, false);
+
+		/* AFTER ROW UPDATE Triggers */
+		ExecARUpdateTriggers(estate, resultRelInfo, tupleid, tuple);
 	}
-
-	/* AFTER ROW UPDATE Triggers */
-	ExecARUpdateTriggers(estate, resultRelInfo, tupleid, tuple);
-
 }
 
 /*

--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -269,11 +269,12 @@ CREATE TABLE fkc_foreign_table1(a int REFERENCES fkc_primary_table1 ON DELETE RE
 INSERT INTO fkc_primary_table1 VALUES (1, 'bar');
 INSERT INTO fkc_primary_table1 VALUES (2, 'bar');
 INSERT INTO fkc_foreign_table1 VALUES (1, 'bar');
+INSERT INTO fkc_foreign_table1 VALUES (2, 'bar');
 UPDATE fkc_foreign_table1 SET b = 'foo';
 DELETE FROM fkc_primary_table1 WHERE a = 1;
 COMMIT;
 -- the following should fail with planner but succeed with gporca
-UPDATE fkc_primary_table1 SET a = 2;
+UPDATE fkc_primary_table1 SET a = 3 where a = 2;
 
 BEGIN;
 -- Test with an ao table and heap table
@@ -284,8 +285,9 @@ CREATE TABLE fkc_foreign_table2(a int REFERENCES fkc_primary_table2 ON DELETE RE
 INSERT INTO fkc_primary_table2 VALUES (1, 'bar');
 INSERT INTO fkc_primary_table2 VALUES (2, 'bar');
 INSERT INTO fkc_foreign_table2 VALUES (1, 'bar');
+INSERT INTO fkc_foreign_table2 VALUES (2, 'bar');
 UPDATE fkc_foreign_table2 SET b = 'foo';
 DELETE FROM fkc_primary_table2 WHERE a = 1;
 COMMIT;
 -- the following should fail with planner but succeed with gporca
-UPDATE fkc_primary_table2 SET a = 2;
+UPDATE fkc_primary_table2 SET a = 3 where a = 2;

--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -258,3 +258,34 @@ SELECT '' AS five, * FROM UNIQUE_TBL;
 
 DROP TABLE UNIQUE_TBL;
 
+--
+-- Test foreign key constraints
+--
+BEGIN;
+-- Test with two heap tables
+CREATE TABLE fkc_primary_table1(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
+CREATE TABLE fkc_foreign_table1(a int REFERENCES fkc_primary_table1 ON DELETE RESTRICT ON UPDATE RESTRICT, b text) DISTRIBUTED BY (a);
+-- the following should succeed
+INSERT INTO fkc_primary_table1 VALUES (1, 'bar');
+INSERT INTO fkc_primary_table1 VALUES (2, 'bar');
+INSERT INTO fkc_foreign_table1 VALUES (1, 'bar');
+UPDATE fkc_foreign_table1 SET b = 'foo';
+DELETE FROM fkc_primary_table1 WHERE a = 1;
+COMMIT;
+-- the following should fail with planner but succeed with gporca
+UPDATE fkc_primary_table1 SET a = 2;
+
+BEGIN;
+-- Test with an ao table and heap table
+CREATE TABLE fkc_primary_table2(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
+CREATE TABLE fkc_foreign_table2(a int REFERENCES fkc_primary_table2 ON DELETE RESTRICT ON UPDATE RESTRICT,
+                                b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
+-- the following should succeed
+INSERT INTO fkc_primary_table2 VALUES (1, 'bar');
+INSERT INTO fkc_primary_table2 VALUES (2, 'bar');
+INSERT INTO fkc_foreign_table2 VALUES (1, 'bar');
+UPDATE fkc_foreign_table2 SET b = 'foo';
+DELETE FROM fkc_primary_table2 WHERE a = 1;
+COMMIT;
+-- the following should fail with planner but succeed with gporca
+UPDATE fkc_primary_table2 SET a = 2;

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -365,3 +365,37 @@ SELECT '' AS five, * FROM UNIQUE_TBL;
 (5 rows)
 
 DROP TABLE UNIQUE_TBL;
+--
+-- Test foreign key constraints
+--
+BEGIN;
+-- Test with two heap tables
+CREATE TABLE fkc_primary_table1(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "fkc_primary_table1_pkey" for table "fkc_primary_table1"
+CREATE TABLE fkc_foreign_table1(a int REFERENCES fkc_primary_table1 ON DELETE RESTRICT ON UPDATE RESTRICT, b text) DISTRIBUTED BY (a);
+-- the following should succeed
+INSERT INTO fkc_primary_table1 VALUES (1, 'bar');
+INSERT INTO fkc_primary_table1 VALUES (2, 'bar');
+INSERT INTO fkc_foreign_table1 VALUES (1, 'bar');
+UPDATE fkc_foreign_table1 SET b = 'foo';
+DELETE FROM fkc_primary_table1 WHERE a = 1;
+COMMIT;
+-- the following should fail with planner but succeed with gporca
+UPDATE fkc_primary_table1 SET a = 2;
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+BEGIN;
+-- Test with an ao table and heap table
+CREATE TABLE fkc_primary_table2(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "fkc_primary_table2_pkey" for table "fkc_primary_table2"
+CREATE TABLE fkc_foreign_table2(a int REFERENCES fkc_primary_table2 ON DELETE RESTRICT ON UPDATE RESTRICT,
+                                b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
+-- the following should succeed
+INSERT INTO fkc_primary_table2 VALUES (1, 'bar');
+INSERT INTO fkc_primary_table2 VALUES (2, 'bar');
+INSERT INTO fkc_foreign_table2 VALUES (1, 'bar');
+UPDATE fkc_foreign_table2 SET b = 'foo';
+DELETE FROM fkc_primary_table2 WHERE a = 1;
+COMMIT;
+-- the following should fail with planner but succeed with gporca
+UPDATE fkc_primary_table2 SET a = 2;
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -377,11 +377,12 @@ CREATE TABLE fkc_foreign_table1(a int REFERENCES fkc_primary_table1 ON DELETE RE
 INSERT INTO fkc_primary_table1 VALUES (1, 'bar');
 INSERT INTO fkc_primary_table1 VALUES (2, 'bar');
 INSERT INTO fkc_foreign_table1 VALUES (1, 'bar');
+INSERT INTO fkc_foreign_table1 VALUES (2, 'bar');
 UPDATE fkc_foreign_table1 SET b = 'foo';
 DELETE FROM fkc_primary_table1 WHERE a = 1;
 COMMIT;
 -- the following should fail with planner but succeed with gporca
-UPDATE fkc_primary_table1 SET a = 2;
+UPDATE fkc_primary_table1 SET a = 3 where a = 2;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 BEGIN;
 -- Test with an ao table and heap table
@@ -393,9 +394,10 @@ CREATE TABLE fkc_foreign_table2(a int REFERENCES fkc_primary_table2 ON DELETE RE
 INSERT INTO fkc_primary_table2 VALUES (1, 'bar');
 INSERT INTO fkc_primary_table2 VALUES (2, 'bar');
 INSERT INTO fkc_foreign_table2 VALUES (1, 'bar');
+INSERT INTO fkc_foreign_table2 VALUES (2, 'bar');
 UPDATE fkc_foreign_table2 SET b = 'foo';
 DELETE FROM fkc_primary_table2 WHERE a = 1;
 COMMIT;
 -- the following should fail with planner but succeed with gporca
-UPDATE fkc_primary_table2 SET a = 2;
+UPDATE fkc_primary_table2 SET a = 3 where a = 2;
 ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns

--- a/src/test/regress/output/constraints_optimizer.source
+++ b/src/test/regress/output/constraints_optimizer.source
@@ -397,3 +397,35 @@ SELECT '' AS five, * FROM UNIQUE_TBL;
 (5 rows)
 
 DROP TABLE UNIQUE_TBL;
+--
+-- Test foreign key constraints
+--
+BEGIN;
+-- Test with two heap tables
+CREATE TABLE fkc_primary_table1(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "fkc_primary_table1_pkey" for table "fkc_primary_table1"
+CREATE TABLE fkc_foreign_table1(a int REFERENCES fkc_primary_table1 ON DELETE RESTRICT ON UPDATE RESTRICT, b text) DISTRIBUTED BY (a);
+-- the following should succeed
+INSERT INTO fkc_primary_table1 VALUES (1, 'bar');
+INSERT INTO fkc_primary_table1 VALUES (2, 'bar');
+INSERT INTO fkc_foreign_table1 VALUES (1, 'bar');
+UPDATE fkc_foreign_table1 SET b = 'foo';
+DELETE FROM fkc_primary_table1 WHERE a = 1;
+COMMIT;
+-- the following should fail with planner but succeed with gporca
+UPDATE fkc_primary_table1 SET a = 2;
+BEGIN;
+-- Test with an ao table and heap table
+CREATE TABLE fkc_primary_table2(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "fkc_primary_table2_pkey" for table "fkc_primary_table2"
+CREATE TABLE fkc_foreign_table2(a int REFERENCES fkc_primary_table2 ON DELETE RESTRICT ON UPDATE RESTRICT,
+                                b text) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
+-- the following should succeed
+INSERT INTO fkc_primary_table2 VALUES (1, 'bar');
+INSERT INTO fkc_primary_table2 VALUES (2, 'bar');
+INSERT INTO fkc_foreign_table2 VALUES (1, 'bar');
+UPDATE fkc_foreign_table2 SET b = 'foo';
+DELETE FROM fkc_primary_table2 WHERE a = 1;
+COMMIT;
+-- the following should fail with planner but succeed with gporca
+UPDATE fkc_primary_table2 SET a = 2;

--- a/src/test/regress/output/constraints_optimizer.source
+++ b/src/test/regress/output/constraints_optimizer.source
@@ -409,11 +409,12 @@ CREATE TABLE fkc_foreign_table1(a int REFERENCES fkc_primary_table1 ON DELETE RE
 INSERT INTO fkc_primary_table1 VALUES (1, 'bar');
 INSERT INTO fkc_primary_table1 VALUES (2, 'bar');
 INSERT INTO fkc_foreign_table1 VALUES (1, 'bar');
+INSERT INTO fkc_foreign_table1 VALUES (2, 'bar');
 UPDATE fkc_foreign_table1 SET b = 'foo';
 DELETE FROM fkc_primary_table1 WHERE a = 1;
 COMMIT;
 -- the following should fail with planner but succeed with gporca
-UPDATE fkc_primary_table1 SET a = 2;
+UPDATE fkc_primary_table1 SET a = 3 where a = 2;
 BEGIN;
 -- Test with an ao table and heap table
 CREATE TABLE fkc_primary_table2(a int PRIMARY KEY, b text) DISTRIBUTED BY (a);
@@ -424,8 +425,9 @@ CREATE TABLE fkc_foreign_table2(a int REFERENCES fkc_primary_table2 ON DELETE RE
 INSERT INTO fkc_primary_table2 VALUES (1, 'bar');
 INSERT INTO fkc_primary_table2 VALUES (2, 'bar');
 INSERT INTO fkc_foreign_table2 VALUES (1, 'bar');
+INSERT INTO fkc_foreign_table2 VALUES (2, 'bar');
 UPDATE fkc_foreign_table2 SET b = 'foo';
 DELETE FROM fkc_primary_table2 WHERE a = 1;
 COMMIT;
 -- the following should fail with planner but succeed with gporca
-UPDATE fkc_primary_table2 SET a = 2;
+UPDATE fkc_primary_table2 SET a = 3 where a = 2;

--- a/src/test/regress/output/misc.source
+++ b/src/test/regress/output/misc.source
@@ -549,6 +549,10 @@ SELECT user_relns() AS user_relns
  equipment_r
  f_star
  fast_emp4000
+ fkc_foreign_table1
+ fkc_foreign_table2
+ fkc_primary_table1
+ fkc_primary_table2
  float4_tbl
  float8_tbl
  floats
@@ -651,7 +655,7 @@ SELECT user_relns() AS user_relns
  toyemp
  usr_define_type
  varchar_tbl
-(147 rows)
+(151 rows)
 
 SELECT name(equipment(hobby_construct(text 'skywalking', text 'mer')));
  name 


### PR DESCRIPTION
Greenplum has limited trigger capabilities which do not work with the current AO
implementation. It was found that after row triggers were being executed for AO
table DMLs using planner resulting in erroneous heap reads. Instead of adding
logic to do AO segfile reads, we disable after row triggers for AO tables as
Greenplum does not really support triggers for AO anyways. The issue with heap
tables started after the 8.3 merge which introduced LockBuffer usage at the
bottom of the GetTupleForTrigger function. LockBuffer assumes that a
MIRROREDLOCK_BUFMGR_LOCK is held so we just needed to release the
MIRROREDLOCK_BUFMGR_LOCK after the buffer lock is released.