### PR TITLE
[#127228435] Adds a GUC to enable array constraint derivation.

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -357,8 +357,8 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elem[] =
 		},
 
 		{
-		EopttraceEnableArrayDerive,
-		&optimizer_enable_array_derivation,
+		EopttraceArrayConstraints,
+		&optimizer_array_constraints,
 		false, // m_fNegate
 		GPOS_WSZ_LIT("Allows the constraint framework to derive array constraints in the optimizer.")
 		}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -563,7 +563,7 @@ bool		optimizer_enable_derive_stats_all_groups;
 bool		optimizer_explain_show_status;
 bool		optimizer_prefer_scalar_dqa_multistage_agg;
 bool 		optimizer_parallel_union;
-bool		optimizer_enable_array_derivation;
+bool		optimizer_array_constraints;
 
 /**
  * GUCs related to code generation.
@@ -3353,12 +3353,12 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_array_derivation", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Allows the constraint framework to derive array constraints in the optimizer."),
+		{"optimizer_array_constraints", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Allows the optimizer's constraint framework to derive array constraints."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
-		&optimizer_enable_array_derivation,
+		&optimizer_array_constraints,
 		false, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -460,7 +460,7 @@ extern bool optimizer_enable_derive_stats_all_groups;
 extern bool optimizer_explain_show_status;
 extern bool optimizer_prefer_scalar_dqa_multistage_agg;
 extern bool optimizer_parallel_union;
-extern bool optimizer_enable_array_derivation;
+extern bool optimizer_array_constraints;
 
 /**
  * GUCs related to code generation.


### PR DESCRIPTION
A new feature of ORCA is to more efficiently handle array constraints.

It includes a new way of internally representing array constraints. This is meant as a temporary GUC to exist while changes to the constraint framework are rolled out incrementally.

@vraghavan78 @oarap @d @hsyuan please take a look.

https://www.pivotaltracker.com/story/show/127228435