### PR TITLE
Enhance foreign key check detection for gpcheckcat

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -34,6 +34,8 @@ try:
     from gpcheckcat_modules.unique_index_violation_check import UniqueIndexViolationCheck
     from gpcheckcat_modules.leaked_schema_dropper import LeakedSchemaDropper
     from gpcheckcat_modules.repair import Repair
+    from gpcheckcat_modules.foreign_key_check import ForeignKeyCheck
+
 
 except ImportError, e:
     sys.exit('Error: unable to import module: ' + str(e))
@@ -2794,7 +2796,7 @@ def checkTableACL(cat):
 
 
 # -------------------------------------------------------------------------------
-def checkForeignKey():
+def checkForeignKey(cat_tables=None):
     logger.info('-----------------------------------')
     logger.info('Performing foreign key tests')
 
@@ -2802,132 +2804,28 @@ def checkForeignKey():
         GV.foreignKeyStatus = True
 
     # looks up information in the catalog:
-    tables = GV.catalog.getCatalogTables()
+    if not cat_tables:
+        cat_tables = GV.catalog.getCatalogTables()
 
-    for cat in sorted(tables):
-        checkTableForeignKey(cat)
+    db_connection = connect2(GV.cfg[1], utilityMode=False)
+    try:
+        foreign_key_check = ForeignKeyCheck(db_connection, logger, GV.opt['-S'])
+        foreign_key_issues = foreign_key_check.runCheck(cat_tables, autoCast)
+        if foreign_key_issues:
+            GV.checkStatus = False
 
-
-# -------------------------------------------------------------------------------
-def checkTableForeignKey(cat):
-    catname = cat.getTableName()
-    fkeylist = cat.getForeignKeys()
-    isShared = cat.isShared()
-    pkeylist = cat.getPrimaryKey()
-    coltypes = cat.getTableColtypes()
-
-    # skip tables without fkey
-    if len(fkeylist) <= 0:
-        return
-    if len(cat.getPrimaryKey()) <= 0:
-        return
-
-    # skip these master-only tables
-    skipped_masteronly = ['gp_relation_node', 'pg_description', 'pg_shdescription',
-                          'pg_stat_last_operation', 'pg_stat_last_shoperation', 'pg_statistic']
-
-    if catname in skipped_masteronly:
-        return
-
-    # skip shared/non-shared tables
-    if GV.opt['-S']:
-        if re.match("none", GV.opt['-S'], re.I) and isShared:
-            return
-        if re.match("only", GV.opt['-S'], re.I) and not isShared:
-            return
-
-    # primary key lists
-    cat1pkeys = []
-    pkeys = []
-
-    # build array of catalog primary keys (with aliases) and
-    # primary key alias list
-    for pk in pkeylist:
-        cat1pkeys.append('cat1.' + pk + ' as %s_%s' % (catname, pk))
-        pkeys.append('%s_%s' % (catname, pk))
-
-    logger.info('Building %d queries to check FK constraint on table %s' % (len(fkeylist), catname))
-    for fkeydef in fkeylist:
-        castedFkey = [c + autoCast.get(coltypes[c], '') for c in fkeydef.getColumns()]
-        fkeystr = ', '.join(castedFkey)
-        cat1fkeystr = 'cat1.' + ', cat1.'.join(fkeydef.getColumns())
-        pkeystr = ', '.join(fkeydef.getPKey())
-        pkcatname = fkeydef.getPkeyTableName()
-
-        qry = fkQuery(catname, pkcatname, fkeystr, pkeystr, pkeys, cat1pkeys)
-
-        # Execute the query
-        try:
-            db = connect2(GV.cfg[1], utilityMode=False)
-            curs = db.query(qry)
-            nrows = curs.ntuples()
-
-            if nrows == 0:
-                logger.info('[OK] Foreign key check for %s(%s) referencing %s(%s)' %
-                            (catname, fkeystr, pkcatname, pkeystr))
-            else:
-                GV.checkStatus = False
-                setError(ERROR_NOREPAIR)
-                GV.foreignKeyStatus = False
-                logger.info('[FAIL] Foreign key check for %s(%s) referencing %s(%s)' %
-                            (catname, fkeystr, pkcatname, pkeystr))
-                logger.error('  %s has %d issue(s): entry has NULL reference of %s(%s)' %
-                             (catname, nrows, pkcatname, pkeystr))
-
-                fields = curs.listfields()
-                log_literal(logger, logging.ERROR, "    " + " | ".join(fields))
-                for row in curs.getresult():
-                    log_literal(logger, logging.ERROR, "    " + " | ".join(map(str, row)))
-                processForeignKeyResult(catname, pkcatname, fields, curs.getresult())
-
-                if catname == 'gp_fastsequence' and pkcatname == 'pg_class':
-                    setError(ERROR_REMOVE)
-                    removeFastSequence(db)
-
-        except Exception, e:
-            setError(ERROR_NOREPAIR)
-            GV.foreignKeyStatus = False
-            myprint('[ERROR] executing: Foreign key check for ' + catname)
-            myprint('  Execution error: ' + str(e))
-            myprint(qry)
-
-
-# -------------------------------------------------------------------------------
-def fkQuery(catname, pkcatname, fkeystr, pkeystr, pkeys, cat1pkeys):
-    qry = """
-          SELECT {primary_key_alias}, {cat2_dot_pk},
-                 array_agg(gp_segment_id order by gp_segment_id) as segids
-          FROM (
-                SELECT cat1.gp_segment_id, {cat1_dot_pk}, cat1.{FK1} as {cat2_dot_pk}
-                FROM
-                    gp_dist_random('{CATALOG1}') cat1 LEFT OUTER JOIN
-                    gp_dist_random('{CATALOG2}') cat2
-                    ON (cat1.gp_segment_id = cat2.gp_segment_id AND
-                        cat1.{FK1} = cat2.{PK2} )
-                WHERE cat2.{PK2} is NULL
-                  AND cat1.{FK1} != 0
-                UNION ALL
-                SELECT -1 as gp_segment_id, {cat1_dot_pk}, cat1.{FK1} as {cat2_dot_pk}
-                FROM
-                    {CATALOG1} cat1 LEFT OUTER JOIN
-                    {CATALOG2} cat2
-                    ON (cat1.gp_segment_id = cat2.gp_segment_id AND
-                        cat1.{FK1} = cat2.{PK2} )
-                WHERE cat2.{PK2} is NULL
-                  AND cat1.{FK1} != 0
-                ORDER BY {primary_key_alias}, gp_segment_id
-          ) allresults
-          GROUP BY {primary_key_alias}, {cat2_dot_pk}
-          """.format(FK1=fkeystr,
-                     PK2=pkeystr,
-                     CATALOG1=catname,
-                     CATALOG2=pkcatname,
-                     cat1_dot_pk=', '.join(cat1pkeys),
-                     cat2_dot_pk='%s_%s' % (pkcatname, pkeystr),
-                     primary_key_alias=', '.join(pkeys))
-
-    return qry
-
+        for catname, tuples in foreign_key_issues.iteritems():
+                for pkcatname, fields, results in tuples:
+                    processForeignKeyResult(catname, pkcatname, fields, results)
+                    if catname == 'gp_fastsequence' and pkcatname == 'pg_class':
+                        setError(ERROR_REMOVE)
+                        removeFastSequence(db_connection)
+                    else:
+                        setError(ERROR_NOREPAIR)
+    except Exception, ex:
+        setError(ERROR_NOREPAIR)
+        GV.foreignKeyStatus = False
+        myprint('  Execution error: ' + str(ex))
 
 # -------------------------------------------------------------------------------
 def checkMissingEntry():
@@ -3612,16 +3510,17 @@ def listAllChecks():
 
 
 #-------------------------------------------------------------------------------
-def runCheckCatname(cat):
+def runCheckCatname(catalog_table_obj):
 
-    checks = {'missing_extraneous': lambda: checkTableMissingEntry(cat),
-             'inconsistent': lambda: checkTableInconsistentEntry(cat),
-             'foreign_key': lambda: checkTableForeignKey(cat),
-             'duplicate': lambda: checkTableDuplicateEntry(cat),
-             'acl': lambda: checkTableACL(cat)}
+    checks = {'missing_extraneous': lambda: checkTableMissingEntry(catalog_table_obj),
+             'inconsistent': lambda: checkTableInconsistentEntry(catalog_table_obj),
+             # We assume that everything is passed as a list to checkForeignKey
+             'foreign_key': lambda:  checkForeignKey([catalog_table_obj]),
+             'duplicate': lambda: checkTableDuplicateEntry(catalog_table_obj),
+             'acl': lambda: checkTableACL(catalog_table_obj)}
 
     for check in sorted(checks):
-        myprint("Performing test '%s' for %s" % (check,cat.getTableName()))
+        myprint("Performing test '%s' for %s" % (check, catalog_table_obj.getTableName()))
         stime = time.time()
         checks[check]()
         etime = time.time()
@@ -3992,14 +3891,14 @@ def getResourceTypeOid(oid):
 def processMissingDuplicateEntryResult(catname, colname, allValues, type):
     # type = {"missing" | "duplicate"}
     '''
-    colname:       proname | pronamespace | proargtypes | exists | segids
-    allValues:         add | 2200 | 23 23 | extra | {2,3}
-                     scube | 2200 | 1700 | missing | {2}
-               scube_accum | 2200 | 1700 1700 | missing | {2}
+    colname:       proname | pronamespace | proargtypes | exists  | segids
+    allValues:         add | 2200         | 23 23       | extra   | {2,3}
+                     scube | 2200         | 1700        | missing | {2}
+               scube_accum | 2200         | 1700 1700   | missing | {2}
 
     colname:        oid | total | segids
-    allValues:    18853 | 2 | {-1,1}
-                  18853 | 3 | {0}
+    allValues:    18853 | 2     | {-1,1}
+                  18853 | 3     | {0}
     '''
     gpObjName = catname
     gpColName = None
@@ -4110,7 +4009,11 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
     gpObjName = pkcatname
     gpColName = colname[-2].rsplit('_', 1)[1]
     fkeytab = catname
-    fkeylist = [name.rsplit('_', 1)[1] for name in colname[:-2]]
+    # The foreign keys are all entries except the last 4
+    # NOTE: We can't assume the first few rows are the expected issues anymore...
+    # or change the query so that we can always assume that the first few
+    # values are the issues...
+    fkeylist = [name.rsplit('_', 1)[1] for name in colname[:-4]]
 
     # This catname may not be a GPObject (e.g. pg_attribute)
     #    1. pg_attrdef(adrelid) referencing pg_attribute(attrelid)
@@ -4123,10 +4026,32 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
     for row in allValues:
         rowObjName = gpObjName
         segids = row[-1]
+
         oid = row[len(colname) - 2]
+        missing_cat = row[-4]
+
+        existing_cat = [pkcatname, fkeytab]
+        existing_cat.remove(missing_cat)
+        existing_cat = existing_cat[0]
+
         # Build fkeys dict: used to find oid of pg_class
-        fkeys = dict((n, row[colname.index(fkeytab + '_' + n)]) for n in fkeylist)
-        issue = CatForeignKeyIssue(pkcatname, {gpColName: oid}, segids, catname, fkeys)
+        fkeys = dict((n, row[colname.index(catname + '_' + n)]) for n in fkeylist)
+
+        # Must get third column from end since fkeylist length can vary
+        if fkeys is None:
+            fkeys = row[-3]
+
+        # We are flipping the values of the primary key and the foreign key
+        # depending on the missing catalog, since we want to print out the
+        # missing catalog at the front of the stderr
+        missing_pkeys={gpColName: oid}
+        existing_fkeys=fkeys
+        if catname == missing_cat:
+            missing_pkeys=fkeys
+            existing_fkeys={gpColName: oid}
+
+        issue = CatForeignKeyIssue(catname=missing_cat, pkeys=missing_pkeys,
+                                   segids=segids, fcatname=existing_cat, fkeys=existing_fkeys)
 
         # Special cases:
         #    1. pg_class(oid) referencing pg_type(oid) - relation & composite type
@@ -4138,7 +4063,6 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
             oid = getResourceTypeOid(oid)
         gpObj = getGPObject(oid, rowObjName)
         gpObj.addForeignKeyIssue(issue)
-
 
 def getPrimaryKeyColumn(catname, pknames):
     # We have to look up key to report (pg_pltemplate)
@@ -4235,12 +4159,8 @@ class CatForeignKeyIssue:
                          (GV.report_cfg[i]['segname'], GV.report_cfg[i]['hostname'],
                           GV.report_cfg[i]['port'])
 
-        if self.fcatname == 'pg_attribute':
-            myprint("        No %s entry for %s column '%s' on %s" \
-                    % (self.catname, self.fcatname, self.fkeys['attname'], idstr))
-        else:
-            myprint("        No %s entry for %s %s on %s" \
-                    % (self.catname, self.fcatname, self.fkeys, idstr))
+        myprint("        No %s %s entry for %s %s on %s" \
+                % (self.catname, self.pkeys, self.fcatname, self.fkeys, idstr))
 
 
 # -------------------------------------------------------------------------------
@@ -4831,8 +4751,8 @@ def main():
         elif GV.opt['-C']:
             namestr = GV.opt['-C']
             try:
-                cat = getCatObj(namestr)
-                runCheckCatname(cat)
+                catalog_table_obj = getCatObj(namestr)
+                runCheckCatname(catalog_table_obj)
             except Exception, e:
                 setError(ERROR_NOREPAIR)
                 sys.exit(GV.retcode)

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2809,8 +2809,8 @@ def checkForeignKey(cat_tables=None):
 
     db_connection = connect2(GV.cfg[1], utilityMode=False)
     try:
-        foreign_key_check = ForeignKeyCheck(db_connection, logger, GV.opt['-S'])
-        foreign_key_issues = foreign_key_check.runCheck(cat_tables, autoCast)
+        foreign_key_check = ForeignKeyCheck(db_connection, logger, GV.opt['-S'], autoCast)
+        foreign_key_issues = foreign_key_check.runCheck(cat_tables)
         if foreign_key_issues:
             GV.checkStatus = False
 
@@ -4001,9 +4001,10 @@ def processInconsistentEntryResult(catname, pknames, colname, allValues):
 # -------------------------------------------------------------------------------
 def processForeignKeyResult(catname, pkcatname, colname, allValues):
     '''
-    colname:    pg_class_relname | pg_class_relnamespace | pg_type_oid | segids
-    allValues:            test11 | 2200 | 17389 | {-1,0,1,2,3}
-                           test4 | 2200 | 17077 | {-1,0,1,2,3}
+    colname:    pg_attribute_attrelid | pg_attribute_attname | missing_catalog | present_key | pg_class_oid | segids
+    allValues:  None                  | None                 | pg_attribute    | oid         | 190683       | {-1}
+    or
+    allValues:  12344                 | foo                  | pg_class        | attrelid    | 190683       | {-1}
     '''
 
     gpObjName = pkcatname
@@ -4011,8 +4012,6 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
     fkeytab = catname
     # The foreign keys are all entries except the last 4
     # NOTE: We can't assume the first few rows are the expected issues anymore...
-    # or change the query so that we can always assume that the first few
-    # values are the issues...
     fkeylist = [name.rsplit('_', 1)[1] for name in colname[:-4]]
 
     # This catname may not be a GPObject (e.g. pg_attribute)
@@ -4030,20 +4029,20 @@ def processForeignKeyResult(catname, pkcatname, colname, allValues):
         oid = row[len(colname) - 2]
         missing_cat = row[-4]
 
-        existing_cat = [pkcatname, fkeytab]
-        existing_cat.remove(missing_cat)
-        existing_cat = existing_cat[0]
-
         # Build fkeys dict: used to find oid of pg_class
         fkeys = dict((n, row[colname.index(catname + '_' + n)]) for n in fkeylist)
 
         # Must get third column from end since fkeylist length can vary
-        if fkeys is None:
+        if not fkeys:
             fkeys = row[-3]
 
         # We are flipping the values of the primary key and the foreign key
         # depending on the missing catalog, since we want to print out the
         # missing catalog at the front of the stderr
+        existing_cat = pkcatname
+        if missing_cat == pkcatname:
+            existing_cat = fkeytab
+
         missing_pkeys={gpColName: oid}
         existing_fkeys=fkeys
         if catname == missing_cat:

--- a/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
@@ -14,14 +14,6 @@ class ForeignKeyCheck:
         self.query_filters['pg_appendonly.relid'] = "(relstorage='a' or relstorage='c')"
         self.query_filters['pg_attribute.attrelid'] = "true"
         self.query_filters["pg_index.indexrelid"] = "(relkind='i')"
-        # NOTE: due to pg_class limitations where some flags (relhaspkey) are maintained lazily (updates are not enforced).
-        # there is no good way to create a one to one mapping between pg_class
-        # and pg_constraint. So, commenting it out for now
-#        self.query_filters['pg_constraint.conrelid'] = "((relchecks>0 or relhaspkey='t') and relkind = 'r')"
-#        self.query_filters['gp_distribution_policy.localoid'] = """(relnamespace not in(select oid from pg_namespace where nspname ~ 'pg_')
-#                                                           and relnamespace not in(select oid from pg_namespace where nspname ~ 'gp_')
-#                                                           and relnamespace!=(select oid from pg_namespace where nspname='information_schema')
-#                                                           and relkind='r' and (relstorage='a' or relstorage='h' or relstorage='c'))"""
 
     def runCheck(self, tables, autoCast):
         foreign_key_issues = dict()

--- a/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+
+from gppylib.gplog import *
+from gppylib.gpcatalog import *
+import re
+
+class ForeignKeyCheck:
+
+    def __init__(self, db_connection, logger, shared_option):
+        self.shared_option = shared_option
+        self.db_connection = db_connection
+        self.logger = logger
+        self.query_filters = dict()
+        self.query_filters['pg_appendonly.relid'] = "(relstorage='a' or relstorage='c')"
+        self.query_filters['pg_attribute.attrelid'] = "true"
+        self.query_filters['pg_constraint.conrelid'] = "((relchecks>0 or relhaspkey='t') and relkind = 'r')"
+#        self.query_filters['gp_distribution_policy.localoid'] = """(relnamespace not in(select oid from pg_namespace where nspname ~ 'pg_')
+#                                                           and relnamespace not in(select oid from pg_namespace where nspname ~ 'gp_')
+#                                                           and relnamespace!=(select oid from pg_namespace where nspname='information_schema')
+#                                                           and relkind='r' and (relstorage='a' or relstorage='h' or relstorage='c'))"""
+        self.query_filters["pg_index.indexrelid"] = "(relkind='i')"
+
+    def runCheck(self, tables, autoCast):
+        foreign_key_issues = dict()
+        for cat in sorted(tables):
+
+            issues = self.checkTableForeignKey(cat, autoCast)
+            if issues:
+                foreign_key_issues[cat.getTableName()] = issues
+
+        return foreign_key_issues
+
+    def checkTableForeignKey(self, cat, autoCast):
+        catname = cat.getTableName()
+        fkeylist = cat.getForeignKeys()
+        isShared = cat.isShared()
+        pkeylist = cat.getPrimaryKey()
+        coltypes = cat.getTableColtypes()
+
+        # skip tables without fkey
+        if len(fkeylist) <= 0:
+            return
+        if len(cat.getPrimaryKey()) <= 0:
+            return
+
+        # skip these master-only tables
+        skipped_masteronly = ['gp_relation_node', 'pg_description',
+                              'pg_shdescription', 'pg_stat_last_operation',
+                              'pg_stat_last_shoperation', 'pg_statistic']
+
+        if catname in skipped_masteronly:
+            return
+
+        # skip shared/non-shared tables
+        if self.shared_option:
+            if re.match("none", self.shared_option, re.I) and isShared:
+                return
+            if re.match("only", self.shared_option, re.I) and not isShared:
+                return
+
+        # primary key lists
+        # cat1.objid as gp_fastsequence_objid
+        cat1_pkeys_column_rename = []
+        pkey_aliases = []
+
+        # build array of catalog primary keys (with aliases) and
+        # primary key alias list
+        for pk in pkeylist:
+            cat1_pkeys_column_rename.append('cat1.' + pk + ' as %s_%s' % (catname, pk))
+            pkey_aliases.append('%s_%s' % (catname, pk))
+
+        self.logger.info('Building %d queries to check FK constraint on table %s' % (len(fkeylist), catname))
+        issue_list = list()
+        for fkeydef in fkeylist:
+            castedFkey = [c + autoCast.get(coltypes[c], '') for c in fkeydef.getColumns()]
+            fkeystr = ', '.join(castedFkey)
+            pkeystr = ', '.join(fkeydef.getPKey())
+            pkcatname = fkeydef.getPkeyTableName()
+
+            # This has to be a result of 1 because foreign key will be a one to
+            # one mapping
+            catname_filter = '%s.%s' % (catname, fkeydef.getColumns()[0])
+
+            if self.query_filters.has_key(catname_filter) and pkcatname == 'pg_class':
+                qry = self.get_fk_query_full_join(catname, pkcatname, fkeystr, pkeystr,
+                                                  pkey_aliases, cat1pkeys=cat1_pkeys_column_rename, filter=self.query_filters[catname_filter])
+            else:
+                qry = self.get_fk_query_left_join(catname, pkcatname, fkeystr, pkeystr, pkey_aliases, cat1_pkeys_column_rename)
+
+            # Execute the query
+            try:
+                curs = self.db_connection.query(qry)
+                nrows = curs.ntuples()
+
+                if nrows == 0:
+                    self.logger.info('[OK] Foreign key check for %s(%s) referencing %s(%s)' %
+                                (catname, fkeystr, pkcatname, pkeystr))
+                else:
+                    self.logger.info('[FAIL] Foreign key check for %s(%s) referencing %s(%s)' %
+                                (catname, fkeystr, pkcatname, pkeystr))
+                    self.logger.error('  %s has %d issue(s): entry has NULL reference of %s(%s)' %
+                                 (catname, nrows, pkcatname, pkeystr))
+
+                    fields = curs.listfields()
+                    log_literal(self.logger, logging.ERROR, "    " + " | ".join(fields))
+                    for row in curs.getresult():
+                        log_literal(self.logger, logging.ERROR, "    " + " | ".join(map(str, row)))
+                    results = curs.getresult()
+                    issue_list.append((pkcatname, fields, results))
+
+            except Exception as e:
+                    err_msg = '[ERROR] executing: Foreign key check for catalog table {0}. Query : \n {1}\n'.format(catname, qry)
+                    err_msg += str(e)
+                    raise Exception(err_msg)
+
+        return issue_list
+
+    # -------------------------------------------------------------------------------
+    def get_fk_query_left_join(self, catname, pkcatname, fkeystr, pkeystr, pkeys, cat1pkeys):
+        qry = """
+              SELECT {primary_key_alias}, missing_catalog, present_key, {cat2_dot_pk},
+                     array_agg(gp_segment_id order by gp_segment_id) as segids
+              FROM (
+                    SELECT (case when cat1.{FK1} is not NULL then '{CATALOG2}' when cat2.{PK2} is not NULL then '{CATALOG1}' end) as missing_catalog,
+                    (case when cat1.{FK1} is not NULL then '{FK1}' when cat2.{PK2} is not NULL then '{PK2}' end) as present_key,
+                    cat1.gp_segment_id, {cat1_dot_pk}, cat1.{FK1} as {cat2_dot_pk}
+                    FROM
+                        gp_dist_random('{CATALOG1}') cat1 LEFT OUTER JOIN
+                        gp_dist_random('{CATALOG2}') cat2
+                        ON (cat1.gp_segment_id = cat2.gp_segment_id AND
+                            cat1.{FK1} = cat2.{PK2} )
+                    WHERE cat2.{PK2} is NULL
+                      AND cat1.{FK1} != 0
+                    UNION ALL
+                    SELECT (case when cat1.{FK1} is not NULL then '{CATALOG2}' when cat2.{PK2} is not NULL then '{CATALOG1}' end) as missing_catalog,
+                    (case when cat1.{FK1} is not NULL then '{FK1}' when cat2.{PK2} is not NULL then '{PK2}' end) as present_key,
+                    -1 as gp_segment_id, {cat1_dot_pk}, cat1.{FK1} as {cat2_dot_pk}
+                    FROM
+                        {CATALOG1} cat1 LEFT OUTER JOIN
+                        {CATALOG2} cat2
+                        ON (cat1.gp_segment_id = cat2.gp_segment_id AND
+                            cat1.{FK1} = cat2.{PK2} )
+                    WHERE cat2.{PK2} is NULL
+                      AND cat1.{FK1} != 0
+                    ORDER BY {primary_key_alias}, gp_segment_id
+              ) allresults
+              GROUP BY {primary_key_alias}, {cat2_dot_pk}, missing_catalog, present_key
+              """.format(FK1=fkeystr,
+                         PK2=pkeystr,
+                         CATALOG1=catname,
+                         CATALOG2=pkcatname,
+                         cat1_dot_pk=', '.join(cat1pkeys),
+                         cat2_dot_pk='%s_%s' % (pkcatname, pkeystr),
+                         primary_key_alias=', '.join(pkeys))
+        return qry
+
+
+    def get_fk_query_full_join(self, catname, pkcatname, fkeystr, pkeystr, pkeys, cat1pkeys, filter):
+        qry = """
+              SELECT {primary_key_alias}, missing_catalog, present_key, {cat2_dot_pk},
+                     array_agg(gp_segment_id order by gp_segment_id) as segids
+              FROM (
+                    SELECT (case when cat1.{FK1} is not NULL then '{CATALOG2}' when cat2.{PK2} is not NULL then '{CATALOG1}' end) as missing_catalog,
+                    (case when cat1.{FK1} is not NULL then '{FK1}' when cat2.{PK2} is not NULL then '{PK2}' end) as present_key,
+                    COALESCE(cat1.gp_segment_id,cat2.gp_segment_id) as gp_segment_id , {cat1_dot_pk}, COALESCE(cat1.{FK1}, cat2.{PK2}) as {cat2_dot_pk}
+                    FROM
+                        gp_dist_random('{CATALOG1}') cat1 FULL OUTER JOIN
+                        gp_dist_random('{CATALOG2}') cat2
+                        ON (cat1.gp_segment_id = cat2.gp_segment_id AND
+                            cat1.{FK1} = cat2.{PK2} )
+                    WHERE (cat2.{PK2} is NULL or cat1.{FK1} is NULL)
+                    AND {filter}
+                    UNION ALL
+                    SELECT (case when cat1.{FK1} is not NULL then '{CATALOG2}' when cat2.{PK2} is not NULL then '{CATALOG1}' end) as missing_catalog,
+                    (case when cat1.{FK1} is not NULL then '{FK1}' when cat2.{PK2} is not NULL then '{PK2}' end) as present_key,
+                    -1, {cat1_dot_pk}, COALESCE(cat1.{FK1}, cat2.{PK2}) as {cat2_dot_pk}
+                    FROM
+                        {CATALOG1} cat1 FULL OUTER JOIN
+                        {CATALOG2} cat2
+                        ON (cat1.gp_segment_id = cat2.gp_segment_id AND
+                            cat1.{FK1} = cat2.{PK2} )
+                    WHERE (cat2.{PK2} is NULL or cat1.{FK1} is NULL)
+                    AND {filter}
+                    ORDER BY {primary_key_alias}, gp_segment_id
+              ) allresults
+              GROUP BY {primary_key_alias}, {cat2_dot_pk}, missing_catalog, present_key
+              """.format(FK1=fkeystr,
+                         PK2=pkeystr,
+                         CATALOG1=catname,
+                         CATALOG2=pkcatname,
+                         cat1_dot_pk=', '.join(cat1pkeys),
+                         cat2_dot_pk='%s_%s' % (pkcatname, pkeystr),
+                         primary_key_alias=', '.join(pkeys),
+                         filter=filter)
+        return qry

--- a/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
@@ -13,12 +13,15 @@ class ForeignKeyCheck:
         self.query_filters = dict()
         self.query_filters['pg_appendonly.relid'] = "(relstorage='a' or relstorage='c')"
         self.query_filters['pg_attribute.attrelid'] = "true"
-        self.query_filters['pg_constraint.conrelid'] = "((relchecks>0 or relhaspkey='t') and relkind = 'r')"
+        self.query_filters["pg_index.indexrelid"] = "(relkind='i')"
+        # NOTE: due to pg_class limitations where some flags (relhaspkey) are maintained lazily (updates are not enforced).
+        # there is no good way to create a one to one mapping between pg_class
+        # and pg_constraint. So, commenting it out for now
+#        self.query_filters['pg_constraint.conrelid'] = "((relchecks>0 or relhaspkey='t') and relkind = 'r')"
 #        self.query_filters['gp_distribution_policy.localoid'] = """(relnamespace not in(select oid from pg_namespace where nspname ~ 'pg_')
 #                                                           and relnamespace not in(select oid from pg_namespace where nspname ~ 'gp_')
 #                                                           and relnamespace!=(select oid from pg_namespace where nspname='information_schema')
 #                                                           and relkind='r' and (relstorage='a' or relstorage='h' or relstorage='c'))"""
-        self.query_filters["pg_index.indexrelid"] = "(relkind='i')"
 
     def runCheck(self, tables, autoCast):
         foreign_key_issues = dict()

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
@@ -39,7 +39,7 @@ Feature: gpcheckcat tests
         Then psql should return a return code of 0
         And psql should not print (0 rows) to stdout
         When the user runs "gpcheckcat unique_index_db"
-        Then gpcheckcat should not return a return code of 0
+        Then gpcheckcat should return a return code of 3
         And gpcheckcat should print Table pg_compression has a violated unique index: pg_compression_compname_index to stdout
         And the user runs "dropdb unique_index_db"
         And verify that a log was created by gpcheckcat in the user's "gpAdminLogs" directory
@@ -213,16 +213,67 @@ Feature: gpcheckcat tests
         Given database "fkey_db" is dropped and recreated
         And the path "gpcheckcat.repair.*" is removed from current working directory
         And there is a "heap" table "gpadmin_tbl" in "fkey_db" with data
-        When the entry for the table "gpadmin_tbl" is removed from "pg_catalog.pg_class" in the database "fkey_db"
-        And the user runs "gpcheckcat -R foreign_key fkey_db"
-        Then gpcheckcat should print No pg_class entry for pg_attribute column to stdout
-        Then the user runs "gpcheckcat -R missing_extraneous -E fkey_db"
+        When the entry for the table "gpadmin_tbl" is removed from "pg_catalog.pg_class" with key "oid" in the database "fkey_db"
+        Then the user runs "gpcheckcat -E -R missing_extraneous fkey_db"
+        And gpcheckcat should print Name of test which found this issue: missing_extraneous_pg_class to stdout
         Then gpcheckcat should return a return code of 1
         Then validate and run gpcheckcat repair
-        Then the user runs "gpcheckcat -R missing_extraneous -E fkey_db"
+        Then the user runs "gpcheckcat -E -R foreign_key fkey_db"
+        Then gpcheckcat should print No pg_class {.*} entry for pg_attribute {.*} to stdout
+        Then gpcheckcat should print No pg_class {.*} entry for pg_type {.*} to stdout
+        Then gpcheckcat should print No pg_class {.*} entry for gp_distribution_policy {.*} to stdout
+        Then gpcheckcat should return a return code of 3
+        Then the user runs "gpcheckcat -E -R missing_extraneous fkey_db"
         Then gpcheckcat should return a return code of 0
         Then the path "gpcheckcat.repair.*" is found in cwd "0" times
         And the user runs "dropdb fkey_db"
+
+    @foreignkey_full_segment
+    Scenario Outline: gpcheckcat foreign key check should report missing catalog entries for segments. Also test missing_extraneous for the same case.
+        Given database "fkey_ta" is dropped and recreated
+        And the path "gpcheckcat.repair.*" is removed from current working directory
+        And the user creates an index for table "index_table" in database "fkey_ta"
+        And there is a "ao" table "ao_table" in "fkey_ta" with data
+        When the entry for the table "<table_name>" is removed from "pg_catalog.<catalog_name>" with key "<catalog_oid_key>" in the database "fkey_ta" on the first primary segment
+        Then the user runs "gpcheckcat -E -R foreign_key fkey_ta"
+        Then gpcheckcat should print No <catalog_name> {.*} entry for pg_class {.*} to stdout
+        Then gpcheckcat should return a return code of 3
+        And the user runs "dropdb fkey_ta"
+        Examples:
+          | catalog_name                | catalog_oid_key | table_name |
+          | pg_attribute                | attrelid        | index_table |
+          | pg_index                    | indrelid        | index_table |
+          | pg_constraint               | conrelid        | index_table |
+          | pg_appendonly               | relid           | ao_table   |
+
+    @foreignkey_full_master
+    Scenario Outline: gpcheckcat foreign key check should report missing catalog entries. Also test missing_extraneous for the same case.
+        Given database "fkey_ta" is dropped and recreated
+        And the path "gpcheckcat.repair.*" is removed from current working directory
+        And the user creates an index for table "index_table" in database "fkey_ta"
+        And there is a "ao" table "ao_table" in "fkey_ta" with data
+        When the entry for the table "<table_name>" is removed from "pg_catalog.<catalog_name>" with key "<catalog_oid_key>" in the database "fkey_ta"
+        Then the user runs "gpcheckcat -E -R foreign_key fkey_ta"
+        Then gpcheckcat should print No <catalog_name> {.*} entry for pg_class {.*} to stdout
+        Then gpcheckcat should return a return code of 3
+        And the user runs "dropdb fkey_ta"
+        Examples:
+          | catalog_name                | catalog_oid_key | table_name |
+          | pg_attribute                | attrelid        | index_table |
+          | pg_index                    | indrelid        | index_table |
+          | pg_constraint               | conrelid        | index_table |
+          | pg_appendonly               | relid           | ao_table   |
+
+    @foreignkey_type
+    Scenario: gpcheckcat foreign key check should report missing catalog entries. Also test missing_extraneous for the same case.
+        Given database "fkey_ta" is dropped and recreated
+        And the path "gpcheckcat.repair.*" is removed from current working directory
+        And there is a "heap" table "gpadmin_tbl" in "fkey_ta" with data
+        When the entry for the table "gpadmin_tbl" is removed from "pg_catalog.pg_type" with key "typrelid" in the database "fkey_ta"
+        Then the user runs "gpcheckcat -E -R foreign_key fkey_ta"
+        Then gpcheckcat should print No pg_type {.*} entry for pg_class {.*} to stdout
+        Then gpcheckcat should return a return code of 3
+        And the user runs "dropdb fkey_ta"
 
     @extra
     Scenario: gpcheckcat should report and repair extra entries in master as well as all the segments
@@ -243,7 +294,7 @@ Feature: gpcheckcat tests
         And the user runs "dropdb extra_db"
         And the path "gpcheckcat.repair.*" is removed from current working directory
 
-    @foreignkey2
+    @foreignkey_gp_fastsequence
     Scenario: gpcheckcat should report inconsistency between gp_fastsequence and pg_class
         Given database "fkey2_db" is dropped and recreated
         And the path "gpcheckcat.repair.*" is removed from current working directory
@@ -251,10 +302,11 @@ Feature: gpcheckcat tests
         And the user runs sql file "gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/create_inconsistent_gpfastsequence.sql" in "fkey2_db" on all the segments
         Then the user runs "gpcheckcat fkey2_db"
         Then gpcheckcat should return a return code of 3
+        Then gpcheckcat should print No pg_class {.*} entry for gp_fastsequence {.*} to stdout
         Then validate and run gpcheckcat repair
-        When the user runs "gpcheckcat fkey2_db"
+        Then the user runs "gpcheckcat -R foreign_key fkey2_db"
+        Then gpcheckcat should not print No pg_class {.*} entry for gp_fastsequence {.*} to stdout
         Then gpcheckcat should return a return code of 3
-        Then the path "gpcheckcat.repair.*" is found in cwd "0" times
         And the user runs "dropdb fkey2_db"
         And the path "gpcheckcat.repair.*" is removed from current working directory
 

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gpcheckcat.feature
@@ -243,7 +243,6 @@ Feature: gpcheckcat tests
           | catalog_name                | catalog_oid_key | table_name |
           | pg_attribute                | attrelid        | index_table |
           | pg_index                    | indrelid        | index_table |
-          | pg_constraint               | conrelid        | index_table |
           | pg_appendonly               | relid           | ao_table   |
 
     @foreignkey_full_master
@@ -261,7 +260,6 @@ Feature: gpcheckcat tests
           | catalog_name                | catalog_oid_key | table_name |
           | pg_attribute                | attrelid        | index_table |
           | pg_index                    | indrelid        | index_table |
-          | pg_constraint               | conrelid        | index_table |
           | pg_appendonly               | relid           | ao_table   |
 
     @foreignkey_type

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3863,12 +3863,21 @@ def impl(context, dir):
     run_command(context, command)
 
 
-@when('the entry for the table "{user_table}" is removed from "{catalog_table}" in the database "{db_name}"')
-def impl(context, user_table, catalog_table, db_name):
-    delete_qry = "delete from %s where relname='%s';" % (catalog_table, user_table)
-
+@when('the entry for the table "{user_table}" is removed from "{catalog_table}" with key "{primary_key}" in the database "{db_name}"')
+def impl(context, user_table, catalog_table, primary_key, db_name):
+    delete_qry = "delete from %s where %s='%s'::regclass::oid;" % (catalog_table, primary_key, user_table)
     with dbconn.connect(dbconn.DbURL(dbname=db_name)) as conn:
         for qry in ["set allow_system_table_mods='dml';", "set allow_segment_dml=true;", delete_qry]:
+            dbconn.execSQL(conn, qry)
+            conn.commit()
+
+@when('the entry for the table "{user_table}" is removed from "{catalog_table}" with key "{primary_key}" in the database "{db_name}" on the first primary segment')
+def impl(context, user_table, catalog_table, primary_key, db_name):
+    host, port = get_primary_segment_host_port()
+    delete_qry = "delete from %s where %s='%s'::regclass::oid;" % (catalog_table, primary_key, user_table)
+
+    with dbconn.connect(dbconn.DbURL(dbname=db_name, port=port, hostname=host), utility=True, allowSystemTableMods='dml') as conn:
+        for qry in [delete_qry]:
             dbconn.execSQL(conn, qry)
             conn.commit()
 
@@ -3944,3 +3953,13 @@ def impl(context, seg):
         context.mirror_segdbname = mirror_segs[0].getSegmentHostName()
         context.mirror_datadir = mirror_segs[0].getSegmentDataDirectory()
         context.mirror_port = mirror_segs[0].getSegmentPort()
+
+@given('the user creates an index for table "{table_name}" in database "{db_name}"')
+@when('the user creates an index for table "{table_name}" in database "{db_name}"')
+@then('the user creates an index for table "{table_name}" in database "{db_name}"')
+def impl(context, table_name, db_name):
+    index_qry = "create table {0}(i int primary key, j varchar); create index test_index on index_table using bitmap(j)".format(table_name)
+
+    with dbconn.connect(dbconn.DbURL(dbname=db_name)) as conn:
+        dbconn.execSQL(conn, index_qry)
+        conn.commit()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_foreign_key_check.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_foreign_key_check.py
@@ -112,7 +112,7 @@ class GpCheckCatTestCase(GpTestCase):
     @patch('gpcheckcat_modules.foreign_key_check.log_literal')
     def test_checkTableForeignKey__returns_correct_join_query(self, log_literal_mock, fk_query_left_join_mock, fk_query_full_join_mock):
         #cat_tables_to_validate = set(['pg_attribute','gp_distribution_policy','pg_appendonly','pg_constraint','pg_index','pg_type','pg_window'])
-        cat_tables_to_validate = set(['pg_attribute', 'pg_appendonly','pg_constraint','pg_index','pg_type','pg_window'])
+        cat_tables_to_validate = set(['pg_attribute', 'pg_appendonly', 'pg_index','pg_type','pg_window'])
 
         foreign_key_mock_calls = []
         foreign_key_mock_calls_left = []

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_foreign_key_check.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_foreign_key_check.py
@@ -1,0 +1,245 @@
+import imp
+import os
+import sys
+from gpcheckcat_modules.foreign_key_check import ForeignKeyCheck
+
+from mock import *
+
+from gp_unittest import *
+
+
+class GpCheckCatTestCase(GpTestCase):
+    def setUp(self):
+        self.logger = Mock(spec=['log', 'info', 'debug', 'error'])
+        self.db_connection = Mock(spec=['close', 'query'])
+        self.subject = ForeignKeyCheck(self.db_connection, self.logger, False)
+
+        self.full_join_cat_tables = set(['pg_attribute','gp_distribution_policy','pg_appendonly','pg_constraint','pg_index'])
+        self.foreign_key_check= Mock(spec=['runCheck'])
+        self.foreign_key_check.runCheck.return_value = []
+        self.autoCast = {'regproc': '::oid',
+                         'regprocedure': '::oid',
+                         'regoper': '::oid',
+                         'regoperator': '::oid',
+                         'regclass': '::oid',
+                         'regtype': '::oid',
+                         'int2vector': '::int2[]'}
+        self.db_connection.query.return_value.ntuples.return_value = 2
+        self.db_connection.query.return_value.listfields.return_value = ['pkey1', 'pkey2']
+        self.db_connection.query.return_value.getresult.return_value = [('r1','r2'), ('r3','r4')]
+
+
+    def test_get_fk_query_left_join_returns_the_correct_query(self):
+        expected_query = """
+              SELECT pkeys-1, pkeys-2, missing_catalog, present_key, pkcatname_pkeystr,
+                     array_agg(gp_segment_id order by gp_segment_id) as segids
+              FROM (
+                    SELECT (case when cat1.fkeystr is not NULL then 'pkcatname' when cat2.pkeystr is not NULL then 'catname' end) as missing_catalog,
+                    (case when cat1.fkeystr is not NULL then 'fkeystr' when cat2.pkeystr is not NULL then 'pkeystr' end) as present_key,
+                    cat1.gp_segment_id, cat1pkeys-1, cat1pkeys-2, cat1.fkeystr as pkcatname_pkeystr
+                    FROM
+                        gp_dist_random('catname') cat1 LEFT OUTER JOIN
+                        gp_dist_random('pkcatname') cat2
+                        ON (cat1.gp_segment_id = cat2.gp_segment_id AND
+                            cat1.fkeystr = cat2.pkeystr )
+                    WHERE cat2.pkeystr is NULL
+                      AND cat1.fkeystr != 0
+                    UNION ALL
+                    SELECT (case when cat1.fkeystr is not NULL then 'pkcatname' when cat2.pkeystr is not NULL then 'catname' end) as missing_catalog,
+                    (case when cat1.fkeystr is not NULL then 'fkeystr' when cat2.pkeystr is not NULL then 'pkeystr' end) as present_key,
+                    -1 as gp_segment_id, cat1pkeys-1, cat1pkeys-2, cat1.fkeystr as pkcatname_pkeystr
+                    FROM
+                        catname cat1 LEFT OUTER JOIN
+                        pkcatname cat2
+                        ON (cat1.gp_segment_id = cat2.gp_segment_id AND
+                            cat1.fkeystr = cat2.pkeystr )
+                    WHERE cat2.pkeystr is NULL
+                      AND cat1.fkeystr != 0
+                    ORDER BY pkeys-1, pkeys-2, gp_segment_id
+              ) allresults
+              GROUP BY pkeys-1, pkeys-2, pkcatname_pkeystr, missing_catalog, present_key
+              """
+
+        result_query = self.subject.get_fk_query_left_join("catname", "pkcatname", "fkeystr", "pkeystr", ["pkeys-1", "pkeys-2"], ["cat1pkeys-1", "cat1pkeys-2"])
+        self.assertEquals(expected_query, result_query)
+
+    def test_get_fk_query_full_join_returns_the_correct_query(self):
+        expected_query = """
+              SELECT pkeys-1, pkeys-2, missing_catalog, present_key, pkcatname_pkeystr,
+                     array_agg(gp_segment_id order by gp_segment_id) as segids
+              FROM (
+                    SELECT (case when cat1.fkeystr is not NULL then 'pkcatname' when cat2.pkeystr is not NULL then 'catname' end) as missing_catalog,
+                    (case when cat1.fkeystr is not NULL then 'fkeystr' when cat2.pkeystr is not NULL then 'pkeystr' end) as present_key,
+                    COALESCE(cat1.gp_segment_id,cat2.gp_segment_id) as gp_segment_id , cat1pkeys-1, cat1pkeys-2, COALESCE(cat1.fkeystr, cat2.pkeystr) as pkcatname_pkeystr
+                    FROM
+                        gp_dist_random('catname') cat1 FULL OUTER JOIN
+                        gp_dist_random('pkcatname') cat2
+                        ON (cat1.gp_segment_id = cat2.gp_segment_id AND
+                            cat1.fkeystr = cat2.pkeystr )
+                    WHERE (cat2.pkeystr is NULL or cat1.fkeystr is NULL)
+                    AND filter
+                    UNION ALL
+                    SELECT (case when cat1.fkeystr is not NULL then 'pkcatname' when cat2.pkeystr is not NULL then 'catname' end) as missing_catalog,
+                    (case when cat1.fkeystr is not NULL then 'fkeystr' when cat2.pkeystr is not NULL then 'pkeystr' end) as present_key,
+                    -1, cat1pkeys-1, cat1pkeys-2, COALESCE(cat1.fkeystr, cat2.pkeystr) as pkcatname_pkeystr
+                    FROM
+                        catname cat1 FULL OUTER JOIN
+                        pkcatname cat2
+                        ON (cat1.gp_segment_id = cat2.gp_segment_id AND
+                            cat1.fkeystr = cat2.pkeystr )
+                    WHERE (cat2.pkeystr is NULL or cat1.fkeystr is NULL)
+                    AND filter
+                    ORDER BY pkeys-1, pkeys-2, gp_segment_id
+              ) allresults
+              GROUP BY pkeys-1, pkeys-2, pkcatname_pkeystr, missing_catalog, present_key
+              """
+        result_query = self.subject.get_fk_query_full_join("catname", "pkcatname", "fkeystr", "pkeystr", ["pkeys-1", "pkeys-2"], ["cat1pkeys-1", "cat1pkeys-2"], "filter")
+        self.assertEquals(expected_query, result_query)
+
+    @patch('gpcheckcat_modules.foreign_key_check.ForeignKeyCheck.checkTableForeignKey')
+    def test_runCheck(self, mock):
+        tables = [self._get_mock_for_catalog_table("table1"), self._get_mock_for_catalog_table("table2")]
+        self.subject.runCheck(tables, None)
+        # self.subject.checkTableForeignKey.return_value = Mock()
+
+        self.assertEquals(len(self.subject.checkTableForeignKey.call_args_list), len(tables))
+
+        for table in tables:
+            self.assertIn(call(table, None), self.subject.checkTableForeignKey.call_args_list)
+
+    @patch('gpcheckcat_modules.foreign_key_check.ForeignKeyCheck.get_fk_query_full_join')
+    @patch('gpcheckcat_modules.foreign_key_check.ForeignKeyCheck.get_fk_query_left_join')
+    @patch('gpcheckcat_modules.foreign_key_check.log_literal')
+    def test_checkTableForeignKey__returns_correct_join_query(self, log_literal_mock, fk_query_left_join_mock, fk_query_full_join_mock):
+        #cat_tables_to_validate = set(['pg_attribute','gp_distribution_policy','pg_appendonly','pg_constraint','pg_index','pg_type','pg_window'])
+        cat_tables_to_validate = set(['pg_attribute', 'pg_appendonly','pg_constraint','pg_index','pg_type','pg_window'])
+
+        foreign_key_mock_calls = []
+        foreign_key_mock_calls_left = []
+        for table_name in cat_tables_to_validate:
+            foreign_key_mock_1  = self._get_mock_for_foreign_key(pkey_tablename="pg_class", cat_table_name=table_name)
+            foreign_key_mock_2 = self._get_mock_for_foreign_key(pkey_tablename="arbitrary_catalog_table", cat_table_name=table_name)
+            catalog_table_mock = self._get_mock_for_catalog_table(table_name, [foreign_key_mock_1, foreign_key_mock_2])
+            col_type = self._get_col_types(table_name)
+
+            issue_list = self.subject.checkTableForeignKey(catalog_table_mock, self.autoCast)
+
+            self.assertEquals(len(issue_list) , 2)
+            self.assertEquals(issue_list[0], ('pg_class', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')]))
+            self.assertEquals(issue_list[1], ('arbitrary_catalog_table', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')]))
+            self.assertEquals(self.db_connection.query.call_count, 2)
+
+            def __generate_pg_class_call(table, primary_key_cat_name, col_type, with_filter=True):
+                if with_filter:
+                    return call(table_name, '%s' % primary_key_cat_name, '%s' % col_type.keys()[0], 'oid',
+                                ['%s_pkey1' % (table_name), '%s_pkey2' % (table_name)],
+                                filter=self._get_filter(table_name),
+                                cat1pkeys=['cat1.pkey1 as %s_pkey1' % (table_name),
+                                        'cat1.pkey2 as %s_pkey2' % (table_name)])
+                else:
+                    return call(table_name, '%s' % primary_key_cat_name, '%s' % col_type.keys()[0], 'oid',
+                                ['%s_pkey1' % (table_name), '%s_pkey2' % (table_name)],
+                                ['cat1.pkey1 as %s_pkey1' % (table_name),
+                                 'cat1.pkey2 as %s_pkey2' % (table_name)])
+
+            # make sure that the correct pg_class_call is used depending on the
+            # foreign key
+            # XXX: if we know that it's the fake catalog, then we can assume
+            # that it will do a left join... we need to figure that out
+            if table_name in self.full_join_cat_tables:
+                pg_class_call = __generate_pg_class_call(table_name, 'pg_class', col_type, with_filter=True)
+                foreign_key_mock_calls.append(pg_class_call)
+
+                pg_class_call = __generate_pg_class_call(table_name, 'arbitrary_catalog_table', col_type, with_filter=False)
+                foreign_key_mock_calls_left.append(pg_class_call)
+            else:
+                pg_class_call = __generate_pg_class_call(table_name, 'pg_class', col_type, with_filter=False)
+                foreign_key_mock_calls_left.append(pg_class_call)
+
+            if table_name in self.full_join_cat_tables:
+                self.assertEquals(fk_query_full_join_mock.call_count, 1)
+                self.assertEquals(fk_query_left_join_mock.call_count, 1)
+                fk_query_full_join_mock.assert_has_calls(foreign_key_mock_calls, any_order=False)
+            else:
+                arbitrary_catalog_table_call = __generate_pg_class_call(table_name, 'arbitrary_catalog_table', col_type, with_filter=False)
+                foreign_key_mock_calls_left.append(arbitrary_catalog_table_call)
+
+                self.assertEquals(fk_query_left_join_mock.call_count, 2)
+                self.assertEquals(fk_query_full_join_mock.call_count, 0)
+                fk_query_left_join_mock.assert_has_calls(foreign_key_mock_calls_left, any_order=False)
+
+            self.db_connection.query.call_count = 0
+            fk_query_full_join_mock.call_count = 0
+            fk_query_left_join_mock.call_count = 0
+
+    ####################### PRIVATE METHODS #######################
+    def _get_filter(self, table_name):
+        query_filters = {}
+        query_filters['pg_appendonly'] = "(relstorage='a' or relstorage='c')"
+        query_filters['pg_attribute'] = "true"
+        query_filters['pg_constraint'] = "((relchecks>0 or relhaspkey='t') and relkind = 'r')"
+        query_filters['gp_distribution_policy'] = """(relnamespace not in(select oid from pg_namespace where nspname ~ 'pg_')
+                                                           and relnamespace not in(select oid from pg_namespace where nspname ~ 'gp_')
+                                                           and relnamespace!=(select oid from pg_namespace where nspname='information_schema')
+                                                           and relkind='r' and (relstorage='a' or relstorage='h' or relstorage='c'))"""
+        query_filters["pg_index"] = "(relkind='i')"
+        if table_name in query_filters:
+            return query_filters[table_name]
+        else:
+            return []
+
+    def _get_col_types(self, table_name):
+        table_col_types = {'pg_attribute': {'attlen': 'int2', 'atthasdef': 'bool', 'attndims': 'int4',
+                                            'attnum': 'int2', 'attname': 'name', 'attalign': 'char',
+                                            'attnotnull': 'bool', 'atttypid': 'oid', 'attrelid': 'oid',
+                                            'attinhcount': 'int4', 'attcacheoff': 'int4',
+                                            'attislocal': 'bool', 'attstattarget': 'int4',
+                                            'attstorage': 'char', 'attbyval': 'bool',
+                                            'atttypmod': 'int4', 'attisdropped': 'bool'},
+                           'pg_appendonly': {'relid': 'oid'},
+                           'pg_attribute': {'attrelid': 'oid'},
+                           'pg_constraint': {'conrelid': 'oid'},
+                           'pg_index': {'indexrelid': 'oid'},
+                           'gp_distribution_policy': {}
+                          }
+
+        if table_name not in table_col_types.keys():
+            table_name = 'pg_attribute'
+
+        return table_col_types[table_name]
+
+    def _get_mock_for_catalog_table(self, table_name, foreign_keys=None):
+        catalog_table_mock = Mock(spec=['getTableName','isShared','getForeignKeys','getPrimaryKey','getTableColtypes'])
+
+        catalog_table_mock.getTableName.return_value = table_name
+        catalog_table_mock.isShared.return_value = True
+        catalog_table_mock.getForeignKeys.return_value = foreign_keys
+        catalog_table_mock.getPrimaryKey.return_value = ["pkey1", "pkey2"]
+        catalog_table_mock.getTableColtypes.return_value = self._get_col_types(table_name)
+
+        return catalog_table_mock
+
+    def _get_mock_for_foreign_key(self, pkey_tablename, cat_table_name):
+
+        spec_list = ['getPKey', 'getPkeyTableName', 'getColumns']
+
+        filter_mapping = {'pg_appendonly': ['relid'],
+                          'pg_attribute': ['attrelid'],
+                          'pg_constraint': ['conrelid'],
+                          'pg_index': ['indexrelid'],
+                          'gp_distribution_policy': []
+                          }
+
+        attribute_foreign_key_mock = Mock(spec=spec_list)
+        attribute_foreign_key_mock.getPKey.return_value = ['oid']
+        attribute_foreign_key_mock.getPkeyTableName.return_value = pkey_tablename
+        query_filter = ['attrelid']
+        if cat_table_name in filter_mapping:
+            query_filter =  filter_mapping[cat_table_name]
+        attribute_foreign_key_mock.getColumns.return_value = query_filter
+
+        return attribute_foreign_key_mock
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -233,9 +233,10 @@ class GpCheckCatTestCase(GpTestCase):
     @patch('gpcheckcat.checkTableMissingEntry')
     def test_runCheckCatname__for_checkForeignKey(self, mock1, mock2, mock3):
         self.subject.checkForeignKey = Mock()
-        cat_table_obj = Mock()
-        mock3.getCatalogTable = cat_table_obj
-        self.subject.getCatObj = cat_table_obj
+        gpcat_class_mock = Mock(spec=['getCatalogTable'])
+        cat_obj_mock = Mock()
+        self.subject.getCatObj = gpcat_class_mock
+        self.subject.getCatObj.return_value = cat_obj_mock
         primaries = [dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=-1, dbid=0, isprimary='t')]
 
         for i in range(1, 50):
@@ -250,7 +251,7 @@ class GpCheckCatTestCase(GpTestCase):
             self.subject.main()
 
         self.subject.getCatObj.assert_called_once_with(' pg_class')
-        self.subject.checkForeignKey.assert_called_once_with(cat_table_obj)
+        self.subject.checkForeignKey.assert_called_once_with([cat_obj_mock])
 
     ####################### PRIVATE METHODS #######################
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -196,7 +196,7 @@ class GpCheckCatTestCase(GpTestCase):
         self.assertFalse(self.subject.GV.checkStatus)
         self.assertTrue(self.subject.GV.foreignKeyStatus)
         self.subject.setError.assert_any_call(self.subject.ERROR_REMOVE)
-        self.foreign_key_check.runCheck.assert_called_once_with(cat_tables, ANY)
+        self.foreign_key_check.runCheck.assert_called_once_with(cat_tables)
         fast_seq_mock.assert_called_once_with(self.db_connection)
 
     @patch('gpcheckcat.processForeignKeyResult')
@@ -211,7 +211,7 @@ class GpCheckCatTestCase(GpTestCase):
         self.assertFalse(self.subject.GV.checkStatus)
         self.assertTrue(self.subject.GV.foreignKeyStatus)
         self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
-        self.foreign_key_check.runCheck.assert_called_once_with(cat_tables, ANY)
+        self.foreign_key_check.runCheck.assert_called_once_with(cat_tables)
 
     @patch('gpcheckcat.processForeignKeyResult')
     def test_checkForeignKey__no_arg(self, process_foreign_key_mock):
@@ -225,7 +225,7 @@ class GpCheckCatTestCase(GpTestCase):
         self.assertFalse(self.subject.GV.checkStatus)
         self.assertTrue(self.subject.GV.foreignKeyStatus)
         self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
-        self.foreign_key_check.runCheck.assert_called_once_with(cat_tables, ANY)
+        self.foreign_key_check.runCheck.assert_called_once_with(cat_tables)
 
     # Test gpcheckat -C option with checkForeignKey
     @patch('gpcheckcat.GPCatalog', return_value=Mock())
@@ -234,7 +234,8 @@ class GpCheckCatTestCase(GpTestCase):
     def test_runCheckCatname__for_checkForeignKey(self, mock1, mock2, mock3):
         self.subject.checkForeignKey = Mock()
         cat_table_obj = Mock()
-        self.subject.getCatObj = Mock()
+        mock3.getCatalogTable = cat_table_obj
+        self.subject.getCatObj = cat_table_obj
         primaries = [dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=-1, dbid=0, isprimary='t')]
 
         for i in range(1, 50):
@@ -244,12 +245,12 @@ class GpCheckCatTestCase(GpTestCase):
 
         self.subject.GV.opt['-C'] = 'pg_class'
 
-        testargs = ['gpcrondump', '-port 1', '-C pg_class']
+        testargs = ['gpcheckcat', '-port 1', '-C pg_class']
         with patch.object(sys, 'argv', testargs):
             self.subject.main()
 
-        self.assertEqual(self.subject.getCatObj.call_count, 1)
-        self.assertEqual(self.subject.checkForeignKey.call_count, 1)
+        self.subject.getCatObj.assert_called_once_with(' pg_class')
+        self.subject.checkForeignKey.assert_called_once_with(cat_table_obj)
 
     ####################### PRIVATE METHODS #######################
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -25,18 +25,25 @@ class GpCheckCatTestCase(GpTestCase):
         self.leaked_schema_dropper = Mock(spec=['drop_leaked_schemas'])
         self.leaked_schema_dropper.drop_leaked_schemas.return_value = []
 
-        # MagicMock: we are choosing to trust the implementation of GV.cfg
-        # If we wanted full coverage we would make this a normal Mock()
-        # and fully define its behavior
+        self.foreign_key_check = Mock(spec=['runCheck', 'checkTableForeignKey'])
+        issues_list = dict()
+        issues_list['cat1'] = [('pg_class', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')]),
+                              ('arbitrary_catalog_table', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')])]
+        issues_list['cat2'] = [('pg_type', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')]),
+                               ('arbitrary_catalog_table', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')])]
+        self.foreign_key_check.runCheck.return_value = issues_list
+
         self.subject.GV.cfg = {0:dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=-1, dbid=0),
                                1:dict(hostname='host1', port=123, id=1, address='123', datadir='dir', content=1, dbid=1)}
         self.subject.GV.checkStatus = True
+        self.subject.GV.foreignKeyStatus = True
         self.subject.setError = Mock()
         self.subject.print_repair_issues = Mock()
 
         self.apply_patches([
             patch("gpcheckcat.pg.connect", return_value=self.db_connection),
             patch("gpcheckcat.UniqueIndexViolationCheck", return_value=self.unique_index_violation_check),
+            patch("gpcheckcat.ForeignKeyCheck", return_value=self.foreign_key_check),
         ])
 
     def test_running_unknown_check__raises_exception(self):
@@ -169,7 +176,83 @@ class GpCheckCatTestCase(GpTestCase):
         self.subject.setError.assert_any_call(self.subject.ERROR_REMOVE)
         self.subject.print_repair_issues.assert_any_call("/tmp")
 
+    @patch('gpcheckcat.removeFastSequence')
+    @patch('gpcheckcat.processForeignKeyResult')
+    def test_checkForeignKey__with_arg_gp_fastsequence(self, process_foreign_key_mock,fast_seq_mock):
+        cat_mock = Mock()
+        self.subject.GV.catalog = cat_mock
+
+        gp_fastsequence_issue = dict()
+        gp_fastsequence_issue['gp_fastsequence'] = [('pg_class', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')]),
+                               ('arbitrary_catalog_table', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')])]
+        gp_fastsequence_issue['cat2'] = [('pg_type', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')]),
+                               ('arbitrary_catalog_table', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')])]
+        self.foreign_key_check.runCheck.return_value = gp_fastsequence_issue
+
+        cat_tables = ["input1", "input2"]
+        self.subject.checkForeignKey(cat_tables)
+
+        self.assertEquals(cat_mock.getCatalogTables.call_count, 0)
+        self.assertFalse(self.subject.GV.checkStatus)
+        self.assertTrue(self.subject.GV.foreignKeyStatus)
+        self.subject.setError.assert_any_call(self.subject.ERROR_REMOVE)
+        self.foreign_key_check.runCheck.assert_called_once_with(cat_tables, ANY)
+        fast_seq_mock.assert_called_once_with(self.db_connection)
+
+    @patch('gpcheckcat.processForeignKeyResult')
+    def test_checkForeignKey__with_arg(self, process_foreign_key_mock):
+        cat_mock = Mock()
+        self.subject.GV.catalog = cat_mock
+
+        cat_tables = ["input1", "input2"]
+        self.subject.checkForeignKey(cat_tables)
+
+        self.assertEquals(cat_mock.getCatalogTables.call_count, 0)
+        self.assertFalse(self.subject.GV.checkStatus)
+        self.assertTrue(self.subject.GV.foreignKeyStatus)
+        self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
+        self.foreign_key_check.runCheck.assert_called_once_with(cat_tables, ANY)
+
+    @patch('gpcheckcat.processForeignKeyResult')
+    def test_checkForeignKey__no_arg(self, process_foreign_key_mock):
+        cat_mock = Mock(spec=['getCatalogTables'])
+        cat_tables = ["input1", "input2"]
+        cat_mock.getCatalogTables.return_value = cat_tables
+        self.subject.GV.catalog = cat_mock
+
+        self.subject.checkForeignKey()
+        self.assertEquals(cat_mock.getCatalogTables.call_count, 1)
+        self.assertFalse(self.subject.GV.checkStatus)
+        self.assertTrue(self.subject.GV.foreignKeyStatus)
+        self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
+        self.foreign_key_check.runCheck.assert_called_once_with(cat_tables, ANY)
+
+    # Test gpcheckat -C option with checkForeignKey
+    @patch('gpcheckcat.GPCatalog', return_value=Mock())
+    @patch('sys.exit')
+    @patch('gpcheckcat.checkTableMissingEntry')
+    def test_runCheckCatname__for_checkForeignKey(self, mock1, mock2, mock3):
+        self.subject.checkForeignKey = Mock()
+        cat_table_obj = Mock()
+        self.subject.getCatObj = Mock()
+        primaries = [dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=-1, dbid=0, isprimary='t')]
+
+        for i in range(1, 50):
+            primaries.append(dict(hostname='host0', port=123, id=1, address='123', datadir='dir', content=1, dbid=i, isprimary='t'))
+        self.db_connection.query.return_value.getresult.return_value = [['4.3']]
+        self.db_connection.query.return_value.dictresult.return_value = primaries
+
+        self.subject.GV.opt['-C'] = 'pg_class'
+
+        testargs = ['gpcrondump', '-port 1', '-C pg_class']
+        with patch.object(sys, 'argv', testargs):
+            self.subject.main()
+
+        self.assertEqual(self.subject.getCatObj.call_count, 1)
+        self.assertEqual(self.subject.checkForeignKey.call_count, 1)
+
     ####################### PRIVATE METHODS #######################
+
     def _run_batch_size_experiment(self, num_primaries):
         BATCH_SIZE = 4
         self.subject.GV.opt['-B'] = BATCH_SIZE


### PR DESCRIPTION
We will now do a bidirectional check for the following
catalogs with foreign key check with pg_class:
    pg_attribute, pg_index, pg_constraints, and pg_appendonly

This is accomplished by doing a full join based on the foreign keys and
primary keys between pg_class and a catalog mentioned above. Once
detected, we will now output missing catalog infront of our stderr.

* Add unit test for foreign_key check in gpcheckcat

* update the behave test to account for gpcheckcat creating a repair for foreign_key.

* Add new module for foreign key check in gpcheckcat
* get unittest in a working state
* refactor unit test to be "smaller"

Update behave and unit test for gpcheckcat foreign_key_check:

* We are keeping gp_distribution_policy to be checked as part of the
  left join instead of skipping it all together just because it's a
  master only catalog table.
* Add behave test that deletes from segments instead of master for
  foreign key check
* Fix unit test to be able to mock out the full and left join queries
  for forign key check

Add unit test for gpcheck -C option

Authors: Nikhil Kak, Chris Hajas, Chumki Roy, and Marbin Tan