### PR TITLE
Timeout codegen ICG after 90 minutes

### DIFF
--- a/concourse/dev_template_pipeline.yml
+++ b/concourse/dev_template_pipeline.yml
@@ -172,3 +172,4 @@ jobs:
         bin_xerces: bin_xerces_centos6
         bin_gpdb: bin_gpdb_with_orca_centos6
       file: gpdb_src/concourse/test_with_orca.yml
+      timeout: 1h30m

--- a/concourse/gpcodegen_pipeline.yml
+++ b/concourse/gpcodegen_pipeline.yml
@@ -92,6 +92,7 @@ jobs:
   - task: test_gpdb
     input_mapping: {bin_gpdb: bin_gpdb_planner}
     file: gpdb_src/concourse/test_with_codegen.yml
+    timeout: 1h30m
     on_failure:
       aggregate:
       - put: regression_diffs
@@ -140,6 +141,7 @@ jobs:
   - task: test_gpdb
     input_mapping: {bin_gpdb: bin_gpdb_orca}
     file: gpdb_src/concourse/test_with_orca_and_codegen.yml
+    timeout: 1h30m
     on_failure:
       aggregate:
       - put: regression_diffs


### PR DESCRIPTION
`installcheck-good` normally runs under an hour (about 40 minutes). If it gets stuck in a deadlock or when the servers are loaded, we should terminate that test run.

We can also change the timeout to longer, say 150 minutes if we don't feel comfortable with what's proposed here. It's more important that we *have* a timeout than not.