### PR TITLE
[#130415107] Remove osx from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@
 
 os:
   - linux
-  - osx
 
 language: c
 sudo: false


### PR DESCRIPTION
The current .travis.yml is no longer special condition the osx, but we still build on osx.
Just remove this osx, since we don't depends on travis to verify the build.

This will make the Travis CI green on GPDB.