### PR TITLE
Fixing codegen related bugs in InitializeSupportedFunction

### DIFF
--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -64,7 +64,7 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           &PGArithFuncGenerator<int32_t, int32_t, int32_t>::MulWithOverflow));
 
   supported_function_[149] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGIRBuilderFuncGenerator<int32_t, int32_t, int32_t>(
+      new PGIRBuilderFuncGenerator<bool, int32_t, int32_t>(
           149,
           "int4le",
           &IRBuilder<>::CreateICmpSLE));
@@ -76,7 +76,7 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           &PGArithFuncGenerator<int32_t, int32_t, int32_t>::AddWithOverflow));
 
   supported_function_[1841] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int64_t, int32_t>(
+      new PGGenericFuncGenerator<int64_t, int64_t, int32_t>(
           1841,
           "int4_sum",
           &PGArithFuncGenerator<int64_t, int64_t, int32_t>::AddWithOverflow));
@@ -88,7 +88,7 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           &PGArithFuncGenerator<int32_t, int32_t, int32_t>::SubWithOverflow));
 
   supported_function_[463] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int64_t, int64_t>(
+      new PGGenericFuncGenerator<int64_t, int64_t, int64_t>(
           463,
           "int8pl",
           &PGArithFuncGenerator<int64_t, int64_t, int64_t>::AddWithOverflow));
@@ -116,7 +116,7 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           1088, "date_le", &IRBuilder<>::CreateICmpSLE));
 
   supported_function_[2339] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int32_t, int32_t, int64_t>(
+      new PGGenericFuncGenerator<bool, int32_t, int64_t>(
           2339,
           "date_le_timestamp",
           &PGDateFuncGenerator::DateLETimestamp));


### PR DESCRIPTION
There are a few bugs in InitializeSupportedFunction.
In particular:
* int4le returns int32 but it should return bool.
* date_le_timestamp returns int32 but it should return bool
* in int4_sum, PGGenericFuncGenerator should take arguments < int64_t, int64_t, int32_t >
* in int8pl, PGGenericFuncGenerator should take arguments < int64_t, int64_t, int64_t >
