### PR TITLE
Initialize the subroot for pre-planned subqueries

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -716,6 +716,7 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 		/* This is a preplanned sub-query RTE. */
 		rel->subplan = rte->subquery_plan;
 		rel->subrtable = rte->subquery_rtable;
+		subroot = root;
 		/* XXX rel->onerow = ??? */
 	}
 

--- a/src/test/regress/sql/qp_olap_window.sql
+++ b/src/test/regress/sql/qp_olap_window.sql
@@ -24036,6 +24036,14 @@ SELECT a,color,sum(a) over (partition by member_id,color) FROM tab12773_test ord
 
 SELECT member_id,a,color,sum(a) over (partition by member_id,color) FROM tab12773_test order by member_id,name;
 
+-- This is a test for a bug in parallel window planning in the GPDB postgres planner
+-- so turn off Orca before running just in case.
+SET optimizer = off;
+SET gp_enable_sequential_window_plans = off;
+SELECT avg(vn) OVER (PARTITION BY cn) FROM ow_sale;
+SET gp_enable_sequential_window_plans = on;
+SELECT avg(vn) OVER (PARTITION BY cn) FROM ow_sale;
+
 -- start_ignore
 reset datestyle;
 drop table tab12773_test;


### PR DESCRIPTION
When we get a pre-planned Plan from window_planner we must set the subroot accordingly to avoid a null pointer deref a few lines later when converting the subquery pathkeys. This would only happen for parallel window plans which had to be enabled with the `gp_enable_sequential_window_plans` GUC. Reading the parallel window planning code this seems to be right thing to me but a careful set of eyes would be much appreciated as I might be missing something. 

Added a test case running for both GUC values to ensure it produce the same results.