### PR TITLE
Add new GUC to control Codegen Optimization level.

### DIFF
--- a/src/backend/codegen/codegen_manager.cc
+++ b/src/backend/codegen/codegen_manager.cc
@@ -23,6 +23,11 @@
 #include "codegen/utils/codegen_utils.h"
 #include "codegen/utils/gp_codegen_utils.h"
 
+extern "C" {
+#include "postgres.h"  // NOLINT(build/include)
+#include "utils/guc.h"
+}
+
 using gpcodegen::CodegenManager;
 
 CodegenManager::CodegenManager(const std::string& module_name) {
@@ -63,10 +68,19 @@ unsigned int CodegenManager::PrepareGeneratedFunctions() {
     return success_count;
   }
 
+  STATIC_ASSERT_OPTIMIZATION_LEVEL(kNone,
+                                   CODEGEN_OPTIMIZATION_LEVEL_NONE);
+  STATIC_ASSERT_OPTIMIZATION_LEVEL(kLess,
+                                   CODEGEN_OPTIMIZATION_LEVEL_LESS);
+  STATIC_ASSERT_OPTIMIZATION_LEVEL(kDefault,
+                                   CODEGEN_OPTIMIZATION_LEVEL_DEFAULT);
+  STATIC_ASSERT_OPTIMIZATION_LEVEL(kAggressive,
+                                   CODEGEN_OPTIMIZATION_LEVEL_AGGRESSIVE);
 
   // Call GpCodegenUtils to compile entire module
   bool compilation_status = codegen_utils_->PrepareForExecution(
-      gpcodegen::GpCodegenUtils::OptimizationLevel::kDefault, true);
+      gpcodegen::GpCodegenUtils::OptimizationLevel(codegen_optimization_level),
+      true);
 
   if (!compilation_status) {
     return success_count;
@@ -99,6 +113,12 @@ const std::string& CodegenManager::GetExplainString() {
 
 void CodegenManager::AccumulateExplainString() {
   explain_string_.clear();
+  // This is called only when EXPLAIN CODEGEN. Because we don't want to compile
+  // at this time, we need to call CodegenUtils::Optimize to "optimize" LLVM IR.
+  codegen_utils_->Optimize(gpcodegen::CodegenUtils::OptimizationLevel(
+                               codegen_optimization_level),
+                           gpcodegen::CodegenUtils::SizeLevel::kNormal,
+                           false);
   llvm::raw_string_ostream out(explain_string_);
   codegen_utils_->PrintUnderlyingModules(out);
 }

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -55,6 +55,15 @@ template <typename> class FunctionTypeUnpacker;
 template <typename, typename> class ArithOpMaker;
 }  // namespace codegen_utils_detail
 
+
+// Easy static check to match integer macros with enum equivalents
+#define STATIC_ASSERT_OPTIMIZATION_LEVEL(ename, mname) \
+    static_assert(gpcodegen::CodegenUtils::OptimizationLevel::ename == \
+    gpcodegen::CodegenUtils::OptimizationLevel(mname), \
+    "gpcodegen::CodegenUtils::OptimizationLevel::" #ename  \
+    " == " #mname)
+
+
 /** \addtogroup gpcodegen
  *  @{
  */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -466,10 +466,16 @@ extern bool optimizer_array_constraints;
 /**
  * GUCs related to code generation.
  **/
+#define CODEGEN_OPTIMIZATION_LEVEL_NONE          0
+#define CODEGEN_OPTIMIZATION_LEVEL_LESS          1
+#define CODEGEN_OPTIMIZATION_LEVEL_DEFAULT       2
+#define CODEGEN_OPTIMIZATION_LEVEL_AGGRESSIVE    3
+
 extern bool init_codegen;
 extern bool codegen;
 extern bool codegen_validate_functions;
 extern int codegen_varlen_tolerance;
+extern int codegen_optimization_level;
 
 /**
  * Enable logging of DPE match in optimizer.


### PR DESCRIPTION
This will allow the GPDB user to control the optimization level used by codegen to compile generated code. This will thus enable the user to decide to trade off compilation time with execution time. 

Used when compiling generated code. EXPLAIN codegen also runs optimize with this optimize level, making it easier to see the features the compiler optimizes.