### PR TITLE
Avoid dereferencing zero in the faultinjector

### DIFF
--- a/src/backend/utils/error/faultinject.c
+++ b/src/backend/utils/error/faultinject.c
@@ -111,7 +111,7 @@ gp_fault_inject_impl(int32 reason, int64 arg)
 	switch(reason)
 	{
 		case GP_FAULT_USER_SEGV:
-			*(int *) 0 = 1234;
+			*(volatile int *) 0 = 1234;
 			break;
 		case GP_FAULT_USER_LEAK:
 			palloc(arg);
@@ -160,13 +160,13 @@ gp_fault_inject_impl(int32 reason, int64 arg)
 
 		case GP_FAULT_USER_SEGV_CRITICAL:
 			START_CRIT_SECTION();
-			*(int *) 0 = 1234;
+			*(volatile int *) 0 = 1234;
 			END_CRIT_SECTION();
 			break;
 
 		case GP_FAULT_USER_SEGV_LWLOCK:
 			LWLockAcquire(WALInsertLock, LW_EXCLUSIVE);
-			*(int *) 0 = 1234;
+			*(volatile int *) 0 = 1234;
 			break;
  	
 		case GP_FAULT_USER_OPEN_MANY_FILES:


### PR DESCRIPTION
Apply the same fix as in 48983e3 which missed these invocations of zero derefs. Dereferencing address zero is undefined behavior in C and the compiler is free to optimize any such calls away (even though that is believed to be rare). Ensure that any optimizations are avoided by declaring the variable volatile and at the same time get rid of a pesky clang compiler warning.