### PR TITLE
Properly deparsing PartitionSelector's printablePredicate

### DIFF
--- a/src/backend/executor/nodeSequence.c
+++ b/src/backend/executor/nodeSequence.c
@@ -38,14 +38,7 @@ ExecInitSequence(Sequence *node, EState *estate, int eflags)
 	Assert(numSubplans >= 1);
 	sequenceState->subplans = (PlanState **)palloc0(numSubplans * sizeof(PlanState *));
 	sequenceState->numSubplans = numSubplans;
-
-	/* Initialize static partition selector, if any */
-	if (node->static_selector)
-	{
-		sequenceState->static_selector =
-			(PartitionSelectorState *) ExecInitNode((Plan *) node->static_selector, estate, eflags);
-	}
-
+	
 	/* Initialize subplans */
 	ListCell *lc;
 	int no = 0;
@@ -117,16 +110,6 @@ ExecSequence(SequenceState *node)
 	 */
 	if (node->initState)
 	{
-		/*
-		 * Run the static partition selector first (XXX: Didn't we do this
-		 * at plan time already?)
-		 */
-		if (node->static_selector)
-		{
-			completeSubplan((PlanState *) node->static_selector);
-			CHECK_FOR_INTERRUPTS();
-		}
-
 		for(int no = 0; no < node->numSubplans - 1; no++)
 		{
 			completeSubplan(node->subplans[no]);

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4174,31 +4174,7 @@ CTranslatorDXLToPlStmt::PplanSequence
 
 		Plan *pplanChild = PplFromDXL(pdxlnChild, &dxltrctxChild, pplan, pdrgpdxltrctxPrevSiblings);
 
-		/*
-		 * When the plan comes out from ORCA, a "static" partition
-		 * selection is represented by a subplan that looks like this:
-		 *
-		 * Sequence
-		 *   -> Partition Selector
-		 *   -> Dynamic Table Scan
-		 *
-		 * The Partition Selector node is a bit special though, as it
-		 * modifies the behaviour of its sibling Dynamic Table Scan
-		 * node, and the printablePredicate can contain Vars that
-		 * refer to a child of the Sequence node, rather than
-		 * children of the PartititionSelector node itself. So in the
-		 * Plan tree, we want to put it in the dedicated
-		 * static_selector field, rather than having it as just
-		 * another child node of the Sequence.
-		 */
-		if (IsA(pplanChild, PartitionSelector))
-		{
-			psequence->static_selector = (PartitionSelector *) pplanChild;
-		}
-		else
-		{
-			psequence->subplans = gpdb::PlAppendElement(psequence->subplans, pplanChild);
-		}
+		psequence->subplans = gpdb::PlAppendElement(psequence->subplans, pplanChild);
 		pplan->nMotionNodes += pplanChild->nMotionNodes;
 	}
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -299,7 +299,6 @@ _copySequence(Sequence *from)
 	Sequence *newnode = makeNode(Sequence);
 	CopyPlanFields((Plan *) from, (Plan *) newnode);
 	COPY_NODE_FIELD(subplans);
-	COPY_NODE_FIELD(static_selector);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -447,7 +447,6 @@ _outSequence(StringInfo str, Sequence *node)
 	WRITE_NODE_TYPE("SEQUENCE");
 	_outPlanInfo(str, (Plan *)node);
 	WRITE_NODE_FIELD(subplans);
-	WRITE_NODE_FIELD(static_selector);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1600,7 +1600,6 @@ _readSequence(void)
 	READ_LOCALS(Sequence);
 	readPlanInfo((Plan *)local_node);
 	READ_NODE_FIELD(subplans);
-	READ_NODE_FIELD(static_selector);
 	READ_DONE();
 }
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -41,8 +41,6 @@ struct FileScanDescData;
 struct MirroredBufferPoolBulkLoadInfo;
 struct SliceTable;
 
-typedef struct PartitionSelectorState PartitionSelectorState;
-
 /* ----------------
  *	  IndexInfo information
  *
@@ -1540,8 +1538,6 @@ typedef struct SequenceState
 	PlanState	ps;
 	PlanState **subplans;
 	int			numSubplans;
-
-	PartitionSelectorState *static_selector;
 
 	/*
 	 * True if no subplan has been executed.

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -41,6 +41,8 @@ struct FileScanDescData;
 struct MirroredBufferPoolBulkLoadInfo;
 struct SliceTable;
 
+typedef struct PartitionSelectorState PartitionSelectorState;
+
 /* ----------------
  *	  IndexInfo information
  *

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -21,8 +21,6 @@
 #include "nodes/primnodes.h"
 #include "storage/itemptr.h"
 
-typedef struct PartitionSelector PartitionSelector;
-
 typedef struct DirectDispatchInfo
 {
      /**
@@ -379,8 +377,6 @@ typedef struct Sequence
 {
 	Plan plan;
 	List *subplans;
-
-	PartitionSelector *static_selector;
 } Sequence;
 
 /* ----------------

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -21,6 +21,8 @@
 #include "nodes/primnodes.h"
 #include "storage/itemptr.h"
 
+typedef struct PartitionSelector PartitionSelector;
+
 typedef struct DirectDispatchInfo
 {
      /**

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -137,8 +137,8 @@ explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..862.16 rows=1 width=8)
    ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.16 rows=1 width=8)
          ->  Aggregate  (cost=0.00..862.16 rows=1 width=8)
@@ -153,14 +153,15 @@ AND ft.id = dt1.id;
                                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
                                              ->  Table Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
                                        ->  Sequence  (cost=0.00..0.16 rows=1 width=2)
-                                             Partitions selected: 20 (out of 20)
+                                             ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                                   Partitions selected:  20 (out of 20)
                                              ->  Bitmap Table Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..0.16 rows=1 width=2)
                                                    Recheck Cond: bfv_tab2_facttable1.id = bfv_tab2_dimtabl1.id
                                                    ->  Bitmap Index Scan on idx_bfv_tab2_facttable1_1_prt_dflt  (cost=0.00..0.00 rows=0 width=0)
                                                          Index Cond: bfv_tab2_facttable1.id = bfv_tab2_dimtabl1.id
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(21 rows)
+ Optimizer status: PQO version 1.621
+(22 rows)
 
 -- start_ignore
 create language plpythonu;

--- a/src/test/regress/expected/bfv_partition_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_optimizer.out
@@ -1565,9 +1565,6 @@ select * from pp where b=2 and c=2;
 (0 rows)
 
 select count_operator('explain select * from pp where b=2 and c=2;','Partition Selector');
-WARNING:  bogus var: varno=65000 varattno=2 (ruleutils.c:3186)
-CONTEXT:  SQL statement "explain select * from pp where b=2 and c=2;"
-PL/Python function "count_operator"
  count_operator 
 ----------------
               1

--- a/src/test/regress/expected/bfv_partition_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_optimizer.out
@@ -1565,6 +1565,9 @@ select * from pp where b=2 and c=2;
 (0 rows)
 
 select count_operator('explain select * from pp where b=2 and c=2;','Partition Selector');
+WARNING:  bogus var: varno=65000 varattno=2 (ruleutils.c:3186)
+CONTEXT:  SQL statement "explain select * from pp where b=2 and c=2;"
+PL/Python function "count_operator"
  count_operator 
 ----------------
               1
@@ -1661,7 +1664,7 @@ select * from ds_4 a1,ds_4 a2 where a1.month_id = a2.month_id and a1.month_id > 
 select count_operator('explain select * from ds_4 a1,ds_4 a2 where a1.month_id = a2.month_id and a1.month_id > E''200800'';','Partition Selector');
  count_operator 
 ----------------
-              1
+              2
 (1 row)
 
 -- CLEANUP

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -8137,15 +8137,17 @@ select * from orca.t order by 1,2;
 explain select * from orca.t order by 1,2;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=32)
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=32)
    Merge Key: timest, user_id
    ->  Sequence  (cost=0.00..431.00 rows=1 width=32)
+         ->  Partition Selector for t (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Partitions selected:  6 (out of 6)
          ->  Sort  (cost=0.00..431.00 rows=1 width=32)
                Sort Key: timest, user_id
                ->  Dynamic Table Scan on t (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=32)
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
-(8 rows)
+ Optimizer status: PQO version 1.630
+(10 rows)
 
 select tag2, tag1 from orca.t order by 1, 2;;
  tag2  | tag1  
@@ -8224,8 +8226,10 @@ set optimizer_plan_id = 2;
 explain select * from orca.t_date where user_id=9;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..437.00 rows=1 width=28)
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..437.00 rows=1 width=28)
    ->  Sequence  (cost=0.00..437.00 rows=1 width=28)
+         ->  Partition Selector for t_date (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Partitions selected:  6 (out of 6)
          ->  Result  (cost=0.00..437.00 rows=1 width=28)
                ->  Append  (cost=0.00..437.00 rows=1 width=28)
                      ->  Dynamic Index Scan on t_date (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=58)
@@ -8233,8 +8237,8 @@ explain select * from orca.t_date where user_id=9;
                      ->  Dynamic Table Scan on t_date (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=58)
                            Filter: user_id = 9::numeric
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
-(10 rows)
+ Optimizer status: PQO version 1.602
+(12 rows)
 
 select * from orca.t_date where user_id=9;
    timest   | user_id | tag1  | tag2  
@@ -8277,8 +8281,10 @@ set optimizer_plan_id = 2;
 explain select * from orca.t_text where user_id=9;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..437.00 rows=1 width=28)
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..437.00 rows=1 width=28)
    ->  Sequence  (cost=0.00..437.00 rows=1 width=28)
+         ->  Partition Selector for t_text (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Partitions selected:  3 (out of 3)
          ->  Result  (cost=0.00..437.00 rows=1 width=28)
                ->  Append  (cost=0.00..437.00 rows=1 width=28)
                      ->  Dynamic Index Scan on t_text (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=58)
@@ -8286,8 +8292,8 @@ explain select * from orca.t_text where user_id=9;
                      ->  Dynamic Table Scan on t_text (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=58)
                            Filter: user_id = 9::numeric
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
-(10 rows)
+ Optimizer status: PQO version 1.602
+(12 rows)
 
 select * from orca.t_text where user_id=9;
    timest   | user_id | tag1  | tag2  
@@ -8342,15 +8348,17 @@ select disable_xform('CXformDynamicGet2DynamicTableScan');
 (1 row)
 
 explain select * from orca.t_employee where user_id = 2;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..6.00 rows=1 width=28)
    ->  Sequence  (cost=0.00..6.00 rows=1 width=28)
+         ->  Partition Selector for t_employee (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Partitions selected:  2 (out of 2)
          ->  Dynamic Index Scan on t_employee (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=28)
                Index Cond: user_id = 2::numeric
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
-(6 rows)
+ Optimizer status: PQO version 1.602
+(8 rows)
 
 select * from orca.t_employee where user_id = 2;
    timest   | user_id | tag1  |     emp      
@@ -8393,8 +8401,10 @@ set optimizer_plan_id = 2;
 explain select * from orca.t_ceeval_ints where user_id=4;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..437.00 rows=1 width=28)
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..437.00 rows=1 width=28)
    ->  Sequence  (cost=0.00..437.00 rows=1 width=28)
+         ->  Partition Selector for t_ceeval_ints (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Partitions selected:  3 (out of 3)
          ->  Result  (cost=0.00..437.00 rows=1 width=28)
                ->  Append  (cost=0.00..437.00 rows=1 width=28)
                      ->  Dynamic Index Scan on t_ceeval_ints (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=58)
@@ -8402,8 +8412,8 @@ explain select * from orca.t_ceeval_ints where user_id=4;
                      ->  Dynamic Table Scan on t_ceeval_ints (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=58)
                            Filter: user_id = 4::numeric
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
-(10 rows)
+ Optimizer status: PQO version 1.602
+(12 rows)
 
 select * from orca.t_ceeval_ints where user_id=4;
  user_id | category_id | tag1  | tag2  
@@ -9203,18 +9213,20 @@ insert into orca.bm_dyn_test values(2, 5, '2');
 set optimizer_enable_bitmapscan=on;
 -- gather on 1 segment because of direct dispatch
 explain select * from orca.bm_dyn_test where i=2 and t='2';
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..0.00 rows=1 width=16)
    ->  Sequence  (cost=0.00..0.00 rows=1 width=16)
+         ->  Partition Selector for bm_dyn_test (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Partitions selected:  6 (out of 6)
          ->  Bitmap Table Scan on bm_dyn_test (dynamic scan id: 1)  (cost=0.00..0.00 rows=1 width=16)
                Recheck Cond: i = 2
                Filter: i = 2 AND t = '2'::text
                ->  Bitmap Index Scan on bm_dyn_test_idx_1_prt_part0  (cost=0.00..0.00 rows=0 width=0)
                      Index Cond: i = 2
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(9 rows)
+ Optimizer status: PQO version 1.602
+(11 rows)
 
 select * from orca.bm_dyn_test where i=2 and t='2';
  i | j | t 
@@ -9738,6 +9750,8 @@ ORDER BY 1 asc ;
                                              ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
                                                    ->  Table Scan on my_tt_agg_opt  (cost=0.00..431.00 rows=1 width=62)
                                        ->  Sequence  (cost=0.00..874.01 rows=1 width=8)
+                                             ->  Partition Selector for my_tq_agg_opt_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+                                                   Partitions selected:  2 (out of 2)
                                              ->  Result  (cost=0.00..874.01 rows=1 width=8)
                                                    ->  Append  (cost=0.00..874.01 rows=1 width=8)
                                                          ->  Nested Loop  (cost=0.00..437.00 rows=1 width=132)

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6757,21 +6757,21 @@ set optimizer_nestloop_factor = 1.0;
 explain select foo_p.b, foo_p.t from foo_p left outer join bar on foo_p.a = bar.k  where foo_p.t is not null and foo_p.a = (array[1])[1];
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..866.75 rows=20500 width=30)
-   ->  Hash Left Join  (cost=0.00..864.46 rows=6834 width=30)
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..866.85 rows=20500 width=30)
+   ->  Hash Left Join  (cost=0.00..864.56 rows=10250 width=30)
          Hash Cond: foo_p.a = bar.k
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.08 rows=134 width=34)
+         ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.09 rows=200 width=34)
                Hash Key: foo_p.a
-               ->  Sequence  (cost=0.00..431.07 rows=134 width=34)
-                     Partitions selected: 6 (out of 6)
-                     ->  Dynamic Table Scan on foo_p (dynamic scan id: 1)  (cost=0.00..431.07 rows=134 width=34)
+               ->  Sequence  (cost=0.00..431.07 rows=200 width=34)
+                     ->  Partition Selector for foo_p (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+                           Partitions selected:  6 (out of 6)
+                     ->  Dynamic Table Scan on foo_p (dynamic scan id: 1)  (cost=0.00..431.07 rows=200 width=34)
                            Filter: NOT t IS NULL AND a = ('{1}'::integer[])[1]
-         ->  Hash  (cost=431.36..431.36 rows=6700 width=4)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.36 rows=6700 width=4)
+         ->  Hash  (cost=431.45..431.45 rows=10050 width=4)
+               ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..431.45 rows=10050 width=4)
                      Hash Key: bar.k
-                     ->  Table Scan on bar  (cost=0.00..431.22 rows=6700 width=4)
+                     ->  Table Scan on bar  (cost=0.00..431.32 rows=10050 width=4)
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
 (15 rows)
 
 reset optimizer_segments;

--- a/src/test/regress/expected/partition_pruning_with_fn_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_with_fn_optimizer.out
@@ -34,94 +34,88 @@ NOTICE:  CREATE TABLE will create partition "ds_4_1_prt_p200803" for table "ds_4
 -- Known_opt_diff: MPP-21316
 -- end_ignore
 explain select * from ds_4 where month_id = '200800';
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-         Partition Selector: ds_4.month_id = '200800'::text::character varying
-         Partitions selected: 1 (out of 4)
-         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+         ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               Filter: month_id::text = '200800'::text
+         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                Filter: month_id::text = '200800'::text
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(8 rows)
+(7 rows)
 
 -- now we can evaluate this function at planning/prune time
 -- start_ignore
 -- Known_opt_diff: MPP-21316
 -- end_ignore
 explain select * from ds_4 where month_id::int = 200800;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-         Partitions selected: 4 (out of 4)
-         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+         ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                Filter: int4(month_id) = 200800
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(7 rows)
+(6 rows)
 
 -- this will be satisfied by 200800
 -- start_ignore
 -- Known_opt_diff: MPP-21316
 -- end_ignore
 explain select * from ds_4 where month_id::int - 801 < 200000;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-         Partitions selected: 4 (out of 4)
-         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+         ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                Filter: (int4(month_id) - 801) < 200000
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(7 rows)
+(6 rows)
 
 -- test OR case -- should NOT get pruning
 explain select * from ds_4 where month_id::int - 801 < 200000 OR count_vas > 10;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-         Partitions selected: 4 (out of 4)
-         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+         ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                Filter: (int4(month_id) - 801) < 200000 OR count_vas > 10
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(7 rows)
+(6 rows)
 
 -- test AND case -- should still get pruning
 -- start_ignore
 -- Known_opt_diff: MPP-21316
 -- end_ignore
 explain select * from ds_4 where month_id::int - 801 < 200000 AND count_vas > 10;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-         Partitions selected: 4 (out of 4)
-         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+         ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                Filter: (int4(month_id) - 801) < 200000 AND count_vas > 10
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(7 rows)
+(6 rows)
 
 -- test expression case : should get pruning
 -- start_ignore
 -- Known_opt_diff: MPP-21316
 -- end_ignore
 explain select * from ds_4 where case when month_id = '200800' then 100 else 2 end = 100;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-         Partitions selected: 4 (out of 4)
-         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+         ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                Filter: CASE WHEN month_id::text = '200800'::text THEN 100 ELSE 2 END = 100
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(7 rows)
+(6 rows)
 
 -- test expression case : should get pruning
 -- start_ignore
@@ -130,30 +124,28 @@ explain select * from ds_4 where case when month_id = '200800' then 100 else 2 e
 explain select * from ds_4 where case when month_id = '200800' then NULL else 2 end IS NULL;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-         Partitions selected: 4 (out of 4)
-         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+         ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                Filter: CASE WHEN month_id::text = '200800'::text THEN NULL::integer ELSE 2 END IS NULL
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(7 rows)
+(6 rows)
 
 -- should still get pruning here -- count_vas is only used in the path for month id = 200800
 -- start_ignore
 -- Known_opt_diff: MPP-21316
 -- end_ignore
 explain select * from ds_4 where case when month_id::int = 200800 then count_vas else 2 end IS NULL;
-                                            QUERY PLAN                                            
---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-         Partitions selected: 4 (out of 4)
-         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+         ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                Filter: CASE WHEN int4(month_id) = 200800 THEN count_vas ELSE 2 END IS NULL
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(7 rows)
+(6 rows)
 
 -- do one that matches a couple partitions
 -- start_ignore
@@ -162,14 +154,13 @@ explain select * from ds_4 where case when month_id::int = 200800 then count_vas
 explain select * from ds_4 where month_id::int in (200801, 1,55,6,6,6,6,66,565,65,65,200803);
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
-   ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-         Partitions selected: 4 (out of 4)
-         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+         ->  Partition Selector for ds_4 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+         ->  Dynamic Table Scan on ds_4 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                Filter: int4(month_id) = ANY ('{200801,1,55,6,6,6,6,66,565,65,65,200803}'::integer[])
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(7 rows)
+(6 rows)
 
 -- cleanup
 drop table ds_4;
@@ -232,37 +223,35 @@ insert into ds_2(month_id) values('200809');
 -- end_ignore
 set optimizer_segments=2;
 explain select * from ds_2 where month_id::int in (200808, 1315) order by month_id;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
    Merge Key: month_id
-   ->  Sort  (cost=0.00..431.00 rows=1 width=72)
+   ->  Sort  (cost=0.00..431.00 rows=1 width=80)
          Sort Key: month_id
-         ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-               Partitions selected: 10 (out of 10)
-               ->  Dynamic Table Scan on ds_2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+         ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+               ->  Partition Selector for ds_2 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               ->  Dynamic Table Scan on ds_2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                      Filter: int4(month_id) = ANY ('{200808,1315}'::integer[])
  Settings:  optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 1.633
-(10 rows)
+(9 rows)
 
 -- start_ignore
 -- Known_opt_diff: MPP-21316
 -- end_ignore
 explain  select * from ds_2 where month_id::int in (200808, 200801, 2008010) order by month_id;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=72)
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=80)
    Merge Key: month_id
-   ->  Sort  (cost=0.00..431.00 rows=1 width=72)
+   ->  Sort  (cost=0.00..431.00 rows=1 width=80)
          Sort Key: month_id
-         ->  Sequence  (cost=0.00..431.00 rows=1 width=72)
-               Partitions selected: 10 (out of 10)
-               ->  Dynamic Table Scan on ds_2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=72)
+         ->  Sequence  (cost=0.00..431.00 rows=1 width=80)
+               ->  Partition Selector for ds_2 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+               ->  Dynamic Table Scan on ds_2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=80)
                      Filter: int4(month_id) = ANY ('{200808,200801,2008010}'::integer[])
  Settings:  optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 1.633
-(10 rows)
+(9 rows)
 
 reset optimizer_segments;
 select * from ds_2 where month_id::int in (200907, 1315) order by month_id;

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -1707,15 +1707,16 @@ NOTICE:  CREATE TABLE will create partition "tbl6833_anl_1_prt_bb_1" for table "
 NOTICE:  CREATE TABLE will create partition "tbl6833_anl_1_prt_bb_2" for table "tbl6833_anl"
 analyze qp_misc_jiras.tbl6833_anl;
 explain select * from qp_misc_jiras.tbl6833_anl; -- should not hit cdbRelSize();
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
-         Partitions selected: 2 (out of 2)
+         ->  Partition Selector for tbl6833_anl (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected:  2 (out of 2)
          ->  Dynamic Table Scan on tbl6833_anl (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
  Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.633
-(6 rows)
+ Optimizer status: PQO version 1.624
+(7 rows)
 
 select relname, reltuples, relpages from pg_class where relname like 'tbl6833_anl%'; -- should show relpages = 1.0
         relname         | reltuples | relpages 
@@ -1730,15 +1731,16 @@ NOTICE:  CREATE TABLE will create partition "tbl6833_vac_1_prt_bb_1" for table "
 NOTICE:  CREATE TABLE will create partition "tbl6833_vac_1_prt_bb_2" for table "tbl6833_vac"
 vacuum qp_misc_jiras.tbl6833_vac;
 explain select * from qp_misc_jiras.tbl6833_vac; -- should not hit cdbRelSize();
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
-         Partitions selected: 2 (out of 2)
+         ->  Partition Selector for tbl6833_vac (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected:  2 (out of 2)
          ->  Dynamic Table Scan on tbl6833_vac (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
  Settings:  enable_indexscan=off; enable_nestloop=on; enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.633
-(6 rows)
+ Optimizer status: PQO version 1.624
+(7 rows)
 
 select relname, reltuples, relpages from pg_class where relname like 'tbl6833_vac%'; -- should show relpages = 1.0
         relname         | reltuples | relpages 

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -870,18 +870,19 @@ INFO:  Dispatch command to ALL contents
 (1 row)
 
 explain select count(*) from mpp7638 where a =1;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..431.00 rows=1 width=8)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
          ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
-                     Partitions selected: 9 (out of 9)
+                     ->  Partition Selector for mpp7638 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                           Partitions selected:  9 (out of 9)
                      ->  Dynamic Table Scan on mpp7638 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
                            Filter: a = 1
  Settings:  optimizer=on
- Optimizer status: PQO version 1.633
-(9 rows)
+ Optimizer status: PQO version 1.624
+(10 rows)
 
 alter table mpp7638 set distributed by (a, b, c);
 INFO:  Dispatch command to ALL contents

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -86,15 +86,16 @@ NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_4" for table "csq_t2"
 insert into csq_t1 select * from csq_t1_base;
 insert into csq_t2 select * from csq_t2_base;
 explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1293.00 rows=1 width=8)
    Filter: (subplan)
    ->  Sort  (cost=0.00..431.00 rows=1 width=8)
          Sort Key: csq_t1.x
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=8)
                ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
-                     Partitions selected: 4 (out of 4)
+                     ->  Partition Selector for csq_t1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+                           Partitions selected:  4 (out of 4)
                      ->  Dynamic Table Scan on csq_t1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
    SubPlan 1
      ->  Result  (cost=0.00..431.00 rows=1 width=1)
@@ -106,13 +107,14 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
                                    ->  Result  (cost=0.00..431.00 rows=1 width=4)
                                          Filter: csq_t2.y = $1
                                          ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                               ->  Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..431.00 rows=1 width=8)
                                                      ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
-                                                           Partitions selected: 4 (out of 4)
+                                                           ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=50 width=4)
+                                                                 Partitions selected:  4 (out of 4)
                                                            ->  Dynamic Table Scan on csq_t2 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
-(24 rows)
+ Optimizer status: PQO version 1.621
+(26 rows)
 
 select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
  x | y 
@@ -1191,25 +1193,26 @@ CASE
 	ELSE 'Q2'::text END  AS  cc,  1 AS nn
 FROM t_mpp_20470 b;
 explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
-                                                                                QUERY PLAN                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Window  (cost=0.00..862.00 rows=1 width=16)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=12)
+   ->  Gather Motion 2:1  (slice3; segments: 2)  (cost=0.00..862.00 rows=2 width=12)
          ->  Result  (cost=0.00..862.00 rows=1 width=12)
                ->  Result  (cost=0.00..862.00 rows=1 width=16)
                      ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
                            Hash Cond: public.t_mpp_20470.col_name::text = public.t_mpp_20470.col_name::text
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=8)
                                  Hash Key: public.t_mpp_20470.col_name
                                  ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
-                                       Partitions selected: 2 (out of 2)
+                                       ->  Partition Selector for t_mpp_20470 (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
+                                             Partitions selected:  2 (out of 2)
                                        ->  Dynamic Table Scan on t_mpp_20470 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
                            ->  Hash  (cost=431.00..431.00 rows=1 width=16)
                                  ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
                                        Group By: public.t_mpp_20470.col_name
                                        ->  Sort  (cost=0.00..431.00 rows=1 width=16)
                                              Sort Key: public.t_mpp_20470.col_name
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                             ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..431.00 rows=1 width=16)
                                                    Hash Key: public.t_mpp_20470.col_name
                                                    ->  Result  (cost=0.00..431.00 rows=1 width=16)
                                                          ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
@@ -1217,11 +1220,12 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                                                                ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                                                                      Sort Key: public.t_mpp_20470.col_name
                                                                      ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
-                                                                           Partitions selected: 2 (out of 2)
+                                                                           ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=50 width=4)
+                                                                                 Partitions selected:  2 (out of 2)
                                                                            ->  Dynamic Table Scan on t_mpp_20470 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.633
-(28 rows)
+ Optimizer status: PQO version 1.621
+(30 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;


### PR DESCRIPTION
In this PR we revert the earlier fix in https://github.com/greenplum-db/gpdb/pull/840, but keep some part of it. This PR is similar in spirit to the earlier as it depends on parent of PartitionSelector (which is expected to be Sequence) to deparse printablePredicate. However, this PR resolves the parent from child, instead of resolving child from parent and localizes the changes to just explain.c. We also keep the old behavior of clearly isolating Sequence node from PartitionSelector node.

Besides this, we also pass the parent to resolve both outer and inner varno of a PartitionSelector's printablePredicate, which is also necessary to make bfv_partition green.