### PR TITLE
Initialize latestCompletedXid after pass3 during recovery

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6129,6 +6129,13 @@ StartupXLOG_InProduction(void)
 						oldestActiveXID,
 						ShmemVariableCache->nextXid);
 
+	/* also initialize latestCompletedXid, to nextXid - 1 */
+	ShmemVariableCache->latestCompletedXid = ShmemVariableCache->nextXid;
+	TransactionIdRetreat(ShmemVariableCache->latestCompletedXid);
+	elog(LOG, "latest completed transaction id is %u and next transaction id is %u",
+		ShmemVariableCache->latestCompletedXid,
+		ShmemVariableCache->nextXid);
+
 	/* Reload shared-memory state for prepared transactions */
 	RecoverPreparedTransactions();
 
@@ -6723,10 +6730,6 @@ StartupXLOG(void)
 	MultiXactSetNextMXact(checkPoint.nextMulti, checkPoint.nextMultiOffset);
 	XLogCtl->ckptXidEpoch = checkPoint.nextXidEpoch;
 	XLogCtl->ckptXid = checkPoint.nextXid;
-
-	/* also initialize latestCompletedXid, to nextXid - 1 */
-	ShmemVariableCache->latestCompletedXid = ShmemVariableCache->nextXid;
-	TransactionIdRetreat(ShmemVariableCache->latestCompletedXid);
 
 	/*
 	 * We must replay WAL entries using the same TimeLineID they were created


### PR DESCRIPTION
latestCompletedXid in ShmemVariableCache is used during visibility checking to
exit early from TransactionIdIsInProgress, if transaction being checked is
higher than latestCompletedXid. During merge to 8.3 this value was set
incorrectly after pass1 of recovery, hence it reflected value what checkpoint
provides for nextXid. In GPDB pass3 is where xlog records are replayed which
would bump-up the nextXID to correctly reflect in-flight transactions. So,
latestCompletedXid needs to be set after pass3 has completed to record correct
value. Without the fix latestCompletedXid was pointing to stale transaction id
yeilding incorrect visibility of tuples post recovery.

Repro:
create table foo(id int);
-- manually kill -9 a segment QE process to simulate SIGSEGV, and force postmaster reset on that segment
select * from foo; -- fails currently, ideally shouldn't fail as well
select * from foo; -- expected to succeed but it fails with error message like "ERROR: relation with OID xxxxxx does not exist"

Thank You @eurekaka for reporting.
Fixes: #1094