### PR TITLE
Assert rather than returning NULL for scan method check

### DIFF
--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -27,12 +27,13 @@
 #include "nodes/tidbitmap.h"
 
 /*
- * Returns BitmapTableScanMethod for a given table type. Returns NULL
- * if the given type is TableTypeInvalid or not defined in TableType.
+ * Returns BitmapTableScanMethod for a given table type.
  */
 static const ScanMethod *
 getBitmapTableScanMethod(TableType tableType)
 {
+	Assert(tableType >= TableTypeHeap && tableType < TableTypeInvalid);
+
 	/*
 	 * scanMethods
 	 *    Array that specifies different scan methods for various table types.
@@ -58,16 +59,6 @@ getBitmapTableScanMethod(TableType tableType)
 	};
 
 	COMPILE_ASSERT(ARRAY_SIZE(scanMethods) == TableTypeInvalid);
-
-	/*
-	 * The test for the tableType being a valid enum member is inverted since
-	 * the actual datatype for an enum is compiler dependent and we can't rely
-	 * on it always being unsigned.
-	 */
-	if (!(tableType > 0 && tableType <= TableTypeInvalid))
-	{
-		return NULL;
-	}
 
 	return &scanMethods[tableType];
 }

--- a/src/backend/executor/execScan.c
+++ b/src/backend/executor/execScan.c
@@ -26,12 +26,12 @@
 /*
  * getScanMethod
  *   Return ScanMethod for a given table type.
- *
- * Return NULL if the given type is TableTypeInvalid or not defined in TableType.
  */
 static const ScanMethod *
 getScanMethod(int tableType)
 {
+	Assert(tableType >= TableTypeHeap && tableType < TableTypeInvalid);
+
 	/*
 	 * scanMethods
 	 *    Array that specifies different scan methods for various table types.
@@ -56,11 +56,6 @@ getScanMethod(int tableType)
 	};
 	
 	COMPILE_ASSERT(ARRAY_SIZE(scanMethods) == TableTypeInvalid);
-
-	if (tableType < 0 && tableType >= TableTypeInvalid)
-	{
-		return NULL;
-	}
 
 	return &scanMethods[tableType];
 }
@@ -438,8 +433,6 @@ getTableType(Relation rel)
 TupleTableSlot *
 ExecTableScanRelation(ScanState *scanState)
 {
-	Assert(scanState->tableType >= 0 && scanState->tableType < TableTypeInvalid);
-	
 	return ExecScan(scanState, getScanMethod(scanState->tableType)->accessMethod);
 }
 
@@ -450,8 +443,6 @@ ExecTableScanRelation(ScanState *scanState)
 void
 BeginTableScanRelation(ScanState *scanState)
 {
-	Assert(scanState->tableType >= 0 && scanState->tableType < TableTypeInvalid);
-
 	getScanMethod(scanState->tableType)->beginScanMethod(scanState);
 }
 
@@ -462,8 +453,6 @@ BeginTableScanRelation(ScanState *scanState)
 void
 EndTableScanRelation(ScanState *scanState)
 {
-	Assert(scanState->tableType >= 0 && scanState->tableType < TableTypeInvalid);
-
 	getScanMethod(scanState->tableType)->endScanMethod(scanState);
 }
 
@@ -474,8 +463,7 @@ EndTableScanRelation(ScanState *scanState)
 void
 ReScanRelation(ScanState *scanState)
 {
-	Assert(scanState->tableType >= 0 && scanState->tableType < TableTypeInvalid);
-
+	const ScanMethod *scanMethod;
 	EState *estate = scanState->ps.state;
 	Index scanrelid = ((Scan *)scanState->ps.plan)->scanrelid;
 	
@@ -487,9 +475,7 @@ ReScanRelation(ScanState *scanState)
 		return;
 	}
 
-	const ScanMethod *scanMethod = getScanMethod(scanState->tableType);
-	Assert(scanMethod != NULL);
-
+	scanMethod = getScanMethod(scanState->tableType);
 	if ((scanState->scan_state & SCAN_SCAN) == 0)
 	{
 		scanMethod->beginScanMethod(scanState);
@@ -505,8 +491,6 @@ ReScanRelation(ScanState *scanState)
 void
 MarkPosScanRelation(ScanState *scanState)
 {
-	Assert(scanState->tableType >= 0 && scanState->tableType < TableTypeInvalid);
-
 	getScanMethod(scanState->tableType)->markPosMethod(scanState);	
 }
 
@@ -517,8 +501,6 @@ MarkPosScanRelation(ScanState *scanState)
 void
 RestrPosScanRelation(ScanState *scanState)
 {
-	Assert(scanState->tableType >= 0 && scanState->tableType < TableTypeInvalid);
-
 	getScanMethod(scanState->tableType)->restrPosMethod(scanState);	
 }
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1610,7 +1610,9 @@ typedef enum
 /*
  * TableType
  *   Enum for different types of tables. The code relies on the enum being
- *   unsigned so the minimum member value should be zero.
+ *   unsigned so the minimum member value should be zero. Reordering and/or
+ *   renumbering the enum will most likely break assumptions and should be
+ *   refrained from.
  */
 typedef enum
 {


### PR DESCRIPTION
Since no callsite of these functions checks for a `NULL` return value and instead deref the returned pointer immediately we need to ensure that only valid values are ever returned. This came up in a discussion around a bug in the vicinity of this and even if not related, deref on something that can return NULL is an accident waiting to happen. Also corrects a logic error in the enum check in `getBitmapTableScanMethod()` where table type is allowed to be zero (TableTypeHeap).

@hlinnaka is this in line with your plans?