### PR TITLE
gpcrondump should not dump pg_temp schemas

### DIFF
--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -599,17 +599,26 @@ class GpCronDump(Operation):
         if self.context.incremental:
             return (dirty_file, exclude_file)
 
+        # Make sure that this happens right before the include_dump_tables
+        # check. We are relying on the filtering that happens on the
+        # include_dump_tables check
+        if self.context.include_dump_tables_file:
+            self.context.include_dump_tables = get_lines_from_file(self.context.include_dump_tables_file)
+
         if self.context.include_dump_tables:
-            include_file = expand_partitions_and_populate_filter_file(dbname, self.context.include_dump_tables, 'include_dump_tables_file')
+            dump_tables_without_pg_temp = []
+            for table in self.context.include_dump_tables:
+                if table.startswith('pg_temp_'):
+                    continue
+                dump_tables_without_pg_temp.append(table)
+            include_file = expand_partitions_and_populate_filter_file(dbname,
+                                                                      dump_tables_without_pg_temp,
+                                                                      'include_dump_tables_file')
             self.context.include_dump_tables = []
 
         if self.context.exclude_dump_tables:
             exclude_file = expand_partitions_and_populate_filter_file(dbname, self.context.exclude_dump_tables, 'exclude_dump_tables_file')
             self.context.exclude_dump_tables = []
-
-        if self.context.include_dump_tables_file:
-            include_tables = get_lines_from_file(self.context.include_dump_tables_file)
-            include_file = expand_partitions_and_populate_filter_file(dbname, include_tables, 'include_dump_tables_file')
 
         if self.context.exclude_dump_tables_file:
             exclude_tables = get_lines_from_file(self.context.exclude_dump_tables_file)

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -3501,6 +3501,20 @@ Feature: Validate command line arguments
         When the user runs "psql -c 'DROP ROLE "Foo%user"' -d bkdb"
         Then psql should return a return code of 0
 
+    @exclude_schema
+    Scenario: Exclude schema (-S) should not dump pg_temp schemas
+        Given the test is initialized
+        And the user runs the command "psql bkdb -f 'gppylib/test/behave/mgmt_utils/steps/data/gpcrondump/create_temp_schema_in_transaction.sql'" in the background without sleep
+        When the user runs "gpcrondump -a -S good_schema -x bkdb"
+        Then gpcrondump should return a return code of 0
+        And the timestamp from gpcrondump is stored
+        Then read pid from file "gppylib/test/behave/mgmt_utils/steps/data/gpcrondump/pid_leak" and kill the process
+        And the temporary file "gppylib/test/behave/mgmt_utils/steps/data/gpcrondump/pid_leak" is removed
+        And waiting "2" seconds
+        And verify that the "dump" file in " " dir does not contain "pg_temp"
+        And the user runs command "dropdb bkdb"
+
+
     # THIS SHOULD BE THE LAST TEST
     @backupfire
     Scenario: cleanup for backup feature

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcrondump/create_temp_schema_in_transaction.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcrondump/create_temp_schema_in_transaction.sql
@@ -1,0 +1,11 @@
+\t
+create temp table temp_table(i int);
+create schema good_schema;
+create table good_schema.good_table(i int);
+\o gppylib/test/behave/mgmt_utils/steps/data/gpcrondump/pid_leak
+select pg_backend_pid();
+begin;
+select * from temp_table;
+-- we are just picking an arbitrary number that's long enough for gpcrondump to finish
+-- we will kill this process once the dump is done.
+select pg_sleep(500)

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1,17 +1,18 @@
 import commands
+import fnmatch
 import getpass
 import glob
+import gzip
+import os
 import platform
 import shutil
 import socket
 import tarfile
 import thread
-import fnmatch
-import os
+import yaml
+
 from collections import defaultdict
 from datetime import datetime
-
-import yaml
 
 from gppylib.commands.gp import SegmentStart, GpStandbyStart
 from gppylib.commands.unix import findCmdInPath
@@ -1070,6 +1071,8 @@ def verify_file_contents(context, file_type, file_dir, text_find, should_contain
         fn = '%sgp_dump_%s_schema' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == 'cdatabase':
         fn = '%sgp_cdatabase_1_1_%s' % (context.dump_prefix, context.backup_timestamp)
+    elif file_type == 'dump':
+        fn = '%sgp_dump_1_1_%s.gz' % (context.dump_prefix, context.backup_timestamp)
 
     subdirectory = context.backup_timestamp[0:8]
 
@@ -1082,8 +1085,13 @@ def verify_file_contents(context, file_type, file_dir, text_find, should_contain
         raise Exception ("Can not find %s file: %s" % (file_type, full_path))
 
     contents = ""
-    with open(full_path) as fd:
-        contents = fd.read()
+
+    if file_type == 'dump':
+        fd = gzip.open(full_path)
+    else:
+        fd =  open(full_path)
+    contents = fd.read()
+    fd.close()
 
     if should_contain and not text_find in contents:
         raise Exception("Did not find '%s' in file %s" % (text_find, full_path))


### PR DESCRIPTION
* We noticed that when gpcrondump is given with a -S option (exclude schema)
  gpcrondump will also try to dump pg_temp schemas.
  This can be detected by the following issue:
  user creates a new schema
  user creates a temp table
  -- Keep the session alive

  On another session:
  ```Run gpcrondump -S <exclude schema> -x <dbname>```
* We've filtered out pg_temp in our queries to prevent this issue.

Dumping pg_temp schemas doesn't make sense as gpdbrestore can't restore
those schemas and tables anyways, since pg_ and gp_ schemas are
restricted for the system.

Authors: Marbin Tan & Karen Huddleston