### PR TITLE
Check for zero persistentTID in xlog record

### DIFF
--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -810,8 +810,7 @@ _bitmap_log_newpage(Relation rel, uint8 info, Buffer buf)
 	RelationFetchGpRelationNodeForXLog(rel);
 
 	xlNewPage.bm_node = rel->rd_node;
-	xlNewPage.bm_persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-	xlNewPage.bm_persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(rel, &xlNewPage.bm_persistentTid, &xlNewPage.bm_persistentSerialNum);
 	xlNewPage.bm_new_blkno = BufferGetBlockNumber(buf);
 
 	elog(DEBUG1, "_bitmap_log_newpage: blkno=%d", xlNewPage.bm_new_blkno);
@@ -845,8 +844,7 @@ _bitmap_log_metapage(Relation rel, Page page)
 	xlMeta = (xl_bm_metapage *)
 		palloc(MAXALIGN(sizeof(xl_bm_metapage)));
 	xlMeta->bm_node = rel->rd_node;
-	xlMeta->bm_persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-	xlMeta->bm_persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(rel, &xlMeta->bm_persistentTid, &xlMeta->bm_persistentSerialNum);
 	xlMeta->bm_lov_heapId = metapage->bm_lov_heapId;
 	xlMeta->bm_lov_indexId = metapage->bm_lov_indexId;
 	xlMeta->bm_lov_lastpage = metapage->bm_lov_lastpage;
@@ -878,8 +876,7 @@ _bitmap_log_bitmap_lastwords(Relation rel, Buffer lovBuffer,
 	RelationFetchGpRelationNodeForXLog(rel);
 
 	xlLastwords.bm_node = rel->rd_node;
-	xlLastwords.bm_persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-	xlLastwords.bm_persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(rel, &xlLastwords.bm_persistentTid, &xlLastwords.bm_persistentSerialNum);
 	xlLastwords.bm_last_compword = lovItem->bm_last_compword;
 	xlLastwords.bm_last_word = lovItem->bm_last_word;
 	xlLastwords.lov_words_header = lovItem->lov_words_header;
@@ -919,8 +916,7 @@ _bitmap_log_lovitem(Relation rel, Buffer lovBuffer, OffsetNumber offset,
 	Assert(BufferGetBlockNumber(lovBuffer) > 0);
 
 	xlLovItem.bm_node = rel->rd_node;
-	xlLovItem.bm_persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-	xlLovItem.bm_persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(rel, &xlLovItem.bm_persistentTid, &xlLovItem.bm_persistentSerialNum);
 	xlLovItem.bm_lov_blkno = BufferGetBlockNumber(lovBuffer);
 	xlLovItem.bm_lov_offset = offset;
 	memcpy(&(xlLovItem.bm_lovItem), lovItem, sizeof(BMLOVItemData));
@@ -988,8 +984,7 @@ _bitmap_log_bitmapwords(Relation rel, Buffer bitmapBuffer, Buffer lovBuffer,
 				MAXALIGN(cwords_size) + MAXALIGN(hwords_size));
 
 	xlBitmapWords->bm_node = rel->rd_node;
-	xlBitmapWords->bm_persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-	xlBitmapWords->bm_persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(rel, &xlBitmapWords->bm_persistentTid, &xlBitmapWords->bm_persistentSerialNum);
 	xlBitmapWords->bm_blkno = BufferGetBlockNumber(bitmapBuffer);
 	xlBitmapWords->bm_next_blkno = nextBlkno;
 	xlBitmapWords->bm_last_tid = bitmapPageOpaque->bm_last_tid_location;
@@ -1056,8 +1051,7 @@ _bitmap_log_updateword(Relation rel, Buffer bitmapBuffer, int word_no)
 	bitmap = (BMBitmap) PageGetContentsMaxAligned(bitmapPage);
 
 	xlBitmapWord.bm_node = rel->rd_node;
-	xlBitmapWord.bm_persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-	xlBitmapWord.bm_persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(rel, &xlBitmapWord.bm_persistentTid, &xlBitmapWord.bm_persistentSerialNum);
 	xlBitmapWord.bm_blkno = BufferGetBlockNumber(bitmapBuffer);
 	xlBitmapWord.bm_word_no = word_no;
 	xlBitmapWord.bm_cword = bitmap->cwords[word_no];
@@ -1146,8 +1140,7 @@ _bitmap_log_updatewords(Relation rel,
 	RelationFetchGpRelationNodeForXLog(rel);
 
 	xlBitmapWords.bm_node = rel->rd_node;
-	xlBitmapWords.bm_persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-	xlBitmapWords.bm_persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(rel, &xlBitmapWords.bm_persistentTid, &xlBitmapWords.bm_persistentSerialNum);
 	xlBitmapWords.bm_lov_blkno = BufferGetBlockNumber(lovBuffer);
 	xlBitmapWords.bm_lov_offset = lovOffset;
 	xlBitmapWords.bm_new_lastpage = new_lastpage;

--- a/src/backend/access/gist/gistvacuum.c
+++ b/src/backend/access/gist/gistvacuum.c
@@ -23,7 +23,6 @@
 #include "utils/memutils.h"
 #include "cdb/cdbfilerepprimary.h"
 
-
 typedef struct GistBulkDeleteResult
 {
 	IndexBulkDeleteResult std;	/* common state */
@@ -122,8 +121,7 @@ gistDeleteSubtree(GistVacuum *gv, BlockNumber blkno)
 		RelationFetchGpRelationNodeForXLog(gv->index);
 
 		xlrec.node = gv->index->rd_node;
-		xlrec.persistentTid = gv->index->rd_segfile0_relationnodeinfo.persistentTid;
-		xlrec.persistentSerialNum = gv->index->rd_segfile0_relationnodeinfo.persistentSerialNum;
+		RelationGetPTInfo(gv->index, &xlrec.persistentTid, &xlrec.persistentSerialNum);
 		xlrec.blkno = blkno;
 
 		rdata[0].buffer = buffer;

--- a/src/backend/access/gist/gistxlog.c
+++ b/src/backend/access/gist/gistxlog.c
@@ -20,7 +20,6 @@
 #include "utils/guc.h"
 #include "cdb/cdbfilerepprimary.h"
 
-
 typedef struct
 {
 	gistxlogPageUpdate *data;
@@ -933,8 +932,7 @@ formSplitRdata(Relation r, BlockNumber blkno, bool page_is_leaf,
 	RelationFetchGpRelationNodeForXLog(r);
 	
 	xlrec->node = r->rd_node;
-	xlrec->persistentTid = r->rd_segfile0_relationnodeinfo.persistentTid;
-	xlrec->persistentSerialNum = r->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(r, &xlrec->persistentTid, &xlrec->persistentSerialNum);
 	xlrec->origblkno = blkno;
 	xlrec->origleaf = page_is_leaf;
 	xlrec->npage = (uint16) npage;
@@ -996,8 +994,7 @@ formUpdateRdata(Relation r, Buffer buffer,
 	RelationFetchGpRelationNodeForXLog(r);
 
 	xlrec->node = r->rd_node;
-	xlrec->persistentTid = r->rd_segfile0_relationnodeinfo.persistentTid;
-	xlrec->persistentSerialNum = r->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(r, &xlrec->persistentTid, &xlrec->persistentSerialNum);
 	xlrec->blkno = BufferGetBlockNumber(buffer);
 	xlrec->ntodelete = ntodelete;
 
@@ -1051,8 +1048,7 @@ formCreateRData(Relation r)
 	RelationFetchGpRelationNodeForXLog(r);
 
 	xlrec->node = r->rd_node;
-	xlrec->persistentTid = r->rd_segfile0_relationnodeinfo.persistentTid;
-	xlrec->persistentSerialNum = r->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(r, &xlrec->persistentTid, &xlrec->persistentSerialNum);
 
 	rdata[0].data = (char *) xlrec;
 	rdata[0].len = sizeof(gistxlogCreateIndex);

--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -1234,8 +1234,7 @@ _bt_split(Relation rel, Buffer buf, OffsetNumber firstright,
 		xlrec.firstright = firstright;
 
 		/* Set persistentTid and persistentSerialNum like xl_btreetid_set() does */
-		xlrec.persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-		xlrec.persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+		RelationGetPTInfo(rel, &xlrec.persistentTid, &xlrec.persistentSerialNum);
 
 		rdata[0].data = (char *) &xlrec;
 		rdata[0].len = SizeOfBtreeSplit;

--- a/src/backend/cdb/cdbpersistentrecovery.c
+++ b/src/backend/cdb/cdbpersistentrecovery.c
@@ -986,7 +986,17 @@ PersistentRecovery_ShouldHandlePass3XLogRec(
 				 xlogRelFileNode.relNode);
 		return true;
 	}
-		
+
+	if (PersistentStore_IsZeroTid(&xlogPersistentTid))
+	{
+		int level = ERROR;
+		if (gp_persistent_statechange_suppress_error)
+		{
+			level = WARNING;
+		}
+		elog(level, "xlog record with zero persistenTID");
+	}
+
 	/*
 	 * Further qualify using the RelFileNode.
 	 */

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -597,8 +597,7 @@ DefineSequence(CreateSeqStmt *seq)
 		XLogRecData rdata[2];
 
 		xlrec.node = rel->rd_node;
-		xlrec.persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-		xlrec.persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+		RelationGetPTInfo(rel, &xlrec.persistentTid, &xlrec.persistentSerialNum);
 
 		rdata[0].data = (char *) &xlrec;
 		rdata[0].len = sizeof(xl_seq_rec);
@@ -727,8 +726,7 @@ AlterSequence(AlterSeqStmt *stmt)
 		Page		page = BufferGetPage(buf);
 
 		xlrec.node = seqrel->rd_node;
-		xlrec.persistentTid = seqrel->rd_segfile0_relationnodeinfo.persistentTid;
-		xlrec.persistentSerialNum = seqrel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+		RelationGetPTInfo(seqrel, &xlrec.persistentTid, &xlrec.persistentSerialNum);
 
 		rdata[0].data = (char *) &xlrec;
 		rdata[0].len = sizeof(xl_seq_rec);
@@ -1077,8 +1075,7 @@ cdb_sequence_nextval(SeqTable elm,
 		seq->log_cnt = 0;
 
 		xlrec.node = seqrel->rd_node;
-		xlrec.persistentTid = seqrel->rd_segfile0_relationnodeinfo.persistentTid;
-		xlrec.persistentSerialNum = seqrel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+		RelationGetPTInfo(seqrel, &xlrec.persistentTid, &xlrec.persistentSerialNum);
 		rdata[0].data = (char *) &xlrec;
 		rdata[0].len = sizeof(xl_seq_rec);
 		rdata[0].buffer = InvalidBuffer;
@@ -1303,8 +1300,7 @@ do_setval(Oid relid, int64 next, bool iscalled)
 		Page		page = BufferGetPage(buf);
 
 		xlrec.node = seqrel->rd_node;
-		xlrec.persistentTid = seqrel->rd_segfile0_relationnodeinfo.persistentTid;
-		xlrec.persistentSerialNum = seqrel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+		RelationGetPTInfo(seqrel, &xlrec.persistentTid, &xlrec.persistentSerialNum);
 
 		rdata[0].data = (char *) &xlrec;
 		rdata[0].len = sizeof(xl_seq_rec);

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -4958,3 +4958,20 @@ unlink_initfile(const char *initfilename)
 			elog(LOG, "could not remove cache file \"%s\": %m", initfilename);
 	}
 }
+
+void
+RelationGetPTInfo(Relation rel,
+	ItemPointer persistentTid,
+	int64 *persistentSerialNum)
+{
+	if (! GpPersistent_SkipXLogInfo(rel->rd_node.relNode) &&
+		! rel->rd_segfile0_relationnodeinfo.isPresent)
+	{
+		elog(ERROR,
+			 "required Persistent Table information missing for relation %u/%u/%u",
+			 rel->rd_node.spcNode, rel->rd_node.dbNode, rel->rd_node.relNode);
+	}
+
+	*persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
+	*persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+}

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -187,8 +187,7 @@ inline static void xl_heaptid_set(
 	ItemPointer tid)
 {
 	heaptid->node = rel->rd_node;
-	heaptid->persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-	heaptid->persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(rel, &heaptid->persistentTid, &heaptid->persistentSerialNum);
 	heaptid->tid = *tid;
 }
 
@@ -198,8 +197,7 @@ inline static void xl_heapnode_set(
 	Relation rel)
 {
 	heapnode->node = rel->rd_node;
-	heapnode->persistentTid = rel->rd_segfile0_relationnodeinfo.persistentTid;
-	heapnode->persistentSerialNum = rel->rd_segfile0_relationnodeinfo.persistentSerialNum;
+	RelationGetPTInfo(rel, &heapnode->persistentTid, &heapnode->persistentSerialNum);
 }
 
 /* in heap/heapam.c */

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -454,5 +454,6 @@ typedef struct TidycatOptions
 /* routines in utils/cache/relcache.c */
 extern void RelationIncrementReferenceCount(Relation rel);
 extern void RelationDecrementReferenceCount(Relation rel);
+extern void RelationGetPTInfo(Relation rel, ItemPointer persistentTid, int64 *persistentSerialNum);
 
 #endif   /* REL_H */


### PR DESCRIPTION
Refactor code to use common routine to fetch PT info for xlogging. Check can
be easliy added at this common place to validate persistent info is
available. Plus still add check during recovery for persistentTID zero. As
with postgres upstream merges possible the function to populate persistent info is
not called at all, so this check will not hit during xlog record construction
but atleast gives clear clue during recovery. 

This came-up as ask from Heikki....

** From Heikki **
> So, the symptom was that if I forcibly killed the server while "make installcheck-good" was running, WAL recovery sometimes failed with an error from xlog_heap_insert(). PageAddItem() failed, because there was no free space on the page to add the new tuple. How's that possible? Surely the page had enough space when the original insertion was made and the insertion record was created.

> This always happened on relation 1247 (pg_type) or 1249 (pg_attribute).

> I put a debug elog()s into ApplyStartupRedo(), to print out every WAL record that's replayed. Filtering the log for those relations, it was indeed clear that there are enough insert-records to fill the page, with no cleanup records applied in between. Adding more debug info, I finally figured out that there actually was a XLOG_HEAP2_CLEAN record for the page, but it was not applied in the "phase 3" of recovery, even though all the insert records were. PersistentRecovery_ShouldHandlePass3XLogRec() returned false for the clean-record. And that turned out to be because the clean-record's persistentTid and persistentSerialNum fields were zero.

> So, the root cause was that those fields were zero for XLOG_HEAP2_CLEAN records emitted by page-pruning. Page-pruning is a new feature added by the HOT patch. It's a kind of mini-VACUUM of a single page, which removes only HOT updated tuples, and truncates other dead tuples to just a placeholder line pointer. It's done opportunistically, whenever a page with less than 10% of free space is accessed. It's done also by plain SELECTs, not only operations that intend to update the page.

> Functions like heap_insert, heap_update, etc. have been modified in GPDB, by adding this line:

```
  // Fetch gp_persistent_relation_node information that will be added to XLOG record.
  RelationFetchGpRelationNodeForXLog(relation);
```
> That was missing from the new page-pruning function, heap_page_prune(), which is why those records didn't carry the gp_persistent_relation_node information they needed.

> The fix is straightforward, but it took me the whole day to hunt this down. If the gp_persistent_relation_node information is always needed on heap-records, there really ought to be an Assertion somewhere to check for that, when the record is created. When it's missing, the symptoms are very strange, and you get very difficult to find bugs.

> I'm not sure how to formulate such an Assertion. Any takers?
