### PR TITLE
Changed backup file naming conventions to incorporate content id.

### DIFF
--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -326,11 +326,8 @@ class GpCronDump(Operation):
                 if schema in CATALOG_SCHEMA:
                     raise Exception("can not exclude catalog schema '%s' in schema file '%s'" % (schema, self.context.exclude_schema_file))
 
-    def getGpArray(self):
-        return GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port), utility=True)
-
-    def getHostSet(self, gparray):
-        hostlist = gparray.get_hostlist(includeMaster=True)
+    def getHostSet(self):
+        hostlist = self.context.gparray.get_hostlist(includeMaster=True)
         hostset = Set(hostlist)
         return hostset
 
@@ -669,7 +666,7 @@ class GpCronDump(Operation):
                 if not self.context.ddboost_remote and not self.context.ddboost_backupdir:
                     raise ExceptionNoStackTraceNeeded("--ddboost-backupdir must be specified when configuring local Data Domain.")
                 self.validateUserName(userName=self.context.ddboost_user)
-                hostset = self.getHostSet(self.getGpArray())
+                hostset = self.getHostSet()
                 p = getpass()
                 self.validatePassword(password=p)
                 self.createDDBoostConfig(hostset, p)
@@ -679,7 +676,7 @@ class GpCronDump(Operation):
 
         if self.context.ddboost_config_remove:
             if self.only_ddboost_options():
-                hostset = self.getHostSet(self.getGpArray())
+                hostset = self.getHostSet()
                 # The username and the password must be at least 2 characters long, so we just use 2 spaces for each
                 self.removeDDBoostConfig(hostset)
                 return 0
@@ -1004,13 +1001,10 @@ class GpCronDump(Operation):
         pipe_list = []
         master_pipe_list = ['metadata', 'postdata']
 
-        mdd = self.context.master_datadir
         for segdb in segdbs:
-            self.context.master_datadir = segdb.getSegmentDataDirectory()
             pipe_list.append('%s:%s' % (segdb.getSegmentHostName(), self.context.generate_filename("dump", dbid=segdb.getSegmentDbId())))
             if self.context.dump_config:
                 pipe_list.append('%s:%s' % (segdb.getSegmentHostName(), self.context.generate_filename("segment_config", dbid=segdb.getSegmentDbId())))
-        self.context.master_datadir = mdd
 
         pipe_list.append('%s:%s' % (master.getSegmentHostName(), self.context.generate_filename("metadata")))
         pipe_list.append('%s:%s' % (master.getSegmentHostName(), self.context.generate_filename("postdata")))
@@ -1040,11 +1034,11 @@ class GpCronDump(Operation):
 
 
     def _list_backup_files(self):
-        gparray = self.getGpArray()
-        segdbs = [segdb for segdb in gparray.getDbList() if segdb.isSegmentPrimary()]
+        segdbs = self.context.get_current_primaries()
 
-        pipe_list = self._get_pipes_file_list(gparray.master, segdbs)
-        file_list = self._get_files_file_list(gparray.master)
+        self.context.old_filename_format = self.context.is_timestamp_in_old_format()
+        pipe_list = self._get_pipes_file_list(self.context.gparray.master, segdbs)
+        file_list = self._get_files_file_list(self.context.gparray.master)
 
         pipes_list_fname = self.context.generate_filename("pipes")
         files_list_fname = self.context.generate_filename("files")

--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -130,8 +130,6 @@ class GpdbRestore(Operation):
         else:
             self.interactive = options.interactive
 
-        self.gparray = None
-
         try:
             if self.context.report_status_dir:
                 check_dir_writable(self.context.report_status_dir)
@@ -162,8 +160,6 @@ class GpdbRestore(Operation):
                 cmdline += ' --ddboost-storage-unit %s' % self.context.ddboost_storage_unit
             cmd = Command('DDBoost sync', cmdline)
             cmd.run(validateAfter=True)
-
-        self.gparray = GpArray.initFromCatalog(dbconn.DbURL(port=self.context.master_port, dbname='template1'), utility=True)
 
         if self.context.netbackup_service_host:
             logger.info("Restoring metadata files with NetBackup")
@@ -332,8 +328,8 @@ class GpdbRestore(Operation):
         """
         Checking cluster status, no primary should be down.
         """
-        fault_action = self.gparray.getFaultStrategy()
-        primaries = [seg for seg in self.gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
+        fault_action = self.context.gparray.getFaultStrategy()
+        primaries = self.context.get_current_primaries()
         fail_count = len([seg for seg in primaries if seg.isSegmentDown()])
 
         if fault_action == 'readonly' and fail_count != 0:
@@ -351,16 +347,19 @@ class GpdbRestore(Operation):
         """
 
         if self.context.timestamp:
-            (restore_timestamp, restore_db, compress) = ValidateTimestamp(self.context).run()
+            (restore_timestamp, restore_db, compress, old_format) = ValidateTimestamp(self.context).run()
             self.context.timestamp = restore_timestamp
             self.context.restore_db = restore_db
             self.context.compress = compress
-        elif self.context.db_date_dir:
-            self._validate_db_date_dir()
-        elif self.context.db_host_path:
-            self._validate_db_host_path()
-        elif self.search_for_dbname:
-            self._search_for_latest()
+            self.context.use_old_filename_format = old_format
+        else:
+            self.context.use_old_filename_format = self.context.is_timestamp_in_old_format()
+            if self.context.db_date_dir:
+                self._validate_db_date_dir()
+            elif self.context.db_host_path:
+                self._validate_db_host_path()
+            elif self.search_for_dbname:
+                self._search_for_latest()
 
         if not self.context.drop_db and not self.context.redirected_restore_db:
             dburl = dbconn.DbURL(port=self.context.master_port)

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -762,17 +762,6 @@ class Segment:
                 return False
         return True
 
-    def get_active_primary(self):
-        if self.primaryDB.isSegmentPrimary(current_role=True):
-            return self.primaryDB
-        else:
-            for mirror in self.mirrorDBs:
-                if mirror.isSegmentPrimary(current_role=True):
-                    return mirror
-
-    def get_primary_dbid(self):
-        return self.primaryDB.getSegmentDbId()
-
 # --------------------------------------------------------------------
 # --------------------------------------------------------------------
 class SegmentRow():

--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -398,7 +398,7 @@ def convert_report_filename_to_cdatabase_filename(context, report_file):
     if context.ddboost:
         ddboost_parent_dir = context.get_backup_dir(segment_dir='')
     report_contents = get_lines_from_file(report_file)
-    old_metadata = context.generate_filename("metadata", use_old_format=True)
+    old_metadata = context.generate_filename("metadata", timestamp=timestamp, use_old_format=True)
     old_format = False
     for line in report_contents:
         if old_metadata in line:

--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -21,12 +21,12 @@ logger = gplog.get_default_logger()
 
 class Context(Values, object):
     filename_dict = {
-        "ao": ("dump", "_ao_state_file"), "cdatabase": ("cdatabase_1_1", ""), "co": ("dump", "_co_state_file"), "dirty_table": ("dump", "_dirty_list"),
-        "dump": ("dump_%d_%d", ""), "files": ("dump", "_regular_files"), "filter": ("dump", "_filter"), "global": ("global_1_1", ""),
+        "ao": ("dump", "_ao_state_file"), "cdatabase": ("cdatabase_%d_%s", ""), "co": ("dump", "_co_state_file"), "dirty_table": ("dump", "_dirty_list"),
+        "dump": ("dump_%d_%s", ""), "files": ("dump", "_regular_files"), "filter": ("dump", "_filter"), "global": ("global_%d_%s", ""),
         "increments": ("dump", "_increments"), "last_operation": ("dump", "_last_operation"), "master_config": ("master_config_files", ".tar"),
-        "metadata": ("dump_1_1", ""), "partition_list": ("dump", "_table_list"), "pipes": ("dump", "_pipes"), "plan": ("restore", "_plan"),
-        "postdata": ("dump_1_1", "_post_data"), "report": ("dump", ".rpt"), "schema": ("dump", "_schema"), "segment_config": ("segment_config_files_%d_%d", ".tar"),
-        "stats": ("statistics_1_1", ""), "status": ("dump_status_%d_%d", ""),
+        "metadata": ("dump_%d_%s", ""), "partition_list": ("dump", "_table_list"), "pipes": ("dump", "_pipes"), "plan": ("restore", "_plan"),
+        "postdata": ("dump_%d_%s", "_post_data"), "report": ("dump", ".rpt"), "schema": ("dump", "_schema"), "segment_config": ("segment_config_files_%d_%s", ".tar"),
+        "stats": ("statistics_%d_%s", ""), "status": ("dump_status_%d_%s", ""),
     }
     defaults = {
         "backup_dir": None, "batch_default": 64, "change_schema": None, "cleanup_date": None, "cleanup_total": None, "clear_catalog_dumps": False,
@@ -65,45 +65,110 @@ class Context(Values, object):
         if self.netbackup_keyword and (len(self.netbackup_keyword) > 100):
             raise Exception('NetBackup Keyword provided has more than max limit (100) characters. Cannot proceed with backup.')
 
+        self.gparray = GpArray.initFromCatalog(dbconn.DbURL(dbname="template1", port=self.master_port), utility=True)
+        self.use_old_filename_format = False # Use new filename format by default
+        self.content_map = self.setup_content_map()
+
     def get_master_port(self):
         pgconf_dict = pgconf.readfile(self.master_datadir + "/postgresql.conf")
         return pgconf_dict.int('port')
 
-    def generate_filename(self, filetype, dbid=1, timestamp=None, directory=None):
+    def setup_content_map(self):
+        content_map = {}
+        for seg in self.gparray.getDbList():
+            content_map[seg.dbid] = seg.content
+        return content_map
+
+    # "Old format" filename format: <prefix>gp_<infix>_<1 if master|0 if segment>_<dbid>_<timestamp><suffix>
+    # "New format" filename format: <prefix>gp_<infix>_<content>_<dbid>_<timestamp><suffix>
+    # The "content" parameter is used to generate a filename pattern for finding files of that content id, not a single filename
+    def generate_filename(self, filetype, dbid=1, content=None, timestamp=None, directory=None, use_old_format=None):
         if timestamp is None:
             timestamp = self.timestamp
+
         if directory:
             use_dir = directory
         else:
-            use_dir = self.get_backup_dir(timestamp)
+            if dbid == 1:
+                use_dir = self.get_backup_dir(timestamp)
+            else:
+                use_dir = self.get_backup_dir(timestamp, segment_dir=self.datadir_for_dbid(dbid))
+
+        if use_old_format is not None:
+            use_old_format = use_old_format
+        else:
+            use_old_format = self.use_old_filename_format
+
         format_str =  "%s/%sgp_%s_%s%s" % (use_dir, self.dump_prefix, "%s", timestamp, "%s")
         filename = format_str % (self.filename_dict[filetype][0], self.filename_dict[filetype][1])
-        if "%d" in filename:
-            if dbid == 1:
-                filename = filename % (1, 1)
+        if "%d_%s" in filename:
+            if use_old_format:
+                if content is not None: # Doesn't use "if not content" because 0 is a valid content id
+                    dbids = ["%d" % id for id in self.content_map if self.content_map[id] == content]
+                    filename = filename % (1 if content == -1 else 0, "[%s]" % ("|".join(dbids)))
+                elif dbid == 1:
+                    filename = filename % (1, 1)
+                else:
+                    filename = filename % (0, dbid)
             else:
-                filename = filename % (0, dbid)
+                if content is not None:
+                    filename = filename % (content, "*")
+                elif dbid == 1:
+                    filename = filename % (-1, 1)
+                else:
+                    content = self.content_map[dbid]
+                    filename = filename % (content, dbid)
         if self.compress and filetype in ["metadata", "dump", "postdata"]:
             filename += ".gz"
         return filename
 
-    def generate_prefix(self, filetype, dbid=1, timestamp=None):
+    def generate_prefix(self, filetype, dbid=1, content=None, timestamp=None, use_old_format=None):
         if timestamp is None:
             timestamp = self.timestamp
         format_str =  "%sgp_%s_" % (self.dump_prefix, "%s")
         filename = format_str % (self.filename_dict[filetype][0])
         if "%d" in filename:
-            if dbid == 1:
-                filename = filename % (1, 1)
+            if use_old_format:
+                if dbid == 1:
+                    filename = filename % (1, 1)
+                else:
+                    filename = filename % (0, dbid)
             else:
-                filename = filename % (0, dbid)
+                if content is not None:
+                    filename = filename % (content, "*")
+                elif dbid == 1:
+                    filename = filename % (-1, 1)
+                else:
+                    content = self.content_map[dbid]
         return filename
 
-    def get_backup_dir(self, timestamp=None, directory=None):
-        if directory is not None:
-            use_dir = directory
-        elif self.backup_dir and not self.ddboost:
+    def datadir_for_dbid(self, dbid):
+        for seg in self.gparray.getDbList():
+            if seg.getSegmentDbId() == dbid:
+                return seg.getSegmentDataDirectory()
+        raise Exception("Segment with dbid %d not found" % dbid)
+
+    def get_current_primaries(self):
+        return [seg for seg in self.gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
+
+    def is_timestamp_in_old_format(self, timestamp=None):
+        if not timestamp:
+            timestamp = self.timestamp
+        dump_dirs = self.get_dump_dirs()
+        for dump_dir in dump_dirs:
+            new_name = self.generate_filename("dump", timestamp=timestamp, directory=dump_dir, use_old_format=False)
+            old_name = self.generate_filename("dump", timestamp=timestamp, directory=dump_dir, use_old_format=True)
+            if os.path.exists(new_name):
+                return False
+            elif os.path.exists(old_name):
+                return True
+        return False
+
+    def get_backup_dir(self, timestamp=None, segment_dir=None):
+        if self.backup_dir and not self.ddboost:
             use_dir = self.backup_dir
+        elif segment_dir is not None:
+            use_dir = segment_dir
         elif self.master_datadir:
             use_dir = self.master_datadir
         else:
@@ -166,6 +231,45 @@ class Context(Values, object):
         self.timestamp = timestamp_key
         self.db_date_dir = "%4d%02d%02d" % (year, month, day)
         self.timestamp_object = datetime(year, month, day, hours, minutes, seconds)
+
+    def get_dump_dirs(self):
+        use_dir = self.get_backup_root()
+        dump_path = os.path.join(use_dir, self.dump_dir)
+
+        if not os.path.isdir(dump_path):
+            return []
+
+        initial_list = os.listdir(dump_path)
+        initial_list = fnmatch.filter(initial_list, '[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]')
+
+        dirnames = []
+        for d in initial_list:
+            pth = os.path.join(dump_path, d)
+            if os.path.isdir(pth):
+                dirnames.append(pth)
+
+        if len(dirnames) == 0:
+            return []
+        dirnames = sorted(dirnames, key=lambda x: int(os.path.basename(x)), reverse=True)
+        return dirnames
+
+
+def get_filename_for_content(context, filetype, content, remote_directory=None, host=None):
+    filetype_glob = context.generate_filename(filetype, content=content, directory=remote_directory)
+    if remote_directory:
+        if not host:
+            raise Exception("Must supply name of remote host to check for %s file" % filetype)
+        cmd = Command(name = "Find file of type %s for content %d on host %s" % (filetype, content, host),
+                cmdStr = 'python -c "import glob; print glob.glob(\'%s\')[0]"' % filetype_glob, ctxt = REMOTE, remoteHost = host)
+        cmd.run()
+        if cmd.get_results().rc == 0 and cmd.get_results().stdout:
+            return cmd.get_results().stdout
+        return None
+    else:
+        filenames = glob.glob(filetype_glob)
+        if filenames and len(filenames):
+            return filenames[0]
+        return None
 
 def expand_partitions_and_populate_filter_file(dbname, partition_list, file_prefix):
     expanded_partitions = expand_partition_tables(dbname, partition_list)
@@ -289,13 +393,16 @@ def check_successful_dump(report_file_contents):
 
 # raise exception for bad data
 def convert_report_filename_to_cdatabase_filename(context, report_file):
-    (dirname, fname) = os.path.split(report_file)
-    timestamp = fname[-18:-4]
+    timestamp = report_file[-18:-4]
 
-    ddboost_parent_dir = None
-    if context.ddboost:
-        ddboost_parent_dir = context.get_backup_dir(directory='')
-    return context.generate_filename("cdatabase", timestamp=timestamp, directory=ddboost_parent_dir)
+    report_contents = get_lines_from_file(report_file)
+    old_metadata = context.generate_filename("metadata", use_old_format=True)
+    old_format = False
+    for line in report_contents:
+        if old_metadata in line:
+            old_format = True
+            break
+    return context.generate_filename("cdatabase", timestamp=timestamp, use_old_format=old_format)
 
 def get_lines_from_dd_file(filename, ddboost_storage_unit):
     cmdStr = 'gpddboost --readFile --from-file=%s' % filename
@@ -481,38 +588,8 @@ def execute_sql(query, master_port, dbname):
     cursor = execSQL(conn, query)
     return cursor.fetchall()
 
-def generate_master_status_prefix(dump_prefix):
-    return '%sgp_dump_status_1_1_' % (dump_prefix)
-
-def generate_seg_dbdump_prefix(dump_prefix):
-    return '%sgp_dump_0_' % (dump_prefix)
-
-def generate_seg_status_prefix(dump_prefix):
-    return '%sgp_dump_status_0_' % (dump_prefix)
-
-def get_dump_dirs(context):
-    use_dir = context.get_backup_root()
-    dump_path = os.path.join(use_dir, context.dump_dir)
-
-    if not os.path.isdir(dump_path):
-        return []
-
-    initial_list = os.listdir(dump_path)
-    initial_list = fnmatch.filter(initial_list, '[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]')
-
-    dirnames = []
-    for d in initial_list:
-        pth = os.path.join(dump_path, d)
-        if os.path.isdir(pth):
-            dirnames.append(pth)
-
-    if len(dirnames) == 0:
-        return []
-    dirnames = sorted(dirnames, key=lambda x: int(os.path.basename(x)), reverse=True)
-    return dirnames
-
 def get_latest_report_timestamp(context):
-    dump_dirs = get_dump_dirs(context)
+    dump_dirs = context.get_dump_dirs()
 
     for d in dump_dirs:
         latest = get_latest_report_in_dir(d, context.dump_prefix)
@@ -571,8 +648,7 @@ def get_full_timestamp_for_incremental(context):
 
 # backup_dir will be either MDD or some other directory depending on call
 def get_latest_full_dump_timestamp(context):
-    backup_dir = context.get_backup_root()
-    dump_dirs = get_dump_dirs(context)
+    dump_dirs = context.get_dump_dirs()
 
     for dump_dir in dump_dirs:
         files = sorted(os.listdir(dump_dir))
@@ -598,9 +674,8 @@ def get_latest_full_dump_timestamp(context):
 
     raise Exception('No full backup found for incremental')
 
-def get_all_segment_addresses(master_port):
-    gparray = GpArray.initFromCatalog(dbconn.DbURL(port=master_port), utility=True)
-    addresses = [seg.getSegmentAddress() for seg in gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
+def get_all_segment_addresses(context):
+    addresses = [seg.getSegmentAddress() for seg in context.gparray.getDbList() if seg.isSegmentPrimary(current_role=True)]
     return list(set(addresses))
 
 def scp_file_to_hosts(host_list, filename, batch_default):
@@ -706,7 +781,7 @@ def restore_file_with_nbu(context, filetype=None, path=None, dbid=1, hostname=No
 
 def check_file_dumped_with_nbu(context, filetype=None, path=None, dbid=1, hostname=None):
     if filetype and path:
-        raise Exception("Cannot supply both a file type and a file path toeck_file_dumped_with_nbu")
+        raise Exception("Cannot supply both a file type and a file path to check_file_dumped_with_nbu")
     if filetype is None and path is None:
         raise Exception("Cannot call check_file_dumped_with_nbu with no type or path argument")
     if filetype:
@@ -863,7 +938,7 @@ def split_fqn(fqn_name):
     return schema, table
 
 def remove_file_on_segments(context, filename):
-    addresses = get_all_segment_addresses(context.master_port)
+    addresses = get_all_segment_addresses(context)
 
     try:
         cmd = 'rm -f %s' % filename

--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -394,7 +394,9 @@ def check_successful_dump(report_file_contents):
 # raise exception for bad data
 def convert_report_filename_to_cdatabase_filename(context, report_file):
     timestamp = report_file[-18:-4]
-
+    ddboost_parent_dir = None
+    if context.ddboost:
+        ddboost_parent_dir = context.get_backup_dir(segment_dir='')
     report_contents = get_lines_from_file(report_file)
     old_metadata = context.generate_filename("metadata", use_old_format=True)
     old_format = False
@@ -402,7 +404,7 @@ def convert_report_filename_to_cdatabase_filename(context, report_file):
         if old_metadata in line:
             old_format = True
             break
-    return context.generate_filename("cdatabase", timestamp=timestamp, use_old_format=old_format)
+    return context.generate_filename("cdatabase", timestamp=timestamp, use_old_format=old_format, directory=ddboost_parent_dir)
 
 def get_lines_from_dd_file(filename, ddboost_storage_unit):
     cmdStr = 'gpddboost --readFile --from-file=%s' % filename

--- a/gpMgmt/bin/gppylib/operations/dump.py
+++ b/gpMgmt/bin/gppylib/operations/dump.py
@@ -1231,7 +1231,7 @@ class DumpGlobal(Operation):
 
         if self.context.ddboost:
             abspath = self.context.generate_filename("global", timestamp=self.timestamp)
-            relpath = abspath.split(self.context.backup_dir+"/")[1]
+            relpath = abspath[abspath.index(self.context.dump_dir):]
             logger.debug('Copying %s to DDBoost' % abspath)
             cmdStr = 'gpddboost --copyToDDBoost --from-file=%s --to-file=%s' % (abspath, relpath)
             if self.context.ddboost_storage_unit:

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -1142,7 +1142,7 @@ class GetDDboostDumpTablesOperation(GetDumpTablesOperation):
     def execute(self):
         # We want to make sure that directory is empty so that we can grab the ddboost directory value
         # with the timestamp
-        ddboost_parent_dir = self.context.get_backup_dir(directory='')
+        ddboost_parent_dir = self.context.get_backup_dir(segment_dir='')
         ddboost_cmdStr = 'gpddboost --readFile --from-file=%s' % self.context.generate_filename("dump", directory=ddboost_parent_dir)
 
         if self.context.ddboost_storage_unit:

--- a/gpMgmt/bin/gppylib/operations/test/unit/__init__.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/__init__.py
@@ -2,3 +2,12 @@
 from os.path import abspath as _abspath
 __path__[0] = _abspath(__path__[0])
 
+from gppylib.gparray import GpArray, GpDB
+
+def setup_fake_gparray():
+    master = GpDB.initFromString("1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+    primary0 = GpDB.initFromString("2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+    primary1 = GpDB.initFromString("3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+    mirror0 = GpDB.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+    mirror1 = GpDB.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+    return GpArray([master,primary0,primary1,mirror0,mirror1])

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
@@ -7,24 +7,27 @@ import shutil
 import time
 import unittest2 as unittest
 from datetime import datetime
+from gppylib.gparray import GpArray, GpDB
 from gppylib.commands.base import Command, CommandResult
 from gppylib.operations.backup_utils import *
 from gppylib.operations.dump import *
 from mock import patch, MagicMock, Mock, mock_open, call
+from . import setup_fake_gparray
 
 class DumpTestCase(unittest.TestCase):
 
     @patch('gppylib.operations.backup_utils.Context.get_master_port', return_value = 5432)
-    def setUp(self, mock):
-        context = Context()
-        context.dump_database='testdb'
-        context.dump_schema='testschema'
-        context.include_dump_tables_file='/tmp/table_list.txt'
-        context.master_datadir=context.backup_dir='/data/master/p1'
-        context.batch_default=None
-        context.timestamp_key = '20160101010101'
-        context.generate_dump_timestamp()
-        context.schema_file = None
+    def setUp(self, mock1):
+        with patch('gppylib.gparray.GpArray.initFromCatalog', return_value=setup_fake_gparray()):
+            context = Context()
+            context.dump_database='testdb'
+            context.dump_schema='testschema'
+            context.include_dump_tables_file='/tmp/table_list.txt'
+            context.master_datadir=context.backup_dir='/data/master'
+            context.batch_default=None
+            context.timestamp_key = '20160101010101'
+            context.generate_dump_timestamp()
+            context.schema_file = None
 
         self.context = context
         self.dumper = DumpDatabase(self.context)
@@ -59,7 +62,12 @@ class DumpTestCase(unittest.TestCase):
         m = mock_open()
         with patch('__builtin__.open', m, create=True):
             tmpfilename = write_dirty_file(self.context, dirty_tables, timestamp)
-            mock1.assert_called_with("dirty_table", timestamp)
+            mock1.assert_called_with("dirty_table", timestamp=timestamp)
+            result = m()
+            self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
+            for i in range(len(dirty_tables)):
+                self.assertEqual(call(dirty_tables[i]+'\n'), result.write.call_args_list[i])
+
             result = m()
             self.assertEqual(len(dirty_tables), len(result.write.call_args_list))
             for i in range(len(dirty_tables)):
@@ -103,7 +111,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.CreateIncrementsFile.validate_increments_file')
     def test_CreateIncrementsFile_init(self, mock1, mock2, mock3):
         obj = CreateIncrementsFile(self.context)
-        self.assertEquals(obj.increments_filename, '/data/master/p1/db_dumps/20160101/gp_dump_20160101000000_increments')
+        self.assertEquals(obj.increments_filename, '/data/master/db_dumps/20160101/gp_dump_20160101000000_increments')
 
     @patch('os.path.isfile', return_value=True)
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101000000')
@@ -200,6 +208,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "", "", True, False))
     @patch('gppylib.operations.dump.DumpDatabase.create_filter_file')
     def test_execute_default(self, mock1, mock2, mock3, mock4):
+        self.context.include_dump_tables_file = ''
         self.dumper.execute()
         # should not raise any exceptions
 
@@ -235,18 +244,18 @@ class DumpTestCase(unittest.TestCase):
     def test_get_partition_state_many_partition(self, mock1, mock2, mock3):
         master_port=5432
         dbname='testdb'
-        partition_info = [(123, 'testschema', 't1', 4444), (234, 'testschema', 't2', 5555)] * 1000
-        expected_output = ['testschema, t1, 100', 'testschema, t2, 100'] * 1000
+        partition_info = [(123, 'testschema', 't1', 4444), (234, 'testschema', 't2', 5555)] * 1
+        expected_output = ['testschema, t1, 100', 'testschema, t2, 100'] * 1
         result = get_partition_state(self.context, 'pg_aoseg', partition_info)
         self.assertEqual(result, expected_output)
 
     def test_get_filename_from_filetype_ao(self):
-        expected_output = '/data/master/p1/db_dumps/20160101/gp_dump_20160101010101_ao_state_file'
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_20160101010101_ao_state_file'
         result = get_filename_from_filetype(self.context, "ao", self.context.timestamp)
         self.assertEqual(result, expected_output)
 
     def test_get_filename_from_filetype_co(self):
-        expected_output = '/data/master/p1/db_dumps/20160101/gp_dump_20160101010101_co_state_file'
+        expected_output = '/data/master/db_dumps/20160101/gp_dump_20160101010101_co_state_file'
         result = get_filename_from_filetype(self.context, "co", self.context.timestamp)
         self.assertEqual(result, expected_output)
 
@@ -636,27 +645,27 @@ class DumpTestCase(unittest.TestCase):
         self.context.schema_file = '/tmp/schema_file '
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_dump_string()
-            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file """
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/db_dumps/20160101 --gp-r=/data/master/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file """
             self.assertEquals(output, expected_output)
 
     def test_create_dump_string_default(self):
         self.context.schema_file = '/tmp/schema_file'
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_dump_string()
-            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file"""
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/db_dumps/20160101 --gp-r=/data/master/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --schema-file=/tmp/schema_file"""
             self.assertEquals(output, expected_output)
 
     def test_create_dump_string_without_incremental(self):
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_dump_string()
-            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/db_dumps/20160101 --gp-r=/data/master/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
             self.assertEquals(output, expected_output)
 
     def test_create_dump_string_with_prefix(self):
         self.context.dump_prefix = 'foo_'
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_dump_string()
-            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/db_dumps/20160101 --gp-r=/data/master/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
             self.assertEquals(output, expected_output)
 
     def test_create_dump_string_with_include_file(self):
@@ -664,7 +673,7 @@ class DumpTestCase(unittest.TestCase):
         self.context.include_dump_tables_file = 'bar'
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_dump_string()
-            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=%s""" % self.context.include_dump_tables_file
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/db_dumps/20160101 --gp-r=/data/master/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=%s""" % self.context.include_dump_tables_file
             self.assertEquals(output, expected_output)
 
     def test_create_dump_string_with_no_file_args(self):
@@ -672,7 +681,7 @@ class DumpTestCase(unittest.TestCase):
         self.context.include_dump_tables_file = None
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_dump_string()
-            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb\""""
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/db_dumps/20160101 --gp-r=/data/master/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=metro_ --no-expand-children -n "\\"testschema\\"" "testdb\""""
             self.assertEquals(output, expected_output)
 
     def test_create_dump_string_with_netbackup_params(self):
@@ -682,11 +691,11 @@ class DumpTestCase(unittest.TestCase):
         self.context.netbackup_schedule = "test_schedule"
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_dump_string()
-            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --netbackup-service-host=mdw --netbackup-policy=test_policy --netbackup-schedule=test_schedule"""
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/db_dumps/20160101 --gp-r=/data/master/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --no-expand-children -n "\\"testschema\\"" "testdb" --netbackup-service-host=mdw --netbackup-policy=test_policy --netbackup-schedule=test_schedule"""
             self.assertEquals(output, expected_output)
 
     def test_get_backup_dir_with_master_data_dir(self):
-        self.assertEquals('/data/master/p1/db_dumps/20160101', self.context.get_backup_dir())
+        self.assertEquals('/data/master/db_dumps/20160101', self.context.get_backup_dir())
 
     def test_get_backup_dir_with_backup_dir(self):
         self.context.backup_dir = '/tmp'
@@ -696,7 +705,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('os.path.isfile', return_value=True)
     def test_get_filter_file_file_exists(self, mock1, mock2):
         self.context.dump_prefix = 'foo_'
-        expected_output = '/data/master/p1/db_dumps/20160101/foo_gp_dump_20160101010101_filter'
+        expected_output = '/data/master/db_dumps/20160101/foo_gp_dump_20160101010101_filter'
         self.assertEquals(expected_output, get_filter_file(self.context))
 
     @patch('os.path.isfile', return_value=False)
@@ -708,7 +717,7 @@ class DumpTestCase(unittest.TestCase):
         self.context.dump_prefix = 'foo_'
         self.context.netbackup_block_size = "1024"
         self.context.netbackup_service_host = "mdw"
-        expected_output = '/data/master/p1/db_dumps/20160101/foo_gp_dump_20160101010101_filter'
+        expected_output = '/data/master/db_dumps/20160101/foo_gp_dump_20160101010101_filter'
         self.assertEquals(expected_output, get_filter_file(self.context))
 
     @patch('gppylib.operations.dump.get_latest_full_dump_timestamp', return_value='20160101010101')
@@ -786,7 +795,7 @@ class DumpTestCase(unittest.TestCase):
         self.context.dump_prefix = 'foo_'
         with patch.dict(os.environ, {'LOGNAME':'gpadmin'}):
             output = self.dumper.create_filtered_dump_string()
-            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt --incremental-filter=/tmp/db_dumps/20160101/foo_gp_dump_01234567891234_filter"""
+            expected_output = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/db_dumps/20160101 --gp-r=/data/master/db_dumps/20160101 --gp-s=p --gp-k=20160101010101 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt --incremental-filter=/tmp/db_dumps/20160101/foo_gp_dump_01234567891234_filter"""
             self.assertEquals(output, expected_output)
 
     @patch('gppylib.operations.dump.Command.get_results', return_value=CommandResult(0, "", "", True, False))
@@ -794,14 +803,14 @@ class DumpTestCase(unittest.TestCase):
     def test_perform_dump_normal(self, mock1, mock2):
         self.context.dump_prefix = 'foo_'
         title = 'Dump process'
-        dump_line = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/p1/db_dumps/20160101 --gp-r=/data/master/p1/db_dumps/20160101 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
+        dump_line = """gp_dump -p 5432 -U gpadmin --gp-d=/data/master/db_dumps/20160101 --gp-r=/data/master/db_dumps/20160101 --gp-s=p --gp-k=01234567891234 --no-lock --gp-c --prefix=foo_ --no-expand-children -n "\\"testschema\\"" "testdb" --table-file=/tmp/table_list.txt"""
         (start, end, rc) = self.dumper.perform_dump(title, dump_line)
         self.assertNotEqual(start, None)
         self.assertNotEqual(end, None)
         self.assertEquals(rc, 0)
 
     def test_create_pgdump_command_line(self):
-        global_file_name = '/data/master/p1/db_dumps/20160101/gp_global_1_1_20160101010101'
+        global_file_name = '/data/master/db_dumps/20160101/gp_global_-1_1_20160101010101'
         expected_output = "pg_dumpall -p 5432 -g --gp-syntax > %s" % global_file_name
         output = self.dump_globals.create_pgdump_command_line()
         self.assertEquals(output, expected_output)
@@ -870,9 +879,8 @@ class DumpTestCase(unittest.TestCase):
                 seg.get_primary_dbid.return_value = id + 2
             return self.mock_segs
 
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog', return_value=MyMock(1))
     @patch('gppylib.gparray.GpDB.getSegmentHostName', return_value='sdw')
-    def test_backup_config_files_with_nbu_single_segment(self, mock1, mock2):
+    def test_backup_config_files_with_nbu_default(self, mock1):
         with patch('gppylib.operations.dump.backup_file_with_nbu', side_effect=my_counter) as nbu_mock:
             global i
             i = 0
@@ -883,32 +891,12 @@ class DumpTestCase(unittest.TestCase):
             backup_config_files_with_nbu(self.context)
             args, _ = nbu_mock.call_args_list[0]
             self.assertEqual(args[1], "master_config")
-            for id, seg in enumerate(mock2.mock_segs):
+            for id, seg in enumerate(mock1.mock_segs):
                 self.assertEqual(seg.get_active_primary.call_count, 1)
                 self.assertEqual(seg.get_primary_dbid.call_count, 1)
                 args, _ = nbu_mock.call_args_list[id]
                 self.assertEqual(args, ("segment_config", id+2, "sdw"))
-            self.assertEqual(i, 2)
-
-    @patch('gppylib.operations.dump.GpArray.initFromCatalog', return_value=MyMock(3))
-    @patch('gppylib.gparray.GpDB.getSegmentHostName', return_value='sdw')
-    def test_backup_config_files_with_nbu_multiple_segments(self, mock1, mock2):
-        with patch('gppylib.operations.dump.backup_file_with_nbu', side_effect=my_counter) as nbu_mock:
-            global i
-            i = 0
-            self.context.netbackup_service_host = "mdw"
-            self.context.netbackup_policy = "test_policy"
-            self.context.netbackup_schedule = "test_schedule"
-
-            backup_config_files_with_nbu(self.context)
-            args, _ = nbu_mock.call_args_list[0]
-            self.assertEqual(args[1], "master_config")
-            for id, seg in enumerate(mock2.mock_segs):
-                self.assertEqual(seg.get_active_primary.call_count, 1)
-                self.assertEqual(seg.get_primary_dbid.call_count, 1)
-                args, _ = nbu_mock.call_args_list[id]
-                self.assertEqual(args, ("segment_config", id+2, "sdw"))
-            self.assertEqual(i, 4)
+            self.assertEqual(i, 3)
 
     @patch('gppylib.operations.backup_utils.Context.generate_filename', return_value='foo_schema')
     @patch('gppylib.commands.base.Command.run')

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -3646,6 +3646,22 @@ Feature: Validate command line arguments
         Then gpdbrestore should return a return code of 2
         And gpdbrestore should print gpdbrestore error: No dump file on to stdout
 
+    Scenario: Full backup with old filename format
+        Given the test is initialized
+        And there is a "ao" table "public.ao_table" in "bkdb" with data
+        And there is a "heap" table "public.heap_table" in "bkdb" with data
+        When the user runs "gpcrondump -a -x bkdb"
+        Then gpcrondump should return a return code of 0
+        And the full backup timestamp from gpcrondump is stored
+        And the timestamp from gpcrondump is stored
+        And the backup files for the stored timestamp are in the old format
+        And database "bkdb" is dropped and recreated
+        When the user runs gpdbrestore with the stored timestamp
+        Then gpdbrestore should return a return code of 0
+        And verify that there is a "ao" table "public.ao_table" in "bkdb"
+        And verify that there is a "heap" table "public.heap_table" in "bkdb"
+        And verify that the tuple count of all appendonly tables are consistent in "bkdb"
+
     Scenario: Incremental backup with new filename format after full backup with old filename format
         Given the test is initialized
         And there is a "ao" table "public.ao_table" in "bkdb" with data
@@ -3653,7 +3669,7 @@ Feature: Validate command line arguments
         When the user runs "gpcrondump -a -x bkdb"
         Then gpcrondump should return a return code of 0
         And the full backup timestamp from gpcrondump is stored
-        # And the backup files for the stored timestamp are in the old format
+        And the backup files for the stored timestamp are in the old format
         And table "public.ao_table" is assumed to be in dirty state in "bkdb"
         And the user runs "gpcrondump -a --incremental -x bkdb"
         And gpcrondump should return a return code of 0
@@ -3677,7 +3693,7 @@ Feature: Validate command line arguments
         And the user runs "gpcrondump -a --incremental -x bkdb"
         And gpcrondump should return a return code of 0
         And the timestamp from gpcrondump is stored
-        # And the backup files for the stored timestamp are in the old format
+        And the backup files for the stored timestamp are in the old format
         And table "public.ao_table" is assumed to be in dirty state in "bkdb"
         And the user runs "gpcrondump -a --incremental -x bkdb"
         And gpcrondump should return a return code of 0

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/backup_mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/backup_mgmt_utils.py
@@ -219,7 +219,7 @@ def impl(context, target):
             fd.close()
 
 def __get_dump_metadata_path(context, dump_dir):
-    filename = "gp_dump_1_1_%s.gz" % context.backup_timestamp
+    filename = "gp_dump_-1_1_%s.gz" % context.backup_timestamp
     metadata_path = os.path.join(dump_dir, "db_dumps", context.backup_timestamp[0:8], filename)
     return metadata_path
 

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -410,8 +410,8 @@ def impl(context, command, options):
     elif bnr_tool == 'gp_restore':
         command_str = "%s %s --gp-k %s --gp-d db_dumps/%s --gp-r db_dumps/%s" % (command, options, context.backup_timestamp, context.backup_timestamp[0:8], context.backup_timestamp[0:8])
     elif bnr_tool == 'gp_restore_agent':
-        command_str = "%s %s --gp-k %s --gp-d db_dumps/%s -p %s -U %s --target-host localhost --target-port %s db_dumps/%s/gp_dump_1_1_%s_post_data.gz" % (command, options, ts, ts[0:8], port, user, port, ts[0:8], ts)
-
+        command_str = "%s %s --gp-k %s --gp-d db_dumps/%s -p %s -U %s --target-host localhost --target-port %s db_dumps/%s/gp_dump_-1_1_%s_post_data.gz" % (command, options, ts, ts[0:8], port, user, port, ts[0:8], ts) 
+        
     run_valgrind_command(context, command_str, "valgrind_suppression.txt")
 
 @then('the user runs valgrind with "{command}" and options "{options}" and suppressions file "{suppressions_file}" using netbackup')
@@ -435,7 +435,7 @@ def impl(context, command, options, suppressions_file):
     elif bnr_tool == 'gp_restore':
         command_str = "%s %s --gp-k %s --gp-d db_dumps/%s --gp-r db_dumps/%s --netbackup-service-host %s" % (command, options, context.backup_timestamp, context.backup_timestamp[0:8], context.backup_timestamp[0:8], netbackup_service_host)
     elif bnr_tool == 'gp_restore_agent':
-        command_str = "%s %s --gp-k %s --gp-d db_dumps/%s -p %s -U %s --target-host localhost --target-port %s db_dumps/%s/gp_dump_1_1_%s_post_data.gz --netbackup-service-host %s" % (command, options, ts, ts[0:8], port, user, port, ts[0:8], ts, netbackup_service_host)
+        command_str = "%s %s --gp-k %s --gp-d db_dumps/%s -p %s -U %s --target-host localhost --target-port %s db_dumps/%s/gp_dump_-1_1_%s_post_data.gz --netbackup-service-host %s" % (command, options, ts, ts[0:8], port, user, port, ts[0:8], ts, netbackup_service_host)
     else:
         command_str = "%s %s" % (command, options)
 
@@ -793,7 +793,7 @@ def impl(context, dbname, backup_dir):
 @when('the user runs gp_restore with the the stored timestamp and subdir for metadata only in "{dbname}"')
 @then('the user runs gp_restore with the the stored timestamp and subdir for metadata only in "{dbname}"')
 def impl(context, dbname):
-    command = 'gp_restore -i --gp-k %s --gp-d db_dumps/%s --gp-i --gp-r db_dumps/%s --gp-l=p -d %s --gp-c -s db_dumps/%s/gp_dump_1_1_%s.gz' % \
+    command = 'gp_restore -i --gp-k %s --gp-d db_dumps/%s --gp-i --gp-r db_dumps/%s --gp-l=p -d %s --gp-c -s db_dumps/%s/gp_dump_-1_1_%s.gz' % \
                             (context.backup_timestamp, context.backup_subdir, context.backup_subdir, dbname, context.backup_subdir, context.backup_timestamp)
     run_gpcommand(context, command)
 
@@ -1062,15 +1062,15 @@ def verify_file_contents(context, file_type, file_dir, text_find, should_contain
     elif file_type == 'report':
         fn = '%sgp_dump_%s.rpt' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == 'status':
-        fn = '%sgp_dump_status_1_1_%s' % (context.dump_prefix, context.backup_timestamp)
+        fn = '%sgp_dump_status_-1_1_%s' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == 'filter':
         fn = '%sgp_dump_%s_filter' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == "statistics":
-        fn = '%sgp_statistics_1_1_%s' % (context.dump_prefix, context.backup_timestamp)
+        fn = '%sgp_statistics_-1_1_%s' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == 'schema':
         fn = '%sgp_dump_%s_schema' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == 'cdatabase':
-        fn = '%sgp_cdatabase_1_1_%s' % (context.dump_prefix, context.backup_timestamp)
+        fn = '%sgp_cdatabase_-1_1_%s' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == 'dump':
         fn = '%sgp_dump_1_1_%s.gz' % (context.dump_prefix, context.backup_timestamp)
 
@@ -1137,11 +1137,10 @@ def impl(context, dbname):
                 dump_dir = os.path.join(context.backup_dir, 'db_dumps', '%s' % (context.timestamp_key[0:8]))
             else:
                 dump_dir = os.path.join(master_data_dir, 'db_dumps', '%s' % (context.timestamp_key[0:8]))
-
-            master_dump_files = ['%s/gp_dump_1_1_%s' % (dump_dir, context.timestamp_key),
-                                 '%s/gp_dump_status_1_1_%s'  % (dump_dir, context.timestamp_key),
-                                 '%s/gp_cdatabase_1_1_%s' % (dump_dir, context.timestamp_key),
-                                 '%s/gp_dump_1_1_%s_post_data' % (dump_dir, context.timestamp_key)]
+            master_dump_files = ['%s/gp_dump_-1_1_%s' % (dump_dir, context.timestamp_key),
+                                 '%s/gp_dump_status_-1_1_%s'  % (dump_dir, context.timestamp_key),
+                                 '%s/gp_cdatabase_-1_1_%s' % (dump_dir, context.timestamp_key),
+                                 '%s/gp_dump_-1_1_%s_post_data' % (dump_dir, context.timestamp_key)]
 
             for dump_file in master_dump_files:
                 cmd = Command('check for dump files', 'ls -1 %s | wc -l' % (dump_file))
@@ -1283,7 +1282,7 @@ def impl(context, filetype, dir):
     elif filetype == "plan":
         filename = 'gp_restore_%s_plan' % context.backup_timestamp
     elif filetype == "global":
-        filename = 'gp_global_1_1_%s' % context.backup_timestamp
+        filename = 'gp_global_-1_1_%s' % context.backup_timestamp
     elif filetype == "report":
         filename = 'gp_dump_%s.rpt' % context.backup_timestamp
     else:
@@ -1309,9 +1308,9 @@ def impl(context, filetype, dir):
     elif filetype == "plan":
         filename = 'gp_restore_%s_plan' % context.backup_timestamp
     elif filetype == "global":
-        filename = 'gp_global_1_1_%s' % context.backup_timestamp
+        filename = 'gp_global_-1_1_%s' % context.backup_timestamp
     elif filetype == "statistics":
-        filename = 'gp_statistics_1_1_%s' % context.backup_timestamp
+        filename = 'gp_statistics_-1_1_%s' % context.backup_timestamp
     elif filetype == 'pipes':
         filename = 'gp_dump_%s_pipes' % context.backup_timestamp
     elif filetype == 'regular_files':
@@ -2360,11 +2359,11 @@ def impl(context, file_type, directory, options):
     reg_file_count = 6
 
     pipes_pattern_list = ['gp_dump_.*_%s.*(?:\.gz)?' % context.backup_timestamp]
-    regular_pattern_list = ['gp_cdatabase_1_1_%s' % context.backup_timestamp, 'gp_dump_%s.*' % context.backup_timestamp, 'gp_dump_status_1_1_%s' % context.backup_timestamp]
+    regular_pattern_list = ['gp_cdatabase_-1_1_%s' % context.backup_timestamp, 'gp_dump_%s.*' % context.backup_timestamp, 'gp_dump_status_-1_1_%s' % context.backup_timestamp]
 
     if '-G' in option_list:
         pipe_file_count += 1
-        pipes_pattern_list += ['gp_global_1_1_%s' % context.backup_timestamp]
+        pipes_pattern_list += ['gp_global_-1_1_%s' % context.backup_timestamp]
     if '-g' in option_list:
         pipe_file_count += get_num_segments(primary=True, mirror=False, master=True, standby=False)
         pipes_pattern_list += ['gp_master_config_files_%s.*' % context.backup_timestamp, 'gp_segment_config_files_.*_.*_%s.*' % context.backup_timestamp]

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1072,7 +1072,7 @@ def verify_file_contents(context, file_type, file_dir, text_find, should_contain
     elif file_type == 'cdatabase':
         fn = '%sgp_cdatabase_-1_1_%s' % (context.dump_prefix, context.backup_timestamp)
     elif file_type == 'dump':
-        fn = '%sgp_dump_1_1_%s.gz' % (context.dump_prefix, context.backup_timestamp)
+        fn = '%sgp_dump_-1_1_%s.gz' % (context.dump_prefix, context.backup_timestamp)
 
     subdirectory = context.backup_timestamp[0:8]
 

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/netbackup_mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/netbackup_mgmt_utils.py
@@ -136,7 +136,7 @@ def impl(context):
 
     for seg in primary_segs:
         segment_config_filename = os.path.join(seg.getSegmentDataDirectory(), 'db_dumps', context.backup_timestamp[0:8],
-                                           '%sgp_segment_config_files_0_%s_%s.tar' % (context.dump_prefix, seg.getSegmentDbId(), context.backup_timestamp))
+                                           '%sgp_segment_config_files_%d_%s_%s.tar' % (context.dump_prefix, seg.getSegmentContentId(), seg.getSegmentDbId(), context.backup_timestamp))
         command_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (netbackup_service_host, segment_config_filename)
         cmd = Command('Validate segment config file', command_str, ctxt=REMOTE, remoteHost = seg.getSegmentHostName())
         cmd.run(validateAfter=True)
@@ -168,7 +168,7 @@ def impl(context, dbname):
         ts = context.backup_timestamp
     if hasattr(context, 'netbackup_service_host'):
         netbackup_service_host = context.netbackup_service_host
-    command = 'gp_restore -i --gp-k %s --gp-d db_dumps/%s --gp-i --gp-r db_dumps/%s --gp-l=p -d %s --gp-c -s db_dumps/%s/gp_dump_1_1_%s.gz --netbackup-service-host %s' % \
+    command = 'gp_restore -i --gp-k %s --gp-d db_dumps/%s --gp-i --gp-r db_dumps/%s --gp-l=p -d %s --gp-c -s db_dumps/%s/gp_dump_-1_1_%s.gz --netbackup-service-host %s' % \
                             (ts, context.backup_subdir, context.backup_subdir, dbname, context.backup_subdir, ts, netbackup_service_host)
     run_gpcommand(context, command)
 
@@ -305,7 +305,7 @@ def impl(context, filetype, prefix, subdir):
             raise Exception('Report file %s was not backup up to NetBackup server %s successfully' % (filename, netbackup_service_host))
 
     elif filetype == 'global':
-        filename = os.path.join(dump_dir, "%sgp_global_1_1_%s" % (prefix, backup_timestamp))
+        filename = os.path.join(dump_dir, "%sgp_global_-1_1_%s" % (prefix, backup_timestamp))
         cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (netbackup_service_host, filename)
         cmd = Command("Querying NetBackup server for global file", cmd_str)
         cmd.run(validateAfter=True)
@@ -326,7 +326,7 @@ def impl(context, filetype, prefix, subdir):
         for seg in segs:
             seg_dir = seg.getSegmentDataDirectory()
             dump_dir = os.path.join(seg_dir, 'db_dumps', '%s' % (backup_timestamp[0:8]))
-            seg_config_filename = os.path.join(dump_dir, "%sgp_segment_config_files_0_%d_%s.tar" % (prefix, seg.getSegmentDbId(), backup_timestamp))
+            seg_config_filename = os.path.join(dump_dir, "%sgp_segment_config_files_%d_%d_%s.tar" % (prefix, seg.getSegmentContentId(), seg.getSegmentDbId(), backup_timestamp))
             seg_host = seg.getSegmentHostName()
             cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (netbackup_service_host, seg_config_filename)
             cmd = Command("Querying NetBackup server for segment config file", cmd_str, ctxt=REMOTE, remoteHost=seg_host)
@@ -357,7 +357,7 @@ def impl(context, filetype, prefix, subdir):
             raise Exception('Last operation state file %s was not backup up to NetBackup server %s successfully' % (filename, netbackup_service_host))
 
     elif filetype == 'cdatabase':
-        filename = "%s/%sgp_cdatabase_1_1_%s" % (dump_dir, prefix, backup_timestamp)
+        filename = "%s/%sgp_cdatabase_-1_1_%s" % (dump_dir, prefix, backup_timestamp)
         cmd_str = "gp_bsa_query_agent --netbackup-service-host %s --netbackup-filename %s" % (netbackup_service_host, filename)
         cmd = Command("Querying NetBackup server for cdatabase file", cmd_str)
         cmd.run(validateAfter=True)

--- a/gpMgmt/bin/gppylib/test/unit/__init__.py
+++ b/gpMgmt/bin/gppylib/test/unit/__init__.py
@@ -2,3 +2,12 @@
 from os.path import abspath as _abspath
 __path__[0] = _abspath(__path__[0])
 
+from gppylib.gparray import GpArray, GpDB
+
+def setup_fake_gparray():
+    master = GpDB.initFromString("1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+    primary0 = GpDB.initFromString("2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+    primary1 = GpDB.initFromString("3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+    mirror0 = GpDB.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+    mirror1 = GpDB.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+    return GpArray([master,primary0,primary1,mirror0,mirror1])

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
@@ -527,7 +527,7 @@ class GpcrondumpTestCase(unittest.TestCase):
         with self.assertRaisesRegexp(Exception, '--ddboost is not supported with NetBackup'):
             GpCronDump(self.options, None)
 
-    def test_gpcrondump_options_h_H(self):
+    def test_gpcrondump_options_h_H(self, mock1):
         testargs = ["","-h", "-H"]
         with patch.object(sys, 'argv', testargs):
             with self.assertRaisesRegexp(Exception, '-H option cannot be selected with -h option. '):

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
@@ -14,10 +14,12 @@ from mock import patch, Mock, MagicMock, mock_open
 from gppylib.commands.base import CommandResult
 from gppylib.operations.dump import MailDumpEvent
 from gppylib.operations.backup_utils import write_lines_to_file
+from . import setup_fake_gparray
 
 
 logger = gplog.get_unittest_logger()
 
+@patch('gppylib.gparray.GpArray.initFromCatalog', return_value=setup_fake_gparray())
 class GpcrondumpTestCase(unittest.TestCase):
 
     class Options:
@@ -84,14 +86,15 @@ class GpcrondumpTestCase(unittest.TestCase):
             self.netbackup_block_size = None
             self.netbackup_keyword = None
 
-    def setUp(self):
+    @patch('gppylib.gparray.GpArray.initFromCatalog', return_value=setup_fake_gparray())
+    def setUp(self, mock1):
         self.options = self.Options()
         self.crondump = GpCronDump(self.options, None)
         self.context = self.crondump.context
 
     @patch('gpcrondump.GpCronDump.validate_dump_schema')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_1(self, mock, mock2):
+    def test_schema_filter_1(self, mock, mock2, mock3):
         self.options.include_schema_file = '/tmp/foo'
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--schema-file option can not be selected with incremental backup'):
@@ -99,209 +102,209 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.GpCronDump.validate_dump_schema')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_2(self, mock, mock2):
+    def test_schema_filter_2(self, mock, mock2, mock3):
         self.options.exclude_schema_file = '/tmp/foo'
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--exclude-schema-file option can not be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_3(self, mock):
+    def test_schema_filter_3(self, mock1, mock2):
         self.options.exclude_dump_schema = 'foo'
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '-S option can not be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_4(self, mock):
+    def test_schema_filter_4(self, mock1, mock2):
         self.options.dump_schema = 'foo'
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '-s option can not be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_5(self, mock):
+    def test_schema_filter_5(self, mock1, mock2):
         self.options.dump_schema = 'foo'
         self.options.exclude_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-s can not be selected with --exclude-schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_6(self, mock):
+    def test_schema_filter_6(self, mock1, mock2):
         self.options.dump_schema = 'foo'
         self.options.include_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-s can not be selected with --schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_7(self, mock):
+    def test_schema_filter_7(self, mock1, mock2):
         self.options.dump_schema = 'foo'
         self.options.exclude_dump_schema = 'foo'
         with self.assertRaisesRegexp(Exception, '-s can not be selected with -S option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_8(self, mock):
+    def test_schema_filter_8(self, mock1, mock2):
         self.options.exclude_dump_schema = 'foo'
         self.options.exclude_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-S can not be selected with --exclude-schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_9(self, mock):
+    def test_schema_filter_9(self, mock1, mock2):
         self.options.exclude_dump_schema = 'foo'
         self.options.include_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-S can not be selected with --schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_10(self, mock):
+    def test_schema_filter_10(self, mock1, mock2):
         self.options.exclude_schema_file = 'foo'
         self.options.include_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--exclude-schema-file can not be selected with --schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_11(self, mock):
+    def test_schema_filter_11(self, mock1, mock2):
         self.options.exclude_schema_file = 'foo'
         self.options.include_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with --exclude-schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_12(self, mock):
+    def test_schema_filter_12(self, mock1, mock2):
         self.options.exclude_schema_file = 'foo'
         self.options.exclude_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with --exclude-schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_13(self, mock):
+    def test_schema_filter_13(self, mock1, mock2):
         self.options.include_schema_file = 'foo'
         self.options.exclude_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with --schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_14(self, mock):
+    def test_schema_filter_14(self, mock1, mock2):
         self.options.include_schema_file = 'foo'
         self.options.include_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with --schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_15(self, mock):
+    def test_schema_filter_15(self, mock1, mock2):
         self.options.dump_schema = 'foo'
         self.options.include_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with -s option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_16(self, mock):
+    def test_schema_filter_16(self, mock1, mock2):
         self.options.dump_schema = 'foo'
         self.options.exclude_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with -s option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_17(self, mock):
+    def test_schema_filter_17(self, mock1, mock2):
         self.options.exclude_dump_schema = 'foo'
         self.options.include_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with -S option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_18(self, mock):
+    def test_schema_filter_18(self, mock1, mock2):
         self.options.exclude_dump_schema = 'foo'
         self.options.exclude_dump_tables_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '--table-file and --exclude-table-file can not be selected with -S option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_19(self, mock):
+    def test_schema_filter_19(self, mock1, mock2):
         self.options.exclude_schema_file = 'foo'
         self.options.exclude_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with --exclude-schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_20(self, mock):
+    def test_schema_filter_20(self, mock1, mock2):
         self.options.exclude_schema_file = 'foo'
         self.options.include_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with --exclude-schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_21(self, mock):
+    def test_schema_filter_21(self, mock1, mock2):
         self.options.include_schema_file = 'foo'
         self.options.exclude_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with --schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_22(self, mock):
+    def test_schema_filter_22(self, mock1, mock2):
         self.options.include_schema_file = 'foo'
         self.options.include_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with --schema-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_23(self, mock):
+    def test_schema_filter_23(self, mock1, mock2):
         self.options.dump_schema = 'foo'
         self.options.exclude_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with -s option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_24(self, mock):
+    def test_schema_filter_24(self, mock1, mock2):
         self.options.dump_schema = 'foo'
         self.options.include_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with -s option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_25(self, mock):
+    def test_schema_filter_25(self, mock1, mock2):
         self.options.exclude_dump_schema = 'foo'
         self.options.exclude_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with -S option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_26(self, mock):
+    def test_schema_filter_26(self, mock1, mock2):
         self.options.exclude_dump_schema = 'foo'
         self.options.include_dump_tables = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, '-t and -T can not be selected with -S option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_27(self, mock):
+    def test_schema_filter_27(self, mock1, mock2):
         self.options.dump_schema = ['information_schema']
         with self.assertRaisesRegexp(Exception, "can not specify catalog schema 'information_schema' using -s option"):
             GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_28(self, mock):
+    def test_schema_filter_28(self, mock1, mock2):
         self.options.exclude_dump_schema = ['information_schema']
         with self.assertRaisesRegexp(Exception, "can not specify catalog schema 'information_schema' using -S option"):
             GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_lines_from_file', return_value=['public', 'information_schema'])
-    def test_schema_filter_29(self, mock, mock2):
+    def test_schema_filter_29(self, mock, mock2, mock3):
         self.options.exclude_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, "can not exclude catalog schema 'information_schema' in schema file '/tmp/foo'"):
             GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_lines_from_file', return_value=['public', 'information_schema'])
-    def test_schema_filter_30(self, mock, mock2):
+    def test_schema_filter_30(self, mock, mock2, mock3):
         self.options.include_schema_file = '/tmp/foo'
         with self.assertRaisesRegexp(Exception, "can not include catalog schema 'information_schema' in schema file '/tmp/foo'"):
             GpCronDump(self.options, None)
 
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_31(self, mock, mock2):
+    def test_schema_filter_31(self, mock, mock2, mock3):
         self.options.masterDataDirectory = '/tmp/foobar'
         gpcd = GpCronDump(self.options, None)
         with patch('__builtin__.open', mock_open(), create=True):
@@ -309,7 +312,7 @@ class GpcrondumpTestCase(unittest.TestCase):
             self.assertEquals(gpcd.context.schema_file, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_schema_filter_32(self, mock1):
+    def test_schema_filter_32(self, mock1, mock2):
         self.options.dump_schema = ['public']
         gpcd = GpCronDump(self.options, None)
         with patch('__builtin__.open', mock_open(), create=True):
@@ -318,7 +321,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_lines_from_file', return_value=['public'])
-    def test_schema_filter_33(self, mock1, mock2):
+    def test_schema_filter_33(self, mock1, mock2, mock3):
         self.options.include_schema_file = '/tmp/foo'
         gpcd = GpCronDump(self.options, None)
         with patch('__builtin__.open', mock_open(), create=True):
@@ -327,7 +330,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_include_schema_list_from_exclude_schema', return_value=['public'])
-    def test_schema_filter_34(self, mock1, mock2):
+    def test_schema_filter_34(self, mock1, mock2, mock3):
         self.options.exclude_schema_file = '/tmp/foo'
         write_lines_to_file('/tmp/foo', ['public'])
         gpcd = GpCronDump(self.options, None)
@@ -337,7 +340,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_include_schema_list_from_exclude_schema', return_value=['public'])
-    def test_schema_filter_35(self, mock1, mock2):
+    def test_schema_filter_35(self, mock1, mock2, mock3):
         self.options.exclude_dump_schema = 'public'
         gpcd = GpCronDump(self.options, None)
         with patch('__builtin__.open', mock_open(), create=True):
@@ -347,7 +350,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_lines_from_file', return_value=['public'])
     @patch('gpcrondump.get_user_table_list_for_schema', return_value=['public', 'table1', 'public', 'table2'])
-    def test_schema_filter_36(self, mock1, mock2, mock3):
+    def test_schema_filter_36(self, mock1, mock2, mock3, mock4):
         gpcd = GpCronDump(self.options, None)
         with patch('__builtin__.open', mock_open(), create=True):
             gpcd.generate_schema_list_file()
@@ -355,35 +358,35 @@ class GpcrondumpTestCase(unittest.TestCase):
             self.assertTrue(inc.startswith('/tmp/include_dump_tables_file'))
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options1(self, mock):
+    def test_options1(self, mock1, mock2):
         self.options.include_dump_tables = 'foo'
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'include table list can not be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options2(self, mock):
+    def test_options2(self, mock1, mock2):
         self.options.exclude_dump_tables = 'foo'
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'exclude table list can not be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options3(self, mock):
+    def test_options3(self, mock1, mock2):
         self.options.include_dump_tables_file = 'foo'
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'include table file can not be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options4(self, mock):
+    def test_options4(self, mock1, mock2):
         self.options.exclude_dump_tables_file = 'foo'
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'exclude table file can not be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options10(self, mock):
+    def test_options10(self, mock1, mock2):
         self.options.local_dump_prefix = 'foo'
         self.options.incremental = False
         self.options.list_filter_tables = True
@@ -395,13 +398,13 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20121225090000')
-    def test_options11(self, mock, mock2):
+    def test_options11(self, mock, mock2, mock3):
         self.options.incremental = True
         cron = GpCronDump(self.options, None)
         self.assertEquals(cron.context.full_dump_timestamp, '20121225090000')
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options12(self, mock):
+    def test_options12(self, mock1, mock2):
         self.options.incremental = True
         self.options.dump_databases = 'bkdb,fulldb'
         with self.assertRaisesRegexp(Exception, 'multi-database backup is not supported with incremental backup'):
@@ -409,7 +412,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20120330090000')
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options13(self, mock, mock2):
+    def test_options13(self, mock, mock2, mock3):
         self.options.incremental = True
         self.options.dump_databases = ['bkdb']
 
@@ -417,7 +420,7 @@ class GpcrondumpTestCase(unittest.TestCase):
         GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options14(self, mock):
+    def test_options14(self, mock1, mock2):
         self.options.dump_databases = 'bkdb'
         self.options.incremental = False
 
@@ -425,7 +428,7 @@ class GpcrondumpTestCase(unittest.TestCase):
         GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options15(self, mock):
+    def test_options15(self, mock1, mock2):
         self.options.dump_databases = 'bkdb,fulldb'
         self.options.incremental = False
 
@@ -433,28 +436,28 @@ class GpcrondumpTestCase(unittest.TestCase):
         GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options16(self, mock):
+    def test_options16(self, mock1, mock2):
         self.options.dump_schema = 'foo'
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '-s option can not be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options17(self, mock):
+    def test_options17(self, mock1, mock2):
         self.options.clear_dumps = True
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '-c option can not be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options18(self, mock):
+    def test_options18(self, mock1, mock2):
         self.options.dump_databases = []
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, 'Must supply -x <database name> with incremental option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options19(self, mock):
+    def test_options19(self, mock1, mock2):
         self.options.ddboost = True
         self.options.replicate = False
         self.options.max_streams = 20
@@ -462,7 +465,7 @@ class GpcrondumpTestCase(unittest.TestCase):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options20(self, mock):
+    def test_options20(self, mock1, mock2):
         self.options.ddboost = True
         self.options.replicate = True
         self.options.max_streams = None
@@ -470,7 +473,7 @@ class GpcrondumpTestCase(unittest.TestCase):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options21(self, mock):
+    def test_options21(self, mock1, mock2):
         self.options.ddboost = True
         self.options.replicate = True
         self.options.max_streams = 0
@@ -478,7 +481,7 @@ class GpcrondumpTestCase(unittest.TestCase):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options22(self, mock):
+    def test_options22(self, mock1, mock2):
         self.options.ddboost = True
         self.options.replicate = True
         self.options.max_streams = "abc"
@@ -486,7 +489,7 @@ class GpcrondumpTestCase(unittest.TestCase):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options23(self, mock):
+    def test_options23(self, mock1, mock2):
         self.options.ddboost = False
         self.options.replicate = False
         self.options.max_streams = 20
@@ -494,21 +497,21 @@ class GpcrondumpTestCase(unittest.TestCase):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options24(self, mock1):
+    def test_options24(self, mock1, mock2):
         self.options.list_backup_files = True
         self.options.timestamp_key = None
         with self.assertRaisesRegexp(Exception, 'Must supply -K option when listing backup files'):
             GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options25(self, mock):
+    def test_options25(self, mock1, mock2):
         self.options.dump_databases = 'bkdb,fulldb'
         self.options.timestamp_key = '20160101010101'
         with self.assertRaisesRegexp(Exception, 'multi-database backup is not supported with -K option'):
             GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options27(self, mock):
+    def test_options27(self, mock1, mock2):
         self.options.ddboost = True
         self.options.list_backup_files = True
         self.options.timestamp_key = '20160101010101'
@@ -516,7 +519,7 @@ class GpcrondumpTestCase(unittest.TestCase):
             GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options28(self, mock):
+    def test_options28(self, mock1, mock2):
         self.options.ddboost = True
         self.options.netbackup_service_host = "mdw"
         self.options.netbackup_policy = "test_policy"
@@ -530,7 +533,7 @@ class GpcrondumpTestCase(unittest.TestCase):
             with self.assertRaisesRegexp(Exception, '-H option cannot be selected with -h option. '):
                 self.crondump = GpCronDump(self.options, None)
 
-    def test_options_ddboost_storage_unit_should_be_used_with_ddboost(self):
+    def test_options_ddboost_storage_unit_should_be_used_with_ddboost(self, mock1):
         """
         --ddboost-storage-unit option must come with --ddboost option
         """
@@ -540,7 +543,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_include_exclude_for_dump_database00(self, mock1, mock2):
+    def test_get_include_exclude_for_dump_database00(self, mock1, mock2, mock3):
         self.options.masterDataDirectory = '/tmp/foobar'
         gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
@@ -553,7 +556,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.expand_partitions_and_populate_filter_file', return_value='/tmp/include_dump_tables_file')
     @patch('gpcrondump.get_lines_from_file', return_value=['public.t1', 'public.t2'])
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_include_exclude_for_dump_database01(self, mock1, mock2, mock3, mock4):
+    def test_get_include_exclude_for_dump_database01(self, mock1, mock2, mock3, mock4, mock5):
         self.options.masterDataDirectory = '/tmp/foobar'
         self.options.include_dump_tables_file = '/mydir/incfile'
         gpcd = GpCronDump(self.options, None)
@@ -566,7 +569,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.expand_partitions_and_populate_filter_file', return_value='/tmp/include_dump_tables_file')
     @patch('gpcrondump.get_lines_from_file')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_include_exclude_for_dump_database02(self, mock1, mock2, mock3, mock4):
+    def test_get_include_exclude_for_dump_database02(self, mock1, mock2, mock3, mock4, mock5):
         self.options.masterDataDirectory = '/tmp/foobar'
         self.options.include_dump_tables = ['public.t1', 'public.t2', 'public.t3']
         gpcd = GpCronDump(self.options, None)
@@ -578,7 +581,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20121225090000')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_include_exclude_for_dump_database03(self, mock1, mock2, mock3):
+    def test_get_include_exclude_for_dump_database03(self, mock1, mock2, mock3, mock4):
         self.options.masterDataDirectory = '/tmp/foobar'
         self.options.incremental = True
         gpcd = GpCronDump(self.options, None)
@@ -592,7 +595,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.expand_partitions_and_populate_filter_file', return_value='/tmp/exclude_dump_tables_file')
     @patch('gpcrondump.get_lines_from_file', return_value=['public.t1', 'public.t2'])
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_include_exclude_for_dump_database04(self, mock1, mock2, mock3, mock4):
+    def test_get_include_exclude_for_dump_database04(self, mock1, mock2, mock3, mock4, mock5):
         self.options.masterDataDirectory = '/tmp/foobar'
         self.options.exclude_dump_tables_file = '/odir/exfile'
         gpcd = GpCronDump(self.options, None)
@@ -605,7 +608,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.expand_partitions_and_populate_filter_file', return_value='/tmp/exclude_dump_tables_file')
     @patch('gpcrondump.get_lines_from_file')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_include_exclude_for_dump_database06(self, mock1, mock2, mock3, mock4):
+    def test_get_include_exclude_for_dump_database06(self, mock1, mock2, mock3, mock4, mock5):
         self.options.masterDataDirectory = '/tmp/foobar'
         self.options.exclude_dump_tables = ['public.t4', 'public.t5', 'public.t6']
         gpcd = GpCronDump(self.options, None)
@@ -616,7 +619,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.GpCronDump._get_table_names_from_partition_list', side_effect = [['public.aot1', 'public.aot2'], ['public.cot1', 'public.cot2']])
-    def test_verify_tablenames_default(self, mock1, mock2):
+    def test_verify_tablenames_default(self, mock1, mock2, mock3):
         cron = GpCronDump(self.options, None)
         ao_partition_list = ['public, aot1, 2190', 'public, aot2, 3190']
         co_partition_list = ['public, cot1, 2190', 'public, cot2, 3190']
@@ -625,7 +628,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.GpCronDump._get_table_names_from_partition_list', side_effect = [['public.aot1:asd', 'public.aot2'], ['public.cot1', 'public.cot2:asd']])
-    def test_verify_tablenames_bad_chars(self, mock1, mock2):
+    def test_verify_tablenames_bad_chars(self, mock1, mock2, mock3):
         cron = GpCronDump(self.options, None)
         ao_partition_list = ['public, aot1!asd, 2190', 'public, aot2, 3190']
         co_partition_list = ['public, cot1, 2190', 'public, cot2\nasd, 3190']
@@ -634,28 +637,28 @@ class GpcrondumpTestCase(unittest.TestCase):
             cron._verify_tablenames(ao_partition_list, co_partition_list, heap_partition_list)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_inserts_with_incremental(self, mock):
+    def test_options_inserts_with_incremental(self, mock1, mock2):
         self.options.output_options = ['--inserts']
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--inserts, --column-inserts, --oids cannot be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_oids_with_incremental(self, mock):
+    def test_options_oids_with_incremental(self, mock1, mock2):
         self.options.output_options = ['--oids']
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--inserts, --column-inserts, --oids cannot be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_column_inserts_with_incremental(self, mock):
+    def test_options_column_inserts_with_incremental(self, mock1, mock2):
         self.options.output_options = ['--column-inserts']
         self.options.incremental = True
         with self.assertRaisesRegexp(Exception, '--inserts, --column-inserts, --oids cannot be selected with incremental backup'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_get_table_names_from_partition_list_00(self, mock1):
+    def test_get_table_names_from_partition_list_00(self, mock1, mock2):
         cron = GpCronDump(self.options, None)
         partition_list = ['public, aot1, 2190', 'public, aot2:aot, 3190']
         expected_output = ['public.aot1', 'public.aot2:aot']
@@ -663,49 +666,49 @@ class GpcrondumpTestCase(unittest.TestCase):
         self.assertEqual(result, expected_output)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_get_table_names_from_partition_list_01(self, mock1):
+    def test_get_table_names_from_partition_list_01(self, mock1, mock2):
         cron = GpCronDump(self.options, None)
         partition_list = ['public, aot1, 2190', 'public, aot2,aot, 3190']
         with self.assertRaisesRegexp(Exception, 'Invalid partition entry "public, aot2,aot, 3190"'):
             cron._get_table_names_from_partition_list(partition_list)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter1(self, mock):
+    def test_options_table_filter1(self, mock1, mock2):
         self.options.include_dump_tables = 'foo'
         self.options.include_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '-t can not be selected with --table-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter2(self, mock):
+    def test_options_table_filter2(self, mock1, mock2):
         self.options.include_dump_tables = 'foo'
         self.options.exclude_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '-t can not be selected with --exclude-table-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter3(self, mock):
+    def test_options_table_filter3(self, mock1, mock2):
         self.options.exclude_dump_tables = 'foo'
         self.options.exclude_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '-T can not be selected with --exclude-table-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter4(self, mock):
+    def test_options_table_filter4(self, mock1, mock2):
         self.options.exclude_dump_tables = 'foo'
         self.options.include_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '-T can not be selected with --table-file option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter5(self, mock):
+    def test_options_table_filter5(self, mock1, mock2):
         self.options.include_dump_tables = 'foo'
         self.options.exclude_dump_tables = 'foo'
         with self.assertRaisesRegexp(Exception, '-t can not be selected with -T option'):
             cron = GpCronDump(self.options, None)
 
     @patch('gpcrondump.validate_current_timestamp')
-    def test_options_table_filter6(self, mock):
+    def test_options_table_filter6(self, mock1, mock2):
         self.options.include_dump_tables_file = 'foo'
         self.options.exclude_dump_tables_file = 'foo'
         with self.assertRaisesRegexp(Exception, '--table-file can not be selected with --exclude-table-file option'):
@@ -713,7 +716,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_files_file_list1(self, mock1, mock2):
+    def test_get_files_file_list1(self, mock1, mock2, mock3):
         self.options.timestamp_key = None
         self.options.masterDataDirectory = '/foo'
         gpcd = GpCronDump(self.options, None)
@@ -722,17 +725,17 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd.context.timestamp = '20130101010101'
         dump_dir = gpcd.context.get_backup_dir()
         files_file_list = gpcd._get_files_file_list(master)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_cdatabase_-1_1_20130101010101' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory]
+                               'foo1:%s/db_dumps/20130101/gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory]
         self.assertEqual(files_file_list, expected_files_list)
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_files_file_list2(self, mock1, mock2):
+    def test_get_files_file_list2(self, mock1, mock2, mock3):
         self.options.timestamp_key = None
         self.options.masterDataDirectory = '/foo'
         gpcd = GpCronDump(self.options, None)
@@ -741,18 +744,18 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd.context.timestamp = '20130101010101'
         dump_dir = gpcd.context.get_backup_dir()
         files_file_list = gpcd._get_files_file_list(master)
-        expected_files_list = ['foo2:%s/db_dumps/20130101/gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+        expected_files_list = ['foo2:%s/db_dumps/20130101/gp_cdatabase_-1_1_20130101010101' % self.options.masterDataDirectory,
                                'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
                                'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
                                'foo2:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
                                'foo2:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
-                               'foo2:%s/db_dumps/20130101/gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory]
+                               'foo2:%s/db_dumps/20130101/gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory]
         self.assertEqual(files_file_list, expected_files_list)
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20130101000000')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_files_file_list3(self, mock1, mock2, mock3):
+    def test_get_files_file_list3(self, mock1, mock2, mock3, mock4):
         self.options.timestamp_key = '20130101010101'
         self.options.incremental = True
         self.options.masterDataDirectory = '/data/foo'
@@ -763,19 +766,19 @@ class GpcrondumpTestCase(unittest.TestCase):
 
         dump_dir = gpcd.context.get_backup_dir()
         files_file_list = gpcd._get_files_file_list(master)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_cdatabase_-1_1_20130101010101' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/gp_dump_20130101000000_increments' % self.options.masterDataDirectory]
         self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.get_latest_full_dump_timestamp', return_value='20130101000000')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_files_file_list_with_filter(self, mock1, mock2, mock3):
+    def test_get_files_file_list_with_filter(self, mock1, mock2, mock3, mock4):
         self.options.timestamp_key = '20130101010101'
         self.options.local_dump_prefix = 'metro'
         self.options.include_dump_tables_file = 'bar'
@@ -786,19 +789,19 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd.context.timestamp = '20130101010101'
         dump_dir = gpcd.context.get_backup_dir()
         files_file_list = gpcd._get_files_file_list(master)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/metro_gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+        expected_files_list = ['foo1:%s/db_dumps/20130101/metro_gp_cdatabase_-1_1_20130101010101' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_filter' % self.options.masterDataDirectory]
         self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gpcrondump.get_latest_full_dump_timestamp', return_value='20130101000000')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_files_file_list_with_prefix(self, mock1, mock2, mock3):
+    def test_get_files_file_list_with_prefix(self, mock1, mock2, mock3, mock4):
         self.options.timestamp_key = '20130101010101'
         self.options.incremental = True
         self.options.local_dump_prefix = 'metro'
@@ -810,19 +813,19 @@ class GpcrondumpTestCase(unittest.TestCase):
 
         dump_dir = gpcd.context.get_backup_dir()
         files_file_list = gpcd._get_files_file_list(master)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/metro_gp_cdatabase_1_1_20130101010101' % self.options.masterDataDirectory,
+        expected_files_list = ['foo1:%s/db_dumps/20130101/metro_gp_cdatabase_-1_1_20130101010101' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_ao_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_co_state_file' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101_last_operation' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101010101.rpt' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/metro_gp_dump_status_1_1_20130101010101' % self.options.masterDataDirectory,
+                               'foo1:%s/db_dumps/20130101/metro_gp_dump_status_-1_1_20130101010101' % self.options.masterDataDirectory,
                                'foo1:%s/db_dumps/20130101/metro_gp_dump_20130101000000_increments' % self.options.masterDataDirectory]
 
         self.assertEqual(sorted(files_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_pipes_file_list1(self, mock1, mock2):
+    def test_get_pipes_file_list1(self, mock1, mock2, mock3):
         self.options.timestamp_key = None
         self.options.masterDataDirectory = '/foo'
         gpcd = GpCronDump(self.options, None)
@@ -832,85 +835,70 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd.context.timestamp = '20130101010101'
         dump_dir = gpcd.context.get_backup_dir()
         pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs)
-        expected_files_list = ['foo2:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % self.options.masterDataDirectory,
-                               'foo2:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % self.options.masterDataDirectory]
+        expected_files_list = ['foo2:%s/db_dumps/20130101/gp_dump_-1_1_20130101010101.gz' % self.options.masterDataDirectory,
+                               'foo2:%s/db_dumps/20130101/gp_dump_-1_1_20130101010101_post_data.gz' % self.options.masterDataDirectory]
         self.assertEqual(pipes_file_list, expected_files_list)
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_pipes_file_list2(self, mock1, mock2):
+    def test_get_pipes_file_list2(self, mock1, mock2, mock3):
         self.options.timestamp_key = None
-        self.options.masterDataDirectory = '/foo'
+        self.options.masterDataDirectory = '/data/master'
         gpcd = GpCronDump(self.options, None)
-        master = Mock()
-        master.getSegmentHostName.return_value = 'foo1'
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.getSegmentDataDirectory.return_value = '/bar'
-            seg.getSegmentHostName.return_value = 'foo1'
-            seg.getSegmentDbId.return_value = id + 2
         gpcd.context.timestamp = '20130101010101'
         dump_dir = gpcd.context.get_backup_dir()
-        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % self.options.masterDataDirectory,
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_2_20130101010101.gz',
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_3_20130101010101.gz']
+        primaries = self.context.get_current_primaries()
+        master = [m for m in self.context.gparray.getDbList() if m.isSegmentMaster()][0]
+        pipes_file_list = gpcd._get_pipes_file_list(master, primaries)
+        expected_files_list = ['mdw:/data/master/db_dumps/20130101/gp_dump_-1_1_20130101010101.gz',
+                               'mdw:/data/master/db_dumps/20130101/gp_dump_-1_1_20130101010101_post_data.gz',
+                               'sdw1:/data/primary0/db_dumps/20130101/gp_dump_0_2_20130101010101.gz',
+                               'sdw2:/data/primary1/db_dumps/20130101/gp_dump_1_3_20130101010101.gz']
         self.assertEqual(sorted(pipes_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_pipes_file_list3(self, mock1, mock2):
+    def test_get_pipes_file_list3(self, mock1, mock2, mock3):
         self.options.timestamp_key = None
         self.options.dump_global = True
-        self.options.masterDataDirectory = '/foo'
+        self.options.masterDataDirectory = '/data/master'
         gpcd = GpCronDump(self.options, None)
-        master = Mock()
-        master.getSegmentHostName.return_value = 'foo1'
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.getSegmentDataDirectory.return_value = '/bar'
-            seg.getSegmentHostName.return_value = 'foo1'
-            seg.getSegmentDbId.return_value = id + 2
         gpcd.context.timestamp = '20130101010101'
         dump_dir = gpcd.context.get_backup_dir()
-        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_global_1_1_20130101010101' % self.options.masterDataDirectory,
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_2_20130101010101.gz',
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_3_20130101010101.gz']
+        primaries = self.context.get_current_primaries()
+        master = [m for m in self.context.gparray.getDbList() if m.isSegmentMaster()][0]
+        pipes_file_list = gpcd._get_pipes_file_list(master, primaries)
+        expected_files_list = ['mdw:/data/master/db_dumps/20130101/gp_dump_-1_1_20130101010101.gz',
+                               'mdw:/data/master/db_dumps/20130101/gp_dump_-1_1_20130101010101_post_data.gz',
+                               'mdw:/data/master/db_dumps/20130101/gp_global_-1_1_20130101010101',
+                               'sdw1:/data/primary0/db_dumps/20130101/gp_dump_0_2_20130101010101.gz',
+                               'sdw2:/data/primary1/db_dumps/20130101/gp_dump_1_3_20130101010101.gz']
         self.assertEqual(sorted(pipes_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_get_pipes_file_list4(self, mock1, mock2):
+    def test_get_pipes_file_list4(self, mock1, mock2, mock3):
         self.options.timestamp_key = None
-        self.options.masterDataDirectory = '/foo'
+        self.options.masterDataDirectory = '/data/master'
         self.options.dump_config = True
         gpcd = GpCronDump(self.options, None)
-        master = Mock()
-        master.getSegmentHostName.return_value = 'foo1'
-        mock_segs = [Mock(), Mock()]
-        for id, seg in enumerate(mock_segs):
-            seg.getSegmentDataDirectory.return_value = '/bar'
-            seg.getSegmentHostName.return_value = 'foo1'
-            seg.getSegmentDbId.return_value = id + 2
         gpcd.context.timestamp = '20130101010101'
         dump_dir = gpcd.context.get_backup_dir()
-        pipes_file_list = gpcd._get_pipes_file_list(master, mock_segs)
-        expected_files_list = ['foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101.gz' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_dump_1_1_20130101010101_post_data.gz' % self.options.masterDataDirectory,
-                               'foo1:%s/db_dumps/20130101/gp_master_config_files_20130101010101.tar' % self.options.masterDataDirectory,
-                               'foo1:/bar/db_dumps/20130101/gp_segment_config_files_0_2_20130101010101.tar',
-                               'foo1:/bar/db_dumps/20130101/gp_segment_config_files_0_3_20130101010101.tar',
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_2_20130101010101.gz',
-                               'foo1:/bar/db_dumps/20130101/gp_dump_0_3_20130101010101.gz']
+        primaries = self.context.get_current_primaries()
+        master = [m for m in self.context.gparray.getDbList() if m.isSegmentMaster()][0]
+        pipes_file_list = gpcd._get_pipes_file_list(master, primaries)
+        expected_files_list = ['mdw:/data/master/db_dumps/20130101/gp_dump_-1_1_20130101010101.gz',
+                               'mdw:/data/master/db_dumps/20130101/gp_dump_-1_1_20130101010101_post_data.gz',
+                               'mdw:/data/master/db_dumps/20130101/gp_master_config_files_20130101010101.tar',
+                               'sdw1:/data/primary0/db_dumps/20130101/gp_segment_config_files_0_2_20130101010101.tar',
+                               'sdw2:/data/primary1/db_dumps/20130101/gp_segment_config_files_1_3_20130101010101.tar',
+                               'sdw1:/data/primary0/db_dumps/20130101/gp_dump_0_2_20130101010101.gz',
+                               'sdw2:/data/primary1/db_dumps/20130101/gp_dump_1_3_20130101010101.gz']
         self.assertEqual(sorted(pipes_file_list), sorted(expected_files_list))
 
     @patch('gpcrondump.validate_current_timestamp')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_gpcrondump_init0(self, mock1, mock2):
+    def test_gpcrondump_init0(self, mock1, mock2, mock3):
         self.options.timestamp_key = None
         self.options.local_dump_prefix = 'foo'
         self.options.ddboost = False
@@ -927,7 +915,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.os.path.getsize', return_value=111)
     @patch('gpcrondump.yaml.load', return_value={'EMAIL_DETAILS': [{'FROM': 'RRP_MPE2_DCA_1', 'DBNAME': 'testdb100', 'SUBJECT': "backup completed for Database 'testdb100'"}]})
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_validate_parse_email_File00(self, mock1, mock2, mock3, mock4):
+    def test_validate_parse_email_File00(self, mock1, mock2, mock3, mock4, mock5):
         self.options.include_email_file = "/tmp/abc.yaml"
         m = MagicMock()
         with patch('__builtin__.open', m, create=True):
@@ -935,7 +923,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.os.path.isfile', return_value=False)
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_validate_parse_email_File01(self, mock1, mock2):
+    def test_validate_parse_email_File01(self, mock1, mock2, mock3):
         self.options.include_email_file = "/tmp/abc.yaml"
         with self.assertRaisesRegexp(Exception, "\'%s\' file does not exist." % self.options.include_email_file):
             cron = GpCronDump(self.options, None)
@@ -943,7 +931,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.os.path.isfile', return_value=True)
     @patch('gpcrondump.os.path.getsize', return_value=111)
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_validate_parse_email_File02(self, mock1, mock2, mock3):
+    def test_validate_parse_email_File02(self, mock1, mock2, mock3, mock4):
         self.options.include_email_file = "/tmp/abc"
         with self.assertRaisesRegexp(Exception, "'%s' is not '.yaml' file. File containing email details should be '.yaml' file." %  self.options.include_email_file):
             cron = GpCronDump(self.options, None)
@@ -951,7 +939,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.os.path.isfile', return_value=True)
     @patch('gpcrondump.os.path.getsize', return_value=0)
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_validate_parse_email_File03(self, mock1, mock2, mock3):
+    def test_validate_parse_email_File03(self, mock1, mock2, mock3, mock4):
         self.options.include_email_file = "/tmp/abc.yaml"
         with self.assertRaisesRegexp(Exception, "'%s' file is empty." % self.options.include_email_file):
             cron = GpCronDump(self.options, None)
@@ -960,7 +948,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.os.path.getsize', return_value=111)
     @patch('gpcrondump.yaml.load', return_value={'EMAIL_DETAILS': [{'FROM': 'RRP_MPE2_DCA_1', 'NAME': 'testdb100', 'SUBJECT': "backup completed for Database 'testdb100'"}]})
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_validate_parse_email_File04(self, mock1, mock2, mock3, mock4):
+    def test_validate_parse_email_File04(self, mock1, mock2, mock3, mock4, mock5):
         self.options.include_email_file = "/tmp/abc.yaml"
         m = MagicMock()
         with self.assertRaisesRegexp(Exception, "\'%s\' file is not formatted properly." % self.options.include_email_file):
@@ -971,7 +959,7 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.os.path.getsize', return_value=111)
     @patch('gpcrondump.yaml.load', return_value={'EMAIL_DETAILS': [{'FROM': 'RRP_MPE2_DCA_1', 'DBNAME': None, 'SUBJECT': "backup completed for Database 'testdb100'"}]})
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_validate_parse_email_File05(self, mock1, mock2, mock3, mock4):
+    def test_validate_parse_email_File05(self, mock1, mock2, mock3, mock4, mock5):
         self.options.include_email_file = "/tmp/abc.yaml"
         m = MagicMock()
         with self.assertRaisesRegexp(Exception, "\'%s\' file is not formatted properly." % self.options.include_email_file):
@@ -980,7 +968,7 @@ class GpcrondumpTestCase(unittest.TestCase):
 
     @patch('gpcrondump.MailDumpEvent')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_send_email00(self, mock1, MailDumpEvent):
+    def test_send_email00(self, mock1, mock2, mock3):
         dump_database = 'testdb1'
         current_exit_status = 0
         time_start = '12:07:09'
@@ -988,46 +976,46 @@ class GpcrondumpTestCase(unittest.TestCase):
         cron = GpCronDump(self.options, None)
         cron._send_email(dump_database, current_exit_status, time_start, time_end)
 
-    @patch('gppylib.commands.base.Command.run')
-    @patch('gppylib.commands.base.Command.get_results')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_show_ddboost_config_local_DDServer(self, mock_get_pgport, mock_result, mock_run):
-        mock_result.return_value = CommandResult(0, '''20160510:15:45:01|ddboost-[DEBUG]:-Libraries were loaded successfully
+    def test_show_ddboost_config_local_DDServer(self, mock1, mock2):
+        self.options.ddboost_show_config = True
+        gpcd = GpCronDump(self.options, None)
+        logger.info = Mock()
+        mock_cmd_result= CommandResult(0, '''20160510:15:45:01|ddboost-[DEBUG]:-Libraries were loaded successfully
 20160510:15:45:01|ddboost-[INFO]:-opening LB on /home/gpadmin/DDBOOST_CONFIG
 Data Domain Hostname:qadd01
 Data Domain Boost Username:metro
 Default Backup Directory:MY_MFR
 Data Domain default log level:WARNING
 Data Domain Storage Unit:GPDB''', '', False, True)
+        # Need to do these patches inline because otherwise they'd come before the initFromCatalog mock
+        with patch('gppylib.commands.base.Command.run'):
+            with patch('gppylib.commands.base.Command.get_results', return_value = mock_cmd_result):
+                gpcd.show_ddboost_config()
+                logger.info.assert_any_call('Data Domain Hostname:qadd01')
+                logger.info.assert_any_call('Data Domain Boost Username:metro')
+                logger.info.assert_any_call('Default Backup Directory:MY_MFR')
+                logger.info.assert_any_call('Data Domain default log level:WARNING')
+                logger.info.assert_any_call('Data Domain Storage Unit:GPDB')
+
+    @patch('gppylib.operations.backup_utils.Context.get_master_port')
+    def test_show_ddboost_config_remote_DDServer(self, mock1, mock2):
         self.options.ddboost_show_config = True
         gpcd = GpCronDump(self.options, None)
         logger.info = Mock()
-        gpcd.show_ddboost_config()
-        logger.info.assert_any_call('Data Domain Hostname:qadd01')
-        logger.info.assert_any_call('Data Domain Boost Username:metro')
-        logger.info.assert_any_call('Default Backup Directory:MY_MFR')
-        logger.info.assert_any_call('Data Domain default log level:WARNING')
-        logger.info.assert_any_call('Data Domain Storage Unit:GPDB')
-
-
-    @patch('gppylib.commands.base.Command.run')
-    @patch('gppylib.commands.base.Command.get_results')
-    @patch('gppylib.operations.backup_utils.Context.get_master_port')
-    def test_show_ddboost_config_remote_DDServer(self, mock_get_pgport, mock_result, mock_run):
-        mock_result.return_value = CommandResult(0, '''20160511:10:28:06|ddboost-[DEBUG]:-Libraries were loaded successfully
+        mock_cmd_result = CommandResult(0, '''20160511:10:28:06|ddboost-[DEBUG]:-Libraries were loaded successfully
 20160511:10:28:06|ddboost-[INFO]:-opening LB on /home/gpadmin/DDBOOST_MFR_CONFIG
 Data Domain Hostname:dd1
 Data Domain Boost Username:gpadmin
 Data Domain default log level:WARNING
 Data Domain default log size:50''', '', False, True)
-        self.options.ddboost_show_config = True
-        gpcd = GpCronDump(self.options, None)
-        logger.info = Mock()
-        gpcd.show_ddboost_config()
-        logger.info.assert_any_call('Data Domain Hostname:dd1')
-        logger.info.assert_any_call('Data Domain Boost Username:gpadmin')
-        logger.info.assert_any_call('Data Domain default log level:WARNING')
-        logger.info.assert_any_call('Data Domain default log size:50')
+        with patch('gppylib.commands.base.Command.run'):
+            with patch('gppylib.commands.base.Command.get_results', return_value = mock_cmd_result):
+                gpcd.show_ddboost_config()
+                logger.info.assert_any_call('Data Domain Hostname:dd1')
+                logger.info.assert_any_call('Data Domain Boost Username:gpadmin')
+                logger.info.assert_any_call('Data Domain default log level:WARNING')
+                logger.info.assert_any_call('Data Domain default log size:50')
 
 #------------------------------- Mainline --------------------------------
 if __name__ == '__main__':

--- a/src/backend/cdb/cdbbackup.c
+++ b/src/backend/cdb/cdbbackup.c
@@ -199,7 +199,7 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
 
 #ifdef USE_DDBOOST
 	char       	*pszDDBoostFileName = NULL;
-	char	   	*pszDDBoostDirName = "db_dumps";		/* Default directory */	
+	char	   	*pszDDBoostDirName = "db_dumps";		/* Default directory */
 	char	   	*pszDDBoostStorageUnitName = NULL;
 	char 	   	*dd_boost_buffer_size = NULL;
 	char		*gpDDBoostCmdLine = NULL;
@@ -275,12 +275,12 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
 	{
 		dd_boost_enabled = 1;
 	}
-	
+
 	if (dd_boost_enabled)
 	{
 		pszDDBoostFileName = formDDBoostFileName(pszBackupKey, false, is_compress);
-	
-		gpDDBoostPg = testProgramExists("gpddboost"); 
+
+		gpDDBoostPg = testProgramExists("gpddboost");
         	if (gpDDBoostPg == NULL)
         	{
                 	ereport(ERROR,
@@ -289,7 +289,7 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
                                                 "gpddboost", getenv("PGPATH"), getenv("PATH")),
                                  errhint("Restart the server and try again")));
         	}
-	
+
 	}
 #endif
 
@@ -622,7 +622,7 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
 				}
 		}
 	}
-	else 
+	else
 	{
 		/* if user selected a compression program */
 		if (pszCompressionProgram[0] != '\0')
@@ -802,7 +802,7 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
 #ifdef USE_DDBOOST
 		if(dd_boost_enabled)
 		{
-		
+
 			pszDDBoostFileName = formDDBoostFileName(pszBackupKey, true, is_compress);
 
 			memset(gpDDBoostCmdLine, 0, strlen(gpDDBoostCmdLine));
@@ -1019,8 +1019,8 @@ gp_restore_launch__(PG_FUNCTION_ARGS)
 	char       *dd_boost_buffer_size = NULL;
 	char       *mkdirStr = NULL;
 	int        err = 0;
-	
-#endif	
+
+#endif
 
 	postDataSchemaOnly = false;
 	verifyGpIdentityIsSet();
@@ -1068,7 +1068,7 @@ gp_restore_launch__(PG_FUNCTION_ARGS)
 	 * where the database resides
 	 */
 	pszBackupDirectory = relativeToAbsolute(pszBackupDirectory);
-    /* if statusDirectory is NULL, it defaults to SEGMENT DATA DIRECTORY */ 
+    /* if statusDirectory is NULL, it defaults to SEGMENT DATA DIRECTORY */
 	statusDirectory    = relativeToAbsolute(statusDirectory);
 
 	/* Validate existence of compression program and gp_restore_agent program */
@@ -1107,7 +1107,7 @@ gp_restore_launch__(PG_FUNCTION_ARGS)
         if (strstr(pszPassThroughParameters,"--dd_boost_enabled") != NULL)
         {
                 dd_boost_enabled = 1;
-                 
+
                 /* When restoring from DDBoost to a fresh cluster, we will not have the *
                 * db_dumps/<date> directory. This is required to store the status file *
                 * Fix is to create the specified backup directory for every ddboost    *
@@ -1120,7 +1120,7 @@ gp_restore_launch__(PG_FUNCTION_ARGS)
                      (errcode(ERRCODE_OUT_OF_MEMORY),
                      errmsg("out of memory")));
                 }
- 
+
                 memset(mkdirStr, 0, MAX_MKDIR_STRING_LEN);
                 sprintf(mkdirStr, "mkdir -p %s", pszBackupDirectory);
                 err = system(mkdirStr);
@@ -1141,7 +1141,7 @@ gp_restore_launch__(PG_FUNCTION_ARGS)
 		if (0 != stat(pszBackupFileName, &info))
 		{
 			if (netbackup_enabled)
-			{		
+			{
 				char *queriedNBUBackupFilePathName = queryNBUBackupFilePathName(netbackup_service_host, pszBackupFileName);
 
 				elog(LOG, "Verify backup file path on netbackup server: %s\n", pszBackupFileName);
@@ -1367,7 +1367,7 @@ gp_restore_launch__(PG_FUNCTION_ARGS)
 		/* Format gp_restore_agent with options, and Redirect both stdout and stderr into the status file */
 #ifdef USE_DDBOOST
 		if (dd_boost_enabled)
-		{	
+		{
 			sprintf(pszCmdLine, "%s --gp-k %s --dd_boost_buf_size %s --gp-d %s %s -p %d -U %s %s %s -d %s %s %s %s 2>&2",
 				bkPg, pszKeyParm, dd_boost_buffer_size, pszBackupDirectory, pszOnErrorStop, port, pszUserName, pszPassThroughParameters,
 				pszPassThroughTargetInfo, pszDBName, pszBackupFileName,
@@ -1392,7 +1392,7 @@ gp_restore_launch__(PG_FUNCTION_ARGS)
 				pszPassThroughTargetInfo, pszDBName, pszBackupFileName,
 				postDataSchemaOnly ? "2>>" : "2>", pszStatusFileName);
 		}
-			
+
 #else
 		if(netbackup_enabled)
 		{
@@ -1540,7 +1540,7 @@ gp_read_backup_file__(PG_FUNCTION_ARGS)
 	fclose(f);
 	f = NULL;
 	pszFullStatus[info.st_size] = '\0';
-	
+
 	return DirectFunctionCall1(textin, CStringGetDatum(positionToError(pszFullStatus)));
 }
 
@@ -1929,7 +1929,7 @@ formBackupFilePathName(char *pszBackupDirectory, char *pszBackupKey, bool is_com
 
 	strcat(pszBackupFileName, szFileNamePrefix);
 	strcat(pszBackupFileName, pszBackupKey);
-	
+
 	if (isPostData)
 	{
 		strcat(pszBackupFileName, "_post_data");
@@ -2288,9 +2288,9 @@ validateBackupDirectory(char *pszBackupDirectory)
 	}
 }
 
-/* 
+/*
  * positionToError - given a char buffer, position to the first error msg in it.
- * 
+ *
  * we are only interested in ERRORs. therefore, search for the first ERROR
  * and return the rest of the status file starting from that point. if no error
  * found, return a "no error found" string. We are only interested in occurrences
@@ -2306,7 +2306,7 @@ static char *positionToError(char *source)
 	while(true)
 	{
 		firstErr = strstr((const char*)sourceCopy, "ERROR");
-		
+
 		if (!firstErr)
 		{
 			break;
@@ -2325,7 +2325,7 @@ static char *positionToError(char *source)
 			}
 		}
 	}
-	
+
 	if (!firstErr)
 	{
 		/* no [ERROR] found */
@@ -2335,7 +2335,7 @@ static char *positionToError(char *source)
 	{
 		/* found [ERROR]. go back to beginning of the line */
 		char *p;
-		
+
 		for (p = firstErr ; p > source ; p--)
 		{
 			if (*p == '\n')
@@ -2344,10 +2344,10 @@ static char *positionToError(char *source)
 				break;
 			}
 		}
-		
+
 		firstErr = p;
 	}
-	
+
 	return firstErr;
 }
 
@@ -2362,7 +2362,7 @@ static char *formDDBoostFileName(char *pszBackupKey, bool isPostData, bool isCom
        char       *pszBackupFileName;
 
        verifyGpIdentityIsSet();
-       instid = GpIdentity.segindex == -1;
+       instid = GpIdentity.segindex;
        segid = GpIdentity.dbid;
 
 	memset(szFileNamePrefix, 0, sizeof(szFileNamePrefix));
@@ -2395,7 +2395,7 @@ static char *formDDBoostFileName(char *pszBackupKey, bool isPostData, bool isCom
 		strcat(pszBackupFileName, "_post_data");
 
 	if (isCompress)
-		strcat(pszBackupFileName, ".gz"); 
+		strcat(pszBackupFileName, ".gz");
 
        return pszBackupFileName;
 }

--- a/src/backend/cdb/cdbbackup.c
+++ b/src/backend/cdb/cdbbackup.c
@@ -1777,7 +1777,7 @@ findAcceptableBackupFilePathName(char *pszBackupDirectory, char *pszBackupKey, i
 		pszRegexNew = (char *) palloc(regex_len + 2);
 		pszRegexOld = (char *) palloc(regex_len);
 
-		snprintf(pszRegexNew, regex_len, "^%sgp_dump_-?%d_[0-9]+_%s(.gz)?$", DUMP_PREFIX, instid, pszBackupKey);
+		snprintf(pszRegexNew, regex_len, "^%sgp_dump_%d_[0-9]+_%s(.gz)?$", DUMP_PREFIX, instid, pszBackupKey);
 		snprintf(pszRegexOld, regex_len, "^%sgp_dump_[0-9]+_%d_%s(.gz)?$", DUMP_PREFIX, segid, pszBackupKey);
 
 		masklenNew = strlen(pszRegexNew);

--- a/src/bin/pg_dump/cdb/cdb_ddboost_util.c
+++ b/src/bin/pg_dump/cdb/cdb_ddboost_util.c
@@ -2456,10 +2456,10 @@ cleanup:
 int
 isFileToBeCopied(const char *filename)
 {
-	if (strstr(filename, "gp_global_1_1_"))
+	if (strstr(filename, "gp_global_"))
 		return 1;
 
-	if (strstr(filename, "gp_cdatabase_1_1_"))
+	if (strstr(filename, "gp_cdatabase_"))
 		return 1;
 
 	if (strstr(filename, "_post_data"))

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -168,6 +168,7 @@ static int	plainText = 0;
 static int	g_role = 0;
 static char *g_CDBDumpInfo = NULL;
 static char *g_CDBDumpKey = NULL;
+static int	g_contentID = 0;
 static int	g_dbID = 0;
 static char *g_CDBPassThroughCredentials = NULL;
 static pthread_t g_main_tid = (pthread_t) 0;
@@ -722,7 +723,7 @@ main(int argc, char **argv)
 
 			case 1:				/* MPP Dump Info Format is Key_role_dbid */
 				g_CDBDumpInfo = pg_strdup(optarg);
-				if (!ParseCDBDumpInfo((char *) progname, g_CDBDumpInfo, &g_CDBDumpKey, &g_role, &g_dbID, &g_CDBPassThroughCredentials))
+				if (!ParseCDBDumpInfo((char *) progname, g_CDBDumpInfo, &g_CDBDumpKey, &g_role, &g_contentID, &g_dbID, &g_CDBPassThroughCredentials))
 					exit(1);
 				break;
 
@@ -1341,7 +1342,7 @@ skipalldata:
 
 		fileFormat = 'f';	/*dump post schema data into local file first*/
 
-		char *postDumpFileName = formPostDumpFilePathName(g_pszCDBOutputDirectory, g_CDBDumpKey, g_role, g_dbID);
+		char *postDumpFileName = formPostDumpFilePathName(g_pszCDBOutputDirectory, g_CDBDumpKey, g_contentID, g_dbID);
 
 		g_fout = makeArchive(postDumpFileName);
 
@@ -8220,7 +8221,7 @@ dumpDatabaseDefinition()
 	/* MPP addition end */
 
 	pszBackupFileName = formCDatabaseFilePathName(g_pszCDBOutputDirectory,
-											   g_CDBDumpKey, g_role, g_dbID);
+											   g_CDBDumpKey, g_contentID, g_dbID);
 
 	/*
 	 * Make sure we can create this file before we spin off sh cause we don't
@@ -8338,7 +8339,7 @@ dumpDatabaseDefinitionToDDBoost()
 	/* MPP addition end */
 
 	pszBackupFileName = formCDatabaseFilePathName(g_pszDDBoostDir,
-								   g_CDBDumpKey, g_role, g_dbID);
+								   g_CDBDumpKey, g_contentID, g_dbID);
 
 	/*
 	 * Make sure we can create this file before we spin off sh cause we don't

--- a/src/bin/pg_dump/cdb/cdb_dump_util.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.c
@@ -450,7 +450,7 @@ MakeString(const char *fmt,...)
  * based on the format convention key_contextid_dbid_credentials
  */
 bool
-ParseCDBDumpInfo(const char *progName, char *pszCDBDumpInfo, char **ppCDBDumpKey, int *pContentID, int *pDbID, char **ppCDBPassThroughCredentials)
+ParseCDBDumpInfo(const char *progName, char *pszCDBDumpInfo, char **ppCDBDumpKey, int *pRole, int *pContentID, int *pDbID, char **ppCDBPassThroughCredentials)
 {
 	int			rtn;
 
@@ -458,7 +458,7 @@ ParseCDBDumpInfo(const char *progName, char *pszCDBDumpInfo, char **ppCDBDumpKey
 
 	regex_t		rCDBDumpInfo;
 
-	if (0 != regcomp(&rCDBDumpInfo, "([0-9]+)_([0-9]+)_([0-9]+)_([^[:space:]]*)", REG_EXTENDED))
+	if (0 != regcomp(&rCDBDumpInfo, "([0-9]+)_(-?[0-9]+)_([0-9]+)_([^[:space:]]*)", REG_EXTENDED))
 	{
 		mpp_err_msg_cache("ERROR", progName, "Error compiling regular expression for parsing CDB Dump Info\n");
 		return false;
@@ -490,6 +490,8 @@ ParseCDBDumpInfo(const char *progName, char *pszCDBDumpInfo, char **ppCDBDumpKey
 	*pContentID = GetMatchInt(&matches[2], pszCDBDumpInfo);
 
 	*pDbID = GetMatchInt(&matches[3], pszCDBDumpInfo);
+
+	*pRole = (*pDbID == 1) ? 1 : 0;
 
 	*ppCDBPassThroughCredentials = GetMatchString(&matches[4], pszCDBDumpInfo);
 	if (*ppCDBPassThroughCredentials == NULL)

--- a/src/bin/pg_dump/cdb/cdb_dump_util.h
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.h
@@ -123,7 +123,7 @@ extern PGconn *MakeDBConnection(const SegmentDatabase *pSegDB, bool bDispatch);
 extern char *MakeString(const char *fmt,...);
 
 /* breaks the input parameter associated with --cdb-k into its components for cdb_dump and cdb_restore*/
-extern bool ParseCDBDumpInfo(const char *progName, char *pszCDBDumpInfo, char **ppCDBDumpKey, int *pCDBInstID, int *pCDBSegID, char **ppCDBPassThroughCredentials);
+extern bool ParseCDBDumpInfo(const char *progName, char *pszCDBDumpInfo, char **ppCDBDumpKey, int *pRole, int *pContentID, int *pDbID, char **ppCDBPassThroughCredentials);
 
 /* reads the contents for "ERROR:" and "[ERROR]" out of the appropriate file on the database server */
 extern int ReadBackendBackupFileError(PGconn *pConn, const char *pszBackupDirectory, const char *pszKey,


### PR DESCRIPTION
Description by @jmcatamney 
Previously, backup files were keyed only to the dbid of the segment from
which they were backed up, which caused problems when trying to restore
files backed up on a mirror segment, restore files to a new cluster with
a different dbid mapping, and so forth.

This commit fixes the above issues by changing the backup file naming
convention to incorporate the content id of the backed-up segment and
enables restoring files based on the content id. Also, gpdbrestore
seamlessly handles mixing the old and new filename formats, so users can
continue making incremental backups on top of full and incremental backups
using the old format after beginning to use this version of gpcrondump.
