### PR TITLE
Fix translator to show missing message from exception and change elog::ERROR to elog::WARNING

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -375,7 +375,8 @@ COptTasks::SzAllocate
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		elog(ERROR, "no available memory to allocate string buffer");
+		elog(WARNING, "no available memory to allocate string buffer");
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiWarningAsError);
 	}
 	GPOS_CATCH_END;
 
@@ -1890,8 +1891,9 @@ COptTasks::UlCmpt
 			return rgcmpt[ul];
 		}
 	}
-	
-	elog(ERROR, "Invalid comparison type code. Valid values are Eq, NEq, LT, LEq, GT, GEq");
+
+	elog(WARNING, "Invalid comparison type code. Valid values are Eq, NEq, LT, LEq, GT, GEq");
+	GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiWarningAsError);
 	return CmptOther;
 }
 

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -565,7 +565,21 @@ COptTasks::Execute
 	params.abort_requested = &abort_flag;
 
 	// execute task and send log message to server log
-	(void) gpos_exec(&params);
+	GPOS_TRY
+	{
+		(void) gpos_exec(&params);
+	}
+	GPOS_CATCH_EX(ex)
+	{
+		LogErrorAndDelete(err_buf);
+		GPOS_RETHROW(ex);
+	}
+	GPOS_CATCH_END;
+	LogErrorAndDelete(err_buf);
+}
+
+void
+COptTasks::LogErrorAndDelete(CHAR* err_buf) {
 
 	if ('\0' != err_buf[0])
 	{

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -167,6 +167,10 @@ class COptTasks
 		static
 		void Execute ( void *(*pfunc) (void *), void *pfuncArg);
 
+		// print error and delete the given error buffer
+		static
+		void LogErrorAndDelete(CHAR* err_buf);
+
 		// task that does the translation from xml to dxl to pplstmt
 		static
 		void* PvPlstmtFromDXLTask(void *pv);

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -10139,6 +10139,28 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2', 47);
  Optimizer status: PQO version 1.647
 (5 rows)
 
+-- Test Logging for unsupported features in ORCA
+-- start_ignore
+drop table if exists foo;
+NOTICE:  table "foo" does not exist, skipping
+-- end_ignore
+create table foo(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set client_min_messages='log';
+select count(*) from foo group by cube(a,b);
+LOG:  statement: select count(*) from foo group by cube(a,b);
+LOG:  2016-08-19 10:46:53:360703 PDT,THD000,NOTICE,"Feature not supported by the Pivotal Query Optimizer: Cube",
+LOG:  Planner produced plan :0
+ count 
+-------
+(0 rows)
+
+reset client_min_messages;
+LOG:  statement: reset client_min_messages;
+-- start_ignore
+drop table foo;
+-- end_ignore
 -- clean up
 drop schema orca cascade;
 NOTICE:  drop cascades to table orca.index_test

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -113,4 +113,8 @@ s/overlaps existing partition "r\d+"/partition "r##########"/
 # Mask out some numbers (part of temp table schema) that vary from run to run.
 m/Table "pg_temp_\d+.temp/
 s/Table "pg_temp_\d+.temp/Table "pg_temp_#####/
+
+# Mask out Log & timestamp for orca message that has feature not supported.
+m/^LOG.*\"Feature/
+s/^LOG.*\"Feature/\"Feature/
 -- end_matchsubs

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -1365,6 +1365,20 @@ EXPLAIN SELECT * FROM bitmap_test WHERE a in ('2', 47);
 EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2');
 EXPLAIN SELECT * FROM bitmap_test WHERE a in ('1', '2', 47);
 
+-- Test Logging for unsupported features in ORCA
+-- start_ignore
+drop table if exists foo;
+-- end_ignore
+
+create table foo(a int, b int);
+set client_min_messages='log';
+select count(*) from foo group by cube(a,b);
+reset client_min_messages;
+
+-- start_ignore
+drop table foo;
+-- end_ignore
+
 -- clean up
 drop schema orca cascade;
 reset optimizer_segments;


### PR DESCRIPTION
Due to 'exception propagate' change, gpos_exec now throw an exception. Hence we are not able to do elog exception message. In this PR, we catch the exception from gpos_exec and do appropriate logging & clean up before rethrowing the exceptions.

Also changed elog::ERROR in the translator to elog::WARNING and throw WarningAsError exception. elog::ERROR will do long jump which would result in a leak. 

@foyzur @vraghavan78 @hsyuan @d @oarap  Please have a look when you get chance. 