### PR TITLE
Add Greenplum specific permissions to \du output

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -2862,6 +2862,13 @@ describeRoles(const char *pattern, bool verbose)
 				 "        JOIN pg_catalog.pg_roles b ON (m.roleid = b.oid)\n"
 						  "        WHERE m.member = r.oid) as memberof");
 
+		/* add Greenplum specific attributes */
+		appendPQExpBufferStr(&buf, "\n, r.rolcreaterextgpfd");
+		appendPQExpBufferStr(&buf, "\n, r.rolcreaterexthttp");
+		appendPQExpBufferStr(&buf, "\n, r.rolcreatewextgpfd");
+		appendPQExpBufferStr(&buf, "\n, r.rolcreaterexthdfs");
+		appendPQExpBufferStr(&buf, "\n, r.rolcreatewexthdfs");
+
 		if (verbose && pset.sversion >= 80200)
 		{
 			appendPQExpBufferStr(&buf, "\n, pg_catalog.shobj_description(r.oid, 'pg_authid') AS description");
@@ -2923,6 +2930,25 @@ describeRoles(const char *pattern, bool verbose)
 		if (strcmp(PQgetvalue(res, i, 4), "t") == 0)
 			add_role_attribute(&buf, _("Create DB"));
 
+
+		/* output Greenplum specific attributes */
+		if (strcmp(PQgetvalue(res, i, 8), "t") == 0)
+			add_role_attribute(&buf, _("Ext gpfdist Table"));
+
+		if (strcmp(PQgetvalue(res, i, 9), "t") == 0)
+			add_role_attribute(&buf, _("Ext http Table"));
+
+		if (strcmp(PQgetvalue(res, i, 10), "t") == 0)
+			add_role_attribute(&buf, _("Wri Ext http Table"));
+
+		if (strcmp(PQgetvalue(res, i, 11), "t") == 0)
+			add_role_attribute(&buf, _("Ext hdfs Table"));
+
+		if (strcmp(PQgetvalue(res, i, 12), "t") == 0)
+			add_role_attribute(&buf, _("Wri Ext hdfs Table"));
+		/* end Greenplum specific attributes */
+
+
 		if (strcmp(PQgetvalue(res, i, 5), "t") != 0)
 			add_role_attribute(&buf, _("Cannot login"));
 
@@ -2948,7 +2974,7 @@ describeRoles(const char *pattern, bool verbose)
 		printTableAddCell(&cont, PQgetvalue(res, i, 7), false, false);
 
 		if (verbose && pset.sversion >= 80200)
-			printTableAddCell(&cont, PQgetvalue(res, i, 8), false, false);
+			printTableAddCell(&cont, PQgetvalue(res, i, 8 + 5 /* Greenplum specific attributes */), false, false);
 	}
 	termPQExpBuffer(&buf);
 

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -2864,8 +2864,8 @@ describeRoles(const char *pattern, bool verbose)
 
 		/* add Greenplum specific attributes */
 		appendPQExpBufferStr(&buf, "\n, r.rolcreaterextgpfd");
-		appendPQExpBufferStr(&buf, "\n, r.rolcreaterexthttp");
 		appendPQExpBufferStr(&buf, "\n, r.rolcreatewextgpfd");
+		appendPQExpBufferStr(&buf, "\n, r.rolcreaterexthttp");
 		appendPQExpBufferStr(&buf, "\n, r.rolcreaterexthdfs");
 		appendPQExpBufferStr(&buf, "\n, r.rolcreatewexthdfs");
 
@@ -2936,10 +2936,10 @@ describeRoles(const char *pattern, bool verbose)
 			add_role_attribute(&buf, _("Ext gpfdist Table"));
 
 		if (strcmp(PQgetvalue(res, i, 9), "t") == 0)
-			add_role_attribute(&buf, _("Ext http Table"));
+			add_role_attribute(&buf, _("Wri Ext gpfdist Table"));
 
 		if (strcmp(PQgetvalue(res, i, 10), "t") == 0)
-			add_role_attribute(&buf, _("Wri Ext http Table"));
+			add_role_attribute(&buf, _("Ext http Table"));
 
 		if (strcmp(PQgetvalue(res, i, 11), "t") == 0)
 			add_role_attribute(&buf, _("Ext hdfs Table"));

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -120,4 +120,8 @@ test: uaocs_compaction/threshold
 test: uaocs_compaction/index_stats
 test: uaocs_compaction/index
 test: uaocs_compaction/drop_column
+
+# Test psql \du output
+test: psql_gpdb_du
+
 # end of tests

--- a/src/test/regress/output/psql_gpdb_du.source
+++ b/src/test/regress/output/psql_gpdb_du.source
@@ -1,0 +1,100 @@
+--
+-- Test extended \du flags
+--
+-- https://github.com/greenplum-db/gpdb/issues/1028
+--
+-- Problem: the cluster can be initialized with any Unix user
+--          therefore create specific test roles here, and only
+--          test the \du output for this role, also drop them afterwards
+CREATE ROLE test_psql_du_1 WITH SUPERUSER;
+\du test_psql_du_1
+                    List of roles
+   Role name    |       Attributes        | Member of 
+----------------+-------------------------+-----------
+ test_psql_du_1 | Superuser, Cannot login | {}
+
+DROP ROLE test_psql_du_1;
+CREATE ROLE test_psql_du_2 WITH SUPERUSER CREATEDB CREATEROLE CREATEEXTTABLE LOGIN CONNECTION LIMIT 5;
+\du test_psql_du_2
+                                   List of roles
+   Role name    |                      Attributes                      | Member of 
+----------------+------------------------------------------------------+-----------
+ test_psql_du_2 | Superuser, Create role, Create DB, Ext gpfdist Table | {}
+                : 5 connections                                          
+
+DROP ROLE test_psql_du_2;
+-- pg_catalog.pg_roles.rolcreaterextgpfd
+CREATE ROLE test_psql_du_e1 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', protocol = 'gpfdist');
+\du test_psql_du_e1
+                              List of roles
+    Role name    |                 Attributes                 | Member of 
+-----------------+--------------------------------------------+-----------
+ test_psql_du_e1 | Superuser, Ext gpfdist Table, Cannot login | {}
+
+DROP ROLE test_psql_du_e1;
+CREATE ROLE test_psql_du_e2 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', protocol = 'gpfdists');
+\du test_psql_du_e2
+                              List of roles
+    Role name    |                 Attributes                 | Member of 
+-----------------+--------------------------------------------+-----------
+ test_psql_du_e2 | Superuser, Ext gpfdist Table, Cannot login | {}
+
+DROP ROLE test_psql_du_e2;
+-- pg_catalog.pg_roles.rolcreatewextgpfd
+CREATE ROLE test_psql_du_e3 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'gpfdist');
+\du test_psql_du_e3
+                                List of roles
+    Role name    |                   Attributes                   | Member of 
+-----------------+------------------------------------------------+-----------
+ test_psql_du_e3 | Superuser, Wri Ext gpfdist Table, Cannot login | {}
+
+DROP ROLE test_psql_du_e3;
+CREATE ROLE test_psql_du_e4 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'gpfdists');
+\du test_psql_du_e4
+                                List of roles
+    Role name    |                   Attributes                   | Member of 
+-----------------+------------------------------------------------+-----------
+ test_psql_du_e4 | Superuser, Wri Ext gpfdist Table, Cannot login | {}
+
+DROP ROLE test_psql_du_e4;
+-- pg_catalog.pg_roles.rolcreaterexthttp
+CREATE ROLE test_psql_du_e5 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', protocol = 'http');
+\du test_psql_du_e5
+                             List of roles
+    Role name    |               Attributes                | Member of 
+-----------------+-----------------------------------------+-----------
+ test_psql_du_e5 | Superuser, Ext http Table, Cannot login | {}
+
+DROP ROLE test_psql_du_e5;
+-- does dot exist
+CREATE ROLE test_psql_du_e6 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'http');
+ERROR:  invalid CREATEEXTTABLE specification. writable http external tables do not exist
+\du test_psql_du_e6
+           List of roles
+ Role name | Attributes | Member of 
+-----------+------------+-----------
+
+DROP ROLE test_psql_du_e6;
+ERROR:  role "test_psql_du_e6" does not exist
+-- pg_catalog.pg_roles.rolcreaterexthdfs
+CREATE ROLE test_psql_du_e7 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', protocol = 'gphdfs');
+WARNING:  GRANT/REVOKE on gphdfs is deprecated
+HINT:  Issue the GRANT or REVOKE on the protocol itself
+\du test_psql_du_e7
+                             List of roles
+    Role name    |               Attributes                | Member of 
+-----------------+-----------------------------------------+-----------
+ test_psql_du_e7 | Superuser, Ext hdfs Table, Cannot login | {}
+
+DROP ROLE test_psql_du_e7;
+-- pg_catalog.pg_roles.rolcreatewexthdfs
+CREATE ROLE test_psql_du_e8 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'gphdfs');
+WARNING:  GRANT/REVOKE on gphdfs is deprecated
+HINT:  Issue the GRANT or REVOKE on the protocol itself
+\du test_psql_du_e8
+                               List of roles
+    Role name    |                 Attributes                  | Member of 
+-----------------+---------------------------------------------+-----------
+ test_psql_du_e8 | Superuser, Wri Ext hdfs Table, Cannot login | {}
+
+DROP ROLE test_psql_du_e8;

--- a/src/test/regress/sql/psql_gpdb_du.sql
+++ b/src/test/regress/sql/psql_gpdb_du.sql
@@ -1,0 +1,58 @@
+--
+-- Test extended \du flags
+--
+-- https://github.com/greenplum-db/gpdb/issues/1028
+--
+-- Problem: the cluster can be initialized with any Unix user
+--          therefore create specific test roles here, and only
+--          test the \du output for this role, also drop them afterwards
+
+CREATE ROLE test_psql_du_1 WITH SUPERUSER;
+\du test_psql_du_1
+DROP ROLE test_psql_du_1;
+
+CREATE ROLE test_psql_du_2 WITH SUPERUSER CREATEDB CREATEROLE CREATEEXTTABLE LOGIN CONNECTION LIMIT 5;
+\du test_psql_du_2
+DROP ROLE test_psql_du_2;
+
+-- pg_catalog.pg_roles.rolcreaterextgpfd
+CREATE ROLE test_psql_du_e1 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', protocol = 'gpfdist');
+\du test_psql_du_e1
+DROP ROLE test_psql_du_e1;
+
+CREATE ROLE test_psql_du_e2 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', protocol = 'gpfdists');
+\du test_psql_du_e2
+DROP ROLE test_psql_du_e2;
+
+
+-- pg_catalog.pg_roles.rolcreatewextgpfd
+CREATE ROLE test_psql_du_e3 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'gpfdist');
+\du test_psql_du_e3
+DROP ROLE test_psql_du_e3;
+
+CREATE ROLE test_psql_du_e4 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'gpfdists');
+\du test_psql_du_e4
+DROP ROLE test_psql_du_e4;
+
+
+-- pg_catalog.pg_roles.rolcreaterexthttp
+CREATE ROLE test_psql_du_e5 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', protocol = 'http');
+\du test_psql_du_e5
+DROP ROLE test_psql_du_e5;
+
+-- does dot exist
+CREATE ROLE test_psql_du_e6 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'http');
+\du test_psql_du_e6
+DROP ROLE test_psql_du_e6;
+
+
+-- pg_catalog.pg_roles.rolcreaterexthdfs
+CREATE ROLE test_psql_du_e7 WITH SUPERUSER CREATEEXTTABLE (type = 'readable', protocol = 'gphdfs');
+\du test_psql_du_e7
+DROP ROLE test_psql_du_e7;
+
+
+-- pg_catalog.pg_roles.rolcreatewexthdfs
+CREATE ROLE test_psql_du_e8 WITH SUPERUSER CREATEEXTTABLE (type = 'writable', protocol = 'gphdfs');
+\du test_psql_du_e8
+DROP ROLE test_psql_du_e8;


### PR DESCRIPTION
Fix #1028 

Output looks like this now:
```
postgres=# \du
                                                                    List of roles
 Role name |                                                          Attributes                                                          | Member of 
-----------+------------------------------------------------------------------------------------------------------------------------------+-----------
 ads       | Superuser, Create role, Create DB, Ext gpfdist Table, Ext http Table, Wri Ext http Table, Ext hdfs Table, Wri Ext hdfs Table | {}
```

Tried to keep the names short.