### PR TITLE
Clean up gpdiff's init_file and built-in ignore- and subs- patterns

### DIFF
--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -283,30 +283,17 @@ sub init_match_subs
 m/\s+(\W)?(\W)?\(seg.*pid.*\)/
 s/\s+(\W)?(\W)?\(seg.*pid.*\)//
 
-m/WARNING:\s+foreign key constraint \".*\" will require costly sequential scans/
-s/\".*\"/\"dummy key\"/
-
-m/CONTEXT:.*\s+of this segment db input data/
-s/\s+of this segment db input data//
-
 # distributed transactions
-m/(ERROR|WARNING|CONTEXT|NOTICE):.*gid\s+=\s+(\d+)/
+m/^(ERROR|WARNING|CONTEXT|NOTICE):.*gid\s+=\s+(\d+)/
 s/gid.*/gid DUMMY/
 
-m/(ERROR|WARNING|CONTEXT|NOTICE):.*DTM error.*gathered (\d+) results from cmd.*/
+m/^(ERROR|WARNING|CONTEXT|NOTICE):.*DTM error.*gathered (\d+) results from cmd.*/
 s/gathered.*results/gathered SOME_NUMBER_OF results/
 
-# fix code locations eg "(xact.c:1458)" to "(xact.c:SOME_LINE)"
-m/(ERROR|WARNING|CONTEXT|NOTICE):\s+Raise an error as directed by/
+m/^(ERROR|WARNING|CONTEXT|NOTICE):\s+Could not .* savepoint/
 s/\.c\:\d+\)/\.c\:SOME_LINE\)/
 
-m/(DETAIL|ERROR|WARNING|CONTEXT|NOTICE):\s+Raise .* for debug_dtm_action\s*\=\s* \d+/
-s/\.c\:\d+\)/\.c\:SOME_LINE\)/
-
-m/(ERROR|WARNING|CONTEXT|NOTICE):\s+Could not .* savepoint/
-s/\.c\:\d+\)/\.c\:SOME_LINE\)/
-
-m/(ERROR|WARNING|CONTEXT|NOTICE):.*connection.*failed.*(http|gpfdist)/
+m/^(ERROR|WARNING|CONTEXT|NOTICE):.*connection.*failed.*(http|gpfdist)/
 s/connection.*failed.*(http|gpfdist).*/connection failed dummy_protocol\:\/\/DUMMY_LOCATION/
 
 # the EOF ends the HERE document
@@ -440,17 +427,16 @@ sub init_matchignores
 
         # XXX XXX: note the discrepancy in the NOTICE messages
         # 'distributed by' vs 'DISTRIBUTED BY'
-m/NOTICE:\s+Table doesn\'t have \'distributed by\' clause\, and no column type is suitable/i
+m/^NOTICE:  Table doesn\'t have \'distributed by\' clause/
+m/^NOTICE:  Table doesn\'t have \'DISTRIBUTED BY\' clause/
 
-m/NOTICE:\s+Table doesn\'t have \'DISTRIBUTED BY\' clause/i
+m/^NOTICE:  Dropping a column that is part of the distribution policy/
 
-m/NOTICE:\s+Dropping a column that is part of the distribution policy/
+m/^NOTICE:  Table has parent\, setting distribution columns to match parent table/
 
-m/NOTICE:\s+Table has parent\, setting distribution columns to match parent table/
+m/^HINT:  The \'DISTRIBUTED BY\' clause determines the distribution of data/
 
-m/HINT:\s+The \'DISTRIBUTED BY\' clause determines the distribution of data/
-
-m/WARNING:\s+Referential integrity \(.*\) constraints are not supported in Greenplum Database/
+m/^WARNING:  Referential integrity \(.*\) constraints are not supported in Greenplum Database/
 
 
 m/^\s*Distributed by:\s+\(.*\)\s*$/
@@ -460,7 +446,7 @@ m/^\s*Distributed by:\s+\(.*\)\s*$/
         #
         # the NOTICE is different from the ERROR case, which does not
         # end with "skipping"
-m/^NOTICE:\s+\w+\s+\".*\"\s+does not exist\,\s+skipping\s*$/
+m/^NOTICE:  \w+ \".*\" does not exist\, skipping\s*$/
 
 
 # the EOF ends the HERE document

--- a/src/test/regress/expected/float8.out
+++ b/src/test/regress/expected/float8.out
@@ -2,8 +2,6 @@
 -- FLOAT8
 --
 CREATE TABLE FLOAT8_TBL(i INT DEFAULT 1, f1 float8);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO FLOAT8_TBL(f1) VALUES ('    0.0   ');
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1004.30  ');
 INSERT INTO FLOAT8_TBL(f1) VALUES ('   -34.84');
@@ -564,8 +562,6 @@ SELECT '' AS five, f1 FROM FLOAT8_TBL ORDER BY 2;
 -- test if you can dump/restore subnormal (1e-323) values
 -- using COPY
 CREATE TABLE FLOATS(a float8);
-psql:cdb-pg/src/test/regress/sql/float8.sql:172: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO FLOATS select 1e-307::float8 / 10^i FROM generate_series(1,16) i;
 SELECT * FROM FLOATS ORDER BY a;
            a           

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -1,14 +1,11 @@
 -- start_matchignore
 # match ignore the gpmon WARNING message
 m/^WARNING:  gpmon:.*Connection refused.*/
-s/^WARNING:  gpmon:.*Connection refused.*//
 
 # MPP-20400
 m/^WARNING:  gpmon:.*No buffer space available socket.*/
-s/^WARNING:  gpmon:.*No buffer space available socket.*//
 
 m/^ Optimizer status:.*/
-s/^ Optimizer status:.*//
 
 # We have disabled ignoring NOTICE statements because some tests rely on these
 # NOTICEs to verify that the test is correct e.g (vacuum). Ignoring them would
@@ -24,7 +21,6 @@ s/^ Optimizer status:.*//
 # to manually modify the corresponding expected output. Hence we want to ignore
 # these.
 m/^NOTICE:.*Table doesn't have 'DISTRIBUTED BY' clause -- Using column named '.*' as the Greenplum Database data distribution key for this table./
-s/^NOTICE:.*Table doesn't have 'DISTRIBUTED BY' clause -- Using column named '.*' as the Greenplum Database data distribution key for this table.//
 
 # The following NOTICE is generated when a partitioned table is created. For
 # each child partition that gets created, it will generate a NOTICE saying that
@@ -34,7 +30,6 @@ s/^NOTICE:.*Table doesn't have 'DISTRIBUTED BY' clause -- Using column named '.*
 # E.g CREATE TABLE will create partition "hhh_1_prt_r1987544232" for table "hhh" 
 #     CREATE TABLE will create partition "hhh_1_prt_r1987553186" for table "hhh"
 m/^NOTICE:.*CREATE TABLE will create partition ".*" for table ".*"/
-s/^NOTICE:.*CREATE TABLE will create partition ".*" for table ".*"//
 
 # The following NOTICE is generated when creating a role. It is to inform the
 # user that the database will assign the default resource queue to the role if
@@ -42,21 +37,18 @@ s/^NOTICE:.*CREATE TABLE will create partition ".*" for table ".*"//
 # cause the tests to output these messages and we would need to manually modify
 # the corresponding expected output. Hence we want to ignore these.
 m/^NOTICE:.*resource queue required -- using default resource queue ".*"/
-s/^NOTICE:.*resource queue required -- using default resource queue ".*"//
 
 # The following NOTICE is generated when a user creates an index on the parent
 # partition table. For each child partition, it informs the user that the
 # database will create an index for that parition. The messages might appear in
 # different order for the child partitions.
-m/NOTICE:.*building index for child partition ".*"/
-s/NOTICE:.*building index for child partition ".*"//
+m/^NOTICE:.*building index for child partition ".*"/
 
 # The following NOTICE is generated when a user tries to split a partition or
 # exchange a partition with the default partition.
 # In case of split partitions we end up creating temp tables to exchange the partitions
 # E.g exchanged partition "p1" of relation "parttest_t" with relation "pg_temp_4062621"
 m/^NOTICE:.*exchanged partition ".*" with relation ".*"/
-s/^NOTICE:.*exchanged partition ".*" with relation ".*"//
 
 # The following two NOTICEs are generated when user runs CREATE function. In
 # some cases, when the database creates a function internally, the NOTICE might
@@ -64,10 +56,8 @@ s/^NOTICE:.*exchanged partition ".*" with relation ".*"//
 # For e.g  NOTICE:  return type pg_atsdb_133977_2_3 is only a shell. It is not
 # really providing useful information to the user and hence can be ignored.
 m/^NOTICE:.*return type .* is only a shell/
-s/^NOTICE:.*return type .* is only a shell//
 
 m/^NOTICE:.*argument type .* is only a shell/
-s/^NOTICE:.*argument type .* is only a shell//
 
 # The following NOTICE is generated when a user creates a table with no
 # columns. E.g CREATE TABLE foo(). It is to inform the user that database
@@ -76,7 +66,6 @@ s/^NOTICE:.*argument type .* is only a shell//
 # manually modify the corresponding expected output. Hence we want to ignore
 # these.
 m/^NOTICE:.*Table has no attributes to distribute on./
-s/^NOTICE:.*Table has no attributes to distribute on.//
 
 # The following NOTICE is generated when user runs ANALYZE. The NOTICE message
 # generated seems to be non deterministic in that separate test runs produce
@@ -84,10 +73,8 @@ s/^NOTICE:.*Table has no attributes to distribute on.//
 # test run it produced the following NOTICE for pg_auth and in other it
 # produced a NOTICE for pg_auth and pg_auth_constraints.
 m/^NOTICE:.*ANALYZE detected all empty sample pages for table .*, please run VACUUM FULL for accurate estimation/
-s/^NOTICE:.*ANALYZE detected all empty sample pages for table .*, please run VACUUM FULL for accurate estimation//
 
 m/^WARNING:  could not close temporary file .*: No such file or directory/
-s/^WARNING:  could not close temporary file .*: No such file or directory//
 -- end_matchignore
 
 -- start_matchsubs


### PR DESCRIPTION
* Anchor all the ERROR, WARNING etc. messages to beginning of line, with
  "/^..."

* Remove obsolete substititions, for error messages that don't appear
  anywhere in the code anymore.

* Remove redundant replacements of source line numbers in error messages,
  like "(xact.c:%d)". There is a special rule that replaces all of those
  with (SOMEFILE:SOMEFUNC).

* Replace case-insensitive rules with case-sensitive ones.

* Replace sloppy use of "\s+", with the actuala mount of whitespace in
  the error messages.

* Remove unnecessary "s/.../" lines from the matchignore block in init_file.
  You don't need those with "matchignore", only with "matchsubs".

Aside from being tidier, these changes make the diffing significantly
faster. There are less regular expressions to parse, and the remaining ones
are faster to evaluate.