### PR TITLE
Fixes bugs from context refactor

### DIFF
--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -100,7 +100,7 @@ class GpCronDump(Operation):
         if self.list_backup_files and not self.context.timestamp_key:
             raise Exception('Must supply -K option when listing backup files')
 
-        if not (self.context.clear_dumps_only or bool(self.context.ddboost_hosts) or bool(self.context.ddboost_user) or 
+        if not (self.context.clear_dumps_only or bool(self.context.ddboost_hosts) or bool(self.context.ddboost_user) or
                 self.context.ddboost_config_remove or self.context.ddboost_show_config):
             if len(self.context.dump_databases) == 0:
                 if 'PGDATABASE' in os.environ:
@@ -297,7 +297,9 @@ class GpCronDump(Operation):
         if self.context.include_schema_file or self.context.dump_schema or self.context.exclude_schema_file or self.context.exclude_dump_schema:
             self.validate_dump_schema()
 
+
         if self.context.incremental:
+            self.context.generate_dump_timestamp()
             if not self.context.netbackup_service_host:
                 self.context.full_dump_timestamp = get_latest_full_dump_timestamp(self.context)
             else:
@@ -486,7 +488,7 @@ class GpCronDump(Operation):
         if self.context.ddboost_remote:
             ddcmdTemplate += " --remote"
         else:
-            ddcmdTemplate += " --defaultBackupDirectory=" + backupDir
+            ddcmdTemplate += " --defaultBackupDirectory=" + self.context.ddboost_backupdir
 
             if self.context.ddboost_storage_unit:
                 ddcmdTemplate += " --ddboost-storage-unit=" + self.context.ddboost_storage_unit
@@ -543,7 +545,7 @@ class GpCronDump(Operation):
     # Verify the DDBoost credentials using the credentials that stored on the Master
     # TODO: verify also all the hosts in self.context.ddboost_hosts (ping to the hosts, I think there is some Python function for that)
     def _ddboostVerify(self):
-        verifyCmdLine = os.environ['GPHOME'] + '/bin/gpddboost --verify' 
+        verifyCmdLine = os.environ['GPHOME'] + '/bin/gpddboost --verify'
         if self.context.ddboost_storage_unit:
             verifyCmdLine += ' --ddboost-storage-unit %s' % self.context.ddboost_storage_unit
         logger.debug("Executing gpddboost to verify DDBoost credentials: %s" % verifyCmdLine)
@@ -689,7 +691,7 @@ class GpCronDump(Operation):
             # --list-filter-tables(currently not supported with ddboost in the document, but no reason/comment found,
             # maybe add support later?), and --incremental, incremental dump of database should not be on different
             # storage unit from other backup set
-            if not self.list_filter_tables and not self.incremental:
+            if not self.list_filter_tables and not self.context.incremental:
                 self._ddboostVerify()
 
             # Check if we need to exit now
@@ -713,7 +715,10 @@ class GpCronDump(Operation):
 
         for dumpdb in self.context.dump_databases:
             self.context.dump_database = dumpdb
-            self.context.generate_dump_timestamp()
+
+            if not self.context.incremental:
+                self.context.generate_dump_timestamp()
+
             if self.list_backup_files:
                 self._list_backup_files()
                 logger.info('Successfully listed the names of backup files and pipes')
@@ -832,11 +837,11 @@ class GpCronDump(Operation):
                         # if this fails, it raises an exception and bombs out RC and to the screen
                         CreateIncrementsFile(self.context).run()
                         if self.context.ddboost:
-                            backup_file_with_ddboost(self.context, "increments", self.context.full_dump_timestamp)
+                            backup_file_with_ddboost(self.context, "increments", timestamp=self.context.full_dump_timestamp)
 
                         write_partition_list_file(self.context, post_dump_outcome['timestamp'])
                         if self.context.netbackup_service_host:
-                            backup_file_with_nbu(self.context, "increments")
+                            backup_file_with_nbu(self.context, "increments", timestamp=self.context.full_dump_timestamp)
                             backup_file_with_nbu(self.context, "partition_list")
 
             finally:
@@ -881,7 +886,7 @@ class GpCronDump(Operation):
                     raise ExceptionNoStackTraceNeeded("Dump incomplete, rollback not processed")
                 elif self.rollback:
                     logger.warn("Dump request was incomplete, rolling back dump")
-                    DeleteCurrentDump(self.context, timestamp = post_dump_outcome['timestamp']).run()
+                    DeleteCurrentDump(self.context).run()
                     MailDumpEvent("Report from gpcrondump on host %s [FAILED]" % self.cur_host,
                                   "Failed for database %s with return code %d dump files rolled back. [Start=%s End=%s] Options passed [%s]"
                                   % (self.context.dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
@@ -898,8 +903,7 @@ class GpCronDump(Operation):
 
             if self.post_vacuum:
                 logger.info('Commencing post-dump vacuum...')
-                VacuumDatabase(database = self.context.dump_database,
-                               master_port = self.context.master_port).run()
+                VacuumDatabase(self.context).run()
 
             dump_type = 'Incremental' if self.context.incremental else 'Full database'
             self._status_report(post_dump_outcome['timestamp'],
@@ -942,9 +946,9 @@ class GpCronDump(Operation):
                     arglist.append("-a")
                 if not self.context.ddboost_ping:
                     arglist.append("--skip-ping")
-                if self.ddboost_storage_unit:
+                if self.context.ddboost_storage_unit:
                     arglist.append('--ddboost-storage-unit')
-                    arglist.append(self.ddboost_storage_unit)
+                    arglist.append(self.context.ddboost_storage_unit)
                 logger.info("Replicating %s to remote Data Domain. (gpmfr.py %s)" % (name, " ".join(arglist)))
                 mfropt, mfrargs = p.parse_args(arglist, None)
                 mfr = gpmfr.GpMfr(mfropt, mfrargs)

--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -226,9 +226,13 @@ class GpdbRestore(Operation):
             raise Exception('--list-backup is not supported for restore with full timestamps')
 
         if is_incremental_restore(self.context) and not self.context.no_plan:
+
+            self.context.full_dump_timestamp = get_full_timestamp_for_incremental(self.context)
             if self.context.netbackup_service_host:
-                restore_file_with_nbu(self.context, "partition_list")
-                restore_file_with_nbu(self.context, "increments")
+                restore_file_with_nbu(self.context, filetype="partition_list")
+                restore_file_with_nbu(self.context, filetype="increments",
+                                      timestamp=self.context.full_dump_timestamp)
+
             plan_file = create_restore_plan(self.context)
 
             if self.context.list_backup and self.context.timestamp:
@@ -419,7 +423,7 @@ class GpdbRestore(Operation):
             temp = match[len(prefix):]
             self.context.timestamp = temp[0:14]
         self.context.restore_db = GetDbName(self.context.generate_filename("cdatabase")).run()
-        compressed_file = self.context.generate_filename("metadata")
+        compressed_file = self.context.generate_filename("postdata")
         self.context.compress = CheckFile(compressed_file).run()
 
     def _validate_db_host_path(self):
@@ -482,7 +486,7 @@ class GpdbRestore(Operation):
         self.context.timestamp = str(max(timestamps))
         logger.info("Identified latest dump timestamp for %s as %s" %  (self.search_for_dbname, self.context.timestamp))
         self.context.restore_db = self.search_for_dbname
-        compressed_file = self.context.generate_filename("cdatabase")
+        compressed_file = self.context.generate_filename("postdata")
         self.context.compress = CheckFile(compressed_file).run()
 
     def _select_multi_file(self, dates_and_times):

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
@@ -628,8 +628,8 @@ class BackupUtilsTestCase(unittest.TestCase):
 
     @patch('glob.glob', return_value=['/tmp/db_dumps/20130207/gp_dump_20130207093000_increments'])
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20130207133001', '20130207133000'])
-    def test_get_full_timestamp_for_incremental_default(self, mock1, mock2):
-        backup_dir = 'home'
+    @patch('os.path.exists', return_value = True)
+    def test_get_full_timestamp_for_incremental_default(self, mock1, mock2, mock3):
         self.context.timestamp = '20130207133000'
         full_ts = get_full_timestamp_for_incremental(self.context)
         self.assertEquals(full_ts, '20130207093000')
@@ -818,7 +818,8 @@ class BackupUtilsTestCase(unittest.TestCase):
 
     @patch('glob.glob', return_value=['/tmp/db_dumps/20130207/foo_gp_dump_20130207093000_increments'])
     @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['20130207133001', '20130207133000'])
-    def test_get_full_timestamp_for_incremental_with_prefix_default(self, mock1, mock2):
+    @patch('os.path.exists', return_value = True)
+    def test_get_full_timestamp_for_incremental_with_prefix_default(self, mock1, mock2, mock3):
         self.context.backup_dir = 'home'
         self.context.dump_prefix = 'foo_'
         self.context.timestamp = '20130207133000'
@@ -943,7 +944,7 @@ class BackupUtilsTestCase(unittest.TestCase):
     def test_restore_file_with_nbu_with_segment_and_big_block_size(self, mock1):
         segment_hostname = "sdw"
         self.context.netbackup_block_size = 2048
-        
+
         restore_file_with_nbu(self.context, path=self.netbackup_filepath, hostname=segment_hostname)
 
     @patch('gppylib.operations.backup_utils.Command.run')

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/netbackup_mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/netbackup_mgmt_utils.py
@@ -215,7 +215,7 @@ def impl(context, filetype):
             backup_utils.master_datadir = seg.getSegmentDataDirectory()
             seg_config_filename = backup_utils.generate_filename('segment_config', dbid=seg.getSegmentDbId())
             seg_host = seg.getSegmentHostName()
-            cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (backup_utils.netbackup_service_host, seg_config_filename) 
+            cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (backup_utils.netbackup_service_host, seg_config_filename)
             cmd = Command("Querying NetBackup server for segment config file", cmd_str, ctxt=REMOTE, remoteHost=seg_host)
             cmd.run(validateAfter=True)
             if cmd.get_results().stdout.strip() != seg_config_filename:
@@ -297,7 +297,6 @@ def impl(context, filetype, prefix, subdir):
         prefix = prefix + '_'
 
     if filetype == 'report':
-        #use_dir = get_backup_directory(master_data_dir, subdir, 'db_dumps', backup_timestamp)
         filename =  "%s/%sgp_dump_%s.rpt" % (dump_dir, prefix, backup_timestamp)
         cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (netbackup_service_host, filename)
         cmd = Command("Querying NetBackup server for report file", cmd_str)
@@ -314,9 +313,8 @@ def impl(context, filetype, prefix, subdir):
             raise Exception('Global file %s was not backup up to NetBackup server %s successfully' % (filename, netbackup_service_host))
 
     elif filetype == 'config':
-        use_dir = get_backup_directory(master_data_dir, subdir, 'db_dumps', backup_timestamp)
         master_config_filename = os.path.join(dump_dir, "%sgp_master_config_files_%s.tar" % (prefix, backup_timestamp))
-        cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (netbackup_service_host, master_config_filename) 
+        cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (netbackup_service_host, master_config_filename)
         cmd = Command("Querying NetBackup server for master config file", cmd_str)
         cmd.run(validateAfter=True)
         if cmd.get_results().stdout.strip() != master_config_filename:
@@ -326,10 +324,11 @@ def impl(context, filetype, prefix, subdir):
         gparray = GpArray.initFromCatalog(dbconn.DbURL(port = master_port), utility=True)
         segs = [seg for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
         for seg in segs:
-            use_dir = get_backup_directory(seg.getSegmentDataDirectory(), subdir, 'db_dumps', backup_timestamp)
-            seg_config_filename = os.path.join(use_dir, "%sgp_segment_config_files_0_%d_%s.tar" % (prefix, seg.getSegmentDbId(), backup_timestamp))
+            seg_dir = seg.getSegmentDataDirectory()
+            dump_dir = os.path.join(seg_dir, 'db_dumps', '%s' % (backup_timestamp[0:8]))
+            seg_config_filename = os.path.join(dump_dir, "%sgp_segment_config_files_0_%d_%s.tar" % (prefix, seg.getSegmentDbId(), backup_timestamp))
             seg_host = seg.getSegmentHostName()
-            cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (netbackup_service_host, seg_config_filename) 
+            cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (netbackup_service_host, seg_config_filename)
             cmd = Command("Querying NetBackup server for segment config file", cmd_str, ctxt=REMOTE, remoteHost=seg_host)
             cmd.run(validateAfter=True)
             if cmd.get_results().stdout.strip() != seg_config_filename:


### PR DESCRIPTION
Commit 9d1ae66cd92f0eab7111541b677c0d2de11e5acb had some regressions in
netbackup, ddboost, and MFR test suites.

A summary of these fixes are:

 * Using the correct timestamp when performing an incremental backup
 * Generating timestamps in the correct order
 * Identify whether compression is enabled in ddboost using the correct file
 * Updating path to retrieve file from on ddboost
 * Removing unused context variables
 * Removing dead code
 * Updates number/ordering in function argumenets

Authors: Chris Hajas, Chumki Roy, Marbin Tan