### PR TITLE
Per segment AO versions

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -73,7 +73,8 @@ static void open_datumstreamread_segfile(
 	Assert(strlen(fn) + 1 <= MAXPGPATH);
 
 	Assert(ds);
-	datumstreamread_open_file(ds, fn, e->eof, e->eof_uncompressed, node, fileSegNo);
+	datumstreamread_open_file(ds, fn, e->eof, e->eof_uncompressed, node, fileSegNo,
+							  segInfo->formatversion);
 }
 
 /*
@@ -101,7 +102,7 @@ static void open_all_datumstreamread_segfiles(Relation rel,
     for(i=0; i<nvp; ++i)
     {
         if (proj[i])
-	{
+		{
 			open_datumstreamread_segfile(basepath, rel->rd_node, segInfo, ds[i], i);
 			datumstreamread_block(ds[i]);
 
@@ -125,7 +126,7 @@ static void open_all_datumstreamread_segfiles(Relation rel,
  */
 static void
 open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
-			  bool *proj, AORelationVersion version, bool checksum)
+			  bool *proj, bool checksum)
 {
 	int		nvp = relationTupleDesc->natts;
 	StdRdOptions 	**opts = RelationGetAttributeOptions(rel);
@@ -163,7 +164,6 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
 									checksum,
 									/* safeFSWriteSize */ 0,	// UNDONE: Need to wire down pg_appendonly column?
 									blksz,
-									version,
 									attr,
 									RelationGetRelationName(rel),
 									/* title */ titleBuf.data);
@@ -177,7 +177,7 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
  */
 static void
 open_ds_read(Relation rel, DatumStreamRead **ds, TupleDesc relationTupleDesc,
-			 bool *proj, AORelationVersion version, bool checksum)
+			 bool *proj, bool checksum)
 {
 	int		nvp = relationTupleDesc->natts;
 	StdRdOptions 	**opts = RelationGetAttributeOptions(rel);
@@ -217,7 +217,6 @@ open_ds_read(Relation rel, DatumStreamRead **ds, TupleDesc relationTupleDesc,
 										checksum,
 										/* safeFSWriteSize */ false,	// UNDONE: Need to wire down pg_appendonly column
 										blksz,
-										version,
 										attr,
 										RelationGetRelationName(rel),
 										/* title */ titleBuf.data);
@@ -265,7 +264,6 @@ static void aocs_initscan(AOCSScanDesc scan)
 
     open_ds_read(scan->aos_rel, scan->ds, scan->relationTupleDesc,
 				 scan->proj,
-				 scan->aos_rel->rd_appendonly->version,
 				 scan->aos_rel->rd_appendonly->checksum);
 
     pgstat_count_heap_scan(scan->aos_rel);
@@ -668,7 +666,6 @@ static void OpenAOCSDatumStreams(AOCSInsertDesc desc)
 								/* dontWait */ false);
 
 	open_ds_write(desc->aoi_rel, desc->ds, tupdesc, NULL,
-				  desc->aoi_rel->rd_appendonly->version,
 				  desc->aoi_rel->rd_appendonly->checksum);
 
 	/* Now open seg info file and get eof mark. */
@@ -728,8 +725,8 @@ static void OpenAOCSDatumStreams(AOCSInsertDesc desc)
 		Assert(strlen(fn) + 1 <= MAXPGPATH);
 
 		datumstreamwrite_open_file(desc->ds[i], fn, e->eof, e->eof_uncompressed,
-				desc->aoi_rel->rd_node,
-				fileSegNo);
+								   desc->aoi_rel->rd_node,
+								   fileSegNo, seginfo->formatversion);
 	}
 
 	pfree(basepath);
@@ -1248,7 +1245,6 @@ aocs_fetch_init(Relation relation,
 								   relation->rd_appendonly->checksum,
 									/* safeFSWriteSize */ false,	// UNDONE: Need to wire down pg_appendonly column
 								   blksz,
-								   relation->rd_appendonly->version,
 								   tupleDesc->attrs[colno],
 								   relation->rd_rel->relname.data,
 								   /* title */ titleBuf.data);
@@ -1703,7 +1699,6 @@ aocs_begin_headerscan(Relation rel, int colno)
 	ao_attr.compressLevel = 0;
 	ao_attr.overflowSize = 0;
 	ao_attr.safeFSWriteSize = 0;
-	ao_attr.version = rel->rd_appendonly->version;
 	hdesc = palloc(sizeof(AOCSHeaderScanDescData));
 	AppendOnlyStorageRead_Init(&hdesc->ao_read,
 							   NULL, // current memory context
@@ -1732,7 +1727,8 @@ void aocs_headerscan_opensegfile(AOCSHeaderScanDesc hdesc,
 							hdesc->colno, &fileSegNo, fn);
 	Assert(strlen(fn) + 1 <= MAXPGPATH);
 	vpe = getAOCSVPEntry(seginfo, hdesc->colno);
-	AppendOnlyStorageRead_OpenFile(&hdesc->ao_read, fn, vpe->eof);
+	AppendOnlyStorageRead_OpenFile(&hdesc->ao_read, fn, seginfo->formatversion,
+								   vpe->eof);
 }
 
 bool aocs_get_nextheader(AOCSHeaderScanDesc hdesc)
@@ -1792,7 +1788,7 @@ aocs_addcol_init(Relation rel,
 		blksz = opts[iattr]->blocksize;
 		desc->dsw[i] = create_datumstreamwrite(
 				ct, clvl, rel->rd_appendonly->checksum, 0, blksz /* safeFSWriteSize */,
-				rel->rd_appendonly->version, attr, RelationGetRelationName(rel),
+				attr, RelationGetRelationName(rel),
 				titleBuf.data);
 	}
 	return desc;
@@ -1826,12 +1822,18 @@ void aocs_addcol_newsegfile(AOCSAddColumnDesc desc,
 			true /* isAOCol */);
 	for (i = 0; i < desc->num_newcols; ++i, ++colno)
 	{
+		int version;
+
+		/* Always write in the latest format */
+		version = AORelationVersion_GetLatest();
+
 		FormatAOSegmentFileName(basepath, seginfo->segno, colno,
 								&fileSegNo, fn);
 		Assert(strlen(fn) + 1 <= MAXPGPATH);
 		datumstreamwrite_open_file(desc->dsw[i], fn,
 								   0 /* eof */, 0 /* eof_uncompressed */,
-								   relfilenode, fileSegNo);
+								   relfilenode, fileSegNo,
+								   version);
 		desc->dsw[i]->blockFirstRowNum = 1;
 	}
 	desc->cur_segno = seginfo->segno;

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -65,11 +65,8 @@ NewAOCSFileSegInfo(int4 segno, int4 nvp)
 	seginfo->vpinfo.nEntry = nvp;
 	seginfo->state = AOSEG_STATE_DEFAULT;
 
-	/*
-	 * New segments are created in the latest format. For testing purposes,
-	 * though, you can force a different version, by settting this GUC.
-	 */
-	seginfo->formatversion = test_appendonly_version_default;
+	/* New segments are always created in the latest format */
+	seginfo->formatversion = AORelationVersion_GetLatest();
 
 	return seginfo;
 }
@@ -84,11 +81,8 @@ InsertInitialAOCSFileSegInfo(Relation prel, int4 segno, int4 nvp)
 	Relation segrel;
 	int16		formatVersion;
 
-	/*
-	 * New segments are created in the latest format. For testing purposes,
-	 * though, you can force a different version, by settting this GUC.
-	 */
-	formatVersion = test_appendonly_version_default;
+	/* New segments are always created in the latest format */
+	formatVersion = AORelationVersion_GetLatest();
 
     segrel = heap_open(prel->rd_appendonly->segrelid, RowExclusiveLock);
 
@@ -650,7 +644,7 @@ ClearAOCSFileSegInfo(Relation prel, int segno, FileSegInfoState newState)
 	repl[Anum_pg_aocs_varblockcount-1] = true;
 
 	/* When the segment is later recreated, it will be in new format */
-	d[Anum_pg_aocs_formatversion-1] = Int16GetDatum(test_appendonly_version_default);
+	d[Anum_pg_aocs_formatversion-1] = Int16GetDatum(AORelationVersion_GetLatest());
 	repl[Anum_pg_aocs_formatversion-1] = true;
 
 	/* We do not reset the modcount here */

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -65,6 +65,12 @@ NewAOCSFileSegInfo(int4 segno, int4 nvp)
 	seginfo->vpinfo.nEntry = nvp;
 	seginfo->state = AOSEG_STATE_DEFAULT;
 
+	/*
+	 * New segments are created in the latest format. For testing purposes,
+	 * though, you can force a different version, by settting this GUC.
+	 */
+	seginfo->formatversion = test_appendonly_version_default;
+
 	return seginfo;
 }
 
@@ -76,6 +82,13 @@ InsertInitialAOCSFileSegInfo(Relation prel, int4 segno, int4 nvp)
     AOCSVPInfo *vpinfo = create_aocs_vpinfo(nvp);
     HeapTuple segtup;
 	Relation segrel;
+	int16		formatVersion;
+
+	/*
+	 * New segments are created in the latest format. For testing purposes,
+	 * though, you can force a different version, by settting this GUC.
+	 */
+	formatVersion = test_appendonly_version_default;
 
     segrel = heap_open(prel->rd_appendonly->segrelid, RowExclusiveLock);
 
@@ -87,6 +100,7 @@ InsertInitialAOCSFileSegInfo(Relation prel, int4 segno, int4 nvp)
     values[Anum_pg_aocs_vpinfo-1] = PointerGetDatum(vpinfo);
 	values[Anum_pg_aocs_tupcount-1] = Int64GetDatum(0);
 	values[Anum_pg_aocs_varblockcount-1] = Int64GetDatum(0);
+	values[Anum_pg_aocs_formatversion-1] = Int16GetDatum(formatVersion);
 	values[Anum_pg_aocs_state-1] = Int16GetDatum(AOSEG_STATE_DEFAULT);
 
     segtup = heap_form_tuple(RelationGetDescr(segrel), values, nulls);
@@ -190,6 +204,9 @@ GetAOCSFileSegInfo(Relation			prel,
 
 	Assert(!null[Anum_pg_aocs_modcount - 1]);
 	seginfo->modcount = DatumGetInt64(d[Anum_pg_aocs_modcount - 1]);
+
+	Assert(!null[Anum_pg_aocs_formatversion - 1]);
+	seginfo->formatversion = DatumGetInt16(d[Anum_pg_aocs_formatversion - 1]);
 
 	Assert(!null[Anum_pg_aocs_state - 1]);
 	seginfo->state = DatumGetInt16(d[Anum_pg_aocs_state - 1]);
@@ -330,6 +347,10 @@ GetAllAOCSFileSegInfo_pg_aocsseg_rel(int numOfColumns,
 		Assert(!null[Anum_pg_aocs_modcount - 1] || snapshot == SnapshotAny);
 		if (!null[Anum_pg_aocs_modcount - 1])
 			seginfo->modcount = DatumGetInt64(d[Anum_pg_aocs_modcount - 1]);
+
+		Assert(!null[Anum_pg_aocs_formatversion - 1]);
+		if (!null[Anum_pg_aocs_formatversion - 1])
+			seginfo->formatversion = DatumGetInt16(d[Anum_pg_aocs_formatversion - 1]);
 
 		Assert(!null[Anum_pg_aocs_state - 1] || snapshot == SnapshotAny);
 		if (!null[Anum_pg_aocs_state - 1])
@@ -627,6 +648,10 @@ ClearAOCSFileSegInfo(Relation prel, int segno, FileSegInfoState newState)
 	Assert(!null[Anum_pg_aocs_varblockcount-1]);
 	d[Anum_pg_aocs_varblockcount-1] = 0;
 	repl[Anum_pg_aocs_varblockcount-1] = true;
+
+	/* When the segment is later recreated, it will be in new format */
+	d[Anum_pg_aocs_formatversion-1] = Int16GetDatum(test_appendonly_version_default);
+	repl[Anum_pg_aocs_formatversion-1] = true;
 
 	/* We do not reset the modcount here */
 
@@ -1118,7 +1143,7 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
 		/* build tupdesc for result tuples */
-		tupdesc = CreateTemplateTupleDesc(9, false);
+		tupdesc = CreateTemplateTupleDesc(10, false);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "gp_tid",
 						   TIDOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "segno",
@@ -1135,7 +1160,9 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 						   INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "modcount",
 						   INT8OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "state",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "formatversion",
+						   INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 10, "state",
 						   INT2OID, -1, 0);
 
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
@@ -1188,8 +1215,8 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 	 */
 	while (true)
 	{
-		Datum		values[9];
-		bool		nulls[9];
+		Datum		values[10];
+		bool		nulls[10];
 		HeapTuple	tuple;
 		Datum		result;
 
@@ -1234,7 +1261,8 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 		values[5] = Int64GetDatum(entry->eof);
 		values[6] = Int64GetDatum(entry->eof_uncompressed);
 		values[7] = Int64GetDatum(aocsSegfile->modcount);
-		values[8] = Int16GetDatum(aocsSegfile->state);
+		values[8] = Int16GetDatum(aocsSegfile->formatversion);
+		values[9] = Int16GetDatum(aocsSegfile->state);
 
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 		result = HeapTupleGetDatum(tuple);
@@ -1327,7 +1355,7 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
 		/* build tupdesc for result tuples */
-		tupdesc = CreateTemplateTupleDesc(19, false);
+		tupdesc = CreateTemplateTupleDesc(20, false);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "gp_tid",
 						   TIDOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "gp_xmin",
@@ -1364,7 +1392,9 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 						   INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 18, "modcount",
 						   INT8OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 19, "state",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 19, "formatversion",
+						   INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 20, "state",
 						   INT2OID, -1, 0);
 
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
@@ -1417,8 +1447,8 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 	 */
 	while (true)
 	{
-		Datum		values[19];
-		bool		nulls[19];
+		Datum		values[20];
+		bool		nulls[20];
 		HeapTuple	tuple;
 		Datum		result;
 
@@ -1467,7 +1497,8 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 		values[15] = Int64GetDatum(entry->eof);
 		values[16] = Int64GetDatum(entry->eof_uncompressed);
 		values[17] = Int64GetDatum(aocsSegfile->modcount);
-		values[18] = Int16GetDatum(aocsSegfile->state);
+		values[18] = Int16GetDatum(aocsSegfile->formatversion);
+		values[19] = Int16GetDatum(aocsSegfile->state);
 
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 		result = HeapTupleGetDatum(tuple);

--- a/src/backend/access/aocs/test/aocsam_test.c
+++ b/src/backend/access/aocs/test/aocsam_test.c
@@ -18,7 +18,6 @@ test__aocs_begin_headerscan(void **state)
 	AOCSHeaderScanDesc desc;
 	RelationData reldata;
 	FormData_pg_appendonly pgappendonly;
-	pgappendonly.version = 1;
 	pgappendonly.checksum = true;
 	reldata.rd_appendonly = &pgappendonly;
 	FormData_pg_class pgclass;
@@ -90,8 +89,6 @@ test__aocs_addcol_init(void **state)
 	expect_value(create_datumstreamwrite, safeFSWriteSize, 0);
 	expect_value(create_datumstreamwrite, maxsz, 8192);
 	expect_value(create_datumstreamwrite, maxsz, 8192*2);
-	expect_any(create_datumstreamwrite, version);
-	expect_any(create_datumstreamwrite, version);
 	expect_any(create_datumstreamwrite, attr);
 	expect_any(create_datumstreamwrite, attr);
 	expect_any(create_datumstreamwrite, relname);
@@ -100,7 +97,6 @@ test__aocs_addcol_init(void **state)
 	expect_any(create_datumstreamwrite, title);
 	will_return_count(create_datumstreamwrite, NULL, 2);
 
-	pgappendonly.version = 1;
 	pgappendonly.checksum = true;
 	reldata.rd_appendonly = &pgappendonly;
 	reldata.rd_att = (TupleDesc) malloc(sizeof(struct tupleDesc));

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -71,6 +71,12 @@ NewFileSegInfo(int segno)
 	fsinfo->segno = segno;
 	fsinfo->state = AOSEG_STATE_DEFAULT;
 
+	/*
+	 * New segments are created in the latest format. For testing purposes,
+	 * though, you can force a different version, by settting this GUC.
+	 */
+	fsinfo->formatversion = test_appendonly_version_default;
+
 	return fsinfo;
 }
 
@@ -92,6 +98,13 @@ InsertInitialSegnoEntry(Relation parentrel, int segno)
 	int			natts = 0;
 	bool	   *nulls;
 	Datum	   *values;
+	int16		formatVersion;
+
+	/*
+	 * New segments are created in the latest format. For testing purposes,
+	 * though, you can force a different version, by settting this GUC.
+	 */
+	formatVersion = test_appendonly_version_default;
 
 	InsertFastSequenceEntry(parentrel->rd_appendonly->segrelid,
 							(int64)segno,
@@ -111,6 +124,7 @@ InsertInitialSegnoEntry(Relation parentrel, int segno)
 	values[Anum_pg_aoseg_eof - 1] = Int64GetDatum(0);
 	values[Anum_pg_aoseg_eofuncompressed - 1] = Int64GetDatum(0);
 	values[Anum_pg_aoseg_modcount - 1] = Int64GetDatum(0);
+	values[Anum_pg_aoseg_formatversion - 1] = Int16GetDatum(formatVersion);
 	values[Anum_pg_aoseg_state - 1] = Int16GetDatum(AOSEG_STATE_DEFAULT);
 
 	/*
@@ -243,6 +257,15 @@ GetFileSegInfo(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot, int segn
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				errmsg("got invalid modcount value: NULL")));
 
+	/* get the file format version number */
+	fsinfo->formatversion = DatumGetInt16(
+			fastgetattr(fstuple, Anum_pg_aoseg_formatversion, pg_aoseg_dsc, &isNull));
+
+	if(isNull)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				errmsg("got invalid formatversion value: NULL")));
+
 	/* get the state */
 	fsinfo->state = DatumGetInt16(
 			fastgetattr(fstuple, Anum_pg_aoseg_state, pg_aoseg_dsc, &isNull));
@@ -348,6 +371,7 @@ GetAllFileSegInfo_pg_aoseg_rel(char *relationName,
 					tupcount,
 					varblockcount,
 					modcount,
+					formatversion,
 					state;
 	bool			isNull;
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
@@ -418,6 +442,12 @@ GetAllFileSegInfo_pg_aoseg_rel(char *relationName,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
 					 errmsg("got invalid modcount value: NULL")));
 		oneseginfo->modcount += DatumGetInt64(modcount);
+
+		/* get the file format version number */
+		formatversion = fastgetattr(tuple, Anum_pg_aoseg_formatversion, pg_aoseg_dsc, &isNull);
+		Assert(!isNull || appendOnlyMetaDataSnapshot == SnapshotAny);
+		if (!isNull)
+			oneseginfo->formatversion = (int64)DatumGetInt16(formatversion);
 
 		/* get the state */
 		state = fastgetattr(tuple, Anum_pg_aoseg_state, pg_aoseg_dsc, &isNull);
@@ -569,6 +599,11 @@ ClearFileSegInfo(Relation parentrel,
 	new_record_repl[Anum_pg_aoseg_varblockcount - 1] = true;
 	new_record[Anum_pg_aoseg_eofuncompressed - 1] = Int64GetDatum(0);
 	new_record_repl[Anum_pg_aoseg_eofuncompressed - 1] = true;
+
+	/* When the segment is later recreated, it will be in new format */
+	new_record[Anum_pg_aoseg_formatversion - 1] = Int16GetDatum(test_appendonly_version_default);
+	new_record_repl[Anum_pg_aoseg_formatversion - 1] = true;
+
 	/* We do not reset the modcount here */
 
 	if (newState > 0)
@@ -988,7 +1023,7 @@ gp_aoseg_history(PG_FUNCTION_ARGS)
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
 		/* build tupdesc for result tuples */
-		tupdesc = CreateTemplateTupleDesc(17, false);
+		tupdesc = CreateTemplateTupleDesc(18, false);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "gp_tid",
 						   TIDOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "gp_xmin",
@@ -1021,7 +1056,9 @@ gp_aoseg_history(PG_FUNCTION_ARGS)
 						   INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 16, "modcount",
 						   INT8OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 17, "state",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 17, "formatversion",
+						   INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 18, "state",
 						   INT2OID, -1, 0);
 
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
@@ -1070,8 +1107,8 @@ gp_aoseg_history(PG_FUNCTION_ARGS)
 	 */
 	while (true)
 	{
-		Datum		values[17];
-		bool		nulls[17];
+		Datum		values[18];
+		bool		nulls[18];
 		HeapTuple	tuple;
 		Datum		result;
 
@@ -1100,7 +1137,8 @@ gp_aoseg_history(PG_FUNCTION_ARGS)
 		values[13] = Int64GetDatum(aoSegfile->eof);
 		values[14] = Int64GetDatum(aoSegfile->eof_uncompressed);
 		values[15] = Int64GetDatum(aoSegfile->modcount);
-		values[16] = Int16GetDatum(aoSegfile->state);
+		values[16] = Int16GetDatum(aoSegfile->formatversion);
+		values[17] = Int16GetDatum(aoSegfile->state);
 
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 		result = HeapTupleGetDatum(tuple);
@@ -1333,7 +1371,7 @@ gp_aoseg_name(PG_FUNCTION_ARGS)
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
 		/* build tupdesc for result tuples */
-		tupdesc = CreateTemplateTupleDesc(7, false);
+		tupdesc = CreateTemplateTupleDesc(8, false);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "segno",
 						   INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "eof",
@@ -1346,7 +1384,9 @@ gp_aoseg_name(PG_FUNCTION_ARGS)
 						   INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "modcount",
 						   INT8OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "state",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "formatversion",
+						   INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "state",
 						   INT2OID, -1, 0);
 
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
@@ -1394,8 +1434,8 @@ gp_aoseg_name(PG_FUNCTION_ARGS)
 	 */
 	while (true)
 	{
-		Datum		values[7];
-		bool		nulls[7];
+		Datum		values[8];
+		bool		nulls[8];
 		HeapTuple	tuple;
 		Datum		result;
 
@@ -1420,7 +1460,8 @@ gp_aoseg_name(PG_FUNCTION_ARGS)
 		values[3] = Int64GetDatum(aoSegfile->varblockcount);
 		values[4] = Int64GetDatum(aoSegfile->eof_uncompressed);
 		values[5] = Int64GetDatum(aoSegfile->modcount);
-		values[6] = Int16GetDatum(aoSegfile->state);
+		values[6] = Int64GetDatum(aoSegfile->formatversion);
+		values[7] = Int16GetDatum(aoSegfile->state);
 
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 		result = HeapTupleGetDatum(tuple);

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -70,12 +70,8 @@ NewFileSegInfo(int segno)
 	fsinfo = (FileSegInfo *) palloc0(sizeof(FileSegInfo));
 	fsinfo->segno = segno;
 	fsinfo->state = AOSEG_STATE_DEFAULT;
-
-	/*
-	 * New segments are created in the latest format. For testing purposes,
-	 * though, you can force a different version, by settting this GUC.
-	 */
-	fsinfo->formatversion = test_appendonly_version_default;
+	/* New segments are always created in the latest format */
+	fsinfo->formatversion = AORelationVersion_GetLatest();
 
 	return fsinfo;
 }
@@ -100,11 +96,8 @@ InsertInitialSegnoEntry(Relation parentrel, int segno)
 	Datum	   *values;
 	int16		formatVersion;
 
-	/*
-	 * New segments are created in the latest format. For testing purposes,
-	 * though, you can force a different version, by settting this GUC.
-	 */
-	formatVersion = test_appendonly_version_default;
+	/* New segments are always created in the latest format */
+	formatVersion = AORelationVersion_GetLatest();
 
 	InsertFastSequenceEntry(parentrel->rd_appendonly->segrelid,
 							(int64)segno,
@@ -601,7 +594,7 @@ ClearFileSegInfo(Relation parentrel,
 	new_record_repl[Anum_pg_aoseg_eofuncompressed - 1] = true;
 
 	/* When the segment is later recreated, it will be in new format */
-	new_record[Anum_pg_aoseg_formatversion - 1] = Int16GetDatum(test_appendonly_version_default);
+	new_record[Anum_pg_aoseg_formatversion - 1] = Int16GetDatum(AORelationVersion_GetLatest());
 	new_record_repl[Anum_pg_aoseg_formatversion - 1] = true;
 
 	/* We do not reset the modcount here */

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -263,7 +263,7 @@ AORelCreateHashEntry(Oid relid)
 
 	/*
 	 * update the tupcount of each 'segment' file in the append
-	 * only hash according to tupcounts in the pg_aoseg table.
+	 * only hash according to the information in the pg_aoseg table.
 	 */
 	for (i = 0 ; i < total_segfiles; i++)
 	{
@@ -1001,9 +1001,9 @@ SetSegnoForCompactionInsert(Relation rel,
 			list_find_int(compactedSegmentFileList, i) >= 0;
 
 		if (segfilestat->total_tupcount < min_tupcount &&
-				segfilestat->state == AVAILABLE && 
-				!usedByConcurrentTransaction(segfilestat, i) &&
-				!in_compaction_list)
+			segfilestat->state == AVAILABLE &&
+			!usedByConcurrentTransaction(segfilestat, i) &&
+			!in_compaction_list)
 		{
 			min_tupcount = segfilestat->total_tupcount;
 			usesegno = i;
@@ -1141,8 +1141,9 @@ SetSegnoForWrite(Relation rel, int existingsegno)
 
 				if(!segfilestat->isfull)
 				{
-					if(segfilestat->state == AVAILABLE && !segno_chosen &&
-					   !usedByConcurrentTransaction(segfilestat, i))
+					if (segfilestat->state == AVAILABLE &&
+						!segno_chosen &&
+						!usedByConcurrentTransaction(segfilestat, i))
 					{
 						/*
 						 * this segno is avaiable and not full. use it.

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -259,26 +259,30 @@ AORelCreateHashEntry(Oid relid)
 		aoHashEntry->relsegfiles[i].total_tupcount = 0;
 		aoHashEntry->relsegfiles[i].tupsadded = 0;
 		aoHashEntry->relsegfiles[i].aborted = false;
+		aoHashEntry->relsegfiles[i].formatversion = AORelationVersion_GetLatest();
 	}
 
 	/*
-	 * update the tupcount of each 'segment' file in the append
+	 * update the tupcount and formatVersion of each 'segment' file in the append
 	 * only hash according to the information in the pg_aoseg table.
 	 */
 	for (i = 0 ; i < total_segfiles; i++)
 	{
 		int segno;
 		int64 total_tupcount;
+		int16 formatversion;
 		if (allfsinfo)
 		{
 			segno = allfsinfo[i]->segno;
 			total_tupcount = allfsinfo[i]->total_tupcount;
+			formatversion = allfsinfo[i]->formatversion;
 		}
 		else
 		{
 			Assert(aocsallfsinfo);
 			segno = aocsallfsinfo[i]->segno;
 			total_tupcount = aocsallfsinfo[i]->total_tupcount;
+			formatversion = aocsallfsinfo[i]->formatversion;
 		}
 
 		if (awaiting_drop[segno])
@@ -289,6 +293,7 @@ AORelCreateHashEntry(Oid relid)
 			aoHashEntry->relsegfiles[segno].state = AWAITING_DROP_READY;
 		}
 		aoHashEntry->relsegfiles[segno].total_tupcount = total_tupcount;
+		aoHashEntry->relsegfiles[segno].formatversion = formatversion;
 	}
 
 	/* record the fact that another hash entry is now taken */
@@ -1002,6 +1007,7 @@ SetSegnoForCompactionInsert(Relation rel,
 
 		if (segfilestat->total_tupcount < min_tupcount &&
 			segfilestat->state == AVAILABLE &&
+			segfilestat->formatversion == AORelationVersion_GetLatest() &&
 			!usedByConcurrentTransaction(segfilestat, i) &&
 			!in_compaction_list)
 		{
@@ -1142,6 +1148,7 @@ SetSegnoForWrite(Relation rel, int existingsegno)
 				if(!segfilestat->isfull)
 				{
 					if (segfilestat->state == AVAILABLE &&
+						segfilestat->formatversion == AORelationVersion_GetLatest() &&
 						!segno_chosen &&
 						!usedByConcurrentTransaction(segfilestat, i))
 					{

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -541,7 +541,7 @@ static int compute_dest_tuplen(TupleDesc tupdesc, MemTupleBinding *pbind, bool h
 	if(pbind) 
 	{
 		uint32 nullsave_dummy;
-		return (int) compute_memtuple_size(pbind, d, isnull, hasnull, &nullsave_dummy, true /* aligned */);
+		return (int) compute_memtuple_size(pbind, d, isnull, hasnull, &nullsave_dummy);
 	}
 
 	return heap_compute_data_size(tupdesc, d, isnull);

--- a/src/backend/catalog/aoseg.c
+++ b/src/backend/catalog/aoseg.c
@@ -46,7 +46,7 @@ AlterTableCreateAoSegTableWithOid(Oid relOid, Oid newOid,
 		prefix = "pg_aoseg";
 
 		/* this is pretty painful...  need a tuple descriptor */
-		tupdesc = CreateTemplateTupleDesc(7, false);
+		tupdesc = CreateTemplateTupleDesc(8, false);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1,
 						"segno",
 						INT4OID,
@@ -72,6 +72,10 @@ AlterTableCreateAoSegTableWithOid(Oid relOid, Oid newOid,
 						INT8OID,
 						-1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 7,
+						"formatversion",
+						INT2OID,
+						-1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 8,
 						"state",
 						INT2OID,
 						-1, 0);
@@ -110,7 +114,7 @@ AlterTableCreateAoSegTableWithOid(Oid relOid, Oid newOid,
 		 * state (smallint)         -- state of the segment file
 		 */
 
-		tupdesc = CreateTemplateTupleDesc(6, false);
+		tupdesc = CreateTemplateTupleDesc(7, false);
 
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1,
 						   "segno",
@@ -133,6 +137,10 @@ AlterTableCreateAoSegTableWithOid(Oid relOid, Oid newOid,
 						INT8OID,
 						-1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 6,
+						   "formatversion",
+						   INT2OID,
+						   -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 7,
 						   "state",
 						   INT2OID,
 						   -1, 0);

--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1843,6 +1843,7 @@ RETURNS TABLE(gp_tid tid,
     eof bigint,
     eof_uncompressed bigint,
     modcount bigint,
+    formatversion smallint,
     state smallint)
 AS '$libdir/gp_ao_co_diagnostics', 'gp_aoseg_history_wrapper'
 LANGUAGE C STRICT;
@@ -1857,6 +1858,7 @@ RETURNS TABLE(gp_tid tid,
     eof bigint,
     eof_uncompressed bigint,
     modcount bigint,
+    formatversion smallint,
     state smallint)
 AS '$libdir/gp_ao_co_diagnostics', 'gp_aocsseg_wrapper'
 LANGUAGE C STRICT;
@@ -1871,6 +1873,7 @@ RETURNS TABLE (gp_tid tid,
     eof bigint,
     eof_uncompressed bigint,
     modcount bigint,
+    formatversion smallint,
     state smallint)
 AS '$libdir/gp_ao_co_diagnostics', 'gp_aocsseg_name_wrapper'
 LANGUAGE C STRICT;
@@ -1895,6 +1898,7 @@ RETURNS TABLE(gp_tid tid,
     eof bigint,
     eof_uncompressed bigint,
     modcount bigint,
+    formatversion smallint,
     state smallint)
 AS '$libdir/gp_ao_co_diagnostics' , 'gp_aocsseg_history_wrapper'
 LANGUAGE C STRICT;
@@ -1954,7 +1958,9 @@ RETURNS TABLE (segno integer, eof bigint,
     tupcount bigint,
     varblockcount bigint,
     eof_uncompressed bigint,
-    modcount bigint, state smallint)
+    modcount bigint,
+    formatversion smallint,
+    state smallint)
 AS '$libdir/gp_ao_co_diagnostics', 'gp_aoseg_name_wrapper'
 LANGUAGE C STRICT;
 GRANT EXECUTE ON FUNCTION gp_toolkit.__gp_aoseg_name(text) TO public;

--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -81,8 +81,6 @@ InsertAppendOnlyEntry(Oid relid,
 	values[Anum_pg_appendonly_visimaprelid - 1] = ObjectIdGetDatum(visimaprelid);
 	values[Anum_pg_appendonly_visimapidxid - 1] = ObjectIdGetDatum(visimapidxid);
 
-	values[Anum_pg_appendonly_version - 1] = test_appendonly_version_default;
-	
 	/*
 	 * form the tuple and insert it
 	 */

--- a/src/backend/cdb/cdbappendonlystorageread.c
+++ b/src/backend/cdb/cdbappendonlystorageread.c
@@ -125,6 +125,7 @@ AppendOnlyStorageRead_Init(AppendOnlyStorageRead *storageRead,
 		   storageRead->largeReadLen);
 
 	storageRead->file = -1;
+	storageRead->formatVersion = -1;
 
 	MemoryContextSwitchTo(oldMemoryContext);
 
@@ -251,6 +252,7 @@ AppendOnlyStorageRead_DoOpenFile(AppendOnlyStorageRead *storageRead,
  *
  * file			- The open file.
  * filePathName - name of the segment file to open.
+ * version		- AO table format version the file is in.
  * logicalEof	- snapshot version of the EOF value to use as the read end
  *				  of the segment file.
  */
@@ -258,12 +260,14 @@ static void
 AppendOnlyStorageRead_FinishOpenFile(AppendOnlyStorageRead *storageRead,
 									 File file,
 									 char *filePathName,
+									 int version,
 									 int64 logicalEof)
-
 {
 	int64		seekResult;
 	MemoryContext oldMemoryContext;
 	int			segmentFileNameLen;
+
+	AORelationVersion_CheckValid(version);
 
 	/*
 	 * Seek to the beginning of the file.
@@ -282,6 +286,7 @@ AppendOnlyStorageRead_FinishOpenFile(AppendOnlyStorageRead *storageRead,
 	}
 
 	storageRead->file = file;
+	storageRead->formatVersion = version;
 
 	/*
 	 * When reading multiple segment files, we throw away the old segment file
@@ -315,12 +320,14 @@ AppendOnlyStorageRead_FinishOpenFile(AppendOnlyStorageRead *storageRead,
  * read location given the logical EOF.
  *
  * filePathName - name of the segment file to open.
+ * version		- AO table format version the file is in.
  * logicalEof	- snapshot version of the EOF value to use as the read end
  *				  of the segment file.
  */
 void
 AppendOnlyStorageRead_OpenFile(AppendOnlyStorageRead *storageRead,
 							   char *filePathName,
+							   int version,
 							   int64 logicalEof)
 {
 	File		file;
@@ -355,6 +362,7 @@ AppendOnlyStorageRead_OpenFile(AppendOnlyStorageRead *storageRead,
 	AppendOnlyStorageRead_FinishOpenFile(storageRead,
 										 file,
 										 filePathName,
+										 version,
 										 logicalEof);
 }
 
@@ -365,12 +373,14 @@ AppendOnlyStorageRead_OpenFile(AppendOnlyStorageRead *storageRead,
  * the logical EOF.
  *
  * filePathName - name of the segment file to open
+ * version		- AO table format version the file is in.
  * logicalEof	- snapshot version of the EOF value to use as the read end of
  *				  the segment file.
  */
 bool
 AppendOnlyStorageRead_TryOpenFile(AppendOnlyStorageRead *storageRead,
 								  char *filePathName,
+								  int version,
 								  int64 logicalEof)
 {
 	File		file;
@@ -388,6 +398,7 @@ AppendOnlyStorageRead_TryOpenFile(AppendOnlyStorageRead *storageRead,
 	AppendOnlyStorageRead_FinishOpenFile(storageRead,
 										 file,
 										 filePathName,
+										 version,
 										 logicalEof);
 
 	return true;
@@ -412,6 +423,7 @@ AppendOnlyStorageRead_SetTemporaryRange(AppendOnlyStorageRead *storageRead,
 {
 	Assert(storageRead->isActive);
 	Assert(storageRead->file != -1);
+	Assert(storageRead->formatVersion != -1);
 	Assert(beginFileOffset >= 0);
 	Assert(beginFileOffset <= storageRead->logicalEof);
 	Assert(afterFileOffset >= 0);
@@ -439,6 +451,7 @@ AppendOnlyStorageRead_CloseFile(AppendOnlyStorageRead *storageRead)
 	FileClose(storageRead->file);
 
 	storageRead->file = -1;
+	storageRead->formatVersion = -1;
 
 	storageRead->logicalEof = INT64CONST(0);
 
@@ -712,10 +725,9 @@ AppendOnlyStorageRead_StorageContentHeaderStr(AppendOnlyStorageRead *storageRead
 
 	header = BufferedReadGetCurrentBuffer(&storageRead->bufferedRead);
 
-	return AppendOnlyStorageFormat_BlockHeaderStr(
-												  header,
+	return AppendOnlyStorageFormat_BlockHeaderStr(header,
 									 storageRead->storageAttributes.checksum,
-									 storageRead->storageAttributes.version);
+												  storageRead->formatVersion);
 }
 
 /*
@@ -749,7 +761,7 @@ AppendOnlyStorageRead_LogBlockHeader(AppendOnlyStorageRead *storageRead,
 	blockHeaderStr =
 		AppendOnlyStorageFormat_SmallContentHeaderStr(header,
 									 storageRead->storageAttributes.checksum,
-									 storageRead->storageAttributes.version);
+									 storageRead->formatVersion);
 	ereport(LOG,
 			(errmsg("%s. %s",
 					contextStr,
@@ -799,8 +811,7 @@ AppendOnlyStorageRead_ReadNextBlock(AppendOnlyStorageRead *storageRead)
 		   "before AppendOnlyStorageRead_PositionToNextBlock, storageRead->current.headerOffsetInFile is" INT64_FORMAT "storageRead->current.overallBlockLen is %d",
 		   storageRead->current.headerOffsetInFile, storageRead->current.overallBlockLen);
 
-	if (!AppendOnlyStorageRead_PositionToNextBlock(
-												   storageRead,
+	if (!AppendOnlyStorageRead_PositionToNextBlock(storageRead,
 									&storageRead->current.headerOffsetInFile,
 												   &header,
 												   &blockLimitLen))
@@ -896,7 +907,7 @@ AppendOnlyStorageRead_ReadNextBlock(AppendOnlyStorageRead *storageRead)
 				 &storageRead->current.uncompressedLen,
 				 &storageRead->current.executorBlockKind,
 				 &storageRead->current.hasFirstRowNum,
-				 storageRead->storageAttributes.version,
+				 storageRead->formatVersion,
 				 &storageRead->current.firstRowNum,
 				 &storageRead->current.rowCount,
 				 &storageRead->current.isCompressed,
@@ -951,7 +962,7 @@ AppendOnlyStorageRead_ReadNextBlock(AppendOnlyStorageRead *storageRead)
 				 &storageRead->current.uncompressedLen,
 				 &storageRead->current.executorBlockKind,
 				 &storageRead->current.hasFirstRowNum,
-				 storageRead->storageAttributes.version,
+				 storageRead->formatVersion,
 				 &storageRead->current.firstRowNum,
 				 &storageRead->current.rowCount
 				);
@@ -980,7 +991,7 @@ AppendOnlyStorageRead_ReadNextBlock(AppendOnlyStorageRead *storageRead)
 				 &storageRead->current.uncompressedLen,
 				 &storageRead->current.executorBlockKind,
 				 &storageRead->current.hasFirstRowNum,
-				 storageRead->storageAttributes.version,
+				 storageRead->formatVersion,
 				 &storageRead->current.firstRowNum,
 				 &storageRead->current.rowCount,
 				 &storageRead->current.isCompressed,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -347,9 +347,6 @@ char	   *gp_connectemc_mode;
 EmcConnectModeType_t gp_emcconnect_transport;
 #endif
 
-/* The following GUC holds the default version for append-only tables */
-int			test_appendonly_version_default = AORelationVersion_GetLatest();
-
 static char *gp_log_gang_str;
 static char *gp_log_fts_str;
 static char *gp_log_interconnect_str;
@@ -3808,16 +3805,6 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&MaxAppendOnlyTables,
 		2048, 0, INT_MAX, NULL, NULL
-	},
-
-	{
-		{"test_appendonly_version_default", PGC_USERSET, APPENDONLY_TABLES,
-			gettext_noop("Align append-only blocks to 64 bits."),
-			NULL,
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&test_appendonly_version_default,
-		AORelationVersion_GetLatest(), 0, INT_MAX, NULL, NULL
 	},
 
 	{

--- a/src/include/access/aocssegfiles.h
+++ b/src/include/access/aocssegfiles.h
@@ -11,13 +11,14 @@
 #include "access/aosegfiles.h"
 #include "utils/tqual.h"
 
-#define Natts_pg_aocsseg 6
+#define Natts_pg_aocsseg 7
 #define Anum_pg_aocs_segno 1
 #define Anum_pg_aocs_tupcount 2
 #define Anum_pg_aocs_varblockcount 3
 #define Anum_pg_aocs_vpinfo 4
 #define Anum_pg_aocs_modcount 5
-#define Anum_pg_aocs_state 6
+#define Anum_pg_aocs_formatversion 6
+#define Anum_pg_aocs_state 7
 
 
 /*
@@ -32,7 +33,8 @@
 { -1, {"varblockcount"},		20, -1, 8, 3, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
 { -1, {"vpinfo"},				17, -1, -1, 4, 0, -1, -1, false, 'x', 'i', false, false, false, true, 0 }, \
 { -1, {"modcount"},				20, -1, 8, 5, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }, \
-{ -1, {"state"}, 				 21, -1, 2, 6, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }
+{ -1, {"formatversion"},		21, -1, 2, 6, 0, -1, -1, true, 'p', 's', false, false, false, true, 0 }, \
+{ -1, {"state"}, 				 21, -1, 2, 7, 0, -1, -1, true, 'p', 's', false, false, false, true, 0 }
 
 /*
  * pg_aoseg_nnnnnn table values for FormData_pg_class.
@@ -49,7 +51,7 @@ typedef struct AOCSVPInfoEntry
         int64 eof;
         int64 eof_uncompressed;
 } AOCSVPInfoEntry;
-        
+
 typedef struct AOCSVPInfo
 {
         /* total len.  Have to be the very first */ 
@@ -103,6 +105,8 @@ typedef struct AOCSFileSegInfo
 	 * The state is only maintained on the segments.
 	 */
 	FileSegInfoState state;
+
+	int16		formatversion;
 
 	/* Must be last */
 	AOCSVPInfo vpinfo;

--- a/src/include/access/aosegfiles.h
+++ b/src/include/access/aosegfiles.h
@@ -14,14 +14,15 @@
 #include "utils/tqual.h"
 #include "catalog/pg_appendonly.h"
 
-#define Natts_pg_aoseg					7
+#define Natts_pg_aoseg					8
 #define Anum_pg_aoseg_segno				1
 #define Anum_pg_aoseg_eof				2
 #define Anum_pg_aoseg_tupcount			3
 #define Anum_pg_aoseg_varblockcount		4
 #define Anum_pg_aoseg_eofuncompressed	5
 #define Anum_pg_aoseg_modcount          6
-#define Anum_pg_aoseg_state             7
+#define Anum_pg_aoseg_formatversion     7
+#define Anum_pg_aoseg_state             8
 
 #define InvalidFileSegNumber			-1
 #define InvalidUncompressedEof			-1
@@ -69,7 +70,8 @@ typedef enum FileSegInfoState
 { -1, {"varblockcount"},		 20, -1, 8, 4, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
 { -1, {"eofuncompressed"},		 20, -1, 8, 5, 0, -1, -1, true, 'p', 'd', false, false, false, true, 0 }, \
 { -1, {"modcount"}, 			 20, -1, 8, 6, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }, \
-{ -1, {"state"}, 				 21, -1, 2, 6, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }
+{ -1, {"formatversion"},		 21, -1, 2, 7, 0, -1, -1, true, 'p', 's', false, false, false, true, 0 }, \
+{ -1, {"state"}, 				 21, -1, 2, 8, 0, -1, -1, true, 'p', 's', false, false, false, true, 0 }
 
 /*
  * pg_aoseg_nnnnnn table values for FormData_pg_class.
@@ -100,7 +102,7 @@ typedef struct FileSegInfo
 	int64 total_tupcount;	
 
 	/* total number of varblocks in this fileseg */	
-	int64 varblockcount;	
+	int64 varblockcount;
 	
 	/*
 	 * Number of data modification operations
@@ -113,6 +115,9 @@ typedef struct FileSegInfo
 	/* what would have been the eof if we didn't 
 	   compress this rel (= eof if no compression) */
 	int64 eof_uncompressed;
+
+	/* File format version number */
+	int16		formatversion;
 
 	/* 
      * state of the segno.

--- a/src/include/access/appendonlywriter.h
+++ b/src/include/access/appendonlywriter.h
@@ -160,6 +160,8 @@ typedef struct AOSegfileStatus
 
 	AOSegfileState state;
 
+	int16			formatversion;
+
 	/* if true - never insert into this segno anymore */ 	
 	bool			isfull;	   	
 	

--- a/src/include/access/appendonlywriter.h
+++ b/src/include/access/appendonlywriter.h
@@ -157,7 +157,7 @@ typedef struct AOSegfileStatus
 	 * transaction id
 	 */
 	DistributedTransactionId latestWriteXid;
-	
+
 	AOSegfileState state;
 
 	/* if true - never insert into this segno anymore */ 	

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -171,11 +171,12 @@ extern MemTupleBinding* create_memtuple_binding(TupleDesc tupdesc);
 extern Datum memtuple_getattr(MemTuple mtup, MemTupleBinding *pbind, int attnum, bool *isnull);
 extern bool memtuple_attisnull(MemTuple mtup, MemTupleBinding *pbind, int attnum);
 
-extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool *isnull, bool hasnull, uint32 *nullsaves, bool use_null_saves_aligned);
+extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool *isnull, bool hasnull, uint32 *nullsaves);
 
 extern MemTuple memtuple_copy_to(MemTuple mtup, MemTupleBinding *pbind, MemTuple dest, uint32 *destlen);
 extern MemTuple memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull, MemTuple dest, uint32 *destlen, bool inline_toast);
 extern void memtuple_deform(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
+extern void memtuple_deform_misaligned(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 
 extern Oid MemTupleGetOid(MemTuple mtup, MemTupleBinding *pbind);
 extern void MemTupleSetOid(MemTuple mtup, MemTupleBinding *pbind, Oid oid);

--- a/src/include/catalog/pg_appendonly.h
+++ b/src/include/catalog/pg_appendonly.h
@@ -29,7 +29,6 @@ CATALOG(pg_appendonly,6105) BKI_WITHOUT_OIDS
     Oid             segrelid;           /* OID of aoseg table; 0 if none */
     Oid             blkdirrelid;        /* OID of aoblkdir table; 0 if none */
     Oid             blkdiridxid;        /* if aoblkdir table, OID of aoblkdir index */
-    int4            version;            /* version of MemTuples and block layout for this table */
 	Oid             visimaprelid;		/* OID of the aovisimap table */
 	Oid             visimapidxid;		/* OID of aovisimap index */
 } FormData_pg_appendonly;
@@ -62,9 +61,8 @@ typedef FormData_pg_appendonly *Form_pg_appendonly;
 #define Anum_pg_appendonly_segrelid         8
 #define Anum_pg_appendonly_blkdirrelid      9
 #define Anum_pg_appendonly_blkdiridxid      10
-#define Anum_pg_appendonly_version          11
-#define Anum_pg_appendonly_visimaprelid     12
-#define Anum_pg_appendonly_visimapidxid     13
+#define Anum_pg_appendonly_visimaprelid     11
+#define Anum_pg_appendonly_visimapidxid     12
 
 /*
  * pg_appendonly table values for FormData_pg_attribute.
@@ -83,9 +81,8 @@ typedef FormData_pg_appendonly *Form_pg_appendonly;
 { AppendOnlyRelationId, {"segrelid"},				26, -1, 4, 8, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }, \
 { AppendOnlyRelationId, {"blkdirrelid"},			26, -1, 4, 10, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }, \
 { AppendOnlyRelationId, {"blkdiridxid"},			26, -1, 4, 11, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }, \
-{ AppendOnlyRelationId, {"version"},				23, -1, 4, 12, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }, \
-{ AppendOnlyRelationId, {"visimaprelid"},			26, -1, 4, 13, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }, \
-{ AppendOnlyRelationId, {"visimapidxid"},			26, -1, 4, 14, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }
+{ AppendOnlyRelationId, {"visimaprelid"},			26, -1, 4, 12, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }, \
+{ AppendOnlyRelationId, {"visimapidxid"},			26, -1, 4, 13, 0, -1, -1, true, 'p', 'i', false, false, false, true, 0 }
 
 /*
  * pg_appendonly table values for FormData_pg_class.

--- a/src/include/catalog/pg_appendonly.h
+++ b/src/include/catalog/pg_appendonly.h
@@ -134,6 +134,4 @@ static inline void AORelationVersion_CheckValid(int version)
 	(version > AORelationVersion_Original) \
 )
 
-extern int test_appendonly_version_default;
-
 #endif   /* PG_APPENDONLY_H */

--- a/src/include/cdb/cdbappendonlystoragelayer.h
+++ b/src/include/cdb/cdbappendonlystoragelayer.h
@@ -116,11 +116,6 @@ typedef struct AppendOnlyStorageAttributes
 			 * When 0, do no zero pad.
 			 */
 
-	int					version;
-			/*
-			 * Version of the MemTuple and block layout for this AO table.
-			 */
-
 } AppendOnlyStorageAttributes;
 
 /*

--- a/src/include/cdb/cdbappendonlystorageread.h
+++ b/src/include/cdb/cdbappendonlystorageread.h
@@ -9,6 +9,7 @@
 #ifndef CDBAPPENDONLYSTORAGEREAD_H
 #define CDBAPPENDONLYSTORAGEREAD_H
 
+#include "catalog/pg_appendonly.h"
 #include "catalog/pg_compression.h"
 #include "cdb/cdbappendonlystorage.h"
 #include "cdb/cdbappendonlystoragelayer.h"
@@ -150,6 +151,11 @@ typedef struct AppendOnlyStorageRead
 	int64		logicalEof;
 
 	/*
+	 * Version number indicating the AO table format version to read in.
+	 */
+	int			formatVersion;
+
+	/*
 	 * The minimum block header length based on the checkum attribute. Does
 	 * not include optional header data (e.g. firstRowNum).
 	 */
@@ -191,9 +197,9 @@ extern char *AppendOnlyStorageRead_SegmentFileName(AppendOnlyStorageRead *storag
 extern void AppendOnlyStorageRead_FinishSession(AppendOnlyStorageRead *storageRead);
 
 extern void AppendOnlyStorageRead_OpenFile(AppendOnlyStorageRead *storageRead,
-							   char *filePathName, int64 logicalEof);
+							   char *filePathName, int version, int64 logicalEof);
 extern bool AppendOnlyStorageRead_TryOpenFile(AppendOnlyStorageRead *storageRead,
-								  char *filePathName, int64 logicalEof);
+								  char *filePathName, int version, int64 logicalEof);
 extern void AppendOnlyStorageRead_SetTemporaryRange(AppendOnlyStorageRead *storageRead,
 							   int64 beginFileOffset, int64 afterFileOffset);
 extern void AppendOnlyStorageRead_CloseFile(AppendOnlyStorageRead *storageRead);

--- a/src/include/cdb/cdbappendonlystoragewrite.h
+++ b/src/include/cdb/cdbappendonlystoragewrite.h
@@ -9,6 +9,7 @@
 #ifndef CDBAPPENDONLYSTORAGEWRITE_H
 #define CDBAPPENDONLYSTORAGEWRITE_H
 
+#include "catalog/pg_appendonly.h"
 #include "catalog/pg_compression.h"
 #include "cdb/cdbappendonlystorage.h"
 #include "cdb/cdbappendonlystoragelayer.h"
@@ -39,6 +40,11 @@ typedef struct AppendOnlyStorageWrite
 	 * The large write length given to the BufferedAppend module.
 	 */
 	int32		largeWriteLen;
+
+	/*
+	 * Version number indicating the AO table format version to write in.
+	 */
+	AORelationVersion formatVersion;
 
 	/*
 	 * Name of the relation to use in system logging and error messages.
@@ -181,6 +187,7 @@ extern void AppendOnlyStorageWrite_TransactionCreateFile(AppendOnlyStorageWrite 
 											 int64 *persistentSerialNum);
 extern void AppendOnlyStorageWrite_OpenFile(AppendOnlyStorageWrite *storageWrite,
 								char *filePathName,
+								int version,
 								int64 logicalEof,
 								int64 fileLen_uncompressed,
 								RelFileNode *relFileNode,

--- a/src/include/utils/datumstream.h
+++ b/src/include/utils/datumstream.h
@@ -235,7 +235,6 @@ extern DatumStreamWrite *create_datumstreamwrite(
 						bool checksum,
 						int32 safeFSWriteSize,
 						int32 maxsz,
-						AORelationVersion version,
 						Form_pg_attribute attr,
 						char *relname,
 						char *title);
@@ -246,7 +245,6 @@ extern DatumStreamRead *create_datumstreamread(
 					   bool checksum,
 					   int32 safeFSWriteSize,
 					   int32 maxsz,
-					   AORelationVersion version,
 					   Form_pg_attribute attr,
 					   char *relname,
 					   char *title);
@@ -257,7 +255,8 @@ extern void datumstreamwrite_open_file(
 						   int64 eof,
 						   int64 eofUncompressed,
 						   RelFileNode relFileNode,
-						   int32 segmentFileNum);
+						   int32 segmentFileNum,
+						   int version);
 
 extern void datumstreamread_open_file(
 						  DatumStreamRead * ds,
@@ -265,7 +264,8 @@ extern void datumstreamread_open_file(
 						  int64 eof,
 						  int64 eofUncompressed,
 						  RelFileNode relFileNode,
-						  int32 segmentFileNum);
+						  int32 segmentFileNum,
+						  int version);
 
 extern void datumstreamwrite_close_file(DatumStreamWrite * ds);
 extern void datumstreamread_close_file(DatumStreamRead * ds);


### PR DESCRIPTION
This patch series contains a bunch of Append-only and AOCS-related changes. I ran into these while working on pg_upgrade for GPDB.

The crux of these patches is the second to last patch, which turns the "file format version" number from a per-table property, to a per-segment property. That way, if you have an AO table that's in the old version, and you upgrade, we don't necessarily need to rewrite the whole table at one go, to change the format. As long as we can read the old format, we can keep the existing segments in the old format, and direct any new data to new segments, in new format. That will come handy with pg_upgrade.
