### PR TITLE
Record external function names for useful debugging

### DIFF
--- a/src/backend/codegen/exec_eval_expr_codegen.cc
+++ b/src/backend/codegen/exec_eval_expr_codegen.cc
@@ -127,7 +127,8 @@ bool ExecEvalExprCodegen::GenerateExecEvalExpr(
   // we revert to use the external slot_getattr()
   if (nullptr == gen_info.llvm_slot_getattr_func) {
     gen_info.llvm_slot_getattr_func =
-        codegen_utils->GetOrRegisterExternalFunction(slot_getattr);
+        codegen_utils->GetOrRegisterExternalFunction(slot_getattr,
+                                                     "slot_getattr");
   }
 
   irb->SetInsertPoint(llvm_entry_block);

--- a/src/backend/codegen/exec_variable_list_codegen.cc
+++ b/src/backend/codegen/exec_variable_list_codegen.cc
@@ -247,7 +247,8 @@ bool ExecVariableListCodegen::GenerateExecVariableList(
       "Falling back to regular ExecVariableList");
 
   codegen_utils->CreateFallback<ExecVariableListFn>(
-      codegen_utils->GetOrRegisterExternalFunction(GetRegularFuncPointer()),
+      codegen_utils->GetOrRegisterExternalFunction(ExecVariableList,
+                                                   "ExecVariableList"),
       exec_variable_list_func);
 
   return true;

--- a/src/backend/codegen/include/codegen/utils/gp_codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/gp_codegen_utils.h
@@ -62,9 +62,9 @@ class GpCodegenUtils : public CodegenUtils {
     assert(NULL != llvm_fmt);
 
     llvm::Function* llvm_elog_start =
-        GetOrRegisterExternalFunction(elog_start);
+        GetOrRegisterExternalFunction(elog_start, "elog_start");
     llvm::Function* llvm_elog_finish =
-        GetOrRegisterExternalFunction(elog_finish);
+        GetOrRegisterExternalFunction(elog_finish, "elog_finish");
 
     ir_builder()->CreateCall(
         llvm_elog_start, {

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -117,9 +117,10 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
 
   // External functions
   llvm::Function* llvm_memset =
-      codegen_utils->GetOrRegisterExternalFunction(memset);
+      codegen_utils->GetOrRegisterExternalFunction(memset, "memset");
   llvm::Function* llvm_slot_deform_tuple =
-      codegen_utils->GetOrRegisterExternalFunction(slot_deform_tuple);
+      codegen_utils->GetOrRegisterExternalFunction(slot_deform_tuple,
+                                                   "slot_deform_tuple");
 
   // Generation-time constants
   llvm::Value* llvm_slot = codegen_utils->GetConstant(slot);
@@ -579,7 +580,8 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
       llvm_error);
 
   codegen_utils->CreateFallback<SlotGetAttrFn>(
-      codegen_utils->GetOrRegisterExternalFunction(slot_getattr),
+      codegen_utils->GetOrRegisterExternalFunction(slot_getattr,
+                                                   "slot_getattr"),
       slot_getattr_func);
   return true;
 }


### PR DESCRIPTION
This way, the external function names will be sensible names in modules dumps, instead of the automatically generated strings.

@karthijrk @foyzur Please have a look.