### PR TITLE
Compiler warnings sweep

### DIFF
--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -2503,8 +2503,6 @@ _bitmap_buildinsert(Relation rel, ItemPointerData ht_ctid, Datum *attdata,
 	TupleDesc	tupDesc;
 	uint64		tidOffset;
 
-	Assert(ItemPointerGetOffsetNumber(&ht_ctid) <= BM_MAX_TUPLES_PER_PAGE);
-
 	tidOffset = BM_IPTR_TO_INT(&ht_ctid); 
 
 	tupDesc = RelationGetDescr(rel);
@@ -2536,7 +2534,6 @@ _bitmap_doinsert(Relation rel, ItemPointerData ht_ctid, Datum *attdata,
 	if (tupDesc->natts <= 0)
 		return ;
 
-	Assert(ItemPointerGetOffsetNumber(&ht_ctid) <= BM_MAX_TUPLES_PER_PAGE);
 	tidOffset = BM_IPTR_TO_INT(&ht_ctid);
 
 	// -------- MirroredLock ----------

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -2118,7 +2118,7 @@ static size_t gp_proto1_read(char *buf, int bufsz, URL_FILE *file, CopyState pst
 			 */
 			memcpy(&line_number, curl->in.ptr + curl->in.bot, len);
 			line_number = local_ntohll(line_number);
-			pstate->cur_lineno = line_number ? line_number - 1 : (int64) - 1 << 63;
+			pstate->cur_lineno = line_number ? line_number - 1 : INT64_MIN;
 			curl->in.bot += 8;
 			Assert(curl->in.bot <= curl->in.top);
 			continue;

--- a/src/backend/access/gin/ginscan.c
+++ b/src/backend/access/gin/ginscan.c
@@ -153,7 +153,7 @@ newScanKey(IndexScanDesc scan)
 	for (i = 0; i < scan->numberOfKeys; i++)
 	{
 		Datum	   *entryValues;
-		int32		nEntryValues;
+		int32		nEntryValues = 0;
 
 		if (scankey[i].sk_flags & SK_ISNULL)
 			elog(ERROR, "Gin doesn't support NULL as scan key");

--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -156,7 +156,7 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString)
 							   "CREATE", "SCHEMA"
 					);
 	}
-	else if (Gp_role == GP_ROLE_EXECUTE)
+	else
 	{
 		namespaceId = NamespaceCreate(schemaName, owner_uid, stmt->schemaOid);
 	}

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4209,16 +4209,19 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 						pc->arg1 = (Node *)lappend((List *)pc->arg1, NULL);
 						continue;
 					}
-					else if (is_at)
-						l1 = (List *)t;
-					else if (!is_at)
+					else
 					{
-						Node *n = t;
-						PartitionRangeItem *ri = (PartitionRangeItem *)n;
+						if (is_at)
+							l1 = (List *)t;
+						else
+						{
+							Node *n = t;
+							PartitionRangeItem *ri = (PartitionRangeItem *)n;
 
-						Assert(IsA(n, PartitionRangeItem));
+							Assert(IsA(n, PartitionRangeItem));
 
-						l1 = ri->partRangeVal;
+							l1 = ri->partRangeVal;
+						}
 					}
 
 					if (IsA(linitial(l1), A_Const) ||

--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -59,7 +59,12 @@ getBitmapTableScanMethod(TableType tableType)
 
 	COMPILE_ASSERT(ARRAY_SIZE(scanMethods) == TableTypeInvalid);
 
-	if (tableType < 0 && tableType >= TableTypeInvalid)
+	/*
+	 * The test for the tableType being a valid enum member is inverted since
+	 * the actual datatype for an enum is compiler dependent and we can't rely
+	 * on it always being unsigned.
+	 */
+	if (!(tableType > 0 && tableType <= TableTypeInvalid))
 	{
 		return NULL;
 	}

--- a/src/backend/executor/execCurrent.c
+++ b/src/backend/executor/execCurrent.c
@@ -48,7 +48,7 @@ execCurrentOf(CurrentOfExpr *cexpr,
 			  Oid table_oid,
 			  ItemPointer current_tid)
 {
-	int			current_gp_segment_id;
+	int			current_gp_segment_id = -1;
 	Oid			current_table_oid;
 
 	/*

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -294,10 +294,10 @@ cost_index(IndexPath *path, PlannerInfo *root,
 	RelOptInfo *baserel = index->rel;
 	Cost		startup_cost = 0;
 	Cost		run_cost = 0;
-	Cost		indexStartupCost;
-	Cost		indexTotalCost;
-	Selectivity indexSelectivity;
-	double		indexCorrelation,
+	Cost		indexStartupCost = 0.0;
+	Cost		indexTotalCost = 0.0;
+	Selectivity indexSelectivity = 0.0;
+	double		indexCorrelation = 0.0,
 				csquared;
 	Cost		min_IO_cost,
 				max_IO_cost;

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -1139,8 +1139,6 @@ patternsel(PG_FUNCTION_ARGS, Pattern_Type ptype, bool negate)
 
 			if (pstatus == Pattern_Prefix_Partial)
             {
-			    Selectivity prefixsel;
-
 				prefixsel = prefix_selectivity(&vardata, vartype,
 											   opfamily, prefix);
 
@@ -1151,8 +1149,10 @@ patternsel(PG_FUNCTION_ARGS, Pattern_Type ptype, bool negate)
                 selec *= prefixsel;
             }
 			else
+			{
 				prefixsel = 1.0;
-			selec = prefixsel * rest_selec;
+				selec = prefixsel * rest_selec;
+			}
 		}
 		else
 		{

--- a/src/backend/utils/adt/tsvector.c
+++ b/src/backend/utils/adt/tsvector.c
@@ -7,7 +7,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/utils/adt/tsvector.c,v 1.11 2008/01/01 19:45:53 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/utils/adt/tsvector.c,v 1.16 2009/05/21 12:54:27 meskes Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -479,7 +479,7 @@ tsvectorrecv(PG_FUNCTION_ARGS)
 		/* sanity checks */
 
 		lex_len = strlen(lexeme);
-		if (lex_len < 0 || lex_len > MAXSTRLEN)
+		if (lex_len > MAXSTRLEN)
 			elog(ERROR, "invalid tsvector: lexeme too long");
 
 		if (datalen > MAXSTRPOS)

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -783,7 +783,7 @@ FaultInjector_InjectFaultIfSet(
 			
 		case FaultInjectorTypeSegv:
 		{
-			*(int *) 0 = 1234;
+			*(volatile int *) 0 = 1234;
 			break;
 		}
 		

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -272,12 +272,12 @@ static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz)
 	MemoryAccounting_SaveToLog();
 	MemoryContextStats(TopMemoryContext);
 
-	if(coredump_on_memerror)
+	if (coredump_on_memerror)
 	{
 		/*
 		 * Generate a core dump by writing to NULL pointer
 		 */
-		*(int *) NULL = ec;
+		*(volatile int *) NULL = ec;
 	}
 
 	if (ec == MemoryFailure_VmemExhausted)

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1609,7 +1609,8 @@ typedef enum
 
 /*
  * TableType
- *   Enum for different types of tables.
+ *   Enum for different types of tables. The code relies on the enum being
+ *   unsigned so the minimum member value should be zero.
  */
 typedef enum
 {

--- a/src/include/regex/regcustom.h
+++ b/src/include/regex/regcustom.h
@@ -25,7 +25,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * $PostgreSQL: pgsql/src/include/regex/regcustom.h,v 1.7 2008/02/14 17:33:37 tgl Exp $
+ * $PostgreSQL: pgsql/src/include/regex/regcustom.h,v 1.8 2009/12/01 21:00:24 tgl Exp $
  */
 
 /* headers if any */
@@ -33,6 +33,17 @@
 
 #include <ctype.h>
 #include <limits.h>
+
+/*
+ * towlower() and friends should be in <wctype.h>, but some pre-C99 systems
+ * declare them in <wchar.h>.
+ */
+#ifdef HAVE_WCHAR_H
+#include <wchar.h>
+#endif
+#ifdef HAVE_WCTYPE_H
+#include <wctype.h>
+#endif
 
 #include "mb/pg_wchar.h"
 

--- a/src/pl/plperl/plperl.c
+++ b/src/pl/plperl/plperl.c
@@ -1651,7 +1651,7 @@ plperl_inline_handler(PG_FUNCTION_ARGS)
 	/* Set up a callback for error reporting */
 	pl_error_context.callback = plperl_inline_callback;
 	pl_error_context.previous = error_context_stack;
-	pl_error_context.arg = (Datum) 0;
+	pl_error_context.arg = NULL;
 	error_context_stack = &pl_error_context;
 
 	/*


### PR DESCRIPTION
In an attempt to get us closer to compiling without warnings I did a little sweep across a few warnings that clang throws during a fresh compilation. This PR needs to be reviewed per commit as the commits are for different things across the codebase, their only common denominator being that they fix code to avoid warnings (I didn't want to create a torrent of tiny PR's since that seemed counterproductive). Where possible I've cherry-picked the fixes from upstream, where not possible (due to the fix being part of a muc larger commit) I've noted the upstream commit sha that has the change.

Some of these warnings uncovered minor bugs but non that I can attribute to being very interesting, ICG for me runs with the expected outcome with these patches.

We are still not at a clean state after this but around half of the warnings or so are removed, further PR's will be opened to fix the rest.