### PR TITLE
Fix double free when using stream bitmaps with hash bitmaps.

### DIFF
--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -214,7 +214,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
    			else
 	   			node->bitmap = subresult;
 		}
-	}
+	} // end for loop over nplans
 
 	/* must provide our own instrumentation support */
 	if (node->ps.instrument)

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -1251,13 +1251,13 @@ tbm_stream_free(StreamNode *self)
         tbm_set_instrument(tbm, NULL);
     }
 
-	/*
-	 * A reference to the plan is kept in the BitmapIndexScanState
-	 * so this is a no-op for now.
-	 */
-	tbm_free(tbm);
-	pfree(op);
-	pfree(self);
+    if (op) {
+        self->opaque = NULL;
+        tbm_free(tbm);
+        pfree(op);
+    }
+
+    pfree(self);
 }
 
 static void

--- a/src/test/regress/expected/bitmapscan_ao.out
+++ b/src/test/regress/expected/bitmapscan_ao.out
@@ -154,8 +154,49 @@ WHERE foo.fid = bar.flex_value_set_id;
  54321
 (2 rows)
 
+-- double free mixed bitmap indexes (StreamBitmap with HashBitmap)
+CREATE TABLE bmcrash (
+    btree_col2 date DEFAULT now(),
+    bitmap_col text NOT NULL,
+    btree_col1 character varying(50) NOT NULL,
+    dist_col serial
+)
+WITH (appendonly=true, compresslevel=5, compresstype=zlib) DISTRIBUTED BY (dist_col);
+NOTICE:  CREATE TABLE will create implicit sequence "bmcrash_dist_col_seq" for serial column "bmcrash.dist_col"
+CREATE INDEX bm_idx ON bmcrash USING bitmap (bitmap_col);
+CREATE INDEX bt_idx ON bmcrash USING btree (btree_col1);
+CREATE INDEX bt_idx_2 ON bmcrash USING btree (btree_col2);
+INSERT INTO bmcrash (btree_col2, bitmap_col, btree_col1)
+SELECT date '2015-01-01' + (i % (365 * 2)), i % 1000, 'abcdefg' || (i% 1000)
+from generate_series(1,10000) as i;
+select count(1) from bmcrash where bitmap_col = '999' AND btree_col1 = 'abcdefg999';
+ count 
+-------
+    10
+(1 row)
+
+select count(1) from bmcrash where bitmap_col = '999' OR btree_col1 = 'abcdefg999';
+ count 
+-------
+    10
+(1 row)
+
+select count(1) from bmcrash where bitmap_col = '999' OR btree_col1 = 'abcdefg999' AND btree_col2 = '2015-01-01';
+ count 
+-------
+    10
+(1 row)
+
+select count(1) from bmcrash where bitmap_col = '999' AND btree_col1 = 'abcdefg999' OR btree_col2 = '2015-01-01';
+ count 
+-------
+    23
+(1 row)
+
 -- start_ignore
 drop schema bm_ao cascade;
+NOTICE:  drop cascades to append only table bmcrash
+NOTICE:  drop cascades to default for append only table bmcrash column dist_col
 NOTICE:  drop cascades to table foo
 NOTICE:  drop cascades to append only columnar table inner_table
 NOTICE:  drop cascades to append only columnar table outer_table

--- a/src/test/regress/sql/bitmapscan_ao.sql
+++ b/src/test/regress/sql/bitmapscan_ao.sql
@@ -151,6 +151,27 @@ and c1.language = 'ZHS') bar,
 foo
 WHERE foo.fid = bar.flex_value_set_id;
 
+-- double free mixed bitmap indexes (StreamBitmap with HashBitmap)
+CREATE TABLE bmcrash (
+    btree_col2 date DEFAULT now(),
+    bitmap_col text NOT NULL,
+    btree_col1 character varying(50) NOT NULL,
+    dist_col serial
+)
+WITH (appendonly=true, compresslevel=5, compresstype=zlib) DISTRIBUTED BY (dist_col);
+
+CREATE INDEX bm_idx ON bmcrash USING bitmap (bitmap_col);
+CREATE INDEX bt_idx ON bmcrash USING btree (btree_col1);
+CREATE INDEX bt_idx_2 ON bmcrash USING btree (btree_col2);
+
+INSERT INTO bmcrash (btree_col2, bitmap_col, btree_col1)
+SELECT date '2015-01-01' + (i % (365 * 2)), i % 1000, 'abcdefg' || (i% 1000)
+from generate_series(1,10000) as i;
+
+select count(1) from bmcrash where bitmap_col = '999' AND btree_col1 = 'abcdefg999';
+select count(1) from bmcrash where bitmap_col = '999' OR btree_col1 = 'abcdefg999';
+select count(1) from bmcrash where bitmap_col = '999' OR btree_col1 = 'abcdefg999' AND btree_col2 = '2015-01-01';
+select count(1) from bmcrash where bitmap_col = '999' AND btree_col1 = 'abcdefg999' OR btree_col2 = '2015-01-01';
 
 -- start_ignore
 drop schema bm_ao cascade;


### PR DESCRIPTION
Fixes double free issue when we use two different types (i.e. Stream and Hash) of bitmap indexes under an AND/OR Bitmap operator.

Consider a query like `select count(1) from bmcrash where bitmap_col = '999' AND btree_col1 = 'abcdefg999';` 
where we have a Btree index on `btree_col1` and a `BitmapIndex` on `bitmap_col`.

```
                                              QUERY PLAN
------------------------------------------------------------------------------------------------------
 Aggregate  (cost=0.00..0.01 rows=1 width=8)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.01 rows=1 width=8)
         ->  Aggregate  (cost=0.00..0.01 rows=1 width=8)
               ->  Bitmap Table Scan on bmcrash  (cost=0.00..0.01 rows=1 width=1)
                     Recheck Cond: bitmap_col = '999'::text AND btree_col1::text = 'abcdefg999'::text
                     ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
                           ->  Bitmap Index Scan on bm_idx  (cost=0.00..0.00 rows=0 width=0)
                                 Index Cond: bitmap_col = '999'::text
                           ->  Bitmap Index Scan on bt_idx  (cost=0.00..0.00 rows=0 width=0)
                                 Index Cond: btree_col1::text = 'abcdefg999'::text
 Settings:  optimizer=on
 Optimizer status: PQO version 1.665
```

In the plan above, we have two `BitmapIndexScan` and a `BitmapAnd` operator that merges the two bitmaps, viz. a `StreamBitmap` (`bm_idx` on `bitmap_col`) 
and a `HashBitmap` (`bt_idx` on `btree_col1`) created at runtime from Btree.

When we have mixed type of bitmaps connected using AND or OR, we wrap the `HashBitmap` into a `StreamBitmap` and combine them in a `OpStreamBitmap` (e.g. `BitmapAnd`), 
which contains pointers to the original two bitmaps. With this scheme there are two pointers to the same `HashBitmap` 
(one from the `OpStreamBitmap` and another in the `BitmapIndexScan` of `bt_idx`).

So when it comes time to free the `HashBitmap`, it gets freed twice - once using `tbm_stream_free` directly from `ExecEndBitmapIndexScan`, 
and then once again via `opstream_free` when we free the `OpStreamBitmap`

ExecEndBitmapIndexScan -> tbm_bitmap_free -> tbm_free
ExecEndBitmapIndexScan -> tbm_bitmap_free -> **opstream_free** -> tbm_stream_free -> tbm_free

To recap, we try to free only once per executor operator. But, the `tidbitmap.c` API `tbm_bitmap_free` will call `tbm_free` on the `HashBitmap` first 
and subsequently for second `OpStreamBitmap` (as produced by appending `HashBitmap` to the StreamBitmap) will iterate through all its contained bitmaps 
and call `tbm_free` on the `HashBitmap` again. This will result in a double free.

To prevent the double free, we set the opaque pointer to NULL in the `IndexStream` (`StreamNode`) when we free the underlying `HashStreamOpaque`.

Signed-off-by: Shreedhar Hardikar <shardikar@pivotal.io>