### PR TITLE
Proclaim that the codegen'ed version of generated functions

### DIFF
--- a/src/backend/codegen/exec_eval_expr_codegen.cc
+++ b/src/backend/codegen/exec_eval_expr_codegen.cc
@@ -132,9 +132,11 @@ bool ExecEvalExprCodegen::GenerateExecEvalExpr(
 
   irb->SetInsertPoint(llvm_entry_block);
 
+#ifdef CODEGEN_DEBUG
   codegen_utils->CreateElog(
       DEBUG1,
-      "Calling codegen'ed expression evaluation");
+      "Codegen'ed expression evaluation called!");
+#endif
 
 
   // Generate code from expression tree generator

--- a/src/backend/codegen/exec_variable_list_codegen.cc
+++ b/src/backend/codegen/exec_variable_list_codegen.cc
@@ -156,6 +156,11 @@ bool ExecVariableListCodegen::GenerateExecVariableList(
   // Entry block
   // -----------
   irb->SetInsertPoint(entry_block);
+#ifdef CODEGEN_DEBUG
+  codegen_utils->CreateElog(
+      DEBUG1,
+      "Codegen'ed ExecVariableList called!");
+#endif
   irb->CreateBr(slot_check_block);
 
   // Slot check block

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -265,11 +265,11 @@ class CodegenUtils {
    **/
   llvm::BasicBlock* CreateBasicBlock(const llvm::Twine& name,
                                      llvm::Function* parent) {
-#ifdef GPCODEGEN_DEBUG
+#ifdef CODEGEN_DEBUG
     // DEBUG-only assertion to make sure that caller does not try to generate IR
     // for an external function.
     assert(!parent->getName().startswith(kExternalFunctionNamePrefix));
-#endif  // GPCODEGEN_DEBUG
+#endif  // CODEGEN_DEBUG
     return llvm::BasicBlock::Create(context_, name, parent, nullptr);
   }
 
@@ -1175,7 +1175,7 @@ template <typename ReturnType, typename... ArgumentTypes>
 auto CodegenUtils::GetFunctionPointerImpl(const std::string& function_name)
     -> ReturnType (*)(ArgumentTypes...) {
   if (engine_) {
-#ifdef GPCODEGEN_DEBUG
+#ifdef CODEGEN_DEBUG
     CheckFunctionType(function_name,
                       GetFunctionType<ReturnType, ArgumentTypes...>());
 #endif

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -123,6 +123,11 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
   // -----------
 
   irb->SetInsertPoint(entry_block);
+#ifdef CODEGEN_DEBUG
+  codegen_utils->CreateElog(
+      DEBUG1,
+      "Codegen'ed slot_getattr called!");
+#endif
   // We start a sequence of checks to ensure that everything is fine and
   // we do not need to fall back.
   irb->CreateBr(slot_check_block);

--- a/src/backend/codegen/tests/codegen_utils_unittest.cc
+++ b/src/backend/codegen/tests/codegen_utils_unittest.cc
@@ -2817,7 +2817,7 @@ TEST_F(CodegenUtilsTest, InlineFunctionTest) {
 }
 
 
-#ifdef GPCODEGEN_DEBUG
+#ifdef CODEGEN_DEBUG
 
 TEST_F(CodegenUtilsDeathTest, WrongFunctionTypeTest) {
   // Create a function identical to the one in TrivialCompilationTest, but try
@@ -2879,7 +2879,7 @@ TEST_F(CodegenUtilsDeathTest, GetPointerToMemberFromWrongTypeBasePointerTest) {
                "");
 }
 
-#endif  // GPCODEGEN_DEBUG
+#endif  // CODEGEN_DEBUG
 
 }  // namespace gpcodegen
 


### PR DESCRIPTION
Only in debug build, create an elog call to proclaim that the codegen'd versions of generated functions are called correctly. This may be followed by "fallback" error messages as before (I'm not exactly sure if they should be wrapped in GPCODEGEN_DEBUG, but that can go in another PR).

The intention here is to aid our PM to easily accept codegen stories without relying on a debugger.

@karthijrk @foyzur @vraghavan78  Please have a look.