### PR TITLE
Remove dead code in partition coalesce functionality

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13974,32 +13974,13 @@ static void
 ATPExecPartCoalesce(Relation rel,
                     AlterPartitionCmd *pc)
 {
-	AlterPartitionId *pid = (AlterPartitionId *)pc->partid;
-	PgPartRule   *prule = NULL;
-
 	if (Gp_role != GP_ROLE_DISPATCH)
 		return;
-
-	prule = get_part_rule(rel, pid, true, true, NULL, false);
-
-	if (0)
-	{
-
-		parruleord_open_gap(
-				prule->pNode->part->partid,
-				prule->pNode->part->parlevel,
-				prule->topRule->parparentoid,
-				prule->topRule->parruleord,
-				0,
-				false /* closegap */);
-
-	}
 
     ereport(ERROR,
             (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
              errmsg("cannot COALESCE PARTITION for relation \"%s\"",
                     RelationGetRelationName(rel))));
-
 }
 
 /* ALTER TABLE ... DROP PARTITION */


### PR DESCRIPTION
The `ALTER TABLE .. COALESCE PARTITION` feature is while partially implemented not supported. Removing all the scaffolding around the parsing might as well be worthwhile but at least it seems reasonable to kill the completely dead code in `ATPExecPartCoalesce()`.

@ivannovick is partition coalescing something which is on the radar? It seems like a pretty cool feature but also one which would be quite complex to get right (and perhaps not terribly useful in practice?)