### PR TITLE
Micro optimizations of atmsort

### DIFF
--- a/src/test/regress/atmsort.pl
+++ b/src/test/regress/atmsort.pl
@@ -32,7 +32,6 @@ Options:
 
     -help            brief help message
     -man             full documentation
-    -ignore_headers  ignore header lines in query output
     -ignore_plans    ignore explain plan content in query output
     -init <file>     load initialization file
     -do_equiv        construct or compare equivalent query regions
@@ -48,16 +47,6 @@ Options:
 =item B<-man>
     
     Prints the manual page and exits.
-
-=item B<-ignore_headers> 
-
-gpdiff/atmsort expect PostgreSQL "psql-style" output for SELECT
-statements, with a two line header composed of the column names,
-separated by vertical bars (|), and a "separator" line of dashes and
-pluses beneath, followed by the row output.  The psql utility performs
-some formatting to adjust the column widths to match the size of the
-row output.  Setting this parameter causes gpdiff to ignore any
-differences in the column naming and format widths globally.
 
 =item B<-ignore_plans> 
 
@@ -257,15 +246,6 @@ command can use the -I flag to ignore lines with this prefix.
 
   Ends the ignored region that started with "start_ignore"
 
-=item -- start_headers_ignore
-
-Similar to the command-line "ignore_headers", ignore differences in
-column naming and format widths.
-
-=item -- end_headers_ignore
-
-  Ends the "headers ignored" region that started with "start_headers_ignore"
-
 =item -- start_equiv
 
 Begin an "equivalent" region, and treat contents according to the
@@ -375,7 +355,6 @@ my $help = 0;
 my $compare_equiv = 0;
 my $make_equiv_expected = 0;
 my $do_equiv;
-my $ignore_headers;
 my $ignore_plans;
 my @init_file;
 my $verbose;
@@ -383,7 +362,6 @@ my $orderwarn;
 
 GetOptions(
     'help|?' => \$help, man => \$man, 
-    'gpd_ignore_headers|gp_ignore_headers|ignore_headers' => \$ignore_headers,
     'gpd_ignore_plans|gp_ignore_plans|ignore_plans' => \$ignore_plans,
     'gpd_init|gp_init|init:s' => \@init_file,
     'do_equiv:s' => \$do_equiv,
@@ -400,7 +378,6 @@ push @{$glob_init}, @init_file;
 
 my %args;
 
-$args{IGNORE_HEADERS} = $ignore_headers if (defined ($ignore_headers));
 $args{IGNORE_PLANS} = $ignore_plans if (defined ($ignore_plans));
 @{$args{INIT_FILES}} = @init_file if (scalar(@init_file));
 $args{DO_EQUIV} = $do_equiv if (defined ($do_equiv));

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -544,7 +544,7 @@ sub format_explain
     if (exists($directive->{explain})
         && ($directive->{explain} =~ m/operator/i))
     {
-        $xopt = "operator";
+        $xopt = 'operator';
         $sort = 1;
     }
 
@@ -1264,7 +1264,7 @@ EOF_formatfix
                 # differ because of session level GUCs.
                 if (exists($directive->{explain}))
                 {
-                    $ini = "GP_IGNORE:" . $ini;
+                    $ini = 'GP_IGNORE:' . $ini;
                 }
 
                 $directive = {};
@@ -1296,7 +1296,7 @@ EOF_formatfix
                 }
                 @outarr = ();
 
-                print $atmsort_outfh "GP_IGNORE:", $ini;
+                print $atmsort_outfh 'GP_IGNORE:', $ini;
                 next;
             }
             elsif ($has_comment && ($glob_make_equiv_expected && $ini =~ m/\-\-\s*start\_equiv\s*$/))
@@ -1471,7 +1471,7 @@ EOF_formatfix
                     $has_order = 0; # need to sort query output
                     $directive->{sql_statement} = $sql_statement;
                 }
-                $sql_statement = "";
+                $sql_statement = '';
 
                 $getrows = 1;
                 next;
@@ -1489,7 +1489,7 @@ EOF_formatfix
             # MPP-1557,AUTO-3: horrific ERROR DETAIL External Table trifecta
             if ($glob_verbose)
             {
-                print $atmsort_outfh "GP_IGNORE: External Table ERROR DETAIL fixup\n";
+                print $atmsort_outfh 'GP_IGNORE: External Table ERROR DETAIL fixup' . "\n";
             }
             if ($ini !~ m/^DETAIL/)
             {
@@ -1507,7 +1507,7 @@ EOF_formatfix
             if (scalar(@outarr) &&
                 ($outarr[-1] =~ m/^ERROR:\s+missing data for column/))
             {
-                $outarr[-1] = "ERROR:  missing data for column DUMMY_COL\n";
+                $outarr[-1] = 'ERROR:  missing data for column DUMMY_COL' . "\n";
             }
         }
 

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -42,7 +42,6 @@ my $dpref = '';
 
 my $glob_compare_equiv;
 my $glob_make_equiv_expected;
-my $glob_ignore_headers;
 my $glob_ignore_plans;
 my $glob_ignore_whitespace;
 my @glob_init;
@@ -73,7 +72,6 @@ sub atmsort_init
 
     $glob_compare_equiv       = 0;
     $glob_make_equiv_expected = 0;
-    $glob_ignore_headers      = 0;
     $glob_ignore_plans        = 0;
     $glob_ignore_whitespace   = 0;
     @glob_init                = ();
@@ -112,7 +110,6 @@ sub atmsort_init
     $glob_compare_equiv       = $compare_equiv;
     $glob_make_equiv_expected = $make_equiv_expected;
 
-    $glob_ignore_headers      = $args{IGNORE_HEADERS};
     $glob_ignore_plans        = $args{IGNORE_PLANS};
 
     $glob_ignore_whitespace   = $ignore_headers; # XXX XXX: for now
@@ -1278,11 +1275,6 @@ EOF_formatfix
             $equiv_expected_rows = undef;
         }
 
-        if ($ini =~ m/\-\-\s*end\_head(er|ers|ing|ings)\_ignore\s*$/i)
-        {
-            $glob_ignore_headers = 0;
-        }
-
         if ($getrows) # getting rows from SELECT output
         {
             # The end of "result set" for a COPY TO STDOUT is a bit tricky
@@ -1498,35 +1490,15 @@ EOF_formatfix
                     # ENGINF-88: fixup explain headers
                     $outarr[-1] = "QUERY PLAN\n";
                     $ini = ("_" x length($outarr[-1])) . "\n";
-
-                    if ($glob_ignore_headers)
-                    {
-                        $ini = "GP_IGNORE:" . $ini;
-                    }
                 }
 
                 $getstatement = 0;
-
-                # ENGINF-180: ignore header formatting
-                # the last line of the outarr is the first line of the header
-                if ($glob_ignore_headers && $outarr[-1])
-                {
-                    $outarr[-1] = "GP_IGNORE:" . $outarr[-1];
-                }
 
                 for my $line (@outarr)
                 {
                     print $atmsort_outfh $apref, $line;
                 }
                 @outarr = ();
-
-                # ENGINF-180: ignore header formatting
-                # the current line is the last line of the header
-                if ($glob_ignore_headers
-                    && ($ini =~ m/^\s*((\-\-)(\-)+(\+(\-)+)*)+\s*$/))
-                {
-                    $ini = "GP_IGNORE:" . $ini;
-                }
 
                 print $atmsort_outfh $apref, $ini;
 

--- a/src/test/regress/expected/information_schema.out
+++ b/src/test/regress/expected/information_schema.out
@@ -12,7 +12,7 @@ from pg_attribute
 where attnum > 0 and attrelid = 'r'::regclass;
                           QUERY PLAN
 --------------------------------------------------------------
- Seq Scan on pg_attribute  (cost=0.00..376.30 rows=5 width=2)
+ Seq Scan on pg_attribute  (cost=0.00..376.30 rows=6 width=2)
    Filter: attnum > 0 AND attrelid = 1699317::oid
  Settings:  enable_bitmapscan=off; enable_indexscan=off
 (3 rows)

--- a/src/test/regress/gpdiff.pl
+++ b/src/test/regress/gpdiff.pl
@@ -139,7 +139,7 @@ sub lazy_pod2usage
 
 my %glob_atmsort_args;
 # need gnu diff on solaris
-our $ATMDIFF = ($Config{'osname'} =~ m/solaris|sunos/i) ? 'gdiff' : 'diff';
+our $ATMDIFF = ($Config{'osname'} =~ m/solaris|sunos/) ? 'gdiff' : 'diff';
 
 my $glob_ignore_plans;
 my $glob_init_file = [];
@@ -168,12 +168,6 @@ sub gpdiff_files
     my @tmpfils;
     my $newf1;
     my $newf2;
-
-    # need gnu diff on solaris
-    if ($Config{'osname'} =~ m/solaris|sunos/i)
-    {
-        $ATMDIFF = "gdiff";
-    }
 
     if (defined($d2d) && exists($d2d->{equiv}))
     {
@@ -274,13 +268,13 @@ sub filefunc
         my $dir = $f1;
         my ($dir_h, $stat);
 
-        if ( opendir($dir_h, $dir) )
+        if (opendir($dir_h, $dir))
         {
             my $fnam;
             while ($fnam = readdir($dir_h))
             {
                 # ignore ., ..
-                next unless ($fnam !~ m/^(\.)(\.)*$/);
+                next if ($fnam eq '.' || $fnam eq '..');
 
                 my $absname = File::Spec->rel2abs(
                                  File::Spec->catfile($dir, $fnam));

--- a/src/test/regress/gpdiff.pl
+++ b/src/test/regress/gpdiff.pl
@@ -185,7 +185,7 @@ sub gpdiff_files
         $newf2 = atmsort::run($f2);
     }
 
-    my $args = join(" ", @ARGV, $newf1, $newf2);
+    my $args = join(' ', @ARGV, $newf1, $newf2);
 
 #   print "args: $args\n";
 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,6 +15,12 @@
 #   hitting max_connections limit on segments.
 #
 
+test: variadic_parameters default_parameters
+
+# test workfiles compressed using zlib
+# 'zlib' utilizes fault injectors so it needs to be in a group by itself
+test: zlib
+
 ignore: leastsquares
 test: opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy gp_create_table
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl bitmap_index information_schema

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -143,9 +143,3 @@ test: plancache limit copy2 temp domain rangefuncs prepare without_oid conversio
 # Disabled because tablespaces live in filespaces in GPDB, so the syntax
 # is quite different.
 #test: tablespace
-test: variadic_parameters
-test: default_parameters
-
-# test workfiles compressed using zlib
-# 'zlib' utilizes fault injectors so it needs to be in a group by itself
-test: zlib


### PR DESCRIPTION
Disclaimer: this PR contains the commit from #946 which it builds on.

In an attempt to squeeze even more speed out of the work done by @hlinnaka in #946, this commit contains a collection of tricks to perform some level of micro optimizations of mostly the regex code for matching output lines in the test parsing but also some of the logic:

 * Avoid capturing parens grouped matches that we dont use: when
   matching with `m/(foo|bar)/` where the match isn't used with `$1`
   the cost of allocating the match in memory can be avoided by
   instead matching for `m/(?:foo|bar)/` which instructs Perl to
   throw away the exact match.
 * Break out early in logic: when possible reorder such that a
   static check might skip over the regex entirely. Where we
   match for line with a comment marker we can for example do
   a first check for the comment marker and only perform the
   subsequent checks if that was found. Also assist Perl with
   branch prediction in case that can be beneficial.
 * Remove case insensitive matching where possible: if we
   know that we can provide the right case in the regex instead
   there is a lot of save on processing.
 * Collapse regexes: where possible ensure that a single regex
   does more by collapsing regexes together with more logic in
   figuring out what matched.
 * Remove regexes: where possible, remove the regex entirely and
   instead use the `index()` function which for short strings is
   much faster (short is around 10k chars).
 * Rather than looping over arrays with foreach for trivial
   operations, use `map()` instead.

On top of this, it removes the `ignore_headers` feature as it's not used yet consumes resources as each commandline in the output is checked for this dynamically. It also reorders the schedule files a little to keep us out of the upstream file and fixes a test error that seems to be have been uncovered.