### PR TITLE
Codegen compiler errors and warnings

### DIFF
--- a/src/backend/codegen/CMakeLists.txt
+++ b/src/backend/codegen/CMakeLists.txt
@@ -55,6 +55,12 @@ if (COMPILER_HAS_WNO_C99_EXTENSIONS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-conversion-null")
 endif()
 
+# Suppress warnings about deprecated keyword register
+CHECK_CXX_COMPILER_FLAG("-Wno-deprecated-register" COMPILER_HAS_WNO_C99_EXTENSIONS)
+if (COMPILER_HAS_WNO_C99_EXTENSIONS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register")
+endif()
+
 # Turn on the CODEGEN_DEBUG flag if this is a debug build.
 if (CMAKE_MAJOR_VERSION GREATER 2)
   cmake_policy(SET CMP0043 NEW)

--- a/src/backend/codegen/CMakeLists.txt
+++ b/src/backend/codegen/CMakeLists.txt
@@ -310,7 +310,6 @@ endif()
 if(EXISTS ${TXT_OBJFILE})
     add_cmockery_gtest(codegen_framework_unittest.t 
         tests/codegen_framework_unittest.cc
-        ${MOCK_DIR}/backend/utils/error/elog_mock.o
     )
 endif()
 

--- a/src/backend/codegen/exec_eval_expr_codegen.cc
+++ b/src/backend/codegen/exec_eval_expr_codegen.cc
@@ -76,11 +76,7 @@ bool ExecEvalExprCodegen::GenerateExecEvalExpr(
       codegen_utils, GetUniqueFuncName());
 
   // Function arguments to ExecVariableList
-  llvm::Value* llvm_expression_arg =
-      ArgumentByPosition(exec_eval_expr_func, 0);
-  llvm::Value* llvm_econtext_arg = ArgumentByPosition(exec_eval_expr_func, 1);
   llvm::Value* llvm_isnull_arg = ArgumentByPosition(exec_eval_expr_func, 2);
-  llvm::Value* llvm_isDone_arg = ArgumentByPosition(exec_eval_expr_func, 3);
 
   // BasicBlock of function entry.
   llvm::BasicBlock* llvm_entry_block = codegen_utils->CreateBasicBlock(

--- a/src/backend/codegen/exec_variable_list_codegen.cc
+++ b/src/backend/codegen/exec_variable_list_codegen.cc
@@ -335,7 +335,8 @@ bool ExecVariableListCodegen::GenerateExecVariableList(
       is_null_block = codegen_utils->CreateBasicBlock(
           "is_null_block_" + std::to_string(attnum), exec_variable_list_func);
       is_not_null_block = codegen_utils->CreateBasicBlock(
-          "is_not_null_block_" + std::to_string(attnum), exec_variable_list_func);
+          "is_not_null_block_" + std::to_string(attnum),
+          exec_variable_list_func);
 
       llvm::Value* llvm_attnum = codegen_utils->GetConstant(attnum);
 

--- a/src/backend/codegen/exec_variable_list_codegen.cc
+++ b/src/backend/codegen/exec_variable_list_codegen.cc
@@ -322,7 +322,7 @@ bool ExecVariableListCodegen::GenerateExecVariableList(
     // Create the block of (attnum+1)th attribute and jump to it after
     // you finish with current attribute.
     next_attribute_block = codegen_utils->CreateBasicBlock(
-        "attribute_block_"+(attnum+1), exec_variable_list_func);
+        "attribute_block_" + std::to_string(attnum+1), exec_variable_list_func);
 
     llvm::Value* llvm_next_values_ptr =
         irb->CreateInBoundsGEP(llvm_slot_PRIVATE_tts_values,
@@ -333,9 +333,9 @@ bool ExecVariableListCodegen::GenerateExecVariableList(
     if (!thisatt->attnotnull) {
       // Create blocks
       is_null_block = codegen_utils->CreateBasicBlock(
-          "is_null_block_"+attnum, exec_variable_list_func);
+          "is_null_block_" + std::to_string(attnum), exec_variable_list_func);
       is_not_null_block = codegen_utils->CreateBasicBlock(
-          "is_not_null_block_"+attnum, exec_variable_list_func);
+          "is_not_null_block_" + std::to_string(attnum), exec_variable_list_func);
 
       llvm::Value* llvm_attnum = codegen_utils->GetConstant(attnum);
 

--- a/src/backend/codegen/exec_variable_list_codegen.cc
+++ b/src/backend/codegen/exec_variable_list_codegen.cc
@@ -161,9 +161,6 @@ bool ExecVariableListCodegen::GenerateExecVariableList(
   llvm::Value* llvm_econtext =
       irb->CreateLoad(codegen_utils->GetPointerToMember(
           llvm_projInfo_arg, &ProjectionInfo::pi_exprContext));
-  llvm::Value* llvm_varSlotOffsets =
-      irb->CreateLoad(codegen_utils->GetPointerToMember(
-          llvm_projInfo_arg, &ProjectionInfo::pi_varSlotOffsets));
 
   // We want to fall back when ExecVariableList is called with a slot that's
   // different from the one we generated the function (eg HashJoin). We also

--- a/src/backend/codegen/include/codegen/expr_tree_generator.h
+++ b/src/backend/codegen/include/codegen/expr_tree_generator.h
@@ -93,11 +93,10 @@ class ExprTreeGenerator {
    **/
   ExprTreeGenerator(ExprState* expr_state,
                     ExprTreeNodeType node_type) :
-                      expr_state_(expr_state), node_type_(node_type) {}
+                      expr_state_(expr_state) {}
 
  private:
   ExprState* expr_state_;
-  ExprTreeNodeType node_type_;
   DISALLOW_COPY_AND_ASSIGN(ExprTreeGenerator);
 };
 

--- a/src/backend/codegen/include/codegen/utils/utility.h
+++ b/src/backend/codegen/include/codegen/utils/utility.h
@@ -33,7 +33,7 @@ namespace gpcodegen {
  * @return A pointer to the specified argument, or NULL if the specified
  *         position was beyond the end of function's arguments.
  **/
-static llvm::Argument* ArgumentByPosition(llvm::Function* function,
+static inline llvm::Argument* ArgumentByPosition(llvm::Function* function,
                                    const unsigned position) {
   llvm::Function::arg_iterator it = function->arg_begin();
   if (it == function->arg_end()) {

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -92,7 +92,8 @@ bool OpExprTreeGenerator::VerifyAndCreateExprTree(
   List *arguments = reinterpret_cast<FuncExprState*>(expr_state)->args;
   assert(nullptr != arguments);
   // In ExecEvalFuncArgs
-  assert(list_length(arguments) == itr->second->GetTotalArgCount());
+  assert(list_length(arguments) ==
+        static_cast<int>(itr->second->GetTotalArgCount()));
 
   ListCell   *arg = nullptr;
   bool supported_tree = true;

--- a/src/backend/codegen/tests/codegen_framework_unittest.cc
+++ b/src/backend/codegen/tests/codegen_framework_unittest.cc
@@ -48,7 +48,7 @@
 extern "C" {
     #include "utils/elog.h"
     #undef elog
-    #define elog
+    #define elog(...)
 }
 
 #include "codegen/utils/codegen_utils.h"

--- a/src/backend/codegen/tests/codegen_utils_unittest.cc
+++ b/src/backend/codegen/tests/codegen_utils_unittest.cc
@@ -1076,7 +1076,7 @@ class CodegenUtilsTest : public ::testing::Test {
      InputType* input = new InputType[input_size];
      for (size_t idx = 0; idx < input_size; ++idx) {
          unsigned int seed = idx;
-         input[idx] = rand_r(&seed) % (2 ^ (sizeof(InputType) * 8) - 1);
+         input[idx] = rand_r(&seed) % ((2 ^ (sizeof(InputType) * 8)) - 1);
      }
      return input;
   }

--- a/src/backend/codegen/tests/codegen_utils_unittest.cc
+++ b/src/backend/codegen/tests/codegen_utils_unittest.cc
@@ -2754,12 +2754,12 @@ TEST_F(CodegenUtilsTest, GetOrGetOrRegisterExternalFunctionTest) {
   EXPECT_EQ(expected_fabs_func, fabs_func);
 
   // Test previously registered vararg function
-  llvm::Function* expected_vprintf_func = codegen_utils_->
-      GetOrRegisterExternalFunction(vprintf);
-  llvm::Function* vprintf_func = codegen_utils_->
-      GetOrRegisterExternalFunction(vprintf);
+  llvm::Function* expected_fprintf_func = codegen_utils_->
+      GetOrRegisterExternalFunction(fprintf);
+  llvm::Function* fprintf_func = codegen_utils_->
+      GetOrRegisterExternalFunction(fprintf);
 
-  EXPECT_EQ(expected_vprintf_func, vprintf_func);
+  EXPECT_EQ(expected_fprintf_func, fprintf_func);
 }
 
 


### PR DESCRIPTION
Tested on Centos 7. Checking OSX.
* The deleted lines are for unused variable warnings.
* inline for unused function
* string + num - to use std::to_string()
* node_type_ was not used.
* elog(a,b,c) would be (a,b,c) in unitttest instead of removing the entire line.

EDIT: Done checking on OSX. Removed all but 2 warnings of unused variables used in asserts.

```
$ make
Scanning dependencies of target SUBSYS.o
[  5%] Building CXX object CMakeFiles/SUBSYS.o.dir/codegen_interface.cc.o
[ 11%] Building CXX object CMakeFiles/SUBSYS.o.dir/codegen_manager.cc.o
[ 17%] Building CXX object CMakeFiles/SUBSYS.o.dir/codegen_wrapper.cc.o
[ 23%] Building CXX object CMakeFiles/SUBSYS.o.dir/base_codegen.cc.o
[ 29%] Building CXX object CMakeFiles/SUBSYS.o.dir/exec_variable_list_codegen.cc.o
[ 35%] Building CXX object CMakeFiles/SUBSYS.o.dir/exec_eval_expr_codegen.cc.o
[ 41%] Building CXX object CMakeFiles/SUBSYS.o.dir/expr_tree_generator.cc.o
[ 47%] Building CXX object CMakeFiles/SUBSYS.o.dir/op_expr_tree_generator.cc.o
[ 52%] Building CXX object CMakeFiles/SUBSYS.o.dir/var_expr_tree_generator.cc.o
[ 58%] Building CXX object CMakeFiles/SUBSYS.o.dir/const_expr_tree_generator.cc.o
[ 64%] Linking CXX executable SUBSYS.o
[ 64%] Built target SUBSYS.o
Scanning dependencies of target gpcodegen
[ 70%] Building CXX object CMakeFiles/gpcodegen.dir/utils/clang_compiler.cc.o
[ 76%] Building CXX object CMakeFiles/gpcodegen.dir/utils/codegen_utils.cc.o
[ 82%] Building CXX object CMakeFiles/gpcodegen.dir/utils/gp_codegen_utils.cc.o
[ 88%] Building CXX object CMakeFiles/gpcodegen.dir/utils/temporary_file.cc.o
[ 94%] Linking CXX shared library libgpcodegen.so
[100%] Built target gpcodegen
```
```
-- Using LLVMConfig.cmake in: /usr/local/share/llvm/cmake
-- Configuring done
-- Generating done
-- Build files have been written to: /workspace/codegen/gpdb/src/backend/codegen
[  3%] Building CXX object gtest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
[  7%] Linking CXX static library libgtest.a
[  7%] Built target gtest
[ 30%] Built target gpcodegen
Scanning dependencies of target codegen_framework_unittest.t
[ 34%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/tests/codegen_framework_unittest.cc.o
[ 38%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/codegen_interface.cc.o
[ 42%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/codegen_manager.cc.o
[ 46%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/codegen_wrapper.cc.o
[ 50%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/base_codegen.cc.o
[ 53%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/exec_variable_list_codegen.cc.o
[ 57%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/exec_eval_expr_codegen.cc.o
[ 61%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/expr_tree_generator.cc.o
[ 65%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/op_expr_tree_generator.cc.o
[ 69%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/var_expr_tree_generator.cc.o
[ 73%] Building CXX object CMakeFiles/codegen_framework_unittest.t.dir/const_expr_tree_generator.cc.o
[ 76%] Linking CXX executable codegen_framework_unittest.t
[ 76%] Built target codegen_framework_unittest.t
Scanning dependencies of target instance_method_wrappers_unittest.t
[ 80%] Building CXX object CMakeFiles/instance_method_wrappers_unittest.t.dir/tests/instance_method_wrappers_unittest.cc.o
[ 84%] Linking CXX executable instance_method_wrappers_unittest.t
[ 84%] Built target instance_method_wrappers_unittest.t
Scanning dependencies of target clang_compiler_unittest.t
[ 88%] Building CXX object CMakeFiles/clang_compiler_unittest.t.dir/tests/clang_compiler_unittest.cc.o
[ 92%] Linking CXX executable clang_compiler_unittest.t
[ 92%] Built target clang_compiler_unittest.t
Scanning dependencies of target codegen_utils_unittest.t
[ 96%] Building CXX object CMakeFiles/codegen_utils_unittest.t.dir/tests/codegen_utils_unittest.cc.o
[100%] Linking CXX executable codegen_utils_unittest.t
[100%] Built target codegen_utils_unittest.t
Scanning dependencies of target check
Test project /workspace/codegen/gpdb/src/backend/codegen
    Start 1: clang_compiler_unittest.t
1/4 Test #1: clang_compiler_unittest.t .............   Passed    0.04 sec
    Start 2: codegen_utils_unittest.t
2/4 Test #2: codegen_utils_unittest.t ..............   Passed    0.05 sec
    Start 3: instance_method_wrappers_unittest.t
3/4 Test #3: instance_method_wrappers_unittest.t ...   Passed    0.00 sec
    Start 4: codegen_framework_unittest.t
4/4 Test #4: codegen_framework_unittest.t ..........   Passed    0.02 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =   0.12 sec
[100%] Built target check
Built target unittest-check
```