### PR TITLE
Add -E flag to gpcheckcat to perform missing/extraneous repair

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -112,6 +112,8 @@ class Global():
         self.opt['-C'] = None
         self.opt['-l'] = False
 
+        self.opt['-E'] = False
+
         self.cfg = None
         self.dbname = None
         self.firstdb = None
@@ -212,7 +214,7 @@ def getalldbs():
 ###############################
 def parseCommandLine():
     try:
-        (options, args) = getopt.getopt(sys.argv[1:], '?p:P:U:B:vg:t:AOS:R:C:l')
+        (options, args) = getopt.getopt(sys.argv[1:], '?p:P:U:B:vg:t:AOS:R:C:lE')
     except Exception, e:
         usage('Error: ' + str(e))
 
@@ -221,7 +223,7 @@ def parseCommandLine():
             usage(0)
         elif switch[1] in 'pBPUgSRC':
             GV.opt[switch] = val
-        elif switch[1] in 'vtAOl':
+        elif switch[1] in 'vtAOlE':
             GV.opt[switch] = True
 
     def setdef(x, v):
@@ -3722,6 +3724,9 @@ def do_repair(sql_repair_contents, issue_type, description):
 
 def do_repair_for_extra(catalog_issues):
     if len(catalog_issues) == 0:
+        return
+    if not GV.opt['-E']:
+        setError(ERROR_NOREPAIR)
         return
 
     setError(ERROR_REMOVE)

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -214,6 +214,7 @@ def getalldbs():
 ###############################
 def parseCommandLine():
     try:
+        # A colon following the flag indicates an argument is expected
         (options, args) = getopt.getopt(sys.argv[1:], '?p:P:U:B:vg:t:AOS:R:C:lE')
     except Exception, e:
         usage('Error: ' + str(e))

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
@@ -232,9 +232,12 @@ Feature: gpcheckcat tests
         Then The user runs sql "set allow_system_table_mods=DML;delete from pg_class where relname='foo'" in "extra_db" on first primary segment
         And the user runs "psql extra_db -c "drop table if exists foo""
         Then the user runs "gpcheckcat -R missing_extraneous extra_db"
+        Then gpcheckcat should return a return code of 3
+        Then the path "gpcheckcat.repair.*" is found in cwd "0" times
+        Then the user runs "gpcheckcat -R missing_extraneous -E extra_db"
         Then gpcheckcat should return a return code of 1
         Then validate and run gpcheckcat repair
-        When the user runs "gpcheckcat -R missing_extraneous extra_db"
+        When the user runs "gpcheckcat -R missing_extraneous -E extra_db"
         Then gpcheckcat should return a return code of 0
         Then the path "gpcheckcat.repair.*" is found in cwd "0" times
         And the user runs "dropdb extra_db"
@@ -256,26 +259,26 @@ Feature: gpcheckcat tests
         And the path "gpcheckcat.repair.*" is removed from current working directory
 
     @extra_gr
-    Scenario: gpcheckcat should genreate repair scripts when both -g and -R options are provided
+    Scenario: gpcheckcat should generate repair scripts when -g, -R, and -E options are provided
         Given database "extra_gr_db" is dropped and recreated
         And the path "repair_dir" is removed from current working directory
         And the user runs "psql extra_gr_db -c "CREATE TABLE foo(i int)""
         Then The user runs sql "set allow_system_table_mods=DML;delete from pg_class where relname='foo'" in "extra_gr_db" on first primary segment
         And the user runs "psql extra_gr_db -c "drop table if exists foo""
-        Then the user runs "gpcheckcat -R missing_extraneous -g repair_dir extra_gr_db"
+        Then the user runs "gpcheckcat -R missing_extraneous -E -g repair_dir extra_gr_db"
         Then gpcheckcat should return a return code of 1
         Then gpcheckcat should print repair script\(s\) generated in dir repair_dir to stdout
         Then the path "repair_dir" is found in cwd "1" times
         Then run all the repair scripts in the dir "repair_dir"
         And the path "repair_dir" is removed from current working directory
-        When the user runs "gpcheckcat -R missing_extraneous -g repair_dir extra_gr_db"
+        When the user runs "gpcheckcat -R missing_extraneous -E -g repair_dir extra_gr_db"
         Then gpcheckcat should return a return code of 0
         Then the path "repair_dir" is found in cwd "0" times
         And the user runs "dropdb extra_gr_db"
         And the path "repair_dir" is removed from current working directory
 
     @constraint_g
-    Scenario: gpcheckcat should genreate repair scripts when only -g option is provided
+    Scenario: gpcheckcat should generate repair scripts when only -g option is provided
         Given database "constraint_g_db" is dropped and recreated
         And the user runs "psql constraint_g_db -f gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_invalid_constraint.sql"
         Then psql should return a return code of 0

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -32,6 +32,7 @@ class GpCheckCatTestCase(GpTestCase):
                                1:dict(hostname='host1', port=123, id=1, address='123', datadir='dir', content=1, dbid=1)}
         self.subject.GV.checkStatus = True
         self.subject.setError = Mock()
+        self.subject.print_repair_issues = Mock()
 
         self.apply_patches([
             patch("gpcheckcat.pg.connect", return_value=self.db_connection),
@@ -149,6 +150,24 @@ class GpCheckCatTestCase(GpTestCase):
         self.assertEquals(last_call, "Truncated batch size to number of primaries: 50")
 
 
+    def test_do_repair_for_extra__no_issues(self):
+        issues = {}
+        self.subject.do_repair_for_extra(issues)
+        self.subject.setError.assert_not_called()
+
+    def test_do_repair_for_extra__issues_no_repair(self):
+        issues = {"a":1}
+        self.subject.do_repair_for_extra(issues)
+        self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
+
+    @patch('gpcheckcat_modules.repair.Repair', return_value=Mock())
+    @patch('gpcheckcat_modules.repair.Repair.create_repair_for_extra_missing', return_value="/tmp")
+    def test_do_repair_for_extra__issues_repair(self, mock1, mock2):
+        issues = {("pg_class", "oid"):"extra"}
+        self.subject.GV.opt['-E'] = True
+        self.subject.do_repair_for_extra(issues)
+        self.subject.setError.assert_any_call(self.subject.ERROR_REMOVE)
+        self.subject.print_repair_issues.assert_any_call("/tmp")
 
     ####################### PRIVATE METHODS #######################
     def _run_batch_size_experiment(self, num_primaries):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -156,7 +156,7 @@ class GpCheckCatTestCase(GpTestCase):
         self.subject.setError.assert_not_called()
 
     def test_do_repair_for_extra__issues_no_repair(self):
-        issues = {"a":1}
+        issues = {("pg_class", "oid"):"extra"}
         self.subject.do_repair_for_extra(issues)
         self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair_missing_extraneous.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair_missing_extraneous.py
@@ -27,7 +27,7 @@ class RepairMissingExtraneousTestCase(GpTestCase):
         self.assertEqual(repair_sql_contents[2], set([49401, 49403, 49404, 49405]))
         self.assertEqual(repair_sql_contents[3], set([49403, 49404, 49405, 49406]))
 
-    def test_get_segment_to_oid_mappin_with_only_extra(self):
+    def test_get_segment_to_oid_mapping_with_only_extra(self):
         issues = [(49401, 'cmax', "extra", '{1,2}'),
                   (49401, 'cmax', "extra", '{1,2}'),
                   (49403, 'cmax', "extra", '{2,3}'),
@@ -41,7 +41,7 @@ class RepairMissingExtraneousTestCase(GpTestCase):
         self.assertEqual(repair_sql_contents[2], set([49401, 49403, 49405]))
         self.assertEqual(repair_sql_contents[3], set([49403, 49405]))
 
-    def test_get_segment_to_oid_mappin_with_only_missing(self):
+    def test_get_segment_to_oid_mapping_with_only_missing(self):
         issues = [(49401, 'cmax', "missing", '{1,2}'),
                   (49401, 'cmax', "missing", '{1,2}'),
                   (49403, 'cmax', "missing", '{2,3}'),
@@ -56,14 +56,14 @@ class RepairMissingExtraneousTestCase(GpTestCase):
         self.assertEqual(repair_sql_contents[1], set([49403, 49405]))
         self.assertEqual(repair_sql_contents[3], set([49401]))
 
-    def test_get_delelte_sql__with_multiple_oids(self):
+    def test_get_delete_sql__with_multiple_oids(self):
         self.subject = RepairMissingExtraneous(self.table_name, None, "attrelid")
         oids = [1,3,4]
         delete_sql = self.subject.get_delete_sql(oids)
         self.assertEqual(delete_sql, 'BEGIN;set allow_system_table_mods="dml";'
                                       'delete from "pg_attribut""e" where "attrelid" in (1,3,4);COMMIT;')
 
-    def test_get_delelte_sql__with_one_oid(self):
+    def test_get_delete_sql__with_one_oid(self):
         self.subject = RepairMissingExtraneous(self.table_name, None, "attrelid")
         oids = [5]
         delete_sql = self.subject.get_delete_sql(oids)


### PR DESCRIPTION
The missing and extraneous repair in gpcheckcat will not generate a repair file unless the -E flag
is provided, as this repair does not cover all cases. Behave and unit tests are also added.

Authors: Chris Hajas and Karen Huddleston