### PR TITLE
Add ORCA optimizer GUC optimizer_parallel_union for parallel append

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -347,8 +347,14 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elem[] =
 		&optimizer_prefer_scalar_dqa_multistage_agg,
 		false, // m_fNegate
 		GPOS_WSZ_LIT("Prefer multistage aggregates for scalar distinct qualified aggregate in the optimizer.")
-		}
+		},
 
+		{
+		EopttraceEnableParallelAppend,
+		&optimizer_parallel_union,
+		false, // m_fNegate
+		GPOS_WSZ_LIT("Enable parallel execution for UNION/UNION ALL queries.")
+		}
 };
 
 //---------------------------------------------------------------------------

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -561,6 +561,7 @@ bool		optimizer_multilevel_partitioning;
 bool		optimizer_enable_derive_stats_all_groups;
 bool		optimizer_explain_show_status;
 bool		optimizer_prefer_scalar_dqa_multistage_agg;
+bool 		optimizer_parallel_union;
 
 /**
  * GUCs related to code generation.
@@ -3337,6 +3338,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_prefer_scalar_dqa_multistage_agg,
 		true, NULL, NULL
+	},
+
+	{
+		{"optimizer_parallel_union", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable parallel execution for UNION/UNION ALL queries."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_parallel_union,
+		false, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -459,6 +459,7 @@ extern bool optimizer_multilevel_partitioning;
 extern bool optimizer_enable_derive_stats_all_groups;
 extern bool optimizer_explain_show_status;
 extern bool optimizer_prefer_scalar_dqa_multistage_agg;
+extern bool optimizer_parallel_union;
 
 /**
  * GUCs related to code generation.


### PR DESCRIPTION
This GUC is disabled by default. Currently, when users run UNION query,
such as SELECT a FROM foo UNION ALL SELECT b FROM bar, GPDB will
parallelize the execution across all the segments, but for every single
the table scan on foo and bar are not executed parallel. With this GUC
enabled, we add redistribution motion node under APPEND(UNION) operator,
which can make all the children of APPEND(UNION) operator being executed
parallel in every single segment.