### PR TITLE
Use HTTPS instead of SSH for gpdb_src in gpcodegen pipeline

### DIFF
--- a/concourse/gpcodegen_pipeline.yml
+++ b/concourse/gpcodegen_pipeline.yml
@@ -10,8 +10,7 @@ resources:
       - src/backend/codegen/*
       - src/include/codegen/*
       - concourse/*
-    private_key: {{gpdb_deploy_key}}
-    uri: git@github.com:greenplum-db/gpdb.git
+    uri: https://github.com/greenplum-db/gpdb.git
 
 - name: bin_gpdb_planner
   type: s3


### PR DESCRIPTION
There were issues using the gpdb keys; and resource checks were failing. Besides there really was no reason to use SSH anyway, since we're open source.