### PR TITLE
[#128106151] Fix wrong results when using case in subquery

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -496,7 +496,7 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 	/**
 	 * If this is a correlated opexpression, we'd need to look inside.
 	 */
-	if (contain_vars_of_level_or_above(node, 1) && IsA(node, OpExpr))
+	else if (contain_vars_of_level_or_above(node, 1) && IsA(node, OpExpr))
 	{
 		OpExpr *opexp = (OpExpr *) node;
 
@@ -544,6 +544,11 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 		/**
 		 * Correlated join expression contains incompatible operators. Not safe to convert.
 		 */
+		context->safeToConvert = false;
+	}
+	else if (contain_vars_of_level_or_above(node, 1))
+	{
+		/* This is a correlated expression, but we don't know how to deal with it. Give up. */
 		context->safeToConvert = false;
 	}
 

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -585,3 +585,22 @@ select '1'::text in (select '1'::name union all select '1'::name);
  t
 (1 row)
 
+--
+-- Test case for when there is case clause in join filter
+--
+drop table if exists t_case_subquery1;
+NOTICE:  table "t_case_subquery1" does not exist, skipping
+create table t_case_subquery1 (a int, b int, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_case_subquery1 values(1, 5, NULL), (1, 2, NULL);
+select t1.* from t_case_subquery1 t1 where t1.b = (
+  select max(b) from t_case_subquery1 t2 where t1.a = t2.a and t2.b < 5 and
+    case
+    when t1.c is not null and t2.c is not null
+    then t1.c = t2.c
+    end
+);
+ a | b | c
+---+---+---
+(0 rows)

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -365,3 +365,19 @@ select * from outer_7597 where (f1, f2) not in (select * from inner_7597);
 --
 
 select '1'::text in (select '1'::name union all select '1'::name);
+
+--
+-- Test case for when there is case clause in join filter
+--
+
+drop table if exists t_case_subquery1;
+create table t_case_subquery1 (a int, b int, c text);
+insert into t_case_subquery1 values(1, 5, NULL), (1, 2, NULL);
+
+select t1.* from t_case_subquery1 t1 where t1.b = (
+  select max(b) from t_case_subquery1 t2 where t1.a = t2.a and t2.b < 5 and
+    case
+    when t1.c is not null and t2.c is not null
+    then t1.c = t2.c
+    end
+);


### PR DESCRIPTION
This pull request resolves the issue when there is a case condition in the join filter that causes the planner to produce a plan without the case filter. 

Below is a test where reproduces the issue. 
It is very simple to reproduce the issue.
```sql
create table t (a int, b int, c text);
insert into t values(1, 5, NULL), (1, 2, NULL);
set optimizer = off;

select t1.* from t t1 where t1.b = (
  select max(b) from t t2 where t1.a = t2.a and t2.b < 5 and 
    case 
    when t1.c is not null and t2.c is not null 
    then t1.c = t2.c 
    end 
);

 a | b | c
---+---+---
 1 | 2 |
(1 row)
```

The correct result should be:
```
 a | b | c
---+---+---
(0 rows)
```

Looking at the plan, we didn't find the case condition in the join filter:
```
                                 QUERY PLAN
-----------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1.07..2.14 rows=4 width=40)
   ->  Hash Join  (cost=1.07..2.14 rows=2 width=40)
         Hash Cond: t1.a = t2.a AND t1.b = (max(t2.b))
         ->  Seq Scan on t t1  (cost=0.00..1.02 rows=1 width=40)
         ->  Hash  (cost=1.06..1.06 rows=1 width=8)
               ->  HashAggregate  (cost=1.03..1.05 rows=1 width=8)
                     Group By: t2.a
                     ->  Seq Scan on t t2  (cost=0.00..1.02 rows=1 width=8)
                           Filter: b < 5
 Settings:  optimizer=off
 Optimizer status: legacy query optimizer
(11 rows)
```

The pull request includes Heikki's explanation of the issue and the fix:

The planner seems to lose that join expression, if it's not of the form
"A op B". For example, this exhibits the same problem:

```
create function foo(a text, b text) returns bool
as $$ select false $$
language sql volatile;

explain select t1.* from t t1 where t1.b = (
   select max(b) from t t2 where t1.a = t2.a and t2.b < 5 and
     foo(t1.c, t2.c)
);
                                  QUERY PLAN
-----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.07..2.14 rows=4 width=40)
    ->  Hash Join  (cost=1.07..2.14 rows=2 width=40)
          Hash Cond: t1.a = t2.a AND t1.b = (max(t2.b))
          ->  Seq Scan on t t1  (cost=0.00..1.02 rows=1 width=40)
          ->  Hash  (cost=1.06..1.06 rows=1 width=8)
                ->  HashAggregate  (cost=1.03..1.05 rows=1 width=8)
                      Group By: t2.a
                      ->  Seq Scan on t t2  (cost=0.00..1.02 rows=1 width=8)
                            Filter: b < 5
(9 rows)

```

SubqueryToJoinWalker() is the function that performs the "pulling-up" of
the subquery, and inserts the GroupBy node. It seems to only know about
simple OpExprs. That would be OK, as long as it failed back to using a
SubPlan for this, but it doesn't do that. If it sees anything it doesn't
know how to handle, it continues to pull-up.

The attached patch seems to fix the immediate problem. I haven't run the
regression tests on it, so I don't know if it breaks something else, or
causes a fallback on a plan that was actually valid.