### PR TITLE
Introduced CreateDatumCast & CreateCast API

### DIFF
--- a/src/backend/codegen/const_expr_tree_generator.cc
+++ b/src/backend/codegen/const_expr_tree_generator.cc
@@ -45,6 +45,7 @@ bool ConstExprTreeGenerator::GenerateCode(GpCodegenUtils* codegen_utils,
                                           llvm::Value** llvm_out_value) {
   assert(nullptr != llvm_out_value);
   Const* const_expr = reinterpret_cast<Const*>(expr_state()->expr);
+  // const_expr->constvalue is a datum
   *llvm_out_value = codegen_utils->GetConstant(const_expr->constvalue);
   return true;
 }

--- a/src/backend/codegen/exec_eval_expr_codegen.cc
+++ b/src/backend/codegen/exec_eval_expr_codegen.cc
@@ -151,7 +151,7 @@ bool ExecEvalExprCodegen::GenerateExecEvalExpr(
     return false;
   }
 
-  llvm::Value* llvm_ret_value = codegen_utils->CreateCast<int64_t>(value);
+  llvm::Value* llvm_ret_value = codegen_utils->CreateCppTypeToDatumCast(value);
   irb->CreateRet(llvm_ret_value);
 
   irb->SetInsertPoint(llvm_error_block);

--- a/src/backend/codegen/include/codegen/utils/gp_codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/gp_codegen_utils.h
@@ -19,6 +19,7 @@
 #define GPCODEGEN_GP_CODEGEN_UTILS_H_
 
 #include "codegen/utils/codegen_utils.h"
+#include "codegen/codegen_wrapper.h"
 
 extern "C" {
 #include "utils/elog.h"
@@ -101,6 +102,72 @@ class GpCodegenUtils : public CodegenUtils {
         const V ... args ) {
     CreateElog(GetConstant(elevel), GetConstant(fmt), args...);
   }
+
+  /**
+   * @brief Create a Cast instruction to convert given llvm::Value of Datum type
+   *        to given Cpp type
+   *
+   * @note Depend on cpp type's size, it will do trunc or bit cast or
+   *       int2ptr cast. This is same as converting gpdb's Datum to cpptype.
+   *
+   * @tparam CppType  Destination cpp type
+   * @param value     LLVM Value on which casting has to be done.
+   *
+   * @return LLVM Value that casted to given Cpp type.
+   **/
+  template <typename CppType>
+  llvm::Value* CreateDatumToCppTypeCast(llvm::Value* value) {
+    assert(nullptr != value);
+    llvm::Type* llvm_dest_type = GetType<CppType>();
+    // If it is a pointer, do direct pointer cast
+    if (llvm_dest_type->isPointerTy()) {
+      return ir_builder()->CreateIntToPtr(value, llvm_dest_type);
+    }
+    unsigned dest_size = llvm_dest_type->getScalarSizeInBits();
+    assert(0 != dest_size);
+
+    llvm::Type* llvm_src_type = value->getType();
+    unsigned src_size = llvm_src_type->getScalarSizeInBits();
+
+    // Given src value, it should be of type Datum(int64_t)
+    assert(llvm_src_type->isIntegerTy());
+    assert(src_size == sizeof(Datum) << 3);
+
+    // Datum size should be the largest
+    assert(dest_size <= src_size);
+
+    // Get dest type as integer type with same size
+    llvm::Type* llvm_dest_as_int_type = llvm::IntegerType::get(*context(),
+                                                             dest_size);
+
+    llvm::Value* llvm_casted_value = value;
+
+    if (dest_size < src_size) {
+      llvm_casted_value = ir_builder()->CreateTrunc(value,
+                                                    llvm_dest_as_int_type);
+    }
+
+    if (llvm_src_type->getTypeID() != llvm_dest_type->getTypeID()) {
+      return ir_builder()->CreateBitCast(llvm_casted_value, llvm_dest_type);
+    }
+
+    return llvm_casted_value;
+  }
+
+  /**
+   * @brief Create a Cast instruction to convert given llvm::Value of any type
+   *        to Datum
+   *
+   * @note This is same as converting any cpptype to Datum in gpdb.
+   *
+   * @param value     LLVM Value on which casting has to be done.
+   * @param is_src_unsigned true if given value is of unsigned type.
+   *
+   *
+   * @return LLVM Value that casted to Datum type.
+   **/
+  llvm::Value* CreateCppTypeToDatumCast(llvm::Value* value,
+                                        bool is_src_unsigned = false);
 };
 
 }  // namespace gpcodegen

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -65,19 +65,19 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
       new PGGenericFuncGenerator<float8, float8>(
           216,
           "float8mul",
-          &PGArithFuncGenerator<float8, float8, int64_t>::MulWithOverflow));
+          &PGArithFuncGenerator<float8, float8, float8>::MulWithOverflow));
 
   supported_function_[218] = std::unique_ptr<PGFuncGeneratorInterface>(
       new PGGenericFuncGenerator<float8, float8>(
           218,
           "float8pl",
-          &PGArithFuncGenerator<float8, float8, int64_t>::AddWithOverflow));
+          &PGArithFuncGenerator<float8, float8, float8>::AddWithOverflow));
 
   supported_function_[219] = std::unique_ptr<PGFuncGeneratorInterface>(
       new PGGenericFuncGenerator<float8, float8>(
           219,
           "float8mi",
-          &PGArithFuncGenerator<float8, float8, int64_t>::SubWithOverflow));
+          &PGArithFuncGenerator<float8, float8, float8>::SubWithOverflow));
 
   supported_function_[1088] = std::unique_ptr<PGFuncGeneratorInterface>(
       new PGIRBuilderFuncGenerator<decltype(&IRBuilder<>::CreateICmpSLE),
@@ -163,9 +163,13 @@ bool OpExprTreeGenerator::GenerateCode(GpCodegenUtils* codegen_utils,
     return false;
   }
 
-  if (arguments_.size() != itr->second->GetTotalArgCount()) {
+  // Get the interface to generate code for operator function
+  PGFuncGeneratorInterface* pg_func_interface = itr->second.get();
+  assert(nullptr != pg_func_interface);
+
+  if (arguments_.size() != pg_func_interface->GetTotalArgCount()) {
     elog(WARNING, "Expected argument size to be %lu\n",
-         itr->second->GetTotalArgCount());
+         pg_func_interface->GetTotalArgCount());
     return false;
   }
   bool arg_generated = true;
@@ -181,9 +185,13 @@ bool OpExprTreeGenerator::GenerateCode(GpCodegenUtils* codegen_utils,
     }
     llvm_arguments.push_back(llvm_arg);
   }
-  return itr->second->GenerateCode(codegen_utils,
+  llvm::Value* llvm_op_value = nullptr;
+  bool retval = pg_func_interface->GenerateCode(codegen_utils,
                                    gen_info.llvm_main_func,
                                    gen_info.llvm_error_block,
                                    llvm_arguments,
-                                   llvm_out_value);
+                                   &llvm_op_value);
+  // convert return type to Datum
+  *llvm_out_value = codegen_utils->CreateCppTypeToDatumCast(llvm_op_value);
+  return retval;
 }

--- a/src/backend/codegen/pg_date_func_generator.cc
+++ b/src/backend/codegen/pg_date_func_generator.cc
@@ -13,6 +13,7 @@
 
 #include "codegen/pg_date_func_generator.h"
 #include "codegen/utils/gp_codegen_utils.h"
+#include "codegen/pg_arith_func_generator.h"
 
 extern "C" {
 #include "postgres.h"  // NOLINT(build/include)
@@ -33,21 +34,16 @@ bool PGDateFuncGenerator::DateLETimestamp(
 
   llvm::IRBuilder<>* irb = codegen_utils->ir_builder();
 
-  llvm::Value* llvm_arg0_DateADT = codegen_utils->
-      CreateCast<DateADT>(llvm_args[0]);
-  /* TODO: Use CreateCast*/
-  llvm::Value* llvm_arg1_Timestamp = irb->CreateSExt(
-      llvm_args[1], codegen_utils->GetType<Timestamp>());
-
+  // llvm_args[0] is of date type
   llvm::Value* llvm_arg0_Timestamp = GenerateDate2Timestamp(
-      codegen_utils, llvm_main_func, llvm_arg0_DateADT, llvm_error_block);
+      codegen_utils, llvm_main_func, llvm_args[0], llvm_error_block);
 
   // timestamp_cmp_internal {{{
 #ifdef HAVE_INT64_TIMESTAMP
   *llvm_out_value =
-      irb->CreateICmpSLE(llvm_arg0_Timestamp, llvm_arg1_Timestamp);
+      irb->CreateICmpSLE(llvm_arg0_Timestamp, llvm_args[1]);
 #else
-  // We do not support NaNs.
+  // TODO(nikos): We do not support NaNs.
   elog(DEBUG1, "Timestamp != int_64: NaNs are not supported.");
   return false;
 #endif
@@ -63,44 +59,30 @@ llvm::Value* PGDateFuncGenerator::GenerateDate2Timestamp(
     llvm::BasicBlock* llvm_error_block) {
 
   assert(nullptr != llvm_arg && nullptr != llvm_arg->getType());
-  llvm::IRBuilder<>* irb = codegen_utils->ir_builder();
 
 #ifdef HAVE_INT64_TIMESTAMP
 
-  llvm::BasicBlock* llvm_non_overflow_block = codegen_utils->CreateBasicBlock(
-      "date_non_overflow_block", llvm_main_func);
-  llvm::BasicBlock* llvm_overflow_block = codegen_utils->CreateBasicBlock(
-      "date_overflow_block", llvm_main_func);
-
   llvm::Value *llvm_USECS_PER_DAY = codegen_utils->
-      GetConstant<int64_t>(USECS_PER_DAY);
+          GetConstant<int64_t>(USECS_PER_DAY);
 
-  /* TODO: Use CreateCast*/
-  llvm::Value* llvm_arg_64 = irb->CreateSExt(
-      llvm_arg, codegen_utils->GetType<int64_t>());
+  llvm::Value* llvm_out_value = nullptr;
+  llvm::Value* llvm_err_msg = codegen_utils->GetConstant(
+      "date out of range for timestamp");
+  PGArithFuncGenerator<int64_t, int32_t, int64_t>::ArithOpWithOverflow(
+      codegen_utils,
+      &gpcodegen::GpCodegenUtils::CreateMulOverflow<int64_t>,
+      llvm_main_func,
+      llvm_error_block,
+      llvm_err_msg,
+      {llvm_arg, llvm_USECS_PER_DAY},
+      &llvm_out_value);
 
-  llvm::Value* llvm_mul_output = codegen_utils->CreateMulOverflow<int64_t>(
-      llvm_USECS_PER_DAY, llvm_arg_64);
-
-  llvm::Value* llvm_overflow_flag = irb->CreateExtractValue(llvm_mul_output, 1);
-
-  irb->CreateCondBr(llvm_overflow_flag,
-                    llvm_overflow_block,
-                    llvm_non_overflow_block);
-
-  irb->SetInsertPoint(llvm_overflow_block);
-  codegen_utils->CreateElog(ERROR, "date out of range for timestamp");
-  irb->CreateBr(llvm_error_block);
-
-  irb->SetInsertPoint(llvm_non_overflow_block);
-
-  return irb->CreateExtractValue(llvm_mul_output, 0);
+  return llvm_out_value;
 #else
+  llvm::Value* llvm_arg_64 = codegen_utils->CreateCast<int64_t, int32_t>(
+      llvm_arg);
   llvm::Value *llvm_SECS_PER_DAY = codegen_utils->
       GetConstant<int64_t>(SECS_PER_DAY);
-  /*TODO: Use CreateCast*/
-  llvm::Value *llvm_arg_64 = irb->CreateSExt(llvm_arg,
-                                             codegen_utils->GetType<int64_t>());
-  return irb->CreateMul(llvm_arg_64, llvm_SECS_PER_DAY);
+  return codegen_utils->ir_builder()->CreateMul(llvm_arg_64, llvm_SECS_PER_DAY);
 #endif
 }

--- a/src/backend/codegen/utils/gp_codegen_utils.cc
+++ b/src/backend/codegen/utils/gp_codegen_utils.cc
@@ -19,6 +19,54 @@
 #include "codegen/utils/gp_codegen_utils.h"
 
 namespace gpcodegen {
+
+llvm::Value* GpCodegenUtils::CreateCppTypeToDatumCast(
+    llvm::Value* value, bool is_src_unsigned) {
+  assert(nullptr != value);
+
+  llvm::Type* llvm_dest_type = GetType<Datum>();
+  unsigned dest_size = llvm_dest_type->getScalarSizeInBits();
+  assert(sizeof(Datum) << 3 == dest_size);
+
+  llvm::Type* llvm_src_type = value->getType();
+  unsigned src_size = llvm_src_type->getScalarSizeInBits();
+  // If the source value is pointer type, just convert to int.
+  if (llvm_src_type->isPointerTy()) {
+    return ir_builder()->CreatePtrToInt(value, llvm_dest_type);
+  }
+
+  assert(0 != src_size);
+  assert(dest_size >= src_size);
+
+  llvm::Value* llvm_int_value = value;
+  // Convert given value to int type to do ext / trunc
+  if (!llvm_src_type->isIntegerTy()) {
+    // Get src type as integer type with same as size
+    llvm::Type* llvm_src_as_int_type = llvm::IntegerType::get(*context(),
+                                                              src_size);
+    llvm_int_value = ir_builder()->CreateBitCast(
+        value, llvm_src_as_int_type);
+  }
+
+  llvm::Value* llvm_casted_value = llvm_int_value;
+  if (src_size < dest_size) {
+    // If a given src type is integer but not a bool and unsigned flag is set to
+    // false, then do signed extension.
+    if (llvm_src_type->isIntegerTy() &&
+        src_size > 1 &&
+        !is_src_unsigned) {
+      llvm_casted_value = ir_builder()->CreateSExt(llvm_int_value,
+                                                   llvm_dest_type);
+    } else {
+      // Datum doesn't do signed extension if src type is not integer, not bool
+      // and given type is unsigned.
+      llvm_casted_value = ir_builder()->CreateZExt(llvm_int_value,
+                                                   llvm_dest_type);
+    }
+  }
+  return llvm_casted_value;
+}
+
 }  // namespace gpcodegen
 
 // EOF


### PR DESCRIPTION
In this PR, I introduced `CreateCppTypeToDatumCast `, `CreateDatumToCppTypeCast` and `CreateCast` to handle casting in IR. Added necessary unit test for this api.

Also refactored existing codegeneration code for expression evaluation as well as PG Function generator. Refactor includes usage of above introduced new api and elimination of duplicate codes.

Note : Template specialization for CreateCast is not complete yet. This PR supports only any integer to integer type or any floating point conversion. Those are the use case we have right now. We can enhance as we encountered different casting use case.

@foyzur @hardikar Please take a look when you get chance.
