### PR TITLE
Skip persistent tables in VACUUM

### DIFF
--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -275,4 +275,8 @@ create table ao_t1(a int, b int) with (appendonly=true) distributed by(a);
 insert into ao_t1 select i, i from generate_series(1, 10000) i;
 update ao_t1 set b = b + 1;
 vacuum full ao_t1;
-drop table ao_t1;
+drop table ao_t0;
+vacuum gp_persistent_relation_node;
+WARNING:  skipping "gp_persistent_relation_node" --- cannot vacuum indexes, views, external tables, or special system tables
+vacuum full gp_persistent_relation_node;
+WARNING:  skipping "gp_persistent_relation_node" --- cannot vacuum indexes, views, external tables, or special system tables

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -181,3 +181,6 @@ insert into ao_t1 select i, i from generate_series(1, 10000) i;
 update ao_t1 set b = b + 1;
 vacuum full ao_t1;
 drop table ao_t1;
+
+vacuum gp_persistent_relation_node;
+vacuum full gp_persistent_relation_node;


### PR DESCRIPTION
Vacuum lazy is harmless, but also no benefit to perform just extra work.
Vacuum full could turn out dangerous as it has potential to move tuples
around causing the TIDs for tuples to change, which voilates its reference
from gp_relation_node. In general persistent table has all frozen tuples
so vacuum full is harmless too, but for example one scenario where it becomes
dangerous is zero-page case due to failure between page extension and
page initialization. Also, since all the tuples in persistent table are
frozen inserts, skip it from database age calculation.