### PR TITLE
Only ereport() on changed default value for non codegen builds

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5637,7 +5637,7 @@ assign_optimizer_log_failure(const char *val, bool assign, GucSource source)
 static const char*
 assign_codegen_optimization_level(const char *val, bool assign, GucSource source) {
 #ifndef USE_CODEGEN
-	if (val)
+	if (val && pg_strcasecmp(val, "default") != 0)
 		ereport(ERROR,
 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("Code generation is not supported by this build")));


### PR DESCRIPTION
If the default value is passed then lets avoid stopping the server for builds without codegen configured. This solves the recent breakage of server start reported in https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/k4Kx4SZxYsw