### PR TITLE
Populate canSetTag of PlannedStmt from Query object

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -211,7 +211,8 @@ CTranslatorDXLToPlStmt::InitTranslators()
 PlannedStmt *
 CTranslatorDXLToPlStmt::PplstmtFromDXL
 	(
-	const CDXLNode *pdxln
+	const CDXLNode *pdxln,
+	const Query *pquery
 	)
 {
 	GPOS_ASSERT(NULL != pdxln);
@@ -248,7 +249,7 @@ CTranslatorDXLToPlStmt::PplstmtFromDXL
 
 	// store partitioned table indexes in planned stmt
 	pplstmt->queryPartOids = m_pctxdxltoplstmt->PlPartitionedTables();
-	pplstmt->canSetTag = true;
+	pplstmt->canSetTag = pquery->canSetTag;
 	pplstmt->relationOids = plOids;
 	pplstmt->numSelectorsPerScanId = m_pctxdxltoplstmt->PlNumPartitionSelectors();
 

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -637,7 +637,8 @@ COptTasks::Pplstmt
 	(
 	IMemoryPool *pmp,
 	CMDAccessor *pmda,
-	const CDXLNode *pdxln
+	const CDXLNode *pdxln,
+	const Query *pquery
 	)
 {
 
@@ -663,7 +664,7 @@ COptTasks::Pplstmt
 	
 	// translate DXL -> PlannedStmt
 	CTranslatorDXLToPlStmt trdxltoplstmt(pmp, pmda, &ctxdxltoplstmt, gpdb::UlSegmentCountGP());
-	return trdxltoplstmt.PplstmtFromDXL(pdxln);
+	return trdxltoplstmt.PplstmtFromDXL(pdxln, pquery);
 }
 
 
@@ -1038,7 +1039,7 @@ COptTasks::PvOptimizeTask
 			// translate DXL->PlStmt only when needed
 			if (poctx->m_fGeneratePlStmt)
 			{
-				poctx->m_pplstmt = (PlannedStmt *) gpdb::PvCopyObject(Pplstmt(pmp, &mda, pdxlnPlan));
+				poctx->m_pplstmt = (PlannedStmt *) gpdb::PvCopyObject(Pplstmt(pmp, &mda, pdxlnPlan, ptrquerytodxl->Pquery()));
 			}
 
 			CStatisticsConfig *pstatsconf = pocconf->Pstatsconf();
@@ -1287,7 +1288,7 @@ COptTasks::PvPlstmtFromDXLTask
 
 		// translate DXL -> PlannedStmt
 		CTranslatorDXLToPlStmt trdxltoplstmt(pmp, amda.Pmda(), &ctxdxlplstmt, gpdb::UlSegmentCountGP());
-		PlannedStmt *pplstmt = trdxltoplstmt.PplstmtFromDXL(pdxlnOriginal);
+		PlannedStmt *pplstmt = trdxltoplstmt.PplstmtFromDXL(pdxlnOriginal, poctx->m_pquery);
 		if (optimizer_print_plan)
 		{
 			elog(NOTICE, "Plstmt: %s", gpdb::SzNodeToString(pplstmt));

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -265,7 +265,7 @@ namespace gpdxl
 				);
 
 			// main translation routine for DXL tree -> PlannedStmt
-			PlannedStmt *PplstmtFromDXL(const CDXLNode *pdxln);
+			PlannedStmt *PplstmtFromDXL(const CDXLNode *pdxln, const Query *pquery);
 
 			// translate the join types from its DXL representation to the GPDB one
 			static JoinType JtFromEdxljt(EdxlJoinType edxljt);

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -205,7 +205,7 @@ class COptTasks
 
 		// translate a DXL tree into a planned statement
 		static
-		PlannedStmt *Pplstmt(IMemoryPool *pmp, CMDAccessor *pmda, const CDXLNode *pdxln);
+		PlannedStmt *Pplstmt(IMemoryPool *pmp, CMDAccessor *pmda, const CDXLNode *pdxln, const Query *pquery);
 
 		// load search strategy from given path
 		static

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -9946,6 +9946,56 @@ select * from (values (2),(null)) v(k);
 
 (2 rows)
 
+-- Checking if ORCA correctly populates canSetTag in PlannedStmt for multiple statements because of rules
+drop table if exists can_set_tag_target;
+NOTICE:  table "can_set_tag_target" does not exist, skipping
+create table can_set_tag_target
+(
+	x int,
+	y int,
+	z char
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+drop table if exists can_set_tag_audit;
+NOTICE:  table "can_set_tag_audit" does not exist, skipping
+create table can_set_tag_audit
+(
+	t timestamp without time zone,
+	x int,
+	y int,
+	z char
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create rule can_set_tag_audit_update AS
+    ON UPDATE TO can_set_tag_target DO  INSERT INTO can_set_tag_audit (t, x, y, z)
+  VALUES (now(), old.x, old.y, old.z);
+insert into can_set_tag_target select i, i + 1, i + 2 from generate_series(1,2) as i;
+create role unpriv;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+grant all on can_set_tag_target to unpriv;
+grant all on can_set_tag_audit to unpriv;
+set role unpriv;
+show optimizer;
+ optimizer 
+-----------
+ on
+(1 row)
+
+update can_set_tag_target set y = y + 1;
+select count(1) from can_set_tag_audit;
+ count 
+-------
+     2
+(1 row)
+
+reset role;
+revoke all on can_set_tag_target from unpriv;
+revoke all on can_set_tag_audit from unpriv;
+drop role unpriv;
+drop table can_set_tag_target;
+drop table can_set_tag_audit;
 -- clean up
 drop schema orca cascade;
 NOTICE:  drop cascades to table orca.index_test

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -1283,6 +1283,45 @@ explain select * from orca.index_test where a = 5 and c = 5;
 -- renaming columns
 select * from (values (2),(null)) v(k);
 
+-- Checking if ORCA correctly populates canSetTag in PlannedStmt for multiple statements because of rules
+drop table if exists can_set_tag_target;
+create table can_set_tag_target
+(
+	x int,
+	y int,
+	z char
+);
+
+drop table if exists can_set_tag_audit;
+create table can_set_tag_audit
+(
+	t timestamp without time zone,
+	x int,
+	y int,
+	z char
+);
+
+create rule can_set_tag_audit_update AS
+    ON UPDATE TO can_set_tag_target DO  INSERT INTO can_set_tag_audit (t, x, y, z)
+  VALUES (now(), old.x, old.y, old.z);
+
+insert into can_set_tag_target select i, i + 1, i + 2 from generate_series(1,2) as i;
+
+create role unpriv;
+grant all on can_set_tag_target to unpriv;
+grant all on can_set_tag_audit to unpriv;
+set role unpriv;
+show optimizer;
+update can_set_tag_target set y = y + 1;
+select count(1) from can_set_tag_audit;
+reset role;
+
+revoke all on can_set_tag_target from unpriv;
+revoke all on can_set_tag_audit from unpriv;
+drop role unpriv;
+drop table can_set_tag_target;
+drop table can_set_tag_audit;
+
 -- clean up
 drop schema orca cascade;
 reset optimizer_segments;


### PR DESCRIPTION
During creation of PlannedStmt from DXL plan the translator wrongly set the canSetTag to true, regardless of the value of canSetTag of the Query object. This caused an execution error during PortalRunMulti if we try to run multiple PlannedStmt as we were trying to lock same portal more than once.

This PR correctly sets the canSetTag of each PlannedStmt based on the underlying Query object.