### PR TITLE
Validate relation for further process in isSimplyUpdatableRelation

### DIFF
--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1500,6 +1500,15 @@ isSimplyUpdatableRelation(Oid relid, bool noerror)
 {
 	Relation rel;
 
+	if (!OidIsValid(relid))
+	{
+		if (!noerror)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_OBJECT),
+					 errmsg("Invalid oid: %d is not simply updatable", relid)));
+		return false;
+	}
+
 	rel = relation_open(relid, AccessShareLock);
 
 	/*

--- a/src/test/regress/expected/portals.out
+++ b/src/test/regress/expected/portals.out
@@ -935,3 +935,13 @@ FETCH FROM c1;
 DELETE FROM ucview WHERE CURRENT OF c1; -- fail, views not supported
 ERROR:  WHERE CURRENT OF on a view is not implemented
 ROLLBACK;
+-- Check cursors for functions.
+BEGIN;
+DECLARE c1 CURSOR FOR SELECT * FROM LOWER('TEST');
+FETCH ALL FROM c1;
+ lower
+-------
+ test
+(1 row)
+
+COMMIT;

--- a/src/test/regress/sql/portals.sql
+++ b/src/test/regress/sql/portals.sql
@@ -393,3 +393,9 @@ DECLARE c1 CURSOR FOR SELECT * FROM ucview;
 FETCH FROM c1;
 DELETE FROM ucview WHERE CURRENT OF c1; -- fail, views not supported
 ROLLBACK;
+
+-- Check cursors for functions.
+BEGIN;
+DECLARE c1 CURSOR FOR SELECT * FROM LOWER('TEST');
+FETCH ALL FROM c1;
+COMMIT;


### PR DESCRIPTION
isSimplyUpdatableRelation may get an invalid input from statements like
"DECLARE XX CURSOR FOR SELECT * FROM LOWER('HH')" where a function is selected.