### PR TITLE
Fix compiler warnings in the MIVP data generator

### DIFF
--- a/gpAux/gpdemo/MIVP/data-generator/main.c
+++ b/gpAux/gpdemo/MIVP/data-generator/main.c
@@ -165,8 +165,8 @@ void table_gen(long long nrows, Stringlist wlist,int numcols, int *column_types,
   int itemp;
   int i,j,ii, nwords;
   int year, month, day, hour, minute, second;
-  int minyear, minmonth, minday, minhour, minminute, minsecond;
-  int maxyear, maxmonth, maxday, maxhour, maxmaxute, maxsecond;
+  int minyear, minmonth, minday;
+  int maxyear, maxmonth, maxday;
 
   int leaps[] = LEAPS;
   int nonleaps[] = NONLEAPS;

--- a/gpAux/gpdemo/MIVP/data-generator/utils.c
+++ b/gpAux/gpdemo/MIVP/data-generator/utils.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "utils.h"
 


### PR DESCRIPTION
Ran across this while debugging a failing `make cluster` and while I'm not sure when or where it's used (or was used) it should at least compile cleanly IMO so fixed some trivial warnings. The warnings were for a set of unused variables and the use of `memcpy()` without including the proper header file.