### PR TITLE
Backup and restore now supports the period, comma, tab, newline, and exclamation point.

### DIFF
--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -584,7 +584,7 @@ class GpCronDump(Operation):
         for schema in dump_schemas:
             tables = get_user_table_list_for_schema(self.context, schema)
             for table in tables:
-                table_name = table[0] + "." + table[1]
+                table_name = tuple_to_tablename(table)
                 table_list.append(table_name)
         return create_temp_file_from_list(table_list, 'include_dump_tables_file')
 
@@ -606,25 +606,24 @@ class GpCronDump(Operation):
             self.context.include_dump_tables = get_lines_from_file(self.context.include_dump_tables_file)
 
         if self.context.include_dump_tables:
+            self.context.include_dump_tables = tablename_list_to_tuple_list(self.context.include_dump_tables)
             dump_tables_without_pg_temp = []
-            for table in self.context.include_dump_tables:
-                if table.startswith('pg_temp_'):
+            for (schema, table) in self.context.include_dump_tables:
+                if schema.startswith('pg_temp_'):
                     continue
-                dump_tables_without_pg_temp.append(table)
-            include_file = expand_partitions_and_populate_filter_file(dbname,
-                                                                      dump_tables_without_pg_temp,
-                                                                      'include_dump_tables_file')
+                dump_tables_without_pg_temp.append([schema, table])
+            self.context.include_dump_tables = dump_tables_without_pg_temp
+            include_file = expand_partitions_and_populate_filter_file(dbname, self.context.include_dump_tables, 'include_dump_tables_file')
             self.context.include_dump_tables = []
 
         if self.context.exclude_dump_tables:
+            self.context.exclude_dump_tables = tablename_list_to_tuple_list(self.context.exclude_dump_tables)
             exclude_file = expand_partitions_and_populate_filter_file(dbname, self.context.exclude_dump_tables, 'exclude_dump_tables_file')
             self.context.exclude_dump_tables = []
 
         if self.context.exclude_dump_tables_file:
-            exclude_tables = get_lines_from_file(self.context.exclude_dump_tables_file)
-            exclude_file = expand_partitions_and_populate_filter_file(dbname,
-                                                                      exclude_tables,
-                                                                      'exclude_dump_tables_file')
+            exclude_tables = get_lines_from_csv_file(self.context.exclude_dump_tables_file)
+            exclude_file = expand_partitions_and_populate_filter_file(dbname, exclude_tables, 'exclude_dump_tables_file')
 
         return (include_file, exclude_file)
 
@@ -763,8 +762,6 @@ class GpCronDump(Operation):
                 co_partition_list = get_co_partition_state(self.context)
                 heap_partitions = get_dirty_heap_tables(self.context)
                 last_operation_list = get_last_operation_data(self.context)
-
-                self._verify_tablenames(ao_partition_list, co_partition_list, heap_partitions)
 
                 dirty_partitions = None
                 dirty_file = None
@@ -1064,31 +1061,20 @@ class GpCronDump(Operation):
             logger.info('No filter file found for database %s and prefix %s.' % (db, self.context.dump_prefix[:-1]))
             logger.info('All tables in %s will be included in the dump.' % db)
             return
-        tables = get_lines_from_file(filter_filename)
+        tables = get_lines_from_csv_file(filter_filename)
         logger.info('Filtering %s for the following tables:' % db)
         for table in tables:
-            logger.info('%s' % table)
+            logger.info('%s' % tuple_to_tablename(table))
 
     def _get_table_names_from_partition_list(self, partition_list):
         tablenames = []
         for part in partition_list:
-            fields = part.split(',')
+            fields = csv_string_to_list(part)
             if len(fields) != 3:
                 raise Exception('Invalid partition entry "%s"' % part)
-            tname = '%s.%s' % (fields[0].strip(), fields[1].strip())
+            tname = tuple_to_tablename(fields[0:2])
             tablenames.append(tname)
         return tablenames
-
-    def _verify_tablenames(self, ao_partition_list, co_partition_list, heap_partitions):
-        tablenames = []
-
-        tablenames.extend(self._get_table_names_from_partition_list(ao_partition_list))
-        tablenames.extend(self._get_table_names_from_partition_list(co_partition_list))
-        tablenames.extend(heap_partitions)
-
-        tablenames = set(tablenames)
-
-        check_funny_chars_in_names(tablenames)
 
     def _prompt_continue(self):
         logger.info("---------------------------------------------------")

--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -97,6 +97,11 @@ class GpdbRestore(Operation):
 
         if self.context.table_file:
             self.context.restore_tables = get_restore_tables_from_table_file(self.context.table_file)
+        else:
+            restore_tables = []
+            for table in self.context.restore_tables:
+                restore_tables.append(tablename_to_tuple(table))
+            self.context.restore_tables = restore_tables
 
         if self.context.db_host_path:
             # MPP-13617
@@ -202,7 +207,6 @@ class GpdbRestore(Operation):
             restore_type = "Full Database"
 
         if self.context.change_schema:
-            check_funny_chars_in_names(self.context.change_schema, is_full_qualified_name = False)
             if not self.context.redirected_restore_db and not check_schema_exists(self.context.change_schema, self.context.restore_db):
                 raise Exception('Cannot restore tables to schema %s: schema does not exist' % self.context.change_schema)
             elif self.context.redirected_restore_db and not check_schema_exists(self.context.change_schema, self.context.redirected_restore_db):
@@ -259,7 +263,7 @@ class GpdbRestore(Operation):
             logger.info("Table restore list")
             logger.info("------------------------------------------")
             for restore_table in self.context.restore_tables:
-                logger.info("Table                      = %s" % restore_table)
+                logger.info("Table                      = %s" % tuple_to_tablename(restore_table))
             if self.table_counts:
                 logger.info("------------------------------------------")
                 logger.warn("Following tables have non-zero row counts %s" % WARN_MARK)

--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -1,7 +1,9 @@
+import csv
 import fnmatch
 import glob
 import os
 import re
+import StringIO
 import tempfile
 from datetime import datetime
 from gppylib import gplog
@@ -169,37 +171,31 @@ class Context(Values, object):
 
 def expand_partitions_and_populate_filter_file(dbname, partition_list, file_prefix):
     expanded_partitions = expand_partition_tables(dbname, partition_list)
-    dump_partition_list = list(set(expanded_partitions + partition_list))
-    return create_temp_file_from_list(dump_partition_list, file_prefix)
-
-def populate_filter_tables(table, rows, non_partition_tables, partition_leaves):
-    if not rows:
-        non_partition_tables.append(table)
-    else:
-        for (schema_name, partition_leaf_name) in rows:
-            partition_leaf = schema_name.strip() + '.' + partition_leaf_name.strip()
-            partition_leaves.append(partition_leaf)
-    return (non_partition_tables, partition_leaves)
+    dump_partition_list = []
+    for pt in expanded_partitions + partition_list:
+        if pt not in dump_partition_list:
+            dump_partition_list.append(pt)
+    return create_temp_csv_file_from_list(dump_partition_list, file_prefix)
 
 def get_all_parent_tables(dbname):
-    SQL = "SELECT DISTINCT (schemaname || '.' || tablename) FROM pg_partitions"
+    SQL = "SELECT DISTINCT schemaname, tablename FROM pg_partitions"
     data = []
     with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
         curs = dbconn.execSQL(conn, SQL)
         data = curs.fetchall()
-    return set([d[0] for d in data])
+    return data
 
 def list_to_quoted_string(filter_tables):
-    filter_string = "'" + "', '".join([pg.escape_string(t) for t in filter_tables]) + "'"
+    filter_string = "(" + "), (".join(["'%s','%s'" % (pg.escape_string(s), pg.escape_string(t)) for (s,t) in filter_tables]) + ")"
     return filter_string
 
-def convert_parents_to_leafs(dbname, parents):
+def convert_parents_to_leaves(dbname, parents):
     partition_leaves_sql = """
-                           SELECT x.partitionschemaname || '.' || x.partitiontablename
+                           SELECT x.partitionschemaname, x.partitiontablename
                            FROM (
                                 SELECT distinct schemaname, tablename, partitionschemaname, partitiontablename, partitionlevel
                                 FROM pg_partitions
-                                WHERE schemaname || '.' || tablename in (%s)
+                                WHERE (schemaname, tablename) in (%s)
                                 ) as X,
                            (SELECT schemaname, tablename maxtable, max(partitionlevel) maxlevel
                             FROM pg_partitions
@@ -214,7 +210,7 @@ def convert_parents_to_leafs(dbname, parents):
     partition_sql = partition_leaves_sql % list_to_quoted_string(parents)
     curs = dbconn.execSQL(conn, partition_sql)
     rows = curs.fetchall()
-    return [r[0] for r in rows]
+    return rows 
 
 
 #input: list of tables to be filtered
@@ -229,6 +225,7 @@ def expand_partition_tables(dbname, filter_tables):
 
     all_parent_tables = get_all_parent_tables(dbname)
     for table in filter_tables:
+        table = list(table)
         if table in all_parent_tables:
             parent_tables.append(table)
         else:
@@ -238,7 +235,7 @@ def expand_partition_tables(dbname, filter_tables):
 
     local_batch_size = 1000
     for (s, e) in get_batch_from_list(len(parent_tables), local_batch_size):
-        tmp = convert_parents_to_leafs(dbname, parent_tables[s:e])
+        tmp = convert_parents_to_leaves(dbname, parent_tables[s:e])
         expanded_list += tmp
 
     return expanded_list
@@ -265,8 +262,25 @@ def create_temp_file_from_list(entries, prefix):
 
     return tmp_file_name
 
+def create_temp_csv_file_from_list(entries, prefix):
+    """
+    When writing the entries into temp file, don't do any strip as there might be
+    white space in schema name and table name.
+    """
+    if len(entries) == 0:
+        return None
+
+    fd = tempfile.NamedTemporaryFile(mode='w', prefix=prefix, delete=False)
+    writer = csv.writer(fd, delimiter='.', quotechar='"', lineterminator='\n')
+    for entry in entries:
+        writer.writerow(entry)
+    tmp_file_name = fd.name
+    fd.close()
+
+    return tmp_file_name
+
 def create_temp_file_with_tables(table_list):
-    return create_temp_file_from_list(table_list, 'table_list_')
+    return create_temp_csv_file_from_list(table_list, 'table_list_')
 
 def create_temp_file_with_schemas(schema_list):
     return create_temp_file_from_list(schema_list, 'schema_file_')
@@ -453,6 +467,74 @@ def write_lines_to_file(filename, lines):
     with open(filename, 'w') as fp:
         for line in lines:
             fp.write("%s\n" % line.strip('\n'))
+
+# Takes a list of "schema.table" strings and turns it into a list of ("schema", "table") tuples
+def tablename_list_to_tuple_list(table_list):
+    content = []
+    tables = "\n".join(table_list)
+    sio = StringIO.StringIO(tables)
+    try:
+        reader = csv.reader(sio, delimiter = '.', quotechar = '"')
+        for row in reader:
+            if row and len(row) != 2:
+                raise Exception("%s is not in the format schema.table" % ".".join(row))
+            content.append(row)
+        return content
+    finally:
+        sio.close()
+
+def list_to_csv_string(items, delimiter=',', terminator='\n'):
+    csv_string = StringIO.StringIO()
+    try:
+        writer = csv.writer(csv_string, delimiter=delimiter, quotechar='"', lineterminator=terminator)
+        writer.writerow(items)
+        return csv_string.getvalue()
+    finally:
+        csv_string.close()
+
+# Should only be used for single-line strings, e.g. 'schema.table'
+def csv_string_to_list(line, delimiter=',', terminator='\n'):
+    sio = StringIO.StringIO(line)
+    try:
+        tokens = []
+        reader = csv.reader(sio, delimiter=delimiter, quotechar='"', lineterminator=terminator)
+        for token in reader:
+            tokens.append(token)
+        if tokens and isinstance(tokens, list):
+            tokens = tokens[0]
+        return tokens
+    finally:
+        sio.close()
+
+def tuple_to_tablename(table_tuple):
+    if len(table_tuple) != 2:
+        raise Exception("%s is not in the format schema.table" % ".".join(table_tuple))
+    return list_to_csv_string(table_tuple, delimiter='.', terminator='')
+
+def tablename_to_tuple(tuple):
+    table_tuple = csv_string_to_list(tuple, delimiter='.', terminator='')
+    if len(table_tuple) != 2:
+        raise Exception("%s is not in the format schema.table" % ".".join(table_tuple))
+    return table_tuple
+
+def get_lines_from_csv_file(fname, context=None, delimiter='.'):
+    content = []
+    if context and context.ddboost:
+        contents = get_lines_from_dd_file(fname, context.ddboost_storage_unit)
+        return tablename_list_to_tuple_list(contents)
+    else:
+        with open(fname) as fd:
+            reader = csv.reader(fd, delimiter=delimiter, quotechar='"')
+            for row in reader:
+                content.append(row)
+        return content
+
+def write_lines_to_csv_file(filename, lines, delimiter='.', alwaysquote=False):
+    with open(filename, 'w') as fp:
+        should_quote = csv.QUOTE_ALL if alwaysquote else csv.QUOTE_MINIMAL
+        writer = csv.writer(fp, delimiter=delimiter, quotechar='"', lineterminator='\n', quoting=should_quote)
+        for line in lines:
+            writer.writerow(line)
 
 def verify_lines_in_file(fname, expected):
     lines = get_lines_from_file(fname)
@@ -828,39 +910,34 @@ def removeEscapingDoubleQuoteInSQLString(string, forceDoubleQuote=True):
         string = '"' + string + '"'
     return string
 
-def formatSQLString(rel_file, isTableName=False):
+def quote_special_chars_in_table_list(table_list):
+    new_list = []
+    for schema, table in table_list:
+        if not re.match('^[\w_-]+$', schema):
+            schema = checkAndAddEnclosingDoubleQuote(schema)
+        if not re.match('^[\w_-]+$', table):
+            table = checkAndAddEnclosingDoubleQuote(table)
+        new_list.append([schema, table])
+    return new_list
+
+def formatSQLString(rel_file):
     """
-    Read the full qualified schema or table name, do a split
-    if each item is a table name into schema and table,
-    escape the double quote inside the name properly.
+    Read the schema name and escape the double quote inside the name properly.
     """
     relnames = []
     if rel_file and os.path.exists(rel_file):
         with open(rel_file, 'r') as fr:
             lines = fr.read().strip('\n').split('\n')
             for line in lines:
-                if isTableName:
-                    schema, table = split_fqn(line)
-                    schema = escapeDoubleQuoteInSQLString(schema)
-                    table = escapeDoubleQuoteInSQLString(table)
-                    relnames.append(schema + '.' + table)
-                else:
                     schema = escapeDoubleQuoteInSQLString(line)
                     relnames.append(schema)
         if len(relnames) > 0:
             write_lines_to_file(rel_file, relnames)
             return rel_file
 
-def split_fqn(fqn_name):
-    """
-    Split full qualified table name into schema and table by separator '.',
-    """
-    try:
-        schema, table = fqn_name.split('.')
-    except Exception as e:
-        logger.error("Failed to split name %s into schema and table, please check the format is schema.table" % fqn_name)
-        raise Exception('%s' % str(e))
-    return schema, table
+def quote_csv_file(filename):
+    lines = get_lines_from_csv_file(filename)
+    write_lines_to_csv_file(filename, lines, alwaysquote=True)
 
 def remove_file_on_segments(context, filename):
     addresses = get_all_segment_addresses(context.master_port)

--- a/gpMgmt/bin/gppylib/operations/dump.py
+++ b/gpMgmt/bin/gppylib/operations/dump.py
@@ -128,12 +128,12 @@ def get_include_schema_list_from_exclude_schema(context, exclude_schema_list):
 
 def get_ao_partition_state(context):
     ao_partition_info = get_ao_partition_list(context)
-    ao_partition_list = get_partition_state(context, 'pg_aoseg', ao_partition_info)
+    ao_partition_list = get_partition_state_tuples(context, 'pg_aoseg', ao_partition_info)
     return ao_partition_list
 
 def get_co_partition_state(context):
     co_partition_info = get_co_partition_list(context)
-    co_partition_list = get_partition_state(context, 'pg_aoseg', co_partition_info)
+    co_partition_list = get_partition_state_tuples(context, 'pg_aoseg', co_partition_info)
     return co_partition_list
 
 def validate_modcount(schema, tablename, cnt):
@@ -193,9 +193,7 @@ def get_partition_state(context, catalog_schema, partition_info):
     representation doesn't handle schema or table names with commas.
     """
     tuples = get_partition_state_tuples(context, catalog_schema, partition_info)
-
-    # Don't put space after comma, which can mess up with the space in schema and table name
-    return map((lambda x: '%s, %s, %s' % x), tuples)
+    return [list_to_csv_string(tuple, terminator='') for tuple in tuples]
 
 def get_tables_with_dirty_metadata(context, cur_pgstatoperations):
     last_dump_timestamp = get_last_dump_timestamp(context)
@@ -224,23 +222,22 @@ def get_last_state(context, table_type):
             if not os.path.exists(last_state_filename):
                 restore_file_with_nbu(context, path=last_state_filename)
 
-    return get_lines_from_file(last_state_filename)
+    return get_lines_from_csv_file(last_state_filename, delimiter=',')
 
 def compare_metadata(old_pgstatoperations, cur_pgstatoperations):
-    diffs = set()
+    diffs = []
     for operation in cur_pgstatoperations:
-        toks = operation.split(',')
+        toks = csv_string_to_list(operation)
         if len(toks) != 6:
             raise Exception('Wrong number of tokens in last_operation data for current backup: "%s"' % operation)
         if (toks[2], toks[3]) not in old_pgstatoperations or old_pgstatoperations[(toks[2], toks[3])] != operation:
-            tname = '%s.%s' % (toks[0], toks[1])
-            diffs.add(tname)
+            diffs.append(toks[0:2])
     return diffs
 
 def get_pgstatlastoperations_dict(last_operations):
     last_operations_dict = {}
     for operation in last_operations:
-        toks = operation.split(',')
+        toks = csv_string_to_list(operation)
         if len(toks) != 6:
             raise Exception('Wrong number of tokens in last_operation data for last backup: "%s"' % operation)
         last_operations_dict[(toks[2], toks[3])] = operation
@@ -272,23 +269,18 @@ def get_last_dump_timestamp(context):
 def create_partition_dict(partition_list):
     table_dict = dict()
     for partition in partition_list:
-        # As of version 4.3.8.0, gpcrondump supports spaces in schema name (field[0]) and table name (field[1])
-        # so we explicitly split on "comma followed by space" instead of just commas since we can't strip() the string
-        fields = partition.split(', ')
-        if len(fields) != 3:
+        if len(partition) != 3:
             raise Exception('Invalid state file format %s' % partition)
-        if fields[2].startswith(' '):
-            fields = [x for x in fields]
-        key = '%s.%s' % (fields[0], fields[1])
-        table_dict[key] = fields[2]
+        key = tuple_to_tablename(partition[0:2])
+        table_dict[key] = partition[2]
 
     return table_dict
 
 def compare_dict(last_dict, curr_dict):
-    diffkeys = set()
+    diffkeys = []
     for k in curr_dict:
         if k not in last_dict or (curr_dict[k] != last_dict[k]):
-            diffkeys.add(k)
+            diffkeys.append(tablename_to_tuple(k))
     return diffkeys
 
 def get_filename_from_filetype(context, table_type, timestamp=None):
@@ -303,7 +295,7 @@ def get_filename_from_filetype(context, table_type, timestamp=None):
 def write_state_file(context, table_type, partition_list):
     filename = get_filename_from_filetype(context, table_type, None)
 
-    write_lines_to_file(filename, partition_list)
+    write_lines_to_csv_file(filename, partition_list, delimiter=',')
 
     if context.ddboost:
         copy_file_to_dd(context, filename)
@@ -314,22 +306,25 @@ def get_dirty_tables(context, ao_partition_list, co_partition_list, last_operati
     dirty_ao_tables = get_dirty_partition_tables(context, 'ao', ao_partition_list)
     dirty_co_tables = get_dirty_partition_tables(context, 'co', co_partition_list)
     dirty_metadata_set = get_tables_with_dirty_metadata(context, last_operation_data)
-    logger.info("%s" % list(dirty_heap_tables | dirty_ao_tables | dirty_co_tables | dirty_metadata_set))
+    #logger.info("heap %s\nao %s\nco %s\nmetadata%s" % (dirty_heap_tables, dirty_ao_tables, dirty_co_tables, dirty_metadata_set))
 
-    return list(dirty_heap_tables | dirty_ao_tables | dirty_co_tables | dirty_metadata_set)
+    dirty = []
+    for table in dirty_heap_tables + dirty_ao_tables + dirty_co_tables + dirty_metadata_set:
+        if table not in dirty:
+            dirty.append(table)
+    return dirty
 
 def get_dirty_heap_tables(context):
-    dirty_tables = set()
+    dirty_tables = []
     qresult = get_heap_partition_list(context)
     for row in qresult:
         if len(row) != 3:
             raise Exception("Heap tables query returned rows with unexpected number of columns %d" % len(row))
-        tname = '%s.%s' % (row[1], row[2])
-        dirty_tables.add(tname)
+        dirty_tables.append(row[1:3])
     return dirty_tables
 
 def write_dirty_file_to_temp(dirty_tables):
-    return create_temp_file_from_list(dirty_tables, 'dirty_backup_list_')
+    return create_temp_csv_file_from_list(dirty_tables, 'dirty_backup_list_')
 
 def write_dirty_file(context, dirty_tables, timestamp=None):
     if dirty_tables is None:
@@ -338,7 +333,7 @@ def write_dirty_file(context, dirty_tables, timestamp=None):
         timestamp = context.timestamp
 
     dirty_list_file = context.generate_filename("dirty_table", timestamp)
-    write_lines_to_file(dirty_list_file, dirty_tables)
+    write_lines_to_csv_file(dirty_list_file, dirty_tables)
 
     if context.ddboost:
         copy_file_to_dd(context, dirty_list_file)
@@ -381,7 +376,7 @@ def get_last_operation_data(context):
     for row in rows:
         if len(row) != 6:
             raise Exception("Invalid return from query in get_last_operation_data: % cols" % (len(row)))
-        line = "%s,%s,%d,%s,%s,%s" % (row[0], row[1], row[2], row[3], row[4], row[5])
+        line = list_to_csv_string(row, terminator='')
         data.append(line)
     return data
 
@@ -399,7 +394,7 @@ def write_partition_list_file(context, timestamp=None):
         for line in lines_to_write:
             if len(line) != 3:
                 raise Exception('Invalid results from query to get all tables: [%s]' % (','.join(line)))
-            partition_list.append("%s.%s" % (line[1], line[2]))
+            partition_list.append(tuple_to_tablename(line[1:3]))
 
         write_lines_to_file(partition_list_file_name, partition_list)
 
@@ -426,17 +421,21 @@ def update_filter_file(context):
     filter_filename = get_filter_file(context)
     if context.netbackup_service_host:
         restore_file_with_nbu(context, path=filter_filename)
-    filter_tables = get_lines_from_file(filter_filename)
-    tables_sql = "SELECT DISTINCT schemaname||'.'||tablename FROM pg_partitions"
-    partitions_sql = "SELECT schemaname||'.'||partitiontablename FROM pg_partitions WHERE schemaname||'.'||tablename='%s';"
+    filter_tables = get_lines_from_csv_file(filter_filename)
+    tables_sql = "SELECT DISTINCT schemaname, tablename FROM pg_partitions"
+    partitions_sql = "SELECT partitionschemaname, partitiontablename FROM pg_partitions WHERE schemaname='%s' AND tablename='%s';"
     table_list = execute_sql(tables_sql, context.master_port, context.dump_database)
 
-    for table in table_list:
-        if table[0] in filter_tables:
-            partitions_list = execute_sql(partitions_sql % table[0], context.master_port, context.dump_database)
-            filter_tables.extend([x[0] for x in partitions_list])
+    for table_tuple in table_list:
+        if table_tuple in filter_tables:
+            partitions_list = execute_sql(partitions_sql % tuple(table_tuple), context.master_port, context.dump_database)
+            filter_tables.extend(partitions_list)
 
-    write_lines_to_file(filter_filename, list(set(filter_tables)))
+    filtered_list = []
+    for table in filter_tables:
+        if table not in filtered_list:
+            filtered_list.append(table)
+    write_lines_to_csv_file(filter_filename, filtered_list)
     if context.netbackup_service_host:
         backup_file_with_nbu(context, path=filter_filename)
 
@@ -465,13 +464,13 @@ def get_filter_file(context):
 def update_filter_file_with_dirty_list(filter_file, dirty_tables):
     filter_list = []
     if filter_file:
-        filter_list = get_lines_from_file(filter_file)
+        filter_list = get_lines_from_csv_file(filter_file)
 
         for table in dirty_tables:
             if table not in filter_list:
                 filter_list.append(table)
 
-        write_lines_to_file(filter_file, filter_list)
+        write_lines_to_csv_file(filter_file, filter_list)
 
 def filter_dirty_tables(context, dirty_tables):
     if context.netbackup_service_host is None:
@@ -483,15 +482,19 @@ def filter_dirty_tables(context, dirty_tables):
             timestamp = FULL_DUMP_TS_WITH_NBU
 
     schema_filename = context.generate_filename("schema", timestamp=timestamp)
+    if os.path.exists(schema_filename):
+        filter_schemas = True
+        schemas_to_filter = get_lines_from_file(schema_filename)
+    else:
+        filter_schemas = False
     filter_file = get_filter_file(context)
     if filter_file:
-        tables_to_filter = get_lines_from_file(filter_file)
+        tables_to_filter = get_lines_from_csv_file(filter_file)
         dirty_copy = dirty_tables[:]
         for table in dirty_copy:
             if table not in tables_to_filter:
-                if os.path.exists(schema_filename):
-                    schemas_to_filter = get_lines_from_file(schema_filename)
-                    table_schema = split_fqn(table)[0]
+                if filter_schemas:
+                    table_schema = table[0]
                     if table_schema not in schemas_to_filter:
                         dirty_tables.remove(table)
                 else:
@@ -501,7 +504,7 @@ def filter_dirty_tables(context, dirty_tables):
     # Any newly added partition to the schema's in schema file is added to the
     # filter file for it to be backed up.
     # Newly added partition can be obtained from dirty table list file.
-    if os.path.exists(schema_filename):
+    if filter_schemas:
         update_filter_file_with_dirty_list(filter_file, dirty_tables)
 
     return dirty_tables
@@ -537,9 +540,7 @@ class DumpDatabase(Operation):
             self.create_filter_file()
 
         # Format sql strings for all schema and table names
-        self.context.include_dump_tables_file = formatSQLString(rel_file=self.context.include_dump_tables_file, isTableName=True)
-        self.context.exclude_dump_tables_file = formatSQLString(rel_file=self.context.exclude_dump_tables_file, isTableName=True)
-        self.context.schema_file = formatSQLString(rel_file=self.context.schema_file, isTableName=False)
+        self.context.schema_file = formatSQLString(self.context.schema_file)
 
         if self.context.incremental and self.context.dump_prefix and get_filter_file(self.context):
             filtered_dump_line = self.create_filtered_dump_string()
@@ -575,14 +576,13 @@ class DumpDatabase(Operation):
             if self.context.netbackup_service_host:
                 backup_file_with_nbu(self.context, path=filter_name)
         elif self.context.exclude_dump_tables_file:
-            filters = get_lines_from_file(self.context.exclude_dump_tables_file)
+            filters = get_lines_from_csv_file(self.context.exclude_dump_tables_file)
             partitions = get_user_table_list(self.context)
             tables = []
             for p in partitions:
-                tablename = '%s.%s' % (p[0], p[1])
-                if tablename not in filters:
-                    tables.append(tablename)
-            write_lines_to_file(filter_name, tables)
+                if p not in filters:
+                    tables.append(p)
+            write_lines_to_csv_file(filter_name, tables)
             if self.context.netbackup_service_host:
                 backup_file_with_nbu(self.context, path=filter_name)
         logger.info('Creating filter file: %s' % filter_name)
@@ -642,16 +642,18 @@ class DumpDatabase(Operation):
         db_name = shellEscape(self.context.dump_database)
         dump_line += " %s" % checkAndAddEnclosingDoubleQuote(db_name)
         for dump_table in self.context.include_dump_tables:
-            schema, table = dump_table.split('.')
+            schema, table = tablename_to_tuple(dump_table)
             dump_line += " --table=\"\\\"%s\\\"\".\"\\\"%s\\\"\"" % (schema, table)
             #dump_line += " --table=\"%s\".\"%s\"" % (schema, table)
         for dump_table in self.context.exclude_dump_tables:
-            schema, table = dump_table.split('.')
+            schema, table = tablename_to_tuple(dump_table)
             dump_line += " --exclude-table=\"\\\"%s\\\"\".\"\\\"%s\\\"\"" % (schema, table)
             #dump_line += " --exclude-table=\"%s\".\"%s\"" % (schema, table)
         if self.context.include_dump_tables_file and not self.context.schema_file:
+            quote_csv_file(self.context.include_dump_tables_file)
             dump_line += " --table-file=%s" % self.context.include_dump_tables_file
         if self.context.exclude_dump_tables_file:
+            quote_csv_file(self.context.exclude_dump_tables_file)
             dump_line += " --exclude-table-file=%s" % self.context.exclude_dump_tables_file
         if self.context.schema_file:
             dump_line += " --schema-file=%s" % self.context.schema_file
@@ -1065,23 +1067,20 @@ class ValidateIncludeTargets(Operation):
             include_file = open(self.context.include_dump_tables_file, 'rU')
             if not include_file:
                 raise ExceptionNoStackTraceNeeded("Can't open file %s" % self.context.include_dump_tables_file)
-            for line in include_file:
-                dump_tables.append(line.strip('\n'))
-            include_file.close()
+            dump_tables = get_lines_from_csv_file(self.context.include_dump_tables_file)
 
         for dump_table in dump_tables:
-            if '.' not in dump_table:
-                raise ExceptionNoStackTraceNeeded("No schema name supplied for table %s" % dump_table)
-            if dump_table.startswith('pg_temp_'):
+            tablename = tuple_to_tablename(dump_table)
+            schema, table = dump_table
+            if schema.startswith('pg_temp_'):
                 continue
-            schema, table = split_fqn(dump_table)
             exists = CheckTableExists(self.context, schema, table).run()
             if not exists:
-                raise ExceptionNoStackTraceNeeded("Table %s does not exist in %s database" % (dump_table, self.context.dump_database))
+                raise ExceptionNoStackTraceNeeded("Table %s does not exist in %s database" % (tablename, self.context.dump_database))
             if self.context.dump_schema:
                 for dump_schema in self.context.dump_schema:
                     if dump_schema != schema:
-                        raise ExceptionNoStackTraceNeeded("Schema name %s not same as schema on %s" % (dump_schema, dump_table))
+                        raise ExceptionNoStackTraceNeeded("Schema name %s not same as schema on %s" % (dump_schema, tablename))
 
 class ValidateExcludeTargets(Operation):
     def __init__(self, context):
@@ -1098,21 +1097,18 @@ class ValidateExcludeTargets(Operation):
             exclude_file = open(self.context.exclude_dump_tables_file, 'rU')
             if not exclude_file:
                 raise ExceptionNoStackTraceNeeded("Can't open file %s" % self.context.exclude_dump_tables_file)
-            for line in exclude_file:
-                dump_tables.append(line.strip('\n'))
-            exclude_file.close()
+            dump_tables = get_lines_from_csv_file(self.context.exclude_dump_tables_file)
 
         for dump_table in dump_tables:
-            if '.' not in dump_table:
-                raise ExceptionNoStackTraceNeeded("No schema name supplied for exclude table %s" % dump_table)
-            schema, table = split_fqn(dump_table)
+            tablename = tuple_to_tablename(dump_table)
+            schema, table = dump_table
             exists = CheckTableExists(self.context, schema, table).run()
             if exists:
                 if self.context.dump_schema:
                     for dump_schema in self.context.dump_schema:
                         if dump_schema != schema:
                             logger.info("Adding table %s to exclude list" % dump_table)
-                            rebuild_excludes.append(dump_table)
+                            rebuild_excludes.append((schema, table))
                         else:
                             logger.warn("Schema dump request and exclude table %s in that schema, ignoring" % dump_table)
             else:
@@ -1162,9 +1158,9 @@ class CheckTableExists(Operation):
         self.schema = schema
         self.table = table
         if CheckTableExists.all_tables is None:
-            CheckTableExists.all_tables = set()
+            CheckTableExists.all_tables = []
             for (schema, table) in get_user_table_list(context):
-                CheckTableExists.all_tables.add((schema, table))
+                CheckTableExists.all_tables.append((schema, table))
 
     def execute(self):
         if (self.schema, self.table) in CheckTableExists.all_tables:
@@ -1196,7 +1192,7 @@ class UpdateHistoryTable(Operation):
         self.pseudo_exit_status = pseudo_exit_status
 
     def execute(self):
-        schema, table = split_fqn(UpdateHistoryTable.HISTORY_TABLE)
+        schema, table = "public", "gpcrondump_history"
         exists = CheckTableExists(self.context, schema, table).run()
         if not exists:
             conn = None
@@ -1527,26 +1523,26 @@ class DumpStats(Operation):
 
         include_tables = []
         if self.context.exclude_dump_tables_file:
-            exclude_tables = get_lines_from_file(self.context.exclude_dump_tables_file)
+            exclude_tables = get_lines_from_csv_file(self.context.exclude_dump_tables_file)
             user_tables = get_user_table_list(self.context)
-            tables = []
+            include_tables = []
             for table in user_tables:
-                tables.append("%s.%s" % (table[0], table[1]))
-            include_tables = list(set(tables) - set(exclude_tables))
+                if table not in exclude_tables:
+                    include_tables.append(table)
         elif self.context.include_dump_tables_file:
-            include_tables = get_lines_from_file(self.context.include_dump_tables_file)
+            include_tables = get_lines_from_csv_file(self.context.include_dump_tables_file)
         elif self.context.schema_file:
             include_schemas = get_lines_from_file(self.context.schema_file)
             for schema in include_schemas:
                 user_tables = get_user_table_list_for_schema(self.context, schema)
                 tables = []
                 for table in user_tables:
-                    tables.append("%s.%s" % (table[0], table[1]))
+                    tables.append(table)
                 include_tables.extend(tables)
         else:
             user_tables = get_user_table_list(self.context)
             for table in user_tables:
-                include_tables.append("%s.%s" % (table[0], table[1]))
+                include_tables.append(table)
 
         with open(self.stats_filename, "w") as outfile:
             outfile.write("""--
@@ -1571,9 +1567,7 @@ set allow_system_table_mods="DML";
             cmd.run(validateAfter=True)
 
     def dump_table(self, table):
-        schemaname, tablename = table.split(".")
-        schemaname = checkAndRemoveEnclosingDoubleQuote(schemaname)
-        tablename = checkAndRemoveEnclosingDoubleQuote(tablename)
+        schemaname, tablename = table
         tuples_query = """SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples
                           FROM pg_class pgc, pg_namespace pgn
                           WHERE pgc.relnamespace = pgn.oid

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -39,23 +39,22 @@ def update_ao_stat_func(conn, ao_schema, ao_table, counter, batch_size):
         conn.commit()
 
 def generate_restored_tables(results, restored_tables, restored_schema, restore_all):
-    restored_ao_tables = set()
+    restored_ao_tables = []
 
-    for (tbl, sch) in results:
+    for (sch, tbl) in results:
         if restore_all:
-            restored_ao_tables.add((sch, tbl))
+            restored_ao_tables.append([sch, tbl])
         elif sch in restored_schema:
-            restored_ao_tables.add((sch, tbl))
+            restored_ao_tables.append([sch, tbl])
         else:
-            tblname = '%s.%s' % (sch, tbl)
-            if tblname in restored_tables:
-                restored_ao_tables.add((sch, tbl))
+            if [sch, tbl] in restored_tables and [sch, tbl] not in restored_ao_tables:
+                restored_ao_tables.append([sch, tbl])
 
     return restored_ao_tables
 
 def update_ao_statistics(context, restored_tables, restored_schema=[], restore_all=False):
     # Restored schema is different from restored tables as restored schema updates all tables within that schema.
-    qry = """SELECT c.relname,n.nspname
+    qry = """SELECT n.nspname,c.relname
              FROM pg_class c, pg_namespace n
              WHERE c.relnamespace=n.oid
                  AND (c.relstorage='a' OR c.relstorage='c')"""
@@ -82,7 +81,7 @@ def get_restore_tables_from_table_file(table_file):
     if not os.path.isfile(table_file):
         raise Exception('Table file does not exist "%s"' % table_file)
 
-    return get_lines_from_file(table_file)
+    return get_lines_from_csv_file(table_file)
 
 def get_incremental_restore_timestamps(context):
     inc_file = context.generate_filename("increments", timestamp=context.full_dump_timestamp)
@@ -97,13 +96,12 @@ def get_incremental_restore_timestamps(context):
 
 def get_partition_list(context):
     partition_list_file = context.generate_filename("partition_list")
-    partition_list = get_lines_from_file(partition_list_file)
-    partition_list = [split_fqn(p) for p in partition_list]
+    partition_list = get_lines_from_csv_file(partition_list_file)
     return partition_list
 
 def get_dirty_table_file_contents(context, timestamp):
     dirty_list_file = context.generate_filename("dirty_table", timestamp=timestamp)
-    return get_lines_from_file(dirty_list_file)
+    return get_lines_from_csv_file(dirty_list_file)
 
 def create_plan_file_contents(context, table_set_from_metadata_file, incremental_restore_timestamps, full_timestamp):
     restore_set = {}
@@ -119,8 +117,8 @@ def create_plan_file_contents(context, table_set_from_metadata_file, incremental
 
     restore_set[full_timestamp] = []
     if len(table_set_from_metadata_file) != 0:
-        for table in table_set_from_metadata_file:
-            restore_set[full_timestamp].append(table)
+        for dt in table_set_from_metadata_file:
+            restore_set[full_timestamp].append(dt)
 
     return restore_set
 
@@ -132,8 +130,11 @@ def write_to_plan_file(plan_file_contents, plan_file):
 
     lines_to_write = []
     for ts in sorted_plan_file_contents:
-        tables_str = ','.join(plan_file_contents[ts])
-        lines_to_write.append(ts + ':' + tables_str)
+        tables_to_write = []
+        for table_tuple in plan_file_contents[ts]:
+            table = tuple_to_tablename(table_tuple)
+            tables_to_write.append(table)
+        lines_to_write.append(ts + ':' + list_to_csv_string(tables_to_write, terminator=''))
 
     write_lines_to_file(plan_file, lines_to_write)
 
@@ -142,11 +143,9 @@ def write_to_plan_file(plan_file_contents, plan_file):
 def create_restore_plan(context):
     dump_tables = get_partition_list(context)
 
-    table_set_from_metadata_file = [schema + '.' + table for schema, table in dump_tables]
-
     incremental_restore_timestamps = get_incremental_restore_timestamps(context)
 
-    plan_file_contents = create_plan_file_contents(context, table_set_from_metadata_file,
+    plan_file_contents = create_plan_file_contents(context, dump_tables,
                                                    incremental_restore_timestamps,
                                                    full_timestamp=context.full_dump_timestamp)
 
@@ -192,8 +191,15 @@ def get_plan_file_contents(context):
             raise Exception('Invalid plan file format')
         # timestamp is of length 14, don't split by ':' in case table name contains ':'
         # don't strip white space on table_list, schema and table name may contain white space
-        ts, table_list = line[:14], line[15:]
-        plan_file_items.append((ts.strip(), table_list))
+        ts, table_csv = line[:14], line[15:]
+        tuple_list = []
+        table_list = csv_string_to_list(table_csv)
+        if not table_list:
+            continue
+        for table in table_list:
+            table_tuple = tablename_to_tuple(table)
+            tuple_list.append(table_tuple)
+        plan_file_items.append((ts.strip(), tuple_list))
     return plan_file_items
 
 def get_restore_table_list(table_list, restore_tables):
@@ -203,12 +209,8 @@ def get_restore_table_list(table_list, restore_tables):
     if restore_tables is None or len(restore_tables) == 0:
         restore_list = table_list
     else:
-        for restore_table in restore_tables:
-            schema, table = split_fqn(restore_table)
-            restore_table_set.add((schema, table))
         for tbl in table_list:
-            schema, table = split_fqn(tbl)
-            if (schema, table) in restore_table_set:
+            if tbl in restore_tables:
                 restore_list.append(tbl)
 
     if restore_list == []:
@@ -225,24 +227,20 @@ def validate_restore_tables_list(plan_file_contents, restore_tables, restore_sch
     if restore_tables is None:
         return
 
-    table_set = set()
-    comp_set = set()
+    table_set = []
 
-    for ts, table in plan_file_contents:
-        tables = table.split(',')
-        for table in tables:
-            table_set.add(table)
+    for ts, table_list in plan_file_contents:
+        for table in table_list:
+            table_set.append(table)
 
     invalid_tables = []
     for table in restore_tables:
-        schema_name, table_name = split_fqn(table)
+        schema_name, table_name = table
         if restore_schemas and schema_name in restore_schemas:
             continue
         else:
-            comp_set.add(table)
-            if not comp_set.issubset(table_set):
+            if not table in table_set:
                 invalid_tables.append(table)
-                comp_set.remove(table)
 
     if invalid_tables != []:
         raise Exception('Invalid tables for -T option: The following tables were not found in plan file : "%s"' % (invalid_tables))
@@ -383,7 +381,7 @@ class RestoreDatabase(Operation):
             self._restore_stats()
 
         self.tmp_files = [table_filter_file, change_schema_file, schema_level_restore_file]
-        self.cleanup_files_on_segments()
+        #self.cleanup_files_on_segments()
 
     def _process_result(self, cmd):
         res = cmd.get_results()
@@ -432,13 +430,10 @@ class RestoreDatabase(Operation):
                         analyze_list.extend(self.get_full_tables_in_schema(conn, schemaname))
                 else:
                     for restore_table in self.context.restore_tables:
-                        schemaname, tablename = split_fqn(restore_table)
+                        schemaname, tablename = restore_table
                         if self.context.change_schema:
-                            schema = escapeDoubleQuoteInSQLString(self.context.change_schema)
-                        else:
-                            schema = escapeDoubleQuoteInSQLString(schemaname)
-                        table = escapeDoubleQuoteInSQLString(tablename)
-                        restore_table = '%s.%s' % (schema, table)
+                            schemaname = self.context.change_schema
+                        restore_table = tuple_to_tablename([schemaname, tablename])
                         analyze_list.append(restore_table)
 
                 for tbl in analyze_list:
@@ -524,7 +519,7 @@ class RestoreDatabase(Operation):
         for (ts, table_list) in plan_file_items:
             if table_list:
                 restore_data = True
-                table_file = get_restore_table_list(table_list.strip('\n').split(','), self.context.restore_tables)
+                table_file = get_restore_table_list(table_list, self.context.restore_tables)
                 if table_file is None:
                     continue
                 cmd = _build_gpdbrestore_cmd_line(self.context, ts, table_file)
@@ -584,8 +579,9 @@ class RestoreDatabase(Operation):
                 for line in infile:
                     matches = search(table_pattern, line)
                     if matches:
-                        tablename = '%s.%s' % (matches.group(1), matches.group(2))
-                        if len(self.context.restore_tables) == 0 or tablename in self.context.restore_tables:
+                        schema, table = matches.group(1), matches.group(2)
+                        tablename = tuple_to_tablename((schema, table))
+                        if len(self.context.restore_tables) == 0 or [schema,table] in self.context.restore_tables:
                             try:
                                 new_oid = relids[tablename]
                                 print_toggle = True
@@ -866,21 +862,20 @@ class RestoreDatabase(Operation):
                     truncate_list.extend(self.get_full_tables_in_schema(conn, schemaname))
             else:
                 for restore_table in self.context.restore_tables:
-                    schemaname, tablename = split_fqn(restore_table)
+                    schema, table = restore_table
                     check_table_exists_qry = """SELECT EXISTS (
                                                        SELECT 1
                                                        FROM pg_catalog.pg_class c
                                                        JOIN pg_catalog.pg_namespace n on n.oid = c.relnamespace
-                                                       WHERE n.nspname = '%s' and c.relname = '%s')""" % (pg.escape_string(schemaname),
-                                                                                                          pg.escape_string(tablename))
+                                                       WHERE n.nspname = '%s' and c.relname = '%s')""" % (pg.escape_string(schema),
+                                                                                                          pg.escape_string(table))
                     exists_result = execSQLForSingleton(conn, check_table_exists_qry)
                     if exists_result:
-                        schema = escapeDoubleQuoteInSQLString(schemaname)
-                        table = escapeDoubleQuoteInSQLString(tablename)
-                        truncate_table = '%s.%s' % (schema, table)
+                        truncate_table = tuple_to_tablename([schema, table])
                         truncate_list.append(truncate_table)
                     else:
-                        logger.warning("Skipping truncate of %s.%s because the relation does not exist." % (self.context.restore_db, restore_table))
+                        logger.warning("Skipping truncate of %s.%s because the relation does not exist." % (self.context.restore_db, \
+                                tuple_to_tablename(restore_table)))
 
             for table in truncate_list:
                 try:
@@ -961,23 +956,17 @@ def check_table_name_format_and_duplicate(table_list, restore_schemas=None):
     """
 
     restore_table_list = []
-    table_set = set()
-
-    # validate special characters
-    check_funny_chars_in_names(restore_schemas, is_full_qualified_name = False)
-    check_funny_chars_in_names(table_list)
 
     # validate schemas
     if restore_schemas:
         restore_schemas = list(set(restore_schemas))
 
     for restore_table in table_list:
-        if '.' not in restore_table:
-            raise Exception("No schema name supplied for %s, removing from list of tables to restore" % restore_table)
-        schema, table = split_fqn(restore_table)
+        if len(restore_table) != 2:
+            raise Exception("%s is not in the format schema.table" % '.'.join(restore_table))
+        schema, table = restore_table
         # schema level restore will be handled before specific table restore, treat as duplicate
-        if not ((restore_schemas and schema in restore_schemas) or (schema, table) in table_set):
-            table_set.add((schema, table))
+        if not ((restore_schemas and schema in restore_schemas) or restore_table in restore_table_list):
             restore_table_list.append(restore_table)
 
     return restore_table_list, restore_schemas
@@ -985,7 +974,7 @@ def check_table_name_format_and_duplicate(table_list, restore_schemas=None):
 def validate_tablenames_exist_in_dump_file(restore_tables, dumped_tables):
     unmatched_table_names = []
     if dumped_tables:
-        dumped_table_names = [schema + '.' + table for (schema, table, _) in dumped_tables]
+        dumped_table_names = [[schema, table] for (schema, table, _) in dumped_tables]
         for table in restore_tables:
             if table not in dumped_table_names:
                 unmatched_table_names.append(table)
@@ -993,7 +982,8 @@ def validate_tablenames_exist_in_dump_file(restore_tables, dumped_tables):
         raise Exception('No dumped tables to restore.')
 
     if len(unmatched_table_names) > 0:
-        raise Exception("Tables %s not found in backup" % unmatched_table_names)
+        err_table_list = [tuple_to_tablename(t) for t in unmatched_table_names]
+        raise Exception("Tables %s not found in backup" % err_table_list)
 
 class CopyPostData(Operation):
     ''' Copy _post_data when using fake timestamp.

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
@@ -9,7 +9,7 @@ import unittest2 as unittest
 from gppylib.commands.base import CommandResult
 from gppylib.operations.backup_utils import *
 
-from mock import patch, MagicMock, Mock
+from mock import call, mock_open, patch, MagicMock, Mock
 from optparse import Values
 
 class BackupUtilsTestCase(unittest.TestCase):
@@ -568,11 +568,11 @@ class BackupUtilsTestCase(unittest.TestCase):
         self.assertEquals(result, '20160125140013')
 
     def test_create_temp_file_with_tables_default(self):
-        dirty_tables = ['public.t1', 'public.t2', 'testschema.t3']
+        dirty_tables = [['public', 't1'], ['public', 't2'], ['testschema', 't3']]
         dirty_file = create_temp_file_with_tables(dirty_tables)
         self.assertTrue(os.path.basename(dirty_file).startswith('table_list'))
         self.assertTrue(os.path.exists(dirty_file))
-        content = get_lines_from_file(dirty_file)
+        content = get_lines_from_csv_file(dirty_file)
         self.assertEqual(dirty_tables, content)
         os.remove(dirty_file)
 
@@ -586,7 +586,7 @@ class BackupUtilsTestCase(unittest.TestCase):
         os.remove(dirty_file)
 
     def test_create_temp_file_from_list_nonstandard_name(self):
-        dirty_tables = ['public.t1', 'public.t2', 'testschema.t3']
+        dirty_tables = ['public', 'tempschema', 'testschema']
         dirty_file = create_temp_file_from_list(dirty_tables, 'dirty_hackup_list_')
         self.assertTrue(os.path.basename(dirty_file).startswith('dirty_hackup_list'))
         self.assertTrue(os.path.exists(dirty_file))
@@ -661,8 +661,8 @@ class BackupUtilsTestCase(unittest.TestCase):
     @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[['public', 'tl1'], ['public', 'tl2']])
     def test_expand_partition_tables_default(self, mock1, mock2, mock3):
         dbname = 'foo'
-        restore_tables = ['public.t1', 'public.t2']
-        expected_output = ['public.tl1', 'public.tl2', 'public.t2']
+        restore_tables = [('public', 't1'), ('public', 't2')]
+        expected_output = [('public', 'tl1'), ('public', 'tl2'), ('public', 't2')]
         result = expand_partition_tables(dbname, restore_tables)
         self.assertEqual(result.sort(), expected_output.sort())
 
@@ -671,33 +671,17 @@ class BackupUtilsTestCase(unittest.TestCase):
     @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[])
     def test_expand_partition_tables_no_change(self, mock1, mock2, mock3):
         dbname = 'foo'
-        restore_tables = ['public.t1', 'public.t2']
-        expected_output = ['public.t1', 'public.t2']
+        restore_tables = [('public', 't1'), ('public', 't2')]
+        expected_output = [('public', 't1'), ('public', 't2')]
         result = expand_partition_tables(dbname, restore_tables)
         self.assertEqual(result.sort(), expected_output.sort())
 
-    def test_populate_filter_tables_all_part_tables(self):
-        table = 'public.t1'
-        rows = [['public', 't1'], ['public', 't2'], ['public', 't3']]
-        non_partition_tables = []
-        partition_leaves = []
-        self.assertEqual(populate_filter_tables(table, rows, non_partition_tables, partition_leaves),
-                            (([], ['public.t1', 'public.t2', 'public.t3'])))
-
-    def test_populate_filter_tables_no_part_tables(self):
-        table = 'public.t1'
-        rows = []
-        non_partition_tables = []
-        partition_leaves = []
-        self.assertEqual(populate_filter_tables(table, rows, non_partition_tables, partition_leaves),
-                            ((['public.t1'], [])))
-
-    @patch('gppylib.operations.backup_utils.expand_partition_tables', return_value=['public.t1_p1', 'public.t1_p2', 'public.t1_p3', 'public.t2', 'public.t3'])
+    @patch('gppylib.operations.backup_utils.expand_partition_tables', return_value=[('public', 't1_p1'), ('public', 't1_p2'), ('public', 't1_p3'), ('public', 't2'), ('public', 't3')])
     def test_expand_partitions_and_populate_filter_file_part_tables(self, mock):
         dbname = 'bkdb'
-        partition_list = ['public.t1', 'public.t2', 'public.t3']
+        partition_list = [('public', 't1'), ('public', 't2'), ('public', 't3')]
         file_prefix = 'include_dump_tables_file'
-        expected_output = ['public.t2', 'public.t3', 'public.t1', 'public.t1_p1', 'public.t1_p2', 'public.t1_p3']
+        expected_output = [('public', 't2'), ('public', 't3'), ('public', 't1'), ('public', 't1_p1'), ('public', 't1_p2'), ('public', 't1_p3')]
         result = expand_partitions_and_populate_filter_file(dbname, partition_list, file_prefix)
         self.assertTrue(os.path.basename(result).startswith(file_prefix))
         self.assertTrue(os.path.exists(result))
@@ -705,10 +689,10 @@ class BackupUtilsTestCase(unittest.TestCase):
         self.assertEqual(contents.sort(), expected_output.sort())
         os.remove(result)
 
-    @patch('gppylib.operations.backup_utils.expand_partition_tables', return_value=['public.t1', 'public.t2', 'public.t3'])
+    @patch('gppylib.operations.backup_utils.expand_partition_tables', return_value=[('public', 't1'), ('public', 't2'), ('public', 't3')])
     def test_expand_partitions_and_populate_filter_file_no_part_tables(self, mock):
         dbname = 'bkdb'
-        partition_list = ['public.t1', 'public.t2', 'public.t3']
+        partition_list = [('public', 't1'), ('public', 't2'), ('public', 't3')]
         file_prefix = 'exclude_dump_tables_file'
         result = expand_partitions_and_populate_filter_file(dbname, partition_list, file_prefix)
         self.assertTrue(os.path.basename(result).startswith(file_prefix))
@@ -765,26 +749,26 @@ class BackupUtilsTestCase(unittest.TestCase):
         self.assertEqual(expected, indices)
 
     def test_list_to_quoted_string_default(self):
-        input = ['public.ao_table', 'public.co_table']
-        expected = "'public.ao_table', 'public.co_table'"
+        input = [('public', 'ao_table'), ('public', 'co_table')]
+        expected = "('public','ao_table'), ('public','co_table')"
         output = list_to_quoted_string(input)
         self.assertEqual(expected, output)
 
     def test_list_to_quoted_string_whitespace(self):
-        input = ['   public.ao_table', 'public.co_table   ']
-        expected = "'   public.ao_table', 'public.co_table   '"
+        input = [('   public', 'ao_table'), ('public', 'co_table   ')]
+        expected = "('   public','ao_table'), ('public','co_table   ')"
         output = list_to_quoted_string(input)
         self.assertEqual(expected, output)
 
     def test_list_to_quoted_string_one_table(self):
-        input = ['public.ao_table']
-        expected = "'public.ao_table'"
+        input = [('public', 'ao_table')]
+        expected = "('public','ao_table')"
         output = list_to_quoted_string(input)
         self.assertEqual(expected, output)
 
     def test_list_to_quoted_string_no_tables(self):
         input = []
-        expected = "''"
+        expected = '()'
         output = list_to_quoted_string(input)
         self.assertEqual(expected, output)
 
@@ -1141,3 +1125,272 @@ class BackupUtilsTestCase(unittest.TestCase):
                 context = Context()
         finally:
             os.environ['MASTER_DATA_DIRECTORY'] = old_mdd
+
+    def test_tablename_list_to_tuple_list_default(self):
+        table_list = ['public.foo', 'public.bar']
+        expected = [['public', 'foo'], ['public', 'bar']]
+        results = tablename_list_to_tuple_list(table_list)
+        self.assertEqual(expected, results)
+
+    def test_tablename_list_to_tuple_list_no_schemas(self):
+        table_list = ['foo', 'public.bar']
+        with self.assertRaisesRegexp(Exception, "not in the format schema.table"):
+            results = tablename_list_to_tuple_list(table_list)
+
+    def test_tablename_list_to_tuple_list_too_many_tokens(self):
+        table_list = ['testdb.public.foo', 'public.bar']
+        with self.assertRaisesRegexp(Exception, "not in the format schema.table"):
+            results = tablename_list_to_tuple_list(table_list)
+
+    def test_tablename_list_to_tuple_list_bad_format(self):
+        table_list = ['public,foo', 'public.bar']
+        with self.assertRaisesRegexp(Exception, "not in the format schema.table"):
+            results = tablename_list_to_tuple_list(table_list)
+
+    def test_tablename_list_to_tuple_list_empty_list(self):
+        results = tablename_list_to_tuple_list([])
+        self.assertEqual([], results)
+
+    def test_tablename_list_to_tuple_list_special_chars(self):
+        table_list = ['public."foo!$""\t\n,."', 'public.bar']
+        expected = [['public', 'foo!$"\t\n,.'], ['public', 'bar']]
+        results = tablename_list_to_tuple_list(table_list)
+        self.assertEqual(expected, results)
+
+    def test_list_to_csv_string_default(self):
+        table_list = ['public', 'foo']
+        expected = 'public,foo\n'
+        results = list_to_csv_string(table_list)
+        self.assertEqual(expected, results)
+
+    def test_list_to_csv_string_more_items(self):
+        table_list = ['testdb', 'public', 'foo']
+        expected = 'testdb,public,foo\n'
+        results = list_to_csv_string(table_list)
+        self.assertEqual(expected, results)
+
+    def test_list_to_csv_string_different_delimiter(self):
+        table_list = ['public', 'foo']
+        expected = 'public.foo\n'
+        results = list_to_csv_string(table_list, delimiter='.')
+        self.assertEqual(expected, results)
+
+    def test_list_to_csv_string_different_terminator(self):
+        table_list = ['public', 'foo']
+        expected = 'public,foo'
+        results = list_to_csv_string(table_list, terminator='')
+        self.assertEqual(expected, results)
+
+    def test_list_to_csv_string_empty_list(self):
+        results = list_to_csv_string([])
+        self.assertEqual('\n', results)
+
+    def test_list_to_csv_string_special_chars(self):
+        table_list = ['public', 'foo!$"\t\n,.']
+        expected = 'public,"foo!$""\t\n,."\n'
+        results = list_to_csv_string(table_list)
+        self.assertEqual(expected, results)
+
+    def test_list_to_csv_string_special_chars_no_delimiter_or_terminator_or_quotechar(self):
+        table_list = ['public', 'foo!$\t.']
+        expected = 'public,foo!$\t.\n'
+        results = list_to_csv_string(table_list)
+        self.assertEqual(expected, results)
+
+    def test_csv_string_to_list_default(self):
+        csv_string = 'public,foo\n'
+        expected = ['public', 'foo']
+        results = csv_string_to_list(csv_string)
+        self.assertEqual(expected, results)
+
+    def test_csv_string_to_list_more_tokens(self):
+        csv_string = 'testdb,public,foo\n'
+        expected = ['testdb', 'public', 'foo']
+        results = csv_string_to_list(csv_string)
+        self.assertEqual(expected, results)
+
+    def test_csv_string_to_list_wrong_delimiter(self):
+        csv_string = 'public.foo\n'
+        expected = ['public.foo']
+        results = csv_string_to_list(csv_string)
+        self.assertEqual(expected, results)
+
+    def test_csv_string_to_list_no_terminator(self):
+        csv_string = 'public,foo'
+        expected = ['public', 'foo']
+        results = csv_string_to_list(csv_string)
+        self.assertEqual(expected, results)
+
+    def test_csv_string_to_list_empty_string(self):
+        results = csv_string_to_list('')
+        self.assertEqual([], results)
+
+    def test_csv_string_to_list_special_chars(self):
+        csv_string = 'public,"foo!$""\t\n,."\n'
+        expected = ['public', 'foo!$"\t\n,.']
+        results = csv_string_to_list(csv_string)
+        self.assertEqual(expected, results)
+
+    def test_list_to_csv_string_special_chars_no_delimiter_or_terminator_or_quotechar(self):
+        csv_string = 'public,foo!$\t.\n'
+        expected = ['public', 'foo!$\t.']
+        results = csv_string_to_list(csv_string)
+        self.assertEqual(expected, results)
+
+    def test_tuple_to_tablename_default(self):
+        tuple = ['public', 'foo']
+        expected = 'public.foo'
+        results = tuple_to_tablename(tuple)
+        self.assertEqual(expected, results)
+
+    def test_tuple_to_tablename_no_schemas(self):
+        tuple = ['foo']
+        with self.assertRaisesRegexp(Exception, 'not in the format schema.table'):
+            results = tuple_to_tablename(tuple)
+
+    def test_tuple_to_tablename_too_long(self):
+        tuple = ['testdb', 'public', 'foo']
+        with self.assertRaisesRegexp(Exception, 'not in the format schema.table'):
+            results = tuple_to_tablename(tuple)
+
+    def test_tuple_to_tablename_empty_list(self):
+        tuple = []
+        with self.assertRaisesRegexp(Exception, 'not in the format schema.table'):
+            results = tuple_to_tablename(tuple)
+
+    def test_tuple_to_tablename_special_chars(self):
+        tuple = ['public', 'foo!$\t\n,.']
+        expected = 'public."foo!$\t\n,."'
+        results = tuple_to_tablename(tuple)
+        self.assertEqual(expected, results)
+
+    def test_tablename_to_tuple_default(self):
+        tablename = 'public.foo'
+        expected = ['public', 'foo']
+        results = tablename_to_tuple(tablename)
+        self.assertEqual(expected, results)
+
+    def test_tablename_to_tuple_no_schemas(self):
+        tablename = 'foo'
+        with self.assertRaisesRegexp(Exception, 'not in the format schema.table'):
+            results = tablename_to_tuple(tablename)
+
+    def test_tablename_to_tuple_bad_format(self):
+        tablename = 'public,foo'
+        with self.assertRaisesRegexp(Exception, 'not in the format schema.table'):
+            results = tablename_to_tuple(tablename)
+
+    def test_tablename_to_tuple_empty_string(self):
+        tablename = ''
+        with self.assertRaisesRegexp(Exception, 'not in the format schema.table'):
+            results = tablename_to_tuple(tablename)
+
+    def test_tablename_to_tuple_special_chars(self):
+        tablename = 'public."foo!$\t\n,."'
+        expected = ['public', 'foo!$\t\n,.']
+        results = tablename_to_tuple(tablename)
+        self.assertEqual(expected, results)
+
+    def test_get_lines_from_csv_file_default(self):
+        lines = ['public.foo\n', 'public.bar\n']
+        filename = '/tmp/testfile'
+        write_lines_to_file(filename, lines)
+        expected = [['public', 'foo'], ['public', 'bar']]
+        results = get_lines_from_csv_file(filename)
+        self.assertEqual(expected, results)
+        os.remove(filename)
+
+    def test_get_lines_from_csv_file_different_delimiter(self):
+        lines = ['public,foo\n', 'public,bar\n']
+        filename = '/tmp/testfile'
+        write_lines_to_file(filename, lines)
+        expected = [['public', 'foo'], ['public', 'bar']]
+        results = get_lines_from_csv_file(filename, delimiter=',')
+        self.assertEqual(expected, results)
+        os.remove(filename)
+
+    def test_get_lines_from_csv_file_empty_file(self):
+        filename = '/tmp/testfile'
+        open(filename, 'a').close()
+        results = get_lines_from_csv_file(filename)
+        self.assertEqual([], results)
+        os.remove(filename)
+
+    def test_get_lines_from_csv_file_nonexistent_file(self):
+        filename = '/tmp/testfile'
+        with self.assertRaisesRegexp(Exception, "No such file or directory"):
+            results = get_lines_from_csv_file(filename)
+
+    def test_get_lines_from_csv_file_special_chars(self):
+        lines = ['public."foo!$\t\n,."\n', 'public.bar\n']
+        filename = '/tmp/testfile'
+        write_lines_to_file(filename, lines)
+        expected = [['public', 'foo!$\t\n,.'], ['public', 'bar']]
+        results = get_lines_from_csv_file(filename)
+        self.assertEqual(expected, results)
+        os.remove(filename)
+
+    @patch('gppylib.operations.backup_utils.get_lines_from_dd_file', return_value=['public.foo', 'public.bar'])
+    def test_get_lines_from_csv_file_ddboost(self, mock1):
+        fake_context = Mock()
+        fake_context.ddboost = True
+        filename = '/tmp/testfile'
+        expected = [['public', 'foo'], ['public', 'bar']]
+        results = get_lines_from_csv_file(filename, fake_context)
+        self.assertEqual(expected, results)
+
+    def test_write_lines_to_csv_file_default(self):
+        lines= [['public', 'foo'], ['public', 'bar']]
+        filename = '/tmp/testfile'
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            write_lines_to_csv_file(filename, lines)
+            result = m()
+            self.assertEqual(len(lines), len(result.write.call_args_list))
+            for i in range(len(lines)):
+                table = "%s.%s\n" % tuple(lines[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])
+
+    def test_write_lines_to_csv_file_different_delimiter(self):
+        lines= [['public', 'foo'], ['public', 'bar']]
+        filename = '/tmp/testfile'
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            write_lines_to_csv_file(filename, lines, delimiter=',')
+            result = m()
+            self.assertEqual(len(lines), len(result.write.call_args_list))
+            for i in range(len(lines)):
+                table = "%s,%s\n" % tuple(lines[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])
+
+    def test_write_lines_to_csv_file_empty_list(self):
+        lines= []
+        filename = '/tmp/testfile'
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            write_lines_to_csv_file(filename, lines)
+            result = m()
+            self.assertEqual(0, len(result.write.call_args_list))
+
+    def test_write_lines_to_csv_file_special_chars(self):
+        lines= [['public', 'foo!$\t\n,.'], ['public', 'bar']]
+        expected = [call('public."foo!$\t\n,."\n'), call('public.bar\n')]
+        filename = '/tmp/testfile'
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            write_lines_to_csv_file(filename, lines)
+            result = m()
+            self.assertEqual(len(lines), len(result.write.call_args_list))
+            self.assertEqual(expected, result.write.call_args_list)
+
+    def test_write_lines_to_csv_file_always_quote(self):
+        lines= [['public', 'foo!$\t\n,.'], ['public', 'bar']]
+        filename = '/tmp/testfile'
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            write_lines_to_csv_file(filename, lines, alwaysquote=True)
+            result = m()
+            self.assertEqual(len(lines), len(result.write.call_args_list))
+            for i in range(len(lines)):
+                table = '"%s"."%s"\n' % tuple(lines[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
@@ -33,7 +33,7 @@ class DumpTestCase(unittest.TestCase):
 
     @patch('gppylib.operations.dump.get_heap_partition_list', return_value=[['123', 'public', 't4'], ['123', 'public', 't5'], ['123', 'testschema', 't6']])
     def test_get_dirty_heap_tables_default(self, mock1):
-        expected_output = set(['public.t4', 'public.t5', 'testschema.t6'])
+        expected_output = [['public', 't4'], ['public', 't5'], ['testschema', 't6']]
         dirty_table_list = get_dirty_heap_tables(self.context)
         self.assertEqual(dirty_table_list, expected_output)
 
@@ -43,18 +43,19 @@ class DumpTestCase(unittest.TestCase):
             dirty_table_list = get_dirty_heap_tables(self.context)
 
     def test_write_dirty_file_default(self):
-        dirty_tables = ['t1', 't2', 't3']
+        dirty_tables = [['public','t1'], ['public','t2'], ['public','t3']]
         m = mock_open()
         with patch('__builtin__.open', m, create=True):
             tmpfilename = write_dirty_file(self.context, dirty_tables)
             result = m()
             self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
             for i in range(len(dirty_tables)):
-                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
+                table = "%s.%s\n" % tuple(dirty_tables[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
     @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='test_dirty_filename')
     def test_write_dirty_file_timestamp(self, mock1):
-        dirty_tables = ['t1', 't2', 't3']
+        dirty_tables = [['public','t1'], ['public','t2'], ['public','t3']]
         timestamp = '20160101010101'
         m = mock_open()
         with patch('__builtin__.open', m, create=True):
@@ -63,7 +64,8 @@ class DumpTestCase(unittest.TestCase):
             result = m()
             self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
             for i in range(len(dirty_tables)):
-                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
+                table = "%s.%s\n" % tuple(dirty_tables[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
     def test_write_dirty_file_no_list(self):
         dirty_tables = None
@@ -175,8 +177,8 @@ class DumpTestCase(unittest.TestCase):
                 result = m()
                 self.assertEqual(len(part_list), len(result.write.call_args_list))
                 for i in range(len(part_list)):
-                    expected = "%s.%s\n" % (part_list[i][1], part_list[i][2])
-                    self.assertEqual(call(expected), result.write.call_args_list[i])
+                    table = "%s.%s\n" % tuple(part_list[i][1:3])
+                    self.assertEqual(call(table), result.write.call_args_list[i])
 
     @patch('gppylib.operations.dump.get_partition_list', return_value=[['t1', 'foo', 'koo'], ['public', 't2'], ['public', 't3']])
     @patch('gppylib.operations.dump.get_filter_file', return_value=None)
@@ -208,7 +210,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.execSQLForSingleton', return_value='100')
     def test_get_partition_state_default(self, mock1, mock2, mock3):
         partition_info = [(123, 'testschema', 't1', 4444), (234, 'testschema', 't2', 5555)]
-        expected_output = ['testschema, t1, 100', 'testschema, t2, 100']
+        expected_output = ['testschema,t1,100', 'testschema,t2,100']
         result = get_partition_state(self.context, 'pg_aoseg', partition_info)
         self.assertEqual(result, expected_output)
 
@@ -233,10 +235,8 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.dbconn.connect')
     @patch('gppylib.operations.dump.execSQLForSingleton', return_value='100')
     def test_get_partition_state_many_partition(self, mock1, mock2, mock3):
-        master_port=5432
-        dbname='testdb'
         partition_info = [(123, 'testschema', 't1', 4444), (234, 'testschema', 't2', 5555)] * 1000
-        expected_output = ['testschema, t1, 100', 'testschema, t2, 100'] * 1000
+        expected_output = ['testschema,t1,100', 'testschema,t2,100'] * 1000
         result = get_partition_state(self.context, 'pg_aoseg', partition_info)
         self.assertEqual(result, expected_output)
 
@@ -263,14 +263,15 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.get_filename_from_filetype', return_value='/tmp/db_dumps/20160101/gp_dump_20160101010101')
     def test_write_state_file_default(self, mock1):
         table_type = 'ao'
-        part_list = ['testschema, t1, 100', 'testschema, t2, 100']
+        part_list = [['testschema', 't1', '100'], ['testschema', 't2', '100']]
         m = mock_open()
         with patch('__builtin__.open', m, create=True):
             write_state_file(self.context, table_type, part_list)
             result = m()
             self.assertEqual(len(part_list), len(result.write.call_args_list))
             for i in range(len(part_list)):
-                self.assertEqual(call(part_list[i]+'\n'), result.write.call_args_list[i])
+                table = "%s,%s,%s\n" % tuple(part_list[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
     @patch('gppylib.operations.dump.execute_sql', return_value=[['public', 'ao_table', 123, 'CREATE', 'table', '2012: 1'], ['testschema', 'co_table', 333, 'TRUNCATE', '', '2033 :1 - 111']])
     def test_get_last_operation_data_default(self, mock):
@@ -291,10 +292,10 @@ class DumpTestCase(unittest.TestCase):
 
     @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101121212')
     @patch('gppylib.operations.dump.os.path.isfile', return_value=True)
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['testschema, t1, 100', 'testschema, t2, 100'])
+    @patch('gppylib.operations.dump.get_lines_from_csv_file', return_value=[['testschema', 't1', '100'], ['testschema', 't2', '100']])
     def test_get_last_state_default(self, mock1, mock2, mock3):
         table_type = 'ao'
-        expected_output = ['testschema, t1, 100', 'testschema, t2, 100']
+        expected_output = [['testschema', 't1', '100'], ['testschema', 't2', '100']]
         output = get_last_state(self.context, table_type)
         self.assertEqual(output, expected_output)
 
@@ -308,7 +309,7 @@ class DumpTestCase(unittest.TestCase):
 
     @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101121212')
     @patch('gppylib.operations.dump.os.path.isfile', return_value=True)
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=[])
+    @patch('gppylib.operations.dump.get_lines_from_csv_file', return_value=[])
     def test_get_last_state_empty_file(self, mock1, mock2, mock3):
         table_type = 'ao'
         output = get_last_state(self.context, table_type)
@@ -316,7 +317,7 @@ class DumpTestCase(unittest.TestCase):
 
     @patch('gppylib.operations.dump.get_last_dump_timestamp', return_value='20160101121212')
     @patch('gppylib.operations.dump.os.path.isfile', return_value=True)
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=[])
+    @patch('gppylib.operations.dump.get_lines_from_csv_file', return_value=[])
     @patch('gppylib.operations.dump.check_file_dumped_with_nbu', return_value=True)
     @patch('gppylib.operations.dump.restore_file_with_nbu')
     def test_get_last_state_nbu(self, mock1, mock2, mock3, mock4, mock5):
@@ -329,33 +330,33 @@ class DumpTestCase(unittest.TestCase):
     def test_compare_dict_different(self):
         last_dict = {'testschema.t1':'100', 'testschema.t2':'200'}
         curr_dict = {'testschema.t1':'200', 'testschema.t2':'200'}
-        expected_output = set(['testschema.t1'])
+        expected_output = [['testschema', 't1']]
         result = compare_dict(last_dict, curr_dict)
         self.assertEqual(result, expected_output)
 
     def test_compare_dict_extra(self):
         last_dict = {'testschema.t1':'100', 'testschema.t2':'200', 'testschema.t3':'300'}
         curr_dict = {'testschema.t1':'100', 'testschema.t2':'100'}
-        expected_output = set(['testschema.t2'])
+        expected_output = [['testschema', 't2']]
         result = compare_dict(last_dict, curr_dict)
         self.assertEqual(result, expected_output)
 
     def test_compare_dict_missing(self):
         last_dict = {'testschema.t1':'100', 'testschema.t2':'200'}
         curr_dict = {'testschema.t1':'100', 'testschema.t2':'200', 'testschema.t3':'300'}
-        expected_output = set(['testschema.t3'])
+        expected_output = [['testschema', 't3']]
         result = compare_dict(last_dict, curr_dict)
         self.assertEqual(result, expected_output)
 
     def test_compare_dict_identical(self):
         last_dict = {'testschema.t1':'100', 'testschema.t2':'200'}
         curr_dict = {'testschema.t1':'100', 'testschema.t2':'200'}
-        expected_output = set([])
+        expected_output = []
         result = compare_dict(last_dict, curr_dict)
         self.assertEqual(result, expected_output)
 
     def test_create_partition_dict_default(self):
-        partition_list = ['testschema, t1, 100', 'testschema, t2, 200']
+        partition_list = [('testschema', 't1', '100'), ('testschema', 't2', '200')]
         expected_output = {'testschema.t1':'100', 'testschema.t2':'200'}
         result = create_partition_dict(partition_list)
         self.assertEqual(result, expected_output)
@@ -446,25 +447,25 @@ class DumpTestCase(unittest.TestCase):
         old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
         cur_metadata = ['public,t1,1234,ALTER,,201601011212:101010']
         dirty_tables = compare_metadata(old_metadata, cur_metadata)
-        self.assertEquals(dirty_tables, set())
+        self.assertEquals(dirty_tables, [])
 
     def test_compare_metadata_different_keyword(self):
         old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
         cur_metadata = ['public,t1,1234,TRUNCATE,,201601011212:101010']
         dirty_tables = compare_metadata(old_metadata, cur_metadata)
-        self.assertEquals(dirty_tables, set(['public.t1']))
+        self.assertEquals(dirty_tables, [['public', 't1']])
 
     def test_compare_metadata_different_timestamp(self):
         old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
         cur_metadata = ['public,t1,1234,ALTER,,201601011212:102510']
         dirty_tables = compare_metadata(old_metadata, cur_metadata)
-        self.assertEquals(dirty_tables, set(['public.t1']))
+        self.assertEquals(dirty_tables, [['public', 't1']])
 
     def test_compare_metadata_duplicate_input(self):
         old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
         cur_metadata = ['public,t1,1234,ALTER,,201601011212:101010','public,t1,1234,TRUNCATE,,201601011212:101010']
         dirty_tables = compare_metadata(old_metadata, cur_metadata)
-        self.assertEquals(dirty_tables, set(['public.t1']))
+        self.assertEquals(dirty_tables, [['public', 't1']])
 
     def test_compare_metadata_invalid_input(self):
         old_metadata = {('1234', 'ALTER'): 'public,t1,1234,ALTER,,201601011212:101010'}
@@ -476,7 +477,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=[])
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
     def test_get_tables_with_dirty_metadata_empty(self, mock1, mock2, mock3):
-        expected_output = set()
+        expected_output = []
         full_timestamp = '20160101010101'
         cur_pgstatoperations = []
         dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
@@ -486,7 +487,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510'])
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
     def test_get_tables_with_dirty_metadata_default(self, mock1, mock2, mock3):
-        expected_output = set()
+        expected_output = []
         cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510']
         dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
         self.assertEqual(dirty_tables, expected_output)
@@ -495,7 +496,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102511'])
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
     def test_get_tables_with_dirty_metadata_changed_table(self, mock1, mock2, mock3):
-        expected_output = set(['testschema.t2'])
+        expected_output = [['testschema', 't2']]
         cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510']
         dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
         self.assertEqual(dirty_tables, expected_output)
@@ -504,7 +505,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=['testschema,t1,2234,TRUNCATE,,201601011213:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510'])
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
     def test_get_tables_with_dirty_metadata_extras(self, mock1, mock2, mock3):
-        expected_output = set(['testschema.t2', 'public.t3'])
+        expected_output = [['testschema', 't2'], ['public', 't3']]
         full_timestamp = '20160101010101'
         cur_pgstatoperations = ['testschema,t2,1234,ALTER,CHANGE COLUMN,201601011212:102510',
                                 'testschema,t2,2234,TRUNCATE,,201601011213:102510',
@@ -517,7 +518,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=['testschema,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510'])
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
     def test_get_tables_with_dirty_metadata_different_schema(self, mock1, mock2, mock3):
-        expected_output = set(['public.t1'])
+        expected_output = [['public', 't1']]
         cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510']
         dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
         self.assertEqual(dirty_tables, expected_output)
@@ -526,40 +527,40 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.get_lines_from_file', return_value=['testschema,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510'])
     @patch('gppylib.operations.dump.restore_file_with_nbu')
     def test_get_tables_with_dirty_metadata_nbu(self, mock1, mock2, mock3):
-        expected_output = set(['public.t1'])
+        expected_output = [['public', 't1']]
         cur_pgstatoperations = ['public,t1,1234,ALTER,CHANGE COLUMN,201601011212:102510', 'testschema,t2,2234,TRUNCATE,,201601011213:102510']
         self.context.netbackup_service_host = "mdw"
         self.context.netbackup_block_size = "1024"
         dirty_tables = get_tables_with_dirty_metadata(self.context, cur_pgstatoperations)
         self.assertEqual(dirty_tables, expected_output)
 
-    @patch('gppylib.operations.dump.get_last_state', return_value=['testschema, t1, 100', 'testschema, t2, 200'])
+    @patch('gppylib.operations.dump.get_last_state', return_value=[('testschema', 't1', '100'), ('testschema', 't2', '200')])
     def test_get_dirty_partition_tables_default(self, mock1):
         table_type = 'ao'
-        curr_state_partition_list = ['testschema, t3, 300', 'testschema, t1, 200']
-        expected_output = set(['testschema.t3', 'testschema.t1'])
+        curr_state_partition_list = [('testschema', 't3', '300'), ('testschema', 't1', '200')]
+        expected_output = [['testschema', 't1'], ['testschema', 't3']]
         result = get_dirty_partition_tables(self.context, table_type, curr_state_partition_list)
         self.assertEqual(result, expected_output)
 
-    @patch('gppylib.operations.dump.get_last_state', return_value=['testschema, t1, 100', 'testschema, t2, 200'])
+    @patch('gppylib.operations.dump.get_last_state', return_value=[('testschema', 't1', '100'), ('testschema', 't2', '200')])
     def test_get_dirty_partition_tables_nbu(self, mock1):
         table_type = 'ao'
-        curr_state_partition_list = ['testschema, t3, 300', 'testschema, t1, 200']
+        curr_state_partition_list = [['testschema', 't3', '300'], ['testschema', 't1', '200']]
         self.context.netbackup_service_host = "mdw"
         self.context.netbackup_block_size = "1024"
-        expected_output = set(['testschema.t3', 'testschema.t1'])
+        expected_output = [['testschema', 't1'], ['testschema', 't3']]
         result = get_dirty_partition_tables(self.context, table_type, curr_state_partition_list)
         self.assertEqual(result, expected_output)
 
-    @patch('gppylib.operations.dump.get_dirty_heap_tables', return_value=set(['public.heap_table1']))
-    @patch('gppylib.operations.dump.get_dirty_partition_tables', side_effect=[set(['public,ao_t1,100', 'public,ao_t2,100']), set(['public,co_t1,100', 'public,co_t2,100'])])
-    @patch('gppylib.operations.dump.get_tables_with_dirty_metadata', return_value=set(['public,ao_t3,1234,CREATE,,20160101101010', 'public,co_t3,2345,VACCUM,,20160101101010', 'public,ao_t1,1234,CREATE,,20160101101010']))
+    @patch('gppylib.operations.dump.get_dirty_heap_tables', return_value=[('public', 'heap_table1')])
+    @patch('gppylib.operations.dump.get_dirty_partition_tables', side_effect=[['public,ao_t1,100', 'public,ao_t2,100'], ['public,co_t1,100', 'public,co_t2,100']])
+    @patch('gppylib.operations.dump.get_tables_with_dirty_metadata', return_value=['public,ao_t3,1234,CREATE,,20160101101010', 'public,co_t3,2345,VACCUM,,20160101101010', 'public,ao_t1,1234,CREATE,,20160101101010'])
     def test_get_dirty_tables(self, mock1, mock2, mock3):
         ao_partition_list = []
         co_partition_list = []
         last_operation_data = []
         dirty_tables = get_dirty_tables(self.context, ao_partition_list, co_partition_list, last_operation_data)
-        expected_output = ['public.heap_table1', 'public.ao_t1', 'public.ao_t2', 'public.co_t1', 'public.co_t2', 'public.ao_t3', 'public.co_t3']
+        expected_output = [('public', 'heap_table1'), ('public', 'ao_t1'), ('public', 'ao_t2'), ('public', 'co_t1'), ('public', 'co_t2'), ('public', 'ao_t3'), ('public', 'co_t3')]
         self.assertEqual(dirty_tables.sort(), expected_output.sort())
 
     @patch('gppylib.operations.dump.get_latest_report_timestamp', return_value = '20160101010100')
@@ -646,20 +647,23 @@ class DumpTestCase(unittest.TestCase):
             expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file"""
             self.assertEquals(output, expected_output)
 
-    def test_create_dump_string_without_incremental(self):
+    @patch('gppylib.operations.backup_utils.get_lines_from_csv_file', return_value=[])
+    def test_create_dump_string_without_incremental(self, mock1):
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_dump_string()
             expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
             self.assertEquals(output, expected_output)
 
-    def test_create_dump_string_with_prefix(self):
+    @patch('gppylib.operations.backup_utils.get_lines_from_csv_file', return_value=[])
+    def test_create_dump_string_with_prefix(self, mock1):
         self.context.dump_prefix = 'foo_'
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_dump_string()
             expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
             self.assertEquals(output, expected_output)
 
-    def test_create_dump_string_with_include_file(self):
+    @patch('gppylib.operations.backup_utils.get_lines_from_csv_file', return_value=['bar'])
+    def test_create_dump_string_with_include_file(self, mock1):
         self.context.dump_prefix = 'metro_'
         self.context.include_dump_tables_file = 'bar'
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
@@ -667,7 +671,8 @@ class DumpTestCase(unittest.TestCase):
             expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=%s""" % self.context.include_dump_tables_file
             self.assertEquals(output, expected_output)
 
-    def test_create_dump_string_with_no_file_args(self):
+    @patch('gppylib.operations.backup_utils.get_lines_from_csv_file', return_value=[])
+    def test_create_dump_string_with_no_file_args(self, mock1):
         self.context.dump_prefix = 'metro_'
         self.context.include_dump_tables_file = None
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
@@ -675,7 +680,8 @@ class DumpTestCase(unittest.TestCase):
             expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb\""""
             self.assertEquals(output, expected_output)
 
-    def test_create_dump_string_with_netbackup_params(self):
+    @patch('gppylib.operations.backup_utils.get_lines_from_csv_file', return_value=[])
+    def test_create_dump_string_with_netbackup_params(self, mock1):
         self.context.include_dump_tables_file = None
         self.context.netbackup_service_host = "mdw"
         self.context.netbackup_policy = "test_policy"
@@ -718,67 +724,70 @@ class DumpTestCase(unittest.TestCase):
 
     def test_update_filter_file_with_dirty_list_default(self):
         filter_file = '/tmp/foo'
-        dirty_tables = ['public.t1', 'public.t2']
-        expected_output = ['public.t1', 'public.t2']
+        dirty_tables = [('public', 't1'), ('public', 't2')]
+        expected_output = [('public', 't1'), ('public', 't2')]
         m = mock_open()
         with patch('__builtin__.open', m, create=True):
             update_filter_file_with_dirty_list(filter_file, dirty_tables)
             result = m()
             self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
             for i in range(len(dirty_tables)):
-                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
+                table = "%s.%s\n" % dirty_tables[i]
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
-    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=['public.t1', 'public.t2'])
+    @patch('gppylib.operations.backup_utils.get_lines_from_file', return_value=[('public', 't1'), ('public', 't2')])
     def test_update_filter_file_with_dirty_list_duplicates(self, mock1):
         filter_file = '/tmp/foo'
-        dirty_tables = ['public.t2']
-        expected_output = ['public.t1', 'public.t2']
+        dirty_tables = [('public', 't2')]
+        expected_output = [('public', 't1'), ('public', 't2')]
         m = mock_open()
         with patch('__builtin__.open', m, create=True):
             update_filter_file_with_dirty_list(filter_file, dirty_tables)
             result = m()
             self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
             for i in range(len(dirty_tables)):
-                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
+                table = "%s.%s\n" % dirty_tables[i]
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
     def test_update_filter_file_with_dirty_list_empty_file(self):
         filter_file = '/tmp/foo'
-        dirty_tables = ['public.t1', 'public.t2']
-        expected_output = ['public.t1', 'public.t2']
+        dirty_tables = [('public', 't1'), ('public', 't2')]
+        expected_output = [('public', 't1'), ('public', 't2')]
         m = mock_open()
         with patch('__builtin__.open', m, create=True):
             update_filter_file_with_dirty_list(filter_file, dirty_tables)
             result = m()
             self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
             for i in range(len(dirty_tables)):
-                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
+                table = "%s.%s\n" % dirty_tables[i]
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'testschema.t2'])
+    @patch('gppylib.operations.dump.get_lines_from_csv_file', return_value=[('public', 't1'), ('testschema', 't2')])
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20130101010101')
     @patch('gppylib.operations.dump.get_filter_file', return_value='/foo/metro_gp_dump_20130101010101_filter')
     @patch('gppylib.operations.dump.get_latest_full_ts_with_nbu', return_value='20130101010101')
     def test_filter_dirty_tables_with_filter(self, mock1, mock2, mock3, mock4):
-        dirty_tables = ['public.t1', 'public.t2', 'testschema.t1', 'testschema.t2']
-        expected_output = ['public.t1', 'testschema.t2']
+        dirty_tables = [('public', 't1'), ('public', 't2'), ('testschema', 't1'), ('testschema', 't2')]
+        expected_output = [('public', 't1'), ('testschema', 't2')]
         self.context.netbackup_service_host = 'mdw'
         self.assertEquals(sorted(expected_output), sorted(filter_dirty_tables(self.context, dirty_tables)))
 
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'testschema.t2'])
+    @patch('gppylib.operations.dump.get_lines_from_csv_file', return_value=[('public', 't1'), ('testschema', 't2')])
     @patch('gppylib.operations.dump.get_filter_file', return_value='/foo/metro_gp_dump_20130101010101_filter')
     @patch('gppylib.operations.dump.get_latest_full_ts_with_nbu', return_value='20130101010101')
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20130101010101')
     def test_filter_dirty_tables_with_filter_with_nbu(self, mock1, mock2, mock3, mock4):
         self.context.netbackup_service_host = "mdw"
         self.context.netbackup_block_size = "1024"
-        dirty_tables = ['public.t1', 'public.t2', 'testschema.t1', 'testschema.t2']
-        expected_output = ['public.t1', 'testschema.t2']
+        dirty_tables = [('public', 't1'), ('public', 't2'), ('testschema', 't1'), ('testschema', 't2')]
+        expected_output = [('public', 't1'), ('testschema', 't2')]
         self.assertEquals(sorted(expected_output), sorted(filter_dirty_tables(self.context, dirty_tables)))
 
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value=['public.t1', 'testschema.t2'])
+    @patch('gppylib.operations.dump.get_lines_from_csv_file', return_value=[('public', 't1'), ('testschema', 't2')])
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20130101010101')
     @patch('gppylib.operations.dump.get_filter_file', return_value=None)
     def test_filter_dirty_tables_without_filter(self, mock1, mock2, mock3):
-        dirty_tables = ['public.t1', 'public.t2', 'testschema.t1', 'testschema.t2']
+        dirty_tables = [('public', 't1'), ('public', 't2'), ('testschema', 't1'), ('testschema', 't2')]
         self.assertEquals(sorted(dirty_tables), sorted(filter_dirty_tables(self.context, dirty_tables)))
 
     @patch('gppylib.operations.dump.get_filter_file', return_value='/tmp/db_dumps/20160101/foo_gp_dump_01234567891234_filter')
@@ -808,12 +817,11 @@ class DumpTestCase(unittest.TestCase):
 
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.dump.get_filter_file', return_value = '/tmp/update_test')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1'])
-    @patch('gppylib.operations.dump.execute_sql', side_effect = [ [['public.ao_part_table']], [['public.ao_part_table_1_prt_p1'], ['public.ao_part_table_1_prt_p2']] ])
+    @patch('gppylib.operations.dump.get_lines_from_csv_file', return_value = [['public', 'heap_table1'], ['public', 'ao_part_table'], ['public', 'ao_part_table_1_prt_p1']])
+    @patch('gppylib.operations.dump.execute_sql', side_effect = [ [['public', 'ao_part_table']], [['public', 'ao_part_table_1_prt_p1'], ['public', 'ao_part_table_1_prt_p2']] ])
     def test_update_filter_file_default(self, mock1, mock2, mock3, mock4):
         filter_filename = '/tmp/update_test'
-        contents = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1']
-        expected_result = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1', 'public.ao_part_table_1_prt_p2']
+        expected_result = [['public', 'heap_table1'], ['public', 'ao_part_table'], ['public', 'ao_part_table_1_prt_p1'], ['public', 'ao_part_table_1_prt_p2']]
         m = mock_open()
         with patch('__builtin__.open', m, create=True):
             update_filter_file(self.context)
@@ -822,22 +830,22 @@ class DumpTestCase(unittest.TestCase):
             expected = sorted(expected_result)
             output = sorted(result.write.call_args_list)
             for i in range(len(expected)):
-                self.assertEqual(call(expected[i]+'\n'), output[i])
+                table = "%s.%s\n" % tuple(expected[i])
+                self.assertEqual(call(table), output[i])
 
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.dump.get_filter_file', return_value = '/tmp/update_test')
-    @patch('gppylib.operations.dump.get_lines_from_file', return_value = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1'])
-    @patch('gppylib.operations.dump.execute_sql', side_effect = [ [['public.ao_part_table']], [['public.ao_part_table_1_prt_p1'], ['public.ao_part_table_1_prt_p2']] ])
+    @patch('gppylib.operations.dump.get_lines_from_csv_file', return_value = [['public', 'heap_table1'], ['public', 'ao_part_table'], ['public', 'ao_part_table_1_prt_p1']])
+    @patch('gppylib.operations.dump.execute_sql', side_effect = [ [['public', 'ao_part_table']], [['public', 'ao_part_table_1_prt_p1'], ['public', 'ao_part_table_1_prt_p2']] ])
     @patch('gppylib.operations.dump.restore_file_with_nbu')
     @patch('gppylib.operations.dump.backup_file_with_nbu')
-    def test_update_filter_file_default_with_nbu(self, mock1, mock2, mock3, mock4, mock5, mock6):
+    def test_update_filter_file_with_nbu(self, mock1, mock2, mock3, mock4, mock5, mock6):
         filter_filename = '/tmp/update_test'
         self.context.netbackup_service_host = "mdw"
         self.context.netbackup_policy = "nbu_policy"
         self.context.netbackup_schedule = "nbu_schedule"
         self.context.netbackup_block_size = "1024"
-        contents = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1']
-        expected_result = ['public.heap_table1','public.ao_part_table','public.ao_part_table_1_prt_p1', 'public.ao_part_table_1_prt_p2']
+        expected_result = [['public', 'heap_table1'], ['public', 'ao_part_table'], ['public', 'ao_part_table_1_prt_p1'], ['public', 'ao_part_table_1_prt_p2']]
         m = mock_open()
         with patch('__builtin__.open', m, create=True):
             update_filter_file(self.context)
@@ -846,7 +854,8 @@ class DumpTestCase(unittest.TestCase):
             expected = sorted(expected_result)
             output = sorted(result.write.call_args_list)
             for i in range(len(expected)):
-                self.assertEqual(call(expected[i]+'\n'), output[i])
+                table = "%s.%s\n" % tuple(expected[i])
+                self.assertEqual(call(table), output[i])
 
     @patch('gppylib.operations.dump.backup_file_with_nbu')
     def test_backup_state_files_with_nbu_default(self, mock):

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -77,9 +77,9 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     def test_multitry_createdb_default(self, mock):
         self.restore._multitry_createdb()
 
-    @patch('gppylib.operations.restore.get_partition_list', return_value=[('public', 't1'), ('public', 't2'), ('public', 't3')])
+    @patch('gppylib.operations.restore.get_partition_list', return_value=[['public', 't1'], ['public', 't2'], ['public', 't3']])
     @patch('gppylib.operations.restore.get_incremental_restore_timestamps', return_value=['20160101010101', '20160101010111'])
-    @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=['public.t1', 'public.t2'])
+    @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=[['public', 't1'], ['public', 't2']])
     def test_create_restore_plan_default(self, mock1, mock2, mock3):
         expected = ["20160101010111:", "20160101010101:public.t1,public.t2", "20160101000000:public.t3"]
         self.context.full_dump_timestamp = '20160101000000'
@@ -92,7 +92,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
                 self.assertEqual(call(expected[i]+'\n'), result.write.call_args_list[i])
 
     @patch('gppylib.operations.restore.get_incremental_restore_timestamps', return_value=['20160101010101', '20160101010111'])
-    @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=['public.t1', 'public.t2'])
+    @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=[['public', 't1'], ['public', 't2']])
     def test_create_restore_plan_empty_list(self, mock1, mock2):
         expected = ["20160101010111:", "20160101010101:", "20160101000000:"]
         self.context.full_dump_timestamp = '20160101000000'
@@ -107,7 +107,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.get_partition_list', return_value=[])
     @patch('gppylib.operations.restore.get_full_timestamp_for_incremental', return_value='20120101000000')
     @patch('gppylib.operations.restore.get_incremental_restore_timestamps', return_value=['20160101010101', '20160101010111'])
-    @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=['public.t1', 'public.t2'])
+    @patch('gppylib.operations.restore.get_dirty_table_file_contents', return_value=[['public', 't1'], ['public', 't2']])
     @patch('gppylib.operations.restore.create_plan_file_contents')
     def test_create_restore_plan_empty_list_with_nbu(self, mock1, mock2, mock3, mock4, mock5):
         self.context.netbackup_service_host = 'mdw'
@@ -139,24 +139,24 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         increments = get_incremental_restore_timestamps(self.context)
         self.assertEqual(increments, [])
 
-    @patch('gppylib.operations.restore.get_lines_from_file', side_effect=[['public.t1'], ['public.t1', 'public.t2', 'public.t3'], ['public.t2', 'public.t4']])
+    @patch('gppylib.operations.restore.get_lines_from_csv_file', side_effect=[[['public', 't1']], [['public', 't1'], ['public', 't2'], ['public', 't3']], [['public', 't2'], ['public', 't4']]])
     def test_create_plan_file_contents_with_file(self, mock):
-        table_set_from_metadata_file = ['public.t1', 'public.t2', 'public.t3', 'public.t4']
+        table_set_from_metadata_file = [['public', 't1'], ['public', 't2'], ['public', 't3'], ['public', 't4']]
         incremental_restore_timestamps = ['20160101010113', '20160101010101', '20160101010111']
         latest_full_timestamp = '20160101010110'
-        expected_output = {'20160101010113': ['public.t1'], '20160101010101': ['public.t2', 'public.t3'], '20160101010111': ['public.t4'], '20160101010110': []}
+        expected_output = {'20160101010113': [['public', 't1']], '20160101010101': [['public', 't2'], ['public', 't3']], '20160101010111': [['public', 't4']], '20160101010110': []}
         file_contents = create_plan_file_contents(self.context, table_set_from_metadata_file, incremental_restore_timestamps, latest_full_timestamp)
         self.assertEqual(file_contents, expected_output)
 
     def test_create_plan_file_contents_no_file(self):
-        table_set_from_metadata_file = ['public.t1', 'public.t2', 'public.t3', 'public.t4']
+        table_set_from_metadata_file = [['public', 't1'], ['public', 't2'], ['public', 't3'], ['public', 't4']]
         incremental_restore_timestamps = []
         latest_full_timestamp = '20160101010110'
-        expected_output = {'20160101010110': ['public.t1', 'public.t2', 'public.t3', 'public.t4']}
+        expected_output = {'20160101010110': [['public', 't1'], ['public', 't2'], ['public', 't3'], ['public', 't4']]}
         file_contents = create_plan_file_contents(self.context, table_set_from_metadata_file, incremental_restore_timestamps, latest_full_timestamp)
         self.assertEqual(file_contents, expected_output)
 
-    @patch('gppylib.operations.restore.get_lines_from_file', side_effect=[['public.t1'], ['public.t1', 'public.t2', 'public.t3'], ['public.t2', 'public.t4']])
+    @patch('gppylib.operations.restore.get_lines_from_csv_file', side_effect=[[['public', 't1']], [['public', 't1'], ['public', 't2'], ['public', 't3']], [['public', 't2'], ['public', 't4']]])
     def test_create_plan_file_contents_no_metadata(self, mock):
         table_set_from_metadata_file = []
         incremental_restore_timestamps = ['20160101010113', '20160101010101', '20160101010111']
@@ -165,7 +165,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         file_contents = create_plan_file_contents(self.context, table_set_from_metadata_file, incremental_restore_timestamps, latest_full_timestamp)
         self.assertEqual(file_contents, expected_output)
 
-    @patch('gppylib.operations.restore.get_lines_from_file', side_effect=[['public.t1'], ['public.t1', 'public.t2', 'public.t3'], ['public.t2', 'public.t4']])
+    @patch('gppylib.operations.restore.get_lines_from_csv_file', side_effect=[[['public', 't1']], [['public', 't1'], ['public', 't2'], ['public', 't3']], [['public', 't2'], ['public', 't4']]])
     @patch('gppylib.operations.restore.restore_file_with_nbu')
     def test_create_plan_file_contents_with_nbu(self, mock1, mock2):
         self.context.netbackup_service_host = 'mdw'
@@ -180,9 +180,9 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.write_lines_to_file')
     def test_write_to_plan_file_default(self, mock1):
         plan_file = 'blah'
-        plan_file_contents = {'20160101010113': ['public.t1'],
-                              '20160101010101': ['public.t2', 'public.t3'],
-                              '20160101010111': ['public.t4']}
+        plan_file_contents = {'20160101010113': [['public', 't1']],
+                              '20160101010101': [['public', 't2'], ['public', 't3']],
+                              '20160101010111': [['public', 't4']]}
 
         expected_output = ['20160101010113:public.t1',
                            '20160101010111:public.t4',
@@ -206,12 +206,12 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         with self.assertRaisesRegexp(Exception, 'Invalid plan file .*'):
             write_to_plan_file(plan_file_contents, plan_file)
 
-    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['public.t1', 'public.t2'])
+    @patch('gppylib.operations.restore.get_lines_from_csv_file', return_value=[['public', 't1'], ['public', 't2']])
     def test_get_partition_list_default(self, mock):
         partition_list = get_partition_list(self.context)
-        self.assertEqual(partition_list, [('public', 't1'), ('public', 't2')])
+        self.assertEqual(partition_list, [['public', 't1'], ['public', 't2']])
 
-    @patch('gppylib.operations.restore.get_lines_from_file', return_value=[])
+    @patch('gppylib.operations.restore.get_lines_from_csv_file', return_value=[])
     def test_get_partition_list_no_partitions(self, mock):
         partition_list = get_partition_list(self.context)
         self.assertEqual(partition_list, [])
@@ -554,9 +554,9 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.execSQL')
     @patch('gppylib.operations.restore.execSQLForSingleton', return_value='t')
     def test_truncate_restore_tables_restore_tables(self, mock1, mock2, mock3, mock4):
-        self.context.restore_tables = ['public.ao1', 'testschema.heap1']
+        self.context.restore_tables = [['public', 'ao1'], ['testschema', 'heap1']]
         self.restore.truncate_restore_tables()
-        calls = [call(ANY,'Truncate "public"."ao1"'), call(ANY,'Truncate "testschema"."heap1"')]
+        calls = [call(ANY,'Truncate public.ao1'), call(ANY,'Truncate testschema.heap1')]
         mock2.assert_has_calls(calls)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -718,10 +718,10 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
             get_plan_file_contents(self.context)
 
     @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo')
-    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20160101010101:t1,t2', '20160101010111:t3,t4', '20160101121210:t5,t6,t7'])
+    @patch('gppylib.operations.restore.get_lines_from_file', return_value=['20160101010101:public.t1,public.t2', '20160101010111:public.t3,public.t4', '20160101121210:public.t5,public.t6,public.t7'])
     @patch('os.path.isfile', return_value=True)
     def test_get_plan_file_contents_default(self, mock1, mock2, mock3):
-        expected_output = [('20160101010101','t1,t2'), ('20160101010111','t3,t4'), ('20160101121210','t5,t6,t7')]
+        expected_output = [('20160101010101',[['public', 't1'], ['public', 't2']]), ('20160101010111',[['public', 't3'], ['public', 't4']]), ('20160101121210',[['public', 't5'], ['public', 't6'], ['public', 't7']])]
         output = get_plan_file_contents(self.context)
         self.assertEqual(output, expected_output)
 
@@ -732,7 +732,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         with self.assertRaisesRegexp(Exception, 'Invalid plan file format'):
             get_plan_file_contents(self.context)
 
-    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20160101010101', 't1,t2'), ('20160101010111', 't3,t4'), ('20160101121210', 't5,t6,t7')])
+    @patch('gppylib.operations.restore.get_plan_file_contents', return_value=[('20160101010101', [['public', 't1'], ['public', 't2']]), ('20160101010111', [['public', 't3'], ['public', 't4']]), ('20160101121210', [['public', 't5'], ['public', 't6'], ['public', 't7']])])
     @patch('gppylib.operations.restore.Command.run')
     @patch('gppylib.operations.restore.update_ao_statistics')
     def test_restore_incremental_data_only_default(self, mock1, mock2, mock3):
@@ -760,37 +760,38 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.restore.get_all_segment_addresses', return_value=['host1'])
     @patch('gppylib.operations.restore.scp_file_to_hosts')
     def test_create_filter_file_default(self, m1, m2):
-        self.context.restore_tables = ['public.ao1', 'testschema.heap1']
+        self.context.restore_tables = [['public', 'ao1'], ['testschema', 'heap1']]
         m = mock_open()
         with patch('tempfile.NamedTemporaryFile', m, create=True):
             fname = self.restore.create_filter_file()
             result = m()
             self.assertEqual(len(self.context.restore_tables), len(result.write.call_args_list))
             for i in range(len(self.context.restore_tables)):
-                self.assertEqual(call(self.context.restore_tables[i]+'\n'), result.write.call_args_list[i])
+                table = "%s.%s\n" % tuple(self.context.restore_tables[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
-    @patch('gppylib.operations.restore.get_lines_from_file', return_value = ['public.t1', 'public.t2', 'public.t3'])
+    @patch('gppylib.operations.restore.get_lines_from_csv_file', return_value = [['public', 't1'], ['public', 't2'], ['public', 't3']])
     @patch('os.path.isfile', return_value = True)
     def test_get_restore_tables_from_table_file_default(self, mock1, mock2):
         table_file = '/foo'
-        expected_result = ['public.t1', 'public.t2', 'public.t3']
+        expected_result = [['public', 't1'], ['public', 't2'], ['public', 't3']]
         result = get_restore_tables_from_table_file(table_file)
         self.assertEqual(expected_result, result)
 
     @patch('os.path.isfile', return_value = False)
     def test_get_restore_tables_from_table_file_no_file(self, mock):
         table_file = '/foo'
-        expected_result = ['public.t1', 'public.t2', 'public.t3']
+        expected_result = [['public', 't1'], ['public', 't2'], ['public', 't3']]
         with self.assertRaisesRegexp(Exception, 'Table file does not exist'):
             result = get_restore_tables_from_table_file(table_file)
 
     def test_check_table_name_format_and_duplicate_missing_schema(self):
-        table_list = ['publicao1', 'public.ao2']
-        with self.assertRaisesRegexp(Exception, 'No schema name supplied'):
+        table_list = [['publicao1'], ['public', 'ao2']]
+        with self.assertRaisesRegexp(Exception, 'publicao1 is not in the format schema.table'):
             check_table_name_format_and_duplicate(table_list, None)
 
     def test_check_table_name_format_and_duplicate_default(self):
-        table_list = ['public.ao1', 'public.ao2']
+        table_list = [['public', 'ao1'], ['public', 'ao2']]
         check_table_name_format_and_duplicate(table_list, [])
 
     def test_check_table_name_format_and_duplicate_no_tables(self):
@@ -799,47 +800,48 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         check_table_name_format_and_duplicate(table_list, schema_list)
 
     def test_check_table_name_format_and_duplicate_duplicate_tables(self):
-        table_list = ['public.ao1', 'public.ao1']
+        table_list = [['public', 'ao1'], ['public', 'ao1']]
         resolved_list, _ = check_table_name_format_and_duplicate(table_list, [])
-        self.assertEqual(resolved_list, ['public.ao1'])
+        self.assertEqual(resolved_list, [['public', 'ao1']])
 
     def test_check_table_name_format_and_duplicate_funny_chars(self):
-        table_list = [' `"@#$%^&( )_|:;<>?/-+={}[]*1Aa . `"@#$%^&( )_|:;<>?/-+={}[]*1Aa ', 'schema.ao1']
+        table_list = [[' `"@#$%^&( )_|:;<>?/-+={}[]*1Aa ', ' `"@#$%^&( )_|:;<>?/-+={}[]*1Aa '], ['schema', 'ao1']]
         schema_list = ['schema']
         resolved_table_list, resolved_schema_list = check_table_name_format_and_duplicate(table_list, schema_list)
-        self.assertEqual(resolved_table_list, [' `"@#$%^&( )_|:;<>?/-+={}[]*1Aa . `"@#$%^&( )_|:;<>?/-+={}[]*1Aa '])
+        self.assertEqual(resolved_table_list, [[' `"@#$%^&( )_|:;<>?/-+={}[]*1Aa ', ' `"@#$%^&( )_|:;<>?/-+={}[]*1Aa ']])
         self.assertEqual(resolved_schema_list, ['schema'])
 
     def test_validate_tablenames_exist_in_dump_file_no_tables(self):
         dumped_tables = []
-        table_list = ['schema.ao']
+        table_list = [['schema', 'ao']]
         with self.assertRaisesRegexp(Exception, 'No dumped tables to restore.'):
             validate_tablenames_exist_in_dump_file(table_list, dumped_tables)
 
     def test_validate_tablenames_exist_in_dump_file_one_table(self):
         dumped_tables = [('schema', 'ao', 'gpadmin')]
-        table_list = ['schema.ao']
+        table_list = [['schema', 'ao']]
         validate_tablenames_exist_in_dump_file(table_list, dumped_tables)
 
     def test_validate_tablenames_exist_in_dump_file_nonexistent_table(self):
         dumped_tables = [('schema', 'ao', 'gpadmin')]
-        table_list = ['schema.ao', 'schema.co']
+        table_list = [['schema', 'ao'], ['schema', 'co']]
         with self.assertRaisesRegexp(Exception, "Tables \['schema.co'\] not found in backup"):
             validate_tablenames_exist_in_dump_file(table_list, dumped_tables)
 
     def test_get_restore_table_list_default(self):
-        table_list = ['public.ao_table', 'public.ao_table2', 'public.co_table', 'public.heap_table']
-        restore_tables = ['public.ao_table2', 'public.co_table']
+        table_list = [['public', 'ao_table'], ['public', 'ao_table2'], ['public', 'co_table'], ['public', 'heap_table']]
+        restore_tables = [['public', 'ao_table2'], ['public', 'co_table']]
         m = mock_open()
         with patch('tempfile.NamedTemporaryFile', m, create=True):
             result = get_restore_table_list(table_list, restore_tables)
             result = m()
             self.assertEqual(len(restore_tables), len(result.write.call_args_list))
             for i in range(len(restore_tables)):
-                self.assertEqual(call(restore_tables[i]+'\n'), result.write.call_args_list[i])
+                table = "%s.%s\n" % tuple(restore_tables[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
     def test_get_restore_table_list_no_restore_tables(self):
-        table_list = ['public.ao_table', 'public.ao_table2', 'public.co_table', 'public.heap_table']
+        table_list = [['public', 'ao_table'], ['public', 'ao_table2'], ['public', 'co_table'], ['public', 'heap_table']]
         restore_tables = None
         m = mock_open()
         with patch('tempfile.NamedTemporaryFile', m, create=True):
@@ -847,28 +849,30 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
             result = m()
             self.assertEqual(len(table_list), len(result.write.call_args_list))
             for i in range(len(table_list)):
-                self.assertEqual(call(table_list[i]+'\n'), result.write.call_args_list[i])
+                table = "%s.%s\n" % tuple(table_list[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
     def test_get_restore_table_list_extra_restore_tables(self):
-        table_list = ['public.ao_table', 'public.ao_table2', 'public.co_table', 'public.heap_table']
-        restore_tables = ['public.ao_table2', 'public.co_table', 'public.ao_table3']
-        expected = ['public.ao_table2', 'public.co_table']
+        table_list = [['public', 'ao_table'], ['public', 'ao_table2'], ['public', 'co_table'], ['public', 'heap_table']]
+        restore_tables = [['public', 'ao_table2'], ['public', 'co_table'], ['public', 'ao_table3']]
+        expected = [['public', 'ao_table2'], ['public', 'co_table']]
         m = mock_open()
         with patch('tempfile.NamedTemporaryFile', m, create=True):
             result = get_restore_table_list(table_list, restore_tables)
             result = m()
             self.assertEqual(len(expected), len(result.write.call_args_list))
             for i in range(len(expected)):
-                self.assertEqual(call(expected[i]+'\n'), result.write.call_args_list[i])
+                table = "%s.%s\n" % tuple(expected[i])
+                self.assertEqual(call(table), result.write.call_args_list[i])
 
     def test_validate_restore_tables_list_default(self):
-        plan_file_contents = [('20160101121213', 'public.t1'), ('20160101010101', 'public.t2,public.t3'), ('20160101010101', 'public.t4')]
-        restore_tables = ['public.t1', 'public.t2']
+        plan_file_contents = [('20160101121213', [['public', 't1']]), ('20160101010101', [['public', 't2'], ['public', 't3']]), ('20160101010101', [['public', 't4']])]
+        restore_tables = [['public', 't1'], ['public', 't2']]
         validate_restore_tables_list(plan_file_contents, restore_tables)
 
     def test_validate_restore_tables_list_invalid_tables(self):
-        plan_file_contents = [('20160101121213', 'public.t1'), ('20160101010101', 'public.t2,public.t3'), ('20160101010101', 'public.t4')]
-        restore_tables = ['public.t5', 'public.t2']
+        plan_file_contents = [('20160101121213', [['public', 't1']]), ('20160101010101', [['public', 't2'], ['public', 't3']]), ('20160101010101', [['public', 't4']])]
+        restore_tables = [['public', 't5'], ['public', 't2']]
         with self.assertRaisesRegexp(Exception, 'Invalid tables for -T option: The following tables were not found in plan file'):
             validate_restore_tables_list(plan_file_contents, restore_tables)
 
@@ -941,33 +945,33 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         restored_tables = []
         update_ao_statistics(self.context, restored_tables)
 
-        update_ao_statistics(self.context, restored_tables=['public.t1'], restored_schema=[], restore_all=False)
+        update_ao_statistics(self.context, restored_tables=[['public', 't1']], restored_schema=[], restore_all=False)
         update_ao_statistics(self.context, restored_tables=[], restored_schema=['public'], restore_all=False)
         update_ao_statistics(self.context, restored_tables=[], restored_schema=[], restore_all=True)
 
     def test_generate_restored_tables_no_table(self):
-        results = [['t1','public'], ['t2', 'public'], ['foo', 'bar']]
+        results = [['public','t1'], ['public','t2'], ['foo', 'bar']]
 
         tables = generate_restored_tables(results, restored_tables=[], restored_schema=[], restore_all=False)
-        self.assertEqual(tables, set())
+        self.assertEqual(tables, [])
 
     def test_generate_restored_tables_specified_table(self):
-        results = [['t1','public'], ['t2', 'public'], ['foo', 'bar']]
+        results = [['public','t1'], ['public','t2'], ['foo', 'bar']]
 
-        tables = generate_restored_tables(results, restored_tables=['public.t1'], restored_schema=[], restore_all=False)
-        self.assertEqual(tables, set([('public','t1')]))
+        tables = generate_restored_tables(results, restored_tables=[['public', 't1']], restored_schema=[], restore_all=False)
+        self.assertEqual(tables, [['public','t1']])
 
     def test_generate_restored_tables_specified_schema(self):
-        results = [['t1','public'], ['t2', 'public'], ['foo', 'bar']]
+        results = [['public','t1'], ['public','t2'], ['foo', 'bar']]
 
         tables = generate_restored_tables(results, restored_tables=[], restored_schema=['public'], restore_all=False)
-        self.assertEqual(tables, set([('public','t1'), ('public', 't2')]))
+        self.assertEqual(tables, [['public','t1'], ['public', 't2']])
 
     def test_generate_restored_tables_full_restore(self):
-        results = [['t1','public'], ['t2', 'public'], ['foo', 'bar']]
+        results = [['public','t1'], ['public','t2'], ['foo', 'bar']]
 
         tables = generate_restored_tables(results, restored_tables=[], restored_schema=[], restore_all=True)
-        self.assertEqual(tables, set([('public','t1'), ('public', 't2'), ('bar', 'foo')]))
+        self.assertEqual(tables, [['public','t1'], ['public', 't2'], ['foo', 'bar']])
 
     @patch('gppylib.operations.restore.dbconn.connect')
     @patch('gppylib.db.dbconn.execSQLForSingleton', return_value=5)
@@ -983,28 +987,28 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     @patch('gppylib.operations.restore.execSQL')
     def test_analyze_restore_tables_default(self, mock1, mock2, mock3):
-        self.context.restore_tables = ['public.t1', 'public.t2']
+        self.context.restore_tables = [['public', 't1'], ['public', 't2']]
         self.restore._analyze_restore_tables()
 
     @patch('gppylib.operations.restore.execSQL', side_effect=Exception('analyze failed'))
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     def test_analyze_restore_tables_analyze_failed(self, mock1, mock2, mock3):
-        self.context.restore_tables = ['public.t1', 'public.t2']
+        self.context.restore_tables = [['public', 't1'], ['public', 't2']]
         self.assertRaises(Exception, self.restore._analyze_restore_tables)
 
     @patch('gppylib.operations.backup_utils.execSQL')
     @patch('gppylib.operations.backup_utils.dbconn.DbURL', side_effect=Exception('Failed'))
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     def test_analyze_restore_tables_connection_failed(self, mock1, mock2, mock3):
-        self.context.restore_tables = ['public.t1', 'public.t2']
+        self.context.restore_tables = [['public', 't1'], ['public', 't2']]
         self.assertRaises(Exception, self.restore._analyze_restore_tables)
 
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     @patch('gppylib.operations.restore.execSQL')
     def test_analyze_restore_tables_three_batches(self, mock1, mock2, mock3):
-        self.context.restore_tables = ['public.t%d' % i for i in range(3002)]
+        self.context.restore_tables = [tablename_to_tuple('public.t%d' % i) for i in range(3002)]
         expected_batch_count = 3
         batch_count = self.restore._analyze_restore_tables()
         self.assertEqual(batch_count, expected_batch_count)
@@ -1013,7 +1017,7 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     @patch('gppylib.operations.backup_utils.dbconn.execSQL')
     def test_analyze_restore_tables_change_schema(self, mock1, mock2, mock3):
-        self.context.restore_tables = ['public.t1', 'public.t2']
+        self.context.restore_tables = [['public', 't1'], ['public', 't2']]
         self.context.change_schema = 'newschema'
         self.restore._analyze_restore_tables()
 
@@ -1022,8 +1026,8 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
     @patch('gppylib.operations.backup_utils.dbconn.connect')
     def test_analyze_restore_tables_execSQL_failed(self, mock1, mock2, mock3):
         self.context.restore_db = 'db1'
-        self.context.restore_tables = ['public.t1', 'public.t2']
-        self.assertRaisesRegexp(Exception, 'Issue with \'ANALYZE\' of restored table \'"public"."t1"\' in \'db1\' database', self.restore._analyze_restore_tables)
+        self.context.restore_tables = [['public', 't1'], ['public', 't2']]
+        self.assertRaisesRegexp(Exception, 'Issue with \'ANALYZE\' of restored table \'public.t1\' in \'db1\' database', self.restore._analyze_restore_tables)
 
     @patch('os.path.exists', side_effect=[True, False])
     def test_validate_metadata_file_with_compression_exists(self, mock):

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/special_chars/funny_char.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/special_chars/funny_char.sql
@@ -3,3 +3,4 @@
 CREATE SCHEMA "Schema\t,1";
 
 CREATE TABLE "Schema\t,1"."Table\n!1" (i int);
+CREATE TABLE public."funny\n\t!." (i int);

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/special_chars/funny_char_table.txt
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/special_chars/funny_char_table.txt
@@ -1,1 +1,1 @@
-public.funny\\n\\t\!.
+public."funny\n\t!."

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1537,7 +1537,7 @@ def impl(context, elem):
         raise Exception('get_partition_state returned more results than expected "%s"' % context.partition_list_res)
 
     if elem not in context.partition_list_res:
-        raise Exception('Expected text "%s" not found in partition list returned by get_partition_state "%s"' % (elem, context.partition_list_res))
+        raise Exception('Expected result "%s" not found in partition list returned by get_partition_state "%s"' % (elem, part_list))
 
 @given('older backup directories "{dirlist}" exists')
 @when('older backup directories "{dirlist}" exists')

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
@@ -345,7 +345,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_lines_from_file', return_value=['public'])
-    @patch('gpcrondump.get_user_table_list_for_schema', return_value=['public', 'table1', 'public', 'table2'])
+    @patch('gpcrondump.get_user_table_list_for_schema', return_value=[['public', 'table1'], ['public', 'table2']])
     def test_schema_filter_36(self, mock1, mock2, mock3):
         gpcd = GpCronDump(self.options, None)
         with patch('__builtin__.open', mock_open(), create=True):
@@ -583,7 +583,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.expand_partitions_and_populate_filter_file', return_value='/tmp/exclude_dump_tables_file')
-    @patch('gpcrondump.get_lines_from_file', return_value=['public.t1', 'public.t2'])
+    @patch('gpcrondump.get_lines_from_csv_file', return_value=[['public', 't1'], ['public', 't2']])
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_get_include_exclude_for_dump_database04(self, mock1, mock2, mock3, mock4):
         self.options.masterDataDirectory = '/tmp/foobar'
@@ -606,25 +606,6 @@ class GpcrondumpTestCase(unittest.TestCase):
         dbname = 'foo'
         (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
         self.assertTrue(exc.startswith('/tmp/exclude_dump_tables_file'))
-
-    @patch('gpcrondump.validate_current_timestamp')
-    @patch('gpcrondump.GpCronDump._get_table_names_from_partition_list', side_effect = [['public.aot1', 'public.aot2'], ['public.cot1', 'public.cot2']])
-    def test_verify_tablenames_default(self, mock1, mock2):
-        cron = GpCronDump(self.options, None)
-        ao_partition_list = ['public, aot1, 2190', 'public, aot2, 3190']
-        co_partition_list = ['public, cot1, 2190', 'public, cot2, 3190']
-        heap_partition_list = ['public.heapt1', 'public.heapt2']
-        cron._verify_tablenames(ao_partition_list, co_partition_list, heap_partition_list) #Should not raise an exception
-
-    @patch('gpcrondump.validate_current_timestamp')
-    @patch('gpcrondump.GpCronDump._get_table_names_from_partition_list', side_effect = [['public.aot1:asd', 'public.aot2'], ['public.cot1', 'public.cot2:asd']])
-    def test_verify_tablenames_bad_chars(self, mock1, mock2):
-        cron = GpCronDump(self.options, None)
-        ao_partition_list = ['public, aot1!asd, 2190', 'public, aot2, 3190']
-        co_partition_list = ['public, cot1, 2190', 'public, cot2\nasd, 3190']
-        heap_partition_list = ['public, heapt1, 2190', 'public, heapt2!asdasd , 3190']
-        with self.assertRaisesRegexp(Exception, ''):
-            cron._verify_tablenames(ao_partition_list, co_partition_list, heap_partition_list)
 
     @patch('gpcrondump.validate_current_timestamp')
     def test_options_inserts_with_incremental(self, mock):
@@ -650,7 +631,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.validate_current_timestamp')
     def test_get_table_names_from_partition_list_00(self, mock1):
         cron = GpCronDump(self.options, None)
-        partition_list = ['public, aot1, 2190', 'public, aot2:aot, 3190']
+        partition_list = ['public,aot1,2190', 'public,aot2:aot,3190']
         expected_output = ['public.aot1', 'public.aot2:aot']
         result = cron._get_table_names_from_partition_list(partition_list)
         self.assertEqual(result, expected_output)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
@@ -33,7 +33,7 @@ class GpRestoreFilterTestCase(unittest.TestCase):
             fd.write('publicao1\n')
             fd.write(' pepper.ao2   \n')
 
-        with self.assertRaisesRegexp(Exception, "need more than 1 value to unpack"):
+        with self.assertRaisesRegexp(Exception, "not in the format schema.table"):
             get_table_schema_set(fname)
 
         os.remove(fname)
@@ -91,13 +91,13 @@ class GpRestoreFilterTestCase(unittest.TestCase):
         line = 'ALTER TABLE "Foo#$1"."Tab#$_1" OWNER TO gpadmin;'
         alter_expr = "ALTER TABLE"
         res = get_table_from_alter_table(line, alter_expr)
-        self.assertEqual(res, '"Tab#$_1"')
+        self.assertEqual(res, 'Tab#$_1')
 
-    def test_get_table_from_alter_table_with_specialchar(self):
+    def test_get_table_from_alter_table_with_specialchar_and_quotes(self):
         line = 'ALTER TABLE "T a""b#$_1" OWNER TO gpadmin;'
         alter_expr = "ALTER TABLE"
         res = get_table_from_alter_table(line, alter_expr)
-        self.assertEqual(res, '"T a""b#$_1"')
+        self.assertEqual(res, 'T a"b#$_1')
 
     def test_get_table_from_alter_table_with_specialchar_and_double_quoted_schema(self):
         line = 'ALTER TABLE "schema1".table1 OWNER TO gpadmin;'

--- a/gpMgmt/bin/gprestore_filter.py
+++ b/gpMgmt/bin/gprestore_filter.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 from gppylib.gpparseopts import OptParser, OptChecker
-from gppylib.operations.backup_utils import split_fqn, checkAndRemoveEnclosingDoubleQuote, removeEscapingDoubleQuoteInSQLString,\
-                                            escapeDoubleQuoteInSQLString 
+from gppylib.operations.backup_utils import checkAndRemoveEnclosingDoubleQuote, removeEscapingDoubleQuoteInSQLString,\
+                                            escapeDoubleQuoteInSQLString, tablename_to_tuple, csv_string_to_list
 import re
 import os
 import sys
@@ -64,30 +64,14 @@ def get_table_from_alter_table(line, alter_expr):
     double quoted already in dump file.
     """
 
-    dot_separator_idx = line.find('.')
-    last_double_quote_idx = line.rfind('"')
-
-    has_schema_table_fmt = True if dot_separator_idx != -1 else False
-    has_special_chars = True if last_double_quote_idx != -1 else False
-
-    if not has_schema_table_fmt and not has_special_chars:
-        return line[len(alter_expr):].split()[0]
-    elif has_schema_table_fmt and not has_special_chars:
-        full_table_name = line[len(alter_expr):].split()[0]
-        _, table = split_fqn(full_table_name)
-        return table
-    elif not has_schema_table_fmt and has_special_chars:
-        return line[len(alter_expr) + 1 : last_double_quote_idx + 1]
+    owner_expr_idx = line.find(" OWNER TO")
+    table_str = line[len(alter_expr)+1:owner_expr_idx]
+    tablename = csv_string_to_list(table_str, delimiter='.', terminator='')
+    if len(tablename) == 2:
+        _, table = tablename
     else:
-        if dot_separator_idx < last_double_quote_idx:
-            # table name is double quoted
-            full_table_name = line[len(alter_expr) : last_double_quote_idx + 1]
-        else:
-            # only schema name double quoted
-            ending_space_idx = line.find(' ', dot_separator_idx)
-            full_table_name = line[len(alter_expr) : ending_space_idx]
-        _, table = split_fqn(full_table_name)
-        return table
+        table = tablename[0]
+    return table
 
 def find_all_expr_start(line, expr):
     """
@@ -201,8 +185,6 @@ def process_schema(dump_schemas, dump_tables, fdin, fdout, change_schema=None, s
                     tablename = get_table_from_alter_table(line, alter_table_only_expr)
                 else:
                     tablename = get_table_from_alter_table(line, alter_table_expr)
-                tablename = checkAndRemoveEnclosingDoubleQuote(tablename)
-                tablename = removeEscapingDoubleQuoteInSQLString(tablename, False)
                 output = check_valid_table(schema, tablename, dump_tables, schema_level_restore_list)
                 if output:
                     if line_buff:
@@ -243,7 +225,7 @@ def get_table_schema_set(filename):
         contents = fd.read()
         tables = contents.splitlines()
         for t in tables:
-            schema, table = split_fqn(t)
+            schema, table = tablename_to_tuple(t)
             dump_tables.add((schema, table))
             dump_schemas.add(schema)
     return (dump_schemas, dump_tables)
@@ -283,9 +265,7 @@ def check_dropped_table(line, dump_tables, schema_level_restore_list, drop_table
     check if table to drop is valid (can be dropped from schema level restore)
     """
     temp = line[len(drop_table_expr):].strip()[:-1]
-    (schema, table) = split_fqn(temp)
-    schema = removeEscapingDoubleQuoteInSQLString(checkAndRemoveEnclosingDoubleQuote(schema), False) 
-    table = removeEscapingDoubleQuoteInSQLString(checkAndRemoveEnclosingDoubleQuote(table), False) 
+    (schema, table) = tablename_to_tuple(temp)
     if (schema_level_restore_list and schema in schema_level_restore_list) or ((schema, table) in dump_tables):
         return True
     return False

--- a/gpMgmt/bin/gprestore_post_data_filter.py
+++ b/gpMgmt/bin/gprestore_post_data_filter.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 from gppylib.gpparseopts import OptParser, OptChecker
-from gppylib.operations.backup_utils import split_fqn, checkAndRemoveEnclosingDoubleQuote, removeEscapingDoubleQuoteInSQLString, \
-                                            escapeDoubleQuoteInSQLString
+from gppylib.operations.backup_utils import checkAndRemoveEnclosingDoubleQuote, removeEscapingDoubleQuoteInSQLString, \
+                                            escapeDoubleQuoteInSQLString, tablename_to_tuple
 import re
 import sys
 import os
@@ -146,7 +146,7 @@ def check_table(schema, line, search_str, dump_tables, schema_level_restore_list
                 table = line[start:].split()[0]
             elif has_schema_table_fmt and not has_special_chars:
                 full_table_name = line[start:].split()[0]
-                _, table = split_fqn(full_table_name)
+                _, table = tablename_to_tuple(full_table_name)
             elif not has_schema_table_fmt and has_special_chars:
                 table = line[start : last_double_quote_idx + 1]
             else:
@@ -157,7 +157,7 @@ def check_table(schema, line, search_str, dump_tables, schema_level_restore_list
                     # only schema name double quoted
                     ending_space_idx = line.find(' ', dot_separator_idx)
                     full_table_name = line[start : ending_space_idx]
-                _, table = split_fqn(full_table_name)
+                _, table = tablename_to_tuple(full_table_name)
 
             table = checkAndRemoveEnclosingDoubleQuote(table)
             table = removeEscapingDoubleQuoteInSQLString(table, False)
@@ -183,7 +183,7 @@ def get_table_schema_set(filename):
         contents = fd.read()
         tables = contents.splitlines()
         for t in tables:
-            schema, table = split_fqn(t)
+            schema, table = tablename_to_tuple(t)
             dump_tables.add((schema, table))
             dump_schemas.add(schema)
     return (dump_schemas, dump_tables)


### PR DESCRIPTION
We now support the above special characters in schema and table naming for backup and restore operations to be more in line with postgres functionality.

Authors: Karen Huddleston and Jamie McAtamney