### PR TITLE
Silence some chatter from make install

### DIFF
--- a/gpAux/extensions/Makefile
+++ b/gpAux/extensions/Makefile
@@ -25,13 +25,13 @@ all: mkdbgen mkgphdfs mks3ext
 
 .PHONY:
 mapreduce:
-	if [ "$(enable_mapreduce)" = "yes" ]; then \
+	@if [ "$(enable_mapreduce)" = "yes" ]; then \
 		echo "gpmapreduce enabled"; \
 		$(MAKE) -C gpmapreduce; \
 	fi
 
 install: mapreduce
-	if [ "$(enable_mapreduce)" = "yes" ]; then \
+	@if [ "$(enable_mapreduce)" = "yes" ]; then \
 		$(MAKE) -C gpmapreduce install; \
 	fi
 

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -104,7 +104,7 @@ install: generate_greenplum_path_file
 	cp $(top_builddir)/src/test/regress/*.pm $(prefix)/bin
 	if [ ! -d ${prefix}/docs ] ; then mkdir ${prefix}/docs ; fi
 	if [ -d doc ]; then cp -rp doc $(prefix)/docs/cli_help; fi
-	if [ -d demo/gpmapreduce ]; then \
+	@if [ -d demo/gpmapreduce ]; then \
 	  mkdir -p $(prefix)/demo; \
 	  $(TAR) -C demo -czf $(prefix)/demo/gpmapreduce.tar.gz gpmapreduce; \
 	fi
@@ -117,13 +117,9 @@ install: generate_greenplum_path_file
 
 	$(MAKE) set_scripts_version prefix=$(prefix)
 	# Remove unwanted files.
-	rm -rf $(prefix)/bin/CVS
-	rm -rf $(prefix)/doc/CVS
 	rm -rf $(prefix)/bin/ext
 	rm -rf $(prefix)/bin/pythonSrc
 	rm -rf $(prefix)/bin/Makefile
-	rm -rf $(prefix)/bin/lib/CVS
-	rm -rf $(prefix)/bin/lib/.p4ignore
 	rm -rf $(prefix)/bin/src
 	rm -f $(prefix)/bin/gpchecksubnetcfg
 	echo "`date` -- INFO: Removing $(prefix)/bin/gpexpandsystem"

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -46,7 +46,6 @@ endif
 STREAM_DIR=$(SRC)/src/stream
 stream:
 	@echo "--- stream"
-	pwd
 	cd $(STREAM_DIR) && NO_M64=TRUE $(CC) stream.c -o stream
 	cp $(STREAM_DIR)/stream $(SERVER_SRC)/lib/stream
 

--- a/src/pl/plperl/.p4ignore
+++ b/src/pl/plperl/.p4ignore
@@ -1,6 +1,0 @@
-libplperl.so.0
-libplperl.so.0.0
-libplperl.so
-libplperl.a
-SPI.c
-plperl.so


### PR DESCRIPTION
Running `make install` is expected to produce lots of output but we perform some steps that can be removed and have some level of printing to STDOUT that is superflous. Suppress output for logic with @ and remove unused commands and filetypes (perforce and CVS) as well as a leftover p4ignore file. This is poking at the things that stood out.