### PR TITLE
Readme update with docker quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,6 @@ throughout the codebase, but a few larger additions worth noting:
   FTS is a process that runs in the master node, and periodically
   polls the segments to maintain the status of each segment.
 
-## Getting Started with Docker
-
-A quickstart guide to Docker can be found on the [Pivotal Engineering Journal](http://engineering.pivotal.io/post/docker-gpdb/).
-
 ## Build GPDB with Planner
 
 ```
@@ -208,12 +204,14 @@ make installcheck-bugbuster
   some tests are known to fail with Greenplum. The
   __installcheck-good__ schedule excludes those tests.
 
-## Development with Docker (alpha)
+## Development with Docker
 
 We provide a docker image with all dependencies required to compile and test
 GPDB. You can view the dependency dockerfile at `./docker/base/Dockerfile`.
 The image is hosted on docker hub at `pivotaldata/gpdb-devel`. This docker
 image is currently under heavy development.
+
+A quickstart guide to Docker can be found on the [Pivotal Engineering Journal](http://engineering.pivotal.io/post/docker-gpdb/).
 
 Known issues:
 * The `installcheck-good` make target has at least 4 failures, some of which

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ throughout the codebase, but a few larger additions worth noting:
   FTS is a process that runs in the master node, and periodically
   polls the segments to maintain the status of each segment.
 
+## Getting Started with Docker
+A quickstart guide to Docker can be found on the [Pivotal Engineering Journal](http://engineering.pivotal.io/post/docker-gpdb/).
+
 ## Build GPDB with Planner
 
 ```

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ throughout the codebase, but a few larger additions worth noting:
   polls the segments to maintain the status of each segment.
 
 ## Getting Started with Docker
+
 A quickstart guide to Docker can be found on the [Pivotal Engineering Journal](http://engineering.pivotal.io/post/docker-gpdb/).
 
 ## Build GPDB with Planner


### PR DESCRIPTION
Added a link to a quickstart docker guide located on the Pivotal Engineering Journal.