### PR TITLE
Codegen advance_aggregates for SUM transition function

### DIFF
--- a/src/backend/codegen/CMakeLists.txt
+++ b/src/backend/codegen/CMakeLists.txt
@@ -179,6 +179,7 @@ set(GPCODEGEN_SRC
     op_expr_tree_generator.cc
     pg_date_func_generator.cc
     var_expr_tree_generator.cc
+    advance_aggregates_codegen.cc
 )
 
 # Integrate with GPDB build system. 

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -28,6 +28,7 @@ extern "C" {
 #include "executor/nodeAgg.h"
 #include "utils/elog.h"
 #include "executor/tuptable.h"
+#include "executor/executor.h"
 #include "nodes/nodes.h"
 }
 
@@ -66,23 +67,151 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
   llvm::Function* advance_aggregates_func = CreateFunction<AdvanceAggregatesFn>(
       codegen_utils, GetUniqueFuncName());
 
-
   // BasicBlock of function entry.
   llvm::BasicBlock* llvm_entry_block = codegen_utils->CreateBasicBlock(
       "entry", advance_aggregates_func);
 
+  // External functions
+  llvm::Function* llvm_ExecVariableList =
+      codegen_utils->GetOrRegisterExternalFunction(ExecVariableList,
+                                                   "ExecVariableList");
+  llvm::Function* llvm_ExecTargetList =
+      codegen_utils->GetOrRegisterExternalFunction(ExecTargetList,
+                                                   "ExecTargetList");
+
+  // Function arguments to advance_aggregates
+  llvm::Value* llvm_aggstate = ArgumentByPosition(advance_aggregates_func, 0);
+  llvm::Value* llvm_pergroup = ArgumentByPosition(advance_aggregates_func, 1);
+  llvm::Value* llvm_mem_manager = ArgumentByPosition(advance_aggregates_func,
+                                                     2);
 
   irb->SetInsertPoint(llvm_entry_block);
 
+  codegen_utils->CreateElog(INFO, "Codegen'ed expression evaluation called!");
 
-  codegen_utils->CreateElog(
-      INFO,
-      "Codegen'ed expression evaluation called!");
+  // Temporary variables taht replace the use of slot and FunctionInfoData
+  llvm::Value *llvm_fcinfo_arg_0 = irb->CreateAlloca(
+      codegen_utils->GetType<Datum>(), 0, "fcinfo_arg[0]");
+  llvm::Value *llvm_fcinfo_argnull_0 = irb->CreateAlloca(
+      codegen_utils->GetType<bool>(), 0, "fcinfo_argnull[0]");
+  llvm::Value *llvm_fcinfo_arg_1 = irb->CreateAlloca(
+      codegen_utils->GetType<Datum>(), 0, "fcinfo_arg[1]");
+  llvm::Value *llvm_fcinfo_argnull_1 = irb->CreateAlloca(
+      codegen_utils->GetType<bool>(), 0, "fcinfo_argnull[1]");
 
-  codegen_utils->CreateFallback<AdvanceAggregatesFn>(
-      codegen_utils->GetOrRegisterExternalFunction(advance_aggregates,
-                                                   "advance_aggregates"),
-                                                   advance_aggregates_func);
+  for (int aggno = 0; aggno < aggstate_->numaggs; aggno++)
+  {
+    AggStatePerAgg peraggstate = &aggstate_->peragg[aggno];
+
+    if (peraggstate->numSortCols > 0) {
+      elog(DEBUG1, "We don't codegen DISTINCT and/or ORDER by case");
+      return false;
+    }
+
+    Aggref *aggref = peraggstate->aggref;
+    if (!aggref)
+    {
+      elog (DEBUG1, "We don't codegen non-aggref functions");
+      return false;
+    }
+
+    int nargs = list_length(aggref->args);
+    Assert(nargs == peraggstate->numArguments);
+    Assert(peraggstate->evalproj);
+
+    if (peraggstate->evalproj->pi_isVarList)
+    {
+      // TODO: call the one with the pointer from previous codegen
+      irb->CreateCall(llvm_ExecVariableList, {
+          codegen_utils->GetConstant<ProjectionInfo *>(peraggstate->evalproj),
+          llvm_fcinfo_arg_1,
+          llvm_fcinfo_argnull_1
+      });
+
+      codegen_utils->CreateElog(INFO, "Variable = %d", irb->CreateLoad(llvm_fcinfo_arg_1));
+    }
+    else
+    {
+      irb->CreateCall(llvm_ExecTargetList, {
+          codegen_utils->GetConstant(peraggstate->evalproj->pi_targetlist),
+          codegen_utils->GetConstant(peraggstate->evalproj->pi_exprContext),
+          llvm_fcinfo_arg_1,
+          llvm_fcinfo_argnull_1,
+          codegen_utils->GetConstant(peraggstate->evalproj->pi_itemIsDone),
+          codegen_utils->GetConstant<ExprDoneCond *>(nullptr)
+      });
+
+      codegen_utils->CreateElog(INFO, "Variable = %d", llvm_fcinfo_arg_1);
+    }
+
+    //    advance_transition_function(aggstate, peraggstate, pergroupstate,
+    //                        &fcinfo, mem_manager); {{{
+
+    if (peraggstate->transfn.fn_strict)
+    {
+      elog(DEBUG1, "We do not support strict functions.");
+      return false;
+    }
+
+    //oldContext = MemoryContextSwitchTo(tuplecontext);
+
+    // Retrieve pergroup's useful members
+    llvm::Value* llvm_pergroupstate = irb->CreateGEP(
+        llvm_pergroup, {codegen_utils->GetConstant(aggno)});
+    llvm::Value* llvm_pergroupstate_transValue =
+        codegen_utils->GetPointerToMember(
+            llvm_pergroupstate, &AggStatePerGroupData::transValue);
+    llvm::Value* llvm_pergroupstate_transValueIsNull =
+        codegen_utils->GetPointerToMember(
+            llvm_pergroupstate, &AggStatePerGroupData::transValueIsNull);
+
+
+    // fcinfo->arg[0] = transValue;
+    // fcinfo->argnull[0] = *transValueIsNull; {{
+    irb->CreateStore(irb->CreateLoad(llvm_pergroupstate_transValue),
+                     llvm_fcinfo_arg_0);
+    irb->CreateStore(irb->CreateLoad(llvm_pergroupstate_transValueIsNull),
+                     llvm_fcinfo_argnull_0);
+    // }}
+
+    //newVal = FunctionCallInvoke(fcinfo); {{
+
+    llvm::Value *llvm_fcinfo_arg_1_i32 = irb->
+        CreateTrunc(irb->CreateLoad(llvm_fcinfo_arg_1), codegen_utils->GetType<int32>());
+
+    llvm::Value *newVal = irb->CreateAdd(
+        irb->CreateLoad(llvm_fcinfo_arg_0),
+        codegen_utils->CreateCast<int64, int32>(llvm_fcinfo_arg_1_i32));
+    // }} FunctionCallInvoke
+
+    // }}} advance_transition_function
+
+
+    if (!peraggstate->transtypeByVal) {
+      elog(DEBUG1, "We do not support pass-by-ref datatypes.");
+      return false;
+    }
+
+    // pergroupstate->transValue = newval {{{
+    irb->CreateStore(newVal, llvm_pergroupstate_transValue);
+    // }}}
+
+//    *transValueIsNull = fcinfo->isnull;
+//    if (!fcinfo->isnull)
+//      *noTransvalue = false;    {{{
+
+    irb->CreateStore(codegen_utils->GetConstant<bool>(false),
+                     llvm_pergroupstate_transValueIsNull);
+
+    // }}}
+
+    codegen_utils->CreateElog(INFO, "transValue = %d", irb->CreateLoad(llvm_pergroupstate_transValue));
+
+  } // End of for loop
+
+  irb->CreateRetVoid();
+
+
 
   return true;
 }

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -70,7 +70,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceTransitionFunction(
   // Instead it errors out. Thus we do not need to check and implement the
   // case that transition function is strict.
 
-  //oldContext = MemoryContextSwitchTo(tuplecontext);
+  // oldContext = MemoryContextSwitchTo(tuplecontext);
   llvm::Value *llvm_oldContext = irb->CreateCall(llvm_MemoryContextSwitchTo,
                                                  {llvm_tuplecontext});
 
@@ -100,8 +100,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceTransitionFunction(
       advance_aggregates_func,
       error_block,
       {irb->CreateLoad(llvm_pergroupstate_transValue_ptr),
-          irb->CreateLoad(llvm_arg)}
-  );
+          irb->CreateLoad(llvm_arg)});
 
   gpcodegen::PGFuncGeneratorInterface* pg_func_gen =
       gpcodegen::OpExprTreeGenerator::GetPGFuncGenerator(
@@ -115,7 +114,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceTransitionFunction(
   llvm::Value *newVal = nullptr;
   bool isGenerated = pg_func_gen->GenerateCode(codegen_utils,
                                                pg_func_info, &newVal);
-  if(!isGenerated) {
+  if (!isGenerated) {
     elog(DEBUG1, "Function with oid = %d was not generated successfully!",
          peraggstate->transfn.fn_oid);
     return false;
@@ -213,8 +212,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
   llvm::Value *llvm_arg = irb->CreateAlloca(codegen_utils->GetType<Datum>());
   llvm::Value *llvm_argnull = irb->CreateAlloca(codegen_utils->GetType<bool>());
 
-  for (int aggno = 0; aggno < aggstate_->numaggs; aggno++)
-  {
+  for (int aggno = 0; aggno < aggstate_->numaggs; aggno++) {
     AggStatePerAgg peraggstate = &aggstate_->peragg[aggno];
 
     if (peraggstate->numSortCols > 0) {
@@ -223,9 +221,8 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
     }
 
     Aggref *aggref = peraggstate->aggref;
-    if (!aggref)
-    {
-      elog (DEBUG1, "We don't codegen non-aggref functions");
+    if (!aggref) {
+      elog(DEBUG1, "We don't codegen non-aggref functions");
       return false;
     }
 
@@ -233,15 +230,12 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
     Assert(nargs == peraggstate->numArguments);
     Assert(peraggstate->evalproj);
 
-    if (peraggstate->evalproj->pi_isVarList)
-    {
+    if (peraggstate->evalproj->pi_isVarList) {
       irb->CreateCall(llvm_ExecVariableList, {
           codegen_utils->GetConstant<ProjectionInfo *>(peraggstate->evalproj),
           llvm_arg,
           llvm_argnull});
-    }
-    else
-    {
+    } else {
       irb->CreateCall(llvm_ExecTargetList, {
           codegen_utils->GetConstant(peraggstate->evalproj->pi_targetlist),
           codegen_utils->GetConstant(peraggstate->evalproj->pi_exprContext),
@@ -272,8 +266,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
         error_block, llvm_arg);
     if (!isGenerated)
       return false;
-
-  } // End of for loop
+  }  // End of for loop
 
   irb->CreateRetVoid();
 

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -170,6 +170,9 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
   llvm::Function* llvm_ExecTargetList =
       codegen_utils->GetOrRegisterExternalFunction(ExecTargetList,
                                                    "ExecTargetList");
+  llvm::Function* llvm_ExecVariableList =
+      codegen_utils->GetOrRegisterExternalFunction(ExecVariableList,
+                                                   "ExecVariableList");
 
   // Function argument to advance_aggregates
   llvm::Value* llvm_aggstate_arg = ArgumentByPosition(
@@ -232,27 +235,10 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 
     if (peraggstate->evalproj->pi_isVarList)
     {
-      llvm::Function* llvm_ExecVariableList = nullptr;
-      if (nullptr != peraggstate->evalproj->
-          ExecVariableList_gen_info.code_generator) {
-        // Use the enrolled ExecVariableList version
-        llvm_ExecVariableList = codegen_utils->
-            GetOrRegisterExternalFunction(
-                peraggstate->evalproj->ExecVariableList_gen_info.
-                ExecVariableList_fn, "ExecVariableList"+std::to_string(aggno));
-      }
-      else
-      {
-        llvm_ExecVariableList = codegen_utils->
-            GetOrRegisterExternalFunction(
-                ExecVariableList, "ExecVariableList"+std::to_string(aggno));
-      }
-
       irb->CreateCall(llvm_ExecVariableList, {
           codegen_utils->GetConstant<ProjectionInfo *>(peraggstate->evalproj),
           llvm_arg,
-          llvm_argnull
-      });
+          llvm_argnull});
     }
     else
     {
@@ -262,8 +248,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
           llvm_arg,
           llvm_argnull,
           codegen_utils->GetConstant(peraggstate->evalproj->pi_itemIsDone),
-          codegen_utils->GetConstant<ExprDoneCond *>(nullptr)
-      });
+          codegen_utils->GetConstant<ExprDoneCond *>(nullptr)});
     }
 
     // Generate the code of each aggregate function in a different block.

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -68,9 +68,6 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
       "implementation block", advance_aggregates_func);
   llvm::BasicBlock* fallback_block = codegen_utils->CreateBasicBlock(
       "fallback block", advance_aggregates_func);
-  llvm::BasicBlock* advance_transition_function_block = codegen_utils->
-      CreateBasicBlock("advance_transition_function block",
-                       advance_aggregates_func);
 
   // External functions
   llvm::Function* llvm_ExecTargetList =
@@ -176,6 +173,10 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
           codegen_utils->GetConstant<ExprDoneCond *>(nullptr)
       });
     }
+
+    llvm::BasicBlock* advance_transition_function_block = codegen_utils->
+        CreateBasicBlock("advance_transition_function block",
+                         advance_aggregates_func);
 
     // Fall-back if attribute is NULL.
     // TODO(nikos): Support null attributes.

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -200,7 +200,8 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 
     // Retrieve pergroup's useful members
     llvm::Value* llvm_pergroupstate = irb->CreateGEP(
-        llvm_pergroup_arg, {codegen_utils->GetConstant(aggno)});
+        llvm_pergroup_arg, {codegen_utils->GetConstant(
+            sizeof(AggStatePerGroupData) * aggno)});
     llvm::Value* llvm_pergroupstate_transValue_ptr =
         codegen_utils->GetPointerToMember(
             llvm_pergroupstate, &AggStatePerGroupData::transValue);

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -81,9 +81,6 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 
 
   // External functions
-  llvm::Function* llvm_ExecVariableList =
-      codegen_utils->GetOrRegisterExternalFunction(ExecVariableList,
-                                                   "ExecVariableList");
   llvm::Function* llvm_ExecTargetList =
       codegen_utils->GetOrRegisterExternalFunction(ExecTargetList,
                                                    "ExecTargetList");
@@ -130,7 +127,22 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 
     if (peraggstate->evalproj->pi_isVarList)
     {
-      // TODO(nikos): call the one with the pointer from previous codegen
+      llvm::Function* llvm_ExecVariableList = nullptr;
+      if (nullptr != peraggstate->evalproj->
+          ExecVariableList_gen_info.code_generator) {
+        // Use the enrolled ExecVariableList version
+        llvm_ExecVariableList = codegen_utils->
+            GetOrRegisterExternalFunction(
+                peraggstate->evalproj->ExecVariableList_gen_info.
+                ExecVariableList_fn, "ExecVariableList"+std::to_string(aggno));
+      }
+      else
+      {
+        llvm_ExecVariableList = codegen_utils->
+            GetOrRegisterExternalFunction(
+                ExecVariableList, "ExecVariableList"+std::to_string(aggno));
+      }
+
       irb->CreateCall(llvm_ExecVariableList, {
           codegen_utils->GetConstant<ProjectionInfo *>(peraggstate->evalproj),
           llvm_arg,

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -182,26 +182,20 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
         codegen_utils->GetPointerToMember(
             llvm_pergroupstate, &AggStatePerGroupData::transValueIsNull);
 
-
     // fcinfo->arg[0] = transValue;
-    // fcinfo->argnull[0] = *transValueIsNull; {{
     irb->CreateStore(irb->CreateLoad(llvm_pergroupstate_transValue),
                      llvm_fcinfo_arg_0);
+    // fcinfo->argnull[0] = *transValueIsNull;
     irb->CreateStore(irb->CreateLoad(llvm_pergroupstate_transValueIsNull),
                      llvm_fcinfo_argnull_0);
-    // }}
 
     //newVal = FunctionCallInvoke(fcinfo); {{
-
-    llvm::Value *llvm_fcinfo_arg_1_i32 = irb->
-        CreateTrunc(irb->CreateLoad(llvm_fcinfo_arg_1),
-                    codegen_utils->GetType<int32>());
 
     PGFuncGeneratorInfo pg_func_info(
         advance_aggregates_func,
         llvm_error_block,
         {irb->CreateLoad(llvm_fcinfo_arg_0),
-            codegen_utils->CreateCast<int64, int32>(llvm_fcinfo_arg_1_i32)}
+         irb->CreateLoad(llvm_fcinfo_arg_1)}
     );
 
     PGFuncGeneratorInterface* pg_func_gen = OpExprTreeGenerator::

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -1,0 +1,101 @@
+//---------------------------------------------------------------------------
+//  Greenplum Database
+//  Copyright (C) 2016 Pivotal Software, Inc.
+//
+//  @filename:
+//    advance_aggregates_codegen.cc
+//
+//  @doc:
+//    Generates code for AdvanceAggregates function.
+//
+//---------------------------------------------------------------------------
+#include <assert.h>
+#include <stddef.h>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "codegen/advance_aggregates_codegen.h"
+#include "codegen/base_codegen.h"
+#include "codegen/codegen_wrapper.h"
+
+#include "codegen/utils/gp_codegen_utils.h"
+#include "codegen/utils/utility.h"
+
+extern "C" {
+#include "postgres.h"  // NOLINT(build/include)
+#include "nodes/execnodes.h"
+#include "executor/nodeAgg.h"
+#include "utils/elog.h"
+#include "executor/tuptable.h"
+#include "nodes/nodes.h"
+}
+
+namespace llvm {
+class BasicBlock;
+class Function;
+class Value;
+}  // namespace llvm
+
+using gpcodegen::AdvanceAggregatesCodegen;
+
+constexpr char AdvanceAggregatesCodegen::kAdvanceAggregatesPrefix[];
+
+AdvanceAggregatesCodegen::AdvanceAggregatesCodegen(
+    CodegenManager* manager,
+    AdvanceAggregatesFn regular_func_ptr,
+    AdvanceAggregatesFn* ptr_to_regular_func_ptr,
+    AggState *aggstate)
+: BaseCodegen(manager,
+              kAdvanceAggregatesPrefix,
+              regular_func_ptr,
+              ptr_to_regular_func_ptr),
+              aggstate_(aggstate) {
+}
+
+bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
+    gpcodegen::GpCodegenUtils* codegen_utils) {
+
+  assert(NULL != codegen_utils);
+  if (nullptr == aggstate_) {
+    return false;
+  }
+
+  auto irb = codegen_utils->ir_builder();
+
+  llvm::Function* advance_aggregates_func = CreateFunction<AdvanceAggregatesFn>(
+      codegen_utils, GetUniqueFuncName());
+
+
+  // BasicBlock of function entry.
+  llvm::BasicBlock* llvm_entry_block = codegen_utils->CreateBasicBlock(
+      "entry", advance_aggregates_func);
+
+
+  irb->SetInsertPoint(llvm_entry_block);
+
+
+  codegen_utils->CreateElog(
+      INFO,
+      "Codegen'ed expression evaluation called!");
+
+  codegen_utils->CreateFallback<AdvanceAggregatesFn>(
+      codegen_utils->GetOrRegisterExternalFunction(advance_aggregates,
+                                                   "advance_aggregates"),
+                                                   advance_aggregates_func);
+
+  return true;
+}
+
+
+bool AdvanceAggregatesCodegen::GenerateCodeInternal(GpCodegenUtils* codegen_utils) {
+  bool isGenerated = GenerateAdvanceAggregates(codegen_utils);
+
+  if (isGenerated) {
+    elog(DEBUG1, "AdvanceAggregates was generated successfully!");
+    return true;
+  } else {
+    elog(DEBUG1, "AdvanceAggregates generation failed!");
+    return false;
+  }
+}

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -9,29 +9,17 @@
 //    Generates code for AdvanceAggregates function.
 //
 //---------------------------------------------------------------------------
-#include <assert.h>
-#include <stddef.h>
-#include <cstdint>
-#include <memory>
-#include <string>
-
 #include "codegen/advance_aggregates_codegen.h"
-#include "codegen/base_codegen.h"
-#include "codegen/codegen_wrapper.h"
 #include "codegen/op_expr_tree_generator.h"
 #include "codegen/pg_func_generator_interface.h"
-
 
 #include "codegen/utils/gp_codegen_utils.h"
 #include "codegen/utils/utility.h"
 
 extern "C" {
 #include "postgres.h"  // NOLINT(build/include)
-#include "nodes/execnodes.h"
 #include "executor/nodeAgg.h"
-#include "utils/elog.h"
 #include "utils/palloc.h"
-#include "executor/tuptable.h"
 #include "executor/executor.h"
 #include "nodes/nodes.h"
 }
@@ -72,12 +60,13 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
       codegen_utils, GetUniqueFuncName());
 
   // BasicBlock of function entry.
-  llvm::BasicBlock* llvm_entry_block = codegen_utils->CreateBasicBlock(
+  llvm::BasicBlock* entry_block = codegen_utils->CreateBasicBlock(
       "entry block", advance_aggregates_func);
-  llvm::BasicBlock* llvm_error_block = codegen_utils->CreateBasicBlock(
-      "error block", advance_aggregates_func);
-  llvm::BasicBlock* llvm_advance_transition_function_block = codegen_utils->CreateBasicBlock(
-      "advance_transition_function block", advance_aggregates_func);
+  llvm::BasicBlock* fallback_block = codegen_utils->CreateBasicBlock(
+      "fallback block", advance_aggregates_func);
+  llvm::BasicBlock* advance_transition_function_block = codegen_utils->
+      CreateBasicBlock("advance_transition_function block",
+                       advance_aggregates_func);
 
 
   // External functions
@@ -95,9 +84,11 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
   llvm::Value *llvm_tuplecontext = codegen_utils->GetConstant<MemoryContext>(
       aggstate_->tmpcontext->ecxt_per_tuple_memory);
 
-  irb->SetInsertPoint(llvm_entry_block);
+  irb->SetInsertPoint(entry_block);
 
-  codegen_utils->CreateElog(INFO, "Codegen'ed expression evaluation called!");
+#ifdef CODEGEN_DEBUG
+  codegen_utils->CreateElog(DEBUG1, "Codegen'ed advance_aggregates called!");
+#endif
 
   // Temporary variables that replace the use of slot and FunctionInfoData
   llvm::Value *llvm_arg = irb->CreateAlloca(
@@ -110,14 +101,14 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
     AggStatePerAgg peraggstate = &aggstate_->peragg[aggno];
 
     if (peraggstate->numSortCols > 0) {
-      elog(INFO, "We don't codegen DISTINCT and/or ORDER by case");
+      elog(DEBUG1, "We don't codegen DISTINCT and/or ORDER by case");
       return false;
     }
 
     Aggref *aggref = peraggstate->aggref;
     if (!aggref)
     {
-      elog (INFO, "We don't codegen non-aggref functions");
+      elog (DEBUG1, "We don't codegen non-aggref functions");
       return false;
     }
 
@@ -148,9 +139,6 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
           llvm_arg,
           llvm_argnull
       });
-
-      codegen_utils->CreateElog(INFO, "Variable = %d",
-                                irb->CreateLoad(llvm_arg));
     }
     else
     {
@@ -162,29 +150,26 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
           codegen_utils->GetConstant(peraggstate->evalproj->pi_itemIsDone),
           codegen_utils->GetConstant<ExprDoneCond *>(nullptr)
       });
-
-      codegen_utils->CreateElog(INFO, "Variable = %d", llvm_arg);
     }
 
-    // Fallback if attribute is NULL.
+    // Fall-back if attribute is NULL.
     // TODO(nikos): Support null attributes.
     irb->CreateCondBr(irb->CreateLoad(llvm_argnull),
-                      llvm_error_block /*true*/,
-                      llvm_advance_transition_function_block /*false*/);
+                      fallback_block /*true*/,
+                      advance_transition_function_block /*false*/);
 
     // advance_transition_function block
     // ----------
     // We generate code for advance_transition_function.
-    irb->SetInsertPoint(llvm_advance_transition_function_block);
+    irb->SetInsertPoint(advance_transition_function_block);
 
-    //    advance_transition_function(aggstate, peraggstate, pergroupstate,
-    //                        &fcinfo, mem_manager); {{{
+    // advance_transition_function {{{
 
-    //
     // TODO(nikos): Currently we do not support NULL attributes. However, if we
-    // support NULL attributes and transition function is
-    // strict (transfn->fn_strict), then we have to initiate transValue,
-    // noTransvalue, transValueIsNull accordingly (see invoke_agg_trans_func).
+    // support NULL attributes and transition function is strict, then we might
+    // have to initiate transValue, noTransvalue, and transValueIsNull
+    // accordingly (see invoke_agg_trans_func).
+    // In case of SUM, we do not have to support this.
 
     //oldContext = MemoryContextSwitchTo(tuplecontext);
     llvm::Value *llvm_oldContext = irb->CreateCall(llvm_MemoryContextSwitchTo,
@@ -203,19 +188,23 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
         codegen_utils->GetPointerToMember(
             llvm_pergroupstate, &AggStatePerGroupData::noTransValue);
 
-    //newVal = FunctionCallInvoke(fcinfo); {{
+    if (!peraggstate->transtypeByVal) {
+      elog(DEBUG1, "We do not support pass-by-ref datatypes.");
+      return false;
+    }
+
+    // FunctionCallInvoke(fcinfo); {{
     PGFuncGeneratorInfo pg_func_info(
         advance_aggregates_func,
-        llvm_error_block,
+        fallback_block,
         {irb->CreateLoad(llvm_pergroupstate_transValue),
             irb->CreateLoad(llvm_arg)}
     );
 
-    PGFuncGeneratorInterface* pg_func_gen = OpExprTreeGenerator::
-        GetPGFuncGenerator(peraggstate->transfn.fn_oid);
-    if (nullptr == pg_func_gen)
-    {
-      elog(INFO, "We do not support function with oid = %d",
+    PGFuncGeneratorInterface* pg_func_gen =
+        OpExprTreeGenerator::GetPGFuncGenerator(peraggstate->transfn.fn_oid);
+    if (nullptr == pg_func_gen) {
+      elog(DEBUG1, "We do not support built-in function with oid = %d",
            peraggstate->transfn.fn_oid);
       return false;
     }
@@ -230,16 +219,8 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 
     // }}} advance_transition_function
 
-
-    if (!peraggstate->transtypeByVal) {
-      elog(DEBUG1, "We do not support pass-by-ref datatypes.");
-      return false;
-    }
-
-    // pergroupstate->transValue = newval {{{
+    // pergroupstate->transValue = newval
     irb->CreateStore(result, llvm_pergroupstate_transValue);
-    // }}}
-
 
     // Currently we do not support null attributes.
     // Thus we set transValueIsNull and noTransValue to false by default.
@@ -249,16 +230,16 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
     irb->CreateStore(codegen_utils->GetConstant<bool>(false),
                      llvm_pergroupstate_noTransValue);
 
-    codegen_utils->CreateElog(INFO, "transValue = %d",
-                              irb->CreateLoad(llvm_pergroupstate_transValue));
-
   } // End of for loop
 
   irb->CreateRetVoid();
 
-  irb->SetInsertPoint(llvm_error_block);
+  // Fall back block
+  // ---------------
+  irb->SetInsertPoint(fallback_block);
 
-  codegen_utils->CreateElog(INFO, "An error has occurred and we are falling back");
+  codegen_utils->CreateElog(DEBUG1,
+                            "Falling back to regular advance_aggregates");
 
   codegen_utils->CreateFallback<AdvanceAggregatesFn>(
       codegen_utils->GetOrRegisterExternalFunction(advance_aggregates,
@@ -269,7 +250,8 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 }
 
 
-bool AdvanceAggregatesCodegen::GenerateCodeInternal(GpCodegenUtils* codegen_utils) {
+bool AdvanceAggregatesCodegen::GenerateCodeInternal(
+    GpCodegenUtils* codegen_utils) {
   bool isGenerated = GenerateAdvanceAggregates(codegen_utils);
 
   if (isGenerated) {

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -137,7 +137,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 
     if (peraggstate->evalproj->pi_isVarList)
     {
-      // TODO: call the one with the pointer from previous codegen
+      // TODO(nikos): call the one with the pointer from previous codegen
       irb->CreateCall(llvm_ExecVariableList, {
           codegen_utils->GetConstant<ProjectionInfo *>(peraggstate->evalproj),
           llvm_fcinfo_arg_1,
@@ -162,7 +162,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
     }
 
     // Fallback if attribute is NULL.
-    // TODO: (nikos) Support null attributes.
+    // TODO(nikos): Support null attributes.
     irb->CreateCondBr(irb->CreateLoad(llvm_fcinfo_argnull_1),
                       llvm_error_block /*true*/,
                       llvm_advance_transition_function_block /*false*/);
@@ -175,12 +175,11 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
     //    advance_transition_function(aggstate, peraggstate, pergroupstate,
     //                        &fcinfo, mem_manager); {{{
 
-    // TODO: Support fn_strict
-    if (peraggstate->transfn.fn_strict)
-    {
-      elog(INFO, "We do not support strict functions.");
-      return false;
-    }
+    //
+    // TODO(nikos): Currently we do not support NULL attributes. However, if we
+    // support NULL attributes and transition function is
+    // strict (transfn->fn_strict), then we have to initiate transValue,
+    // noTransvalue, transValueIsNull accordingly (see invoke_agg_trans_func).
 
     //oldContext = MemoryContextSwitchTo(tuplecontext);
     llvm::Value *llvm_oldContext = irb->CreateCall(llvm_MemoryContextSwitchTo,
@@ -226,7 +225,6 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 
     llvm::Value *newVal = nullptr;
     pg_func_gen->GenerateCode(codegen_utils, pg_func_info, &newVal);
-
     llvm::Value *result = codegen_utils->CreateCppTypeToDatumCast(newVal);
 
     // }} FunctionCallInvoke
@@ -249,7 +247,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 
     // Currently we do not support null attributes.
     // Thus we set transValueIsNull and noTransValue to false by default.
-    // TODO: (nikos) Support null attributes.
+    // TODO(nikos): Support null attributes.
     irb->CreateStore(codegen_utils->GetConstant<bool>(false),
                      llvm_pergroupstate_transValueIsNull);
     irb->CreateStore(codegen_utils->GetConstant<bool>(false),

--- a/src/backend/codegen/codegen_wrapper.cc
+++ b/src/backend/codegen/codegen_wrapper.cc
@@ -22,6 +22,7 @@
 #include "codegen/exec_variable_list_codegen.h"
 #include "codegen/expr_tree_generator.h"
 #include "codegen/utils/gp_codegen_utils.h"
+#include "codegen/advance_aggregates_codegen.h"
 
 extern "C" {
 #include "lib/stringinfo.h"
@@ -31,6 +32,7 @@ using gpcodegen::CodegenManager;
 using gpcodegen::BaseCodegen;
 using gpcodegen::ExecVariableListCodegen;
 using gpcodegen::ExecEvalExprCodegen;
+using gpcodegen::AdvanceAggregatesCodegen;
 
 // Current code generator manager that oversees all code generators
 static void* ActiveCodeGeneratorManager = nullptr;
@@ -165,5 +167,12 @@ void* ExecEvalExprCodegenEnroll(
   return generator;
 }
 
-
+void* AdvanceAggregatesCodegenEnroll(
+    AdvanceAggregatesFn regular_func_ptr,
+    AdvanceAggregatesFn* ptr_to_chosen_func_ptr,
+    AggState *aggstate) {
+  AdvanceAggregatesCodegen* generator = CodegenEnroll<AdvanceAggregatesCodegen>(
+      regular_func_ptr, ptr_to_chosen_func_ptr, aggstate);
+  return generator;
+}
 

--- a/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
+++ b/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
@@ -36,10 +36,11 @@ class AdvanceAggregatesCodegen: public BaseCodegen<AdvanceAggregatesFn> {
    *        function or the corresponding regular version.
    *
    **/
-  explicit AdvanceAggregatesCodegen(CodegenManager* manager,
-                                    AdvanceAggregatesFn regular_func_ptr,
-                                    AdvanceAggregatesFn* ptr_to_regular_func_ptr,
-                                    AggState *aggstate);
+  explicit AdvanceAggregatesCodegen(
+      CodegenManager* manager,
+      AdvanceAggregatesFn regular_func_ptr,
+      AdvanceAggregatesFn* ptr_to_regular_func_ptr,
+      AggState *aggstate);
 
   virtual ~AdvanceAggregatesCodegen() = default;
 
@@ -95,7 +96,6 @@ class AdvanceAggregatesCodegen: public BaseCodegen<AdvanceAggregatesFn> {
       llvm::Function* advance_aggregates_func,
       llvm::BasicBlock* error_block,
       llvm::Value *llvm_arg);
-
 };
 
 /** @} */

--- a/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
+++ b/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
@@ -72,6 +72,29 @@ class AdvanceAggregatesCodegen: public BaseCodegen<AdvanceAggregatesFn> {
    **/
   bool GenerateAdvanceAggregates(gpcodegen::GpCodegenUtils* codegen_utils);
 
+  /**
+   * @brief Generates runtime code that implements advance_transition_function.
+   * It is called by GenerateAdvanceAggregates to generate code for a given
+   * aggregate function.
+   *
+   * @param codegen_utils Utility to ease the code generation process.
+   * @param llvm_pergroup_arg LLVM pointer to pergroup argument of regular
+   *        advance_aggregates
+   * @param aggno ith aggregate function
+   * @param advance_aggregates_func LLVM function pointer to the code generated
+   *        advance_aggregate function
+   * @param fallback_block Falling back LLVM block
+   *
+   * @return true on successful generation; false otherwise.
+   */
+  bool GenerateAdvanceTransitionFunction(
+      gpcodegen::GpCodegenUtils* codegen_utils,
+      llvm::Value* llvm_pergroup_arg,
+      int aggno,
+      llvm::Function* advance_aggregates_func,
+      llvm::BasicBlock* fallback_block,
+      llvm::Value *llvm_arg);
+
 };
 
 /** @} */

--- a/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
+++ b/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
@@ -1,0 +1,80 @@
+//---------------------------------------------------------------------------
+//  Greenplum Database
+//  Copyright (C) 2016 Pivotal Software, Inc.
+//
+//  @filename:
+//    advance_aggregates_codegen.h
+//
+//  @doc:
+//    Headers for AdvanceAggregates codegen.
+//
+//---------------------------------------------------------------------------
+
+#ifndef GPCODEGEN_ADVANCEAGGREGATES_CODEGEN_H_  // NOLINT(build/header_guard)
+#define GPCODEGEN_ADVANCEAGGREGATES_CODEGEN_H_
+
+#include "codegen/base_codegen.h"
+#include "codegen/codegen_wrapper.h"
+
+namespace gpcodegen {
+
+/** \addtogroup gpcodegen
+ *  @{
+ */
+
+class AdvanceAggregatesCodegen: public BaseCodegen<AdvanceAggregatesFn> {
+ public:
+  /**
+   * @brief Constructor
+   *
+   * @param regular_func_ptr        Regular version of the target function.
+   * @param ptr_to_chosen_func_ptr  Reference to the function pointer that the
+   *                                caller will call.
+   * @param aggstate                The AggState to use for generating code.
+   *
+   * @note 	The ptr_to_chosen_func_ptr can refer to either the generated
+   *        function or the corresponding regular version.
+   *
+   **/
+  explicit AdvanceAggregatesCodegen(CodegenManager* manager,
+                                    AdvanceAggregatesFn regular_func_ptr,
+                                    AdvanceAggregatesFn* ptr_to_regular_func_ptr,
+                                    AggState *aggstate);
+
+  virtual ~AdvanceAggregatesCodegen() = default;
+
+ protected:
+  /**
+   * @brief Generate code for advance_aggregates.
+   *
+   * @param codegen_utils
+   *
+   * @return true on successful generation; false otherwise.
+   *
+   * This implementation does not support percentile and ordered aggregates.
+   *
+   * If at execution time, we see any of the above types of attributes,
+   * we fall backs to the regular function.
+   *
+   */
+  bool GenerateCodeInternal(gpcodegen::GpCodegenUtils* codegen_utils) final;
+
+ private:
+  AggState *aggstate_;
+
+  static constexpr char kAdvanceAggregatesPrefix[] = "AdvanceAggregates";
+
+  /**
+   * @brief Generates runtime code that implements advance_aggregates.
+   *
+   * @param codegen_utils Utility to ease the code generation process.
+   * @return true on successful generation.
+   **/
+  bool GenerateAdvanceAggregates(gpcodegen::GpCodegenUtils* codegen_utils);
+
+};
+
+/** @} */
+
+}  // namespace gpcodegen
+#endif  // GPCODEGEN_ADVANCEAGGREGATES_CODEGEN_H_

--- a/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
+++ b/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
@@ -83,7 +83,8 @@ class AdvanceAggregatesCodegen: public BaseCodegen<AdvanceAggregatesFn> {
    * @param aggno ith aggregate function
    * @param advance_aggregates_func LLVM function pointer to the code generated
    *        advance_aggregate function
-   * @param fallback_block Falling back LLVM block
+   * @param error_block LLVM block for treating errors
+   * @param llvm_arg argument of aggregate function
    *
    * @return true on successful generation; false otherwise.
    */
@@ -92,7 +93,7 @@ class AdvanceAggregatesCodegen: public BaseCodegen<AdvanceAggregatesFn> {
       llvm::Value* llvm_pergroup_arg,
       int aggno,
       llvm::Function* advance_aggregates_func,
-      llvm::BasicBlock* fallback_block,
+      llvm::BasicBlock* error_block,
       llvm::Value *llvm_arg);
 
 };

--- a/src/backend/codegen/include/codegen/op_expr_tree_generator.h
+++ b/src/backend/codegen/include/codegen/op_expr_tree_generator.h
@@ -45,6 +45,9 @@ class OpExprTreeGenerator : public ExprTreeGenerator {
         ExprTreeGeneratorInfo* gen_info,
         std::unique_ptr<ExprTreeGenerator>* expr_tree);
 
+  static gpcodegen::PGFuncGeneratorInterface* GetPGFuncGenerator(
+      unsigned int oid);
+
   bool GenerateCode(gpcodegen::GpCodegenUtils* codegen_utils,
                     const ExprTreeGeneratorInfo& gen_info,
                     llvm::Value* llvm_isnull_ptr,

--- a/src/backend/codegen/include/codegen/op_expr_tree_generator.h
+++ b/src/backend/codegen/include/codegen/op_expr_tree_generator.h
@@ -45,6 +45,13 @@ class OpExprTreeGenerator : public ExprTreeGenerator {
         ExprTreeGeneratorInfo* gen_info,
         std::unique_ptr<ExprTreeGenerator>* expr_tree);
 
+  /**
+   * @brief Checks if a built-in function can be code generated.
+   *
+   * @param oid The oid of the function.
+   * @return If function is supported, then returns a pointer to the
+   * PGFuncGeneratorInterface of the function; nullptr otherwise.
+   **/
   static gpcodegen::PGFuncGeneratorInterface* GetPGFuncGenerator(
       unsigned int oid);
 

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -84,6 +84,12 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           "int4mi",
           &PGArithFuncGenerator<int32_t, int32_t, int32_t>::SubWithOverflow));
 
+  supported_function_[463] = std::unique_ptr<PGFuncGeneratorInterface>(
+      new PGGenericFuncGenerator<int64_t, int64_t>(
+          463,
+          "int8pl",
+          &PGArithFuncGenerator<int64_t, int64_t, int64_t>::AddWithOverflow));
+
   supported_function_[216] = std::unique_ptr<PGFuncGeneratorInterface>(
       new PGGenericFuncGenerator<float8, float8>(
           216,

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -72,6 +72,12 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           "int4pl",
           &PGArithFuncGenerator<int32_t, int32_t, int32_t>::AddWithOverflow));
 
+  supported_function_[1841] = std::unique_ptr<PGFuncGeneratorInterface>(
+      new PGGenericFuncGenerator<int64_t, int64_t>(
+          1841,
+          "int4_sum",
+          &PGArithFuncGenerator<int64_t, int64_t, int64_t>::AddWithOverflow));
+
   supported_function_[181] = std::unique_ptr<PGFuncGeneratorInterface>(
       new PGGenericFuncGenerator<int32_t, int32_t>(
           181,
@@ -105,6 +111,16 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           2339,
           "date_le_timestamp",
           &PGDateFuncGenerator::DateLETimestamp));
+}
+
+PGFuncGeneratorInterface* OpExprTreeGenerator::GetPGFuncGenerator(
+      unsigned int oid) {
+  InitializeSupportedFunction();
+  auto itr = supported_function_.find(oid);
+  if (itr == supported_function_.end()) {
+    return nullptr;
+  }
+  return itr->second.get();
 }
 
 OpExprTreeGenerator::OpExprTreeGenerator(

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -73,10 +73,10 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           &PGArithFuncGenerator<int32_t, int32_t, int32_t>::AddWithOverflow));
 
   supported_function_[1841] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int64_t, int64_t>(
+      new PGGenericFuncGenerator<int64_t, int32_t>(
           1841,
           "int4_sum",
-          &PGArithFuncGenerator<int64_t, int64_t, int64_t>::AddWithOverflow));
+          &PGArithFuncGenerator<int64_t, int64_t, int32_t>::AddWithOverflow));
 
   supported_function_[181] = std::unique_ptr<PGFuncGeneratorInterface>(
       new PGGenericFuncGenerator<int32_t, int32_t>(

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -148,9 +148,8 @@ bool OpExprTreeGenerator::VerifyAndCreateExprTree(
 
   OpExpr* op_expr = reinterpret_cast<OpExpr*>(expr_state->expr);
   expr_tree->reset(nullptr);
-  CodeGenFuncMap::iterator itr =  supported_function_.find(op_expr->opfuncid);
-  if (itr == supported_function_.end()) {
-    // Operators are stored in pg_proc table. See postgres.bki for more details.
+  PGFuncGeneratorInterface* pg_func_gen = GetPGFuncGenerator(op_expr->opfuncid);
+  if (nullptr == pg_func_gen) {
     elog(DEBUG1, "Unsupported operator %d.", op_expr->opfuncid);
     return false;
   }
@@ -159,7 +158,7 @@ bool OpExprTreeGenerator::VerifyAndCreateExprTree(
   assert(nullptr != arguments);
   // In ExecEvalFuncArgs
   assert(list_length(arguments) ==
-        static_cast<int>(itr->second->GetTotalArgCount()));
+        static_cast<int>(pg_func_gen->GetTotalArgCount()));
 
   ListCell   *arg = nullptr;
   bool supported_tree = true;

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -662,7 +662,8 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttr(
   // Note: We collect error code information, based on the block from which we
   // fall back, and log it for debugging purposes.
   irb->SetInsertPoint(fallback_block);
-  llvm::PHINode* llvm_error = irb->CreatePHI(codegen_utils->GetType<char *>(), 2);
+  llvm::PHINode* llvm_error = irb->CreatePHI(
+      codegen_utils->GetType<char *>(), 2);
   llvm_error->addIncoming(codegen_utils->GetConstant("slot check failed"),
       slot_check_block);
   llvm_error->addIncoming(codegen_utils->GetConstant("tuple check failed"),

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -662,15 +662,15 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttr(
   // Note: We collect error code information, based on the block from which we
   // fall back, and log it for debugging purposes.
   irb->SetInsertPoint(fallback_block);
-  llvm::PHINode* llvm_error = irb->CreatePHI(codegen_utils->GetType<int>(), 4);
-  llvm_error->addIncoming(codegen_utils->GetConstant(0),
+  llvm::PHINode* llvm_error = irb->CreatePHI(codegen_utils->GetType<char *>(), 2);
+  llvm_error->addIncoming(codegen_utils->GetConstant("slot check failed"),
       slot_check_block);
-  llvm_error->addIncoming(codegen_utils->GetConstant(1),
+  llvm_error->addIncoming(codegen_utils->GetConstant("tuple check failed"),
       heap_tuple_check_block);
 
   codegen_utils->CreateElog(
       DEBUG1,
-      "Falling back to regular slot_getattr, reason = %d",
+      "Falling back to regular slot_getattr, reason = %s",
       llvm_error);
 
   codegen_utils->CreateFallback<SlotGetAttrFn>(

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -868,7 +868,7 @@ agg_hash_initial_pass(AggState *aggstate)
 		}
 			
 		/* Advance the aggregates */
-		advance_aggregates(aggstate, hashtable->groupaggs->aggs, &(aggstate->mem_manager));
+		call_AdvanceAggregates(aggstate, hashtable->groupaggs->aggs, &(aggstate->mem_manager));
 		
 		hashtable->num_tuples++;
 

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -880,14 +880,13 @@ void
 EnrollTransitionFunctions(AggState* aggstate)
 {
 #ifdef USE_CODEGEN
-  if (NULL == aggstate ||
-      NULL == aggstate->pergroup)
-  {
-    return;
-  }
-  enroll_AdvanceAggregates_codegen(advance_aggregates,
-                                   &aggstate->pergroup->AdvanceAggregates_gen_info.AdvanceAggregates_fn,
-                                   aggstate);
+	if (NULL == aggstate)
+	{
+		return;
+	}
+	enroll_AdvanceAggregates_codegen(advance_aggregates,
+			&aggstate->AdvanceAggregates_gen_info.AdvanceAggregates_fn,
+			aggstate);
 #endif
 }
 

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -168,9 +168,6 @@ static void ExecCdbTraceNode(PlanState *node, bool entry, TupleTableSlot *result
  static void
  EnrollProjInfoTargetList(PlanState* result, ProjectionInfo* ProjInfo);
 
- static void
- EnrollTransitionFunctions(AggState* aggState);
-
 /*
  * setSubplanSliceId
  *   Set the slice id info for the given subplan.
@@ -592,8 +589,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			    AggStatePerAgg peraggstate = &aggstate->peragg[aggno];
 			    EnrollProjInfoTargetList(result, peraggstate->evalproj);
 			  }
-			  EnrollTransitionFunctions(aggstate);
-			}
+			  enroll_AdvanceAggregates_codegen(advance_aggregates,
+			        &aggstate->AdvanceAggregates_gen_info.AdvanceAggregates_fn,
+			        aggstate);			}
 			}
 			END_MEMORY_ACCOUNT();
 			break;
@@ -870,25 +868,6 @@ EnrollProjInfoTargetList(PlanState* result, ProjectionInfo* ProjInfo)
 #endif
 }
 
-/* ----------------------------------------------------------------
- *    EnrollTransitionFunctions
- *
- *    Enroll trasition functions to Codegen
- * ----------------------------------------------------------------
- */
-void
-EnrollTransitionFunctions(AggState* aggstate)
-{
-#ifdef USE_CODEGEN
-	if (NULL == aggstate)
-	{
-		return;
-	}
-	enroll_AdvanceAggregates_codegen(advance_aggregates,
-			&aggstate->AdvanceAggregates_gen_info.AdvanceAggregates_fn,
-			aggstate);
-#endif
-}
 
 /* ----------------------------------------------------------------
  *		ExecSliceDependencyNode

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -5984,6 +5984,9 @@ ExecCleanTargetListLength(List *targetlist)
  * of *isDone = ExprMultipleResult signifies a set element, and a return
  * of *isDone = ExprEndResult signifies end of the set of tuple.
  */
+#ifndef USE_CODEGEN
+static
+#endif
 bool
 ExecTargetList(List *targetlist,
 			   ExprContext *econtext,

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -5984,7 +5984,7 @@ ExecCleanTargetListLength(List *targetlist)
  * of *isDone = ExprMultipleResult signifies a set element, and a return
  * of *isDone = ExprEndResult signifies end of the set of tuple.
  */
-static bool
+bool
 ExecTargetList(List *targetlist,
 			   ExprContext *econtext,
 			   Datum *values,

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1324,7 +1324,7 @@ agg_retrieve_direct(AggState *aggstate)
 					if (!aggstate->has_partial_agg)
 					{
 						has_partial_agg = true;
-						advance_aggregates(aggstate, pergroup, &(aggstate->mem_manager));
+						call_AdvanceAggregates(aggstate, pergroup, &(aggstate->mem_manager));
 					}
 
 					/* Reset per-input-tuple context after each tuple */
@@ -1400,7 +1400,7 @@ agg_retrieve_direct(AggState *aggstate)
 							{
 								has_partial_agg = true;
 								tmpcontext->ecxt_outertuple = outerslot;
-								advance_aggregates(aggstate, pergroup, &(aggstate->mem_manager));
+								call_AdvanceAggregates(aggstate, pergroup, &(aggstate->mem_manager));
 							}
 							
 							passthru_ready = true;
@@ -1440,7 +1440,7 @@ agg_retrieve_direct(AggState *aggstate)
 			ResetExprContext(tmpcontext);
 			tmpcontext->ecxt_outertuple = outerslot;
 
-			advance_aggregates(aggstate, perpassthru, &(aggstate->mem_manager));
+			call_AdvanceAggregates(aggstate, perpassthru, &(aggstate->mem_manager));
 		}
 		
 

--- a/src/include/codegen/codegen_wrapper.h
+++ b/src/include/codegen/codegen_wrapper.h
@@ -243,7 +243,7 @@ AdvanceAggregatesCodegenEnroll(AdvanceAggregatesFn regular_func_ptr,
  * Function pointer may point to regular version or generated function
  */
 #define call_AdvanceAggregates(aggstate, pergroup, mem_manager) \
-		aggstate->pergroup->AdvanceAggregates_gen_info.AdvanceAggregates_fn(aggstate, pergroup, mem_manager)
+		aggstate->AdvanceAggregates_gen_info.AdvanceAggregates_fn(aggstate, pergroup, mem_manager)
 
 /*
  * Enrollment macros
@@ -261,9 +261,9 @@ AdvanceAggregatesCodegenEnroll(AdvanceAggregatesFn regular_func_ptr,
         Assert(exprstate->evalfunc == regular_func); \
 
 #define enroll_AdvanceAggregates_codegen(regular_func, ptr_to_regular_func_ptr, aggstate) \
-		aggstate->pergroup->AdvanceAggregates_gen_info.code_generator = AdvanceAggregatesCodegenEnroll( \
+		aggstate->AdvanceAggregates_gen_info.code_generator = AdvanceAggregatesCodegenEnroll( \
         regular_func, ptr_to_regular_func_ptr, aggstate); \
-        Assert(aggstate->pergroup->AdvanceAggregates_gen_info.AdvanceAggregates_fn == regular_func); \
+        Assert(aggstate->AdvanceAggregates_gen_info.AdvanceAggregates_fn == regular_func); \
 
 #endif //USE_CODEGEN
 

--- a/src/include/codegen/codegen_wrapper.h
+++ b/src/include/codegen/codegen_wrapper.h
@@ -31,7 +31,9 @@ struct ProjectionInfo;
 struct ExprContext;
 struct ExprState;
 struct PlanState;
-
+struct AggState;
+struct MemoryManagerContainer;
+struct AggStatePerGroupData;
 /*
  * Enum used to mimic ExprDoneCond in ExecEvalExpr function pointer.
  */
@@ -39,6 +41,7 @@ typedef enum tmp_enum{
 	TmpResult
 }tmp_enum;
 
+typedef void (*AdvanceAggregatesFn) (struct AggState *aggstate, /*struct AggStatePerGroup*/struct AggStatePerGroupData *pergroup, struct MemoryManagerContainer *mem_manager);
 typedef void (*ExecVariableListFn) (struct ProjectionInfo *projInfo, Datum *values, bool *isnull);
 typedef Datum (*ExecEvalExprFn) (struct ExprState *expression, struct ExprContext *econtext, bool *isNull, /*ExprDoneCond*/ tmp_enum *isDone);
 typedef Datum (*SlotGetAttrFn) (struct TupleTableSlot *slot, int attnum, bool *isnull);
@@ -62,7 +65,8 @@ typedef Datum (*SlotGetAttrFn) (struct TupleTableSlot *slot, int attnum, bool *i
 #define init_codegen()
 #define call_ExecVariableList(projInfo, values, isnull) ExecVariableList(projInfo, values, isnull)
 #define enroll_ExecVariableList_codegen(regular_func, ptr_to_chosen_func, proj_info, slot)
-
+#define #define call_AdvanceAggregates(aggstate, pergroup, mem_manager) advance_aggregates(aggstate, pergroup, mem_manager)
+#define enroll_AdvanceAggregates_codegen(regular_func, ptr_to_chosen_func, aggstate)
 #else
 
 /*
@@ -176,6 +180,14 @@ ExecEvalExprCodegenEnroll(ExecEvalExprFn regular_func_ptr,
                           struct ExprContext *econtext,
                           struct PlanState* plan_state);
 
+/*
+ * Enroll and returns the pointer to AdvanceAggregateGenerator
+ */
+void*
+AdvanceAggregatesCodegenEnroll(AdvanceAggregatesFn regular_func_ptr,
+		AdvanceAggregatesFn* ptr_to_regular_func_ptr,
+		struct AggState *aggstate);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif
@@ -225,6 +237,14 @@ ExecEvalExprCodegenEnroll(ExecEvalExprFn regular_func_ptr,
  */
 #define call_ExecVariableList(projInfo, values, isnull) \
 		projInfo->ExecVariableList_gen_info.ExecVariableList_fn(projInfo, values, isnull)
+
+/*
+ * Call AdvanceAggregates using function pointer AdvanceAggregates_fn.
+ * Function pointer may point to regular version or generated function
+ */
+#define call_AdvanceAggregates(aggstate, pergroup, mem_manager) \
+		aggstate->pergroup->AdvanceAggregates_gen_info.AdvanceAggregates_fn(aggstate, pergroup, mem_manager)
+
 /*
  * Enrollment macros
  * The enrollment process also ensures that the generated function pointer
@@ -239,6 +259,11 @@ ExecEvalExprCodegenEnroll(ExecEvalExprFn regular_func_ptr,
 		exprstate->ExecEvalExpr_code_generator = ExecEvalExprCodegenEnroll( \
         (ExecEvalExprFn)regular_func, (ExecEvalExprFn*)ptr_to_regular_func_ptr, exprstate, econtext, plan_state); \
         Assert(exprstate->evalfunc == regular_func); \
+
+#define enroll_AdvanceAggregates_codegen(regular_func, ptr_to_regular_func_ptr, aggstate) \
+		aggstate->pergroup->AdvanceAggregates_gen_info.code_generator = AdvanceAggregatesCodegenEnroll( \
+        regular_func, ptr_to_regular_func_ptr, aggstate); \
+        Assert(aggstate->pergroup->AdvanceAggregates_gen_info.AdvanceAggregates_fn == regular_func); \
 
 #endif //USE_CODEGEN
 

--- a/src/include/codegen/codegen_wrapper.h
+++ b/src/include/codegen/codegen_wrapper.h
@@ -65,7 +65,7 @@ typedef Datum (*SlotGetAttrFn) (struct TupleTableSlot *slot, int attnum, bool *i
 #define init_codegen()
 #define call_ExecVariableList(projInfo, values, isnull) ExecVariableList(projInfo, values, isnull)
 #define enroll_ExecVariableList_codegen(regular_func, ptr_to_chosen_func, proj_info, slot)
-#define #define call_AdvanceAggregates(aggstate, pergroup, mem_manager) advance_aggregates(aggstate, pergroup, mem_manager)
+#define call_AdvanceAggregates(aggstate, pergroup, mem_manager) advance_aggregates(aggstate, pergroup, mem_manager)
 #define enroll_AdvanceAggregates_codegen(regular_func, ptr_to_chosen_func, aggstate)
 #else
 
@@ -262,8 +262,8 @@ AdvanceAggregatesCodegenEnroll(AdvanceAggregatesFn regular_func_ptr,
 
 #define enroll_AdvanceAggregates_codegen(regular_func, ptr_to_regular_func_ptr, aggstate) \
 		aggstate->AdvanceAggregates_gen_info.code_generator = AdvanceAggregatesCodegenEnroll( \
-        regular_func, ptr_to_regular_func_ptr, aggstate); \
-        Assert(aggstate->AdvanceAggregates_gen_info.AdvanceAggregates_fn == regular_func); \
+				regular_func, ptr_to_regular_func_ptr, aggstate); \
+				Assert(aggstate->AdvanceAggregates_gen_info.AdvanceAggregates_fn == regular_func); \
 
 #endif //USE_CODEGEN
 

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -301,6 +301,7 @@ extern ExprState *ExecInitExpr(Expr *node, PlanState *parent);
 extern ExprState *ExecPrepareExpr(Expr *node, EState *estate);
 extern bool ExecQual(List *qual, ExprContext *econtext, bool resultForNull);
 extern int	ExecTargetListLength(List *targetlist);
+extern bool ExecTargetList(List *targetlist, ExprContext *econtext, Datum *values, bool *isnull, ExprDoneCond *itemIsDone, ExprDoneCond *isDone);
 extern int	ExecCleanTargetListLength(List *targetlist);
 extern TupleTableSlot *ExecProject(ProjectionInfo *projInfo,
 			ExprDoneCond *isDone);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -301,7 +301,9 @@ extern ExprState *ExecInitExpr(Expr *node, PlanState *parent);
 extern ExprState *ExecPrepareExpr(Expr *node, EState *estate);
 extern bool ExecQual(List *qual, ExprContext *econtext, bool resultForNull);
 extern int	ExecTargetListLength(List *targetlist);
+#ifdef USE_CODEGEN
 extern bool ExecTargetList(List *targetlist, ExprContext *econtext, Datum *values, bool *isnull, ExprDoneCond *itemIsDone, ExprDoneCond *isDone);
+#endif
 extern int	ExecCleanTargetListLength(List *targetlist);
 extern TupleTableSlot *ExecProject(ProjectionInfo *projInfo,
 			ExprDoneCond *isDone);

--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -136,16 +136,6 @@ typedef struct AggStatePerAggData
 	void *sortstate;	/* sort object, if DISTINCT or ORDER BY */
 } AggStatePerAggData;
 
-
-typedef struct AdvanceAggregatesCodegenInfo
-{
-	/* Pointer to store AdvanceAggregatesCodegen from Codegen */
-	void* code_generator;
-	/* Function pointer that points to either regular or generated advance_aggregates */
-	AdvanceAggregatesFn AdvanceAggregates_fn;
-} AdvanceAggregatesCodegenInfo;
-
-
 /*
  * AggStatePerGroupData - per-aggregate-per-group working state
  *
@@ -176,11 +166,6 @@ typedef struct AggStatePerGroupData
 	 * NULL and not auto-replace it with a later input value. Only the first
 	 * non-NULL input will be auto-substituted.
 	 */
-
-#ifdef USE_CODEGEN
-	AdvanceAggregatesCodegenInfo AdvanceAggregates_gen_info;
-#endif
-
 } AggStatePerGroupData;
 
 extern void 

--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -136,6 +136,16 @@ typedef struct AggStatePerAggData
 	void *sortstate;	/* sort object, if DISTINCT or ORDER BY */
 } AggStatePerAggData;
 
+
+typedef struct AdvanceAggregatesCodegenInfo
+{
+	/* Pointer to store AdvanceAggregatesCodegen from Codegen */
+	void* code_generator;
+	/* Function pointer that points to either regular or generated advance_aggregates */
+	AdvanceAggregatesFn AdvanceAggregates_fn;
+} AdvanceAggregatesCodegenInfo;
+
+
 /*
  * AggStatePerGroupData - per-aggregate-per-group working state
  *
@@ -166,6 +176,11 @@ typedef struct AggStatePerGroupData
 	 * NULL and not auto-replace it with a later input value. Only the first
 	 * non-NULL input will be auto-substituted.
 	 */
+
+#ifdef USE_CODEGEN
+	AdvanceAggregatesCodegenInfo AdvanceAggregates_gen_info;
+#endif
+
 } AggStatePerGroupData;
 
 extern void 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2344,6 +2344,15 @@ typedef struct SortState
  *	expressions and run the aggregate transition functions.
  * -------------------------
  */
+
+typedef struct AdvanceAggregatesCodegenInfo
+{
+	/* Pointer to store AdvanceAggregatesCodegen from Codegen */
+	void* code_generator;
+	/* Function pointer that points to either regular or generated advance_aggregates */
+	AdvanceAggregatesFn AdvanceAggregates_fn;
+} AdvanceAggregatesCodegenInfo;
+
 /* these structs are private in nodeAgg.c: */
 typedef struct AggStatePerAggData *AggStatePerAgg;
 typedef struct AggStatePerGroupData *AggStatePerGroup;
@@ -2392,6 +2401,9 @@ typedef struct AggState
 	/* set if the operator created workfiles */
 	bool		workfiles_created;
 
+#ifdef USE_CODEGEN
+	AdvanceAggregatesCodegenInfo AdvanceAggregates_gen_info;
+#endif
 } AggState;
 
 


### PR DESCRIPTION
In this PR, we generate code for advance_aggregates. In particular, we create  AdvanceAggregateGenerator and enroll for advance_aggregates. 

We support codegen for SUM function on int4 and float8 datatypes. We don't support percentile & ordered aggregate. Also, we do not support null and pass-by-ref arguments. 

**Test**
`set codegen=on;`
`set client_min_messages=debug1;`
`create table foo (i float8, j float8);`
`insert into foo values (0.1, 0.2), (0.1, 0.2);`
`select sum(i) from foo;`
`select sum(i) from foo group by j;` 
`select sum(i*j + i) from foo;`
