### PR TITLE
Rewrite PGFuncBaseGenerator and PGGenericFuncGenerator to support variable number of types.

### DIFF
--- a/src/backend/codegen/CMakeLists.txt
+++ b/src/backend/codegen/CMakeLists.txt
@@ -315,6 +315,10 @@ if(EXISTS ${TXT_OBJFILE})
         tests/codegen_framework_unittest.cc
         ${MOCK_DIR}/backend/postmaster/postmaster_mock.o
     )
+    add_cmockery_gtest(codegen_pg_func_generator_unittest.t 
+        tests/codegen_pg_func_generator_unittest.cc
+        ${MOCK_DIR}/backend/postmaster/postmaster_mock.o
+    )
 endif()
 
 

--- a/src/backend/codegen/include/codegen/pg_arith_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_arith_func_generator.h
@@ -214,10 +214,6 @@ bool PGArithFuncGenerator<rtype, Arg0, Arg1>::ArithOpWithOverflow(
   return true;
 }
 
-
-
-
-
 /** @} */
 }  // namespace gpcodegen
 

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -50,6 +50,7 @@ using gpcodegen::PGFuncGenerator;
 using gpcodegen::CodeGenFuncMap;
 using llvm::IRBuilder;
 
+
 CodeGenFuncMap
 OpExprTreeGenerator::supported_function_;
 
@@ -57,17 +58,19 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
   if (!supported_function_.empty()) { return; }
 
   supported_function_[141] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int32_t, int32_t>(
+      new PGGenericFuncGenerator<int32_t, int32_t, int32_t>(
           141,
           "int4mul",
           &PGArithFuncGenerator<int32_t, int32_t, int32_t>::MulWithOverflow));
 
   supported_function_[149] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGIRBuilderFuncGenerator<decltype(&IRBuilder<>::CreateICmpSLE),
-      int32_t, int32_t>(149, "int4le", &IRBuilder<>::CreateICmpSLE));
+      new PGIRBuilderFuncGenerator<int32_t, int32_t, int32_t>(
+          149,
+          "int4le",
+          &IRBuilder<>::CreateICmpSLE));
 
   supported_function_[177] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int32_t, int32_t>(
+      new PGGenericFuncGenerator<int32_t, int32_t, int32_t>(
           177,
           "int4pl",
           &PGArithFuncGenerator<int32_t, int32_t, int32_t>::AddWithOverflow));
@@ -79,7 +82,7 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           &PGArithFuncGenerator<int64_t, int64_t, int32_t>::AddWithOverflow));
 
   supported_function_[181] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int32_t, int32_t>(
+      new PGGenericFuncGenerator<int32_t, int32_t, int32_t>(
           181,
           "int4mi",
           &PGArithFuncGenerator<int32_t, int32_t, int32_t>::SubWithOverflow));
@@ -91,29 +94,29 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           &PGArithFuncGenerator<int64_t, int64_t, int64_t>::AddWithOverflow));
 
   supported_function_[216] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<float8, float8>(
+      new PGGenericFuncGenerator<float8, float8, float8>(
           216,
           "float8mul",
           &PGArithFuncGenerator<float8, float8, float8>::MulWithOverflow));
 
   supported_function_[218] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<float8, float8>(
+      new PGGenericFuncGenerator<float8, float8, float8>(
           218,
           "float8pl",
           &PGArithFuncGenerator<float8, float8, float8>::AddWithOverflow));
 
   supported_function_[219] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<float8, float8>(
+      new PGGenericFuncGenerator<float8, float8, float8>(
           219,
           "float8mi",
           &PGArithFuncGenerator<float8, float8, float8>::SubWithOverflow));
 
   supported_function_[1088] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGIRBuilderFuncGenerator<decltype(&IRBuilder<>::CreateICmpSLE),
-      int32_t, int32_t>(1088, "date_le", &IRBuilder<>::CreateICmpSLE));
+      new PGIRBuilderFuncGenerator<bool, int32_t, int32_t>(
+          1088, "date_le", &IRBuilder<>::CreateICmpSLE));
 
   supported_function_[2339] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int32_t, int64_t>(
+      new PGGenericFuncGenerator<int32_t, int32_t, int64_t>(
           2339,
           "date_le_timestamp",
           &PGDateFuncGenerator::DateLETimestamp));

--- a/src/backend/codegen/tests/codegen_pg_func_generator_unittest.cc
+++ b/src/backend/codegen/tests/codegen_pg_func_generator_unittest.cc
@@ -1,0 +1,294 @@
+//---------------------------------------------------------------------------
+//  Greenplum Database
+//  Copyright 2016 Pivotal Software, Inc.
+//
+//  @filename:
+//    codegen_pg_func_generator_unittest.cc
+//
+//  @doc:
+//    Unit tests for PGFuncGenerator
+//
+//  @test:
+//
+//---------------------------------------------------------------------------
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <ctime>
+#include <initializer_list>
+#include <limits>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "postgres.h"  // NOLINT(build/include)
+#undef newNode  // undef newNode so it doesn't have name collision with llvm
+#include "utils/elog.h"
+#undef elog
+#define elog(...)
+}
+
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/IR/Argument.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constant.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+#include "llvm/IR/Value.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/Support/Casting.h"
+
+
+#include "codegen/utils/codegen_utils.h"
+#include "codegen/utils/gp_codegen_utils.h"
+#include "codegen/utils/utility.h"
+#include "codegen/codegen_manager.h"
+#include "codegen/codegen_wrapper.h"
+#include "codegen/codegen_interface.h"
+#include "codegen/base_codegen.h"
+#include "codegen/pg_func_generator.h"
+#include "codegen/pg_arith_func_generator.h"
+
+
+namespace gpcodegen {
+
+class PGFuncGeneratorTestEnvironment : public ::testing::Environment {
+ public:
+  virtual void SetUp() {
+    ASSERT_TRUE(CodegenUtils::InitializeGlobal());
+  }
+};
+
+class CodegenPGFuncGeneratorTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    codegen_utils_.reset(new GpCodegenUtils("test_module"));
+  }
+
+  std::unique_ptr<gpcodegen::GpCodegenUtils> codegen_utils_;
+};
+
+
+
+// Helper Variadic template classes for recursive checking the types in an array
+// of llvm::Values*
+template<typename ... CppTypes>
+class LLVMTypeChecker {
+};
+
+template<>
+class LLVMTypeChecker<> {
+ public:
+  static void check(gpcodegen::GpCodegenUtils* codegen_utils,
+             std::vector<llvm::Value*>::const_iterator val_iter) {
+  }
+};
+
+template<typename HeadType, typename ... TailTypes>
+class LLVMTypeChecker<HeadType, TailTypes...> {
+ public:
+  static void check(gpcodegen::GpCodegenUtils* codegen_utils,
+             std::vector<llvm::Value*>::const_iterator val_iter) {
+    EXPECT_EQ((*val_iter)->getType(), codegen_utils->GetType<HeadType>());
+    LLVMTypeChecker<TailTypes...>::check(codegen_utils, ++val_iter);
+  }
+
+  static void check(gpcodegen::GpCodegenUtils* codegen_utils,
+             const std::vector<llvm::Value*> & values) {
+    check(codegen_utils, values.begin());
+  }
+};
+
+// Helper method to check
+template <typename ... CppTypes>
+void CheckPGFuncArgPreProcessor(gpcodegen::GpCodegenUtils* codegen_utils) {
+  std::vector<llvm::Value*> in_values;
+  std::vector<llvm::Value*> out_values;
+
+  for (int i=0; i< sizeof...(CppTypes); ++i) {
+    in_values.push_back(codegen_utils->GetConstant<Datum>(i));
+  }
+
+  EXPECT_TRUE(pg_func_generator_detail::PGFuncArgPreProcessor<CppTypes...>
+      ::PreProcessArgs(codegen_utils, in_values, &out_values));
+  EXPECT_EQ(sizeof...(CppTypes), out_values.size());
+  LLVMTypeChecker<CppTypes...>::check(codegen_utils, out_values);
+}
+
+
+// Test PGFuncArgPreProcessor with 1, 2 and 3 arguments of various types
+TEST_F(CodegenPGFuncGeneratorTest, PGFuncArgPreProcessorTest ) {
+  using VoidFn = void (*) (void);
+
+  // Start of boiler plate
+  llvm::Function* dummy_fn =
+      codegen_utils_->CreateFunction<VoidFn>("dummy_fn");
+
+  llvm::BasicBlock* main_block =
+      codegen_utils_->CreateBasicBlock("main", dummy_fn);
+  codegen_utils_->ir_builder()->SetInsertPoint(main_block);
+  // end of boiler plate
+
+  // Test with one type
+  CheckPGFuncArgPreProcessor<u_int32_t>(codegen_utils_.get());
+  // Test with two types
+  CheckPGFuncArgPreProcessor<u_int32_t, u_int32_t>(
+      codegen_utils_.get());
+  // Test with three types
+  CheckPGFuncArgPreProcessor<u_int32_t, uint32_t, u_int32_t>(
+      codegen_utils_.get());
+  // Test with different types
+  CheckPGFuncArgPreProcessor<u_int32_t, int64_t, bool>(codegen_utils_.get());
+
+  // More boiler plate
+  codegen_utils_->ir_builder()->CreateRetVoid();
+
+  EXPECT_FALSE(llvm::verifyFunction(*dummy_fn));
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
+
+    // Prepare generated code for execution.
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodegenUtils::OptimizationLevel::kNone,
+      true));
+  EXPECT_EQ(nullptr, codegen_utils_->module());
+}
+
+// Test PGGenericFuncGenerator with 2 arguments
+TEST_F(CodegenPGFuncGeneratorTest, PGGenericFuncGeneratorTwoArgsTest) {
+  using DoubleFn = double (*) (Datum, Datum);
+
+  llvm::Function* double_add_fn =
+      codegen_utils_->CreateFunction<DoubleFn>("double_add_fn");
+
+  llvm::BasicBlock* main_block =
+      codegen_utils_->CreateBasicBlock("main", double_add_fn);
+  llvm::BasicBlock* error_block =
+      codegen_utils_->CreateBasicBlock("error", double_add_fn);
+
+  auto irb = codegen_utils_->ir_builder();
+
+  irb->SetInsertPoint(main_block);
+
+  auto generator = std::unique_ptr<PGFuncGeneratorInterface>(
+      new PGGenericFuncGenerator<float8, float8, float8>(
+          218,
+          "float8pl",
+          &PGArithFuncGenerator<float8, float8, float8>::AddWithOverflow));
+
+  llvm::Value* result;
+  std::vector<llvm::Value*> args = {
+      ArgumentByPosition(double_add_fn, 0),
+      ArgumentByPosition(double_add_fn, 1)};
+  PGFuncGeneratorInfo pg_gen_info(double_add_fn, error_block, args);
+
+  EXPECT_TRUE(generator->GenerateCode(codegen_utils_.get(),
+                                      pg_gen_info, &result));
+  irb->CreateRet(result);
+
+  irb->SetInsertPoint(error_block);
+  irb->CreateRet(codegen_utils_->GetConstant<double>(0.0));
+
+
+  EXPECT_FALSE(llvm::verifyFunction(*double_add_fn));
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
+
+  // Prepare generated code for execution.
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodegenUtils::OptimizationLevel::kNone,
+      true));
+  EXPECT_EQ(nullptr, codegen_utils_->module());
+
+  DoubleFn fn = codegen_utils_->GetFunctionPointer<DoubleFn>("double_add_fn");
+
+  double d1 = 1.0, d2 = 2.0;
+  EXPECT_EQ(3.0, fn(*reinterpret_cast<Datum*>(&d1),
+                    *reinterpret_cast<Datum*>(&d2)));
+}
+
+// A method of type PGFuncGenerator as expected by PGGenericFuncGenerator
+// that generates instructions to add 1 to the first input argument.
+template <typename CppType>
+bool GenerateAddOne(
+    gpcodegen::GpCodegenUtils* codegen_utils,
+    const PGFuncGeneratorInfo& pg_func_info,
+    llvm::Value** llvm_out_value) {
+  *llvm_out_value = codegen_utils->ir_builder()->CreateAdd(
+      pg_func_info.llvm_args[0],
+      codegen_utils->GetConstant<CppType>(1));
+  return true;
+}
+
+// Test PGGenericFuncGenerator with 1 arguments
+TEST_F(CodegenPGFuncGeneratorTest, PGGenericFuncGeneratorOneArgTest) {
+  using AddOneFn = int32_t (*) (Datum);
+
+  llvm::Function* add_one_fn =
+      codegen_utils_->CreateFunction<AddOneFn>("add_one_fn");
+
+  llvm::BasicBlock* main_block =
+      codegen_utils_->CreateBasicBlock("main", add_one_fn);
+  llvm::BasicBlock* error_block =
+      codegen_utils_->CreateBasicBlock("error", add_one_fn);
+
+  auto irb = codegen_utils_->ir_builder();
+
+  irb->SetInsertPoint(main_block);
+
+  auto generator = std::unique_ptr<PGFuncGeneratorInterface>(
+      new PGGenericFuncGenerator<int32_t, int32_t>(
+          0,
+          "",
+          &GenerateAddOne<int32_t>));
+
+  llvm::Value* result = nullptr;
+  std::vector<llvm::Value*> args = {ArgumentByPosition(add_one_fn, 0)};
+  PGFuncGeneratorInfo pg_gen_info(add_one_fn, error_block, args);
+
+  EXPECT_TRUE(generator->GenerateCode(codegen_utils_.get(),
+                                      pg_gen_info,
+                                      &result));
+  irb->CreateRet(result);
+
+  irb->SetInsertPoint(error_block);
+  irb->CreateRet(codegen_utils_->GetConstant<int32_t>(-1));
+
+
+  EXPECT_FALSE(llvm::verifyFunction(*add_one_fn));
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
+
+  // Prepare generated code for execution.
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodegenUtils::OptimizationLevel::kNone,
+      true));
+  EXPECT_EQ(nullptr, codegen_utils_->module());
+
+  AddOneFn fn = codegen_utils_->GetFunctionPointer<AddOneFn>("add_one_fn");
+
+  EXPECT_EQ(1, fn(0));
+  EXPECT_EQ(3, fn(2));
+}
+
+}  // namespace gpcodegen
+
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  AddGlobalTestEnvironment(new gpcodegen::PGFuncGeneratorTestEnvironment);
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
Currently PGFuncBaseGenerator and PGGenericFuncGenerator classes have only one template that takes two argument only, i.e., two datums. These templates can support only (built-in) functions that take two arguments as input only (e.g., int4pl). However, there are built-in functions that take either more or less than two arguments.
This will benefit count and average aggregate function.

This PR aims to make a Variadic template for PGFuncBaseGenerator and PGGenericFuncGenerator that take variable length arguments.

@karthijrk @foyzur @xinzweb @armenatzoglou Please take a look.