### PR TITLE
Refactor to use SIMPLE_FAULT_INJECTOR() macro where possible

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1247,13 +1247,7 @@ StartPrepare(GlobalTransaction gxact)
 		pfree(persistentPrepareBuffer);
 	}
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-		StartPrepareTx,
-		DDLNotSpecified,
-		"",  // databaseName
-		""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(StartPrepareTx);
 }
 
 /*
@@ -1388,13 +1382,7 @@ EndPrepare(GlobalTransaction gxact)
 
 	MIRRORED_UNLOCK;
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-		EndPreparedTwoPhaseSleep,
-		DDLNotSpecified,
-		"", // databaseName
-		""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(EndPreparedTwoPhaseSleep);
 
 	/*
 	 * Wait for synchronous replication, if required.
@@ -2139,13 +2127,7 @@ RecordTransactionCommitPrepared(TransactionId xid,
 	}
 	rdata[lastrdata].next = NULL;
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-		TwoPhaseTransactionCommitPrepared,
-		DDLNotSpecified,
-		"" /* databaseName */,
-		"" /* tableName */);
-#endif
+	SIMPLE_FAULT_INJECTOR(TwoPhaseTransactionCommitPrepared);
 
 	recptr = XLogInsert(RM_XACT_ID, XLOG_XACT_COMMIT_PREPARED, rdata);
 
@@ -2288,13 +2270,7 @@ RecordTransactionAbortPrepared(TransactionId xid,
 	}
 	rdata[lastrdata].next = NULL;
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-		TwoPhaseTransactionAbortPrepared,
-		DDLNotSpecified,
-		"" /* databaseName */,
-		"" /* tableName */);
-#endif
+	SIMPLE_FAULT_INJECTOR(TwoPhaseTransactionAbortPrepared);
 
 	recptr = XLogInsert(RM_XACT_ID, XLOG_XACT_ABORT_PREPARED, rdata);
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1362,13 +1362,7 @@ RecordTransactionCommit(void)
 		}
 	}
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-		DtmXLogDistributedCommit,
-		DDLNotSpecified,
-		"",	// databaseName
-		""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(DtmXLogDistributedCommit);
 
 	/*
 	 * If we entered a commit critical section, leave it now, and let
@@ -2535,13 +2529,7 @@ AppendToSubxidFile(TransactionId *subxids, uint32 subcnt)
 		elog(ERROR, "Error in saving subtransaction ids");
 	}
 
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-			SubtransactionFlushToFile,
-			DDLNotSpecified,
-			"",  // databaseName
-			""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(SubtransactionFlushToFile);
 }
 
 static void
@@ -2769,13 +2757,7 @@ GetSubXidsInXidBuffer(void)
 			}
 		}
 
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-			SubtransactionReadFromFile,
-			DDLNotSpecified,
-			"",  // databaseName
-			""); // tableName
-#endif
+		SIMPLE_FAULT_INJECTOR(SubtransactionReadFromFile);
 
 		offset = FileSeek(subxip_file, 0, SEEK_SET);
 		size = (SharedLocalSnapshotSlot->total_subcnt -
@@ -3980,13 +3962,7 @@ AbortTransaction(void)
 	bool needDistribAborted = false;
 	bool willHaveObjectsFromSmgr;
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-			AbortTransactionFail,
-			DDLNotSpecified,
-			"",  // databaseName
-			""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(AbortTransactionFail);
 
 	LocalDistribXactRef_Init(&localDistribXactRef);
 
@@ -6211,13 +6187,7 @@ CommitSubTransaction(void)
 		elog(WARNING, "CommitSubTransaction while in %s state",
 			 TransStateAsString(s->state));
 
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-			SubtransactionRelease,
-			DDLNotSpecified,
-			"",  // databaseName
-			""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(SubtransactionRelease);
 
 	/* Pre-commit processing goes here -- nothing to do at the moment */
 
@@ -6338,13 +6308,7 @@ AbortSubTransaction(void)
 		elog(WARNING, "AbortSubTransaction while in %s state",
 			 TransStateAsString(s->state));
 
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-			SubtransactionRollback,
-			DDLNotSpecified,
-			"",  // databaseName
-			""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(SubtransactionRollback);
 
 	s->state = TRANS_ABORT;
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8812,13 +8812,7 @@ CreateCheckPoint(int flags)
 		/* database transitions to suspended state, IO activity on the segment is suspended */
 		primaryMirrorSetIOSuspended(TRUE);
 
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-									   FileRepTransitionToInSyncBeforeCheckpoint,
-									   DDLNotSpecified,
-									   "",	// databaseName
-									   ""); // tableName
-#endif
+		SIMPLE_FAULT_INJECTOR(FileRepTransitionToInSyncBeforeCheckpoint);
 	}
 	else
 	{
@@ -11863,13 +11857,7 @@ int XLogAddRecordsToChangeTracking(
 
 		lastEndLoc = EndRecPtr;
 
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-					       FileRepTransitionToChangeTracking,
-					       DDLNotSpecified,
-					       "",//databaseName
-					       ""); // tableName
-#endif
+		SIMPLE_FAULT_INJECTOR(FileRepTransitionToChangeTracking);
 
 		if (filerep_inject_change_tracking_recovery_fault)
 		{

--- a/src/backend/cdb/cdbfilerep.c
+++ b/src/backend/cdb/cdbfilerep.c
@@ -2212,13 +2212,8 @@ FileRep_ProcessSignals()
 			FileRep_SetPostmasterReset();
 		else
 		{
-#ifdef FAULT_INJECTOR
-			FaultInjector_InjectFaultIfSet(
-						   FileRepImmediateShutdownRequested,
-						   DDLNotSpecified,
-						   "",	// databaseName
-						   ""); // tableName
-#endif
+			SIMPLE_FAULT_INJECTOR(FileRepImmediateShutdownRequested);
+
 			FileRep_SignalChildren(SIGQUIT, false);
 			processExit = true;
 			exitWithImmediateShutdown = true;

--- a/src/backend/cdb/cdbfilerepmirror.c
+++ b/src/backend/cdb/cdbfilerepmirror.c
@@ -383,13 +383,8 @@ FileRepMirror_RunReceiver(void)
 									   spareField,
 									   FILEREP_UNDEFINED);	
 				
-#ifdef FAULT_INJECTOR
-				FaultInjector_InjectFaultIfSet(
-											   FileRepReceiver,
-											   DDLNotSpecified,
-											   "",	//databaseName
-											   ""); // tableName
-#endif				
+				SIMPLE_FAULT_INJECTOR(FileRepReceiver);
+
 				fileRepShmemMessageDescr = (FileRepShmemMessageDescr_s*) msgPositionInsert;	
 		
 				/* it is not in use */
@@ -701,13 +696,8 @@ FileRepMirror_RunConsumer(void)
 			break;
 		}
 			
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-									   FileRepConsumer,
-									   DDLNotSpecified,
-									   "",	//databaseName
-									   ""); // tableName
-#endif
+		SIMPLE_FAULT_INJECTOR(FileRepConsumer);
+
 		/* Calculate and compare FileRepMessageHeader_s Crc */
 		fileRepMessageHeader = (FileRepMessageHeader_s*) (fileRepShmem->positionConsume + 
 								  sizeof(FileRepShmemMessageDescr_s));
@@ -1334,13 +1324,8 @@ FileRepMirror_RunConsumer(void)
 						}
 				}
 				
-#ifdef FAULT_INJECTOR
-				FaultInjector_InjectFaultIfSet(
-											   FileRepFlush,
-											   DDLNotSpecified,
-											   "",	//databaseName
-											   ""); // tableName
-#endif								
+				SIMPLE_FAULT_INJECTOR(FileRepFlush);
+
 				gettimeofday(&currentTime, NULL);
 				beginTime = (pg_time_t) currentTime.tv_sec;
 				

--- a/src/backend/cdb/cdbfilerepmirrorack.c
+++ b/src/backend/cdb/cdbfilerepmirrorack.c
@@ -417,13 +417,7 @@ FileRepAckMirror_RunSender(void)
 							   FILEREP_UNDEFINED,
 							   FILEREP_UNDEFINED);		
 				
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-									   FileRepSender,
-									   DDLNotSpecified,
-									   "",	//databaseName
-									   ""); // tableName
-#endif						
+		SIMPLE_FAULT_INJECTOR(FileRepSender);
 		
 		fileRepMessage = (char*) (fileRepAckShmem->positionConsume + 
 								  sizeof(FileRepShmemMessageDescr_s));

--- a/src/backend/cdb/cdbfilerepprimary.c
+++ b/src/backend/cdb/cdbfilerepprimary.c
@@ -1688,13 +1688,7 @@ FileRepPrimary_RunSender(void)
 			break;
 		}
 				
-#ifdef FAULT_INJECTOR	
-		FaultInjector_InjectFaultIfSet(
-									   FileRepSender, 
-									   DDLNotSpecified,
-									   "",	// databaseName
-									   ""); // tableName
-#endif
+		SIMPLE_FAULT_INJECTOR(FileRepSender);
 		
 		fileRepMessage = (char*) (fileRepShmem->positionConsume + 
 								  sizeof(FileRepShmemMessageDescr_s));

--- a/src/backend/cdb/cdbfilerepprimaryack.c
+++ b/src/backend/cdb/cdbfilerepprimaryack.c
@@ -317,13 +317,7 @@ FileRepAckPrimary_RunReceiver(void)
 			break;
 		}		
 		
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-									   FileRepReceiver,
-									   DDLNotSpecified,
-									   "",	//databaseName
-									   ""); // tableName
-#endif				
+		SIMPLE_FAULT_INJECTOR(FileRepReceiver);
 		
 		fileRepShmemMessageDescr = 
 		(FileRepShmemMessageDescr_s*) msgPositionInsert;	
@@ -1037,13 +1031,7 @@ FileRepAckPrimary_RunConsumer(void)
 			break;
 		}
 		
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-									   FileRepConsumer,
-									   DDLNotSpecified,
-									   "",	//databaseName
-									   ""); // tableName
-#endif				
+		SIMPLE_FAULT_INJECTOR(FileRepConsumer);
 		
 		/* Calculate and compare FileRepMessageHeader_s Crc */
 		fileRepMessageHeader = (FileRepMessageHeader_s*) (fileRepAckShmem->positionConsume + 

--- a/src/backend/cdb/cdbfilerepresyncmanager.c
+++ b/src/backend/cdb/cdbfilerepresyncmanager.c
@@ -943,13 +943,7 @@ FileRepResyncManager_InResyncTransition(void)
 		goto exit;
 	}		
 
-#ifdef FAULT_INJECTOR	
-	FaultInjector_InjectFaultIfSet(
-								   FileRepTransitionToInResyncMirrorReCreate, 
-								   DDLNotSpecified,
-								   "",	// databaseName
-								   ""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(FileRepTransitionToInResyncMirrorReCreate);
 	
 	FileRep_InsertConfigLogEntry("run resync transition, mirror recreate");	
 	
@@ -965,13 +959,7 @@ FileRepResyncManager_InResyncTransition(void)
 
 	FileRepSubProcess_SetState(FileRepStateReady);
 	
-#ifdef FAULT_INJECTOR	
-	FaultInjector_InjectFaultIfSet(
-								   FileRepTransitionToInResyncMarkReCreated, 
-								   DDLNotSpecified,
-								   "",	// databaseName
-								   ""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(FileRepTransitionToInResyncMarkReCreated);
 
 	/*
 	 * Mark Persistent Table entries as 'Dropped (i.e. Free)' to indicate the drops
@@ -999,13 +987,8 @@ FileRepResyncManager_InResyncTransition(void)
 		goto exit;
 	}		
 	
-#ifdef FAULT_INJECTOR	
-	FaultInjector_InjectFaultIfSet(
-								   FileRepTransitionToInResyncMarkCompleted, 
-								   DDLNotSpecified,
-								   "",	// databaseName
-								   ""); // tableName
-#endif		
+	SIMPLE_FAULT_INJECTOR(FileRepTransitionToInResyncMarkCompleted);
+
 	FileRep_InsertConfigLogEntry("run resync transition, mark transition to resync completed");	
 
 	ChangeTracking_MarkTransitionToResyncCompleted();
@@ -1210,15 +1193,9 @@ FileRepPrimary_RunResyncManager(void)
 					elog(LOG, "Not adding this entry to hash table %s", entry.fileName);
 				continue;
 		}
-		
-#ifdef FAULT_INJECTOR	
-		FaultInjector_InjectFaultIfSet(
-									   FileRepResync, 
-									   DDLNotSpecified,
-									   "",	// databaseName
-									   ""); // tableName
-#endif
-		
+
+		SIMPLE_FAULT_INJECTOR(FileRepResync);
+
 		FileRep_GetRelationPath(
 								entry.fileName, 
 								entry.relFileNode, 
@@ -1304,15 +1281,8 @@ FileRepResyncManager_InSyncTransition(void)
 	
 	FileRep_InsertConfigLogEntry("run resync sync transition");
 
-	
-#ifdef FAULT_INJECTOR	
-	FaultInjector_InjectFaultIfSet(
-								   FileRepTransitionToInSyncBegin, 
-								   DDLNotSpecified,
-								   "",	// databaseName
-								   ""); // tableName
-#endif	
-	
+	SIMPLE_FAULT_INJECTOR(FileRepTransitionToInSyncBegin);
+
 	while (1) {
 		/*
 		 * (MirroredLock, LW_EXCLUSIVE) is acquired and released in CreateCheckPoint
@@ -1351,15 +1321,9 @@ FileRepResyncManager_InSyncTransition(void)
 		/* primary and mirror have now completed re-sync */
 		setResyncCompleted();
 		primaryMirrorSetInSync();
-		
-#ifdef FAULT_INJECTOR	
-		FaultInjector_InjectFaultIfSet(
-									   FileRepTransitionToInSyncMarkCompleted, 
-									   DDLNotSpecified,
-									   "",	// databaseName
-									   ""); // tableName
-#endif	
-		
+
+		SIMPLE_FAULT_INJECTOR(FileRepTransitionToInSyncMarkCompleted);
+
 		break;
 	}
 		
@@ -1375,15 +1339,9 @@ FileRepResyncManager_ResyncFlatFiles(void)
 	int status = STATUS_OK;
 	
 	FileRep_SetSegmentState(SegmentStateInSyncTransition, FaultTypeNotInitialized);
-	
-#ifdef FAULT_INJECTOR	
-	FaultInjector_InjectFaultIfSet(
-								   FileRepTransitionToInSync, 
-								   DDLNotSpecified,
-								   "",	// databaseName
-								   ""); // tableName
-#endif	
-	
+
+	SIMPLE_FAULT_INJECTOR(FileRepTransitionToInSync);
+
 	while (1) 
 	{
 		FileRep_InsertConfigLogEntry("run sync transition, resync pg_control file");

--- a/src/backend/cdb/cdbpersistentbuild.c
+++ b/src/backend/cdb/cdbpersistentbuild.c
@@ -627,13 +627,7 @@ PersistentBuild_BuildDb(
 
 	gp_before_persistence_work = false;
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-								   RebuildPTDB,
-								   DDLNotSpecified,
-								   "",	// databaseName
-								   ""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(RebuildPTDB);
 
 	/* 
 	 * Since we have written XLOG records with <persistentTid,

--- a/src/backend/cdb/cdbpersistentdatabase.c
+++ b/src/backend/cdb/cdbpersistentdatabase.c
@@ -557,14 +557,7 @@ void PersistentDatabase_MarkCreatePending(
 	mmxlog_log_create_database(dbDirNode->tablespace, dbDirNode->database); 
 #endif
 
-
-	#ifdef FAULT_INJECTOR
-			FaultInjector_InjectFaultIfSet(
-										   FaultBeforePendingDeleteDatabaseEntry,
-										   DDLNotSpecified,
-										   "",  // databaseName
-										   ""); // tableName
-	#endif
+	SIMPLE_FAULT_INJECTOR(FaultBeforePendingDeleteDatabaseEntry);
 
 	/*
 	 * MPP-18228

--- a/src/backend/cdb/cdbpersistentfilespace.c
+++ b/src/backend/cdb/cdbpersistentfilespace.c
@@ -899,14 +899,7 @@ void PersistentFilespace_MarkCreatePending(
 	mmxlog_log_create_filespace(filespaceOid);
 #endif
 
-
-	#ifdef FAULT_INJECTOR
-			FaultInjector_InjectFaultIfSet(
-										   FaultBeforePendingDeleteFilespaceEntry,
-										   DDLNotSpecified,
-										   "",  // databaseName
-										   ""); // tableName
-	#endif
+	SIMPLE_FAULT_INJECTOR(FaultBeforePendingDeleteFilespaceEntry);
 
 	/*
 	 * MPP-18228

--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -3809,13 +3809,8 @@ void PersistentFileSysObj_PreparedEndXactAction(
 				mirrorCatchupRequired = false;
 			}
 
-#ifdef FAULT_INJECTOR
-			FaultInjector_InjectFaultIfSet(
-							UpdateCommittedEofInPersistentTable,
-							DDLNotSpecified,
-							"", 	// databaseName
-							"");	// tablename
-#endif
+			SIMPLE_FAULT_INJECTOR(UpdateCommittedEofInPersistentTable);
+
 			PersistentFileSysObj_UpdateAppendOnlyMirrorResyncEofs(
 															&eofs->relFileNode,
 															eofs->segmentFileNum,

--- a/src/backend/cdb/cdbpersistentrelation.c
+++ b/src/backend/cdb/cdbpersistentrelation.c
@@ -340,13 +340,7 @@ void PersistentRelation_AddCreatePending(
 						segmentFileNum);	
 #endif
 
-	#ifdef FAULT_INJECTOR
-			FaultInjector_InjectFaultIfSet(
-										   FaultBeforePendingDeleteRelationEntry,
-										   DDLNotSpecified,
-										   "",  // databaseName
-										   ""); // tableName
-	#endif
+	SIMPLE_FAULT_INJECTOR(FaultBeforePendingDeleteRelationEntry);
 
    /* We'll add an entry to the PendingDelete LinkedList (LL) to remeber what we
     * created in this transaction (or sub-transaction). If the transaction

--- a/src/backend/cdb/cdbpersistenttablespace.c
+++ b/src/backend/cdb/cdbpersistenttablespace.c
@@ -750,13 +750,7 @@ void PersistentTablespace_MarkCreatePending(
 						tablespaceOid);
 #endif
 
-	#ifdef FAULT_INJECTOR
-			FaultInjector_InjectFaultIfSet(
-										   FaultBeforePendingDeleteTablespaceEntry,
-										   DDLNotSpecified,
-										   "",  // databaseName
-										   ""); // tableName
-	#endif
+	SIMPLE_FAULT_INJECTOR(FaultBeforePendingDeleteTablespaceEntry);
 
 	/*
 	 * MPP-18228

--- a/src/backend/cdb/cdbresynchronizechangetracking.c
+++ b/src/backend/cdb/cdbresynchronizechangetracking.c
@@ -3240,15 +3240,8 @@ int ChangeTracking_CompactLogFile(CTFType source, CTFType dest, XLogRecPtr*	upto
 				persistentTid = DatumGetPointer(DirectFunctionCall1(tidin, CStringGetDatum(str_tid)));
 				persistentSerialNum = DatumGetInt64(DirectFunctionCall1(int8in, CStringGetDatum(str_sn)));
 
-				
-				#ifdef FAULT_INJECTOR	
-						FaultInjector_InjectFaultIfSet(
-									  FileRepChangeTrackingCompacting, 
-									   DDLNotSpecified,
-									   "",	// databaseName
-									   ""); // tableName
-				#endif
-	
+				SIMPLE_FAULT_INJECTOR(FileRepChangeTrackingCompacting);
+
 				/* write this record to the compact file */
 				ChangeTracking_AddBufferPoolChange(dest,
 												   endlsn, 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -701,13 +701,7 @@ doPrepareTransaction(void)
 	setCurrentGxactState( DTX_STATE_PREPARED );
 	releaseTmLock();
 
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-									   DtmBroadcastPrepare,
-									   DDLNotSpecified,
-									   "",	// databaseName
-									   ""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(DtmBroadcastPrepare);
 
 	elog(DTM_DEBUG5, "doPrepareTransaction leaving in state = %s", DtxStateToString(currentGxact->state));
 }
@@ -769,13 +763,8 @@ doNotifyingCommitPrepared(void)
 		elog(PANIC, "Distribute transaction identifier too long (%d)",
 			 (int)strlen(currentGxact->gid));
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-								   DtmBroadcastCommitPrepared,
-								   DDLNotSpecified,
-								   "",	// databaseName
-								   ""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(DtmBroadcastCommitPrepared);
+
 	succeeded = doDispatchDtxProtocolCommand(DTX_PROTOCOL_COMMAND_COMMIT_PREPARED, /* flags */ 0,
 											 currentGxact->gid, currentGxact->gxid,
 											 &badGangs, /* raiseError */ false,
@@ -953,13 +942,7 @@ doNotifyingAbort(void)
 			 abortString, currentGxact->gid);
 	}
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-								   DtmBroadcastAbortPrepared,
-								   DDLNotSpecified,
-								   "",	// databaseName
-								   ""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(DtmBroadcastAbortPrepared);
 
 	/*
 	 * Global locking order: ProcArrayLock then DTM lock.
@@ -1558,13 +1541,8 @@ initTM(void)
 		 * and then restores it back.
 		 */
 		olduser = ChangeToSuperuser();
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-		DtmInit,
-		DDLNotSpecified,
-		"", //databaseName,
-		""); //tableName;
-#endif
+
+		SIMPLE_FAULT_INJECTOR(DtmInit);
 
 		oldcontext = CurrentMemoryContext;
 		succeeded = false;

--- a/src/backend/executor/nodeDynamicTableScan.c
+++ b/src/backend/executor/nodeDynamicTableScan.c
@@ -223,14 +223,8 @@ ExecDynamicTableScan(DynamicTableScanState *node)
 		   initNextTableToScan(node))
 	{
 		slot = ExecTableScanRelation(scanState);
-		
-#ifdef FAULT_INJECTOR
-    FaultInjector_InjectFaultIfSet(
-    		FaultDuringExecDynamicTableScan,
-            DDLNotSpecified,
-            "",  // databaseName
-            ""); // tableName
-#endif
+
+		SIMPLE_FAULT_INJECTOR(FaultDuringExecDynamicTableScan);
 
 		if (!TupIsNull(slot))
 		{

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -113,13 +113,7 @@ MultiExecHash(HashState *node)
 	hashkeys = node->hashkeys;
 	econtext = node->ps.ps_ExprContext;
 
-#ifdef FAULT_INJECTOR
-    FaultInjector_InjectFaultIfSet(
-    		MultiExecHashLargeVmem,
-            DDLNotSpecified,
-            "",  // databaseName
-            ""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(MultiExecHashLargeVmem);
 
 	/*
 	 * get all inner tuples and insert into the hash table (or temp files)

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -812,14 +812,7 @@ ExecHashJoinNewBatch(HashJoinState *hjstate)
 	TupleTableSlot *slot;
 	uint32		hashvalue;
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-			FaultExecHashJoinNewBatch,
-			DDLNotSpecified,
-			"",  // databaseName
-			""); // tableName
-#endif
-
+	SIMPLE_FAULT_INJECTOR(FaultExecHashJoinNewBatch);
 
 	HashState *hashState = (HashState *) innerPlanState(hjstate);
 

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -225,13 +225,7 @@ ShareInputNext(ShareInputScanState *node)
 		Gpmon_M_Incr_Rows_Out(GpmonPktFromShareInputState(node)); 
 		CheckSendPlanStateGpmonPkt(&node->ss.ps);
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-			ExecShareInputNext,
-			DDLNotSpecified,
-			"",  // databaseName
-			""); // tableName
-#endif
+		SIMPLE_FAULT_INJECTOR(ExecShareInputNext);
 
 		return slot;
 	}

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -283,14 +283,7 @@ ExecSort(SortState *node)
 				tuplesort_puttupleslot(tuplesortstate, slot);
 		}
 
-#ifdef FAULT_INJECTOR
-		FaultInjector_InjectFaultIfSet(
-				ExecSortBeforeSorting,
-				DDLNotSpecified,
-				"" /* databaseName */,
-				"" /* tableName */
-				);
-#endif
+		SIMPLE_FAULT_INJECTOR(ExecSortBeforeSorting);
 
 		/*
 		 * Complete the sort.

--- a/src/backend/postmaster/bgwriter.c
+++ b/src/backend/postmaster/bgwriter.c
@@ -299,13 +299,7 @@ BackgroundWriterMain(void)
 			exit(1);
 
 #ifdef USE_ASSERT_CHECKING
-#ifdef FAULT_INJECTOR
-    FaultInjector_InjectFaultIfSet(
-    		FaultInBackgroundWriterMain,
-            DDLNotSpecified,
-            "",  // databaseName
-            ""); // tableName
-#endif
+		SIMPLE_FAULT_INJECTOR(FaultInBackgroundWriterMain);
 #endif
 		/*
 		 * Process any requests or signals received recently.

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2365,13 +2365,8 @@ ServerLoop(void)
                     return STATUS_ERROR;
                 }
             }
-#ifdef FAULT_INJECTOR
-			FaultInjector_InjectFaultIfSet(
-										   Postmaster,
-										   DDLNotSpecified,
-										   "",	//databaseName
-										   ""); // tableName
-#endif											
+
+			SIMPLE_FAULT_INJECTOR(Postmaster);
         }
         else
         {
@@ -3569,16 +3564,7 @@ processPrimaryMirrorTransitionRequest(Port *port, void *pkt)
 		strcpy(args->peerAddress, peer);
 	}
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet
-		(
-		SegmentTransitionRequest,
-		DDLNotSpecified,
-		"",	//databaseName
-		""  // tableName
-		)
-		;
-#endif
+	SIMPLE_FAULT_INJECTOR(SegmentTransitionRequest);
 
     char extraResultInfo[MAX_TRANSITION_RESULT_EXTRA_INFO];
 	result = requestTransitionToPrimaryMirrorMode(args, extraResultInfo);
@@ -3649,16 +3635,7 @@ processPrimaryMirrorTransitionQuery(Port *port, void *pkt)
 		return;
 	}
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet
-		(
-		SegmentProbeResponse,
-		DDLNotSpecified,
-		"",	//databaseName
-		""  // tableName
-		)
-		;
-#endif
+	SIMPLE_FAULT_INJECTOR(SegmentProbeResponse);
 
 	getPrimaryMirrorStatusCodes(&pm_mode, &s_state, &d_state, &f_type);
 

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1341,14 +1341,8 @@ FileSync(File file)
 	if (returnCode < 0)
 		return returnCode;
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-								   FileRepFlush,
-								   DDLNotSpecified,
-								   "",	//databaseName
-								   ""); // tableName
-#endif								
-	
+	SIMPLE_FAULT_INJECTOR(FileRepFlush);
+
 	returnCode =  pg_fsync(VfdCache[file].fd);
 	
 	if (returnCode >= 0)

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -145,13 +145,7 @@ ProcArrayAdd(PGPROC *proc)
 
 	LWLockAcquire(ProcArrayLock, LW_EXCLUSIVE);
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-		ProcArray_Add,
-		DDLNotSpecified,
-		"", // databaseName
-		""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(ProcArray_Add);
 
 	if (arrayP->numProcs >= arrayP->maxProcs)
 	{

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -1943,13 +1943,8 @@ smgrDoDeleteActions(
 			if (forCommit)
 			{
 				dropPending = true;
-#ifdef FAULT_INJECTOR
-				FaultInjector_InjectFaultIfSet(
-											   TransactionCommitPass1FromDropInMemoryToDropPending,
-											   DDLNotSpecified,
-											   "",	// databaseName
-											   ""); // tableName
-#endif
+
+				SIMPLE_FAULT_INJECTOR(TransactionCommitPass1FromDropInMemoryToDropPending);
 			}
 			break;
 

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -1199,13 +1199,8 @@ datumstreamread_block_content(DatumStreamRead * acc)
 				{
 					pfree(acc->large_object_buffer);
 					acc->large_object_buffer = NULL;
-#ifdef FAULT_INJECTOR
-					FaultInjector_InjectFaultIfSet(MallocFailure,
-												   DDLNotSpecified,
-												   "", //databaseName
-												   "");
-					/* tableName */
-#endif
+
+					SIMPLE_FAULT_INJECTOR(MallocFailure);
 				}
 
 				acc->large_object_buffer_size = acc->getBlockInfo.contentLen;

--- a/src/backend/utils/mmgr/runaway_cleaner.c
+++ b/src/backend/utils/mmgr/runaway_cleaner.c
@@ -122,13 +122,7 @@ RunawayCleaner_StartCleanup()
 			/* Super user is terminated only when it's the primary runaway consumer (i.e., the top consumer) */
 			(!superuser() || MySessionState->runawayStatus == RunawayStatus_PrimaryRunawaySession))
 		{
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-			RunawayCleanup,
-			DDLNotSpecified,
-			"",  // databaseName
-			""); // tableName
-#endif
+			SIMPLE_FAULT_INJECTOR(RunawayCleanup);
 
 			ereport(ERROR, (errmsg("Canceling query because of high VMEM usage. Used: %dMB, available %dMB, red zone: %dMB",
 					VmemTracker_ConvertVmemChunksToMB(MySessionState->sessionVmem), VmemTracker_GetAvailableVmemMB(),

--- a/src/backend/utils/workfile_manager/workfile_file.c
+++ b/src/backend/utils/workfile_manager/workfile_file.c
@@ -54,13 +54,7 @@ workfile_mgr_create_fileno(workfile_set *work_set, uint32 file_no)
 			true /* del_on_close */,
 			work_set->metadata.bfz_compress_type);
 
-#ifdef FAULT_INJECTOR
-  FaultInjector_InjectFaultIfSet(
-      WorkfileCreationFail,
-      DDLNotSpecified,
-      "",  // databaseName
-      ""); // tableName
-#endif
+	SIMPLE_FAULT_INJECTOR(WorkfileCreationFail);
 
 	ExecWorkfile_SetWorkset(ewfile, work_set);
 


### PR DESCRIPTION
Callers to `FaultInjector_InjectFaultIfSet()` which don't pass neither a database name nor a table name and that use `DDLNotSpecified` can instead use the convenient macro `SIMPLE_FAULT_INJECTOR()` which cuts down on the boilerplate in the code. The current callsites are quite verbose and use varying style so IMO the use of the macro improves readability of the code.

The callers which aren't plain calls to `FaultInjector_InjectFaultIfSet()` have been left for now in the true sense of the macro name, only the "simple" calls (which were in majority) were touched.

This commit does not bring any changes in functionality, merely refactoring for readability.