### PR TITLE
Error out during serialization/deserialization in motion node if send/receive functions are not provided

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -196,40 +196,45 @@ InitSerTupInfo(TupleDesc tupdesc, SerTupInfo * pSerInfo)
 								format_type_be(attrInfo->atttypid))));
 								
 			/* If we don't have both binary routines */
-			if (!OidIsValid(pt->typsend))
+			//			if (!OidIsValid(pt->typsend))
+			//			{
+			//				ereport(ERROR,
+			//					(errcode(ERRCODE_UNDEFINED_FUNCTION),
+			//					 errmsg("No send function available for type %s. Motion requires send function",
+			//							format_type_be(attrInfo->atttypid))));
+			//			}
+			//
+			//			if (!OidIsValid(pt->typreceive))
+			//			{
+			//				ereport(ERROR,
+			//					(errcode(ERRCODE_UNDEFINED_FUNCTION),
+			//					 errmsg("No receive function available for type %s. Motion requires receive function",
+			//							format_type_be(attrInfo->atttypid))));
+			//			}
+
+
+			attrInfo->typsend = pt->typsend;
+
+			if (OidIsValid(pt->typsend))
 			{
-				ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_FUNCTION),
-					 errmsg("No send function available for type %s. Motion requires send function",
-							format_type_be(attrInfo->atttypid))));
-		
-				attrInfo->typsend = pt->typoutput;
-				attrInfo->send_typio_param = getTypeIOParam(typeTuple);
-				attrInfo->typisvarlena = (!pt->typbyval) && (pt->typlen == -1);
-				attrInfo->typrecv = pt->typinput;
-				attrInfo->recv_typio_param = getTypeIOParam(typeTuple);
+				fmgr_info(attrInfo->typsend, &attrInfo->send_finfo);
 			}
 
-			if (!OidIsValid(pt->typreceive))
+			attrInfo->typrecv  = pt->typreceive;
+			if (OidIsValid(pt->typreceive))
 			{
-				ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_FUNCTION),
-					 errmsg("No receive function available for type %s. Motion requires receive function",
-							format_type_be(attrInfo->atttypid))));
+				fmgr_info(attrInfo->typrecv, &attrInfo->recv_finfo);
 			}
-			attrInfo->typsend = pt->typsend;
+
 			attrInfo->send_typio_param = getTypeIOParam(typeTuple);
 			attrInfo->typisvarlena = (!pt->typbyval) && (pt->typlen == -1);
-			attrInfo->typrecv  = pt->typreceive;
 			attrInfo->recv_typio_param = getTypeIOParam(typeTuple);
 			
 			caql_endscan(pcqCtx);
 		}
 
 		
-		fmgr_info(attrInfo->typsend, &attrInfo->send_finfo);
 
-		fmgr_info(attrInfo->typrecv, &attrInfo->recv_finfo);
 
 #ifdef TUPSER_SCRATCH_SPACE
 
@@ -593,37 +598,50 @@ SerializeTupleIntoChunks(HeapTuple tuple, SerTupInfo * pSerInfo, TupleChunkList 
 				if (fHandled)
 					continue;
 
-				/*
-				 * the FunctionCall2 call into the send function may result in some
-				 * allocations which we'd like to have contained by our reset-able
-				 * context
-				 */
-				oldCtxt = MemoryContextSwitchTo(s_tupSerMemCtxt);						  
-							  
-				/* Call the attribute type's binary input converter. */
-				if (attrInfo->send_finfo.fn_nargs == 1)
-					outputbytes =
-						DatumGetByteaP(FunctionCall1(&attrInfo->send_finfo,
-													 attr));
-				else if (attrInfo->send_finfo.fn_nargs == 2)
-					outputbytes =
-						DatumGetByteaP(FunctionCall2(&attrInfo->send_finfo,
-													 attr,
-													 ObjectIdGetDatum(attrInfo->send_typio_param)));
-				else if (attrInfo->send_finfo.fn_nargs == 3)
-					outputbytes =
-						DatumGetByteaP(FunctionCall3(&attrInfo->send_finfo,
-													 attr,
-													 ObjectIdGetDatum(attrInfo->send_typio_param),
-													 Int32GetDatum(tupdesc->attrs[i]->atttypmod)));
+				if (OidIsValid(attrInfo->typsend))
+				{
+					/*
+					 * the FunctionCall2 call into the send function may result in some
+					 * allocations which we'd like to have contained by our reset-able
+					 * context
+					 */
+					oldCtxt = MemoryContextSwitchTo(s_tupSerMemCtxt);
+
+					/* Call the attribute type's binary input converter. */
+					if (attrInfo->send_finfo.fn_nargs == 1)
+						outputbytes =
+							DatumGetByteaP(FunctionCall1(&attrInfo->send_finfo,
+														 attr));
+					else if (attrInfo->send_finfo.fn_nargs == 2)
+						outputbytes =
+							DatumGetByteaP(FunctionCall2(&attrInfo->send_finfo,
+														 attr,
+														 ObjectIdGetDatum(attrInfo->send_typio_param)));
+					else if (attrInfo->send_finfo.fn_nargs == 3)
+						outputbytes =
+							DatumGetByteaP(FunctionCall3(&attrInfo->send_finfo,
+														 attr,
+														 ObjectIdGetDatum(attrInfo->send_typio_param),
+														 Int32GetDatum(tupdesc->attrs[i]->atttypmod)));
+					else
+					{
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
+								 errmsg("Conversion function takes %d args",attrInfo->send_finfo.fn_nargs)));
+					}
+
+					MemoryContextSwitchTo(oldCtxt);
+				}
 				else
 				{
-					ereport(ERROR,
-							(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
-							 errmsg("Conversion function takes %d args",attrInfo->recv_finfo.fn_nargs)));
+					elog(WARNING, "No Send. Entering debug break");
+					debug_break();
+
+						ereport(ERROR,
+							(errcode(ERRCODE_UNDEFINED_FUNCTION),
+							 errmsg("No send function available for type %s. Motion requires send function",
+									format_type_be(attrInfo->atttypid))));
 				}
-		
-				MemoryContextSwitchTo(oldCtxt);
 
 				/* We assume the result will not have been toasted */
 				addInt32ToChunkList(tcList, VARSIZE(outputbytes) - VARHDRSZ, &pSerInfo->chunkCache);
@@ -979,24 +997,37 @@ DeserializeTuple(SerTupInfo * pSerInfo, StringInfo serialTup)
 							   pq_getmsgbytes(serialTup, attr_size), attr_size);
 		skipPadding(serialTup);
 
-		/* Call the attribute type's binary input converter. */
-		if (attrInfo->recv_finfo.fn_nargs == 1)
-			pSerInfo->values[i] = FunctionCall1(&attrInfo->recv_finfo,
-												PointerGetDatum(&attr_data));
-		else if (attrInfo->recv_finfo.fn_nargs == 2)
-			pSerInfo->values[i] = FunctionCall2(&attrInfo->recv_finfo,
-												PointerGetDatum(&attr_data),
-												ObjectIdGetDatum(attrInfo->recv_typio_param));
-		else if (attrInfo->recv_finfo.fn_nargs == 3)
-			pSerInfo->values[i] = FunctionCall3(&attrInfo->recv_finfo,
-												PointerGetDatum(&attr_data),
-												ObjectIdGetDatum(attrInfo->recv_typio_param),
-												Int32GetDatum(tupdesc->attrs[i]->atttypmod) );  
+		if (OidIsValid(attrInfo->typrecv))
+		{
+			/* Call the attribute type's binary input converter. */
+			if (attrInfo->recv_finfo.fn_nargs == 1)
+				pSerInfo->values[i] = FunctionCall1(&attrInfo->recv_finfo,
+													PointerGetDatum(&attr_data));
+			else if (attrInfo->recv_finfo.fn_nargs == 2)
+				pSerInfo->values[i] = FunctionCall2(&attrInfo->recv_finfo,
+													PointerGetDatum(&attr_data),
+													ObjectIdGetDatum(attrInfo->recv_typio_param));
+			else if (attrInfo->recv_finfo.fn_nargs == 3)
+				pSerInfo->values[i] = FunctionCall3(&attrInfo->recv_finfo,
+													PointerGetDatum(&attr_data),
+													ObjectIdGetDatum(attrInfo->recv_typio_param),
+													Int32GetDatum(tupdesc->attrs[i]->atttypmod) );
+			else
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
+						 errmsg("Conversion function takes %d args",attrInfo->recv_finfo.fn_nargs)));
+			}
+		}
 		else
 		{
+			elog(WARNING, "No Receive. Entering debug break");
+			debug_break();
+
 			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
-					 errmsg("Conversion function takes %d args",attrInfo->recv_finfo.fn_nargs)));
+				(errcode(ERRCODE_UNDEFINED_FUNCTION),
+				 errmsg("No receive function available for type %s. Motion requires receive function",
+						format_type_be(attrInfo->atttypid))));
 		}
 
 		/* Trouble if it didn't eat the whole buffer */

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -195,33 +195,15 @@ InitSerTupInfo(TupleDesc tupdesc, SerTupInfo * pSerInfo)
 						 errmsg("type %s is only a shell",
 								format_type_be(attrInfo->atttypid))));
 								
-			/* If we don't have both binary routines */
-			//			if (!OidIsValid(pt->typsend))
-			//			{
-			//				ereport(ERROR,
-			//					(errcode(ERRCODE_UNDEFINED_FUNCTION),
-			//					 errmsg("No send function available for type %s. Motion requires send function",
-			//							format_type_be(attrInfo->atttypid))));
-			//			}
-			//
-			//			if (!OidIsValid(pt->typreceive))
-			//			{
-			//				ereport(ERROR,
-			//					(errcode(ERRCODE_UNDEFINED_FUNCTION),
-			//					 errmsg("No receive function available for type %s. Motion requires receive function",
-			//							format_type_be(attrInfo->atttypid))));
-			//			}
-
-
 			attrInfo->typsend = pt->typsend;
 
-			if (OidIsValid(pt->typsend))
+			if (OidIsValid(attrInfo->typsend))
 			{
 				fmgr_info(attrInfo->typsend, &attrInfo->send_finfo);
 			}
 
 			attrInfo->typrecv  = pt->typreceive;
-			if (OidIsValid(pt->typreceive))
+			if (OidIsValid(attrInfo->typrecv))
 			{
 				fmgr_info(attrInfo->typrecv, &attrInfo->recv_finfo);
 			}
@@ -634,13 +616,10 @@ SerializeTupleIntoChunks(HeapTuple tuple, SerTupInfo * pSerInfo, TupleChunkList 
 				}
 				else
 				{
-					elog(WARNING, "No Send. Entering debug break");
-					debug_break();
-
-						ereport(ERROR,
-							(errcode(ERRCODE_UNDEFINED_FUNCTION),
-							 errmsg("No send function available for type %s. Motion requires send function",
-									format_type_be(attrInfo->atttypid))));
+					ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_FUNCTION),
+						 errmsg("No send function available for type %s. Motion requires send function",
+								format_type_be(attrInfo->atttypid))));
 				}
 
 				/* We assume the result will not have been toasted */
@@ -1021,9 +1000,6 @@ DeserializeTuple(SerTupInfo * pSerInfo, StringInfo serialTup)
 		}
 		else
 		{
-			elog(WARNING, "No Receive. Entering debug break");
-			debug_break();
-
 			ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_FUNCTION),
 				 errmsg("No receive function available for type %s. Motion requires receive function",

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -322,6 +322,15 @@ DefineType(List *names, List *parameters, Oid newOid, Oid newArrayOid)
 				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 				 errmsg("type output function must be specified")));
 
+	if (receiveName == NIL)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+				 errmsg("type receive function must be specified")));
+	if (sendName == NIL)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+				 errmsg("type send function must be specified")));
+
 	if (typmodinName == NIL && typmodoutName != NIL)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
@@ -332,10 +341,8 @@ DefineType(List *names, List *parameters, Oid newOid, Oid newArrayOid)
 	 */
 	inputOid = findTypeInputFunction(inputName, typoid);
 	outputOid = findTypeOutputFunction(outputName, typoid);
-	if (receiveName)
-		receiveOid = findTypeReceiveFunction(receiveName, typoid);
-	if (sendName)
-		sendOid = findTypeSendFunction(sendName, typoid);
+	receiveOid = findTypeReceiveFunction(receiveName, typoid);
+	sendOid = findTypeSendFunction(sendName, typoid);
 
 	/*
 	 * Verify that I/O procs return the expected thing.  If we see OPAQUE,

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -322,15 +322,6 @@ DefineType(List *names, List *parameters, Oid newOid, Oid newArrayOid)
 				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 				 errmsg("type output function must be specified")));
 
-	if (receiveName == NIL)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
-				 errmsg("type receive function must be specified")));
-	if (sendName == NIL)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
-				 errmsg("type send function must be specified")));
-
 	if (typmodinName == NIL && typmodoutName != NIL)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
@@ -341,8 +332,10 @@ DefineType(List *names, List *parameters, Oid newOid, Oid newArrayOid)
 	 */
 	inputOid = findTypeInputFunction(inputName, typoid);
 	outputOid = findTypeOutputFunction(outputName, typoid);
-	receiveOid = findTypeReceiveFunction(receiveName, typoid);
-	sendOid = findTypeSendFunction(sendName, typoid);
+	if (receiveName)
+		receiveOid = findTypeReceiveFunction(receiveName, typoid);
+	if (sendName)
+		sendOid = findTypeSendFunction(sendName, typoid);
 
 	/*
 	 * Verify that I/O procs return the expected thing.  If we see OPAQUE,

--- a/src/include/cdb/tupser.h
+++ b/src/include/cdb/tupser.h
@@ -49,19 +49,19 @@ typedef struct SerAttrInfo
 	bool		typisvarlena;	/* is type varlena (ie possibly toastable)? */
 
 	Oid			typsend;		/* Oid for the type's binary output fn */
-	Oid			send_typio_param;		/* param to pass to the output fn */
+	Oid			send_typio_param;		/* param to pass to the send fn */
 	/*
-	 * Precomputed call info for output fn.
-	 * Valid only if typsend is valid, i.e., a send function was provided.
+	 * Precomputed call info for send fn. Valid only if typsend is valid,
+	 * i.e., a send function was provided.
 	 */
 	FmgrInfo	send_finfo;		/* Precomputed call info for output fn */
 
 	Oid			typrecv;		/* Oid for the type's binary input fn */
-	Oid			recv_typio_param;		/* param to pass to the input fn */
+	Oid			recv_typio_param;		/* param to pass to the receive fn */
 
 	/*
-	 * Precomputed call info for input fn.
-	 * Valid only if typrecv is valid, i.e., a receive function was provided.
+	 * Precomputed call info for receive fn. Valid only if typrecv is valid,
+	 * i.e., a receive function was provided.
 	 */
 	FmgrInfo	recv_finfo;
 

--- a/src/include/cdb/tupser.h
+++ b/src/include/cdb/tupser.h
@@ -50,11 +50,20 @@ typedef struct SerAttrInfo
 
 	Oid			typsend;		/* Oid for the type's binary output fn */
 	Oid			send_typio_param;		/* param to pass to the output fn */
+	/*
+	 * Precomputed call info for output fn.
+	 * Valid only if typsend is valid, i.e., a send function was provided.
+	 */
 	FmgrInfo	send_finfo;		/* Precomputed call info for output fn */
 
 	Oid			typrecv;		/* Oid for the type's binary input fn */
 	Oid			recv_typio_param;		/* param to pass to the input fn */
-	FmgrInfo	recv_finfo;		/* Precomputed call info for output fn */
+
+	/*
+	 * Precomputed call info for input fn.
+	 * Valid only if typrecv is valid, i.e., a receive function was provided.
+	 */
+	FmgrInfo	recv_finfo;
 
 #ifdef TUPSER_SCRATCH_SPACE
 	void	   *pv_varlen_scratch;		/* For deserializing varlena

--- a/src/include/cdb/tupser.h
+++ b/src/include/cdb/tupser.h
@@ -58,7 +58,6 @@ typedef struct SerAttrInfo
 
 	Oid			typrecv;		/* Oid for the type's binary input fn */
 	Oid			recv_typio_param;		/* param to pass to the receive fn */
-
 	/*
 	 * Precomputed call info for receive fn. Valid only if typrecv is valid,
 	 * i.e., a receive function was provided.

--- a/src/test/regress/expected/create_type.out
+++ b/src/test/regress/expected/create_type.out
@@ -126,3 +126,33 @@ CREATE TYPE compfoo as (f1 int, f2 text);
 DROP TYPE compfoo;
 RESET SESSION AUTHORIZATION;
 DROP USER user_bob;
+-- Check if motion layer correctly errors out in the absence of send/receive functions
+CREATE TYPE incomplete_type;
+CREATE FUNCTION incomplete_type_in(cstring)
+   RETURNS incomplete_type
+   AS 'textin'
+   LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type incomplete_type is only a shell
+CREATE FUNCTION incomplete_type_out(incomplete_type)
+   RETURNS cstring
+   AS 'textout'
+   LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type incomplete_type is only a shell
+CREATE TYPE incomplete_type (
+   internallength = variable,
+   input = incomplete_type_in,
+   output = incomplete_type_out,
+   alignment = double,
+   storage = EXTENDED,
+   default = 'zippo'
+);
+CREATE TABLE table_with_incomplete_type (id int, incomplete incomplete_type);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO table_with_incomplete_type(id, incomplete) VALUES(1, repeat('abcde', 1000000)::incomplete_type);
+ERROR:  No send function available for type incomplete_type. Motion requires send function  (seg0 slice1 127.0.0.1:25432 pid=81043)
+CONTEXT:  SQL statement "select Ta.id, Ta.incomplete from public.table_with_incomplete_type as Ta  limit 7500 "
+drop table table_with_incomplete_type;
+drop type incomplete_type cascade; 
+NOTICE:  drop cascades to function incomplete_type_out(incomplete_type)
+NOTICE:  drop cascades to function incomplete_type_in(cstring)


### PR DESCRIPTION
The motion node uses a binary serializer to serialize a type inside SerializeTupleIntoChunks. This binary serializer is supposed to produce at varlena with header to indicate compression info, toasting info etc. The serializer is passed into SerializeTupleIntoChunks as pSerInfo. This pSerInfo originally came during motion layer setup from InitSerTupInfo, which uses CAQL to read the type functions from pg_type.

Unfortunately, if a type doesn't have send/receive, then the InitSerTupInfo forcefully populates out/in functions in send/recv function

If the out function returns only a string, and not a varlena, the headers are not set. Therefore, during byte serialization we will actually obtain a string datum. This datum is then passed to DatumGetByteaP to do the detoasting (if necessary, of course). Unfortunately, pg_detoast_datum cannot find the header info (that was supposed to be in varlena header) as we only have a string datum, and not a varlena. This results in wrong size information and a successive attempt to allocate a very large memory that errors out with memory context error "ERROR:  invalid memory alloc request size". Refer to https://github.com/greenplum-db/gpdb/issues/661.

This PR fixes this by not substituting send/receive with out/in functions. It doesn't, however, error out swiftly (e.g., in parser). This is to ensure highest backward compatibility. In fact, it defers it all the way to actual serialization/deserialization time. It doesn't even error out during InitSerTupInfo() as we may not need a particular column during motion and we may still be successful to execute the query.