### PR TITLE
fix bug for external sort

### DIFF
--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -191,8 +191,8 @@ typedef struct TupsortMergeReadCtxt
     int cnt;
     int cur;
 
-    int mem_allowed;
-    int mem_used;
+    int64 mem_allowed;
+    int64 mem_used;
 } TupsortMergeReadCtxt;
 
 
@@ -205,7 +205,7 @@ struct Tuplesortstate_mk
     int		nKeys;		/* number of columns in sort key */
     bool		randomAccess;	/* did caller request random access? */
 
-    long 		memAllowed;
+    int64 		memAllowed;
 
     int		maxTapes;	/* number of tapes (Knuth's T) */
     int		tapeRange;	/* maxTapes-1 (Knuth's P) */
@@ -2171,7 +2171,7 @@ beginmerge(Tuplesortstate_mk *state)
     int			srcTape;
     int 		totalSlots;
     int			slotsPerTape;
-    long		spacePerTape;
+    int64		spacePerTape;
 
     int i;
 


### PR DESCRIPTION
hi 
　In my test environment, I found a bug for external sorting. Now I have fixed this bug. 
    My analysis is as below:
     If we set statement_mem is too big( for example 15GB).  and the size of the data to sort is too large. GP will use external sort. If so, TupsortMergeReadCtxt->mem_allowed(>2^32) will be  negative. and we will lost all data in external sorting. Now i change type of TupsortMergeReadCtxt->mem_allowed to long. and Test is OK.


# the test is described below

# SQL as follows:

      explain analyze  select date_id,
      province_id,
province_name,
city_id,
max(city_name) as city_name,
-1 as county_id,
'' as county_name,
max(vendor_id) as vendor_id,
max(vendor_name) as vendor_name,
max(tac) as tac,
max(SGW_POOL) as SGW_POOL,
max(enb_ip) as enb_ip,
max(sgw_ip) as MME_SGW_IP_ADD,
imsi,
cid as eci,
max(cid) as eci_name,
APP_CLASS_ID,
max(service_name) as app_class_name,
APP_SUB_CLASS_ID,
max(subservice_name) as app_sub_class_name,
sum(HTTP_SUCC_COUNT) as HTTP_SUCC_COUNT,
sum(HTTP_XDR_COUNT) as HTTP_XDR_COUNT,
sum(HTTP_RES_DELAY) as HTTP_RES_DELAY,
sum(UP_FLOW) as UP_FLOW,
sum(DOWN_FLOW) as DOWN_FLOW,
sum(HTTP_RES_DELAY_COUNT) as HTTP_RES_DELAY_COUNT,
sum( HTTP_DOWN) as HTTP_DOWN, 
sum(HTTP_RE_DELAY) as HTTP_RE_DELAY, 
sum(COMM_TCP_SUCC_COUNT) as COMM_TCP_SUCC_COUNT,
sum(COMM_TCP_REQ_COUNT) as COMM_TCP_REQ_COUNT,
sum(COMM_TCP_HX_DELAY) as COMM_TCP_HX_DELAY,
sum(COMM_TCP_WX_SUCC_COUNT) as COMM_TCP_WX_SUCC_COUNT,
sum(COMM_TCP_WX_DELAY) as COMM_TCP_WX_DELAY
from F_LTE_S1U_HTTP_H_TMP_N1_tmp 
group by date_id,province_id,province_name,city_id,cid,APP_CLASS_ID,APP_SUB_CLASS_ID,imsi;
     


         
       we set some guc as follows
             SET statement_mem = '1GB';
             set optimizer=off;
             set enable_hashagg=off;
         we can got the right result.
   but if we set statement_mem = '15GB', we got nothing.




# explain plan  as follows(right result):

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Redistribute Motion 60:60  (slice2; segments: 60)  (cost=2479187882.92..2526876056.58 rows=5046368 width=920)
   Hash Key: partial_aggregation.date_id, partial_aggregation.province_id, partial_aggregation.city_id, partial_aggregation.eci, partial_aggregation.app_class_id, partial_aggregation.app_sub_class_id, partial_aggregation.imsi
   Rows out:  Avg 49723542.9 rows x 60 workers at destination.  Max 49737324 rows (seg59) with 1087965 ms to first row, 1396237 ms to end, start offset by 748 ms.
   ->  GroupAggregate  (cost=2479187882.92..2526876056.58 rows=5046368 width=920)
         Group By: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
         Rows out:  Avg 49723542.9 rows x 60 workers.  Max 49736680 rows (seg29) with 1088260 ms to first row, 1423966 ms to end, start offset by 734 ms.
         Executor memory:  8K bytes avg, 8K bytes max (seg0).
         ->  Sort  (cost=2479187882.92..2479944838.06 rows=5046368 width=884)
               Sort Key: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
               Rows out:  Avg 49871523.4 rows x 60 workers.  Max 49884791 rows (seg29) with 1088260 ms to first row, 1224516 ms to end, start offset by 734 ms.
               Executor memory:  657267K bytes avg, 657267K bytes max (seg0).
               Work_mem used:  657267K bytes avg, 657267K bytes max (seg0). Workfile: (60 spilling, 0 reused)
               Work_mem wanted: 24679628K bytes avg, 24686183K bytes max (seg29) to lessen workfile I/O affecting 60 workers.
               ->  Redistribute Motion 60:60  (slice1; segments: 60)  (cost=1733823788.92..2002542862.25 rows=5046368 width=884)
                     Hash Key: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
                     Rows out:  Avg 49871523.4 rows x 60 workers at destination.  Max 49884791 rows (seg29) with 364183 ms to first row, 644261 ms to end, start offset by 734 ms.
                     ->  GroupAggregate  (cost=1733823788.92..1996487221.15 rows=5046368 width=884)
                           Group By: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
                           Rows out:  Avg 49871523.4 rows x 60 workers.  Max 49887665 rows (seg6) with 436205 ms to first row, 857718 ms to end, start offset by 735 ms.
                           Executor memory:  8K bytes avg, 8K bytes max (seg0).
                           ->  Sort  (cost=1733823788.92..1741393340.28 rows=50463676 width=229)
                                 Sort Key: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
                                 Rows out:  Avg 50463676.4 rows x 60 workers.  Max 50479655 rows (seg40) with 400331 ms to first row, 555052 ms to end, start offset by 736 ms.
                                 Executor memory:  798896K bytes avg, 802309K bytes max (seg1).
                                 Work_mem used:     798896K bytes avg, 802309K bytes max (seg1). Workfile: (60 spilling, 0 reused)
                                 Work_mem wanted: 21682539K bytes avg, 21689405K bytes max (seg40) to lessen workfile I/O affecting 60 workers.
                                 ->  Append-only Scan on f_lte_s1u_http_h_tmp_n1_tmp  (cost=0.00..38783500.44 rows=50463676 width=229)
                                       Rows out:  Avg 50463676.4 rows x 60 workers.  Max 50479655 rows (seg40) with 11 ms to first row, 100206 ms to end, start offset by 736 ms.
 Slice statistics:
   (slice0)    Executor memory: 919K bytes avg x 60 workers, 919K bytes max (seg0).
   (slice1)  * Executor memory: 800393K bytes avg x 60 workers, 803807K bytes max (seg1).  Work_mem: 802309K bytes max, 21689405K bytes wanted.
   (slice2)  * Executor memory: 658875K bytes avg x 60 workers, 658875K bytes max (seg0).  Work_mem: 657267K bytes max, 24686183K bytes wanted.
 Statement statistics:
   Memory used: 1024000K bytes
   Memory wanted: 49372864K bytes
 Settings:  enable_hashagg=off; optimizer=off
 Optimizer status: legacy query optimizer
 Total runtime: 1584360.904 ms
(38 rows)
        


# explain plan  as follows(wrong result):

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Redistribute Motion 60:60  (slice2; segments: 60)  (cost=2479187882.92..2526876056.58 rows=5046368 width=920)
   Hash Key: partial_aggregation.date_id, partial_aggregation.province_id, partial_aggregation.city_id, partial_aggregation.eci, partial_aggregation.app_class_id, partial_aggregation.app_sub_class_id, partial_aggregation.imsi
   Rows out:  0 rows at destination (seg0) with 584781 ms to end, start offset by 716 ms.
   ->  GroupAggregate  (cost=2479187882.92..2526876056.58 rows=5046368 width=920)
         Group By: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
         Rows out:  0 rows (seg0) with 584794 ms to end, start offset by 703 ms.
         ->  Sort  (cost=2479187882.92..2479944838.06 rows=5046368 width=884)
               Sort Key: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
               Rows out:  0 rows (seg0) with 584794 ms to end, start offset by 703 ms.
               Executor memory:  74K bytes avg, 74K bytes max (seg0).
               Work_mem used:  74K bytes avg, 74K bytes max (seg0). Workfile: (0 spilling, 0 reused)
               ->  Redistribute Motion 60:60  (slice1; segments: 60)  (cost=1733823788.92..2002542862.25 rows=5046368 width=884)
                     Hash Key: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
                     Rows out:  0 rows at destination (seg0) with 584793 ms to end, start offset by 704 ms.
                     ->  GroupAggregate  (cost=1733823788.92..1996487221.15 rows=5046368 width=884)
                           Group By: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
                           Rows out:  0 rows (seg0) with 584791 ms to end, start offset by 706 ms.
						   //sort 在seg0 上的输出为0
                           ->  Sort  (cost=1733823788.92..1741393340.28 rows=50463676 width=229)
                                 Sort Key: f_lte_s1u_http_h_tmp_n1_tmp.date_id, f_lte_s1u_http_h_tmp_n1_tmp.province_id, f_lte_s1u_http_h_tmp_n1_tmp.province_name, f_lte_s1u_http_h_tmp_n1_tmp.city_id, f_lte_s1u_http_h_tmp_n1_tmp.cid, f_lte_s1u_http_h_tmp_n1_tmp.app_class_id, f_lte_s1u_http_h_tmp_n1_tmp.app_sub_class_id, f_lte_s1u_http_h_tmp_n1_tmp.imsi
                                 Rows out:  0 rows (seg0) with 584791 ms to end, start offset by 706 ms.
                                 Executor memory: 10004760K bytes avg, 10004907K bytes max (seg0).
                                 Work_mem used:   10004760K bytes avg, 10004907K bytes max (seg0). Workfile: (60 spilling, 0 reused)
                                 Work_mem wanted: 22853101K bytes avg, 22865686K bytes max (seg40) to lessen workfile I/O affecting 60 workers.
                                 ->  Append-only Scan on f_lte_s1u_http_h_tmp_n1_tmp  (cost=0.00..38783500.44 rows=50463676 width=229)
                                       Rows out:  Avg 50463676.4 rows x 60 workers.  Max 50479655 rows (seg40) with 11 ms to first row, 97564 ms to end, start offset by 707 ms.
 Slice statistics:
   (slice0)    Executor memory: 742K bytes avg x 60 workers, 742K bytes max (seg0).
   (slice1)  * Executor memory: 10005829K bytes avg x 60 workers, 10005976K bytes max (seg0).  Work_mem: 10004907K bytes max, 22865686K bytes wanted.
   (slice2)    Executor memory: 1020K bytes avg x 60 workers, 1020K bytes max (seg0).  Work_mem: 74K bytes max.
 Statement statistics:
   Memory used: 15192000K bytes
   Memory wanted: 45731870K bytes
 Settings:  enable_hashagg=off; optimizer=off
 Optimizer status: legacy query optimizer
 Total runtime: 585499.674 ms
(35 rows)




     
