### PR TITLE
Release lock when close the table

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -2704,7 +2704,7 @@ setRelhassubclassInRelation(Oid relationId, bool relhassubclass)
 	}
 
 	heap_freetuple(tuple);
-	heap_close(relationRelation, NoLock);
+	heap_close(relationRelation, RowExclusiveLock);
 }
 
 


### PR DESCRIPTION
Regression test find a deadlock issue, the test is as follow:

BEGIN;
CREATE TABLE dtm_plpg_foo (C_CUSTKEY INTEGER, C_NAME VARCHAR(25), C_ADDRESS VARCHAR(40))
partition by range (c_custkey) (partition p1 start(0) end(100000) every(1000));
INSERT INTO dtm_plpg_foo SELECT * FROM dtm_plpg_foo LIMIT 10000;
COMMIT;

The create statement leaked a ROW EXCLUSIVE lock on pg_class. If some other session request
and wait on ACCESS EXCLUSIVE lock before the insert statement, the insert statement will not
be able to get the ACCESS SHARE lock. So the entryDB reader gang will wait the lock holding
by QD process, while the QD process will wait the results from primary reader gangs.