### PR TITLE
Support variable length attributes in SlotGetAttrCodegen

### DIFF
--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -1342,7 +1342,10 @@ heap_deformtuple(HeapTuple tuple,
  *		re-computing information about previously extracted attributes.
  *		slot->tts_nvalid is the number of attributes already extracted.
  */
-static void
+#ifndef USE_CODEGEN
+static
+#endif
+void
 slot_deform_tuple(TupleTableSlot *slot, int natts)
 {
 	HeapTuple	tuple = TupGetHeapTuple(slot); 

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -42,9 +42,17 @@ extern "C" {
 #include "access/htup.h"
 #include "nodes/execnodes.h"
 #include "executor/tuptable.h"
+
+extern void slot_deform_tuple(TupleTableSlot* slot, int nattr);
 }
 
 using gpcodegen::SlotGetAttrCodegen;
+
+// TODO(shardikar): Retire this GUC after performing experiments to find the
+// tradeoff of codegen-ing slot_getattr() (potentially by measuring the
+// difference in the number of instructions) when one of the first few
+// attributes is varlen.
+extern const int codegen_varlen_tolerance;
 
 // TODO(shardikar, krajaraman) Remove this wrapper after implementing an
 // interface to share code generation logic.
@@ -73,11 +81,12 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttr(
 }
 
 bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
-     gpcodegen::GpCodegenUtils* codegen_utils,
-     const std::string& function_name,
-     TupleTableSlot *slot,
-     int max_attr,
-     llvm::Function** out_func) {
+    gpcodegen::GpCodegenUtils* codegen_utils,
+    const std::string& function_name,
+    TupleTableSlot *slot,
+    int max_attr,
+    llvm::Function** out_func) {
+
   // So looks like we're going to generate code
   *out_func = codegen_utils->CreateFunction<SlotGetAttrFn>(function_name);
   llvm::Function* slot_getattr_func = *out_func;
@@ -109,6 +118,8 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
   // External functions
   llvm::Function* llvm_memset =
       codegen_utils->GetOrRegisterExternalFunction(memset);
+  llvm::Function* llvm_slot_deform_tuple =
+      codegen_utils->GetOrRegisterExternalFunction(slot_deform_tuple);
 
   // Generation-time constants
   llvm::Value* llvm_slot = codegen_utils->GetConstant(slot);
@@ -273,14 +284,24 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
 
   irb->CreateBr(attribute_block);
 
-  for (int attnum = 0; attnum < max_attr; ++attnum) {
+  bool varlen_attrs_found = false;
+  int attnum = 0;
+  for (; attnum < max_attr; ++attnum) {
     Form_pg_attribute thisatt = att[attnum];
 
     // If any thisatt is varlen
     if (thisatt->attlen < 0) {
-      // We don't support variable length attributes.
-      elog(DEBUG1, "We don't support variable length attributes.");
-      return false;
+      // When we have variable length attributes, we can no longer benefit
+      // from codegen, since the next offset needs to be computed after the
+      // tuple is read into memory.
+      if (attnum < codegen_varlen_tolerance) {
+        // Also, if one of the first few attributes is varlen, might as well
+        // call slot_deform_tuple directly, instead of going through a codegen'd
+        // wrapper function.
+        return false;
+      }
+      varlen_attrs_found = true;
+      break;
     }
 
     // ith attribute's block
@@ -450,8 +471,10 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
   irb->SetInsertPoint(next_attribute_block);
   irb->CreateBr(final_block);
 
+
   // Final block
   // ----------------
+  // Save the state for the next execution
 
   irb->SetInsertPoint(final_block);
 
@@ -464,7 +487,17 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
       llvm_slot_PRIVATE_tts_off_ptr);
 
   // slot->PRIVATE_tts_nvalid = attnum;
-  irb->CreateStore(llvm_max_attr, llvm_slot_PRIVATE_tts_nvalid_ptr);
+  irb->CreateStore(codegen_utils->GetConstant(attnum),
+                   llvm_slot_PRIVATE_tts_nvalid_ptr);
+
+  if (varlen_attrs_found) {
+    // If we encountered any varlen attribute, we stop codegen from that
+    // attribute onwards and call slot_deform_tuple() directly to deform the
+    // rest of the tuple.
+    irb->CreateCall(llvm_slot_deform_tuple, {
+        llvm_slot_arg,
+        llvm_max_attr});
+  }
 
   // End of slot_deform_tuple
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -568,6 +568,7 @@ bool		optimizer_prefer_scalar_dqa_multistage_agg;
 bool		init_codegen;
 bool		codegen;
 bool		codegen_validate_functions;
+int			codegen_varlen_tolerance;
 
 /* Security */
 bool		gp_reject_internal_tcp_conn = true;
@@ -4770,6 +4771,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		(int *) &gp_indexcheck_vacuum,
 		INDEX_CHECK_NONE, 0, INDEX_CHECK_ALL, NULL, NULL
+	},
+
+	{
+		{"codegen_varlen_tolerance", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Minimum number of initial fixed length attributes in the table to generate code for deforming tuples."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		&codegen_varlen_tolerance,
+		5, 0, INT_MAX, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -466,6 +466,7 @@ extern bool optimizer_prefer_scalar_dqa_multistage_agg;
 extern bool init_codegen;
 extern bool codegen;
 extern bool codegen_validate_functions;
+extern int codegen_varlen_tolerance;
 
 /**
  * Enable logging of DPE match in optimizer.


### PR DESCRIPTION
When we encounter a variable length attribute, we can no longer benefit from codegen, since the next offset needs to be computed after the tuple is read into memory. There is still some benefit in partial loop unrolling, but I would like to tackle that at a later time since that is a more complex story.

In this PR, if we encountered any varlen attribute while generating code for slot_getattr, we stop  from that attribute onwards and call slot_deform_tuple() directly to deform the rest of the tuple. Also, if one of the first few attributes is varlen, might as well call slot_deform_tuple directly, instead of going through a codegen'd wrapper function. 
That limit is defined by MIN_NATTRS_FOR_VARLEN_CODEGEN which is a hard-coded constant. We can decided if this needs to be guc for runtime manipulation, and if not, what value is appropriate here ( 5 is something I just imagined out of thin air).

Testing : 
```
create table bar (i int, j int, k int, l int, m int, a char(1), b char(1));
insert into bar values (1, 2, 3, 4, 5, 'A', 'B');
set codegen = on;
set client_min_messages = on;
select a from bar;
```
```
DEBUG1:  ExecVariableList was generated successfully!  (seg2 slice1 10.0.0.139:25434 pid=15022)
DEBUG1:  ExecVariableList was generated successfully!  (seg0 slice1 10.0.0.139:25432 pid=15020)
DEBUG1:  ExecVariableList was generated successfully!  (seg1 slice1 10.0.0.139:25433 pid=15021)
DEBUG1:  ExecEvalExpr was generated successfully!  (seg0 slice1 10.0.0.139:25432 pid=15020)
DEBUG1:  ExecEvalExpr was generated successfully!  (seg2 slice1 10.0.0.139:25434 pid=15022)
DEBUG1:  ExecEvalExpr was generated successfully!  (seg1 slice1 10.0.0.139:25433 pid=15021)
```

Before this change, we would get failures because we did not support variable length attributes.

@karthijrk @foyzur Please take a look.