### PR TITLE
Fix mixed-up arguments to expandRTE

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -1517,9 +1517,9 @@ transformFromClauseItem(ParseState *pstate, Node *n,
 		 *
 		 * Note: expandRTE returns new lists, safe for me to modify
 		 */
-		expandRTE(l_rte, l_rtindex, 0, false, -1,
+		expandRTE(l_rte, l_rtindex, 0, -1, false,
 				  &l_colnames, &l_colvars);
-		expandRTE(r_rte, r_rtindex, 0, false, -1,
+		expandRTE(r_rte, r_rtindex, 0, -1, false,
 				  &r_colnames, &r_colvars);
 
 		/*


### PR DESCRIPTION
This seems to have been harmless, by pure chance. Passing the 0 (false)
instead of -1 as the location would only affect the context information in
error messages. Passing -1 as the boolean 'include_dropped' variable makes
expandRTE to include dropped columns in the returned list, but that seems
to be harmless too, given what the caller uses the list for. Nevertheless,
it's clearly a bug, so fix it.