### PR TITLE
Exclude gpperfmon/logs directory from gpinitstandby copy

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -832,13 +832,12 @@ def copy_master_filespaces_to_standby(options, array, master_filespace_map, stan
     for i in standby_filespace_map:
         standby_fs_dict[i[0]] = i[1]
 
-    """We exclude certain unnecessary directories from being copied as
-    they will greatly slow down the speed of gpinitstandby if containing
-    a lot of data (MPP-6398, MPP-26059)"""
+    # We exclude certain unnecessary directories from being copied as they will greatly
+    # slow down the speed of gpinitstandby if containing a lot of data
     cmd_str = ' '.join(['pg_basebackup',
                         '-x', '-R',
                         '-E', './pg_log',
-                        '-E', './gp_dumps',
+                        '-E', './db_dumps',
                         '-E', './gpperfmon/data',
                         '-E', './gpperfmon/logs',
                         '-D', standby_fs_dict['pg_system'],

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -816,11 +816,11 @@ def remove_standby_from_catalog(options, array):
         raise GpInitStandbyException(ex)
         
 
-#-------------------------------------------------------------------------   
+#-------------------------------------------------------------------------
 def copy_master_filespaces_to_standby(options, array, master_filespace_map, standby_filespace_map):
     """Copies the filespaces from the master to the standby according to
     the maps provided."""
-    
+
     global g_init_standby_state
 
     g_init_standby_state=INIT_STANDBY_STATE_COPY_FILES
@@ -832,11 +832,15 @@ def copy_master_filespaces_to_standby(options, array, master_filespace_map, stan
     for i in standby_filespace_map:
         standby_fs_dict[i[0]] = i[1]
 
+    """We exclude certain unnecessary directories from being copied as
+    they will greatly slow down the speed of gpinitstandby if containing
+    a lot of data (MPP-6398, MPP-26059)"""
     cmd_str = ' '.join(['pg_basebackup',
                         '-x', '-R',
                         '-E', './pg_log',
                         '-E', './gp_dumps',
                         '-E', './gpperfmon/data',
+                        '-E', './gpperfmon/logs',
                         '-D', standby_fs_dict['pg_system'],
                         '-h', array.master.getSegmentHostName(),
                         '-p', str(array.master.getSegmentPort())])

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/test_gpinitstandby.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/test_gpinitstandby.py
@@ -76,6 +76,34 @@ class GpinitStandsbyTestCase(MPPTestCase):
         os.chmod(filepath, 777)
         os.remove(filepath)
 
+    def touch_file(self, filename):
+        with open(filename, 'w') as fp:
+            pass
+
+    def test_gpinitstandby_exclude_dirs(self):
+        """
+        Test pg_basebackup exclusions when copying filespaces from
+        the master to the standby during gpinitstandby
+        """
+        os.makedirs(self.mdd + '/db_dumps')
+        self.touch_file(self.mdd + '/db_dumps/testfile')
+        self.touch_file(self.mdd + '/gpperfmon/logs/test.log')
+        self.touch_file(self.mdd + '/gpperfmon/data/testfile')
+        self.touch_file(self.mdd + '/pg_log/testfile')
+
+        self.gp.run(option = '-P %s -s %s -F pg_system:%s' % (self.standby_port, self.host, self.standby_loc))
+
+        shutil.rmtree(self.mdd + '/db_dumps')
+        os.remove(self.mdd + '/gpperfmon/logs/test.log')
+        os.remove(self.mdd + '/gpperfmon/data/testfile')
+        os.remove(self.mdd + '/pg_log/testfile')
+
+        self.assertFalse(os.path.exists(self.standby_loc + '/db_dumps/testfile'))
+        self.assertFalse(os.path.exists(self.standby_loc + '/gpperfmon/logs/test.log'))
+        self.assertFalse(os.path.exists(self.standby_loc + '/gpperfmon/data/testfile'))
+        self.assertFalse(os.path.exists(self.standby_loc + '/pg_log/testfile'))
+        self.assertTrue(self.gp.run(option = '-r'))
+
     @unittest.skipIf(not config.is_multinode(), "Test applies only to a multinode cluster")
     def test_gpinitstanby_to_new_host(self):
         self.create_directory(self.mdd)

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/test_gpinitstandby.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpinitstandby/test_gpinitstandby.py
@@ -77,6 +77,10 @@ class GpinitStandsbyTestCase(MPPTestCase):
         os.remove(filepath)
 
     def touch_file(self, filename):
+        file_dir = os.path.split(filename)[0]
+        if not os.path.exists(file_dir):
+            os.makedirs(file_dir)
+
         with open(filename, 'w') as fp:
             pass
 


### PR DESCRIPTION
This commit excludes the gpperfmon/logs directory from being copied in gpinitstandby. This was done after discussion with O2 team (@deepesh1081 @asimrp).
I have not tested yet.

https://www.pivotaltracker.com/n/projects/989808
```
gpinitstandby took a long time to complete at one customer site. Further investigation showed that it spent a lot of time in copying files under $MASTER_DATA_DIRECTORY/gpperfmon/logs to standby master side.
There are huge amount of files under gpperfmon/logs
Strace of pg_basebackup process showed the process was busy with processing files under gpperfmon/logs
```