### PR TITLE
Enable gcov for gpfdist and pg_basebackup

### DIFF
--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -7,7 +7,7 @@ ifeq ($(PORTNAME),win32)
 endif
 
 override CPPFLAGS := -I. $(CPPFLAGS) $(apr_includes) $(apr_cppflags)
-override CLAGS := $(CFLAGS) $(apr_cflags)
+override CFLAGS := $(CFLAGS) $(apr_cflags)
 
 OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o
 # configure should have been run by this point.
@@ -40,7 +40,7 @@ gfile.c: $(top_builddir)/src/backend/utils/misc/fstream/gfile.c
 	ln -s $< $@
 
 gpfdist$(EXE_EXT): $(OBJS)
-	$(CC) $(LDFLAGS) $(OBJS) $(LDLIBS) -o $@
+	$(CC) $(LDFLAGS) $(CFLAGS) $(OBJS) $(LDLIBS) -o $@
 
 install: all
 	$(INSTALL) gpfdist$(EXE_EXT) $(prefix)/bin

--- a/src/bin/pg_basebackup/Makefile
+++ b/src/bin/pg_basebackup/Makefile
@@ -17,8 +17,10 @@ top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
 ifneq ($(PORTNAME), win32)
-override CFLAGS := -I$(libpq_srcdir) $(CPPFLAGS) $(PTHREAD_CFLAGS) -pthread
+override CFLAGS += $(PTHREAD_CFLAGS) -pthread
 endif
+
+override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 
 OBJS=receivelog.o streamutil.o $(WIN32RES)
 


### PR DESCRIPTION
Add -fprofile-arcs -ftest-coverage flags for gpfdist and pg_basebackup so we
can compile GPDB successfully with enable-coverage specified. Not using CFLAGS directly here can avoid bringing side effect.