### PR TITLE
Speed up cancelling process when one or more QEs got error.

### DIFF
--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -57,8 +57,6 @@ typedef struct DispatcherInternalFuncs
 			int sliceIndex, CdbDispatchDirectDesc *direct);
 }DispatcherInternalFuncs;
 
-#define DISPATCH_WAIT_TIMEOUT_SEC 2
-
 /*--------------------------------------------------------------------*/
 /*
  * cdbdisp_dispatchToGang:


### PR DESCRIPTION
QD need to cancel QEs when
1) QD get a error
2) one or more QEs got error and cancelOnError was set to true.

We want to cancel QEs as soon as possible once above conditions are reached, but considering
the cost of cancelling QEs is high, we want to process as many pending finish QEs as possible
before actually cancel. The original interval before cancelling is 2 seconds which is too
long that users will see an obvious delay before errors are reported, this commit lower
this interval to 100 ms to speed up the cancelling process.


Repo steps:
create table t1 (c1 int, c2 int);
insert into t1 select 1, 0 from generate_series(1,1000);
insert into t1 select 2, 1 from generate_series(1,1000);

create table t2 as select 1/c2 from t1; -- report a error after 3 seconds
select 1/c2 from t1;  --  report a error after 3 seconds