### PR TITLE
Support virtual tuples and memtuples in SlotGetAttr

### DIFF
--- a/src/backend/codegen/codegen_manager.cc
+++ b/src/backend/codegen/codegen_manager.cc
@@ -40,6 +40,13 @@ bool CodegenManager::EnrollCodeGenerator(
 }
 
 unsigned int CodegenManager::GenerateCode() {
+  // First, allow all code generators to initialize their dependencies
+  for (size_t i = 0; i < enrolled_code_generators_.size(); ++i) {
+    // NB: This list is still volatile at this time, as more generators may be
+    // enrolled as we iterate to initialize dependencies.
+    enrolled_code_generators_[i]->InitDependencies();
+  }
+  // Then ask them to generate code
   unsigned int success_count = 0;
   for (std::unique_ptr<CodegenInterface>& generator :
       enrolled_code_generators_) {

--- a/src/backend/codegen/codegen_wrapper.cc
+++ b/src/backend/codegen/codegen_wrapper.cc
@@ -130,7 +130,7 @@ ClassType* CodegenEnroll(FuncType regular_func_ptr,
     }
 
   ClassType* generator = new ClassType(
-      regular_func_ptr, ptr_to_chosen_func_ptr, std::forward<Args>(args)...);
+      manager, regular_func_ptr, ptr_to_chosen_func_ptr, std::forward<Args>(args)...);
     bool is_enrolled = manager->EnrollCodeGenerator(
         CodegenFuncLifespan_Parameter_Invariant, generator);
     assert(is_enrolled);

--- a/src/backend/codegen/exec_eval_expr_codegen.cc
+++ b/src/backend/codegen/exec_eval_expr_codegen.cc
@@ -48,18 +48,19 @@ using gpcodegen::SlotGetAttrCodegen;
 
 constexpr char ExecEvalExprCodegen::kExecEvalExprPrefix[];
 
-ExecEvalExprCodegen::ExecEvalExprCodegen
-(
+ExecEvalExprCodegen::ExecEvalExprCodegen(
+    CodegenManager* manager,
     ExecEvalExprFn regular_func_ptr,
     ExecEvalExprFn* ptr_to_regular_func_ptr,
     ExprState *exprstate,
     ExprContext *econtext,
-    PlanState* plan_state) :
-    BaseCodegen(kExecEvalExprPrefix,
-                regular_func_ptr, ptr_to_regular_func_ptr),
-                exprstate_(exprstate),
-                econtext_(econtext),
-                plan_state_(plan_state) {
+    PlanState* plan_state)
+    : BaseCodegen(manager,
+                  kExecEvalExprPrefix,
+                  regular_func_ptr, ptr_to_regular_func_ptr),
+      exprstate_(exprstate),
+      econtext_(econtext),
+      plan_state_(plan_state) {
 }
 
 void ExecEvalExprCodegen::PrepareSlotGetAttr(

--- a/src/backend/codegen/exec_variable_list_codegen.cc
+++ b/src/backend/codegen/exec_variable_list_codegen.cc
@@ -51,17 +51,18 @@ using gpcodegen::SlotGetAttrCodegen;
 
 constexpr char ExecVariableListCodegen::kExecVariableListPrefix[];
 
-ExecVariableListCodegen::ExecVariableListCodegen
-(
+ExecVariableListCodegen::ExecVariableListCodegen(
+    CodegenManager* manager,
     ExecVariableListFn regular_func_ptr,
     ExecVariableListFn* ptr_to_regular_func_ptr,
     ProjectionInfo* proj_info,
-    TupleTableSlot* slot) :
-    BaseCodegen(kExecVariableListPrefix,
-        regular_func_ptr,
-        ptr_to_regular_func_ptr),
-    proj_info_(proj_info),
-    slot_(slot) {
+    TupleTableSlot* slot)
+    : BaseCodegen(manager,
+                  kExecVariableListPrefix,
+                  regular_func_ptr,
+                  ptr_to_regular_func_ptr),
+      proj_info_(proj_info),
+      slot_(slot) {
 }
 
 

--- a/src/backend/codegen/include/codegen/base_codegen.h
+++ b/src/backend/codegen/include/codegen/base_codegen.h
@@ -51,6 +51,10 @@ class BaseCodegen: public CodegenInterface {
     SetToRegular(regular_func_ptr_, ptr_to_chosen_func_ptr_);
   }
 
+  bool InitDependencies() override {
+    return true;
+  }
+
   bool GenerateCode(gpcodegen::GpCodegenUtils* codegen_utils) final {
     bool valid_generated_functions = true;
     valid_generated_functions &= GenerateCodeInternal(codegen_utils);
@@ -128,10 +132,6 @@ class BaseCodegen: public CodegenInterface {
     return regular_func_ptr_;
   }
 
-  gpcodegen::CodegenManager* manager() const {
-    return manager;
-  }
-
   /**
    * @brief Sets up the caller to use the corresponding regular version of the
    *        target function.
@@ -166,14 +166,18 @@ class BaseCodegen: public CodegenInterface {
                        const std::string& orig_func_name,
                        FuncPtrType regular_func_ptr,
                        FuncPtrType* ptr_to_chosen_func_ptr)
-  : orig_func_name_(orig_func_name),
+  : manager_(manager),
+    orig_func_name_(orig_func_name),
     unique_func_name_(CodegenInterface::GenerateUniqueName(orig_func_name)),
     regular_func_ptr_(regular_func_ptr),
     ptr_to_chosen_func_ptr_(ptr_to_chosen_func_ptr),
-    is_generated_(false),
-    manager_(manager) {
+    is_generated_(false) {
     // Initialize the caller to use regular version of target function.
     SetToRegular(regular_func_ptr, ptr_to_chosen_func_ptr);
+  }
+
+  gpcodegen::CodegenManager* manager() const {
+    return manager_;
   }
 
   /**
@@ -217,12 +221,12 @@ class BaseCodegen: public CodegenInterface {
   }
 
  private:
+  gpcodegen::CodegenManager* manager_;
   std::string orig_func_name_;
   std::string unique_func_name_;
   FuncPtrType regular_func_ptr_;
   FuncPtrType* ptr_to_chosen_func_ptr_;
   bool is_generated_;
-  gpcodegen::CodegenManager* manager_;
   // To track uncompiled llvm functions it creates and erase from
   // llvm module on failed generations.
   std::vector<llvm::Function*> uncompiled_generated_functions_;

--- a/src/backend/codegen/include/codegen/base_codegen.h
+++ b/src/backend/codegen/include/codegen/base_codegen.h
@@ -19,6 +19,7 @@ extern "C" {
 #include <string>
 #include <vector>
 #include "codegen/utils/gp_codegen_utils.h"
+#include "codegen/codegen_manager.h"
 #include "codegen/codegen_interface.h"
 
 #include "llvm/IR/Function.h"
@@ -127,6 +128,10 @@ class BaseCodegen: public CodegenInterface {
     return regular_func_ptr_;
   }
 
+  gpcodegen::CodegenManager* manager() const {
+    return manager;
+  }
+
   /**
    * @brief Sets up the caller to use the corresponding regular version of the
    *        target function.
@@ -148,6 +153,7 @@ class BaseCodegen: public CodegenInterface {
   /**
    * @brief Constructor
    *
+   * @param manager                The manager in which this is enrolled.
    * @param orig_func_name         Original function name.
    * @param regular_func_ptr       Regular version of the target function.
    * @param ptr_to_chosen_func_ptr Reference to the function pointer that the caller will call.
@@ -156,14 +162,16 @@ class BaseCodegen: public CodegenInterface {
    * 			corresponding regular version.
    *
    **/
-  explicit BaseCodegen(const std::string& orig_func_name,
+  explicit BaseCodegen(gpcodegen::CodegenManager* manager,
+                       const std::string& orig_func_name,
                        FuncPtrType regular_func_ptr,
                        FuncPtrType* ptr_to_chosen_func_ptr)
   : orig_func_name_(orig_func_name),
     unique_func_name_(CodegenInterface::GenerateUniqueName(orig_func_name)),
     regular_func_ptr_(regular_func_ptr),
     ptr_to_chosen_func_ptr_(ptr_to_chosen_func_ptr),
-    is_generated_(false) {
+    is_generated_(false),
+    manager_(manager) {
     // Initialize the caller to use regular version of target function.
     SetToRegular(regular_func_ptr, ptr_to_chosen_func_ptr);
   }
@@ -214,6 +222,7 @@ class BaseCodegen: public CodegenInterface {
   FuncPtrType regular_func_ptr_;
   FuncPtrType* ptr_to_chosen_func_ptr_;
   bool is_generated_;
+  gpcodegen::CodegenManager* manager_;
   // To track uncompiled llvm functions it creates and erase from
   // llvm module on failed generations.
   std::vector<llvm::Function*> uncompiled_generated_functions_;

--- a/src/backend/codegen/include/codegen/codegen_interface.h
+++ b/src/backend/codegen/include/codegen/codegen_interface.h
@@ -15,7 +15,6 @@
 #include <string>
 #include <vector>
 
-
 namespace gpcodegen {
 
 /** \addtogroup gpcodegen
@@ -31,6 +30,13 @@ class GpCodegenUtils;
 class CodegenInterface {
  public:
   virtual ~CodegenInterface() = default;
+
+  /**
+   * @brief Hook to request for and initialize any dependencies
+   *
+   * @return true on success
+   */
+  virtual bool InitDependencies() = 0;
 
   /**
    * @brief Generates specialized code at run time.

--- a/src/backend/codegen/include/codegen/exec_eval_expr_codegen.h
+++ b/src/backend/codegen/include/codegen/exec_eval_expr_codegen.h
@@ -13,9 +13,10 @@
 #ifndef GPCODEGEN_EXECEVALEXPR_CODEGEN_H_  // NOLINT(build/header_guard)
 #define GPCODEGEN_EXECEVALEXPR_CODEGEN_H_
 
-#include "codegen/codegen_wrapper.h"
 #include "codegen/base_codegen.h"
+#include "codegen/codegen_wrapper.h"
 #include "codegen/expr_tree_generator.h"
+#include "codegen/slot_getattr_codegen.h"
 
 namespace gpcodegen {
 
@@ -48,6 +49,8 @@ class ExecEvalExprCodegen: public BaseCodegen<ExecEvalExprFn> {
 
   virtual ~ExecEvalExprCodegen() = default;
 
+  bool InitDependencies() override;
+
  protected:
   /**
    * @brief Generate code for expression evaluation.
@@ -71,8 +74,11 @@ class ExecEvalExprCodegen: public BaseCodegen<ExecEvalExprFn> {
 
  private:
   ExprState *exprstate_;
-  ExprContext *econtext_;
   PlanState* plan_state_;
+
+  ExprTreeGeneratorInfo gen_info_;
+  SlotGetAttrCodegen* slot_getattr_codegen_;
+  std::unique_ptr<ExprTreeGenerator> expr_tree_generator_;
 
   static constexpr char kExecEvalExprPrefix[] = "ExecEvalExpr";
 
@@ -88,8 +94,7 @@ class ExecEvalExprCodegen: public BaseCodegen<ExecEvalExprFn> {
    * @brief Prepare generation of dependent slot_getattr() if necessary
    * @return true on successful generation.
    **/
-  void PrepareSlotGetAttr(gpcodegen::GpCodegenUtils* codegen_utils,
-                          ExprTreeGeneratorInfo* gen_info);
+  void PrepareSlotGetAttr();
 };
 
 /** @} */

--- a/src/backend/codegen/include/codegen/exec_eval_expr_codegen.h
+++ b/src/backend/codegen/include/codegen/exec_eval_expr_codegen.h
@@ -39,7 +39,8 @@ class ExecEvalExprCodegen: public BaseCodegen<ExecEvalExprFn> {
    *        function or the corresponding regular version.
    *
    **/
-  explicit ExecEvalExprCodegen(ExecEvalExprFn regular_func_ptr,
+  explicit ExecEvalExprCodegen(CodegenManager* manager,
+                               ExecEvalExprFn regular_func_ptr,
                                ExecEvalExprFn* ptr_to_regular_func_ptr,
                                ExprState *exprstate,
                                ExprContext *econtext,

--- a/src/backend/codegen/include/codegen/exec_variable_list_codegen.h
+++ b/src/backend/codegen/include/codegen/exec_variable_list_codegen.h
@@ -35,7 +35,8 @@ class ExecVariableListCodegen: public BaseCodegen<ExecVariableListFn> {
    * 			corresponding regular version.
    *
    **/
-  explicit ExecVariableListCodegen(ExecVariableListFn regular_func_ptr,
+  explicit ExecVariableListCodegen(CodegenManager* manager,
+                                   ExecVariableListFn regular_func_ptr,
                                    ExecVariableListFn* ptr_to_regular_func_ptr,
                                    ProjectionInfo* proj_info,
                                    TupleTableSlot* slot);

--- a/src/backend/codegen/include/codegen/exec_variable_list_codegen.h
+++ b/src/backend/codegen/include/codegen/exec_variable_list_codegen.h
@@ -14,6 +14,7 @@
 #define GPCODEGEN_EXECVARIABLELIST_CODEGEN_H_
 
 #include "codegen/codegen_wrapper.h"
+#include "codegen/slot_getattr_codegen.h"
 #include "codegen/base_codegen.h"
 
 namespace gpcodegen {
@@ -42,6 +43,8 @@ class ExecVariableListCodegen: public BaseCodegen<ExecVariableListFn> {
                                    TupleTableSlot* slot);
 
   virtual ~ExecVariableListCodegen() = default;
+
+  bool InitDependencies() override;
 
  protected:
   /**
@@ -82,6 +85,9 @@ class ExecVariableListCodegen: public BaseCodegen<ExecVariableListFn> {
  private:
   ProjectionInfo* proj_info_;
   TupleTableSlot* slot_;
+
+  int max_attr_;
+  SlotGetAttrCodegen* slot_getattr_codegen_;
 
 
   static constexpr char kExecVariableListPrefix[] = "ExecVariableList";

--- a/src/backend/codegen/include/codegen/slot_getattr_codegen.h
+++ b/src/backend/codegen/include/codegen/slot_getattr_codegen.h
@@ -14,9 +14,20 @@
 #define GPCODEGEN_SLOT_GETATTR_CODEGEN_H_
 
 #include <string>
+#include <utility>
 
 #include "codegen/codegen_wrapper.h"
+#include "codegen/base_codegen.h"
 #include "codegen/utils/gp_codegen_utils.h"
+
+extern "C" {
+#include "postgres.h"  // NOLINT(build/include)
+#include "utils/elog.h"
+#include "access/htup.h"
+#include "nodes/execnodes.h"
+#include "executor/tuptable.h"
+
+}
 
 namespace gpcodegen {
 
@@ -24,63 +35,139 @@ namespace gpcodegen {
  *  @{
  */
 
-class SlotGetAttrCodegen {
+class SlotGetAttrCodegen : public BaseCodegen<SlotGetAttrFn> {
+ public:
+  /**
+   * @brief Request code generation for the codepath slot_getattr >
+   * _slot_getsomeattr > slot_deform_tuple for the given slot and max_attr
+   *
+   * @param codegen_utils Utilities for easy code generation
+   * @param slot          Use the TupleDesc from this slot to generate
+   * @param max_attr      Generate slot deformation up to this many attributes
+   * @param out_func      Return the llvm::Function that will be generated
+   *
+   * @note This method does not actually do any code generation, but simply
+   * caches the information necessary for code generation when
+   * GenerateSlotGetAttr() is called. This way we can de-duplicate multiple
+   * requests for multiple slot_getattr() implementation producing only one per
+   * slot.
+   *
+   **/
+  static SlotGetAttrCodegen* GetCodegenInstance(
+      gpcodegen::CodegenManager* manager,
+      TupleTableSlot* slot,
+      int max_attr);
+
+  virtual ~SlotGetAttrCodegen();
+
   /**
    * @brief Generate code for the codepath slot_getattr > _slot_getsomeattr >
-   * slot_deform_tuple
+   * slot_deform_tuple for the given slot and max_attr
    *
-   * @param codegen_utils
-   * @param function_name Name of the generated function
-   * @param slot Use the TupleDesc for this slot to generate
-   * @param max_attr Generate slot deformation upto this many attributes
-   * @param out_func Return the generated llvm::Function
+   * @param codegen_utils Utilities for easy code generation
+   *
+   * Based on parameters given to SlotGetAttr::GetCodegenInstance(), the maximum
+   * max_attr is tracked for each slot. Then for each slot, we generate code for
+   * slot_getattr() that deforms tuples in that slot up to the maximum max_attr.
    *
    * @note This is a wrapper around GenerateSlotGetAttrInternal that handles the
    * case when generation fails, and cleans up a possible broken function by
    * removing it from the module.
-   **/
- public:
-  static bool GenerateSlotGetAttr(
-      gpcodegen::GpCodegenUtils* codegen_utils,
-      const std::string& function_name,
-      TupleTableSlot* slot,
-      int max_attr,
-      llvm::Function** out_func);
+   *
+   * TODO(shardikar, krajaraman) Remove this wrapper after a shared code
+   * generation framework implementation is complete.
+   */
+  bool GenerateCodeInternal(gpcodegen::GpCodegenUtils* codegen_utils) override;
+
+  /*
+   * @return A pointer to the yet un-compiled llvm::Function that will be
+   * generated and populate by this module
+   *
+   * @note This is initialized as NULL when on creation. Only if after code
+   * generation is performed by calling SlotGetAttrCodegen::GenerateCode and is
+   * successful, can this be assumed return a valid llvm::Function*
+   */
+  llvm::Function* GetGeneratedFunction() {
+    return llvm_function_;
+  }
 
  private:
+  /**
+   * @brief Constructor for SlotGetAttrCodegen
+   *
+   * @note The call to the constructor of BaseCodegen passes in a pointer to a
+   * dummy SlotGetAttrFn stored in this class. Thus SlotGetAttrCodegen can
+   * inherit all the functionality of BaseCodegen, including the pointer
+   * swapping logic, with low risk. However the pointer swapping will be of no
+   * consequence.
+   */
+  SlotGetAttrCodegen(gpcodegen::CodegenManager* manager,
+                     TupleTableSlot* slot,
+                     int max_attr)
+  : BaseCodegen(manager, kSlotGetAttrPrefix, slot_getattr, &dummy_func_),
+    slot_(slot),
+    max_attr_(max_attr),
+    llvm_function_(nullptr) {
+  }
+
   /**
    * @brief Generate code for the codepath slot_getattr > _slot_getsomeattr >
    * slot_deform_tuple
    *
-   * @param codegen_utils
-   * @param function_name Name of the generated function
-   * @param slot Use the TupleDesc for this slot to generate
-   * @param max_attr Generate slot deformation upto this many attributes
-   * @param out_func Return the generated llvm::Function
+   * @param codegen_utils Utilities for easy code generation
+   * @param slot          Use the TupleDesc from this slot to generate
+   * @param max_attr      Generate slot deformation up to this many attributes
+   * @param out_func      Return the llvm::Function that will be generated
    *
    * @return true on success generation; false otherwise
    *
    * @note Generate code for code path slot_getattr > * _slot_getsomeattrs >
    * slot_deform_tuple. slot_getattr() will eventually call slot_deform_tuple
    * (through _slot_getsomeattrs), which fetches all yet unread attributes of
-   * the slot until the given attribute. Moreover, instead of looping over the
-   * target list one at a time, this approach uses slot_getattr only once, with
-   * the largest attribute index from the target list.
-   *
+   * the slot until the given attribute.
    *
    * This implementation does not support:
-   *  (1) Variable length attributes
-   *  (2) Attributes passed by reference
+   *  (1) Attributes passed by reference
    *
    * If at execution time, we see any of the above types of attributes,
    * we fall backs to the regular function.
    **/
-  static bool GenerateSlotGetAttrInternal(
+  bool GenerateSlotGetAttr(
       gpcodegen::GpCodegenUtils* codegen_utils,
-      const std::string& function_name,
       TupleTableSlot* slot,
       int max_attr,
-      llvm::Function** out_func);
+      llvm::Function* out_func);
+
+  /**
+   * @brief Removes the entry of this SlotGetAttrCodegen from the static cache.
+   */
+  void RemoveSelfFromCache();
+
+  TupleTableSlot* slot_;
+  // Max attribute to deform to
+  int max_attr_;
+  // Primary function to be generated and populated
+  llvm::Function* llvm_function_;
+  // A dummy function pointer that can be swapped by the BaseCodegen implementation
+  SlotGetAttrFn dummy_func_;
+
+  static constexpr char kSlotGetAttrPrefix[] = "slot_getattr";
+  /**
+   * Utility map indexed by CodegenManager pointer to track all instances of
+   * SlotGetAttrCodegen created by SlotGetAttrCodegen::GetCodegenInstance.
+   * Each entry of the utility map contains another map keyed on the de-duplication key
+   * used by SlotGetAttrCodegen::GetCodegenInstance i.e slot.
+   *
+   * Entries are inserted into this map on creation of SlotGetAttrCodegen objects, and
+   * removed on destruction. When an inner-map for some manager becomes empty
+   * (when the manager itself is destroyed), the entry for that manager is
+   * erased from the outer-map as well
+   *
+   * Map of the form: { manager -> { slot -> slot_getattr_codegen } }
+   */
+  typedef std::unordered_map<TupleTableSlot*, SlotGetAttrCodegen*> SlotGetAttrCodegenCache;
+  static std::unordered_map<gpcodegen::CodegenManager*, SlotGetAttrCodegenCache> codegen_cache_by_manager;
+
 };
 
 /** @} */

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -48,49 +48,100 @@ class Value;
 
 using gpcodegen::SlotGetAttrCodegen;
 
+constexpr char SlotGetAttrCodegen::kSlotGetAttrPrefix[];
+
 // TODO(shardikar): Retire this GUC after performing experiments to find the
 // tradeoff of codegen-ing slot_getattr() (potentially by measuring the
 // difference in the number of instructions) when one of the first few
 // attributes is varlen.
 extern const int codegen_varlen_tolerance;
 
-// TODO(shardikar, krajaraman) Remove this wrapper after implementing an
-// interface to share code generation logic.
-bool SlotGetAttrCodegen::GenerateSlotGetAttr(
-    gpcodegen::GpCodegenUtils* codegen_utils,
-    const std::string& function_name,
+std::unordered_map<gpcodegen::CodegenManager*,
+    SlotGetAttrCodegen::SlotGetAttrCodegenCache> SlotGetAttrCodegen::codegen_cache_by_manager;
+
+SlotGetAttrCodegen* SlotGetAttrCodegen::GetCodegenInstance(
+    gpcodegen::CodegenManager* manager,
     TupleTableSlot *slot,
-    int max_attr,
-    llvm::Function** out_func) {
+    int max_attr) {
 
-  *out_func = nullptr;
+  // Create an cache entry for this manager if it doesn't already exist
+  auto it = codegen_cache_by_manager[manager].find(slot);
 
-  bool ret = GenerateSlotGetAttrInternal(
-      codegen_utils, function_name, slot, max_attr, out_func);
-
-  assert(nullptr != *out_func);
-
-  if (!ret ||
-      (codegen_validate_functions && llvm::verifyFunction(**out_func))) {
-    (*out_func)->eraseFromParent();
-    *out_func = nullptr;
-    return false;
+  SlotGetAttrCodegen* generator = nullptr;
+  if (it != codegen_cache_by_manager[manager].end()) {
+    // For a slot already seen before, update max_attr value only
+    generator = it->second;
+    generator->max_attr_ = std::max(generator->max_attr_, max_attr);
+  } else {
+    // For a slot we haven't see before, create and add a new object
+    generator = new SlotGetAttrCodegen(manager, slot, max_attr);
+    codegen_cache_by_manager[manager].insert(std::make_pair(slot, generator));
+    // Enroll this in the manager so that it can take ownership
+    manager->EnrollCodeGenerator(CodegenFuncLifespan_Parameter_Invariant,
+                                 generator);
   }
 
-  return ret;
+  assert(nullptr != generator);
+  return generator;
 }
 
-bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
+void SlotGetAttrCodegen::RemoveSelfFromCache() {
+  CodegenManager* manager = this->manager();
+
+  assert(manager != nullptr && codegen_cache_by_manager.find(manager) != codegen_cache_by_manager.end());
+  std::unordered_map<TupleTableSlot*, SlotGetAttrCodegen*>& cache_map =
+      codegen_cache_by_manager[manager];
+  auto it = codegen_cache_by_manager[manager].find(slot_);
+
+  assert(it != cache_map.end() && it->second == this);
+  // Delete this SlotGetAttr from it's manager
+  cache_map.erase(it);
+
+  // Clean up manager data out of the map if this was the last instance
+  if (cache_map.empty()) {
+    codegen_cache_by_manager.erase(manager);
+  }
+}
+
+SlotGetAttrCodegen::~SlotGetAttrCodegen() {
+  RemoveSelfFromCache();
+}
+
+bool SlotGetAttrCodegen::GenerateCodeInternal(
+    gpcodegen::GpCodegenUtils* codegen_utils) {
+
+  // This function may be called multiple times, but it should generate code only once
+  if (IsGenerated()) {
+    return true;
+  }
+
+  // Give the function a human readable name
+  std::string function_name = GetUniqueFuncName() + "_" +
+      std::to_string(reinterpret_cast<uint64_t>(slot_)) + "_" +
+      std::to_string(max_attr_);
+  llvm::Function* function = CreateFunction<SlotGetAttrFn>(codegen_utils, function_name);
+
+  bool isGenerated = GenerateSlotGetAttr(codegen_utils, slot_, max_attr_, function);
+
+  if (isGenerated) {
+    elog(DEBUG1, "slot_getattr was generated successfully!");
+    assert(nullptr != function);
+    llvm_function_ = function;
+    return true;
+  } else {
+    elog(DEBUG1, "slot_getattr generation failed!");
+    llvm_function_ = nullptr;
+    return false;
+  }
+}
+
+bool SlotGetAttrCodegen::GenerateSlotGetAttr(
     gpcodegen::GpCodegenUtils* codegen_utils,
-    const std::string& function_name,
     TupleTableSlot *slot,
     int max_attr,
-    llvm::Function** out_func) {
+    llvm::Function* slot_getattr_func) {
 
   // So looks like we're going to generate code
-  *out_func = codegen_utils->CreateFunction<SlotGetAttrFn>(function_name);
-  llvm::Function* slot_getattr_func = *out_func;
-
   auto irb = codegen_utils->ir_builder();
 
   // BasicBlock of function entry.
@@ -99,9 +150,15 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
   // BasicBlock for checking correct slot
   llvm::BasicBlock* slot_check_block = codegen_utils->CreateBasicBlock(
       "slot_check", slot_getattr_func);
-  // BasicBlock for checking tuple type.
-  llvm::BasicBlock* tuple_type_check_block = codegen_utils->CreateBasicBlock(
-      "tuple_type_check", slot_getattr_func);
+  // BasicBlock for checking virtual tuple type.
+  llvm::BasicBlock* virtual_tuple_check_block = codegen_utils->CreateBasicBlock(
+      "virtual_tuple_check", slot_getattr_func);
+  // BasicBlock for checking memtuple type.
+  llvm::BasicBlock* memtuple_check_block = codegen_utils->CreateBasicBlock(
+      "memtuple_check", slot_getattr_func);
+  // BasicBlock for handling memtuple.
+  llvm::BasicBlock* memtuple_block = codegen_utils->CreateBasicBlock(
+      "memtuple", slot_getattr_func);
   // BasicBlock for heap tuple check.
   llvm::BasicBlock* heap_tuple_check_block = codegen_utils->CreateBasicBlock(
       "heap_tuple_check", slot_getattr_func);
@@ -111,6 +168,9 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
   // BasicBlock for final computations.
   llvm::BasicBlock* final_block = codegen_utils->CreateBasicBlock(
       "final", slot_getattr_func);
+  // BasicBlock for return
+  llvm::BasicBlock* return_block = codegen_utils->CreateBasicBlock(
+      "return", slot_getattr_func);
   // BasicBlock for fall back.
   llvm::BasicBlock* fallback_block = codegen_utils->CreateBasicBlock(
       "fallback", slot_getattr_func);
@@ -118,6 +178,9 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
   // External functions
   llvm::Function* llvm_memset =
       codegen_utils->GetOrRegisterExternalFunction(memset, "memset");
+  llvm::Function* llvm_memtuple_getattr =
+      codegen_utils->GetOrRegisterExternalFunction(memtuple_getattr,
+                                                   "memtuple_getattr");
   llvm::Function* llvm_slot_deform_tuple =
       codegen_utils->GetOrRegisterExternalFunction(slot_deform_tuple,
                                                    "slot_deform_tuple");
@@ -140,6 +203,20 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
       DEBUG1,
       "Codegen'ed slot_getattr called!");
 #endif
+  // Retrieve slot's PRIVATE variables
+  llvm::Value* llvm_slot_PRIVATE_tts_isnull /* bool* */ =
+      irb->CreateLoad(codegen_utils->GetPointerToMember(
+          llvm_slot, &TupleTableSlot::PRIVATE_tts_isnull));
+  llvm::Value* llvm_slot_PRIVATE_tts_values /* Datum* */ =
+      irb->CreateLoad(codegen_utils->GetPointerToMember(
+          llvm_slot, &TupleTableSlot::PRIVATE_tts_values));
+  llvm::Value* llvm_slot_PRIVATE_tts_nvalid_ptr /* int* */ =
+      codegen_utils->GetPointerToMember(
+          llvm_slot, &TupleTableSlot::PRIVATE_tts_nvalid);
+  llvm::Value* llvm_slot_tts_mt_bind /* MemTupleBinding* */ =
+      irb->CreateLoad(codegen_utils->GetPointerToMember(
+          llvm_slot, &TupleTableSlot::tts_mt_bind));
+
   // We start a sequence of checks to ensure that everything is fine and
   // we do not need to fall back.
   irb->CreateBr(slot_check_block);
@@ -152,39 +229,61 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
   // in as an argument to slot_getattr
   irb->CreateCondBr(
       irb->CreateICmpEQ(llvm_slot, llvm_slot_arg),
-      tuple_type_check_block /* true */,
+      virtual_tuple_check_block /* true */,
       fallback_block /* false */);
 
+  // Virtual tuple check block
+  // -------------------------
 
-  // Tuple type check block
-  // ----------------------
-  // We fall back if we see a virtual tuple or mem tuple,
-  // but it's possible to partially handle those cases also
-
-  irb->SetInsertPoint(tuple_type_check_block);
+  irb->SetInsertPoint(virtual_tuple_check_block);
+  // (slot->PRIVATE_tts_flags & TTS_VIRTUAL) != 0
   llvm::Value* llvm_slot_PRIVATE_tts_flags_ptr =
       codegen_utils->GetPointerToMember(
           llvm_slot, &TupleTableSlot::PRIVATE_tts_flags);
-  llvm::Value* llvm_slot_PRIVATE_tts_memtuple =
-      irb->CreateLoad(codegen_utils->GetPointerToMember(
-          llvm_slot, &TupleTableSlot::PRIVATE_tts_memtuple));
-
-  // (slot->PRIVATE_tts_flags & TTS_VIRTUAL) != 0
   llvm::Value* llvm_tuple_is_virtual = irb->CreateICmpNE(
       irb->CreateAnd(
           irb->CreateLoad(llvm_slot_PRIVATE_tts_flags_ptr),
           codegen_utils->GetConstant(TTS_VIRTUAL)),
           codegen_utils->GetConstant(0));
 
+  // If it is indeed a virtual tuple, we must have already deformed this tuple,
+  // so go straight to returning the contained values
+  irb->CreateCondBr(
+      llvm_tuple_is_virtual,
+      return_block /* true */,
+      memtuple_check_block /* false */);
+
+
+  // Memtuple type check block
+  // ----------------------
+
+  irb->SetInsertPoint(memtuple_check_block);
+
   // slot->PRIVATE_tts_memtuple != NULL
+  llvm::Value* llvm_slot_PRIVATE_tts_memtuple =
+      irb->CreateLoad(codegen_utils->GetPointerToMember(
+          llvm_slot, &TupleTableSlot::PRIVATE_tts_memtuple));
   llvm::Value* llvm_tuple_has_memtuple = irb->CreateICmpNE(
       llvm_slot_PRIVATE_tts_memtuple,
       codegen_utils->GetConstant((MemTuple) NULL));
 
-  // Fall back if tuple is virtual or memtuple is null
   irb->CreateCondBr(
-      irb->CreateOr(llvm_tuple_is_virtual, llvm_tuple_has_memtuple),
-      fallback_block /*true*/, heap_tuple_check_block /*false*/);
+      llvm_tuple_has_memtuple,
+      memtuple_block /*true*/, heap_tuple_check_block /*false*/);
+
+  // Memtuple Block
+  // --------------
+
+  irb->SetInsertPoint(memtuple_block);
+  // return memtuple_getattr(slot->PRIVATE_tts_memtuple,
+  //    slot->tts_mt_bind, attnum, isnull);
+  llvm::Value* llvm_memtuple_ret = irb->CreateCall(llvm_memtuple_getattr, {
+      llvm_slot_PRIVATE_tts_memtuple,
+      llvm_slot_tts_mt_bind,
+      llvm_attnum_arg,
+      llvm_isnull_ptr_arg});
+  irb->CreateRet(llvm_memtuple_ret);
+
 
   // HeapTuple check block
   // ---------------------
@@ -237,17 +336,6 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
           llvm_attno_t0,
           llvm_max_attr);
   // }}}
-
-  // Retrieve slot's PRIVATE variables
-  llvm::Value* llvm_slot_PRIVATE_tts_isnull /* bool* */ =
-      irb->CreateLoad(codegen_utils->GetPointerToMember(
-          llvm_slot, &TupleTableSlot::PRIVATE_tts_isnull));
-  llvm::Value* llvm_slot_PRIVATE_tts_values /* Datum* */ =
-      irb->CreateLoad(codegen_utils->GetPointerToMember(
-          llvm_slot, &TupleTableSlot::PRIVATE_tts_values));
-  llvm::Value* llvm_slot_PRIVATE_tts_nvalid_ptr /* int* */ =
-      codegen_utils->GetPointerToMember(
-          llvm_slot, &TupleTableSlot::PRIVATE_tts_nvalid);
 
   llvm::Value* llvm_heaptuple_t_data_t_hoff = irb->CreateLoad(
       codegen_utils->GetPointerToMember(llvm_heaptuple_t_data,
@@ -541,11 +629,13 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
           llvm_slot_PRIVATE_tts_flags_ptr);
 
   // }}}
+  irb->CreateBr(return_block);
 
+  // Return block
+  // ------------
   // slot_getattr() after calling _slot_getsomeattrs() {{{
-  //
-  // TODO(hardikar): We can optimize this further by getting rid of
-  // the follow computation and changing the signature of this function
+
+  irb->SetInsertPoint(return_block);
 
   // *isnull = slot->PRIVATE_tts_isnull[attnum-1];
   llvm::Value* llvm_isnull_from_slot_val =
@@ -570,8 +660,6 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttrInternal(
   llvm_error->addIncoming(codegen_utils->GetConstant(0),
       slot_check_block);
   llvm_error->addIncoming(codegen_utils->GetConstant(1),
-      tuple_type_check_block);
-  llvm_error->addIncoming(codegen_utils->GetConstant(2),
       heap_tuple_check_block);
 
   codegen_utils->CreateElog(


### PR DESCRIPTION
The initial implementation for codegen-ing SlotGetAttr ignored handling cases when the tuple becomes a virtual tuple or memtuple. This PR addresses and handles those cases. 
The changes in slot_getattr are minimal, but there is a change in the steps taken in its generation. 

Since its generation in Scan is now shared by ExecEvalExpr and ExecVariableList, we can make a few more optimizations:
* We can avoid generating multiple versions of the slot_getattr (one for each)
* Once we deform any of the attributes in the tuples, we make it a virtual tuple. At code generation time, we know exactly how many need to be deformed and can in fact go ahead deform all the way. This way we don't need to worry about the case when slot_getattr is called on a virtual tuple with attnum > nvalid - that is deformation is partially complete.
* This PR also implements a crude way of collecting the information needed (maximum attnum) to completely generate slot_getattr, by maintaining a map keyed on the slot.

@karthijrk @foyzur Please have a look.