### PR TITLE
Fix the self-deadlock caused by reentrance of malloc/free when QD is in idle state.

### DIFF
--- a/src/backend/commands/async.c
+++ b/src/backend/commands/async.c
@@ -95,6 +95,7 @@
 #include "libpq/pqformat.h"
 #include "miscadmin.h"
 #include "storage/ipc.h"
+#include "storage/proc.h"
 #include "storage/sinval.h"
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
@@ -960,9 +961,11 @@ ProcessIncomingNotify(void)
 	bool		repl[Natts_pg_listener],
 				nulls[Natts_pg_listener];
 	bool		catchup_enabled;
+	bool		client_wait_timeout_enabled;
 
-	/* Must prevent SIGUSR1 interrupt while I am running */
+	/* Must prevent SIGUSR1 and SIGALRM(for IdleSessionGangTimeout) interrupt while I am running */
 	catchup_enabled = DisableCatchupInterrupt();
+	client_wait_timeout_enabled = DisableClientWaitTimeoutInterrupt();
 
 	if (Trace_notify)
 		elog(DEBUG1, "ProcessIncomingNotify");
@@ -1042,6 +1045,9 @@ ProcessIncomingNotify(void)
 
 	if (catchup_enabled)
 		EnableCatchupInterrupt();
+
+	if (client_wait_timeout_enabled)
+		EnableClientWaitTimeoutInterrupt();
 }
 
 /*

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -39,11 +39,13 @@
 #include "access/transam.h"
 #include "access/xact.h"
 #include "catalog/namespace.h" /* TempNamespaceOidIsValid */
+#include "commands/async.h"
 #include "miscadmin.h"
 #include "postmaster/autovacuum.h"
 #include "replication/syncrep.h"
 #include "storage/ipc.h"
 #include "storage/spin.h"
+#include "storage/sinval.h"
 #include "storage/lmgr.h"
 #include "storage/proc.h"
 #include "storage/procarray.h"
@@ -93,6 +95,8 @@ static LOCALLOCK *lockAwaited = NULL;
 static volatile bool statement_timeout_active = false;
 static volatile bool deadlock_timeout_active = false;
 static volatile DeadLockState deadlock_state = DS_NOT_YET_CHECKED;
+static volatile sig_atomic_t clientWaitTimeoutInterruptEnabled = 0;
+static volatile sig_atomic_t clientWaitTimeoutInterruptOccurred = 0;
 volatile bool cancel_from_timeout = false;
 
 /* timeout_start_time is set when log_lock_waits is true */
@@ -101,11 +105,12 @@ static TimestampTz timeout_start_time;
 /* statement_fin_time is valid only if statement_timeout_active is true */
 static TimestampTz statement_fin_time;
 
-
 static void RemoveProcFromArray(int code, Datum arg);
 static void ProcKill(int code, Datum arg);
 static void AuxiliaryProcKill(int code, Datum arg);
 static bool CheckStatementTimeout(void);
+static void ClientWaitTimeoutInterruptHandler(void);
+static void ProcessClientWaitTimeout(void);
 
 
 /*
@@ -1822,12 +1827,115 @@ handle_sig_alarm(SIGNAL_ARGS)
 		 */
 		if (DoingCommandRead)
 		{
-			(void) HandleClientWaitTimeout();
+			(void) ClientWaitTimeoutInterruptHandler();
 			deadlock_timeout_active = false;
 		}
 	}
 
 	errno = save_errno;
+}
+
+static void
+ClientWaitTimeoutInterruptHandler(void)
+{
+	int save_errno = errno;
+
+	/* Don't joggle the elbow of proc_exit */
+	if (proc_exit_inprogress)
+		return;
+
+	if (clientWaitTimeoutInterruptEnabled)
+	{
+		bool save_ImmediateInterruptOK = ImmediateInterruptOK;
+
+		/*
+		 * We may be called while ImmediateInterruptOK is true; turn it off
+		 * while messing with the client wait timeout state.
+		 */
+		ImmediateInterruptOK = false;
+
+		/*
+		 * I'm not sure whether some flavors of Unix might allow another
+		 * SIGALRM occurrence to recursively interrupt this routine. To cope
+		 * with the possibility, we do the same sort of dance that
+		 * EnableNotifyInterrupt must do -- see that routine for comments.
+		 */
+		clientWaitTimeoutInterruptEnabled = 0; /* disable any recursive signal */
+		clientWaitTimeoutInterruptOccurred = 1; /* do at least one iteration */
+		for (;;)
+		{
+			clientWaitTimeoutInterruptEnabled = 1;
+			if (!clientWaitTimeoutInterruptOccurred)
+				break;
+			clientWaitTimeoutInterruptEnabled = 0;
+			if (clientWaitTimeoutInterruptOccurred)
+			{
+				ProcessClientWaitTimeout();
+			}
+		}
+
+		/*
+		 * Restore ImmediateInterruptOK, and check for interrupts if needed.
+		 */
+		ImmediateInterruptOK = save_ImmediateInterruptOK;
+		if (save_ImmediateInterruptOK)
+			CHECK_FOR_INTERRUPTS();
+	}
+	else
+	{
+		/*
+		 * In this path it is NOT SAFE to do much of anything, except this:
+		 */
+		clientWaitTimeoutInterruptOccurred = 1;
+	}
+
+	errno = save_errno;
+}
+
+void
+EnableClientWaitTimeoutInterrupt(void)
+{
+	for (;;)
+	{
+		clientWaitTimeoutInterruptEnabled = 1;
+		if (!clientWaitTimeoutInterruptOccurred)
+			break;
+		clientWaitTimeoutInterruptEnabled = 0;
+		if (clientWaitTimeoutInterruptOccurred)
+		{
+			ProcessClientWaitTimeout();
+		}
+	}
+}
+
+bool
+DisableClientWaitTimeoutInterrupt(void)
+{
+	bool result = (clientWaitTimeoutInterruptEnabled != 0);
+
+	clientWaitTimeoutInterruptEnabled = 0;
+
+	return result;
+}
+
+static void
+ProcessClientWaitTimeout(void)
+{
+	bool notify_enabled;
+	bool catchup_enabled;
+
+	/* Must prevent SIGUSR1 and SIGUSR2 interrupt while I am running */
+	notify_enabled = DisableNotifyInterrupt();
+	catchup_enabled = DisableCatchupInterrupt();
+
+	clientWaitTimeoutInterruptOccurred = 0;
+
+	HandleClientWaitTimeout();
+
+	if (notify_enabled)
+		EnableNotifyInterrupt();
+	if (catchup_enabled)
+		EnableCatchupInterrupt();
 }
 
 /*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -616,6 +616,7 @@ prepare_for_client_read(void)
 		/* Enable immediate processing of asynchronous signals */
 		EnableNotifyInterrupt();
 		EnableCatchupInterrupt();
+		EnableClientWaitTimeoutInterrupt();
 
 		/* Allow "die" interrupt to be processed while waiting */
 		ImmediateInterruptOK = true;
@@ -653,6 +654,7 @@ client_read_ended(void)
 
 		DisableNotifyInterrupt();
 		DisableCatchupInterrupt();
+		DisableClientWaitTimeoutInterrupt();
 	}
 	else
 	{
@@ -3467,6 +3469,7 @@ die(SIGNAL_ARGS)
 			LockWaitCancel();	/* prevent CheckDeadLock from running */
 			DisableNotifyInterrupt();
 			DisableCatchupInterrupt();
+			DisableClientWaitTimeoutInterrupt();
 			InterruptHoldoffCount--;
 			ProcessInterrupts();
 		}
@@ -3651,6 +3654,7 @@ ProcessInterrupts(void)
 		ImmediateDieOK = false;		/* prevent re-entry */
 		DisableNotifyInterrupt();
 		DisableCatchupInterrupt();
+		DisableClientWaitTimeoutInterrupt();
 		if (IsAutoVacuumWorkerProcess())
 			ereport(FATAL,
 					(errcode(ERRCODE_ADMIN_SHUTDOWN),
@@ -3669,6 +3673,7 @@ ProcessInterrupts(void)
 		ImmediateInterruptOK = false;	/* not idle anymore */
 		DisableNotifyInterrupt();
 		DisableCatchupInterrupt();
+		DisableClientWaitTimeoutInterrupt();
 		/* don't send to client, we already know the connection to be dead. */
 		whereToSendOutput = DestNone;
 		ereport(FATAL,
@@ -4712,6 +4717,7 @@ PostgresMain(int argc, char *argv[],
 		DoingCommandRead = false;
 		DisableNotifyInterrupt();
 		DisableCatchupInterrupt();
+		DisableClientWaitTimeoutInterrupt();
 
 		/* Make sure libpq is in a good state */
 		pq_comm_reset();

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -253,6 +253,8 @@ extern void ProcSendSignal(int pid);
 extern bool enable_sig_alarm(int delayms, bool is_statement_timeout);
 extern bool disable_sig_alarm(bool is_statement_timeout);
 extern void handle_sig_alarm(SIGNAL_ARGS);
+extern void EnableClientWaitTimeoutInterrupt(void);
+extern bool DisableClientWaitTimeoutInterrupt(void);
 
 extern int ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet);
 


### PR DESCRIPTION
There are two cases leading to this self-deadlock:
(1) SIGALRM for IdleSessionGangTimeout comes when QD is in malloc function call
of SSL code for example, and the handler HandleClientWaitTimeout would call
function free to destroy Gangs, hence we are calling free inside malloc, which
would produce a deadlock;
(2) If a SIGUSR1 come when we are inside HandleClientWaitTimeout and calling
function free, then we would be interrupted to process the Catchup event first,
in which we would possibly call malloc, hence we are calling malloc inside free,
which would cause a deadlock also.

To fix this issue, for case 1, we only enable SIGALRM handling of IdleSessionGangTimeout
exactly before recv call, which can protect malloc/free from being interrupted
by this kind of SIGALRM; for case 2, we prevent reentrant signal handling.

This fix is mainly borrowed from a patch of Tao Ma in Apache HAWK project.