### PR TITLE
Resync flat files from primary to mirror on startup only if they are …

### DIFF
--- a/gpMgmt/bin/gpcheckmirrorseg.pl
+++ b/gpMgmt/bin/gpcheckmirrorseg.pl
@@ -498,6 +498,7 @@ sub ignore_list
 		db_dumps
 		gp_temporary_files_filespace
 		gp_transaction_files_filespace
+		slru_checksum_file
 		);
 
 	# add any other expressions (eg user-supplied)

--- a/src/backend/access/transam/slru.c
+++ b/src/backend/access/transam/slru.c
@@ -1473,8 +1473,8 @@ SlruRecoverMirrorDir(char *dirName)
 	retval = SlruVerifyDirectoryChecksum(fullDirName);
 
 	/*
-	 * If any of the checksums mismatched, we will copy all files in the
-	 * directory from the primary to the mirror
+	 * If checksum mismatch, copy all files in the directory from the
+	 * primary to the mirror.
 	 */
 	if (retval != STATUS_OK)
 		retval = SlruCopyDirectory(dirName, fullDirName);

--- a/src/backend/access/transam/slru.c
+++ b/src/backend/access/transam/slru.c
@@ -1508,7 +1508,12 @@ SlruVerifyDirectoryChecksum(char *fullDirName)
 		FileRep_GetFlatFileIdentifier(fullDirName, SLRU_CHECKSUM_FILENAME));
 
 	if (retval != STATUS_OK)
+	{
+		ereport(WARNING,
+				(errmsg("FileRepPrimary_MirrorStartChecksum() returned: %d",
+						retval)));
 		return retval;
+	}
 
 	retval = SlruCreateChecksumFile(fullDirName);
 
@@ -1521,8 +1526,15 @@ SlruVerifyDirectoryChecksum(char *fullDirName)
 	if (retval != STATUS_OK)
 		return retval;
 
-	return FileRepPrimary_MirrorVerifyDirectoryChecksum(
+	retval = FileRepPrimary_MirrorVerifyDirectoryChecksum(
 				FileRep_GetFlatFileIdentifier(fullDirName, SLRU_CHECKSUM_FILENAME), md5);
+
+	if (retval != STATUS_OK)
+		ereport(WARNING,
+				(errmsg("FileRepPrimary_MirrorVerifyDirectoryChecksum() returned: %d",
+						retval)));
+
+	return retval;
 }
 
 /*

--- a/src/backend/access/transam/slru.c
+++ b/src/backend/access/transam/slru.c
@@ -57,8 +57,10 @@
 #include "storage/fd.h"
 #include "storage/shmem.h"
 #include "miscadmin.h"
+#include "cdb/cdbfilerepprimary.h"
 #include "cdb/cdbmirroredflatfile.h"
 #include "postmaster/primary_mirror_mode.h"
+#include "libpq/md5.h"
 
 /*
  * Define segment size.  A page is the same BLCKSZ as is used everywhere
@@ -162,6 +164,11 @@ static bool SlruPhysicalWritePage(SlruCtl ctl, int pageno, int slotno,
 					  SlruFlush fdata);
 static void SlruReportIOError(SlruCtl ctl, int pageno, TransactionId xid);
 static int	SlruSelectLRUPage(SlruCtl ctl, int pageno);
+static int SlruRecoverMirrorDir(char *dirName);
+static int SlruVerifyDirectoryChecksum(char *fullDirName);
+static bool isSlruFileName(const char *fileName);
+static int SlruComputeChecksum(char *filePath, char *md5);
+static int SlruCopyDirectory(char *dirName, char *fullDirName);
 
 
 /*
@@ -1290,8 +1297,7 @@ SlruScanDirectory(SlruCtl ctl, int cutoffPage, bool doDeletions)
 	cldir = AllocateDir(dir);
 	while ((clde = ReadDir(cldir, dir)) != NULL)
 	{
-		if (strlen(clde->d_name) == 4 &&
-			strspn(clde->d_name, "0123456789ABCDEF") == 4)
+		if (isSlruFileName(clde->d_name))
 		{
 			segno = (int) strtol(clde->d_name, NULL, 16);
 			segpage = segno * SLRU_PAGES_PER_SEGMENT;
@@ -1399,57 +1405,10 @@ SimpleLruPageExists(SlruCtl ctl, int pageno)
 	return false;	// Should not reach here.
 }
 
-static int
-SlruRecoverMirrorDir(char *slru_dir)
-{
-	DIR				*cldir;
-	struct dirent	*clde;
-	int				retval = 0;
-	
-	char		*dir = NULL;
-	char		*mirrorDir = NULL;
-
-	int 		counter = 0;
-
-	if (isTxnDir(slru_dir))
-        {
-                dir = makeRelativeToTxnFilespace(slru_dir);
-                mirrorDir = makeRelativeToPeerTxnFilespace(slru_dir);
-        }
-        else
-        {
-                dir = (char*)palloc(MAXPGPATH);
-                strncpy(dir, slru_dir, MAXPGPATH);
-                mirrorDir = (char*)palloc(MAXPGPATH);
-                strncpy(mirrorDir, slru_dir, MAXPGPATH);
-        }
-	
-	cldir = AllocateDir(dir);
-	while ((clde = ReadDir(cldir, dir)) != NULL) {
-		if (strlen(clde->d_name) == 4 &&
-			strspn(clde->d_name, "0123456789ABCDEF") == 4) {
-			
-			retval = MirrorFlatFile(slru_dir, clde->d_name);
-			
-			if (retval != 0)
-				break;
-			
-		}
-		counter++;
-
-		if (counter % log_count_recovered_files_batch == 0)
-		{
-			elog(LOG, "completed recovering %d files", counter);
-		}
-	}
-	elog(LOG, "completed recovering %d files", counter);
-	FreeDir(cldir);
-
-	pfree(dir);
-	pfree(mirrorDir);	
-	return retval;
-}
-
+/*
+ * This externally visible function will copy several directories from the
+ * primary segment to the mirror segment, if needed.
+ */
 int
 SlruRecoverMirror(void)
 {
@@ -1459,34 +1418,301 @@ SlruRecoverMirror(void)
 	retval = SlruRecoverMirrorDir(CLOG_DIR);
 
 	if (retval != 0)
-		return retval;	
-	
+		return retval;
+
 	elog(LOG, "recovering %s", DISTRIBUTEDLOG_DIR);
 	retval = SlruRecoverMirrorDir(DISTRIBUTEDLOG_DIR);
 
 	if (retval != 0)
-		return retval;	
-	
+		return retval;
+
 	elog(LOG, "recovering %s", DISTRIBUTEDXIDMAP_DIR);
 	retval = SlruRecoverMirrorDir(DISTRIBUTEDXIDMAP_DIR);
 
 	if (retval != 0)
-		return retval;	
-	
+		return retval;
+
 	elog(LOG, "recovering %s", MULTIXACT_MEMBERS_DIR);
 	retval = SlruRecoverMirrorDir(MULTIXACT_MEMBERS_DIR);
 
 	if (retval != 0)
-		return retval;	
-	
+		return retval;
+
 	elog(LOG, "recovering %s", MULTIXACT_OFFSETS_DIR);
 	retval = SlruRecoverMirrorDir(MULTIXACT_OFFSETS_DIR);
 
 	if (retval != 0)
-		return retval;	
-	
+		return retval;
+
 	elog(LOG, "recovering %s", SUBTRANS_DIR);
 	retval = SlruRecoverMirrorDir(SUBTRANS_DIR);
 
+	return retval;
+}
+
+/*
+ * This function will check if the checksum of all the files in 'dirName' match
+ * with those on the mirror and transfer the files if the checksums don't match.
+ */
+static int
+SlruRecoverMirrorDir(char *dirName)
+{
+	char *fullDirName = NULL;
+	int	 retval = STATUS_OK;
+
+	if (isTxnDir(dirName))
+	{
+		fullDirName = makeRelativeToTxnFilespace(dirName);
+	}
+	else
+	{
+		fullDirName = (char*)palloc(MAXPGPATH);
+		strncpy(fullDirName, dirName, MAXPGPATH);
+	}
+
+	retval = SlruVerifyDirectoryChecksum(fullDirName);
+
+	/*
+	 * If any of the checksums mismatched, we will copy all files in the
+	 * directory from the primary to the mirror
+	 */
+	if (retval != STATUS_OK)
+		retval = SlruCopyDirectory(dirName, fullDirName);
+
+	pfree(fullDirName);
+
+	return retval;
+}
+
+/*
+ * Verify checksum of a primary directory wrt. to the corresponding mirror
+ * directory.
+ */
+static int
+SlruVerifyDirectoryChecksum(char *fullDirName)
+{
+	char checksumFilePath[MAXPGPATH];
+	char md5[SLRU_MD5_BUFLEN] = {0};
+
+	snprintf(checksumFilePath, sizeof(checksumFilePath), "%s/%s", fullDirName,
+			 SLRU_CHECKSUM_FILENAME);
+
+	/*
+	 * We generate the checksum file and then compute its checksum in an
+	 * SlruComputeChecksum() call.  We keep the checksum file so that if needed
+	 * support can diff the checksum files at the primary and the mirror to see
+	 * which file(s) were not in sync.
+	 */
+	return 	FileRepPrimary_MirrorStartChecksum(
+				FileRep_GetFlatFileIdentifier(fullDirName, SLRU_CHECKSUM_FILENAME)) ||
+			SlruCreateChecksumFile(fullDirName) ||
+			SlruComputeChecksum(checksumFilePath, md5) ||
+			FileRepPrimary_MirrorVerifyDirectoryChecksum(
+				FileRep_GetFlatFileIdentifier(fullDirName, SLRU_CHECKSUM_FILENAME), md5);
+}
+
+/*
+ * Create a checksum file called 'slru_checksum_file' in the directory
+ * specified by 'fullDirName'.
+ */
+int
+SlruCreateChecksumFile(const char *fullDirName)
+{
+	DIR			  *slruDir = NULL;
+	struct dirent *dirEntry;
+	char 		  *fileName;
+	char		   filePath[MAXPGPATH];
+	char		   checksumFilePath[MAXPGPATH];
+	File		   checksumFileHandle = 0;
+	int			   retval = 0;
+	char		   buf[SLRU_CKSUM_LINE_LEN];
+
+	snprintf(checksumFilePath, sizeof(checksumFilePath), "%s/%s", fullDirName,
+			 SLRU_CHECKSUM_FILENAME);
+
+	checksumFileHandle = PathNameOpenFile(checksumFilePath, O_CREAT | O_TRUNC | O_WRONLY,
+										  S_IRUSR | S_IWUSR);
+	if (checksumFileHandle < 0)
+	{
+		ereport(WARNING,
+				(errcode_for_file_access(),
+				 errmsg("could not open file \"%s\": %m", checksumFilePath)));
+		retval = STATUS_ERROR;
+		goto cleanup;
+	}
+
+	slruDir = AllocateDir(fullDirName);
+	if (!slruDir)
+	{
+		retval = STATUS_ERROR;
+		goto cleanup;
+	}
+
+	while ((dirEntry = ReadDir(slruDir, fullDirName)) != NULL)
+	{
+		char  md5[SLRU_MD5_BUFLEN] = {0};
+
+		fileName = dirEntry->d_name;
+
+		if (isSlruFileName(fileName))
+		{
+			snprintf(filePath, sizeof(filePath), "%s/%s", fullDirName, fileName);
+
+			if (SlruComputeChecksum(filePath, md5) < 0)
+			{
+				ereport(LOG,
+						(errmsg("could not compute checksum for file %s: %m",
+								filePath)));
+				retval = STATUS_ERROR;
+				goto cleanup;
+			}
+
+			snprintf(buf, sizeof(buf), "%s: %s\n", fileName, md5);
+
+			if (FileWrite(checksumFileHandle, buf, strlen(buf)) < 0)
+			{
+				ereport(LOG,
+						(errmsg("could not write to checksum file %s: %m",
+								checksumFilePath)));
+				retval = STATUS_ERROR;
+				goto cleanup;
+			}
+		}
+	}
+
+cleanup:
+	if (slruDir)
+		FreeDir(slruDir);
+
+	if (checksumFileHandle > 0)
+		FileClose(checksumFileHandle);
+
+	return retval;
+}
+
+/*
+ * Given a filename, this function will return true if and only if it is a valid
+ * SLRU filename. Filenames with 4 hex characters are valid.
+ */
+static bool
+isSlruFileName(const char *fileName)
+{
+	return (strlen(fileName) == SLRU_FILENAME_LEN &&
+			strspn(fileName, "0123456789ABCDEF") == SLRU_FILENAME_LEN);
+}
+
+/*
+ * Compute the md5 hash of the file specified by 'filePath'.
+ */
+static int
+SlruComputeChecksum(char *filePath, char *md5)
+{
+	File fileHandle = 0;
+	int  retval = 0;
+	char buf[BLCKSZ * SLRU_PAGES_PER_SEGMENT];
+	int  bytesRead;
+
+	fileHandle = PathNameOpenFile(filePath, O_RDONLY | PG_BINARY, S_IRUSR);
+	if (fileHandle < 0)
+	{
+		ereport(LOG,
+				(errcode_for_file_access(),
+				 errmsg("could not open file %s: %m", filePath)));
+		retval = STATUS_ERROR;
+	}
+	else
+	{
+		bytesRead = FileRead(fileHandle, buf, sizeof(buf));
+		if (bytesRead >= 0)
+			pg_md5_hash(buf, bytesRead, md5);
+		else
+		{
+			ereport(LOG,
+					(errcode_for_file_access(),
+					 errmsg("could not read file %s: %m", filePath)));
+			retval = STATUS_ERROR;
+		}
+	}
+
+	if (fileHandle > 0)
+		FileClose(fileHandle);
+
+	return retval;
+}
+
+/*
+ * Copy all the files from the fullDirName to the corresponding directory at the
+ * mirror.
+ */
+static int
+SlruCopyDirectory(char *dirName, char *fullDirName)
+{
+	DIR			  *slruDir = NULL;
+	struct dirent *dirEntry;
+	int			   retval = STATUS_OK;
+	int			   counter = 0;
+
+	slruDir = AllocateDir(fullDirName);
+	if (!slruDir)
+		return STATUS_ERROR;
+
+	while ((dirEntry = ReadDir(slruDir, fullDirName)) != NULL)
+	{
+		if (isSlruFileName(dirEntry->d_name))
+		{
+			retval = MirrorFlatFile(dirName, dirEntry->d_name);
+
+			if (retval != 0)
+				break;
+
+			counter++;
+
+			if (counter % log_count_recovered_files_batch == 0)
+			{
+				elog(LOG, "completed recovering %d files for directory %s",
+					 counter, dirName);
+			}
+		}
+	}
+
+	elog(LOG, "completed recovering %d files for directory %s", counter,
+		 dirName);
+
+	FreeDir(slruDir);
+
+	return retval;
+}
+
+/*
+ * This function is called from the mirror to compute the checksum of the
+ * mirror's checksum file and compare the mirror's checksum with that of the
+ * primary (variable 'md5').
+ */
+int
+SlruMirrorVerifyDirectoryChecksum(char *dirName, char *checksumFile, char *md5)
+{
+	int  retval = STATUS_OK;
+	char mirrorMd5[SLRU_MD5_BUFLEN] = {0};
+	char filePath[MAXPGPATH];
+
+	snprintf(filePath, sizeof(filePath), "%s/%s", dirName, checksumFile);
+
+	if (SlruComputeChecksum(filePath, mirrorMd5) < 0)
+	{
+		ereport(LOG,
+				(errmsg("could not compute checksum for file %s/%s: %m",
+						dirName, filePath)));
+		retval = STATUS_ERROR;
+	}
+	else
+	{
+		if (memcmp(md5, mirrorMd5, sizeof(mirrorMd5)))
+		{
+			ereport(LOG,
+					(errmsg("checksum mismatch for file: %s/%s",
+							dirName, checksumFile)));
+			retval = STATUS_ERROR;
+		}
+	}
 	return retval;
 }

--- a/src/backend/cdb/cdbfilerep.c
+++ b/src/backend/cdb/cdbfilerep.c
@@ -293,8 +293,9 @@ FileRepOperationToString[] = {
 	_("validation filespace dir or existence"),
 	_("drop files from dir"),
 	_("drop temporary files"),
+	_("start checksum computation of a SLRU directory"),
+	_("verify checksum of a SLRU directory"),
 	_("not specified"),
-
 };
 
 const char*
@@ -338,6 +339,7 @@ FileRepStatusToString[] = {
 	_("read-only file system"),
 	_("mirror loss occurred"),
 	_("mirror error"),
+	_("slru checksum failed")
 };
 
 const char *
@@ -2934,6 +2936,7 @@ FileRep_IsOperationSynchronous(FileRepOperation_e fileRepOperation)
 		case FileRepOperationHeartBeat:
 		case FileRepOperationCreateAndOpen:
 		case FileRepOperationValidation:
+		case FileRepOperationVerifySlruDirectoryChecksum:
 			return TRUE;
 
 		case FileRepOperationOpen:
@@ -2942,7 +2945,7 @@ FileRep_IsOperationSynchronous(FileRepOperation_e fileRepOperation)
 		case FileRepOperationWrite:
 		case FileRepOperationDropFilesFromDir:
 		case FileRepOperationDropTemporaryFiles:
-
+		case FileRepOperationStartSlruChecksum:
 			return FALSE;
 
 		case FileRepOperationNotSpecified:

--- a/src/backend/cdb/cdbfilerepmirror.c
+++ b/src/backend/cdb/cdbfilerepmirror.c
@@ -2045,12 +2045,9 @@ FileRepMirror_RunConsumer(void)
 			case FileRepOperationStartSlruChecksum:
 				Assert(fileRepMessageHeader->fileRepRelationType == FileRepRelationTypeFlatFile);
 
-				if (Debug_filerep_print)
-				{
-					ereport(LOG,
+				ereport(LOG,
 						(errmsg("mirror beginning SLRU checksum file creation, dir: %s",
 								fileRepMessageHeader->fileRepIdentifier.fileRepFlatFileIdentifier.directorySimpleName)));
-				}
 
 				if (SlruCreateChecksumFile(
 						fileRepMessageHeader->fileRepIdentifier.fileRepFlatFileIdentifier.directorySimpleName) < 0)
@@ -2064,13 +2061,10 @@ FileRepMirror_RunConsumer(void)
 			case FileRepOperationVerifySlruDirectoryChecksum:
 				Assert(fileRepMessageHeader->fileRepRelationType == FileRepRelationTypeFlatFile);
 
-				if (Debug_filerep_print)
-				{
-					ereport(LOG,
+				ereport(LOG,
 						(errmsg("mirror beginning checksum comparison, dir: %s, checksum file: %s",
 								fileRepMessageHeader->fileRepIdentifier.fileRepFlatFileIdentifier.directorySimpleName,
 								fileRepMessageHeader->fileRepIdentifier.fileRepFlatFileIdentifier.fileSimpleName)));
-				}
 
 				if (SlruMirrorVerifyDirectoryChecksum(
 						fileRepMessageHeader->fileRepIdentifier.fileRepFlatFileIdentifier.directorySimpleName,

--- a/src/backend/cdb/cdbfilerepmirror.c
+++ b/src/backend/cdb/cdbfilerepmirror.c
@@ -2067,7 +2067,7 @@ FileRepMirror_RunConsumer(void)
 				if (Debug_filerep_print)
 				{
 					ereport(LOG,
-						(errmsg("mirror beginning checksum comparison, dir: %s, cksumfile: %s",
+						(errmsg("mirror beginning checksum comparison, dir: %s, checksum file: %s",
 								fileRepMessageHeader->fileRepIdentifier.fileRepFlatFileIdentifier.directorySimpleName,
 								fileRepMessageHeader->fileRepIdentifier.fileRepFlatFileIdentifier.fileSimpleName)));
 				}

--- a/src/backend/cdb/cdbfilerepmirrorack.c
+++ b/src/backend/cdb/cdbfilerepmirrorack.c
@@ -132,6 +132,8 @@ FileRepAckMirror_ConstructAndInsertMessage(
 		case FileRepOperationReconcileXLogEof:
 		case FileRepOperationValidation:
 		case FileRepOperationCreate:
+		case FileRepOperationStartSlruChecksum:
+		case FileRepOperationVerifySlruDirectoryChecksum:
 			fileRepMessageHeader->fileRepOperationDescription = fileRepOperationDescription;
 			break;
 			

--- a/src/backend/cdb/cdbfilerepprimaryack.c
+++ b/src/backend/cdb/cdbfilerepprimaryack.c
@@ -1105,6 +1105,34 @@ FileRepAckPrimary_RunConsumer(void)
 								FileRepStatusToString[mirrorStatus])));	
 
 				break;
+
+			case FileRepOperationStartSlruChecksum:
+				mirrorStatus =
+					fileRepMessageHeader->fileRepOperationDescription.startChecksum.mirrorStatus;
+
+				if (Debug_filerep_print)
+				{
+					ereport(LOG,
+						(errmsg("ack start SLRU checksum: status = '%s', directory = '%s' ",
+								FileRepStatusToString[mirrorStatus],
+								fileRepMessageHeader->fileRepIdentifier.fileRepFlatFileIdentifier.directorySimpleName)));
+				}
+
+				break;
+
+			case FileRepOperationVerifySlruDirectoryChecksum:
+				mirrorStatus =
+					fileRepMessageHeader->fileRepOperationDescription.verifyDirectoryChecksum.mirrorStatus;
+
+				if (Debug_filerep_print)
+				{
+					ereport(LOG,
+						(errmsg("ack verify SLRU directory checksum: status = '%s', directory = '%s' ",
+								FileRepStatusToString[mirrorStatus],
+								fileRepMessageHeader->fileRepIdentifier.fileRepFlatFileIdentifier.directorySimpleName)));
+				}
+
+				break;
 				
 			default:
 				break;

--- a/src/include/access/slru.h
+++ b/src/include/access/slru.h
@@ -23,6 +23,15 @@
 #define MULTIXACT_OFFSETS_DIR	"pg_multixact/offsets"
 #define SUBTRANS_DIR			"pg_subtrans" 
 
+#define SLRU_FILENAME_LEN		4     /* SLRU filenames are 4 characters each */
+#define SLRU_CHECKSUM_FILENAME 	"slru_checksum_file"
+#define SLRU_MD5_BUFLEN			33     /* MD5 is 32 bytes + 1 null-terminator */
+
+                           /* room for filename + ":" + " " + md5 hash + "\n" */
+#define SLRU_CKSUM_LINE_LEN		(SLRU_FILENAME_LEN + 3 + SLRU_MD5_BUFLEN)
+
+#define SLRU_CKSUM_LINE_DELIM	"\n"
+
 /*
  * Page status codes.  Note that these do not include the "dirty" bit.
  * page_dirty can be TRUE only in the VALID or WRITE_IN_PROGRESS states;
@@ -139,5 +148,7 @@ extern void SimpleLruTruncateWithLock(SlruCtl ctl, int cutoffPage);
 extern bool SlruScanDirectory(SlruCtl ctl, int cutoffPage, bool doDeletions);
 extern bool SimpleLruPageExists(SlruCtl ctl, int pageno);
 extern int SlruRecoverMirror(void);
+extern int SlruCreateChecksumFile(const char *fullDirName);
+extern int SlruMirrorVerifyDirectoryChecksum(char *dirName, char *cksumFile, char *md5);
 
 #endif   /* SLRU_H */

--- a/src/include/access/slru.h
+++ b/src/include/access/slru.h
@@ -149,6 +149,7 @@ extern bool SlruScanDirectory(SlruCtl ctl, int cutoffPage, bool doDeletions);
 extern bool SimpleLruPageExists(SlruCtl ctl, int pageno);
 extern int SlruRecoverMirror(void);
 extern int SlruCreateChecksumFile(const char *fullDirName);
-extern int SlruMirrorVerifyDirectoryChecksum(char *dirName, char *cksumFile, char *md5);
+extern int SlruMirrorVerifyDirectoryChecksum(char *dirName, char *cksumFile,
+											 char *primaryMd5);
 
 #endif   /* SLRU_H */

--- a/src/include/cdb/cdbfilerepprimary.h
+++ b/src/include/cdb/cdbfilerepprimary.h
@@ -274,6 +274,13 @@ extern int FileRepPrimary_MirrorVerify(
 									   uint32							*responseDataLength, 
 									   FileRepOperationDescription_u	*responseDesc);
 
+
+extern int FileRepPrimary_MirrorStartChecksum(FileRepIdentifier_u fileRepIdentifier);
+
+extern int FileRepPrimary_MirrorVerifyDirectoryChecksum(
+	FileRepIdentifier_u fileRepIdentifier,
+	char *md);
+
 // -----------------------------------------------------------------------------
 // SENDER THREAD
 // -----------------------------------------------------------------------------

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/__init__.py
@@ -75,15 +75,11 @@ class FilerepTestCase(MPPTestCase):
         dbid = self.config.get_dbid(content=content, seg_role=role)
         host, datadir = self.config.get_host_and_datadir_of_segment(dbid=dbid)
         file_path = os.path.join(datadir, filename)
-        cmd = Command('check timestamp', "stat -s %s" %
+        cmd = Command('check timestamp', """ python -c "import os; print os.stat('%s').st_mtime" """ %
                       file_path, ctxt=REMOTE, remoteHost=host)
         cmd.run(validateAfter=True)
         res = cmd.get_results().stdout.strip()
-        m = re.search('st_mtime=(\d+)', res)
-        timestamp = None
-        if m:
-            timestamp = m.group(1)
-        return timestamp
+        return res
 
     def verify_file_exists(self, content, role, filename):
         dbid = self.config.get_dbid(content=content, seg_role=role)

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/__init__.py
@@ -85,7 +85,7 @@ class FilerepTestCase(MPPTestCase):
         dbid = self.config.get_dbid(content=content, seg_role=role)
         host, datadir = self.config.get_host_and_datadir_of_segment(dbid=dbid)
         file_path = os.path.join(datadir, filename)
-        cmd = Command('check if file exists', 'ls %s' % file_path, ctxt=REMOTE, remoteHost=host)
+        cmd = Command('check if file exists', 'test -f %s' % file_path, ctxt=REMOTE, remoteHost=host)
         cmd.run(validateAfter=True)
 
     def handle_ext_cases(self,file):

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/__init__.py
@@ -15,13 +15,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import datetime
 import fileinput
 import re
+import time
 import unittest2 as unittest
 import socket
 import os, string, sys
 
 import tinctest
+from gppylib.commands.base import Command, REMOTE
 from tinctest.lib import local_path, Gpdiff, run_shell_command
 from mpp.models import MPPTestCase
 from mpp.lib.PSQL import PSQL
@@ -50,6 +53,41 @@ class FilerepTestCase(MPPTestCase):
         self.gpstart = GpStart()
         self.gpstop = GpStop()
         super(FilerepTestCase,self).__init__(methodName)
+
+    def sleep(self, seconds=60):
+        time.sleep(seconds)
+
+    def create_file_in_mirr_datadir(self, content, filename):
+        dbid = self.config.get_dbid(content=content, seg_role='m')
+        host, datadir = self.config.get_host_and_datadir_of_segment(dbid=dbid)
+        file_path = os.path.join(datadir, filename)
+        cmd = Command('create a file', 'touch %s' % file_path, ctxt=REMOTE, remoteHost=host)
+        cmd.run(validateAfter=True)
+
+    def remove_file_in_mirr_datadir(self, content, filename):
+        dbid = self.config.get_dbid(content=content, seg_role='m')
+        host, datadir = self.config.get_host_and_datadir_of_segment(dbid=dbid)
+        file_path = os.path.join(datadir, filename)
+        cmd = Command('remove a file', 'rm %s' % file_path, ctxt=REMOTE, remoteHost=host)
+        cmd.run(validateAfter=True)
+
+    def get_timestamp_of_file_in_mirr_datadir(self, content, filename):
+        dbid = self.config.get_dbid(content=content, seg_role='m')
+        host, datadir = self.config.get_host_and_datadir_of_segment(dbid=dbid)
+        file_path = os.path.join(datadir, filename)
+        cmd = Command('check timestamp', "ls -l %s" %
+                      file_path, ctxt=REMOTE, remoteHost=host)
+        cmd.run(validateAfter=True)
+        res = cmd.get_results().stdout.strip()
+        return ''.join(res.split()[5:8])
+
+    def verify_timestamp_newer(self, content, filename1, filename2):
+        ts1 = datetime.datetime.strptime(
+              self.get_timestamp_of_file_in_mirr_datadir(content, filename1), '%b%d%H:%M')
+        ts2 = datetime.datetime.strptime(
+              self.get_timestamp_of_file_in_mirr_datadir(content, filename2), '%b%d%H:%M')
+        if ts1 <= ts2:
+            raise Exception('Timestamp of %s not newer than %s' % (filename1, filename2))
 
     def handle_ext_cases(self,file):
         """

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/test_filerep_e2e.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/test_filerep_e2e.py
@@ -88,7 +88,31 @@ class FilerepE2EScenarioTestCase(ScenarioTestCase, MPPTestCase):
 
     def test_full_primary(self):
         self.do_test('full', 'primary')
-    
+
+    def test_flat_file_resync(self):
+
+        # This should cause the md5 check to fail and trigger a resync of the flat files
+        test_case1 = []
+        test_case1.append(("mpp.gpdb.tests.storage.filerep_end_to_end.FilerepTestCase.create_file_in_mirr_datadir", [0, 'pg_distributedlog/FFFF']))
+        self.test_case_scenario.append(test_case1)
+
+        test_case1 = []
+        test_case1.append("mpp.gpdb.tests.storage.filerep_end_to_end.FilerepTestCase.sleep")
+        self.test_case_scenario.append(test_case1)
+
+        test_case1 = []
+        test_case1.append("mpp.gpdb.tests.storage.filerep_end_to_end.FilerepTestCase.stop_start_validate")
+        self.test_case_scenario.append(test_case1)
+
+        test_case1 = []
+        test_case1.append(("mpp.gpdb.tests.storage.filerep_end_to_end.FilerepTestCase.verify_timestamp_newer", [0, 'pg_distributedlog/0000', 'pg_distributedlog/FFFF']))
+        self.test_case_scenario.append(test_case1)
+
+        test_case1 = []
+        test_case1.append(("mpp.gpdb.tests.storage.filerep_end_to_end.FilerepTestCase.remove_file_in_mirr_datadir", [0, 'pg_distributedlog/FFFF']))
+        self.test_case_scenario.append(test_case1)
+
+
     def do_test(self,rec_mode,fail_type):
         '''
         @rec_mode: recovery mode, can be full or incremental

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/test_filerep_e2e.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/test_filerep_e2e.py
@@ -113,9 +113,9 @@ class FilerepE2EScenarioTestCase(ScenarioTestCase, MPPTestCase):
             timestamp_before_restart = self.filerep.get_timestamp_of_file_in_datadir(0, 'm', filename)
             self.filerep.stop_start_validate()
             timestamp_after_restart = self.filerep.get_timestamp_of_file_in_datadir(0, 'm', filename)
-            if timestamp_before_restart != timestamp_after_restart:
-                raise Exception('File %s transferred after restart. timestamp before restart (%s), timestamp after restart (%s)' %
-                                filename, timestamp_before_restart, timestamp_after_restart)
+            self.assertEqual(timestamp_before_restart, timestamp_after_restart,
+                             'File %s transferred after restart. timestamp before restart (%s), timestamp after restart (%s)' %
+                              (filename, timestamp_before_restart, timestamp_after_restart))
         finally:
             self.filerep.remove_file_in_datadir(0, 'p', filename)
             self.filerep.remove_file_in_datadir(0, 'm', filename)


### PR DESCRIPTION
…out of

sync.

Currently when the cluster starts up, all flat files from the following
directories are unconditionally copied from the primaries to the mirrors.

pg_clog
pg_distributedlog
pg_distributedxidmap
pg_multixact/members
pg_multixact/offsets
pg_subtrans

This can take hours on a large cluster (100+ nodes).  If the files are already
in sync, there is no need to transfer them.

In this commit, we compute a md5 checksum for each of the files in the above
directories and store them in a file called 'slru_checksum_file' in each
directory.  The primary then computes the checksum of the slru_checksum_file and
sends it to the mirror.

The mirror also computes the slru_checksum_file for each of the directories in
parallel, and when it receives the checksum of the slru_checksum_file from the
primary it computes the checksum of its local slru_checksum_file and compares
it.

If the two checksums match, then no files are transferred from the primary to
the mirror for that directory.  In case of a mismatch all the files in the
directory are transferred as before.  The mismatch is logged.

Authors: Shoaib Lari, Amil Khanzada, Abhijit Subramanya