### PR TITLE
Fix deparsing of group by columns in EXPLAIN of Agg node when Append is the outer child

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2052,10 +2052,29 @@ show_grouping_keys(Plan        *plan,
         appendStringInfoString(str, "  ");
     appendStringInfo(str, "  %s: ", qlabel);
 
+    Node *outerPlan = (Node *) outerPlan(subplan);
+    Node *innerPlan = (Node *) innerPlan(subplan);
+
+    /*
+     * For Append we cannot obtain outerPlan as the lefttree
+     * is set to NULL. So, we extract the first child from the
+     * list of appendplans
+     */
+    if (IsA(subplan, Append))
+    {
+    	Assert(NULL == outerPlan);
+    	Assert(NULL == innerPlan);
+
+    	Append *append = (Append *) subplan;
+    	outerPlan = list_nth(append->appendplans, 0);
+
+    	Assert(NULL != outerPlan);
+    }
+
 	/* Set up deparse context */
-	context = deparse_context_for_plan((Node *) outerPlan(subplan),
-									   (Node *) innerPlan(subplan),
-									   es->rtable);
+	context = deparse_context_for_plan(outerPlan,
+									   innerPlan,
+										   es->rtable);
 
 	if (IsA(plan, Agg))
 	{


### PR DESCRIPTION
If Agg has an Append as the outer child, group by cannot resolve the variable names of
the group by expression. This is because of incorrect assumption that it can take outerPlan
of any child to access the outer child of its child, which is not true for Append. For
Append we keep a list of children and lefttee and righttree are set to NULL.

This breaks bfv_partition test suite when optimizer is enabled. For repro:

```
drop table if exists t;
drop table if exists p1;
drop table if exists p2;
-- end_ignore

create table p1 (a int, b int) partition by range(b) (start (1) end(100) every (20));
create table p2 (a int, b int) partition by range(b) (start (1) end(100) every (20));
create table t(a int, b int);

insert into t select g, g*10 from generate_series(1,100) g;
insert into p1 select g, g%99 +1 from generate_series(1,10000) g;
insert into p2 select g, g%99 +1 from generate_series(1,10000) g;

analyze t;
analyze p1;
analyze p2;

explain select * from (select * from p1 union select * from p2) as p_all, t where p_all.b=t.b;
```

This commit fixes this by considering Append as special child and properly extracting the first
subplan under Append as its outer child.