### PR TITLE
gpperfmon: fix code vulnerabilities which may lead to wrong data in queries_ table

### DIFF
--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -445,6 +445,7 @@ postquel_start(execution_state *es, SQLFunctionCachePtr fcache)
 		{
 			/* For log level of DEBUG4, gpmon is sent information about queries inside SQL functions as well */
 			Assert(fcache->src);
+			gpmon_qlog_query_submit(es->qd->gpmon_pkt);
 			gpmon_qlog_query_text(es->qd->gpmon_pkt,
 					fcache->src,
 					application_name,

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1903,6 +1903,7 @@ _SPI_execute_plan(_SPI_plan * plan, ParamListInfo paramLI,
                     {
                     	/* For log level of DEBUG4, gpmon is sent information about SPI internal queries as well */
 						Assert(plansource->query_string);
+						gpmon_qlog_query_submit(qdesc->gpmon_pkt);
 						gpmon_qlog_query_text(qdesc->gpmon_pkt,
 											  plansource->query_string,
 											  application_name,

--- a/src/backend/gpopt/utils/funcs.cpp
+++ b/src/backend/gpopt/utils/funcs.cpp
@@ -800,6 +800,9 @@ static int extractFrozenQueryPlanAndExecute(char *pcQuery)
 			NULL /*paramLI*/,
 			false);
 
+	// Do not record gpperfmon information about internal queries
+	pqueryDesc->gpmon_pkt = NULL;
+
 	elog(NOTICE, "Executing thawed plan...");
 
 	ExecutorStart(pqueryDesc, 0);
@@ -846,6 +849,9 @@ static int extractFrozenPlanAndExecute(char *pcSerializedPS)
 			NULL /*paramLI*/,
 			false);
 
+	// Do not record gpperfmon information about internal queries
+	pqueryDesc->gpmon_pkt = NULL;
+
 	elog(NOTICE, "Executing thawed plan...");
 
 	ExecutorStart(pqueryDesc, 0);
@@ -874,6 +880,9 @@ static int executeXMLPlan(char *szXml)
 			pdest,
 			NULL /*paramLI*/,
 			false);
+
+	// Do not record gpperfmon information about internal queries
+	pqueryDesc->gpmon_pkt = NULL;
 
 	elog(NOTICE, "Executing thawed plan...");
 


### PR DESCRIPTION
Reviewed all occurrence of CreateQueryDesc which creates a gpmon packet inside.
Following places have inconsistent handling of the gpmon packet may leads to wrong tsubmit value in queries_* table
1. For executor/spi.c and executor/functions.c, on certain log level the code missed call of gpmon_qlog_query_submit
2. For gpopt/utils/funcs.cpp, it is a ORCA internal query, set the gpmon packet to NULL to prevent record this query to gpperfmon.
@yydzero @hsyuan