### PR TITLE
Remove OS X UDP signalling code

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1505,13 +1505,12 @@ waitOnCondition(int timeout_us, pthread_cond_t *cond, pthread_mutex_t *mutex)
 
 
 	/*
-	 * interrupts may occurs when we are waiting. the interrupt handler
+	 * Interrupts may occur when we are waiting. The interrupt handler
 	 * only set some flags. Only when interrupt checking function is called,
 	 * the interrupts are handled.
 	 *
 	 * We should pay attention to the fact that in elog/erreport/write_log,
 	 * interrupts are checked.
-	 *
 	 */
 
 	wait = pthread_cond_timedwait(cond, mutex, &ts);

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -670,7 +670,6 @@ static void putRxBufferAndSendAck(MotionConn *conn, AckSendParam *param);
 static inline void putRxBufferToFreeList(RxBufferPool *p, icpkthdr *buf);
 static inline icpkthdr *getRxBufferFromFreeList(RxBufferPool *p);
 static icpkthdr *getRxBuffer(RxBufferPool *p);
-static void initRxBufferPool(RxBufferPool *p);
 
 /* ICBufferList functions. */
 static inline void icBufferListInitHeadLink(ICBufferLink *link);
@@ -1372,7 +1371,10 @@ InitMotionUDPIFC(int *listenerSocketFd, uint16 *listenerPort)
 	rx_control_info.lastTornIcId = 0;
 	initCursorICHistoryTable(&rx_control_info.cursorHistoryTable);
 
-	initRxBufferPool(&rx_buffer_pool);
+	/* Initialize receive buffer pool */
+	rx_buffer_pool.count = 0;
+	rx_buffer_pool.maxCount = 1;
+	rx_buffer_pool.freeList = NULL;
 
 	/* Initialize send control data */
 	snd_control_info.cwnd = 0;
@@ -1962,19 +1964,6 @@ MlPutRxBufferIFC(ChunkTransportState *transportStates, int motNodeID, int route)
 	if (param.msg.len != 0)
 		sendAckWithParam(&param);
 }
-
-/*
- * initRxBufferPool
- * 		Initialize receive buffer pool.
- */
-static void
-initRxBufferPool(RxBufferPool *p)
-{
-	p->count = 0;
-	p->maxCount = 1;
-	p->freeList = NULL;
-}
-
 
 /*
  * getRxBuffer


### PR DESCRIPTION
The UDP signalling code was added due to a supposed bug (unable to find the radar report for it) in the pthreads code in OS X 10.6 Snow Leopard which prevented `pthread_cond_timedwait()` to work as intended. This version of the OS was discontinued in 2011 so it's time to retire this work around. This works without problems on 10.11.6 El Capitan and should at least theoretically perform better (not to mention avoid an errorlogging per signal due to a bug in the `sendto()` checking in the implementation). OS X is not a supported GPDB platform and as such we only make a best effort to run it on the currently latest version. In the process also made OS X use `_timedwait()` and not the relative
function for simplicity.

While in the file, inlined a single-use trivial function to aid readability of the code and fixed a typo, see commits bb5e2f8 and b67167d.