### PR TITLE
Bug fix which append only temp table cannot be inserted multiple times.

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -432,7 +432,6 @@ AOCSDrop(Relation aorel,
 	LockAcquireResult acquireResult;
 	AOCSFileSegInfo* fsinfo;
 
-	Assert (Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 	Assert (RelationIsAoCols(aorel));
 
 	relname = RelationGetRelationName(aorel);

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -509,7 +509,6 @@ AppendOnlyDrop(Relation aorel,
 	int i, segno;
 	FileSegInfo* fsinfo;
 
-	Assert (Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 	Assert (RelationIsAoRows(aorel));
 
 	relname = RelationGetRelationName(aorel);

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -369,6 +369,70 @@ select count(*) from tenk_ao5_temp_pres_rows;
 commit;
 select count(*) from tenk_ao5_temp_pres_rows;
 
+-- TEMP TABLES w/ access multiple times
+BEGIN;
+CREATE TEMP TABLE aocs_temp_delete_rows_multi(c int, d TEXT) WITH (appendonly=true, orientation=column)
+    ON COMMIT DELETE ROWS;
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+COMMIT;
+
+SELECT * FROM aocs_temp_delete_rows_multi;
+
+BEGIN;
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+COMMIT;
+
+BEGIN;
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+ROLLBACK;
+
+SELECT * FROM aocs_temp_delete_rows_multi;
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+
+BEGIN;
+CREATE TEMP TABLE ao_temp_delete_rows_multi(c int, d TEXT) WITH (appendonly=true, orientation=row)
+    ON COMMIT DELETE ROWS;
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
+COMMIT;
+
+SELECT * FROM ao_temp_delete_rows_multi;
+
+BEGIN;
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
+COMMIT;
+
+BEGIN;
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
+ROLLBACK;
+
+SELECT * FROM ao_temp_delete_rows_multi;
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
 -- RULES
 insert into tenk_ao5(unique1, unique2) values (1, 99998889);
 create rule ao_rule_update as on insert to tenk_ao5 do instead update tenk_ao5 set two=2;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -815,6 +815,143 @@ select count(*) from tenk_ao5_temp_pres_rows;
      0
 (1 row)
 
+-- TEMP TABLES w/ access multiple times
+BEGIN;
+CREATE TEMP TABLE aocs_temp_delete_rows_multi(c int, d TEXT) WITH (appendonly=true, orientation=column)
+    ON COMMIT DELETE ROWS;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+ c |  d   
+---+------
+ 1 | test
+(1 row)
+
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+ c |  d   
+---+------
+ 0 | test
+ 1 | test
+(2 rows)
+
+COMMIT;
+SELECT * FROM aocs_temp_delete_rows_multi;
+ c | d 
+---+---
+(0 rows)
+
+BEGIN;
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+ c |  d   
+---+------
+ 0 | test
+ 0 | test
+ 1 | test
+ 1 | test
+(4 rows)
+
+COMMIT;
+BEGIN;
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+ c |  d   
+---+------
+ 1 | test
+ 1 | test
+ 0 | test
+ 0 | test
+(4 rows)
+
+ROLLBACK;
+SELECT * FROM aocs_temp_delete_rows_multi;
+ c | d 
+---+---
+(0 rows)
+
+INSERT INTO aocs_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO aocs_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM aocs_temp_delete_rows_multi;
+ c | d 
+---+---
+(0 rows)
+
+BEGIN;
+CREATE TEMP TABLE ao_temp_delete_rows_multi(c int, d TEXT) WITH (appendonly=true, orientation=row)
+    ON COMMIT DELETE ROWS;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
+ c |  d   
+---+------
+ 1 | test
+(1 row)
+
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
+ c |  d   
+---+------
+ 0 | test
+ 1 | test
+(2 rows)
+
+COMMIT;
+SELECT * FROM ao_temp_delete_rows_multi;
+ c | d 
+---+---
+(0 rows)
+
+BEGIN;
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
+ c |  d   
+---+------
+ 0 | test
+ 0 | test
+ 1 | test
+ 1 | test
+(4 rows)
+
+COMMIT;
+BEGIN;
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
+ c |  d   
+---+------
+ 1 | test
+ 1 | test
+ 0 | test
+ 0 | test
+(4 rows)
+
+ROLLBACK;
+SELECT * FROM ao_temp_delete_rows_multi;
+ c | d 
+---+---
+(0 rows)
+
+INSERT INTO ao_temp_delete_rows_multi VALUES(1, 'test');
+INSERT INTO ao_temp_delete_rows_multi VALUES(0, 'test');
+SELECT * FROM ao_temp_delete_rows_multi;
+ c | d 
+---+---
+(0 rows)
+
 -- RULES
 insert into tenk_ao5(unique1, unique2) values (1, 99998889);
 create rule ao_rule_update as on insert to tenk_ao5 do instead update tenk_ao5 set two=2;


### PR DESCRIPTION
I opened the Issue #913 and @asimrp reproduce it.

I digged into the code and found that append-only temp table do not implement the delete rows behaviour.

For the heap table, a truncation is enough. But the append only table save the data file information in the aoseg heap table. Truncate aoseg heap table will ruin the dependency between it and the gp_relation_node.

The correct way to delete rows from a append only table is that drop the data file or truncate them. The compaction codes is a good candidate to be the foundation of append-only temp table.

I add some basic tests for the fix too.
