### PR TITLE
Silence warnings about failed inlining, by removing 'inline' attributes.

### DIFF
--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -52,7 +52,8 @@
  * then we use off minus saved bytes to find the attribute.
  */
 
-static inline int compute_null_bitmap_extra_size(TupleDesc tupdesc, int col_align)
+static int
+compute_null_bitmap_extra_size(TupleDesc tupdesc, int col_align)
 {
 	int nbytes = (tupdesc->natts + 7) >> 3;
 	int avail_bytes = (tupdesc->tdhasoid || col_align == 4) ? 0 : 4;
@@ -96,13 +97,15 @@ void destroy_memtuple_binding(MemTupleBinding *pbind)
 /* Compute how much space to store the null save entries.
  * The null save entries are stored in the binding, not per tuple.
  */
-static inline uint32 compute_null_save_entries(int i)
+static uint32
+compute_null_save_entries(int i)
 {
 	return ((i+7)/8) * 32; 
 }
 
 /* Add null save space into the entries */
-static inline void add_null_save(short *null_save, int i, short sz)
+static void
+add_null_save(short *null_save, int i, short sz)
 {
 	short* first = null_save + ((i/4) * 16);
 	unsigned int bit = 1 << (i%4);
@@ -119,7 +122,8 @@ static inline void add_null_save(short *null_save, int i, short sz)
  * Adds the aligned length into the array holding the space saved from null attributes.
  * Returns true if the binding length is aligned to the following binding's alignment.
  */
-static inline bool add_null_save_aligned(MemTupleAttrBinding *bind, short *null_save_aligned, int i, char next_attr_align)
+static bool
+add_null_save_aligned(MemTupleAttrBinding *bind, short *null_save_aligned, int i, char next_attr_align)
 {
 	Assert(bind);
 	Assert(bind->len > 0);
@@ -161,7 +165,8 @@ static inline int compute_null_save(short *null_saves, unsigned char *nullbitmap
 		
 #undef MEMTUPLE_INLINE_CHARTYPE
 /* Determine if an attr should be treated as offset_len in memtuple */
-static inline bool att_bind_as_varoffset(Form_pg_attribute attr)
+static bool
+att_bind_as_varoffset(Form_pg_attribute attr)
 {
 #ifdef MEMTUPLE_INLINE_CHARTYPE 
 	return (attr->attlen < 0 /* Varlen type */

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -764,7 +764,7 @@ static void checkQDConnectionAlive(void);
 static void *rxThreadFunc(void *arg);
 
 static bool handleMismatch(icpkthdr *pkt, struct sockaddr_storage *peer, int peer_len);
-static void inline handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now);
+static void handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now);
 static bool handleAcks(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry);
 static void handleStopMsgs(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, int16 motionId);
 static void handleDisorderPacket(MotionConn *conn, int pos, uint32 tailSeq, icpkthdr *pkt);
@@ -4366,7 +4366,7 @@ logPkt(char *prefix, icpkthdr *pkt)
  *	Here y is a constant (In implementation, we use 4) and retry is the times the
  *	packet is retransmitted.
  */
-static void inline
+static void
 handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 {
 	uint64 ackTime = 0;


### PR DESCRIPTION
The functions in memtuple.c were only called when building a column
binding struct. That's not a hot path, as that only gets done once, when
starting the executor, not at every row.

handleAckedPacket() is probably in a somewhat hot path, as it's called for
every received Ack interconnect packet. However, all the calls to it are
straight unconditional jumps, so branch prediction should make those
very cheap. Inlining them would increase the code size quite a bit, so the
compiler is probably making a good choice by refusing to inline them. Let's
not try to force it.

I'm seeing a few more warnings like this from tqual.c and tuplesort.c, but
those are in upstream code, so I'm reluctant to just remove the inline
attributes there. Should do something about those too, to reduce the noise,
but let's at least get these straightforward gpdb-specific cases fixed.

For reference, these are the warnings I was getting:

```
memtuple.c: In function ‘create_col_bind’:
memtuple.c:122:20: warning: inlining failed in call to ‘add_null_save_aligned’: call is unlikely and code size would grow [-Winline]
 static inline bool add_null_save_aligned(MemTupleAttrBinding *bind, short *null_save_aligned, int i, char next_attr_align)
                    ^
memtuple.c:241:10: warning: called from here [-Winline]
      if (add_null_save_aligned(previous_bind, colbind->null_saves_aligned, physical_col - 1, 'd'))
          ^
memtuple.c:122:20: warning: inlining failed in call to ‘add_null_save_aligned’: call is unlikely and code size would grow [-Winline]
 static inline bool add_null_save_aligned(MemTupleAttrBinding *bind, short *null_save_aligned, int i, char next_attr_align)
                    ^
memtuple.c:270:10: warning: called from here [-Winline]
      if (add_null_save_aligned(previous_bind, colbind->null_saves_aligned, physical_col - 1, 'i'))
          ^
memtuple.c:122:20: warning: inlining failed in call to ‘add_null_save_aligned’: call is unlikely and code size would grow [-Winline]
 static inline bool add_null_save_aligned(MemTupleAttrBinding *bind, short *null_save_aligned, int i, char next_attr_align)
                    ^
memtuple.c:308:10: warning: called from here [-Winline]
      if (add_null_save_aligned(previous_bind, colbind->null_saves_aligned, physical_col - 1, 's'))
          ^
memtuple.c:122:20: warning: inlining failed in call to ‘add_null_save_aligned’: call is unlikely and code size would grow [-Winline]
 static inline bool add_null_save_aligned(MemTupleAttrBinding *bind, short *null_save_aligned, int i, char next_attr_align)
                    ^
memtuple.c:354:10: warning: called from here [-Winline]
      if (add_null_save_aligned(previous_bind, colbind->null_saves_aligned, physical_col - 1, 'c'))
          ^
ic_udpifc.c: In function ‘handleAcks.isra.25’:
ic_udpifc.c:4370:1: warning: inlining failed in call to ‘handleAckedPacket’: call is unlikely and code size would grow [-Winline]
 handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 ^
ic_udpifc.c:5177:3: warning: called from here [-Winline]
   handleAckedPacket(conn, buf, now);
   ^
ic_udpifc.c:4370:1: warning: inlining failed in call to ‘handleAckedPacket’: call is unlikely and code size would grow [-Winline]
 handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 ^
ic_udpifc.c:5189:4: warning: called from here [-Winline]
    handleAckedPacket(conn, buf, now);
    ^
ic_udpifc.c:4370:1: warning: inlining failed in call to ‘handleAckedPacket’: call is unlikely and code size would grow [-Winline]
 handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 ^
ic_udpifc.c:5073:4: warning: called from here [-Winline]
    handleAckedPacket(conn, buf, now);
    ^
ic_udpifc.c:4370:1: warning: inlining failed in call to ‘handleAckedPacket’: call is unlikely and code size would grow [-Winline]
 handleAckedPacket(MotionConn *ackConn, ICBuffer *buf, uint64 now)
 ^
ic_udpifc.c:5112:4: warning: called from here [-Winline]
    handleAckedPacket(conn, buf, now);
    ^
```