### PR TITLE
Update error hint to include all supported formats

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17439,9 +17439,8 @@ static Datum transformExecOnClause(List	*on_clause)
 }
 
 /*
- * transform format name to format code and validate that
- * the format is supported. Currently the only supported formats
- * are "text" (type 't') ,"csv" (type 'c') and "custom" (type 'b')
+ * Transform format name for external table FORMAT option to format code and
+ * validate that the requested format is supported.
  */
 static char transformFormatType(char *formatname)
 {
@@ -17461,7 +17460,8 @@ static char transformFormatType(char *formatname)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("unsupported format '%s'", formatname),
-				 errhint("available formats are \"text\", \"csv\", or \"custom\"")));
+				 errhint("Available formats for external tables are \"text\", "
+				 		 "\"csv\", \"avro\", \"parquet\" and \"custom\"")));
 
 	return result;
 }


### PR DESCRIPTION
Include all the supported formats for the `FORMAT` option on external tables in the `errhint()` call and perform minor copy editing to make it conform to the error message guidelines. Also remove the list of formats from the function comment since those lists are notorious for getting outdated (case in point).

Spotted while reading over some other code and can't see a reason why not to include these?