### PR TITLE
Using proper canSetTag during ORCA PlannedStmt translation

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -212,7 +212,7 @@ PlannedStmt *
 CTranslatorDXLToPlStmt::PplstmtFromDXL
 	(
 	const CDXLNode *pdxln,
-	const Query *pquery
+	bool canSetTag
 	)
 {
 	GPOS_ASSERT(NULL != pdxln);
@@ -249,7 +249,7 @@ CTranslatorDXLToPlStmt::PplstmtFromDXL
 
 	// store partitioned table indexes in planned stmt
 	pplstmt->queryPartOids = m_pctxdxltoplstmt->PlPartitionedTables();
-	pplstmt->canSetTag = pquery->canSetTag;
+	pplstmt->canSetTag = canSetTag;
 	pplstmt->relationOids = plOids;
 	pplstmt->numSelectorsPerScanId = m_pctxdxltoplstmt->PlNumPartitionSelectors();
 

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -670,7 +670,7 @@ COptTasks::Pplstmt
 	IMemoryPool *pmp,
 	CMDAccessor *pmda,
 	const CDXLNode *pdxln,
-	const Query *pquery
+	bool canSetTag
 	)
 {
 
@@ -696,7 +696,7 @@ COptTasks::Pplstmt
 	
 	// translate DXL -> PlannedStmt
 	CTranslatorDXLToPlStmt trdxltoplstmt(pmp, pmda, &ctxdxltoplstmt, gpdb::UlSegmentCountGP());
-	return trdxltoplstmt.PplstmtFromDXL(pdxln, pquery);
+	return trdxltoplstmt.PplstmtFromDXL(pdxln, canSetTag);
 }
 
 
@@ -1071,7 +1071,9 @@ COptTasks::PvOptimizeTask
 			// translate DXL->PlStmt only when needed
 			if (poctx->m_fGeneratePlStmt)
 			{
-				poctx->m_pplstmt = (PlannedStmt *) gpdb::PvCopyObject(Pplstmt(pmp, &mda, pdxlnPlan, ptrquerytodxl->Pquery()));
+				// always use poctx->m_pquery->canSetTag as the ptrquerytodxl->Pquery() is a mutated Query object
+				// that may not have the correct canSetTag
+				poctx->m_pplstmt = (PlannedStmt *) gpdb::PvCopyObject(Pplstmt(pmp, &mda, pdxlnPlan, poctx->m_pquery->canSetTag));
 			}
 
 			CStatisticsConfig *pstatsconf = pocconf->Pstatsconf();
@@ -1320,7 +1322,7 @@ COptTasks::PvPlstmtFromDXLTask
 
 		// translate DXL -> PlannedStmt
 		CTranslatorDXLToPlStmt trdxltoplstmt(pmp, amda.Pmda(), &ctxdxlplstmt, gpdb::UlSegmentCountGP());
-		PlannedStmt *pplstmt = trdxltoplstmt.PplstmtFromDXL(pdxlnOriginal, poctx->m_pquery);
+		PlannedStmt *pplstmt = trdxltoplstmt.PplstmtFromDXL(pdxlnOriginal, poctx->m_pquery->canSetTag);
 		if (optimizer_print_plan)
 		{
 			elog(NOTICE, "Plstmt: %s", gpdb::SzNodeToString(pplstmt));

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -265,7 +265,7 @@ namespace gpdxl
 				);
 
 			// main translation routine for DXL tree -> PlannedStmt
-			PlannedStmt *PplstmtFromDXL(const CDXLNode *pdxln, const Query *pquery);
+			PlannedStmt *PplstmtFromDXL(const CDXLNode *pdxln, bool canSetTag);
 
 			// translate the join types from its DXL representation to the GPDB one
 			static JoinType JtFromEdxljt(EdxlJoinType edxljt);

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -209,7 +209,7 @@ class COptTasks
 
 		// translate a DXL tree into a planned statement
 		static
-		PlannedStmt *Pplstmt(IMemoryPool *pmp, CMDAccessor *pmda, const CDXLNode *pdxln, const Query *pquery);
+		PlannedStmt *Pplstmt(IMemoryPool *pmp, CMDAccessor *pmda, const CDXLNode *pdxln, bool canSetTag);
 
 		// load search strategy from given path
 		static

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -10010,6 +10010,27 @@ revoke all on can_set_tag_audit from unpriv;
 drop role unpriv;
 drop table can_set_tag_target;
 drop table can_set_tag_audit;
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+-- Checking if ORCA uses parser's canSetTag for CREATE TABLE AS SELECT
+create or replace function canSetTag_Func(x int) returns int as $$
+    if (x is None):
+        return 0
+    else:
+        return x * 3
+$$ language plpythonu;
+create table canSetTag_input_data (domain integer, class integer, attr text, value integer)
+   distributed by (domain);
+insert into canSetTag_input_data values(1, 1, 'A', 1);
+insert into canSetTag_input_data values(2, 1, 'A', 0);
+insert into canSetTag_input_data values(3, 0, 'B', 1);
+create table canSetTag_bug_table as 
+SELECT attr, class, (select canSetTag_Func(count(distinct class)::int) from canSetTag_input_data)
+   as dclass FROM canSetTag_input_data GROUP BY attr, class distributed by (attr);
+drop function canSetTag_Func(x int);
+drop table canSetTag_bug_table;
+drop table canSetTag_input_data;
 -- clean up
 drop schema orca cascade;
 NOTICE:  drop cascades to table orca.index_test

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -1322,6 +1322,32 @@ drop role unpriv;
 drop table can_set_tag_target;
 drop table can_set_tag_audit;
 
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+
+-- Checking if ORCA uses parser's canSetTag for CREATE TABLE AS SELECT
+create or replace function canSetTag_Func(x int) returns int as $$
+    if (x is None):
+        return 0
+    else:
+        return x * 3
+$$ language plpythonu;
+
+create table canSetTag_input_data (domain integer, class integer, attr text, value integer)
+   distributed by (domain);
+insert into canSetTag_input_data values(1, 1, 'A', 1);
+insert into canSetTag_input_data values(2, 1, 'A', 0);
+insert into canSetTag_input_data values(3, 0, 'B', 1);
+
+create table canSetTag_bug_table as 
+SELECT attr, class, (select canSetTag_Func(count(distinct class)::int) from canSetTag_input_data)
+   as dclass FROM canSetTag_input_data GROUP BY attr, class distributed by (attr);
+
+drop function canSetTag_Func(x int);
+drop table canSetTag_bug_table;
+drop table canSetTag_input_data;
+
 -- clean up
 drop schema orca cascade;
 reset optimizer_segments;


### PR DESCRIPTION
In PR https://github.com/greenplum-db/gpdb/pull/934 we ensured that we always use parser's canSetTag so that we can properly handle multiple PlannedStmt in the presence of rules. Unfortunately, during DXL translation and ORCA plan generation the DXL Query object is actually a mutated copy of the original parser's Query object without proper setting of canSetTag. We lose this information during CQueryMutators::PqueryConvertToDerivedTable(). 

One solution to ensure we properly populate canSetTag is to change mutator to preserve the original value of canSetTag as is present in parser's Query object. However, that mutated copy of Query object is only intended to be used by ORCA and ORCA does not care about canSetTag. Therefore, it makes sense to just use the parser's Query object during DXL to PlannedStmt translation. 

Additionally, we no longer pass the entire Query object in PpstmtFromDXL as it raises confusion about whether the passed Query object is parer's version or mutated version. Rather, we pass canSetTag directly, correctly extracted from parser's Query object at the call site.