### PR TITLE
Update create_index test by replacing SELECT INTO query to CTAS with DISTRIBUTED BY

### DIFF
--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -450,7 +450,7 @@ DROP TABLE concur_heap;
 --
 -- Tests for IS NULL with b-tree indexes
 --
-SELECT unique1, unique2 INTO onek_with_null FROM onek;
+CREATE TABLE onek_with_null AS SELECT unique1, unique2 FROM onek DISTRIBUTED BY (unique1);
 INSERT INTO onek_with_null (unique1,unique2) VALUES (NULL, -1), (NULL, NULL);
 CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2,unique1);
 SET enable_seqscan = OFF;

--- a/src/test/regress/sql/create_index.sql
+++ b/src/test/regress/sql/create_index.sql
@@ -275,7 +275,7 @@ DROP TABLE concur_heap;
 -- Tests for IS NULL with b-tree indexes
 --
 
-SELECT unique1, unique2 INTO onek_with_null FROM onek;
+CREATE TABLE onek_with_null AS SELECT unique1, unique2 FROM onek DISTRIBUTED BY (unique1);
 INSERT INTO onek_with_null (unique1,unique2) VALUES (NULL, -1), (NULL, NULL);
 CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2,unique1);
 


### PR DESCRIPTION
Problem: **create_index** test failing when Orca is turned on.

In GPDB, **SELECT INTO** clause in GPDB is similar to **CTAS** without a distribution key.

When Orca is turned on, **by design** when CTAS has no distribution key we generate a table with random distribution. However, Planner generates a table that is distributed on the first distributable column. The roadmap of GPDB was to change the planner behavior to match that already in Orca. We however have not gotten to that parity due higher priority items.

So in this test when Orca is enabled, **onek_with_null** is randomly distributed and we cannot create unique index on that thereby resulting in a test failure. 

As far as this test in concerned, we can convert the SELECT INTO to a CTAS with distribution key to fulfill the intent of these tests that where brought in from 8.3 merge.


