### PR TITLE
Fix partial update to relcache entry during new relfilenode creation

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -3582,9 +3582,6 @@ HeapSatisfiesHOTUpdate(Relation relation, Bitmapset *hot_attrs,
 {
 	int			attrnum;
 
-	if (gp_disable_HOT)
-		return false;
-
 	while ((attrnum = bms_first_member(hot_attrs)) >= 0)
 	{
 		/* Adjust for system attributes */

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -3582,6 +3582,9 @@ HeapSatisfiesHOTUpdate(Relation relation, Bitmapset *hot_attrs,
 {
 	int			attrnum;
 
+	if (gp_disable_HOT)
+		return false;
+
 	while ((attrnum = bms_first_member(hot_attrs)) >= 0)
 	{
 		/* Adjust for system attributes */

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -2531,6 +2531,7 @@ RelationClearRelation(Relation relation, bool rebuild)
  		Oid			save_relid = RelationGetRelid(relation);
 		bool		keep_tupdesc;
 		bool		keep_rules;
+		bool		keep_pt_info;
 
 		/* Build temporary entry, but don't link it into hashtable */
 		newrel = RelationBuildDesc(save_relid, false);
@@ -2544,6 +2545,8 @@ RelationClearRelation(Relation relation, bool rebuild)
  
 		keep_tupdesc = equalTupleDescs(relation->rd_att, newrel->rd_att, true);
 		keep_rules = equalRuleLocks(relation->rd_rules, newrel->rd_rules);
+		keep_pt_info = (relation->rd_rel->relfilenode ==
+						newrel->rd_rel->relfilenode);
 
 		/*
 		 * Perform swapping of the relcache entry contents.  Within this
@@ -2596,7 +2599,8 @@ RelationClearRelation(Relation relation, bool rebuild)
 		SWAPFIELD(struct PgStat_TableStatus *, pgstat_info);
 
 		/* preserve persistent table information for the relation  */
-		SWAPFIELD(struct RelationNodeInfo, rd_segfile0_relationnodeinfo);
+		if (keep_pt_info)
+			SWAPFIELD(struct RelationNodeInfo, rd_segfile0_relationnodeinfo);
 
 #undef SWAPFIELD
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -258,7 +258,6 @@ bool		gp_change_tracking = true;
 bool		gp_persistent_skip_free_list = false;
 bool		gp_persistent_repair_global_sequence = false;
 bool		gp_validate_pt_info_relcache = false;
-bool		gp_disable_HOT = false;
 bool		Debug_print_xlog_relation_change_info = false;
 bool		Debug_print_xlog_relation_change_info_skip_issues_only = false;
 bool		Debug_print_xlog_relation_change_info_backtrace_skip_issues = false;
@@ -2203,16 +2202,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_validate_pt_info_relcache,
-		false, NULL, NULL
-	},
-
-	{
-		{"gp_disable_HOT", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Disable Heap Only Tuple (HOT) feature."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_disable_HOT,
 		false, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -257,6 +257,8 @@ bool		gp_startup_integrity_checks = true;
 bool		gp_change_tracking = true;
 bool		gp_persistent_skip_free_list = false;
 bool		gp_persistent_repair_global_sequence = false;
+bool		gp_validate_pt_info_relcache = false;
+bool		gp_disable_HOT = false;
 bool		Debug_print_xlog_relation_change_info = false;
 bool		Debug_print_xlog_relation_change_info_skip_issues_only = false;
 bool		Debug_print_xlog_relation_change_info_backtrace_skip_issues = false;
@@ -2191,6 +2193,26 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_persistent_repair_global_sequence,
+		false, NULL, NULL
+	},
+
+	{
+		{"gp_validate_pt_info_relcache", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Validate persistent TID and serial number in relcache entry."),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_validate_pt_info_relcache,
+		false, NULL, NULL
+	},
+
+	{
+		{"gp_disable_HOT", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Disable Heap Only Tuple (HOT) feature."),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_disable_HOT,
 		false, NULL, NULL
 	},
 

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -129,8 +129,7 @@ extern void RelationFetchGpRelationNodeForXLog_Index(Relation relation);
 static inline bool
 RelationNeedToFetchGpRelationNodeForXLog(Relation relation)
 {
-	if (!InRecovery && !relation->rd_segfile0_relationnodeinfo.isPresent &&
-		!GpPersistent_SkipXLogInfo(relation->rd_id))
+	if (!InRecovery && !GpPersistent_SkipXLogInfo(relation->rd_id))
 	{
 		return true;
 	}

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -225,6 +225,8 @@ extern bool gp_startup_integrity_checks;
 extern bool gp_change_tracking;
 extern bool	gp_persistent_skip_free_list;
 extern bool	gp_persistent_repair_global_sequence;
+extern bool gp_validate_pt_info_relcache;
+extern bool gp_disable_HOT;
 extern bool Debug_print_xlog_relation_change_info;
 extern bool Debug_print_xlog_relation_change_info_skip_issues_only;
 extern bool Debug_print_xlog_relation_change_info_backtrace_skip_issues;

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -226,7 +226,6 @@ extern bool gp_change_tracking;
 extern bool	gp_persistent_skip_free_list;
 extern bool	gp_persistent_repair_global_sequence;
 extern bool gp_validate_pt_info_relcache;
-extern bool gp_disable_HOT;
 extern bool Debug_print_xlog_relation_change_info;
 extern bool Debug_print_xlog_relation_change_info_skip_issues_only;
 extern bool Debug_print_xlog_relation_change_info_backtrace_skip_issues;

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -356,4 +356,5 @@ crash_recovery_filerep_end_to_end:
 crash_recovery_schema_topology:
 	$(TESTER) $(DISCOVER) \
 	-s tincrepo/mpp/gpdb/tests/storage/crashrecovery \
-	-p test_crash_recovery_schema_topology.py
+	-p test_crash_recovery_schema_topology.py \
+	-p test_reindex_pg_class.py

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/reindex_pg_class.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/reindex_pg_class.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS reindex_pg_class_test;
+CREATE TABLE reindex_pg_class_test(a int);
+REINDEX INDEX pg_class_oid_index;
+REINDEX INDEX pg_class_relname_nsp_index;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_reindex_pg_class.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_reindex_pg_class.py
@@ -1,0 +1,69 @@
+"""
+Copyright (C) 2004-2016 Pivotal Software, Inc. All rights reserved.
+
+This program and the accompanying materials are made available under
+the terms of the under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from gppylib.commands.base import Command
+
+import tinctest
+from tinctest.lib import local_path
+from tinctest.case import TINCTestCase
+
+from mpp.lib.PSQL import PSQL
+
+class ReindexPgClass(TINCTestCase):
+    """Test recovery after reindex of pg_class indexes.
+    """
+
+    def __init__(self, methodName):
+        super(ReindexPgClass, self).__init__(methodName)
+
+
+    def test_reindex_pg_class(self):
+        tinctest.logger.info("create checkpoint")
+        results = {'rc':0, 'stdout':'', 'stderr':''}
+        PSQL.run_sql_command("checkpoint", results=results)
+        assert results['rc'] == 0, results['stderr']
+
+        tinctest.logger.info("inject fault to skip checkpoints")
+        cmd = Command("skip checkpoint on primaries",
+                      "gpfaultinjector -f checkpoint -m async -y skip -o 0"
+                      " -H ALL -r primary")
+        cmd.run(validateAfter=True)
+        tinctest.logger.info(cmd.get_results().printResult())
+
+        cmd = Command("skip checkpoint on master",
+                      "gpfaultinjector -f checkpoint -m async -y skip -o 0 -s 1")
+        cmd.run(validateAfter=True)
+        tinctest.logger.info(cmd.get_results().printResult())
+
+        tinctest.logger.info("reindex pg_class indexes")
+        assert PSQL.run_sql_file(local_path('reindex_pg_class.sql'))
+
+        tinctest.logger.info("shutdown immediate")
+        cmd = Command("shutdown immediate", "gpstop -ai")
+        cmd.run(validateAfter=True)
+        tinctest.logger.info(cmd.get_results().printResult())
+
+        tinctest.logger.info("trigger recovery")
+        cmd = Command("restart the cluster", "gpstart -a")
+        cmd.run(validateAfter=True)
+        tinctest.logger.info(cmd.get_results().printResult())
+
+        tinctest.logger.info("validate recovery succeeded")
+        results = {'rc':0, 'stdout':'', 'stderr':''}
+        PSQL.run_sql_command("DROP TABLE reindex_pg_class_test", results=results)
+        assert results['rc'] == 0, results['stderr']
+


### PR DESCRIPTION
We encountered a customer issue in 4.3 branch where reindex of the pg_class table followed by an immediate shutdown caused crash recovery to fail due to invalid page references in XLog.  

Digging further it turns out that the relcache entry for pg_class index is updated incorrectly during reindex.  This is because the persistent information for the new relfile is updated in the relcache entry before cache invalidation.  This leaves the relcache entry with old relfilenode and new persistent TID and the persistent serial number (PSN).   

Any update of or insert into the relation described by the relcache entry would generate a XLog record with old (deleted) relfilenode and new persistent information (TID/PSN).

Ideally, XLog records with deleted relfilenode should be skipped during pass3 of the recovery.  However, the new persistent TID contained in the XLog record is in Created state.  Therefore, it cannot be skipped during pass3/Redo Apply stage of recovery.

The proposed fix is to leave the relcache entry unchanged and rely on the next cache invalidation iteration to update it.

The HOT (Heap Only Tuple) feature in the master branch prevents index related XLog records from being generated during reindex.  Therefore, reindex of pg_class does not manifest the problem of partial relcache update in the master branch.  However, the problem exists in the master branch.

To expose this problem in the master branch, we have added the `gp_validate_pt_info_relcache` GUC.  Setting this GUC will:
1. Disable HOT
2. Fetch persistent information from the `gp_relation_node` table.

If the fetched information does not match the persistent TID and PSN recorded in the relcache entry, the transaction aborts.
