### PR TITLE
Codegen expressions that contain <= operator for date/timestamp data types

### DIFF
--- a/src/backend/codegen/CMakeLists.txt
+++ b/src/backend/codegen/CMakeLists.txt
@@ -171,12 +171,13 @@ set(GPCODEGEN_SRC
     codegen_interface.cc
     codegen_manager.cc
     codegen_wrapper.cc
+    const_expr_tree_generator.cc
     exec_variable_list_codegen.cc
     exec_eval_expr_codegen.cc
     expr_tree_generator.cc
     op_expr_tree_generator.cc
+    pg_date_func_generator.cc
     var_expr_tree_generator.cc
-    const_expr_tree_generator.cc
 )
 
 # Integrate with GPDB build system. 

--- a/src/backend/codegen/const_expr_tree_generator.cc
+++ b/src/backend/codegen/const_expr_tree_generator.cc
@@ -39,7 +39,7 @@ ConstExprTreeGenerator::ConstExprTreeGenerator(ExprState* expr_state) :
     ExprTreeGenerator(expr_state, ExprTreeNodeType::kConst) {
 }
 
-bool ConstExprTreeGenerator::GenerateCode(CodegenUtils* codegen_utils,
+bool ConstExprTreeGenerator::GenerateCode(GpCodegenUtils* codegen_utils,
                                         ExprContext* econtext,
                                         llvm::Function* llvm_main_func,
                                         llvm::BasicBlock* llvm_error_block,

--- a/src/backend/codegen/include/codegen/const_expr_tree_generator.h
+++ b/src/backend/codegen/include/codegen/const_expr_tree_generator.h
@@ -32,7 +32,7 @@ class ConstExprTreeGenerator : public ExprTreeGenerator {
       ExprContext* econtext,
       std::unique_ptr<ExprTreeGenerator>* expr_tree);
 
-  bool GenerateCode(gpcodegen::CodegenUtils* codegen_utils,
+  bool GenerateCode(gpcodegen::GpCodegenUtils* codegen_utils,
                     ExprContext* econtext,
                     llvm::Function* llvm_main_func,
                     llvm::BasicBlock* llvm_error_block,

--- a/src/backend/codegen/include/codegen/expr_tree_generator.h
+++ b/src/backend/codegen/include/codegen/expr_tree_generator.h
@@ -18,7 +18,7 @@
 #include <utility>
 #include <unordered_map>
 
-#include "codegen/utils/codegen_utils.h"
+#include "codegen/utils/gp_codegen_utils.h"
 
 #include "llvm/IR/Value.h"
 
@@ -71,7 +71,7 @@ class ExprTreeGenerator {
    *
    * @return true when it generated successfully otherwise it return false.
    **/
-  virtual bool GenerateCode(gpcodegen::CodegenUtils* codegen_utils,
+  virtual bool GenerateCode(gpcodegen::GpCodegenUtils* codegen_utils,
                             ExprContext* econtext,
                             llvm::Function* llvm_main_func,
                             llvm::BasicBlock* llvm_error_block,

--- a/src/backend/codegen/include/codegen/op_expr_tree_generator.h
+++ b/src/backend/codegen/include/codegen/op_expr_tree_generator.h
@@ -45,7 +45,7 @@ class OpExprTreeGenerator : public ExprTreeGenerator {
         ExprContext* econtext,
         std::unique_ptr<ExprTreeGenerator>* expr_tree);
 
-  bool GenerateCode(gpcodegen::CodegenUtils* codegen_utils,
+  bool GenerateCode(gpcodegen::GpCodegenUtils* codegen_utils,
                     ExprContext* econtext,
                     llvm::Function* llvm_main_func,
                     llvm::BasicBlock* llvm_error_block,

--- a/src/backend/codegen/include/codegen/pg_date_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_date_func_generator.h
@@ -1,0 +1,78 @@
+//---------------------------------------------------------------------------
+//  Greenplum Database
+//  Copyright (C) 2016 Pivotal Software, Inc.
+//
+//  @filename:
+//    pg_date_func_generator.h
+//
+//  @doc:
+//    Base class for date functions to generate code
+//
+//---------------------------------------------------------------------------
+#ifndef GPCODEGEN_PG_DATE_FUNC_GENERATOR_H_  // NOLINT(build/header_guard)
+#define GPCODEGEN_PG_DATE_FUNC_GENERATOR_H_
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "codegen/utils/codegen_utils.h"
+#include "codegen/base_codegen.h"
+
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Value.h"
+
+namespace gpcodegen {
+
+/** \addtogroup gpcodegen
+ *  @{
+ */
+
+/**
+ * @brief Class with Static member function to generate code for date
+ *        operators.
+ **/
+class PGDateFuncGenerator {
+ public:
+  /**
+   * @brief Create instructions for date_le_timestamp function
+   *
+   * @param codegen_utils     Utility to easy code generation.
+   * @param llvm_main_func    Current function for which we are generating code
+   * @param llvm_error_block  Basic Block to jump when error happens
+   * @param llvm_args         Vector of llvm arguments for the function
+   * @param llvm_out_value    Store the results of function
+   *
+   * @return true if generation was successful otherwise return false
+   *
+   **/
+  static bool DateLETimestamp(gpcodegen::GpCodegenUtils* codegen_utils,
+                              llvm::Function* llvm_main_func,
+                              llvm::BasicBlock* llvm_error_block,
+                              const std::vector<llvm::Value*>& llvm_args,
+                              llvm::Value** llvm_out_value);
+
+ private:
+  /**
+   * @brief Internal routines for promoting date to timestamp and timestamp
+   *        with time zone (see date2timestamp).
+   *
+   * @param codegen_utils     Utility to easy code generation.
+   * @param llvm_main_func    Current function for which we are generating code
+   * @param llvm_arg          llvm value for the date
+   * @param llvm_error_block  Basic Block to jump when error happens
+   *
+   * @note  If there is overflow, it will do elog::ERROR and then jump to given
+   *        error block.
+   */
+  static llvm::Value* GenerateDate2Timestamp(
+      GpCodegenUtils* codegen_utils,
+      llvm::Function* llvm_main_func,
+      llvm::Value* llvm_arg,
+      llvm::BasicBlock* llvm_error_block);
+};
+
+/** @} */
+}  // namespace gpcodegen
+
+#endif  // GPCODEGEN_PG_ARITH_FUNC_GENERATOR_H_

--- a/src/backend/codegen/include/codegen/pg_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_func_generator.h
@@ -17,7 +17,7 @@
 #include <memory>
 
 #include "codegen/pg_func_generator_interface.h"
-#include "codegen/utils/codegen_utils.h"
+#include "codegen/utils/gp_codegen_utils.h"
 
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Value.h"
@@ -28,7 +28,7 @@ namespace gpcodegen {
  *  @{
  */
 
-typedef bool (*PGFuncGenerator)(gpcodegen::CodegenUtils* codegen_utils,
+typedef bool (*PGFuncGenerator)(gpcodegen::GpCodegenUtils* codegen_utils,
     llvm::Function* llvm_main_func,
     llvm::BasicBlock* llvm_error_block,
     const std::vector<llvm::Value*>& llvm_args,
@@ -63,7 +63,7 @@ class PGFuncBaseGenerator : public PGFuncGeneratorInterface {
    *
    * @return true on successful preprocess otherwise return false.
    **/
-  bool PreProcessArgs(gpcodegen::CodegenUtils* codegen_utils,
+  bool PreProcessArgs(gpcodegen::GpCodegenUtils* codegen_utils,
                       const std::vector<llvm::Value*>& llvm_in_args,
                       std::vector<llvm::Value*>* llvm_out_args) {
     assert(nullptr != codegen_utils &&
@@ -132,7 +132,7 @@ Arg0, Arg1> {
                                              mem_func_ptr) {
   }
 
-  bool GenerateCode(gpcodegen::CodegenUtils* codegen_utils,
+  bool GenerateCode(gpcodegen::GpCodegenUtils* codegen_utils,
                     llvm::Function* llvm_main_func,
                     llvm::BasicBlock* llvm_error_block,
                     const std::vector<llvm::Value*>& llvm_args,
@@ -178,7 +178,7 @@ Arg0, Arg1> {
                                              func_ptr) {
   }
 
-  bool GenerateCode(gpcodegen::CodegenUtils* codegen_utils,
+  bool GenerateCode(gpcodegen::GpCodegenUtils* codegen_utils,
                     llvm::Function* llvm_main_func,
                     llvm::BasicBlock* llvm_error_block,
                     const std::vector<llvm::Value*>& llvm_args,

--- a/src/backend/codegen/include/codegen/pg_func_generator_interface.h
+++ b/src/backend/codegen/include/codegen/pg_func_generator_interface.h
@@ -18,7 +18,7 @@
 
 #include "llvm/IR/Value.h"
 
-#include "codegen/utils/codegen_utils.h"
+#include "codegen/utils/gp_codegen_utils.h"
 
 namespace gpcodegen {
 
@@ -54,7 +54,7 @@ class PGFuncGeneratorInterface {
    *
    * @return true when it generated successfully otherwise it return false.
    **/
-  virtual bool GenerateCode(gpcodegen::CodegenUtils* codegen_utils,
+  virtual bool GenerateCode(gpcodegen::GpCodegenUtils* codegen_utils,
                             llvm::Function* llvm_main_func,
                             llvm::BasicBlock* llvm_error_block,
                             const std::vector<llvm::Value*>& llvm_args,

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -492,7 +492,7 @@ class CodegenUtils {
     // Check that the call instruction belongs to a BasicBlock which is part of
     // a valid function
     if (!(call_inst && call_inst->getParent()
-          && call_inst->getParent()->getParent())){
+          && call_inst->getParent()->getParent())) {
       return false;
     }
     llvm::InlineFunctionInfo info;
@@ -1360,7 +1360,6 @@ class ArithOpMaker<float> {
 template <>
 class ArithOpMaker<double> {
  public:
-
   static llvm::Value* CreateAddOverflow(CodegenUtils* generator,
                                         llvm::Value* arg0,
                                         llvm::Value* arg1) {
@@ -1370,7 +1369,7 @@ class ArithOpMaker<double> {
     llvm::Value* casted_arg1 = generator->ir_builder()->
         CreateBitCast(arg1, generator->GetType<double>());
 
-    // TODO: armenatzoglou Support overflow
+    // TODO(armenatzoglou) Support overflow
     return generator->ir_builder()->CreateFAdd(casted_arg0, casted_arg1);
   }
 
@@ -1383,7 +1382,7 @@ class ArithOpMaker<double> {
     llvm::Value* casted_arg1 = generator->ir_builder()->
         CreateBitCast(arg1, generator->GetType<double>());
 
-    // TODO: armenatzoglou Support overflow
+    // TODO(armenatzoglou) Support overflow
     return generator->ir_builder()->CreateFSub(casted_arg0, casted_arg1);
   }
 
@@ -1396,7 +1395,7 @@ class ArithOpMaker<double> {
     llvm::Value* casted_arg1 = generator->ir_builder()->
         CreateBitCast(arg1, generator->GetType<double>());
 
-    // TODO: armenatzoglou Support overflow
+    // TODO(armenatzoglou) Support overflow
     return generator->ir_builder()->CreateFMul(casted_arg0, casted_arg1);
   }
 

--- a/src/backend/codegen/include/codegen/var_expr_tree_generator.h
+++ b/src/backend/codegen/include/codegen/var_expr_tree_generator.h
@@ -32,7 +32,7 @@ class VarExprTreeGenerator : public ExprTreeGenerator {
         ExprContext* econtext,
         std::unique_ptr<ExprTreeGenerator>* expr_tree);
 
-  bool GenerateCode(gpcodegen::CodegenUtils* codegen_utils,
+  bool GenerateCode(gpcodegen::GpCodegenUtils* codegen_utils,
                     ExprContext* econtext,
                     llvm::Function* llvm_main_func,
                     llvm::BasicBlock* llvm_error_block,

--- a/src/backend/codegen/pg_date_func_generator.cc
+++ b/src/backend/codegen/pg_date_func_generator.cc
@@ -1,0 +1,103 @@
+//---------------------------------------------------------------------------
+//  Greenplum Database
+//  Copyright (C) 2016 Pivotal Software, Inc.
+//
+//  @filename:
+//    pg_date_func_generator.cc
+//
+//  @doc:
+//    Base class for date functions to generate code
+//
+//---------------------------------------------------------------------------
+
+
+#include "codegen/pg_date_func_generator.h"
+#include "codegen/utils/gp_codegen_utils.h"
+
+extern "C" {
+#include "postgres.h"
+#include "utils/elog.h"
+#include "utils/date.h"
+#include "utils/timestamp.h"
+}
+
+using gpcodegen::GpCodegenUtils;
+using gpcodegen::PGDateFuncGenerator;
+
+bool PGDateFuncGenerator::DateLETimestamp(
+    gpcodegen::GpCodegenUtils* codegen_utils,
+    llvm::Function* llvm_main_func,
+    llvm::BasicBlock* llvm_error_block,
+    const std::vector<llvm::Value*>& llvm_args,
+    llvm::Value** llvm_out_value) {
+
+  llvm::IRBuilder<>* irb = codegen_utils->ir_builder();
+
+  llvm::Value* llvm_arg0_DateADT = codegen_utils->
+      CreateCast<DateADT>(llvm_args[0]);
+  /* TODO: Use CreateCast*/
+  llvm::Value* llvm_arg1_Timestamp = irb->CreateSExt(
+      llvm_args[1], codegen_utils->GetType<Timestamp>());
+
+  llvm::Value* llvm_arg0_Timestamp = GenerateDate2Timestamp(
+      codegen_utils, llvm_main_func, llvm_arg0_DateADT, llvm_error_block);
+
+  // timestamp_cmp_internal {{{
+#ifdef HAVE_INT64_TIMESTAMP
+  *llvm_out_value = irb->CreateICmpSLE(llvm_arg0_Timestamp, llvm_arg1_Timestamp);
+#else
+  // TODO: We do not support NaNs.
+  elog(DEBUG1,"Timestamp != int_64: NaNs are not supported.");
+  return false;
+#endif
+  // }}}
+
+  return true;
+}
+
+llvm::Value* PGDateFuncGenerator::GenerateDate2Timestamp(
+    GpCodegenUtils* codegen_utils,
+    llvm::Function* llvm_main_func,
+    llvm::Value* llvm_arg,
+    llvm::BasicBlock* llvm_error_block) {
+
+  assert(nullptr != llvm_arg && nullptr != llvm_arg->getType());
+  llvm::IRBuilder<>* irb = codegen_utils->ir_builder();
+
+#ifdef HAVE_INT64_TIMESTAMP
+
+  llvm::BasicBlock* llvm_non_overflow_block = codegen_utils->CreateBasicBlock(
+      "date_non_overflow_block", llvm_main_func);
+  llvm::BasicBlock* llvm_overflow_block = codegen_utils->CreateBasicBlock(
+      "date_overflow_block", llvm_main_func);
+
+  llvm::Value *llvm_USECS_PER_DAY = codegen_utils->
+      GetConstant<int64_t>(USECS_PER_DAY);
+
+  /* TODO: Use CreateCast*/
+  llvm::Value* llvm_arg_64 = irb->CreateSExt(
+      llvm_arg, codegen_utils->GetType<int64_t>());
+
+  llvm::Value* llvm_mul_output = codegen_utils->CreateMulOverflow<int64_t>(
+      llvm_USECS_PER_DAY, llvm_arg_64);
+
+  llvm::Value* llvm_overflow_flag = irb->CreateExtractValue(llvm_mul_output, 1);
+
+  irb->CreateCondBr(llvm_overflow_flag, llvm_overflow_block, llvm_non_overflow_block);
+
+  irb->SetInsertPoint(llvm_overflow_block);
+  codegen_utils->CreateElog(ERROR, "date out of range for timestamp");
+  irb->CreateBr(llvm_error_block);
+
+  irb->SetInsertPoint(llvm_non_overflow_block);
+
+  return irb->CreateExtractValue(llvm_mul_output, 0);
+#else
+  llvm::Value *llvm_SECS_PER_DAY = codegen_utils->
+      GetConstant<int64_t>(SECS_PER_DAY);
+  /*TODO: Use CreateCast*/
+  llvm::Value *llvm_arg_64 = irb->CreateSExt(llvm_arg,
+                                             codegen_utils->GetType<int64_t>());
+  return irb->CreateMul(llvm_arg_64, llvm_SECS_PER_DAY);
+#endif
+}

--- a/src/backend/codegen/var_expr_tree_generator.cc
+++ b/src/backend/codegen/var_expr_tree_generator.cc
@@ -23,7 +23,7 @@ extern "C" {
 
 using gpcodegen::VarExprTreeGenerator;
 using gpcodegen::ExprTreeGenerator;
-using gpcodegen::CodegenUtils;
+using gpcodegen::GpCodegenUtils;
 
 bool VarExprTreeGenerator::VerifyAndCreateExprTree(
     ExprState* expr_state,
@@ -41,7 +41,7 @@ VarExprTreeGenerator::VarExprTreeGenerator(ExprState* expr_state) :
     ExprTreeGenerator(expr_state, ExprTreeNodeType::kVar) {
 }
 
-bool VarExprTreeGenerator::GenerateCode(CodegenUtils* codegen_utils,
+bool VarExprTreeGenerator::GenerateCode(GpCodegenUtils* codegen_utils,
                                         ExprContext* econtext,
                                         llvm::Function* llvm_main_func,
                                         llvm::BasicBlock* llvm_error_block,


### PR DESCRIPTION
This PR enhances the functionality of codegen's expression evaluation framework with support of '<=' operator for date/timestamp data types.

Also, it modifies several functions and constructors to get GpCodegenUtils as an argument, instead of CodegenUtils, so that elog wrappers can be used.   

@karthijrk @hardikar @foyzur Please take a look if you have some time. Thanks