### PR TITLE
Fix inconsistent trigger names.

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -241,7 +241,10 @@ CreateTrigger(CreateTrigStmt *stmt, Oid constraintOid)
 	 */
 	tgrel = heap_open(TriggerRelationId, RowExclusiveLock);
 
-	trigoid = GetNewOid(tgrel);
+	if (OidIsValid(stmt->trigOid))
+		trigoid = stmt->trigOid;
+	else
+		trigoid = GetNewOid(tgrel);
 
 	/*
 	 * If trigger is for an RI constraint, the passed-in name is the


### PR DESCRIPTION
Running gpcheckcat after constraints installcheck test shows trigger metadata
inconsistencies between the master and segments. This issue was introduced
in the 8.3 merge. If CreateTrigger Statement has a trigger oid already, we
should reuse it like before the 8.3 merge.