### PR TITLE
Added a new GUC gp_enable_relsize_collection to enable stats collection.

### DIFF
--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -451,12 +451,20 @@ cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 
 		curpages = relpages;
 	}
+	else if (RelationIsExternal(rel))
+	{
+		/*
+		 * If the relation is an external table use default curpages
+		 */
+		curpages = DEFAULT_EXTERNAL_TABLE_PAGES;
+	}
 	else
 	{
 		/*
-		 * Put default estimates in case no statistics are available. This saves cost of asking QEs
+		 * If GUC gp_enable_relsize_collection is on, get the size of the table to derive curpages
+		 * else use the default value
 		 */
-		curpages = RelationIsExternal(rel) ? DEFAULT_EXTERNAL_TABLE_PAGES : DEFAULT_INTERNAL_TABLE_PAGES;
+		curpages = gp_enable_relsize_collection ? cdbRelMaxSegSize(rel) / BLCKSZ : DEFAULT_INTERNAL_TABLE_PAGES;
 	}
 
 	/* report estimated # pages */

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -478,6 +478,7 @@ bool		gp_enable_groupext_distinct_gather = true;
 bool		gp_dynamic_partition_pruning = true;
 bool		gp_log_dynamic_partition_pruning = false;
 bool		gp_cte_sharing = false;
+bool		gp_enable_relsize_collection = false;
 
 /* ORCA related gucs */
 bool		optimizer_control = true;
@@ -2551,6 +2552,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_cte_sharing,
+		false, NULL, NULL
+	},
+
+	{
+		{"gp_enable_relsize_collection", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("This guc enables relsize collection when stats are not present. If disabled and stats are not present a default "
+					     "value is used."),
+			NULL
+		},
+		&gp_enable_relsize_collection,
 		false, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -302,6 +302,8 @@ extern bool gp_temporary_files_filespace_repair;
 extern bool gp_perfmon_print_packet_info;
 extern bool fts_diskio_check;
 
+extern bool gp_enable_relsize_collection;
+
 /* Debug DTM Action */
 typedef enum
 {

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -33,6 +33,22 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
  Optimizer status: legacy query optimizer
 (7 rows)
 
+set gp_enable_relsize_collection=on;
+explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
+    WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.01..0.09 rows=4 width=280)
+   ->  Hash Join  (cost=0.01..0.09 rows=2 width=280)
+         Hash Cond: "*VALUES*".column1 = bfv_tab1.unique1 AND "*VALUES*".column2 = bfv_tab1.stringu1::text
+         ->  Values Scan on "*VALUES*"  (cost=0.00..0.03 rows=1 width=36)
+         ->  Hash  (cost=0.00..0.00 rows=1 width=244)
+               ->  Seq Scan on bfv_tab1  (cost=0.00..0.00 rows=1 width=244)
+ Settings:  gp_enable_relsize_collection=on
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+reset gp_enable_relsize_collection;
 --start_ignore
 DROP TABLE IF EXISTS bfv_tab2_facttable1;
 NOTICE:  table "bfv_tab2_facttable1" does not exist, skipping

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -39,6 +39,27 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
  Optimizer status: PQO version 1.621
 (13 rows)
 
+set gp_enable_relsize_collection=on;
+explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
+    WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.00 rows=1 width=256)
+   ->  Nested Loop  (cost=0.00..2.00 rows=1 width=256)
+         Join Filter: true
+         ->  Append  (cost=0.00..0.00 rows=1 width=12)
+               ->  Result  (cost=0.00..0.00 rows=1 width=12)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=12)
+               ->  Result  (cost=0.00..0.00 rows=1 width=12)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=12)
+         ->  Index Scan using bfv_tab1_idx1 on bfv_tab1  (cost=0.00..2.00 rows=1 width=244)
+               Index Cond: bfv_tab1.unique1 = (147)
+               Filter: bfv_tab1.stringu1::text = ('RFAAAA'::text)
+ Settings:  gp_enable_relsize_collection=on; optimizer=on
+ Optimizer status: PQO version 1.667
+(13 rows)
+
+reset gp_enable_relsize_collection;
 --start_ignore
 DROP TABLE IF EXISTS bfv_tab2_facttable1;
 NOTICE:  table "bfv_tab2_facttable1" does not exist, skipping

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -25,6 +25,13 @@ create index bfv_tab1_idx1 on bfv_tab1 using btree(unique1);
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
 
+set gp_enable_relsize_collection=on;
+
+explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
+    WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
+
+reset gp_enable_relsize_collection;
+
 --start_ignore
 DROP TABLE IF EXISTS bfv_tab2_facttable1;
 DROP TABLE IF EXISTS bfv_tab2_dimdate;


### PR DESCRIPTION
Currently, when the stats are not existing for a relation, planner
relies on default values instead of running pg_relation_size to save
time. However, this causes planner to produce bad plans. Earlier, the
code had the feature to collect stats for planner if the table did not
had any stats, but it was removed.

This fix re-introduces the feature with the GUC to control whether to use
default values or run pg_relation_size to get actual stats if stats are
not present. By default, the GUC is turned off.

[#129570829]