### PR TITLE
Generate codeg for COUNT aggregate function

### DIFF
--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -157,15 +157,15 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
 
   // BasicBlock of function entry.
   llvm::BasicBlock* entry_block = codegen_utils->CreateBasicBlock(
-      "entry block", advance_aggregates_func);
+      "entry_block", advance_aggregates_func);
   llvm::BasicBlock* implementation_block = codegen_utils->CreateBasicBlock(
-      "implementation block", advance_aggregates_func);
+      "implementation_block", advance_aggregates_func);
   llvm::BasicBlock* error_aggstate_block = codegen_utils->CreateBasicBlock(
-      "error aggstate block", advance_aggregates_func);
+      "error_aggstate_block", advance_aggregates_func);
   llvm::BasicBlock* overflow_block = codegen_utils->CreateBasicBlock(
-      "overflow block", advance_aggregates_func);
+      "overflow_block", advance_aggregates_func);
   llvm::BasicBlock* null_attribute_block = codegen_utils->CreateBasicBlock(
-      "null attribute block", advance_aggregates_func);
+      "null_attribute_block", advance_aggregates_func);
 
   // External functions
   llvm::Function* llvm_ExecTargetList =

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -90,8 +90,8 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceTransitionFunction(
     return false;
   }
 
-  assert(nullptr != peraggstate->aggref &&
-         pg_func_info.llvm_args.size() == 1 +
+  assert(nullptr != peraggstate->aggref);
+  assert(pg_func_info.llvm_args.size() == 1 +
              list_length(peraggstate->aggref->args));
   pg_func_info.llvm_args[0] = irb->CreateLoad(llvm_pergroupstate_transValue_ptr);
 

--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -11,7 +11,6 @@
 //---------------------------------------------------------------------------
 #include "codegen/advance_aggregates_codegen.h"
 #include "codegen/op_expr_tree_generator.h"
-#include "codegen/pg_func_generator_interface.h"
 
 #include "codegen/utils/gp_codegen_utils.h"
 #include "codegen/utils/utility.h"
@@ -50,12 +49,10 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceTransitionFunction(
     gpcodegen::GpCodegenUtils* codegen_utils,
     llvm::Value* llvm_pergroup_arg,
     int aggno,
-    llvm::Function* advance_aggregates_func,
-    llvm::BasicBlock* error_block,
-    llvm::Value *llvm_in_arg_ptr) {
-
+    gpcodegen::PGFuncGeneratorInfo& pg_func_info) {
   auto irb = codegen_utils->ir_builder();
   AggStatePerAgg peraggstate = &aggstate_->peragg[aggno];
+
 
   // External functions
   llvm::Function* llvm_MemoryContextSwitchTo =
@@ -88,19 +85,16 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceTransitionFunction(
       codegen_utils->GetPointerToMember(
           llvm_pergroupstate, &AggStatePerGroupData::noTransValue);
 
+  assert(nullptr != peraggstate);
   if (!peraggstate->transtypeByVal) {
     elog(DEBUG1, "We do not support pass-by-ref datatypes.");
     return false;
   }
 
-  // FunctionCallInvoke(fcinfo); {{
-  // We do not need to use a FunctionCallInfoData struct, since the supported
-  // aggregate functions are simple enough.
-  gpcodegen::PGFuncGeneratorInfo pg_func_info(
-      advance_aggregates_func,
-      error_block,
-      {irb->CreateLoad(llvm_pergroupstate_transValue_ptr),
-          irb->CreateLoad(llvm_in_arg_ptr)});
+  assert(nullptr != peraggstate->aggref &&
+         pg_func_info.llvm_args.size() == 1 +
+             list_length(peraggstate->aggref->args));
+  pg_func_info.llvm_args[0] = irb->CreateLoad(llvm_pergroupstate_transValue_ptr);
 
   gpcodegen::PGFuncGeneratorInterface* pg_func_gen =
       gpcodegen::OpExprTreeGenerator::GetPGFuncGenerator(
@@ -110,6 +104,7 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceTransitionFunction(
          peraggstate->transfn.fn_oid);
     return false;
   }
+
 
   llvm::Value *newVal = nullptr;
   bool isGenerated = pg_func_gen->GenerateCode(codegen_utils,
@@ -203,14 +198,6 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
   // ----------
   irb->SetInsertPoint(implementation_block);
 
-  // Since we do not support ordered functions, we do not need to store
-  // the value of the variables, which are used as input to the aggregate
-  // function, in a slot. Instead we simply store them in a stuck variable.
-  llvm::Value *llvm_in_arg_ptr = irb->CreateAlloca(
-      codegen_utils->GetType<Datum>());
-  llvm::Value *llvm_in_argnull_ptr = irb->CreateAlloca(
-      codegen_utils->GetType<bool>());
-
   for (int aggno = 0; aggno < aggstate_->numaggs; aggno++) {
     // Generate the code of each aggregate function in a different block.
     llvm::BasicBlock* advance_aggregate_block = codegen_utils->
@@ -237,43 +224,74 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
       return false;
     }
 
-    int nargs = list_length(aggref->args);
-    assert(nargs == peraggstate->numArguments);
     assert(peraggstate->evalproj);
+    // TODO: why -1 ??
+    int nargs = peraggstate->transfn.fn_nargs - 1;
 
-    if (peraggstate->evalproj->pi_isVarList) {
-      irb->CreateCall(llvm_ExecVariableList, {
-          codegen_utils->GetConstant<ProjectionInfo *>(peraggstate->evalproj),
-          llvm_in_arg_ptr,
-          llvm_in_argnull_ptr});
-    } else {
-      irb->CreateCall(llvm_ExecTargetList, {
-          codegen_utils->GetConstant(peraggstate->evalproj->pi_targetlist),
-          codegen_utils->GetConstant(peraggstate->evalproj->pi_exprContext),
-          llvm_in_arg_ptr,
-          llvm_in_argnull_ptr,
-          codegen_utils->GetConstant(peraggstate->evalproj->pi_itemIsDone),
-          codegen_utils->GetConstant<ExprDoneCond *>(nullptr)});
-    }
+    // Since we do not support ordered functions, we do not need to store
+    // the value of the variables, which are used as input to the aggregate
+    // function, in a slot. Instead we simply store them in a stuck variable.
+    // TODO why -1 ??
+    llvm::Value* llvm_in_args_ptr = irb->CreateAlloca(
+        codegen_utils->GetType<Datum>(),
+        codegen_utils->GetConstant(nargs));
+    llvm::Value* llvm_in_isnulls_ptr = irb->CreateAlloca(
+        codegen_utils->GetType<bool>(),
+        codegen_utils->GetConstant(nargs));
 
     llvm::BasicBlock* advance_transition_function_block = codegen_utils->
         CreateBasicBlock("advance_transition_function_block_aggno_"
             + std::to_string(aggno), advance_aggregates_func);
 
-    // Error out if attribute is NULL.
-    // TODO(nikos): Support null attributes.
-    irb->CreateCondBr(irb->CreateLoad(llvm_in_argnull_ptr),
-                      null_attribute_block /*true*/,
-                      advance_transition_function_block /*false*/);
+    // TODO add comment: this is different from advance_aggregates
+    if (nargs > 0) {
+      if (peraggstate->evalproj->pi_isVarList) {
+        irb->CreateCall(llvm_ExecVariableList, {
+            codegen_utils->GetConstant<ProjectionInfo *>(peraggstate->evalproj),
+            llvm_in_args_ptr,
+            llvm_in_isnulls_ptr});
+      } else {
+        irb->CreateCall(llvm_ExecTargetList, {
+            codegen_utils->GetConstant(peraggstate->evalproj->pi_targetlist),
+            codegen_utils->GetConstant(peraggstate->evalproj->pi_exprContext),
+            llvm_in_args_ptr,
+            llvm_in_isnulls_ptr,
+            codegen_utils->GetConstant(peraggstate->evalproj->pi_itemIsDone),
+            codegen_utils->GetConstant<ExprDoneCond *>(nullptr)});
+      }
+
+      // Error out if attribute is NULL.
+      // TODO(nikos): Support null attributes.
+      // FIXME: This really should be a GEP
+      irb->CreateCondBr(irb->CreateLoad(llvm_in_isnulls_ptr),
+                        null_attribute_block /*true*/,
+                        advance_transition_function_block /*false*/);
+    } else {
+      irb->CreateBr(advance_transition_function_block);
+    }
 
     // advance_transition_function block
     // ----------
     // We generate code for advance_transition_function.
     irb->SetInsertPoint(advance_transition_function_block);
 
+    // TODO : extra space for transition function
+    std::vector<llvm::Value*> llvm_in_args(nargs+1);
+    for (int i=0; i < nargs; ++i) {
+      llvm_in_args[i+1] = irb->CreateLoad(
+          irb->CreateInBoundsGEP(
+              codegen_utils->GetType<Datum>(),
+              llvm_in_args_ptr,
+              codegen_utils->GetConstant(i)));
+    }
+
+    gpcodegen::PGFuncGeneratorInfo pg_func_info(
+        advance_aggregates_func,
+        overflow_block,
+        llvm_in_args);
+
     bool isGenerated = GenerateAdvanceTransitionFunction(
-        codegen_utils, llvm_pergroup_arg, aggno, advance_aggregates_func,
-        overflow_block, llvm_in_arg_ptr);
+        codegen_utils, llvm_pergroup_arg, aggno, pg_func_info);
     if (!isGenerated)
       return false;
   }  // End of for loop

--- a/src/backend/codegen/exec_variable_list_codegen.cc
+++ b/src/backend/codegen/exec_variable_list_codegen.cc
@@ -68,7 +68,8 @@ ExecVariableListCodegen::ExecVariableListCodegen(
 }
 
 bool ExecVariableListCodegen::InitDependencies() {
-  assert(proj_info_ != nullptr);
+  assert(nullptr != proj_info_);
+  assert(nullptr != proj_info_->pi_targetlist);
 
   // Find the largest attribute index in projInfo->pi_targetlist
   max_attr_ = *std::max_element(

--- a/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
+++ b/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
@@ -16,6 +16,8 @@
 #include "codegen/base_codegen.h"
 #include "codegen/codegen_wrapper.h"
 
+#include "codegen/pg_func_generator_interface.h"
+
 namespace gpcodegen {
 
 /** \addtogroup gpcodegen
@@ -93,9 +95,7 @@ class AdvanceAggregatesCodegen: public BaseCodegen<AdvanceAggregatesFn> {
       gpcodegen::GpCodegenUtils* codegen_utils,
       llvm::Value* llvm_pergroup_arg,
       int aggno,
-      llvm::Function* advance_aggregates_func,
-      llvm::BasicBlock* error_block,
-      llvm::Value *llvm_arg);
+      gpcodegen::PGFuncGeneratorInfo& pg_func_info);
 };
 
 /** @} */

--- a/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
+++ b/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
@@ -15,7 +15,6 @@
 
 #include "codegen/base_codegen.h"
 #include "codegen/codegen_wrapper.h"
-
 #include "codegen/pg_func_generator_interface.h"
 
 namespace gpcodegen {

--- a/src/backend/codegen/include/codegen/pg_arith_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_arith_func_generator.h
@@ -133,34 +133,6 @@ class PGArithFuncGenerator {
   }
 
   /**
-   * @brief Increase the value of a variable with check for overflow
-   *
-   * @param codegen_utils     Utility to easy code generation.
-   * @param llvm_main_func    Current function for which we are generating code
-   * @param llvm_error_block  Basic Block to jump when error happens
-   * @param llvm_args         Vector that contains the llvm argument for the
-   *                          function
-   * @param llvm_out_value    Store the results of function
-   *
-   * @return true if generation was successful otherwise return false
-   *
-   * @note  If there is overflow, it will do elog::ERROR and then jump to given
-   *        error block.
-   **/
-  static bool IncWithOverflow(gpcodegen::GpCodegenUtils* codegen_utils,
-                              const PGFuncGeneratorInfo& pg_func_info,
-                              llvm::Value** llvm_out_value) {
-    llvm::Value* llvm_err_msg = codegen_utils->GetConstant(
-        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg());
-    return ArithOpWithOverflow(
-        codegen_utils,
-        &gpcodegen::GpCodegenUtils::CreateIncOverflow<rtype>,
-        llvm_err_msg,
-        pg_func_info,
-        llvm_out_value);
-  }
-
-  /**
    * @brief Create LLVM Sub instruction with check for overflow
    *
    * @param codegen_utils     Utility to easy code generation.
@@ -192,6 +164,54 @@ class PGArithFuncGenerator {
                                   llvm::Value* llvm_error_msg,
                                   const PGFuncGeneratorInfo& pg_func_info,
                                   llvm::Value** llvm_out_value);
+};
+
+
+/**
+ * @brief Class with Static member function to generate code for ++
+ *        operator
+ *
+ * @tparam rtype  Return type of function
+ * @tparam Arg   Argument's type
+ **/
+template <typename rtype, typename Arg>
+class PGArithUnaryFuncGenerator {
+  template <typename CppType>
+  using CGArithOpTemplateFunc = llvm::Value* (GpCodegenUtils::*)(
+      llvm::Value* arg);
+  using CGArithOpFunc = CGArithOpTemplateFunc<rtype>;
+
+ public:
+
+
+  /**
+   * @brief Increase the value of a variable with check for overflow
+   *
+   * @param codegen_utils     Utility to easy code generation.
+   * @param llvm_main_func    Current function for which we are generating code
+   * @param llvm_error_block  Basic Block to jump when error happens
+   * @param llvm_args         Vector that contains the llvm argument for the
+   *                          function
+   * @param llvm_out_value    Store the results of function
+   *
+   * @return true if generation was successful otherwise return false
+   *
+   * @note  If there is overflow, it will do elog::ERROR and then jump to given
+   *        error block.
+   **/
+  static bool IncWithOverflow(gpcodegen::GpCodegenUtils* codegen_utils,
+                              const PGFuncGeneratorInfo& pg_func_info,
+                              llvm::Value** llvm_out_value) {
+    llvm::Value* llvm_err_msg = codegen_utils->GetConstant(
+        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg());
+    return PGArithFuncGenerator<rtype, Arg, Arg>::ArithOpWithOverflow(
+        codegen_utils,
+        &gpcodegen::GpCodegenUtils::CreateIncOverflow<rtype>,
+        llvm_err_msg,
+        pg_func_info,
+        llvm_out_value);
+  }
+
 };
 
 template <typename rtype, typename Arg0, typename Arg1>

--- a/src/backend/codegen/include/codegen/pg_arith_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_arith_func_generator.h
@@ -62,6 +62,7 @@ double> {
 
 using gpcodegen_ArithOp_detail::ArithOpOverFlowErrorMsg;
 
+
 /**
  * @brief Class with Static member function to generate code for +, - and *
  *        operator
@@ -168,11 +169,11 @@ class PGArithFuncGenerator {
 
 
 /**
- * @brief Class with Static member function to generate code for ++
- *        operator
+ * @brief Class with Static member function to generate code for unary
+ *        operator such as ++, -- etc.
  *
  * @tparam rtype  Return type of function
- * @tparam Arg   Argument's type
+ * @tparam Arg    Argument's type
  **/
 template <typename rtype, typename Arg>
 class PGArithUnaryFuncGenerator {
@@ -182,17 +183,12 @@ class PGArithUnaryFuncGenerator {
   using CGArithOpFunc = CGArithOpTemplateFunc<rtype>;
 
  public:
-
-
   /**
    * @brief Increase the value of a variable with check for overflow
    *
-   * @param codegen_utils     Utility to easy code generation.
-   * @param llvm_main_func    Current function for which we are generating code
-   * @param llvm_error_block  Basic Block to jump when error happens
-   * @param llvm_args         Vector that contains the llvm argument for the
-   *                          function
-   * @param llvm_out_value    Store the results of function
+   * @param codegen_utils     Utility for easy code generation.
+   * @param pg_func_info      Details for pgfunc generation
+   * @param llvm_out_value    Store location for the result
    *
    * @return true if generation was successful otherwise return false
    *
@@ -217,30 +213,35 @@ class PGArithUnaryFuncGenerator {
                                    llvm::Value* llvm_error_msg,
                                    const PGFuncGeneratorInfo& pg_func_info,
                                    llvm::Value** llvm_out_value);
-
 };
 
-
-template <typename rtype, typename Arg>
-bool PGArithUnaryFuncGenerator<rtype, Arg>::ArithOpWithOverflow(
+/**
+ * @brief Utility function for generating code for overflow checking. This
+ * includes an overflow block and non-overflow block, check and conditional
+ * branch instructions.
+ *
+ * @param codegen_utils     Utility for easy code generation.
+ * @param pg_func_info      Details for pgfunc generation
+ * @param llvm_arith_output Result of the arithmetic operation
+ * @param llvm_error_msg    Error message to use when overflow occurs
+ * @param llvm_out_value    Store location for the result
+ *
+ * @return true if generation was successful otherwise return false
+ *
+ * @note  Only integral types are currently supported.
+ **/
+template<typename rtype>
+static bool CreateOverflowCheckLogic(
     gpcodegen::GpCodegenUtils* codegen_utils,
-    CGArithOpFunc codegen_mem_funcptr,
-    llvm::Value* llvm_error_msg,
     const PGFuncGeneratorInfo& pg_func_info,
+    llvm::Value* llvm_arith_output,
+    llvm::Value* llvm_error_msg,
     llvm::Value** llvm_out_value) {
-
-  assert(nullptr != llvm_out_value);
-  assert(nullptr != codegen_mem_funcptr);
+  assert(nullptr != codegen_utils);
+  assert(nullptr != llvm_arith_output);
   assert(nullptr != llvm_error_msg);
-  // Assumed caller checked vector size and nullptr for codegen_utils
-  llvm::Value* casted_arg =
-      codegen_utils->CreateCast<rtype, Arg>(pg_func_info.llvm_args[0]);
-
-  llvm::Value* llvm_arith_output = (codegen_utils->*codegen_mem_funcptr)(
-      casted_arg);
 
   llvm::IRBuilder<>* irb = codegen_utils->ir_builder();
-
   // Check if it is a Integer type
   if (std::is_integral<rtype>::value) {
     llvm::BasicBlock* llvm_non_overflow_block = codegen_utils->CreateBasicBlock(
@@ -252,20 +253,47 @@ bool PGArithUnaryFuncGenerator<rtype, Arg>::ArithOpWithOverflow(
     llvm::Value* llvm_overflow_flag =
         irb->CreateExtractValue(llvm_arith_output, 1);
 
-    irb->CreateCondBr(llvm_overflow_flag,
-                      llvm_overflow_block,
+    irb->CreateCondBr(llvm_overflow_flag, llvm_overflow_block,
                       llvm_non_overflow_block);
 
     irb->SetInsertPoint(llvm_overflow_block);
     codegen_utils->CreateElog(
-        ERROR, "%s", llvm_error_msg);
+        ERROR,
+        "%s", llvm_error_msg);
     irb->CreateBr(pg_func_info.llvm_error_block);
 
     irb->SetInsertPoint(llvm_non_overflow_block);
   } else {
     *llvm_out_value = llvm_arith_output;
   }
+
   return true;
+}
+
+template <typename rtype, typename Arg>
+bool PGArithUnaryFuncGenerator<rtype, Arg>::ArithOpWithOverflow(
+    gpcodegen::GpCodegenUtils* codegen_utils,
+    CGArithOpFunc codegen_mem_funcptr,
+    llvm::Value* llvm_error_msg,
+    const PGFuncGeneratorInfo& pg_func_info,
+    llvm::Value** llvm_out_value) {
+  assert(nullptr != codegen_utils);
+  assert(nullptr != llvm_out_value);
+  assert(nullptr != codegen_mem_funcptr);
+  assert(nullptr != llvm_error_msg);
+
+  // Assumed caller checked vector size and nullptr for codegen_utils
+  llvm::Value* casted_arg =
+      codegen_utils->CreateCast<rtype, Arg>(pg_func_info.llvm_args[0]);
+
+  llvm::Value* llvm_arith_output = (codegen_utils->*codegen_mem_funcptr)(
+      casted_arg);
+
+  return CreateOverflowCheckLogic<rtype>(codegen_utils,
+                                         pg_func_info,
+                                         llvm_arith_output,
+                                         llvm_error_msg,
+                                         llvm_out_value);
 }
 
 
@@ -276,46 +304,25 @@ bool PGArithFuncGenerator<rtype, Arg0, Arg1>::ArithOpWithOverflow(
     llvm::Value* llvm_error_msg,
     const PGFuncGeneratorInfo& pg_func_info,
     llvm::Value** llvm_out_value) {
-
+  assert(nullptr != codegen_utils);
   assert(nullptr != llvm_out_value);
   assert(nullptr != codegen_mem_funcptr);
   assert(nullptr != llvm_error_msg);
+
   // Assumed caller checked vector size and nullptr for codegen_utils
   llvm::Value* casted_arg0 =
       codegen_utils->CreateCast<rtype, Arg0>(pg_func_info.llvm_args[0]);
   llvm::Value* casted_arg1 =
       codegen_utils->CreateCast<rtype, Arg1>(pg_func_info.llvm_args[1]);
 
-  llvm::Value* llvm_arith_output = (codegen_utils->*codegen_mem_funcptr)(
-      casted_arg0, casted_arg1);
+  llvm::Value* llvm_arith_output =
+      (codegen_utils->*codegen_mem_funcptr)(casted_arg0, casted_arg1);
 
-  llvm::IRBuilder<>* irb = codegen_utils->ir_builder();
-
-  // Check if it is a Integer type
-  if (std::is_integral<rtype>::value) {
-    llvm::BasicBlock* llvm_non_overflow_block = codegen_utils->CreateBasicBlock(
-        "arith_non_overflow_block", pg_func_info.llvm_main_func);
-    llvm::BasicBlock* llvm_overflow_block = codegen_utils->CreateBasicBlock(
-        "arith_overflow_block", pg_func_info.llvm_main_func);
-
-    *llvm_out_value = irb->CreateExtractValue(llvm_arith_output, 0);
-    llvm::Value* llvm_overflow_flag =
-        irb->CreateExtractValue(llvm_arith_output, 1);
-
-    irb->CreateCondBr(llvm_overflow_flag,
-                      llvm_overflow_block,
-                      llvm_non_overflow_block);
-
-    irb->SetInsertPoint(llvm_overflow_block);
-    codegen_utils->CreateElog(
-        ERROR, "%s", llvm_error_msg);
-    irb->CreateBr(pg_func_info.llvm_error_block);
-
-    irb->SetInsertPoint(llvm_non_overflow_block);
-  } else {
-    *llvm_out_value = llvm_arith_output;
-  }
-  return true;
+  return CreateOverflowCheckLogic<rtype>(codegen_utils,
+                                         pg_func_info,
+                                         llvm_arith_output,
+                                         llvm_error_msg,
+                                         llvm_out_value);
 }
 
 /** @} */

--- a/src/backend/codegen/include/codegen/pg_arith_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_arith_func_generator.h
@@ -131,6 +131,35 @@ class PGArithFuncGenerator {
         pg_func_info,
         llvm_out_value);
   }
+
+  /**
+   * @brief Increase the value of a variable with check for overflow
+   *
+   * @param codegen_utils     Utility to easy code generation.
+   * @param llvm_main_func    Current function for which we are generating code
+   * @param llvm_error_block  Basic Block to jump when error happens
+   * @param llvm_args         Vector that contains the llvm argument for the
+   *                          function
+   * @param llvm_out_value    Store the results of function
+   *
+   * @return true if generation was successful otherwise return false
+   *
+   * @note  If there is overflow, it will do elog::ERROR and then jump to given
+   *        error block.
+   **/
+  static bool IncWithOverflow(gpcodegen::GpCodegenUtils* codegen_utils,
+                              const PGFuncGeneratorInfo& pg_func_info,
+                              llvm::Value** llvm_out_value) {
+    llvm::Value* llvm_err_msg = codegen_utils->GetConstant(
+        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg());
+    return ArithOpWithOverflow(
+        codegen_utils,
+        &gpcodegen::GpCodegenUtils::CreateIncOverflow<rtype>,
+        llvm_err_msg,
+        pg_func_info,
+        llvm_out_value);
+  }
+
   /**
    * @brief Create LLVM Sub instruction with check for overflow
    *

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -309,6 +309,18 @@ class CodegenUtils {
   llvm::Value* CreateAddOverflow(llvm::Value* arg0, llvm::Value* arg1);
 
   /**
+     * @brief Use LLVM intrinsic to increase the value of a variable by one
+     *        with overflow instruction
+     *
+     * @tparam CppType  CppType for add
+     * @param arg   Input variable
+     *
+     * @return LLVM Value as a pair of results and overflow flag.
+     **/
+  template <typename CppType>
+  llvm::Value* CreateIncOverflow(llvm::Value* arg0, llvm::Value* arg1);
+
+  /**
    * @brief Use LLVM intrinsic to create Subtract with overflow
    *        instruction
    *
@@ -1408,6 +1420,13 @@ llvm::Value* CodegenUtils::CreateAddOverflow(llvm::Value* arg0,
   return codegen_utils_detail::ArithOpMaker<CppType>::CreateAddOverflow(this,
                                                                         arg0,
                                                                         arg1);
+}
+
+template <typename CppType>
+llvm::Value* CodegenUtils::CreateIncOverflow(llvm::Value* arg0,
+                                             llvm::Value* arg1) {
+  return codegen_utils_detail::ArithOpMaker<CppType>::
+      CreateAddOverflow(this, arg0, GetConstant(1));
 }
 
 template <typename CppType>

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -1426,7 +1426,7 @@ template <typename CppType>
 llvm::Value* CodegenUtils::CreateIncOverflow(llvm::Value* arg0,
                                              llvm::Value* arg1) {
   return codegen_utils_detail::ArithOpMaker<CppType>::
-      CreateAddOverflow(this, arg0, GetConstant(1));
+      CreateAddOverflow(this, arg0, GetConstant<CppType>(1));
 }
 
 template <typename CppType>

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -313,7 +313,7 @@ class CodegenUtils {
      *        with overflow instruction
      *
      * @tparam CppType  CppType for add
-     * @param arg   Input variable
+     * @param arg       Input variable
      *
      * @return LLVM Value as a pair of results and overflow flag.
      **/

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -1486,6 +1486,7 @@ class CastMaker<
     assert(nullptr != value);
     assert(nullptr != value->getType());
     assert(value->getType()->isIntegerTy());
+    assert(nullptr != llvm_dest_type);
     assert(llvm_dest_type->isIntegerTy());
   }
 };
@@ -1515,6 +1516,7 @@ class CastMaker<
     assert(nullptr != value);
     assert(nullptr != value->getType());
     assert(value->getType()->isIntegerTy());
+    assert(nullptr != llvm_dest_type);
     assert(llvm_dest_type->isIntegerTy());
   }
 };
@@ -1543,6 +1545,7 @@ class CastMaker<
       assert(nullptr != value->getType());
       assert(value->getType()->isFloatTy() ||
              value->getType()->isDoubleTy());
+      assert(nullptr != llvm_dest_type);
       assert(llvm_dest_type->isFloatTy());
     }
 };
@@ -1571,6 +1574,7 @@ class CastMaker<
     assert(nullptr != value->getType());
     assert(value->getType()->isFloatTy() ||
            value->getType()->isDoubleTy());
+    assert(nullptr != llvm_dest_type);
     assert(llvm_dest_type->isDoubleTy());
   }
 };

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -318,7 +318,7 @@ class CodegenUtils {
      * @return LLVM Value as a pair of results and overflow flag.
      **/
   template <typename CppType>
-  llvm::Value* CreateIncOverflow(llvm::Value* arg0, llvm::Value* arg1);
+  llvm::Value* CreateIncOverflow(llvm::Value* arg);
 
   /**
    * @brief Use LLVM intrinsic to create Subtract with overflow
@@ -1423,10 +1423,9 @@ llvm::Value* CodegenUtils::CreateAddOverflow(llvm::Value* arg0,
 }
 
 template <typename CppType>
-llvm::Value* CodegenUtils::CreateIncOverflow(llvm::Value* arg0,
-                                             llvm::Value* arg1) {
+llvm::Value* CodegenUtils::CreateIncOverflow(llvm::Value* arg) {
   return codegen_utils_detail::ArithOpMaker<CppType>::
-      CreateAddOverflow(this, arg0, GetConstant<CppType>(1));
+      CreateAddOverflow(this, arg, GetConstant<CppType>(1));
 }
 
 template <typename CppType>

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -93,6 +93,12 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           "int8pl",
           &PGArithFuncGenerator<int64_t, int64_t, int64_t>::AddWithOverflow));
 
+  supported_function_[2803] = std::unique_ptr<PGFuncGeneratorInterface>(
+      new PGGenericFuncGenerator<int64_t, int64_t, int64_t>(
+          2803,
+          "int8inc",
+          &PGArithFuncGenerator<int64_t, int64_t, int64_t>::IncWithOverflow));
+
   supported_function_[216] = std::unique_ptr<PGFuncGeneratorInterface>(
       new PGGenericFuncGenerator<float8, float8, float8>(
           216,

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -94,16 +94,16 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           &PGArithFuncGenerator<int64_t, int64_t, int64_t>::AddWithOverflow));
 
   supported_function_[1219] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int64_t, int64_t, int64_t>(
+      new PGGenericFuncGenerator<int64_t, int64_t>(
           1219,
           "int8inc",
-          &PGArithFuncGenerator<int64_t, int64_t, int64_t>::IncWithOverflow));
+          &PGArithUnaryFuncGenerator<int64_t, int64_t>::IncWithOverflow));
 
   supported_function_[2803] = std::unique_ptr<PGFuncGeneratorInterface>(
-      new PGGenericFuncGenerator<int64_t, int64_t, int64_t>(
+      new PGGenericFuncGenerator<int64_t, int64_t>(
           2803,
           "int8inc",
-          &PGArithFuncGenerator<int64_t, int64_t, int64_t>::IncWithOverflow));
+          &PGArithUnaryFuncGenerator<int64_t, int64_t>::IncWithOverflow));
 
   supported_function_[216] = std::unique_ptr<PGFuncGeneratorInterface>(
       new PGGenericFuncGenerator<float8, float8, float8>(

--- a/src/backend/codegen/op_expr_tree_generator.cc
+++ b/src/backend/codegen/op_expr_tree_generator.cc
@@ -93,6 +93,12 @@ void OpExprTreeGenerator::InitializeSupportedFunction() {
           "int8pl",
           &PGArithFuncGenerator<int64_t, int64_t, int64_t>::AddWithOverflow));
 
+  supported_function_[1219] = std::unique_ptr<PGFuncGeneratorInterface>(
+      new PGGenericFuncGenerator<int64_t, int64_t, int64_t>(
+          1219,
+          "int8inc",
+          &PGArithFuncGenerator<int64_t, int64_t, int64_t>::IncWithOverflow));
+
   supported_function_[2803] = std::unique_ptr<PGFuncGeneratorInterface>(
       new PGGenericFuncGenerator<int64_t, int64_t, int64_t>(
           2803,

--- a/src/backend/executor/execScan.c
+++ b/src/backend/executor/execScan.c
@@ -298,7 +298,10 @@ InitScanStateRelationDetails(ScanState *scanState, Plan *plan, EState *estate)
 	ExecAssignScanProjectionInfo(scanState);
 
 	ProjectionInfo *projInfo = scanState->ps.ps_ProjInfo;
-	if (NULL != projInfo && projInfo->pi_isVarList){
+	if (NULL != projInfo &&
+	    projInfo->pi_isVarList &&
+	    NULL != projInfo->pi_targetlist)
+	{
 		enroll_ExecVariableList_codegen(ExecVariableList,
 				&projInfo->ExecVariableList_gen_info.ExecVariableList_fn, projInfo, scanState->ss_ScanTupleSlot);
 	}


### PR DESCRIPTION
In this PR we enhance GenerateAdvanceAggregates and supported built-in functions to generate code for COUNT aggregate function.

Test:
```
CREATE TABLE lineitem (
    l_orderkey integer NOT NULL,
    l_partkey integer NOT NULL,
    l_suppkey integer NOT NULL,
    l_linenumber integer NOT NULL,
    l_quantity float8 NOT NULL,
    l_extendedprice float8 NOT NULL,
    l_discount float8 NOT NULL,
    l_tax float8 NOT NULL,

    l_shipdate date NOT NULL,
    l_commitdate date NOT NULL,
    l_receiptdate date NOT NULL,
    l_returnflag char NOT NULL,
    l_linestatus char NOT NULL,

    l_shipinstruct character(25) NOT NULL,
    l_shipmode character(10) NOT NULL,
    l_comment character varying(44) NOT NULL
)
WITH (appendonly=false) DISTRIBUTED BY (l_orderkey);

\copy lineitem ( L_ORDERKEY, L_PARTKEY, L_SUPPKEY,L_LINENUMBER,L_QUANTITY, L_EXTENDEDPRICE,L_DISCOUNT,L_TAX,L_RETURNFLAG,L_LINESTATUS,L_SHIPDATE,L_COMMITDATE,L_RECEIPTDATE,L_SHIPINSTRUCT,L_SHIPMODE,L_COMMENT) from 'src/test/regress/data/lineitem.csv' with delimiter '|';
 
set codegen=on;

SELECT
   sum(l_quantity) as sum_qty,
   sum(l_extendedprice) as sum_base_price,
   sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
   sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
   count(*) as count_order
FROM
   lineitem
WHERE
   l_shipdate <= date '1998-12-01'
GROUP BY
   l_returnflag,
   l_linestatus
ORDER BY
   l_returnflag,
   l_linestatus;
```