### PR TITLE
Fix bug in index dxl translators that can't translatte ScalarArrayOpExpr [#126158185]

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1449,7 +1449,8 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 
 		Expr *pexprOrigIndexCond = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnIndexCond, &mapcidvarplstmt);
 		Expr *pexprIndexCond = m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnIndexCond, &mapcidvarplstmt);
-		GPOS_ASSERT(IsA(pexprIndexCond, OpExpr) && "expected OpExpr in index qual");
+		GPOS_ASSERT((IsA(pexprIndexCond, OpExpr) || IsA(pexprIndexCond, ScalarArrayOpExpr))
+				&& "expected OpExpr or ScalarArrayOpExpr in index qual");
 
 		// for indexonlyscan, we already have the attno referring to the index
 		if (!fIndexOnlyScan)
@@ -1460,7 +1461,16 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 		}
 		
 		// find index key's attno
-		List *plistArgs = ((OpExpr *) pexprIndexCond)->args;
+		List *plistArgs = NULL;
+		if (IsA(pexprIndexCond, OpExpr))
+		{
+			plistArgs = ((OpExpr *) pexprIndexCond)->args;
+		}
+		else
+		{
+			plistArgs = ((ScalarArrayOpExpr *) pexprIndexCond)->args;
+		}
+
 		Node *pnodeFst = (Node *) lfirst(gpdb::PlcListHead(plistArgs));
 		Node *pnodeSnd = (Node *) lfirst(gpdb::PlcListTail(plistArgs));
 				
@@ -1478,10 +1488,16 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 		
 		if (fRelabel)
 		{
-			List *plArgs = ((OpExpr *) pexprIndexCond)->args;
 			List *plNewArgs = ListMake2(pnodeFst, pnodeSnd);
-			gpdb::GPDBFree(plArgs);
-			((OpExpr *) pexprIndexCond)->args = plNewArgs;
+			gpdb::GPDBFree(plistArgs);
+			if (IsA(pexprIndexCond, OpExpr))
+			{
+				((OpExpr *) pexprIndexCond)->args = plNewArgs;
+			}
+			else
+			{
+				((ScalarArrayOpExpr *) pexprIndexCond)->args = plNewArgs;
+			}
 		}
 		
 		GPOS_ASSERT(IsA(pnodeFst, Var) || IsA(pnodeSnd, Var) && "expected index key in index qual");
@@ -1512,7 +1528,7 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 		GPOS_ASSERT(!fRecheck);
 		
 		// create index qual
-		pdrgpindexqualinfo->Append(GPOS_NEW(m_pmp) CIndexQualInfo(iAttno, (OpExpr *)pexprIndexCond, (OpExpr *)pexprOrigIndexCond, (StrategyNumber) iSN, oidIndexSubtype));
+		pdrgpindexqualinfo->Append(GPOS_NEW(m_pmp) CIndexQualInfo(iAttno, (Expr *)pexprIndexCond, (Expr *)pexprOrigIndexCond, (StrategyNumber) iSN, oidIndexSubtype));
 	}
 
 	// the index quals much be ordered by attribute number

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1528,7 +1528,7 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 		GPOS_ASSERT(!fRecheck);
 		
 		// create index qual
-		pdrgpindexqualinfo->Append(GPOS_NEW(m_pmp) CIndexQualInfo(iAttno, (Expr *)pexprIndexCond, (Expr *)pexprOrigIndexCond, (StrategyNumber) iSN, oidIndexSubtype));
+		pdrgpindexqualinfo->Append(GPOS_NEW(m_pmp) CIndexQualInfo(iAttno, pexprIndexCond, pexprOrigIndexCond, (StrategyNumber) iSN, oidIndexSubtype));
 	}
 
 	// the index quals much be ordered by attribute number
@@ -1538,8 +1538,8 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 	for (ULONG ul = 0; ul < ulLen; ul++)
 	{
 		CIndexQualInfo *pindexqualinfo = (*pdrgpindexqualinfo)[ul];
-		*pplIndexConditions = gpdb::PlAppendElement(*pplIndexConditions, pindexqualinfo->m_popExpr);
-		*pplIndexOrigConditions = gpdb::PlAppendElement(*pplIndexOrigConditions, pindexqualinfo->m_popOriginalExpr);
+		*pplIndexConditions = gpdb::PlAppendElement(*pplIndexConditions, pindexqualinfo->m_pexpr);
+		*pplIndexOrigConditions = gpdb::PlAppendElement(*pplIndexOrigConditions, pindexqualinfo->m_pexprOriginal);
 		*pplIndexStratgey = gpdb::PlAppendInt(*pplIndexStratgey, pindexqualinfo->m_sn);
 		*pplIndexSubtype = gpdb::PlAppendOid(*pplIndexSubtype, pindexqualinfo->m_oidIndexSubtype);
 	}

--- a/src/include/gpopt/translate/CIndexQualInfo.h
+++ b/src/include/gpopt/translate/CIndexQualInfo.h
@@ -43,10 +43,10 @@ namespace gpdxl
 			AttrNumber m_attno;
 
 			// index qual expression tailored for GPDB
-			Expr *m_popExpr;
+			Expr *m_pexpr;
 
 			// original index qual expression
-			Expr *m_popOriginalExpr;
+			Expr *m_pexprOriginal;
 
 			// index strategy information
 			StrategyNumber m_sn;
@@ -58,20 +58,20 @@ namespace gpdxl
 			CIndexQualInfo
 				(
 				AttrNumber attno,
-				Expr *popExpr,
-				Expr *popOriginalExpr,
+				Expr *pexpr,
+				Expr *pexprOriginal,
 				StrategyNumber sn,
 				OID oidIndexSubtype
 				)
 				:
 				m_attno(attno),
-				m_popExpr(popExpr),
-				m_popOriginalExpr(popOriginalExpr),
+				m_pexpr(pexpr),
+				m_pexprOriginal(pexprOriginal),
 				m_sn(sn),
 				m_oidIndexSubtype(oidIndexSubtype)
 				{
-					GPOS_ASSERT((IsA(m_popExpr, OpExpr) && IsA(m_popOriginalExpr, OpExpr)) ||
-						(IsA(m_popExpr, ScalarArrayOpExpr) && IsA(m_popOriginalExpr, ScalarArrayOpExpr)));
+					GPOS_ASSERT((IsA(m_pexpr, OpExpr) && IsA(m_pexprOriginal, OpExpr)) ||
+						(IsA(m_pexpr, ScalarArrayOpExpr) && IsA(m_pexprOriginal, ScalarArrayOpExpr)));
 				}
 
 				// dtor

--- a/src/include/gpopt/translate/CIndexQualInfo.h
+++ b/src/include/gpopt/translate/CIndexQualInfo.h
@@ -43,10 +43,10 @@ namespace gpdxl
 			AttrNumber m_attno;
 
 			// index qual expression tailored for GPDB
-			OpExpr *m_popExpr;
+			Expr *m_popExpr;
 
 			// original index qual expression
-			OpExpr *m_popOriginalExpr;
+			Expr *m_popOriginalExpr;
 
 			// index strategy information
 			StrategyNumber m_sn;
@@ -58,8 +58,8 @@ namespace gpdxl
 			CIndexQualInfo
 				(
 				AttrNumber attno,
-				OpExpr *popExpr,
-				OpExpr *popOriginalExpr,
+				Expr *popExpr,
+				Expr *popOriginalExpr,
 				StrategyNumber sn,
 				OID oidIndexSubtype
 				)
@@ -69,7 +69,10 @@ namespace gpdxl
 				m_popOriginalExpr(popOriginalExpr),
 				m_sn(sn),
 				m_oidIndexSubtype(oidIndexSubtype)
-				{}
+				{
+					GPOS_ASSERT((IsA(m_popExpr, OpExpr) && IsA(m_popOriginalExpr, OpExpr)) ||
+						(IsA(m_popExpr, ScalarArrayOpExpr) && IsA(m_popOriginalExpr, ScalarArrayOpExpr)));
+				}
 
 				// dtor
 				~CIndexQualInfo()

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -10031,6 +10031,131 @@ SELECT attr, class, (select canSetTag_Func(count(distinct class)::int) from canS
 drop function canSetTag_Func(x int);
 drop table canSetTag_bug_table;
 drop table canSetTag_input_data;
+-- Test B-Tree index scan with in list
+CREATE TABLE btree_test as SELECT * FROM generate_series(1,100) as a distributed randomly;
+CREATE INDEX btree_test_index ON btree_test(a);
+EXPLAIN SELECT * FROM btree_test WHERE a in (select 1);
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=4)
+   ->  Nested Loop  (cost=0.00..2.00 rows=1 width=4)
+         Join Filter: true
+         ->  Result  (cost=0.00..0.00 rows=1 width=4)
+               ->  Result  (cost=0.00..0.00 rows=1 width=1)
+         ->  Index Scan using btree_test_index on btree_test  (cost=0.00..2.00 rows=1 width=4)
+               Index Cond: btree_test.a = (1)
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 1.647
+(9 rows)
+
+EXPLAIN SELECT * FROM btree_test WHERE a in (1, 47);
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=3 width=4)
+   ->  Index Scan using btree_test_index on btree_test  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: a = ANY ('{1,47}'::integer[])
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 1.647
+(5 rows)
+
+EXPLAIN SELECT * FROM btree_test WHERE a in ('2', 47);
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=3 width=4)
+   ->  Index Scan using btree_test_index on btree_test  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: a = ANY ('{2,47}'::integer[])
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 1.647
+(5 rows)
+
+EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2');
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=3 width=4)
+   ->  Index Scan using btree_test_index on btree_test  (cost=0.00..6.00 rows=1 width=4)
+         Index Cond: a = ANY ('{1,2}'::integer[])
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 1.647
+(5 rows)
+
+EXPLAIN SELECT * FROM btree_test WHERE a in ('1', '2', 47);
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=4 width=4)
+   ->  Index Scan using btree_test_index on btree_test  (cost=0.00..8.00 rows=2 width=4)
+         Index Cond: a = ANY ('{1,2,47}'::integer[])
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 1.647
+(5 rows)
+
+-- Test Bitmap index scan with in list
+CREATE TABLE bitmap_test as SELECT * FROM generate_series(1,100) as a distributed randomly;
+CREATE INDEX bitmap_index ON bitmap_test USING BITMAP(a);
+-- The following query should fall back to planner. 
+-- Update the result file when this has been fixed in ORCA.
+EXPLAIN SELECT * FROM bitmap_test WHERE a in (select 1);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.07..4.38 rows=7 width=4)
+   ->  Hash Join  (cost=0.07..4.38 rows=3 width=4)
+         Hash Cond: bitmap_test.a = (1)
+         ->  Seq Scan on bitmap_test  (cost=0.00..4.00 rows=34 width=4)
+         ->  Hash  (cost=0.05..0.05 rows=1 width=4)
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.02..0.05 rows=1 width=4)
+                     ->  HashAggregate  (cost=0.02..0.03 rows=1 width=4)
+                           Group By: 1
+                           ->  Result  (cost=0.00..0.01 rows=1 width=0)
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(11 rows)
+
+-- The following queries should work without falling back to planner.
+EXPLAIN SELECT * FROM bitmap_test WHERE a in (1, 47);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..408.76 rows=3 width=4)
+   ->  Bitmap Table Scan on bitmap_test  (cost=0.00..408.76 rows=1 width=4)
+         Recheck Cond: a = ANY ('{1,47}'::integer[])
+         ->  Bitmap Index Scan on bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: a = ANY ('{1,47}'::integer[])
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 1.647
+(7 rows)
+
+EXPLAIN SELECT * FROM bitmap_test WHERE a in ('2', 47);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..408.76 rows=3 width=4)
+   ->  Bitmap Table Scan on bitmap_test  (cost=0.00..408.76 rows=1 width=4)
+         Recheck Cond: a = ANY ('{2,47}'::integer[])
+         ->  Bitmap Index Scan on bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: a = ANY ('{2,47}'::integer[])
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 1.647
+(7 rows)
+
+EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2');
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..408.76 rows=3 width=4)
+   ->  Bitmap Table Scan on bitmap_test  (cost=0.00..408.76 rows=1 width=4)
+         Recheck Cond: a = ANY ('{1,2}'::integer[])
+         ->  Bitmap Index Scan on bitmap_index  (cost=0.00..0.00 rows=0 width=0)
+               Index Cond: a = ANY ('{1,2}'::integer[])
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 1.647
+(7 rows)
+
+EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2', 47);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+   ->  Table Scan on bitmap_test  (cost=0.00..431.00 rows=2 width=4)
+         Filter: a = ANY ('{1,2,47}'::integer[])
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 1.647
+(5 rows)
+
 -- clean up
 drop schema orca cascade;
 NOTICE:  drop cascades to table orca.index_test


### PR DESCRIPTION
Orca couldn't pickup plan that uses index scan for the following cases:
- `select * from btree_tbl where a in (1,2); // Orca generated table scan instead of index scan`
- `select * from bitmap_tbl where a in (1,2); // Orca generated table scan instead of bitmap scan`

Orca failed to consider the case that uses ArrayComp when trying to pick up index. 
The issue has been fixed in this patch.