### PR TITLE
Silence a clang warning which also is a real bug

### DIFF
--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/utils/adt/datetime.c,v 1.206 2009/06/01 16:55:11 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/utils/adt/datetime.c,v 1.213 2010/08/02 01:24:53 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -3199,7 +3199,7 @@ DecodeInterval(char **field, int *ftype, int nf, int range,
 						break;
 
 					case RESERV:
-						tmask = (DTK_DATE_M || DTK_TIME_M);
+						tmask = (DTK_DATE_M | DTK_TIME_M);
 						*dtype = val;
 						break;
 

--- a/src/interfaces/ecpg/pgtypeslib/interval.c
+++ b/src/interfaces/ecpg/pgtypeslib/interval.c
@@ -1,4 +1,4 @@
-/* $PostgreSQL: pgsql/src/interfaces/ecpg/pgtypeslib/interval.c,v 1.41 2009/06/11 14:49:13 momjian Exp $ */
+/* $PostgreSQL: pgsql/src/interfaces/ecpg/pgtypeslib/interval.c,v 1.43 2010/08/02 01:24:54 tgl Exp $ */
 
 #include "postgres_fe.h"
 #include <time.h>
@@ -606,7 +606,7 @@ DecodeInterval(char **field, int *ftype, int nf,		/* int range, */
 						break;
 
 					case RESERV:
-						tmask = (DTK_DATE_M || DTK_TIME_M);
+						tmask = (DTK_DATE_M | DTK_TIME_M);
 						*dtype = val;
 						break;
 


### PR DESCRIPTION
commit fbcf2cfb53513b9ade1c897e088aeb27252c43d7
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Mon Aug 2 01:24:54 2010 +0000

    Fix an ancient typo that prevented the detection of conflicting fields when
    interval input "invalid" was specified together with other fields.  Spotted
    by Neil Conway with the help of a clang warning.  Although this has been
    wrong since the interval code was written more than 10 years ago, it doesn't
    affect anything beyond which error message you get for a wrong input, so not
    worth back-patching very far.