### PR TITLE
Remove gp_flush_buffer_pages_when_evicted GUC.

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -69,7 +69,6 @@
 
 /* GUC variables */
 bool        memory_protect_buffer_pool = true;
-bool 		flush_buffer_pages_when_evicted = false;
 bool		zero_damaged_pages = false;
 int			bgwriter_lru_maxpages = 100;
 double		bgwriter_lru_multiplier = 2.0;
@@ -559,8 +558,7 @@ BufferAlloc(SMgrRelation smgr,
 		 * won't prevent hint-bit updates).  We will recheck the dirty bit
 		 * after re-locking the buffer header.
 		 */
-		if (oldFlags & BM_DIRTY ||
-				(flush_buffer_pages_when_evicted && (oldFlags & BM_VALID)))
+		if (oldFlags & BM_DIRTY)
 		{
 			/*
 			 * If using a nondefault strategy, and writing the buffer
@@ -2749,8 +2747,6 @@ WaitIO(volatile BufferDesc *buf)
 static bool
 StartBufferIO(volatile BufferDesc *buf, bool forInput)
 {
-	bool ioNeeded;
-
 	Assert(!InProgressBuf);
 
 	for (;;)
@@ -2780,24 +2776,7 @@ StartBufferIO(volatile BufferDesc *buf, bool forInput)
 	/* Once we get here, there is definitely no I/O active on this buffer */
 
 	/* check if we can avoid io because some else already did it */
-	if (forInput)
-	{
-		ioNeeded = !(buf->flags & BM_VALID);
-	}
-	else if (flush_buffer_pages_when_evicted)
-	{
-		/* not 100% accurate because this flush could be called during non-eviction time,
-		* but it should cause only an extra unneeded flush, which we have lots of with this
-		* option on anyway
-		*/
-		ioNeeded = buf->flags & BM_VALID;
-	}
-	else
-	{
-		ioNeeded = buf->flags & BM_DIRTY;
-	}
-
-	if (!ioNeeded)
+	if (forInput ? (buf->flags & BM_VALID) : !(buf->flags & BM_DIRTY))
 	{
 		/* someone else already did the I/O */
 		UnlockBufHdr(buf);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -707,15 +707,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&memory_protect_buffer_pool, false, NULL, NULL
 	},
 	{
-		{"gp_flush_buffer_pages_when_evicted", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Always flushes buffer pages, regardless of dirty status"),
-			gettext_noop("When buffer pool pages are evicted, flush them to disk regardless of their dirty status."),
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&flush_buffer_pages_when_evicted,
-		false, NULL, NULL
-	},
-	{
 		{"debug_print_prelim_plan", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Prints the preliminary execution plan to server log."),
 			NULL


### PR DESCRIPTION
Looking at old git history, this was added back in 2009. The related
ticket on adding it said:

    Add GUC that make every buffer page from the buffer pool flushed on
    eviction.

    Note that this will NOT necessarily flush all buffer pages when the
    postmaster is shutdown. I think this is acceptable for our purposes.

    (Our purpose is to make sure that overwrites of the buffer pages are not
    lost and instead are always written to disk so we can catch errors)

I'm not sure what errors that was meant to catch, or how, but I don't
think we have any regression tests or anything that uses it anymore.
Let's remove it, to make merging with upstream easier.