### PR TITLE
Remove gp_verification_history from the list MASTER_ONLY_TABLES from gpcatalog.py

### DIFF
--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -31,7 +31,6 @@ MASTER_ONLY_TABLES = [
     'gp_fault_strategy',
     'gp_san_configuration',
     'gp_segment_configuration',
-    'gp_verification_history',
     'pg_description',
     'pg_listener',  # ???
     'pg_partition',


### PR DESCRIPTION
There is a problem in _gpexpand_ in function _cleanup_new_segments(self)_. It tries to delete from all the catalog tables. The list of them is defined in _gpcatalog.py_ and is called _MASTER_ONLY_TABLES_. The table gp_verification_history was removed with commit
8afc1dd138ec5effcf4cae1799a0d3b9d76aa2a5 therefore the script _gpexpand_ fails.

In gpexpand it looks like this:

```
class gpexpand:
...
    def cleanup_new_segments(self):
        """
        This method is called after all new segments have been configured.
        """
...
        """
        Build the list of delete statements based on the MASTER_ONLY_TABLES
        defined in gpcatalog.py
        """
        statements = [ "delete from pg_catalog.%s" % tab for tab in MASTER_ONLY_TABLES ]
...
               execSQLCmd = ExecuteSQLStatementsCommand( name = name
                                                       , url = dburl
                                                       , sqlCommandList = statements
                                                       )

```

It looks like the list MASTER_ONLY_TABLES is used only by gpexpand and only at that place.