### PR TITLE
Fix gpperfmon bug that explain/analyze statement produce a wrong tsub…

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -20,6 +20,7 @@
 #include "commands/explain.h"
 #include "commands/prepare.h"
 #include "commands/trigger.h"
+#include "commands/queue.h"
 #include "executor/execUtils.h"
 #include "executor/instrument.h"
 #include "nodes/pg_list.h"
@@ -389,6 +390,17 @@ ExplainOnePlan(PlannedStmt *plannedstmt, ParamListInfo params,
 								ActiveSnapshot, InvalidSnapshot,
 								None_Receiver, params,
 								stmt->analyze);
+
+	if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
+	{
+		Assert(queryString);
+		gpmon_qlog_query_submit(queryDesc->gpmon_pkt);
+		gpmon_qlog_query_text(queryDesc->gpmon_pkt,
+				queryString,
+				application_name,
+				GetResqueueName(GetResQueueId()),
+				GetResqueuePriority(GetResQueueId()));
+	}
 
 	/* Initialize ExplainState structure. */
 	es = (ExplainState *) palloc0(sizeof(ExplainState));

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1416,22 +1416,6 @@ PortalRunUtility(Portal portal, Node *utilityStmt, bool isTopLevel,
 		ActiveSnapshot = CopySnapshot(GetTransactionSnapshot());
 	else
 		ActiveSnapshot = NULL;
-	gpmon_packet_t *gpmon_pkt = NULL;
-	if(gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
-	{
-		gpmon_pkt = (gpmon_packet_t *) palloc0(sizeof(gpmon_packet_t));
-		gpmon_qlog_packet_init(gpmon_pkt);
-		/* set gpmon_pkt->u.qlog.key.ccnt to 0 in utility mode becasue the gp_command_count is changing */
-		gpmon_pkt->u.qlog.key.ccnt = 0;
-		gpmon_qlog_query_submit(gpmon_pkt);
-		gpmon_qlog_query_text(gpmon_pkt,
-				portal->sourceText ? portal->sourceText: "(Source text for portal is not available)",
-				application_name,
-				GetResqueueName(portal->queueId),
-				GetResqueuePriority(portal->queueId));
-				gpmon_qlog_query_start(gpmon_pkt);
-	}
-
 
 	/* check if this utility statement need to be involved into resoure queue
 	 * mgmt */
@@ -1450,12 +1434,6 @@ PortalRunUtility(Portal portal, Node *utilityStmt, bool isTopLevel,
 	if (ActiveSnapshot)
 		FreeSnapshot(ActiveSnapshot);
 	ActiveSnapshot = NULL;
-
-	if(gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
-	{
-		gpmon_qlog_query_end(gpmon_pkt);
-		pfree(gpmon_pkt);
-	}
 }
 
 /*


### PR DESCRIPTION
…mit in queries_now @yydzero 
1. Remove the fake gpmon packet in PortalRunUtility, this packet is wrong in ccnt field and cannot handle cancel query cases.
2. The real packet for explain/analyze statement is in explain.c but has a wrong life cycle. It missed to call submit before calling start. This leads to the packet does not initialize tsubmit, status and query text. This fix is to make up this life cycle.