### PR TITLE
A Worker should finish all acquired cmd before it stops.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -218,6 +218,9 @@ class Worker(Thread):
                 else:
                     try_count += 1
                     if self.shouldStop:
+                        # if we got a cmd from work queue, we should finish it before stop.
+                        if self.cmd is not None:
+                            self.pool.addFinishedWorkItem(self.cmd)
                         self.logger.debug("[%s] stopping" % self.name)
                         return
                       


### PR DESCRIPTION
If a worker acquired a cmd from work queue then halts immediately, the script will be hung to wait till the cmd finishes. Thus we should finish the cmd before worker stops。see #899