### PR TITLE
Set CurrentMemoryContext back correctly in cdbRelMaxSegSize()

### DIFF
--- a/src/backend/cdb/cdbrelsize.c
+++ b/src/backend/cdb/cdbrelsize.c
@@ -40,6 +40,7 @@ cdbRelMaxSegSize(Relation rel)
 	char *schemaName;
 	char *relName;
 
+	MemoryContext oldcontext = CurrentMemoryContext;
 	/*
 	 * Let's ask the QEs for the size of the relation
 	 */
@@ -70,6 +71,12 @@ cdbRelMaxSegSize(Relation rel)
 	}
 	PG_CATCH();
 	{
+		/*
+		 * To pass through this error, we need to set CurrentMemoryContext back,
+		 * because current memory context is pointing to ErrorContext.
+		 */
+		MemoryContextSwitchTo(oldcontext);
+
 		ErrorData *edata = CopyErrorData();
 		hasError = true;
 


### PR DESCRIPTION
Within PG_CATCH() block, if you want to ignore some errors, you need to set
CurrentMemoryContext back to correct context, otherwise it will point to
ErrorContex which is not expected.