### PR TITLE
Skip var code generation in scans

### DIFF
--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -349,10 +349,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			EnrollQualList(result, ((ScanState*) result)->ss_ScanTupleSlot);
 			if (NULL !=result)
 			{
-			  bool skip_var = true;
 			  EnrollProjInfoTargetList(result->ps_ProjInfo,
 			                           ((ScanState*) result)->ss_ScanTupleSlot,
-			                           skip_var);
+			                           true /* skip_var */);
 			}
 			}
 			END_MEMORY_ACCOUNT();
@@ -586,14 +585,13 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			EnrollQualList(result, ((ScanState*) result)->ss_ScanTupleSlot);
 			if (NULL != result)
 			{
-			  bool skip_var = false;
 			  AggState* aggstate = (AggState*)result;
 			  for (int aggno = 0; aggno < aggstate->numaggs; aggno++)
 			  {
 			    AggStatePerAgg peraggstate = &aggstate->peragg[aggno];
 			    EnrollProjInfoTargetList(peraggstate->evalproj,
 			                             ((ScanState*) result)->ss_ScanTupleSlot,
-			                             skip_var);
+			                             false /* skip_var */);
 			  }
 			}
 			}


### PR DESCRIPTION
When generating code for a query such as ```select i from foo;```, the targetlist is populated with a VAR member corresponding to 'i' from the query. This will trigger the code generation for ExecVariableList (which will be used when deforming the tuple), and also trigger the generation to evaluate the expression with only the VAR attribute. This is simply a waste of effort, to generate code for merely extracting the values from the tuple, and calling that. So, we add a boolean flag to the enroll to skill VAR expressions when generating code in scans.