### PR TITLE
Fix gpdbrestore -S schema level restore with truncate option

### DIFF
--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -66,9 +66,8 @@ class GpdbRestore(Operation):
         if self.context.restore_stats:
             self.context.no_analyze = True
 
-        # NetBackup params
-        if self.context.truncate and not (self.context.restore_tables or self.context.table_file):
-            raise Exception('--truncate can be specified only with -T or --table-file option')
+        if self.context.truncate and not (self.context.restore_tables or self.context.table_file or self.context.restore_schemas):
+            raise Exception('--truncate can be specified only with -S, -T, or --table-file option')
 
         if self.context.truncate and self.context.drop_db:
             raise Exception('Cannot specify --truncate and -e together')
@@ -107,6 +106,7 @@ class GpdbRestore(Operation):
             else:
                 self.context.db_host_path = self.context.db_host_path.split(':')
 
+        # NetBackup params
         if self.context.db_host_path and self.context.netbackup_service_host:
             raise Exception('-R is not supported for restore with NetBackup.')
 
@@ -185,7 +185,6 @@ class GpdbRestore(Operation):
         info = self._gather_cluster_info()
 
         self.validate_tablename_from_filtering_options()
-
         if self.context.restore_stats == "only":
             restore_type = "Statistics-Only Restore"
 

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -286,48 +286,6 @@ def _build_gpdbrestore_cmd_line(context, ts, table_file):
 
     return cmd
 
-def truncate_restore_tables(context):
-    """
-    Truncate either specific table or all tables under a schema
-    """
-
-    try:
-        dburl = dbconn.DbURL(port=context.master_port, dbname=context.restore_db)
-        conn = dbconn.connect(dburl)
-        truncate_list = []
-
-        if context.restore_schemas:
-            for schemaname in context.restore_schemas:
-                truncate_list.extend(self.get_full_tables_in_schema(conn, schemaname))
-        else:
-            for restore_table in context.restore_tables:
-                schemaname, tablename = split_fqn(restore_table)
-                check_table_exists_qry = """SELECT EXISTS (
-                                                   SELECT 1
-                                                   FROM pg_catalog.pg_class c
-                                                   JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace
-                                                   WHERE n.nspname = '%s' and c.relname = '%s')""" % (pg.escape_string(schemaname),
-                                                                                                      pg.escape_string(tablename))
-                exists_result = execSQLForSingleton(conn, check_table_exists_qry)
-                if exists_result:
-                    schema = escapeDoubleQuoteInSQLString(schemaname)
-                    table = escapeDoubleQuoteInSQLString(tablename)
-                    truncate_table = '%s.%s' % (schema, table)
-                    truncate_list.append(truncate_table)
-                else:
-                    logger.warning("Skipping truncate of %s.%s because the relation does not exist." % (context.restore_db, restore_table))
-
-        for t in truncate_list:
-            try:
-                qry = 'Truncate %s' % t
-                execSQL(conn, qry)
-            except Exception as e:
-                raise Exception("Could not truncate table %s.%s: %s" % (dbname, t, str(e).replace('\n', '')))
-
-        conn.commit()
-    except Exception as e:
-        raise Exception("Failure from truncating tables, %s" % (str(e).replace('\n', '')))
-
 class RestoreDatabase(Operation):
     def __init__(self, context):
         self.context = context
@@ -337,7 +295,7 @@ class RestoreDatabase(Operation):
             self.context.restore_db = self.context.redirected_restore_db
 
         if len(self.context.restore_tables) > 0 and self.context.truncate:
-            truncate_restore_tables(self.context)
+            self.truncate_restore_tables()
 
         if not self.context.ddboost:
             ValidateSegments(self.context).run()
@@ -503,7 +461,7 @@ class RestoreDatabase(Operation):
 
     def get_full_tables_in_schema(self, conn, schemaname):
         res = []
-        get_all_tables_qry = 'select \'"\' || schemaname || \'"\', \'"\' || tablename || \'"\'from pg_tables where schemaname = \'%s\';' % pg.escape_string(schemaname)
+        get_all_tables_qry = 'select schemaname, tablename from pg_tables where schemaname = \'%s\';' % pg.escape_string(schemaname)
         relations = execSQL(conn, get_all_tables_qry)
         for relation in relations:
             schema, table = relation[0], relation[1]
@@ -889,6 +847,48 @@ class RestoreDatabase(Operation):
             gpd_path = "%s/%s" % (self.context.dump_dir, self.context.timestamp[0:8])
 
         return (gpr_path, status_path, gpd_path)
+
+    def truncate_restore_tables(self):
+        """
+        Truncate either specific table or all tables under a schema
+        """
+
+        try:
+            dburl = dbconn.DbURL(port=self.context.master_port, dbname=self.context.restore_db)
+            conn = dbconn.connect(dburl)
+            truncate_list = []
+
+            if self.context.restore_schemas:
+                for schemaname in self.context.restore_schemas:
+                    truncate_list.extend(self.get_full_tables_in_schema(conn, schemaname))
+            else:
+                for restore_table in self.context.restore_tables:
+                    schemaname, tablename = split_fqn(restore_table)
+                    check_table_exists_qry = """SELECT EXISTS (
+                                                       SELECT 1
+                                                       FROM pg_catalog.pg_class c
+                                                       JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace
+                                                       WHERE n.nspname = '%s' and c.relname = '%s')""" % (pg.escape_string(schemaname),
+                                                                                                          pg.escape_string(tablename))
+                    exists_result = execSQLForSingleton(conn, check_table_exists_qry)
+                    if exists_result:
+                        schema = escapeDoubleQuoteInSQLString(schemaname)
+                        table = escapeDoubleQuoteInSQLString(tablename)
+                        truncate_table = '%s.%s' % (schema, table)
+                        truncate_list.append(truncate_table)
+                    else:
+                        logger.warning("Skipping truncate of %s.%s because the relation does not exist." % (self.context.restore_db, restore_table))
+
+            for table in truncate_list:
+                try:
+                    qry = 'Truncate %s' % table
+                    execSQL(conn, qry)
+                except Exception as e:
+                    raise Exception("Could not truncate table %s.%s: %s" % (self.context.restore_db, table, str(e).replace('\n', '')))
+
+            conn.commit()
+        except Exception as e:
+            raise Exception("Failure from truncating tables, %s" % (str(e).replace('\n', '')))
 
 class ValidateTimestamp(Operation):
     def __init__(self, context):

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -461,7 +461,7 @@ class RestoreDatabase(Operation):
 
     def get_full_tables_in_schema(self, conn, schemaname):
         res = []
-        get_all_tables_qry = 'select schemaname, tablename from pg_tables where schemaname = \'%s\';' % pg.escape_string(schemaname)
+        get_all_tables_qry = "select schemaname, tablename from pg_tables where schemaname = '%s';" % pg.escape_string(schemaname)
         relations = execSQL(conn, get_all_tables_qry)
         for relation in relations:
             schema, table = relation[0], relation[1]

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -294,7 +294,7 @@ class RestoreDatabase(Operation):
         if self.context.redirected_restore_db:
             self.context.restore_db = self.context.redirected_restore_db
 
-        if len(self.context.restore_tables) > 0 and self.context.truncate:
+        if (len(self.context.restore_tables) > 0 or len(self.context.restore_schemas) > 0) and self.context.truncate:
             self.truncate_restore_tables()
 
         if not self.context.ddboost:

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -561,17 +561,17 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.RestoreDatabase.get_full_tables_in_schema', return_value=['"public"."tablename1"', '"public"."tablename2"', '"public"."tablename3"'])
     def test_truncate_restore_tables_restore_schemas(self, mock1, mock2, mock3, mock4):
         self.context.restore_schemas = ['public']
-        restore_line = self.restore.truncate_restore_tables()
+        self.restore.truncate_restore_tables()
         calls = [call(ANY,'Truncate "public"."tablename1"'), call(ANY,'Truncate "public"."tablename2"'), call(ANY,'Truncate "public"."tablename3"')]
         mock2.assert_has_calls(calls)
 
     @patch('gppylib.operations.restore.dbconn.DbURL')
     @patch('gppylib.operations.restore.dbconn.connect')
     @patch('gppylib.operations.restore.execSQL')
-    @patch('gppylib.operations.restore.execSQLForSingleton')
+    @patch('gppylib.operations.restore.execSQLForSingleton', return_value='t')
     def test_truncate_restore_tables_restore_tables(self, mock1, mock2, mock3, mock4):
         self.context.restore_tables = ['public.ao1', 'testschema.heap1']
-        restore_line = self.restore.truncate_restore_tables()
+        self.restore.truncate_restore_tables()
         calls = [call(ANY,'Truncate "public"."ao1"'), call(ANY,'Truncate "testschema"."heap1"')]
         mock2.assert_has_calls(calls)
 

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -555,6 +555,21 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         restore_line = _build_gpdbrestore_cmd_line(self.context, ts, 'foo')
         self.assertEqual(restore_line, expected_output)
 
+    @patch('gppylib.operations.restore.dbconn.DbURL')
+    @patch('gppylib.operations.restore.dbconn.connect')
+    @patch('gppylib.operations.restore.execSQL')
+    def test_truncate_restore_tables_restore_schemas(self, mock1, mock2, mock3):
+        self.context.restore_schemas = ['public']
+        restore_line = self.restore.truncate_restore_tables()
+
+    @patch('gppylib.operations.restore.dbconn.DbURL')
+    @patch('gppylib.operations.restore.dbconn.connect')
+    @patch('gppylib.operations.restore.execSQL')
+    @patch('gppylib.operations.restore.execSQLForSingleton')
+    def test_truncate_restore_tables_restore_tables(self, mock1, mock2, mock3, mock4):
+        self.context.restore_tables = ['public.ao1', 'testschema.heap1']
+        restore_line = self.restore.truncate_restore_tables()
+
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
     def test_create_restore_string_no_filter_file(self, mock1, mock2):

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -12,7 +12,7 @@ from gppylib.operations.backup_utils import *
 from gppylib.operations.restore import *
 from gppylib.operations.restore import _build_gpdbrestore_cmd_line
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
-from mock import patch, MagicMock, Mock, mock_open, call
+from mock import patch, MagicMock, Mock, mock_open, call, ANY
 
 class RestoreTestCase(unittest.TestCase):
 
@@ -561,6 +561,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     def test_truncate_restore_tables_restore_schemas(self, mock1, mock2, mock3):
         self.context.restore_schemas = ['public']
         restore_line = self.restore.truncate_restore_tables()
+        mock1.assert_called_with(ANY,"select schemaname, tablename from pg_tables where schemaname = 'public';")
 
     @patch('gppylib.operations.restore.dbconn.DbURL')
     @patch('gppylib.operations.restore.dbconn.connect')
@@ -569,6 +570,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     def test_truncate_restore_tables_restore_tables(self, mock1, mock2, mock3, mock4):
         self.context.restore_tables = ['public.ao1', 'testschema.heap1']
         restore_line = self.restore.truncate_restore_tables()
+        mock2.assert_called_with(ANY,'Truncate "testschema"."heap1"')
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -558,10 +558,12 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.dbconn.DbURL')
     @patch('gppylib.operations.restore.dbconn.connect')
     @patch('gppylib.operations.restore.execSQL')
-    def test_truncate_restore_tables_restore_schemas(self, mock1, mock2, mock3):
+    @patch('gppylib.operations.restore.RestoreDatabase.get_full_tables_in_schema', return_value=['"public"."tablename1"', '"public"."tablename2"', '"public"."tablename3"'])
+    def test_truncate_restore_tables_restore_schemas(self, mock1, mock2, mock3, mock4):
         self.context.restore_schemas = ['public']
         restore_line = self.restore.truncate_restore_tables()
-        mock1.assert_called_with(ANY,"select schemaname, tablename from pg_tables where schemaname = 'public';")
+        calls = [call(ANY,'Truncate "public"."tablename1"'), call(ANY,'Truncate "public"."tablename2"'), call(ANY,'Truncate "public"."tablename3"')]
+        mock2.assert_has_calls(calls)
 
     @patch('gppylib.operations.restore.dbconn.DbURL')
     @patch('gppylib.operations.restore.dbconn.connect')
@@ -570,7 +572,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     def test_truncate_restore_tables_restore_tables(self, mock1, mock2, mock3, mock4):
         self.context.restore_tables = ['public.ao1', 'testschema.heap1']
         restore_line = self.restore.truncate_restore_tables()
-        mock2.assert_called_with(ANY,'Truncate "testschema"."heap1"')
+        calls = [call(ANY,'Truncate "public"."ao1"'), call(ANY,'Truncate "testschema"."heap1"')]
+        mock2.assert_has_calls(calls)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -3321,7 +3321,8 @@ Feature: Validate command line arguments
         Then verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
 
         # -S with truncate option
-        When the user runs gpdbrestore with the stored timestamp and options "-S " S\`~@#\$%^&*()-+[{]}|\\;: \\'\"/?><1 " --truncate"
+        When the user runs "gpdbrestore -S " S\`~@#\$%^&*()-+[{]}|\\;: \\'\"/?><1 " -a --truncate" with the stored timestamp
+        Then gpdbrestore should return a return code of 0
         And the user runs command "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.out"
         Then verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
 

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -139,7 +139,7 @@ Feature: Validate command line arguments
     Scenario: Valid option combinations for gpdbrestore
         When the user runs "gpdbrestore -t 20140101010101 --truncate -a"
         Then gpdbrestore should return a return code of 2
-        And gpdbrestore should print --truncate can be specified only with -T or --table-file option to stdout
+        And gpdbrestore should print --truncate can be specified only with -S, -T, or --table-file option to stdout
         When the user runs "gpdbrestore -t 20140101010101 --truncate -e -T public.foo -a"
         Then gpdbrestore should return a return code of 2
         And gpdbrestore should print Cannot specify --truncate and -e together to stdout
@@ -3305,7 +3305,7 @@ Feature: Validate command line arguments
         When the user runs command "gpdbrestore -s " DB\`~@#\$%^&*()_-+[{]}|\\;:.;\n\t \\'/?><;2 ""
         Then gpdbrestore should print Name has an invalid character to stdout
 
-    Scenario: gpdbrestore, -S option, schema level restore with special chars in schema name
+    Scenario: gpdbrestore, -S option, -S truncate option schema level restore with special chars in schema name
         Given the test is initialized
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_database.sql template1"
         And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/create_special_schema.sql template1"
@@ -3317,6 +3317,11 @@ Feature: Validate command line arguments
         And the timestamp from gpcrondump is stored
         When the user runs command "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.ans"
         When the user runs gpdbrestore with the stored timestamp and options "-S " S\`~@#\$%^&*()-+[{]}|\\;: \\'\"/?><1 ""
+        And the user runs command "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.out"
+        Then verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
+
+        # -S with truncate option
+        When the user runs gpdbrestore with the stored timestamp and options "-S " S\`~@#\$%^&*()-+[{]}|\\;: \\'\"/?><1 " --truncate"
         And the user runs command "psql -f gppylib/test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.out"
         Then verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
 

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -3439,7 +3439,18 @@ Feature: Validate command line arguments
         And verify that there are "730" tuples in "bkdb" for table "testschema.ao_foo_1_prt_p2_2_prt_3"
         And verify that there are "4380" tuples in "bkdb" for table "schema_ao.ao_index_table"
         And verify that there are "0" tuples in "bkdb" for table "schema_ao.ao_part_table"
-
+        When the user runs gpdbrestore with the stored timestamp and options "-S schema_ao -S testschema --truncate" without -e option
+        Then gpdbrestore should return a return code of 0
+        And verify that there are "0" tuples in "bkdb" for table "public.ao_index_table"
+        And verify that there are "0" tuples in "bkdb" for table "public.ao_table"
+        And verify that there are "365" tuples in "bkdb" for table "testschema.ao_foo_1_prt_p1_2_prt_1"
+        And verify that there are "365" tuples in "bkdb" for table "testschema.ao_foo_1_prt_p1_2_prt_2"
+        And verify that there are "365" tuples in "bkdb" for table "testschema.ao_foo_1_prt_p1_2_prt_3"
+        And verify that there are "365" tuples in "bkdb" for table "testschema.ao_foo_1_prt_p2_2_prt_1"
+        And verify that there are "365" tuples in "bkdb" for table "testschema.ao_foo_1_prt_p2_2_prt_2"
+        And verify that there are "365" tuples in "bkdb" for table "testschema.ao_foo_1_prt_p2_2_prt_3"
+        And verify that there are "2190" tuples in "bkdb" for table "schema_ao.ao_index_table"
+        And verify that there are "0" tuples in "bkdb" for table "schema_ao.ao_part_table"
     Scenario: Restore with --redirect option should not rely on existance of dumped database
         Given the test is initialized
         When the user runs "gpcrondump -a -x bkdb"

--- a/gpMgmt/doc/gpdbrestore_help
+++ b/gpMgmt/doc/gpdbrestore_help
@@ -365,8 +365,9 @@ OPTIONS
 
  Schema names to restore, specify multiple times for multiple schemas. 
  Existing tables are not automatically truncated before data is restored 
- from backup. If your intention is to replace existing data in the table 
- from backup, truncate the table prior to running gpdbrestore -S. 
+ from backup. To replace the data in the schema tables with the data from
+ backup, you can specify the --truncate option. The schema tables are 
+ truncated.
 
 
 --table-file <file_name> 
@@ -379,8 +380,9 @@ OPTIONS
 --truncate
 
  Truncate table data before restoring data to the table from the backup.
- This option is supported only when restoring a set of tables with the 
- option -T or --table-file. 
+ If this option is not specified, existing table data is not removed 
+ before data is restored to the table. This option is supported only 
+ when restoring a set of tables with the option -S, -T, or --table-file. 
  This option is not supported with the -e option.
 
 


### PR DESCRIPTION
This commit fixes a bug when performing a gpdbrestore -S on a schema with
the truncate option. The restore would fail stating using truncate with -S (a schema) was unsupported.
This code was previously not reached and was also not properly escaped for
special characters. Behave and unit tests have been added.

Authors: Chris Hajas and Chumki Roy