### PR TITLE
Refactor : Remove unused header and just include what you use.

### DIFF
--- a/src/backend/codegen/codegen_interface.cc
+++ b/src/backend/codegen/codegen_interface.cc
@@ -11,6 +11,8 @@
 //---------------------------------------------------------------------------
 #include "codegen/codegen_interface.h"
 
+#include <string>
+
 using gpcodegen::CodegenInterface;
 
 // Initalization of unique counter

--- a/src/backend/codegen/codegen_manager.cc
+++ b/src/backend/codegen/codegen_manager.cc
@@ -9,36 +9,19 @@
 //    Implementation of a code generator manager
 //
 //---------------------------------------------------------------------------
-
-extern "C" {
-#include <utils/elog.h>
-}
-
-#include <cstdint>
+#include <assert.h>
+#include <iosfwd>
+#include <memory>
 #include <string>
+#include <vector>
 
-#include "codegen/utils/clang_compiler.h"
-#include "codegen/utils/utility.h"
-#include "codegen/utils/instance_method_wrappers.h"
-#include "codegen/utils/gp_codegen_utils.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include "codegen/codegen_interface.h"
-
 #include "codegen/codegen_manager.h"
-#include "llvm/ADT/APFloat.h"
-#include "llvm/ADT/APInt.h"
-#include "llvm/IR/Argument.h"
-#include "llvm/IR/BasicBlock.h"
-#include "llvm/IR/Constant.h"
-#include "llvm/IR/DerivedTypes.h"
-#include "llvm/IR/Function.h"
-#include "llvm/IR/GlobalVariable.h"
-#include "llvm/IR/Instruction.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Type.h"
-#include "llvm/IR/Value.h"
-#include "llvm/IR/Verifier.h"
-#include "llvm/Support/Casting.h"
+#include "codegen/codegen_wrapper.h"
+#include "codegen/utils/codegen_utils.h"
+#include "codegen/utils/gp_codegen_utils.h"
 
 using gpcodegen::CodegenManager;
 

--- a/src/backend/codegen/codegen_wrapper.cc
+++ b/src/backend/codegen/codegen_wrapper.cc
@@ -11,10 +11,16 @@
 //---------------------------------------------------------------------------
 
 #include "codegen/codegen_wrapper.h"
-#include "codegen/codegen_manager.h"
-#include "codegen/exec_variable_list_codegen.h"
-#include "codegen/exec_eval_expr_codegen.h"
 
+#include <assert.h>
+#include <string>
+#include <type_traits>
+
+#include "codegen/base_codegen.h"
+#include "codegen/codegen_manager.h"
+#include "codegen/exec_eval_expr_codegen.h"
+#include "codegen/exec_variable_list_codegen.h"
+#include "codegen/expr_tree_generator.h"
 #include "codegen/utils/gp_codegen_utils.h"
 
 extern "C" {

--- a/src/backend/codegen/const_expr_tree_generator.cc
+++ b/src/backend/codegen/const_expr_tree_generator.cc
@@ -10,15 +10,26 @@
 //
 //---------------------------------------------------------------------------
 
-#include "codegen/expr_tree_generator.h"
-#include "codegen/const_expr_tree_generator.h"
+#include <assert.h>
+#include <memory>
 
-#include "llvm/IR/Value.h"
+#include "codegen/const_expr_tree_generator.h"
+#include "codegen/expr_tree_generator.h"
+#include "codegen/utils/gp_codegen_utils.h"
+
+#include "llvm/IR/Constant.h"
+
 
 extern "C" {
 #include "postgres.h"  // NOLINT(build/include)
 #include "nodes/execnodes.h"
+#include "nodes/nodes.h"
+#include "nodes/primnodes.h"
 }
+namespace llvm {
+class Value;
+}  // namespace llvm
+
 
 using gpcodegen::ConstExprTreeGenerator;
 using gpcodegen::ExprTreeGenerator;

--- a/src/backend/codegen/exec_eval_expr_codegen.cc
+++ b/src/backend/codegen/exec_eval_expr_codegen.cc
@@ -9,39 +9,39 @@
 //    Generates code for ExecEvalExpr function.
 //
 //---------------------------------------------------------------------------
-#include <algorithm>
+#include <assert.h>
+#include <stddef.h>
 #include <cstdint>
+#include <memory>
 #include <string>
 
-#include "codegen/slot_getattr_codegen.h"
+#include "codegen/base_codegen.h"
+#include "codegen/codegen_wrapper.h"
 #include "codegen/exec_eval_expr_codegen.h"
 #include "codegen/expr_tree_generator.h"
 #include "codegen/op_expr_tree_generator.h"
-#include "codegen/utils/clang_compiler.h"
+#include "codegen/slot_getattr_codegen.h"
+#include "codegen/utils/gp_codegen_utils.h"
 #include "codegen/utils/utility.h"
-#include "codegen/utils/codegen_utils.h"
 
-#include "llvm/ADT/APFloat.h"
-#include "llvm/ADT/APInt.h"
 #include "llvm/IR/Argument.h"
-#include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constant.h"
-#include "llvm/IR/DerivedTypes.h"
-#include "llvm/IR/Function.h"
-#include "llvm/IR/GlobalVariable.h"
-#include "llvm/IR/Instruction.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Type.h"
-#include "llvm/IR/Value.h"
-#include "llvm/IR/Verifier.h"
-#include "llvm/Support/Casting.h"
+#include "llvm/IR/IRBuilder.h"
+
 
 extern "C" {
 #include "postgres.h"  // NOLINT(build/include)
-#include "utils/elog.h"
 #include "nodes/execnodes.h"
+#include "utils/elog.h"
+#include "executor/tuptable.h"
+#include "nodes/nodes.h"
 }
+
+namespace llvm {
+class BasicBlock;
+class Function;
+class Value;
+}  // namespace llvm
 
 using gpcodegen::ExecEvalExprCodegen;
 using gpcodegen::SlotGetAttrCodegen;

--- a/src/backend/codegen/exec_variable_list_codegen.cc
+++ b/src/backend/codegen/exec_variable_list_codegen.cc
@@ -11,40 +11,40 @@
 //---------------------------------------------------------------------------
 
 
+#include <assert.h>
+#include <stddef.h>
 #include <algorithm>
-#include <cstdint>
 #include <string>
+#include <cstdint>
 
+
+#include "codegen/base_codegen.h"
+#include "codegen/codegen_wrapper.h"
 #include "codegen/exec_variable_list_codegen.h"
 #include "codegen/slot_getattr_codegen.h"
-#include "codegen/utils/clang_compiler.h"
-#include "codegen/utils/utility.h"
 #include "codegen/utils/gp_codegen_utils.h"
-#include "codegen/base_codegen.h"
+#include "codegen/utils/utility.h"
 
-#include "llvm/ADT/APFloat.h"
-#include "llvm/ADT/APInt.h"
 #include "llvm/IR/Argument.h"
-#include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constant.h"
-#include "llvm/IR/DerivedTypes.h"
-#include "llvm/IR/Function.h"
-#include "llvm/IR/GlobalVariable.h"
-#include "llvm/IR/Instruction.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Type.h"
-#include "llvm/IR/Value.h"
-#include "llvm/IR/Verifier.h"
-#include "llvm/Support/Casting.h"
+
 
 extern "C" {
 #include "postgres.h"  // NOLINT(build/include)
-#include "utils/elog.h"
-#include "access/htup.h"
-#include "nodes/execnodes.h"
 #include "executor/tuptable.h"
+#include "nodes/execnodes.h"
+#include "utils/elog.h"
+#include "access/tupdesc.h"
+#include "nodes/pg_list.h"
 }
+
+namespace llvm {
+class BasicBlock;
+class Function;
+class Value;
+}  // namespace llvm
 
 using gpcodegen::ExecVariableListCodegen;
 using gpcodegen::SlotGetAttrCodegen;
@@ -67,11 +67,11 @@ ExecVariableListCodegen::ExecVariableListCodegen
 
 bool ExecVariableListCodegen::GenerateExecVariableList(
     gpcodegen::GpCodegenUtils* codegen_utils) {
-  assert(NULL != codegen_utils);
-  static_assert(sizeof(Datum) == sizeof(int64),
+  assert(nullptr != codegen_utils);
+  static_assert(sizeof(Datum) == sizeof(int64_t),
       "sizeof(Datum) doesn't match sizeof(int64)");
 
-  if ( NULL == proj_info_->pi_varSlotOffsets ) {
+  if ( nullptr == proj_info_->pi_varSlotOffsets ) {
     elog(DEBUG1,
         "Cannot codegen ExecVariableList because varSlotOffsets are null");
     return false;

--- a/src/backend/codegen/expr_tree_generator.cc
+++ b/src/backend/codegen/expr_tree_generator.cc
@@ -10,17 +10,18 @@
 //
 //---------------------------------------------------------------------------
 #include <cassert>
+#include <memory>
+
+#include "codegen/const_expr_tree_generator.h"
 #include "codegen/expr_tree_generator.h"
 #include "codegen/op_expr_tree_generator.h"
 #include "codegen/var_expr_tree_generator.h"
-#include "codegen/const_expr_tree_generator.h"
-
-#include "llvm/IR/Value.h"
 
 extern "C" {
 #include "postgres.h"  // NOLINT(build/include)
-#include "utils/elog.h"
 #include "nodes/execnodes.h"
+#include "utils/elog.h"
+#include "nodes/nodes.h"
 }
 
 using gpcodegen::ExprTreeGenerator;

--- a/src/backend/codegen/include/codegen/pg_arith_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_arith_func_generator.h
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include "codegen/utils/gp_codegen_utils.h"
+#include "codegen/pg_func_generator_interface.h"
 
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Value.h"
@@ -26,6 +27,7 @@ namespace gpcodegen {
 /** \addtogroup gpcodegen
  *  @{
  */
+
 
 namespace gpcodegen_ArithOp_detail {
 // ArithOpOverFlowErrorMsg has various template specializations to

--- a/src/backend/codegen/include/codegen/pg_date_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_date_func_generator.h
@@ -12,16 +12,20 @@
 #ifndef GPCODEGEN_PG_DATE_FUNC_GENERATOR_H_  // NOLINT(build/header_guard)
 #define GPCODEGEN_PG_DATE_FUNC_GENERATOR_H_
 
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
-#include "codegen/utils/codegen_utils.h"
 #include "codegen/base_codegen.h"
 #include "codegen/pg_func_generator_interface.h"
+#include "codegen/utils/codegen_utils.h"
 
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Value.h"
+
+namespace llvm {
+class Value;
+}  // namespace llvm
 
 namespace gpcodegen {
 
@@ -29,10 +33,14 @@ namespace gpcodegen {
  *  @{
  */
 
+class GpCodegenUtils;
+struct PGFuncGeneratorInfo;
+
 /**
  * @brief Class with Static member function to generate code for date
  *        operators.
  **/
+
 class PGDateFuncGenerator {
  public:
   /**

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -10,20 +10,37 @@
 //
 //---------------------------------------------------------------------------
 
+#include <assert.h>
+#include <cstdint>
+#include <memory>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "codegen/expr_tree_generator.h"
 #include "codegen/op_expr_tree_generator.h"
+#include "codegen/pg_func_generator.h"
+#include "codegen/pg_func_generator_interface.h"
+#include "codegen/utils/gp_codegen_utils.h"
+#include "codegen/pg_arith_func_generator.h"
+#include "codegen/pg_date_func_generator.h"
 
-#include "include/codegen/pg_arith_func_generator.h"
-#include "include/codegen/pg_date_func_generator.h"
-
-#include "llvm/IR/Value.h"
+#include "llvm/IR/IRBuilder.h"
 
 extern "C" {
-#include "c.h"  // NOLINT(build/include)
 #include "postgres.h"  // NOLINT(build/include)
-#include "utils/elog.h"
+#include "c.h"  // NOLINT(build/include)
 #include "nodes/execnodes.h"
+#include "utils/elog.h"
+#include "nodes/nodes.h"
+#include "nodes/pg_list.h"
+#include "nodes/primnodes.h"
 }
+
+namespace llvm {
+class Value;
+}  // namespace llvm
 
 using gpcodegen::OpExprTreeGenerator;
 using gpcodegen::ExprTreeGenerator;

--- a/src/backend/codegen/pg_date_func_generator.cc
+++ b/src/backend/codegen/pg_date_func_generator.cc
@@ -10,20 +10,29 @@
 //
 //---------------------------------------------------------------------------
 
+#include <assert.h>
+#include <cstdint>
+#include <memory>
+#include <vector>
 
-#include "codegen/pg_date_func_generator.h"
-#include "codegen/utils/gp_codegen_utils.h"
 #include "codegen/pg_arith_func_generator.h"
+#include "codegen/pg_date_func_generator.h"
+#include "codegen/pg_func_generator_interface.h"
+#include "codegen/utils/gp_codegen_utils.h"
+
+#include "llvm/IR/Constant.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Value.h"
 
 extern "C" {
 #include "postgres.h"  // NOLINT(build/include)
-#include "utils/elog.h"
-#include "utils/date.h"
+#include "c.h"  // NOLINT(build/include)
 #include "utils/timestamp.h"
 }
 
 using gpcodegen::GpCodegenUtils;
 using gpcodegen::PGDateFuncGenerator;
+using gpcodegen::PGFuncGeneratorInfo;
 
 bool PGDateFuncGenerator::DateLETimestamp(
     gpcodegen::GpCodegenUtils* codegen_utils,

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -9,42 +9,42 @@
 //    Contains slot_getattr generator
 //
 //---------------------------------------------------------------------------
-
-#include <algorithm>
-#include <cstdint>
+#include <assert.h>
+#include <string.h>
 #include <string>
 
-#include "codegen/slot_getattr_codegen.h"
-#include "codegen/utils/clang_compiler.h"
-#include "codegen/utils/utility.h"
-#include "codegen/utils/gp_codegen_utils.h"
 #include "codegen/base_codegen.h"
+#include "codegen/codegen_wrapper.h"
+#include "codegen/slot_getattr_codegen.h"
+#include "codegen/utils/gp_codegen_utils.h"
+#include "codegen/utils/utility.h"
 
-#include "llvm/ADT/APFloat.h"
-#include "llvm/ADT/APInt.h"
 #include "llvm/IR/Argument.h"
-#include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constant.h"
-#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/GlobalVariable.h"
-#include "llvm/IR/Instruction.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Type.h"
-#include "llvm/IR/Value.h"
 #include "llvm/IR/Verifier.h"
-#include "llvm/Support/Casting.h"
 
 extern "C" {
 #include "postgres.h"  // NOLINT(build/include)
+#include "c.h"  // NOLINT(build/include)
+#include "executor/tuptable.h"
 #include "utils/elog.h"
 #include "access/htup.h"
-#include "nodes/execnodes.h"
-#include "executor/tuptable.h"
+#include "access/memtup.h"
+#include "access/tupdesc.h"
+#include "access/tupmacs.h"
+#include "catalog/pg_attribute.h"
 
 extern void slot_deform_tuple(TupleTableSlot* slot, int nattr);
 }
+
+namespace llvm {
+class BasicBlock;
+class Value;
+}  // namespace llvm
+
 
 using gpcodegen::SlotGetAttrCodegen;
 

--- a/src/backend/codegen/var_expr_tree_generator.cc
+++ b/src/backend/codegen/var_expr_tree_generator.cc
@@ -9,19 +9,30 @@
 //    Object that generator code for variable expression.
 //
 //---------------------------------------------------------------------------
-
+#include <assert.h>
+#include <cstdint>
 #include <algorithm>
+#include <memory>
 
 #include "codegen/expr_tree_generator.h"
+#include "codegen/utils/gp_codegen_utils.h"
 #include "codegen/var_expr_tree_generator.h"
 
-#include "llvm/IR/Value.h"
+#include "llvm/IR/Constant.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
 
 extern "C" {
 #include "postgres.h"  // NOLINT(build/include)
-#include "utils/elog.h"
 #include "nodes/execnodes.h"
+#include "executor/tuptable.h"
+#include "nodes/nodes.h"
+#include "nodes/primnodes.h"
 }
+
+namespace llvm {
+class Value;
+}  // namespace llvm
 
 using gpcodegen::VarExprTreeGenerator;
 using gpcodegen::ExprTreeGenerator;
@@ -60,7 +71,7 @@ bool VarExprTreeGenerator::GenerateCode(GpCodegenUtils* codegen_utils,
   // At code generation time, slot is NULL.
   // For that reason, we keep a double pointer to slot and at execution time
   // we load slot.
-  TupleTableSlot **ptr_to_slot_ptr = NULL;
+  TupleTableSlot **ptr_to_slot_ptr = nullptr;
   switch (var_expr->varno) {
     case INNER:  /* get the tuple from the inner node */
       ptr_to_slot_ptr = &gen_info.econtext->ecxt_innertuple;

--- a/src/include/codegen/codegen_wrapper.h
+++ b/src/include/codegen/codegen_wrapper.h
@@ -12,6 +12,8 @@
 #ifndef CODEGEN_WRAPPER_H_
 #define CODEGEN_WRAPPER_H_
 
+#include <stddef.h>
+
 #include "pg_config.h"
 #include "c.h"
 


### PR DESCRIPTION
In this PR, based on the recommendation from [iwyu](http://include-what-you-use.org/) program, removed unused header and just included what we need in codegen.

``building with comments on header file``` commit will have the comments on why we need that header file.

@hardikar @foyzur Please take a look when you get chance 