### PR TITLE
Print exception message as warning and abort plan generation.

### DIFF
--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -22,8 +22,8 @@
     </configurations>
 
     <dependencies>
-      <dependency org="emc"             name="optimizer"       rev="1.641"          conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
-      <dependency org="emc"             name="libgpos"         rev="1.139"          conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="optimizer"       rev="1.646"          conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
+      <dependency org="emc"             name="libgpos"         rev="1.142"          conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="OpenSSL"         name="openssl"         rev="0.9.8zg"        conf="osx106_x86->osx105_x86;aix5_ppc_32->aix5_ppc_32;aix5_ppc_64->aix5_ppc_64;hpux_ia64->hpux_ia64;rhel5_x86_32->rhel5_x86_32;rhel5_x86_64->rhel5_x86_64;rhel6_x86_64->rhel6_x86_64;sol10_x86_32->sol10_x86_32;sol10_x86_64->sol10_x86_64;sol10_sparc_32->sol10_sparc_32;sol10_sparc_64->sol10_sparc_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse11_x86_64" />
       <dependency org="emc"             name="DDBoostSDK"      rev="3.0.0.3-446710" conf="rhel5_x86_64->rhel5_x86_64" />

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -61,9 +61,13 @@ CGPOptimizer::PplstmtOptimize
 	}
 	GPOS_CATCH_EX(ex)
 	{
+		if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiWarningAsError))
+		{
+		  elog(ERROR, "PQO unable to generate plan, please see the above message for details.");
+		}
 		if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
 		{
-		  elog(ERROR, "GPDB exception. Aborting GPORCA plan generation.");
+		  elog(ERROR, "GPDB exception. Aborting PQO plan generation.");
 		}
 	}
 	GPOS_CATCH_END;

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -431,8 +431,6 @@ CTranslatorQueryToDXL::CheckSupportedCmdType
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, mapelem.m_wsz);
 		}
 	}
-
-	GPOS_ASSERT(!"Unrecognized command type");
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -35,6 +35,7 @@
 #include "utils/guc.h"
 
 #include "gpos/base.h"
+#include "gpos/error/CException.h"
 #undef setstate
 
 #include "gpos/_api.h"
@@ -162,6 +163,37 @@ COptTasks::SOptContext::SOptContext()
 	m_fUnexpectedFailure(false),
 	m_szErrorMsg(NULL)
 {}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		COptTasks::SOptContext::HandleError
+//
+//	@doc:
+//		If there is an error print as warning and throw GPOS_EXCEPTION to abort
+//		plan generation. Calling elog::ERROR will result in longjump and hence
+//		a memory leak.
+//---------------------------------------------------------------------------
+void
+COptTasks::SOptContext::HandleError
+	(
+	BOOL *pfUnexpectedFailure
+	)
+{
+	BOOL bhasError = false;
+	if (NULL != m_szErrorMsg)
+	{
+		bhasError = true;
+		elog(WARNING, "%s", m_szErrorMsg);
+	}
+	*pfUnexpectedFailure = m_fUnexpectedFailure;
+
+	// clean up context
+	Free(epinQuery, epinPlStmt);
+	if (bhasError)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiWarningAsError);
+	}
+}
 
 
 //---------------------------------------------------------------------------
@@ -1620,17 +1652,17 @@ COptTasks::PplstmtOptimize
 	SOptContext octx;
 	octx.m_pquery = pquery;
 	octx.m_fGeneratePlStmt= true;
-	Execute(&PvOptimizeTask, &octx);
-
-	if (NULL != octx.m_szErrorMsg)
+	GPOS_TRY
 	{
-		elog(ERROR, "%s", octx.m_szErrorMsg);
+		Execute(&PvOptimizeTask, &octx);
 	}
-	*pfUnexpectedFailure = octx.m_fUnexpectedFailure;
-
-	// clean up context
-	octx.Free(octx.epinQuery, octx.epinPlStmt);
-
+	GPOS_CATCH_EX(ex)
+	{
+		octx.HandleError(pfUnexpectedFailure);
+		GPOS_RETHROW(ex);
+	}
+	GPOS_CATCH_END;
+	octx.HandleError(pfUnexpectedFailure);
 	return octx.m_pplstmt;
 }
 

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -98,6 +98,10 @@ class COptTasks
 			// ctor
 			SOptContext();
 
+			// If there is an error print as warning and throw exception to abort
+			// plan generation
+			void HandleError(BOOL *pfUnexpectedFailure);
+
 			// free all members except input and output pointers
 			void Free(EPin epinInput, EPin epinOutput);
 

--- a/src/test/regress/expected/abstime_optimizer.out
+++ b/src/test/regress/expected/abstime_optimizer.out
@@ -45,7 +45,7 @@ LINE 1: INSERT INTO ABSTIME_TBL (f1) VALUES ('bad date format');
                                              ^
 INSERT INTO ABSTIME_TBL (f1) VALUES ('Jun 10, 1843');
 ERROR:  cannot convert abstime "invalid" to timestamp
-ERROR:  GPDB exception. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
+ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:70)
 -- test abstime operators
 SELECT '' AS eight, * FROM ABSTIME_TBL ORDER BY 2;
  eight |              f1              

--- a/src/test/regress/expected/aoco_privileges_optimizer.out
+++ b/src/test/regress/expected/aoco_privileges_optimizer.out
@@ -46,7 +46,7 @@ SELECT has_table_privilege('user_with_no_privileges', 'aoco_privileges_table', '
 SET ROLE user_with_no_privileges;
 SELECT * FROM aoco_privileges_table;
 ERROR:  permission denied for relation aoco_privileges_table
-ERROR:  GPDB exception. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
+ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:70)
 RESET ROLE;
 -- Now change ownership to the new owner
 ALTER TABLE aoco_privileges_table OWNER TO new_aoco_table_owner;
@@ -112,7 +112,7 @@ SELECT has_table_privilege('aoco_privileges_table', 'SELECT');
 
 SELECT * FROM aoco_privileges_table;
 ERROR:  permission denied for relation aoco_privileges_table
-ERROR:  GPDB exception. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
+ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:70)
 -- Revoke privileges
 RESET ROLE;
 REVOKE ALL ON aoco_privileges_table FROM user_with_privileges_from_first_owner;

--- a/src/test/regress/expected/errors.out
+++ b/src/test/regress/expected/errors.out
@@ -485,8 +485,8 @@ create function infinite_recurse() returns int as
 -- # mpp-2756
 -- m/(ERROR|WARNING|CONTEXT|NOTICE):.*stack depth limit exceeded\s+at\s+character/
 -- s/\s+at\s+character.*//
--- m/ERROR:.*GPDB exception. Aborting GPORCA.*/
--- s/ERROR:.*GPDB exception. Aborting GPORCA.*//
+-- m/ERROR:.*GPDB exception. Aborting PQO.*/
+-- s/ERROR:.*GPDB exception. Aborting PQO.*//
 -- end_matchsubs
 -- start_ignore
 select infinite_recurse();

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -10194,37 +10194,3 @@ NOTICE:  drop cascades to table orca.r
 NOTICE:  drop cascades to table orca.bar2
 NOTICE:  drop cascades to table orca.bar1
 reset optimizer_segments;
--- Check if ORCA can handle GPDB's error properly
-drop table if exists orca_exc_handle;
-NOTICE:  table "orca_exc_handle" does not exist, skipping
-create table orca_exc_handle(
-	a int primary key,
-	b char
-);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "orca_exc_handle_pkey" for table "orca_exc_handle"
-insert into orca_exc_handle select i, i from generate_Series(1,4) as i; 
--- enable the fault injector
---start_ignore
-\! gpfaultinjector -f opt_relcache_translator_catalog_access -y error --seg_dbid 1
-20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f opt_relcache_translator_catalog_access -y error --seg_dbid 1
-20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
-20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
-20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/qddir/demoDataDir-1:content=-1:dbid=1:mode=s:status=u
-20160425:14:59:22:001357 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
---end_ignore
-select a from orca_exc_handle;
-ERROR:  fault triggered, fault name:'opt_relcache_translator_catalog_access' fault type:'error' (faultinjector.c:671)
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:66)
--- reset the fault injector
---start_ignore
-\! gpfaultinjector -f opt_relcache_translator_catalog_access -y reset --seg_dbid 1
-20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f opt_relcache_translator_catalog_access -y reset --seg_dbid 1
-20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
-20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
-20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/qddir/demoDataDir-1:content=-1:dbid=1:mode=s:status=u
-20160425:14:59:23:001374 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
---end_ignore
-drop table orca_exc_handle;
--- End of Check if ORCA can handle GPDB's error properly

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -10215,7 +10215,7 @@ insert into orca_exc_handle select i, i from generate_Series(1,4) as i;
 --end_ignore
 select a from orca_exc_handle;
 ERROR:  fault triggered, fault name:'opt_relcache_translator_catalog_access' fault type:'error' (faultinjector.c:671)
-ERROR:  GPDB exception. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
+ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:66)
 -- reset the fault injector
 --start_ignore
 \! gpfaultinjector -f opt_relcache_translator_catalog_access -y reset --seg_dbid 1

--- a/src/test/regress/expected/horology_optimizer.out
+++ b/src/test/regress/expected/horology_optimizer.out
@@ -14,7 +14,7 @@ INSERT INTO ABSTIME_HOROLOGY_TBL (f1) VALUES ('Jan 14, 1973 03:14:21'),
 -- orca will fail for this
 INSERT INTO ABSTIME_HOROLOGY_TBL (f1) VALUES('Jun 10, 1843');
 ERROR:  cannot convert abstime "invalid" to timestamp
-ERROR:  GPDB exception. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
+ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:70)
 CREATE TABLE INTERVAL_HOROLOGY_TBL (f1 interval);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/insert_optimizer.out
+++ b/src/test/regress/expected/insert_optimizer.out
@@ -1,0 +1,84 @@
+--
+-- insert with DEFAULT in the target_list
+--
+create table inserttest (col1 int4, col2 int4 NOT NULL, col3 text default 'testing');
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into inserttest (col1, col2, col3) values (DEFAULT, DEFAULT, DEFAULT);
+WARNING:  null value in column "col2" violates not-null constraint
+ERROR:  PQO unable to generate plan, please see the above message for details. (CGPOptimizer.cpp:66)
+insert into inserttest (col2, col3) values (3, DEFAULT);
+insert into inserttest (col1, col2, col3) values (DEFAULT, 5, DEFAULT);
+insert into inserttest values (DEFAULT, 5, 'test');
+insert into inserttest values (DEFAULT, 7);
+select * from inserttest order by 1,2,3;
+ col1 | col2 |  col3   
+------+------+---------
+      |    3 | testing
+      |    5 | test
+      |    5 | testing
+      |    7 | testing
+(4 rows)
+
+--
+-- insert with similar expression / target_list values (all fail)
+--
+insert into inserttest (col1, col2, col3) values (DEFAULT, DEFAULT);
+ERROR:  INSERT has more target columns than expressions
+insert into inserttest (col1, col2, col3) values (1, 2);
+ERROR:  INSERT has more target columns than expressions
+insert into inserttest (col1) values (1, 2);
+ERROR:  INSERT has more expressions than target columns
+insert into inserttest (col1) values (DEFAULT, DEFAULT);
+ERROR:  INSERT has more expressions than target columns
+select * from inserttest order by 1,2,3;
+ col1 | col2 |  col3   
+------+------+---------
+      |    3 | testing
+      |    5 | test
+      |    5 | testing
+      |    7 | testing
+(4 rows)
+
+--
+-- VALUES test
+--
+insert into inserttest values(10, 20, '40'), (-1, 2, DEFAULT),
+    ((select 2), (select i from (values(3)) as foo (i)), 'values are fun!');
+select * from inserttest order by 1,2,3;
+ col1 | col2 |      col3       
+------+------+-----------------
+   -1 |    2 | testing
+    2 |    3 | values are fun!
+   10 |   20 | 40
+      |    3 | testing
+      |    5 | test
+      |    5 | testing
+      |    7 | testing
+(7 rows)
+
+drop table inserttest;
+-- MPP-6775 : Adding and dropping a column. Then perform an insert.
+ 
+create table bar(x int) distributed randomly;        
+create table foo(like bar) distributed randomly;
+alter table foo add column y int;
+alter table foo drop column y;
+insert into bar values(1);
+insert into bar values(2);
+insert into foo(x) select  t1.x from    bar t1 join bar t2 on t1.x=t2.x;
+insert into foo(x) select  t1.x from    bar t1;
+insert into foo(x) select  t1.x from    bar t1 group by t1.x;
+drop table if exists foo;
+drop table if exists bar;
+-- MPP-6775 : Dropping a column. Then perform an insert.
+create table bar(x int, y int) distributed randomly;        
+create table foo(like bar) distributed randomly;
+alter table foo drop column y;
+insert into bar values(1,1);
+insert into bar values(2,2);
+insert into foo(x) select  t1.x from    bar t1 join bar t2 on t1.x=t2.x;
+insert into foo(x) select  t1.x from    bar t1;
+insert into foo(x) select  t1.x from    bar t1 group by t1.x;
+drop table if exists foo;
+drop table if exists bar;

--- a/src/test/regress/expected/namespace_optimizer.out
+++ b/src/test/regress/expected/namespace_optimizer.out
@@ -50,7 +50,7 @@ CREATE TABLE test_schema_2.grant_test(a int) DISTRIBUTED BY (a); -- no permissio
 ERROR:  permission denied for schema test_schema_2
 SELECT * FROM test_schema_1.abc; -- no permissions on table
 ERROR:  permission denied for relation abc
-ERROR:  GPDB exception. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
+ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:70)
 SELECT * FROM test_schema_2.abc; -- no permissions on schema
 ERROR:  permission denied for schema test_schema_2
 LINE 1: SELECT * FROM test_schema_2.abc;

--- a/src/test/regress/expected/privileges_optimizer.out
+++ b/src/test/regress/expected/privileges_optimizer.out
@@ -282,7 +282,7 @@ SELECT testfunc1(5); -- fail
 ERROR:  permission denied for function testfunc1
 SELECT col1 FROM atest2 WHERE col2 = true; -- fail
 ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
+ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:70)
 SELECT testfunc4(true); -- ok
  testfunc4 
 -----------

--- a/src/test/regress/expected/role_optimizer.out
+++ b/src/test/regress/expected/role_optimizer.out
@@ -99,7 +99,7 @@ revoke all privileges on TABLE t1, t1_view FROM u1;
 set role u1;
 select * from t1_view order by 1;
 ERROR:  permission denied for relation t1_view
-ERROR:  GPDB exception. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
+ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:70)
 reset role;
 drop view t1_view;
 drop table t1;

--- a/src/test/regress/output/constraints_optimizer.source
+++ b/src/test/regress/output/constraints_optimizer.source
@@ -317,7 +317,8 @@ DETAIL:  Key (i)=(1) already exists.
 INSERT INTO PRIMARY_TBL VALUES (4, 'three');
 INSERT INTO PRIMARY_TBL VALUES (5, 'one');
 INSERT INTO PRIMARY_TBL (t) VALUES ('six');
-ERROR:  null value in column "i" violates not-null constraint
+WARNING:  null value in column "i" violates not-null constraint
+ERROR:  PQO unable to generate plan, please see the above message for details. (CGPOptimizer.cpp:66)
 SELECT '' AS four, * FROM PRIMARY_TBL;
  four | i |   t   
 ------+---+-------
@@ -337,7 +338,8 @@ INSERT INTO PRIMARY_TBL VALUES (1, 'three');
 INSERT INTO PRIMARY_TBL VALUES (4, 'three');
 INSERT INTO PRIMARY_TBL VALUES (5, 'one');
 INSERT INTO PRIMARY_TBL (t) VALUES ('six');
-ERROR:  null value in column "i" violates not-null constraint
+WARNING:  null value in column "i" violates not-null constraint
+ERROR:  PQO unable to generate plan, please see the above message for details. (CGPOptimizer.cpp:66)
 SELECT '' AS three, * FROM PRIMARY_TBL;
  three | i |   t   
 -------+---+-------

--- a/src/test/regress/sql/errors.sql
+++ b/src/test/regress/sql/errors.sql
@@ -400,8 +400,8 @@ create function infinite_recurse() returns int as
 -- # mpp-2756
 -- m/(ERROR|WARNING|CONTEXT|NOTICE):.*stack depth limit exceeded\s+at\s+character/
 -- s/\s+at\s+character.*//
--- m/ERROR:.*GPDB exception. Aborting GPORCA.*/
--- s/ERROR:.*GPDB exception. Aborting GPORCA.*//
+-- m/ERROR:.*GPDB exception. Aborting PQO.*/
+-- s/ERROR:.*GPDB exception. Aborting PQO.*//
 -- end_matchsubs
 -- start_ignore
 select infinite_recurse();

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -1325,26 +1325,3 @@ drop table can_set_tag_audit;
 -- clean up
 drop schema orca cascade;
 reset optimizer_segments;
-
--- Check if ORCA can handle GPDB's error properly
-drop table if exists orca_exc_handle;
-create table orca_exc_handle(
-	a int primary key,
-	b char
-);
-
-insert into orca_exc_handle select i, i from generate_Series(1,4) as i; 
-
--- enable the fault injector
---start_ignore
-\! gpfaultinjector -f opt_relcache_translator_catalog_access -y error --seg_dbid 1
---end_ignore
-
-select a from orca_exc_handle;
--- reset the fault injector
---start_ignore
-\! gpfaultinjector -f opt_relcache_translator_catalog_access -y reset --seg_dbid 1
---end_ignore
-
-drop table orca_exc_handle;
--- End of Check if ORCA can handle GPDB's error properly


### PR DESCRIPTION
In COptTasks::PplstmtOptimize, we print exception message from context using elog::ERROR. Because orca / gpos enhanced to rethrow exception, we were not executing this code.

In this PR, we catch the exception and print the message as warning. After printing, we throw the exception and abort the plan generation in CGPOptimizer::PplstmtOptimize.

We can't use elog::ERROR because it will do sigjmp to PostgresMain and hence result in memory leak. Also since there is no easy way to carry the message in CException, as an initial implementation we decided to print as warning.

There is a story to handle this case properly in backlog : https://www.pivotaltracker.com/story/show/118056737

@foyzur @vraghavan78 @xinzweb @d  Please take a look when you get chance.
Orca related changes : https://github.com/greenplum-db/gporca/pull/68

E.g. query and console message:

```
krajaraman=# select * from wet_pos1;
WARNING:  External scan error: It is not possible to read from a WRITABLE external table. Create the table as READABLE instead.
ERROR:  Unrecoverable warning. Aborting GPORCA plan generation. (CGPOptimizer.cpp:66)
```



