### PR TITLE
Textsearch dispatch

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1992,6 +1992,13 @@ _outNode(StringInfo str, void *obj)
 				_outTupleDescNode(str, obj);
 				break;
 
+			case T_AlterTSConfigurationStmt:
+				_outAlterTSConfigurationStmt(str, obj);
+				break;
+			case T_AlterTSDictionaryStmt:
+				_outAlterTSDictionaryStmt(str, obj);
+				break;
+
 			default:
 				elog(ERROR, "could not serialize unrecognized node type: %d",
 						 (int) nodeTag(obj));

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4298,6 +4298,28 @@ _outAlterTypeStmt(StringInfo str, AlterTypeStmt *node)
 	WRITE_NODE_FIELD(encoding);
 }
 
+static void
+_outAlterTSConfigurationStmt(StringInfo str, AlterTSConfigurationStmt *node)
+{
+	WRITE_NODE_TYPE("ALTERTSCONFIGURATIONSTMT");
+
+	WRITE_NODE_FIELD(cfgname);
+	WRITE_NODE_FIELD(tokentype);
+	WRITE_NODE_FIELD(dicts);
+	WRITE_BOOL_FIELD(override);
+	WRITE_BOOL_FIELD(replace);
+	WRITE_BOOL_FIELD(missing_ok);
+}
+
+static void
+_outAlterTSDictionaryStmt(StringInfo str, AlterTSDictionaryStmt *node)
+{
+	WRITE_NODE_TYPE("ALTERTSDICTIONARYSTMT");
+
+	WRITE_NODE_FIELD(dictname);
+	WRITE_NODE_FIELD(options);
+}
+
 #ifndef COMPILING_BINARY_FUNCS
 static void
 _outTupleDescNode(StringInfo str, TupleDescNode *node)
@@ -5186,6 +5208,13 @@ _outNode(StringInfo str, void *obj)
 				break;
 			case T_TupleDescNode:
 				_outTupleDescNode(str, obj);
+				break;
+
+			case T_AlterTSConfigurationStmt:
+				_outAlterTSConfigurationStmt(str, obj);
+				break;
+			case T_AlterTSDictionaryStmt:
+				_outAlterTSDictionaryStmt(str, obj);
 				break;
 
 			default:

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2575,6 +2575,32 @@ _readTupleDescNode(void)
 	READ_DONE();
 }
 
+static AlterTSConfigurationStmt *
+_readAlterTSConfigurationStmt(void)
+{
+	READ_LOCALS(AlterTSConfigurationStmt);
+
+	READ_NODE_FIELD(cfgname);
+	READ_NODE_FIELD(tokentype);
+	READ_NODE_FIELD(dicts);
+	READ_BOOL_FIELD(override);
+	READ_BOOL_FIELD(replace);
+	READ_BOOL_FIELD(missing_ok);
+
+	READ_DONE();
+}
+
+static AlterTSDictionaryStmt *
+_readAlterTSDictionaryStmt(void)
+{
+	READ_LOCALS(AlterTSDictionaryStmt);
+
+	READ_NODE_FIELD(dictname);
+	READ_NODE_FIELD(options);
+
+	READ_DONE();
+}
+
 static Node *
 _readValue(NodeTag nt)
 {
@@ -3399,6 +3425,13 @@ readNodeBinary(void)
 				break;
 			case T_TupleDescNode:
 				return_value = _readTupleDescNode();
+				break;
+
+			case T_AlterTSConfigurationStmt:
+				return_value = _readAlterTSConfigurationStmt();
+				break;
+			case T_AlterTSDictionaryStmt:
+				return_value = _readAlterTSDictionaryStmt();
 				break;
 
 			default:

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -627,6 +627,35 @@ ProcessDropStatement(DropStmt *stmt)
 				RemoveExtProtocol(names, stmt->behavior, stmt->missing_ok);
 				break;
 
+
+			case OBJECT_TSPARSER:
+				/*
+				 * RemoveTSParser does it's own permission checks
+				 */
+				RemoveTSParser(names, stmt->behavior, stmt->missing_ok);
+				break;
+
+			case OBJECT_TSDICTIONARY:
+				/*
+				 * RemoveTSDictionary does it's own permission checks
+				 */
+				RemoveTSDictionary(names, stmt->behavior, stmt->missing_ok);
+				break;
+
+			case OBJECT_TSTEMPLATE:
+				/*
+				 * RemoveTSTemplate does it's own permission checks
+				 */
+				RemoveTSTemplate(names, stmt->behavior, stmt->missing_ok);
+				break;
+
+			case OBJECT_TSCONFIGURATION:
+				/*
+				 * RemoveTSConfiguration does it's own permission checks
+				 */
+				RemoveTSConfiguration(names, stmt->behavior, stmt->missing_ok);
+				break;
+
 			default:
 				elog(ERROR, "unrecognized drop object type: %d",
 					 (int) stmt->removeType);
@@ -1252,19 +1281,19 @@ ProcessUtility(Node *parsetree,
 						break;						
 					case OBJECT_TSPARSER:
 						Assert(stmt->args == NIL);
-						DefineTSParser(stmt->defnames, stmt->definition);
+						DefineTSParser(stmt->defnames, stmt->definition, stmt->newOid);
 						break;
 					case OBJECT_TSDICTIONARY:
 						Assert(stmt->args == NIL);
-						DefineTSDictionary(stmt->defnames, stmt->definition);
+						DefineTSDictionary(stmt->defnames, stmt->definition, stmt->newOid);
 						break;
 					case OBJECT_TSTEMPLATE:
 						Assert(stmt->args == NIL);
-						DefineTSTemplate(stmt->defnames, stmt->definition);
+						DefineTSTemplate(stmt->defnames, stmt->definition, stmt->newOid);
 						break;
 					case OBJECT_TSCONFIGURATION:
 						Assert(stmt->args == NIL);
-						DefineTSConfiguration(stmt->defnames, stmt->definition);
+						DefineTSConfiguration(stmt->defnames, stmt->definition, stmt->newOid);
 						break;
 					default:
 						elog(ERROR, "unrecognized define stmt type: %d",

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -544,10 +544,12 @@ ProcessDropStatement(DropStmt *stmt)
 						CheckDropRelStorage(rel, stmt->removeType))
 				{
 					/*
-					 * RemoveRelation fails to find the relation on QD, will return false.
-					 * Should not dispatch the drop to segments as not holding Exclusive Lock.
+					 * If RemoveRelation fails to find the relation on QD, it
+					 * will return false and we should not dispatch the drop
+					 * to segments as not holding Exclusive Lock.
 					 */
-					dispatchDrop = RemoveRelation(rel, stmt->behavior, stmt, RELKIND_RELATION);
+					dispatchDrop = RemoveRelation(rel, stmt->behavior, stmt,
+												  RELKIND_RELATION);
 				}
 				else
 					dispatchDrop = false;
@@ -557,15 +559,15 @@ ProcessDropStatement(DropStmt *stmt)
 				rel = makeRangeVarFromNameList(names);
 				if (CheckDropPermissions(rel, RELKIND_SEQUENCE,
 										 stmt->missing_ok))
-					dispatchDrop = RemoveRelation(rel, stmt->behavior, stmt, RELKIND_SEQUENCE);
+					dispatchDrop = RemoveRelation(rel, stmt->behavior, stmt,
+												  RELKIND_SEQUENCE);
 				else
 					dispatchDrop = false;
 				break;
 
 			case OBJECT_VIEW:
 				rel = makeRangeVarFromNameList(names);
-				if (CheckDropPermissions(rel, RELKIND_VIEW,
-										 stmt->missing_ok))
+				if (CheckDropPermissions(rel, RELKIND_VIEW, stmt->missing_ok))
 					RemoveView(rel, stmt->behavior);
 				else
 					dispatchDrop = false;
@@ -573,60 +575,54 @@ ProcessDropStatement(DropStmt *stmt)
 
 			case OBJECT_INDEX:
 				rel = makeRangeVarFromNameList(names);
-				if (CheckDropPermissions(rel, RELKIND_INDEX,
-										 stmt->missing_ok))
+				if (CheckDropPermissions(rel, RELKIND_INDEX, stmt->missing_ok))
 					RemoveIndex(rel, stmt->behavior);
 				else
 					dispatchDrop = false;
 				break;
 
 			case OBJECT_TYPE:
-				/* RemoveType does its own permissions checks */
-				RemoveType(names, stmt->behavior,
-						   stmt->missing_ok);
+				/*
+				 * RemoveType does it's own permissions checks
+				 */
+				RemoveType(names, stmt->behavior, stmt->missing_ok);
 				break;
 
 			case OBJECT_DOMAIN:
-
 				/*
-				 * RemoveDomain does its own permissions checks
+				 * RemoveDomain does it's own permissions checks
 				 */
-				RemoveDomain(names, stmt->behavior,
-							 stmt->missing_ok);
+				RemoveDomain(names, stmt->behavior, stmt->missing_ok);
 				break;
 
 			case OBJECT_CONVERSION:
-				DropConversionCommand(names, stmt->behavior,
-									  stmt->missing_ok);
+				DropConversionCommand(names, stmt->behavior, stmt->missing_ok);
 				break;
 
 			case OBJECT_SCHEMA:
-
 				/*
-				 * RemoveSchema does its own permissions checks
+				 * RemoveSchema does it's own permissions checks
 				 */
-				RemoveSchema(names, stmt->behavior,
-							 stmt->missing_ok);
+				RemoveSchema(names, stmt->behavior, stmt->missing_ok);
 				break;
 
 			case OBJECT_FILESPACE:
 				/*
-				 * RemoveFileSpace does its own permissions checks
+				 * RemoveFileSpace does it's own permissions checks
 				 */
 				RemoveFileSpace(names, stmt->behavior, stmt->missing_ok);
 				break;
 
 			case OBJECT_TABLESPACE:
 				/*
-				 * RemoveTableSpace does its own permissions checks
+				 * RemoveTableSpace does it's own permissions checks
 				 */
 				RemoveTableSpace(names, stmt->behavior, stmt->missing_ok);
 				break;
 
 			case OBJECT_EXTPROTOCOL:
-				
 				/*
-				 * RemoveExtProtocol does its own permissions checks
+				 * RemoveExtProtocol does it's own permissions checks
 				 */
 				RemoveExtProtocol(names, stmt->behavior, stmt->missing_ok);
 				break;

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -100,13 +100,13 @@ extern void AlterOpFamilyOwner(List *name, const char *access_method, Oid newOwn
 extern void AlterOpFamilyOwner_oid(Oid opfamilyOid, Oid newOwnerId);
 
 /* commands/tsearchcmds.c */
-extern void DefineTSParser(List *names, List *parameters);
+extern void DefineTSParser(List *names, List *parameters, Oid newOid);
 extern void RenameTSParser(List *oldname, const char *newname);
 extern void RemoveTSParser(List *names, DropBehavior behavior,
 			   bool missing_ok);
 extern void RemoveTSParserById(Oid prsId);
 
-extern void DefineTSDictionary(List *names, List *parameters);
+extern void DefineTSDictionary(List *names, List *parameters, Oid newOid);
 extern void RenameTSDictionary(List *oldname, const char *newname);
 extern void RemoveTSDictionary(List *names, DropBehavior behavior,
 				   bool missing_ok);
@@ -114,13 +114,13 @@ extern void RemoveTSDictionaryById(Oid dictId);
 extern void AlterTSDictionary(AlterTSDictionaryStmt *stmt);
 extern void AlterTSDictionaryOwner(List *name, Oid newOwnerId);
 
-extern void DefineTSTemplate(List *names, List *parameters);
+extern void DefineTSTemplate(List *names, List *parameters, Oid newOid);
 extern void RenameTSTemplate(List *oldname, const char *newname);
 extern void RemoveTSTemplate(List *names, DropBehavior behavior,
 				 bool missing_ok);
 extern void RemoveTSTemplateById(Oid tmplId);
 
-extern void DefineTSConfiguration(List *names, List *parameters);
+extern void DefineTSConfiguration(List *names, List *parameters, Oid newOid);
 extern void RenameTSConfiguration(List *oldname, const char *newname);
 extern void RemoveTSConfiguration(List *names, DropBehavior behavior,
 					  bool missing_ok);


### PR DESCRIPTION
In a post to [gpdb-dev](https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/TKY_j7cMg7M) @jimmyyih pointed out that the text search commands weren't properly dispatched to the segments. Text search was added to core in upstream PostgreSQL 8.3 and as we merged it we subsequently added it to GPDB. The dispatching of the utility commands for creating the text search catalog entries was however overlooked in that merge. Implement dispatch for the catalog commands and also implement the missing support for DROP. With this the gpcheckcat test passes and ICG passes for all text search tests.

This also includes a small fixup commit for inconsistent style and spelling in the `ProcessDropStatement()` code that I wanted to address before adding more code to it.