### PR TITLE
Remove useless idle tracker assert which access shared memory without properly lock.

### DIFF
--- a/src/backend/utils/mmgr/idle_tracker.c
+++ b/src/backend/utils/mmgr/idle_tracker.c
@@ -180,9 +180,6 @@ IdleTracker_DeactivateProcess()
 		/* At this point the process must be clean, unless we don't have a runaway event before deactivation */
 		Assert(*latestRunawayVersion > deactivationVersion ||
 				!RunawayCleaner_IsCleanupInProgress());
-
-		/* At least 1 process is deactivated at this point */
-		Assert(MySessionState->activeProcessCount < MySessionState->pinCount);
 	}
 
 	/* At this point the process is ready to be blocked in ReadCommand() */


### PR DESCRIPTION
I found the a core file with the following info:

    (gdb) bt
    #0  0x00007f594cfa15f7 in raise () from /lib64/libc.so.6
    #1  0x00007f594cfa2ce8 in abort () from /lib64/libc.so.6
    #2  0x00000000009acf28 in ExceptionalCondition (conditionName=0xd6aaf8 "!(MySessionState->activeProcessCount < MySessionState->pinCount)", errorType=0xd6a89f "FailedAssertion",
        fileName=0xd6a890 "idle_tracker.c", lineNumber=185) at assert.c:59
    #3  0x00000000009f0fa2 in IdleTracker_DeactivateProcess () at idle_tracker.c:185
    #4  0x00000000009f0c13 in IdleTracker_Shutdown () at idle_tracker.c:91
    #5  0x00000000009ef198 in VmemTracker_Shutdown () at vmem_tracker.c:175
    #6  0x00000000009ee703 in GPMemoryProtect_Shutdown () at memprot.c:199
    #7  0x00000000009c5845 in ShutdownPostgres (code=0, arg=0) at postinit.c:1070
    #8  0x0000000000897d46 in shmem_exit (code=0) at ipc.c:255
    #9  0x0000000000897c3a in proc_exit_prepare (code=0) at ipc.c:215
    #10 0x0000000000897b70 in proc_exit (code=0) at ipc.c:95
    #11 0x00000000008bd18f in PostgresMain (argc=1, argv=0x18caf10, dbname=0x18c8ff0 "tiny_db", username=0x18c8fb0 "gpadmin") at postgres.c:5234
    #12 0x00000000008549af in BackendRun (port=0x18c6760) at postmaster.c:6963
    #13 0x00000000008540b0 in BackendStartup (port=0x18c6760) at postmaster.c:6658
    #14 0x000000000084c77a in ServerLoop () at postmaster.c:2464
    #15 0x000000000084afe1 in PostmasterMain (argc=15, argv=0x189b030) at postmaster.c:1540
    #16 0x000000000076f978 in main (argc=15, argv=0x189b030) at main.c:206


The code in IdleTracker_DeactivateProcess(), access activeProcessCount and pinCount without lock protection.

If there are other process go into active just before the assert read activeProcessCount. And get into shutdown and release the session state before the assert read pinCount. The assert will fail.

There is assertion to check the equation activeProcessCount < pinCount in SessionState_Release(), so remove this assert is ok.