### PR TITLE
Some refactorings on the Postmaster 

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -4314,13 +4314,13 @@ static bool CommenceNormalOperations(void)
 	{
 		char version[512];
 
-		strcpy(version, PG_VERSION_STR " compiled on " __DATE__ " " __TIME__);
+		strlcpy(version, PG_VERSION_STR " compiled on " __DATE__ " " __TIME__,
+			sizeof(version));
 
 #ifdef USE_ASSERT_CHECKING
-		strcat(version, " (with assert checking)");
+		strlcat(version, " (with assert checking)", sizeof(version));
 #endif
 		ereport(LOG,(errmsg("%s", version)));
-
 
 		ereport(LOG,
 			 (errmsg("database system is ready to accept connections"),

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -772,7 +772,7 @@ PostmasterGetMppLocalProcessCounter(void)
 static void
 signal_child_if_up(int pid, int signal)
 {
-	if ( pid != 0)
+	if (pid != 0)
 	{
 		signal_child(pid, signal);
 	}
@@ -1974,9 +1974,7 @@ checkIODataDirectory(void)
  */
 static void SimExProcExit()
 {
-	if (gp_simex_init &&
-	    gp_simex_run &&
-	    pmState == PM_RUN)
+	if (gp_simex_init && gp_simex_run && pmState == PM_RUN)
 	{
 		pid_t pid = 0;
 		int sig = 0;
@@ -4223,9 +4221,10 @@ do_immediate_shutdown_reaper(void)
 }
 
 /*
-* Startup succeeded, commence normal operations
-*/
-static bool CommenceNormalOperations(void)
+ * Startup succeeded, commence normal operations
+ */
+static bool
+CommenceNormalOperations(void)
 {
 	bool didServiceProcessWork = false;
 	int s;
@@ -4298,11 +4297,9 @@ static bool CommenceNormalOperations(void)
 		{
 			PMSubProc *subProc = &PMSubProcList[s];
 
-			if (subProc->pid == 0 &&
-				ServiceStartable(subProc))
+			if (subProc->pid == 0 && ServiceStartable(subProc))
 			{
-				subProc->pid =
-					(subProc->serverStart)();
+				subProc->pid = (subProc->serverStart)();
 
 				if (Debug_print_server_processes)
 				{
@@ -4356,7 +4353,8 @@ reaper(SIGNAL_ARGS)
     }
 }
 
-static void do_reaper()
+static void
+do_reaper()
 {
 	int			save_errno = errno;
 	int         s;
@@ -4367,8 +4365,7 @@ static void do_reaper()
 
 	need_call_reaper = 0;
 
-	ereport(DEBUG4,
-			(errmsg_internal("reaping dead processes")));
+	ereport(DEBUG4, (errmsg_internal("reaping dead processes")));
 
 	while (REAPER_LOOPTEST())
 	{
@@ -4431,8 +4428,7 @@ static void do_reaper()
 			if (!EXIT_STATUS_0(exitstatus))
 			{
 				RecoveryError = true;
-				HandleChildCrash(pid, exitstatus,
-								 _("startup process"));
+				HandleChildCrash(pid, exitstatus, _("startup process"));
 				continue;
 			}
 
@@ -4697,14 +4693,12 @@ static void do_reaper()
 		{
 			PMSubProc *subProc = &PMSubProcList[s];
 
-			if (subProc->pid != 0 &&
-				pid == subProc->pid)
+			if (subProc->pid != 0 && pid == subProc->pid)
 			{
 				subProc->pid = 0;
 
 				if (!EXIT_STATUS_0(exitstatus))
-					LogChildExit(LOG, subProc->procName,
-								 pid, exitstatus);
+					LogChildExit(LOG, subProc->procName, pid, exitstatus);
 
 				if (ServiceStartable(subProc))
 				{
@@ -4723,21 +4717,11 @@ static void do_reaper()
 						}
 
 						/*
-						 * MPP-7676, we can't restart during
-						 * do_reaper() since we may initiate a
-						 * postmaster reset (in which case we'll wind
-						 * up waiting for the restarted process to
-						 * die). Leave the startup to ServerLoop().
+						 * We can't restart during do_reaper() since we may
+						 * initiate a postmaster reset (in which case we'll
+						 * wind up waiting for the restarted process to die).
+						 * Leave the startup to ServerLoop(). (MPP-7676)
 						 */
-						/*
-						  subProc->pid =
-						  (subProc->serverStart)();
-						  if (Debug_print_server_processes)
-						  {
-						  elog(LOG,"restarted '%s' as pid %ld", subProc->procName, (long)subProc->pid);
-						  didServiceProcessWork = true;
-						  }
-						*/
 					}
 				}
 
@@ -4835,7 +4819,7 @@ static void do_reaper()
 				 * revive.  Because they are still connected to shared memory
 				 * and can change segment status etc in case mirror starts
 				 * the peer reset, we should tell them to die immediately
-				 * before runnig reset.  Since this is an immediate shutdown
+				 * before running reset.  Since this is an immediate shutdown
 				 * request, we don't have a way to wait for the completion.
 				 *
 				 * status 2 is not expected here as this is non-shutdown
@@ -4848,7 +4832,6 @@ static void do_reaper()
 									 _("filerep main process"));
 				}
 			}
-
 
             /* PostmasterStateMachine logic does the rest */
 			continue;
@@ -5437,16 +5420,17 @@ HandleChildCrash(int pid, int exitstatus, const char *procname)
             signal_child(FilerepPID, SIGSTOP);
         else
         {
-            /**
-             * For filerep, a graceful shutdown is performed.  This will have the
-             *     primary send a shutdown message to the mirror, so that mirror does
-             *     not enter fault from the reset.  Also, since filerep manages
-             *     its own subprocesses, we want filerep to exit only when
-             *     all its children are gone -- which is done using regular, not immediate,
-             *     shutdown
-             * Note that this is not ideal from a "don't touch shared memory during reset"
-             *     perspective.
-             */
+			/*
+			 * For filerep, a graceful shutdown is performed.  This will have the
+			 * primary send a shutdown message to the mirror, so that mirror does
+			 * not enter fault from the reset.  Also, since filerep manages it's
+			 * own subprocesses, we want filerep to exit only when all its
+			 * children are gone -- which is done using regular, not immediate,
+			 * shutdown
+			 *
+			 * Note that this is not ideal from a "don't touch shared memory
+			 * during reset" perspective.
+			 */
             signal_filerep_to_shutdown(SegmentStateImmediateShutdown);
         }
     }
@@ -5463,7 +5447,7 @@ HandleChildCrash(int pid, int exitstatus, const char *procname)
 		signal_child(WalWriterPID, (SendStop ? SIGSTOP : SIGQUIT));
 	}
 
-	/* Take care of walreceiver */
+	/* Take care of the walreceiver too */
 	if (pid == WalReceiverPID)
 		WalReceiverPID = 0;
 	else if (WalReceiverPID != 0 && !FatalError)
@@ -5649,14 +5633,15 @@ LogChildExit(int lev, const char *procname, int pid, int exitstatus)
  * POSTMASTER STATE MACHINE WAITING!
  */
 
-/**
+/*
  *  Check to see if PM_CHILD_STOP_WAIT_BACKENDS state is done
  */
-static PMState StateMachineCheck_WaitBackends(void)
+static PMState
+StateMachineCheck_WaitBackends(void)
 {
     bool moveToNextState = false;
 
-    Assert(pmState == PM_CHILD_STOP_WAIT_BACKENDS );
+    Assert(pmState == PM_CHILD_STOP_WAIT_BACKENDS);
 
     /*
      * If we are in a state-machine state that implies waiting for backends to
@@ -5682,8 +5667,11 @@ static PMState StateMachineCheck_WaitBackends(void)
             autovacShutdown &&
             isFilerepBackendsDoneShutdown)
         {
-            /* note: on fatal error, children are killed all at once by HandleChildCrash, so asserts are not valid */
-            if ( ! FatalError )
+            /*
+			 * Note: on fatal error, children are killed all at once by
+			 * HandleChildCrash, so asserts are not valid
+			 */
+            if (!FatalError)
             {
                 Assert(StartupPID == 0);
             }
@@ -5708,7 +5696,7 @@ static PMState StateMachineCheck_WaitBackends(void)
         }
         else
         {
-            if ( Debug_print_server_processes )
+            if (Debug_print_server_processes)
             {
                 elog(LOG, "Postmaster State Machine: waiting on backends, children %d, filerep backends %s, av %s",
                     childCount,
@@ -5870,7 +5858,8 @@ static PMState StateMachineCheck_WaitBgWriterCheckpointComplete(void)
 /**
  * Called to transition to PM_CHILD_STOP_WAIT_STARTUP_PROCESSES -- so tell any startup processes to complete
  */
-static void StateMachineTransition_ShutdownStartupProcesses(void)
+static void
+StateMachineTransition_ShutdownStartupProcesses(void)
 {
 	signal_child_if_up(StartupPID, SIGTERM);
 	signal_child_if_up(StartupPass2PID, SIGTERM);
@@ -5879,14 +5868,15 @@ static void StateMachineTransition_ShutdownStartupProcesses(void)
 	signal_child_if_up(WalReceiverPID, SIGTERM);
 }
 
-/**
+/*
  * Called to transition to PM_CHILD_STOP_WAIT_BACKENDS : waiting for all backends to finish
  */
-static void StateMachineTransition_ShutdownBackends(void)
+static void
+StateMachineTransition_ShutdownBackends(void)
 {
-    if ( Shutdown == FastShutdown )
+    if (Shutdown == FastShutdown)
     {
-        /* shut down all backend, including autovac workers */
+        /* shut down all backends, including autovac workers */
         SignalChildren(SIGTERM);
     }
     else
@@ -5902,13 +5892,13 @@ static void StateMachineTransition_ShutdownBackends(void)
 	signal_child_if_up(WalWriterPID, SIGTERM);
 
     signal_filerep_to_shutdown(SegmentStateShutdownFilerepBackends);
-
 }
 
 /**
  * Called to transition to PM_CHILD_STOP_WAIT_PREBGWRITER : waiting for pre-bgwriter processes to finish
  */
-static void StateMachineTransition_ShutdownPreBgWriter(void)
+static void
+StateMachineTransition_ShutdownPreBgWriter(void)
 {
     /* SIGUSR2, regardless of shutdown mode */
     StopServices(/* excludeFlags */ PMSUBPROC_FLAG_STOP_AFTER_BGWRITER, SIGUSR2 );
@@ -6084,8 +6074,9 @@ PostmasterStateMachine(void)
                 nextPmState = pmState;
                 break;
 
+            /* immediately move to next step and run its transition actions ... */
             case PM_CHILD_STOP_BEGIN:
-                nextPmState = pmState + 1; /* immediately move to next step and run its transition actions ... */
+                nextPmState = pmState + 1;
                 break;
 
             /* shutdown has been requested -- check to make sure startup processes are done */

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -253,7 +253,11 @@ char	   *bonjour_name;
 
 static PrimaryMirrorMode gInitialMode = PMModeMirrorlessSegment;
 
-/* PIDs of special child processes; 0 when not running */
+/*
+ * PIDs of special child processes; 0 when not running. When adding a new PID
+ * to the list, remember to add the process title to GetServerProcessTitle()
+ * as well.
+ */
 static pid_t StartupPID = 0,
 			StartupPass2PID = 0,
 			StartupPass3PID = 0,
@@ -539,7 +543,7 @@ static void do_reaper(void);
 static void do_immediate_shutdown_reaper(void);
 static bool ServiceProcessesExist(int excludeFlags);
 static bool StopServices(int excludeFlags, int signal);
-static char *GetServerProcessTitle(int pid);
+static const char *GetServerProcessTitle(int pid);
 static void sigusr1_handler(SIGNAL_ARGS);
 static void dummy_handler(SIGNAL_ARGS);
 static void CleanupBackend(int pid, int exitstatus);
@@ -1988,7 +1992,7 @@ static void SimExProcExit()
 			if (subclass == SimExESSubClass_ProcKill_BgWriter)
 			{
 				pid = BgWriterPID;
-				procName = "writer process";
+				procname = GetServerProcessTitle(pid);
 			}
 			else
 			{
@@ -4374,7 +4378,7 @@ static void do_reaper()
 
 		if (Debug_print_server_processes)
 		{
-			char *procName;
+			const char *procName;
 
 			procName = GetServerProcessTitle(pid);
 			if (procName != NULL)
@@ -5153,12 +5157,12 @@ StopServices(int excludeFlags, int signal)
 	return signaled;
 }
 
-static char *
+static const char *
 GetServerProcessTitle(int pid)
 {
 	int s;
 
-	for (s=0; s < MaxPMSubType; s++)
+	for (s = 0; s < MaxPMSubType; s++)
 	{
 		PMSubProc *subProc = &PMSubProcList[s];
 		if (subProc->pid == pid)
@@ -5169,31 +5173,31 @@ GetServerProcessTitle(int pid)
 		return "background writer process";
 	if (pid == CheckpointPID)
 		return "checkpoint process";
-	else if (pid == WalWriterPID)
+	if (pid == WalWriterPID)
 		return "walwriter process";
-	else if (pid == WalReceiverPID)
+	if (pid == WalReceiverPID)
 		return "walreceiver process";
-	else if (pid == AutoVacPID)
+	if (pid == AutoVacPID)
 		return "autovacuum process";
-	else if (pid == PgStatPID)
+	if (pid == PgStatPID)
 		return "statistics collector process";
-	else if (pid == PgArchPID)
+	if (pid == PgArchPID)
 		return "archiver process";
-	else if (pid == SysLoggerPID)
+	if (pid == SysLoggerPID)
 		return "system logger process";
-	else if (pid == StartupPID)
+	if (pid == StartupPID)
 		return "startup process";
-    else if (pid == StartupPass2PID)
-        return "startup pass 2 process";
-    else if (pid == StartupPass3PID)
-        return "startup pass 3 process";
-    else if (pid == StartupPass4PID)
-        return "startup pass 4 process";
-	else if (pid == PostmasterPid)
+	if (pid == StartupPass2PID)
+		return "startup pass 2 process";
+	if (pid == StartupPass3PID)
+		return "startup pass 3 process";
+	if (pid == StartupPass4PID)
+		return "startup pass 4 process";
+	if (pid == PostmasterPid)
 		return "postmaster process";
-    else if (pid == FilerepPID )
-        return "filerep process";
-	else if (pid == FilerepPeerResetPID)
+	if (pid == FilerepPID )
+		return "filerep process";
+	if (pid == FilerepPeerResetPID)
 		return "filerep peer reset process";
 
 	return NULL;
@@ -6241,7 +6245,7 @@ signal_child(pid_t pid, int signal)
 
 	if (Debug_print_server_processes)
 	{
-		char *procName;
+		const char *procName;
 
 		procName = GetServerProcessTitle(pid);
 		if (procName != NULL)

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -5440,7 +5440,7 @@ HandleChildCrash(int pid, int exitstatus, const char *procname)
 		WalWriterPID = 0;
 	else if (WalWriterPID != 0 && !FatalError)
 	{
-		ereport(DEBUG2,
+		ereport((Debug_print_server_processes ? LOG : DEBUG2),
 				(errmsg_internal("sending %s to process %d",
 								 (SendStop ? "SIGSTOP" : "SIGQUIT"),
 								 (int) WalWriterPID)));

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -6237,20 +6237,17 @@ signal_child(pid_t pid, int signal)
 	if (Debug_print_server_processes)
 	{
 		const char *procName;
+		const char *signalName;
 
 		procName = GetServerProcessTitle(pid);
-		if (procName != NULL)
-		{
-			const char *signalName;
+		signalName = signal_to_name(signal);
 
-			signalName = signal_to_name(signal);
-			if (signalName != NULL)
-				elog(LOG,"signal %s sent to '%s' pid %ld",
-				     signalName, procName, (long)pid);
-			else
-				elog(LOG,"signal %d sent to '%s' pid %ld",
-				     signal, procName, (long)pid);
-		}
+		if (signalName != NULL)
+			elog(LOG,"signal %s sent to '%s' pid %ld",
+			     signalName, (procName ? procName : "unknown"), (long)pid);
+		else
+			elog(LOG,"signal %d sent to '%s' pid %ld",
+			     signal, (procName ? procName : "unknown"), (long)pid);
 	}
 
 	if (kill(pid, signal) < 0)


### PR DESCRIPTION
In PR #871 the discussion was raised (by among other me) about refactoring the intricate startup/shutdown logic in `postmaster.c` and to put some code where my mouth is I decided to kick the tyres a bit. Given the size of such a project it seems best to tackle it in bitesize chunks so this pull request contains a bit of a mixed bag of cleanups and small refactorings. This is a call for review but also for testing, this patch works fine for me with `make cluster` and gpstop/gpstart and when randomly shooting down some things but I would like to see more exercise given how critical these codepaths are.

When looking, please review by commit and not via the "Files changed" tab as the commit message contains vital information and the combined weight of the diffs might be confusing to read. Most of these commits should be fairly non-controversial with some style fixes along the paths I was reading, the most interesting ones are:

* 0b2e1d0 moves the status check inside `CommenceNormalOperations()` and `do_reaper()` from out under a debug GUC (by means of archaeology it seems to originally be a copy-pasto that spread) and reverses the logic of setting the status. The end result should be the same with the added twist that it might actually work now.
* 0274221 adds the walwriter to the logic which was missed in the 8.3 merge. One patch that seemed instinctively right, but which made `make cluster` fail (even though bare `gpstart` and `gpstop` commands work) is below. I can't really follow the logic as to *why* this isn't required but I also can't make it break without it. I may be thick here so any clues are welcome. This is not included in this PR:
```diff
diff --git a/src/backend/postmaster/postmaster.c b/src/backend/postmaster/postmaster.c
index 9c0a38e..5f35895 100644
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -5661,7 +5661,7 @@ StateMachineCheck_WaitBackends(void)
                 * TODO: CHAD_PM why wait for BgWriterPID here? Can't we just allow
                 * normal state advancement to hit there?
                 */
-        if (childCount == 0 && WalReceiverPID == 0
+        if (childCount == 0 && WalReceiverPID == 0 && WalWriterPID == 0
                        && (BgWriterPID == 0 || !FatalError)
                        && autovacShutdown && isFilerepBackendsDoneShutdown)
         {
```
@asimrp, @amilkh, @ashwinstar can you spare a moment and have a look? @asimrp can you run this through Tinc tests and see where it falls apart?