### PR TITLE
Change datatype of pg_aoseg.pg_aovisimap_<oid>.visimap from varbit to bytea

### DIFF
--- a/src/backend/catalog/aovisimap.c
+++ b/src/backend/catalog/aovisimap.c
@@ -64,7 +64,7 @@ AlterTableCreateAoVisimapTableWithOid(Oid relOid, Oid newOid, Oid newIndexOid,
 					   -1, 0);
 	TupleDescInitEntry(tupdesc, (AttrNumber) 3,
 					   "visimap",
-					   VARBITOID,
+					   BYTEAOID,
 					   -1, 0);
 
 	/*


### PR DESCRIPTION
What we store in that field is not actually a valid "varbit" datum. If you
try to read it out as a varbit, it looks like a single "1" bit. That's
clearly bogus, but it's also problematic for pg_upgrade, because there's
no easy way to read the actual contents. There are functions in gp_toolkit
for reading it and decompressing it out, but it'd be much better to keep
it in compressed form in memory, as an uncompressed bitmap can be quite
large. Also, there's no easy way to restore the uncompressed bitmap back
into a valid visimap entry. We'll have to deal with it for the GPDB 4.3
to 5.0 upgrade, but let's fix the datatype in 5.0 so that the next upgrade
will be easier.

Bytea is a bit rough for this too. A custom "compressed bitmap" datatype
would probably be best. But this'll do for now.