### PR TITLE
Atmsort array out of bound access in regression testing

### DIFF
--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -1507,7 +1507,7 @@ EOF_formatfix
                 # special case for explain
                if (exists($directive->{explain}) &&
                    ($ini =~ m/^\s*((\-\-)(\-)+(\+(\-)+)*)+\s*$/) &&
-                   ($outarr[-1] =~ m/QUERY PLAN/))
+                   (scalar(@outarr) && $outarr[-1] =~ m/QUERY PLAN/))
                 {
                     # ENGINF-88: fixup explain headers
                     $outarr[-1] = "QUERY PLAN\n";

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -1299,19 +1299,19 @@ EOF_formatfix
 
         if ($getrows) # getting rows from SELECT output
         {
-        # The end of "result set" for a COPY TO STDOUT is a bit tricky
-        # to find. There is no explicit marker for it. We look for a
-        # line that looks like a SQL comment or a new query, or an ERROR.
-        # This is not bullet-proof, but works for the current tests.
+            # The end of "result set" for a COPY TO STDOUT is a bit tricky
+            # to find. There is no explicit marker for it. We look for a
+            # line that looks like a SQL comment or a new query, or an ERROR.
+            # This is not bullet-proof, but works for the current tests.
             if ($copy_to_stdout_result &&
                 ($ini =~ m/\-\-/ ||
                  $ini =~ m/ERROR/ ||
-         $ini =~ m/(copy)|(create)|(drop)|(select)|(insert)|(update)/i))
+                 $ini =~ m/(copy)|(create)|(drop)|(select)|(insert)|(update)/i))
             {
-                my @ggg= sort @outarr;
+                my @ggg = sort @outarr;
                 for my $line (@ggg)
                 {
-            print $atmsort_outfh $bpref, $line;
+                    print $atmsort_outfh $bpref, $line;
                 }
 
                 @outarr = ();
@@ -1319,9 +1319,9 @@ EOF_formatfix
                 $has_order = 0;
                 $copy_to_stdout_result = 0;
 
-        # Process the row again, in case it begins another
-        # COPY TO STDOUT statement, or another query.
-        goto reprocess_row;
+                # Process the row again, in case it begins another
+                # COPY TO STDOUT statement, or another query.
+                goto reprocess_row;
             }
 
             # regex example: (5 rows)
@@ -1330,9 +1330,9 @@ EOF_formatfix
                 format_query_output($glob_fqo,
                                     $has_order, \@outarr, $directive);
 
-
-                # Always ignore the rowcount for explain plan out as the skeleton plans might be the
-                # same even if the row counts differ because of session level GUCs.
+                # Always ignore the rowcount for explain plan out as the
+                # skeleton plans might be the same even if the row counts
+                # differ because of session level GUCs.
                 if (exists($directive->{explain}))
                 {
                     $ini = "GP_IGNORE:" . $ini;
@@ -1386,9 +1386,8 @@ EOF_formatfix
 
                 if ($ini =~ m/explain.*(insert|update|delete|select)/i)
                 {
-                   $directive->{explain} = "normal";
+                    $directive->{explain} = "normal";
                 }
-
             }
 
             if ($ini =~ m/\-\-\s*force\_explain\s+operator.*$/i)
@@ -1432,7 +1431,6 @@ EOF_formatfix
             }
 
             # prune notices with segment info if they are duplicates
-#            if ($ini =~ m/^\s*(NOTICE|ERROR|HINT|DETAIL|WARNING)\:.*\s+\(seg.*pid.*\)/)
             if ($ini =~ m/^\s*(NOTICE|ERROR|HINT|DETAIL|WARNING)\:/)
             {
                 $ini =~ s/\s+(\W)?(\W)?\(seg.*pid.*\)//;
@@ -1471,8 +1469,6 @@ EOF_formatfix
                     $lastguy--;
                 } # end for
 
-
-
             } # end if pruning notices
 
             # MPP-1492 allow:
@@ -1481,11 +1477,11 @@ EOF_formatfix
             # and special case these guys:
             #  copy test1 to stdout
             #  \copy test1 to stdout
-        my $matches_copy_to_stdout = 0;
+            my $matches_copy_to_stdout = 0;
             if ($ini =~ m/^copy\s+((\(select.*\))|\w+)\s+to stdout.*;$/i ||
                 $ini =~ m/^\\copy\s+((\(select.*\))|\w+)\s+to stdout.*$/i)
             {
-            $matches_copy_to_stdout = 1;
+                $matches_copy_to_stdout = 1;
             }
             # regex example: ---- or ---+---
             # need at least 3 dashes to avoid confusion with "--" comments
@@ -1513,14 +1509,14 @@ EOF_formatfix
                    ($ini =~ m/^\s*((\-\-)(\-)+(\+(\-)+)*)+\s*$/) &&
                    ($outarr[-1] =~ m/QUERY PLAN/))
                 {
-                   # ENGINF-88: fixup explain headers
-                   $outarr[-1] = "QUERY PLAN\n";
-                   $ini = ("_" x length($outarr[-1])) . "\n";
+                    # ENGINF-88: fixup explain headers
+                    $outarr[-1] = "QUERY PLAN\n";
+                    $ini = ("_" x length($outarr[-1])) . "\n";
 
-                   if ($glob_ignore_headers)
-                   {
-                      $ini = "GP_IGNORE:" . $ini;
-                   }
+                    if ($glob_ignore_headers)
+                    {
+                        $ini = "GP_IGNORE:" . $ini;
+                    }
                 }
 
                 $getstatement = 0;
@@ -1554,17 +1550,11 @@ EOF_formatfix
                     && ($sql_statement =~ m/select.*order.*by/is))
                 {
                     $has_order = 1; # so do *not* sort output
-
-#                   $sql_statement =~ s/\n/ /gm;
-#                   print "has order: ", $sql_statement, "\n";
                     $directive->{sql_statement} = $sql_statement;
                 }
                 else
                 {
                     $has_order = 0; # need to sort query output
-
-#                    $sql_statement =~ s/\n/ /gm;
-#                    print "no order: ", $sql_statement, "\n";
                     $directive->{sql_statement} = $sql_statement;
                 }
                 $sql_statement = "";
@@ -1574,7 +1564,6 @@ EOF_formatfix
             } # end sort this region
         } # end finding SQL
 
-
         # if MATCH then SUBSTITUTE
         # see HERE document for definitions
         $ini = match_then_subs($ini);
@@ -1582,37 +1571,37 @@ EOF_formatfix
         if ($ini =~ m/External table .*line (\d)+/)
         {
             $ini =~ s/External table .*line (\d)+.*/External table DUMMY_EX, line DUMMY_LINE of DUMMY_LOCATION/;
-              $ini =~ s/\s+/ /;
-             # MPP-1557,AUTO-3: horrific ERROR DETAIL External Table trifecta
+            $ini =~ s/\s+/ /;
+            # MPP-1557,AUTO-3: horrific ERROR DETAIL External Table trifecta
             if ($glob_verbose)
             {
                 print $atmsort_outfh "GP_IGNORE: External Table ERROR DETAIL fixup\n";
             }
-             if ($ini !~ m/^DETAIL/)
-             {
+            if ($ini !~ m/^DETAIL/)
+            {
                 # find a "blank" DETAIL tag preceding current line
                 if (scalar(@outarr) && ($outarr[-1] =~ m/^DETAIL:\s+$/))
                 {
-                   pop @outarr;
-                   $ini = "DETAIL: " . $ini;
-                   $ini =~ s/\s+/ /;
-                   # need to skip the next record
-                   $error_detail_exttab_trifecta_skip = 1;
+                    pop @outarr;
+                    $ini = "DETAIL: " . $ini;
+                    $ini =~ s/\s+/ /;
+                    # need to skip the next record
+                    $error_detail_exttab_trifecta_skip = 1;
                 }
-             }
-             if (scalar(@outarr) &&
-                 ($outarr[-1] =~ m/^ERROR:\s+missing\s+data\s+for\s+column/))
-             {
-                $outarr[-1] = "ERROR:  missing data for column DUMMY_COL\n";
-             }
+            }
 
+            if (scalar(@outarr) &&
+                ($outarr[-1] =~ m/^ERROR:\s+missing\s+data\s+for\s+column/))
+            {
+                $outarr[-1] = "ERROR:  missing data for column DUMMY_COL\n";
+            }
         }
 
         # if MATCH then IGNORE
         # see HERE document for definitions
         if ( match_then_ignore($ini))
         {
-           next; # ignore matching lines
+            next; # ignore matching lines
         }
 
 L_push_outarr:


### PR DESCRIPTION
The `@outarr` array may at this point be empty and thus subscript -1 will throw an uninitialized error. Test for array contents before accessing to avoid. This has been observed in the wild for the `bfv_partition` test suite which failed on this in [concourse pipeline build 7](https://gporca.ci.pivotalci.info/pipelines/gpdb/jobs/icg/builds/7) (granted, it might've failed anyways but this didn't help):
```
bfv_aggregate        ... ok (40.05 sec)  (diff:0.96 sec)
bfv_partition        ... Use of uninitialized value $outarr[-1] in pattern match (m//) at /tmp/build/3845b065/gpdb_src/src/test/regress/atmsort.pm line 1512, <$infh> line 1392.
Use of uninitialized value $outarr[-1] in pattern match (m//) at /tmp/build/3845b065/gpdb_src/src/test/regress/atmsort.pm line 1512, <$infh> line 1392.
FAILED (166.30 sec)  (diff:0.79 sec)
DML_over_joins       ... ok (309.21 sec)  (diff:0.35 sec)
```

There are two commits in this PR, the first one is just a whitespace/style cleanup. This is by no means all the offending lines in this file, but they were the ones I had to read in order to figure out the bug (and the state of these lines was frankly too bad to overlook). Remove the worst offenders such as three-space indentation, commented out code and and blocks at the wrong level. Thus, read the commits individually.
