### PR TITLE
Remove and fix old cdb-pg references

### DIFF
--- a/src/backend/catalog/cdb_util.sql
+++ b/src/backend/catalog/cdb_util.sql
@@ -1,15 +1,8 @@
 -- --------------------------------------------------------------------
 --
--- cdb_schema.sql
+-- cdb_util.sql
 --
--- Define mpp administrative schema and several SQL functions to aid 
--- in maintaining the mpp administrative schema.  
---
--- This is version 2 of the schema.
---
--- TODO Error checking is rudimentary and needs improvment.
---
--- $Id: //cdb2/main/cdb-pg/src/backend/catalog/cdb_schema.in#31 $
+-- src/backend/catalog/cdb_util.sql
 --
 -- --------------------------------------------------------------------
 

--- a/src/backend/cdb/cdbtmutils.c
+++ b/src/backend/cdb/cdbtmutils.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * cdtm.c
+ * cdbtmutils.c
  *	  Provides routines for help performing distributed transaction management
  *
  *	  Unlike cdbtm.c, this file deals mainly with packing and unpacking structures,
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2005-2009, Greenplum inc
  *
- * $Id: //cdb2/main/cdb-pg/src/backend/cdb/cdbtmutils.c#180 $
+ * src/backend/cdb/cdbtmutils.c
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/postmaster/perfmon.c
+++ b/src/backend/postmaster/perfmon.c
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2006-2009, Greenplum inc
  *
- * $Id: //cdb2/private/cpedrotti/main/cdb-pg/src/backend/postmaster/perfmon.c#1 $
+ * src/backend/postmaster/perfmon.c
  *
  *-------------------------------------------------------------------------
  */

--- a/src/backend/utils/adt/interpolate.c
+++ b/src/backend/utils/adt/interpolate.c
@@ -257,8 +257,8 @@ linterp_abscissa(PG_FUNCTION_ARGS, bool *p_eq_bounds, bool *p_eq_abscissas)
 		PG_RETURN_T(result);
 	}
  *
- * The Python script cdb-pg/src/include/catalog/li_extras.py generates
- * declarations appropriate for cdb-pg/src/include/catalog/pg_proc.sql 
+ * The Python script src/include/catalog/li_extras.py generates
+ * declarations appropriate for src/include/catalog/pg_proc.sql
  * and the upgrade script upg2_catupgrade_XXX.sql as well as human-
  * readable and terse regression tests for make installcheck.
  */

--- a/src/bin/pg_dump/cdb/Makefile
+++ b/src/bin/pg_dump/cdb/Makefile
@@ -5,7 +5,7 @@
 # Portions Copyright (c) 1996-2002, PostgreSQL Global Development Group
 # Portions Copyright (c) 1994, Regents of the University of California
 #
-# $Header: /var/cvsroot/cdb/cdb-pg/src/bin/pg_dump/cdb/Makefile,v 1.2 2004/08/06 23:25:50 donniep Exp $
+# src/bin/pg_dump/cdb/Makefile
 #
 #-------------------------------------------------------------------------
 

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
  *
  * url.h
- * routines for external table access to urls.
- * to the qExec processes.
+ *    routines for external table access to urls.
+ *    to the qExec processes.
  *
  * Copyright (c) 2005-2008, Greenplum inc
  *
- * $Id: //cdb2/main/cdb-pg/src/include/cdb/cdbdisp.h#78 $
+ * src/include/access/url.h
  *
  *-------------------------------------------------------------------------
  */

--- a/src/include/catalog/README.add_catalog_function
+++ b/src/include/catalog/README.add_catalog_function
@@ -7,16 +7,16 @@ that will expose the backend function, fn_be() as a built_in function,
 the following steps are needed.
 
 1. Get an unused OID by running the script unused_oids located in
-   cdb-pg/src/include/catalog/unused_oids. Claim an unused OID. For eg, for our
+   src/include/catalog/unused_oids. Claim an unused OID. For eg, for our
    example we are claiming 5075.
 
-2. Add the new function definition in cdb-pg/src/include/catalog/pg_proc.sql.
+2. Add the new function definition in src/include/catalog/pg_proc.sql.
    An example function definition: 
    	CREATE FUNCTION fn_sql(int4, int4) RETURNS bool LANGUAGE 
   		internal VOLATILE NO SQL AS 'fn_be' 
 		WITH (OID=5075, DESCRIPTION="Description of the function");
 
-3. Run the following command in cdb-pg/src/include/catalog:
+3. Run the following command in src/include/catalog:
 
    $ perl catullus.pl -procdef pg_proc.sql -prochdr pg_proc_gp.h
 
@@ -24,10 +24,10 @@ the following steps are needed.
   DATA statement for the fn_sql function definition.
 
   For more information on catullus.pl, please refer to 
-  cdb-pg/src/include/catalog/README.modifying_catalogs.
+  src/include/catalog/README.modifying_catalogs.
 
 4. Since the catalogs are being modified, the catalog number in
-   cdb-pg/src/include/catalog/catversion.h should be bumped up. This is to 
+   src/include/catalog/catversion.h should be bumped up. This is to
    indicate an initdb is required so the version number in the backend matches
    the version number on disk.
  

--- a/src/include/catalog/li_extras.py
+++ b/src/include/catalog/li_extras.py
@@ -348,7 +348,7 @@ COMMENT ON FUNCTION @gpupgradeschemaname@.linear_interpolate(
         ) 
     IS '{desc}';""" 
     
-    result = ['-- for cdb-pg/src/test/regress/data/upgradeXX/upg2_catupgrade_XXX.sql.in', '']
+    result = ['-- for src/test/regress/data/upgradeXX/upg2_catupgrade_XXX.sql.in', '']
     
     upg_1 = ' '.join([x.strip() for x in upgrade_1.split('\n')])
     upg_2 = ' '.join([x.strip() for x in upgrade_2.split('\n')])

--- a/src/include/pg_trace.h
+++ b/src/include/pg_trace.h
@@ -46,7 +46,7 @@
 enum 
 {
 	/* Postgres dtrace family, 1 to 999,999 */
-	/* See cdb-pg/src/backend/utils/probes.d */
+	/* See src/backend/utils/probes.d */
 	transaction__start  = 1, 
 	transaction__commit,
 	transaction__abort,

--- a/src/include/postmaster/perfmon.h
+++ b/src/include/postmaster/perfmon.h
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2005-2009, Greenplum inc
  *
- * $Id: //cdb2/private/cpedrotti/main/cdb-pg/src/include/postmaster/permfon.h#1 $
+ * src/include/postmaster/perfmon.h
  *
  *-------------------------------------------------------------------------
  */

--- a/src/test/unit/README.txt
+++ b/src/test/unit/README.txt
@@ -11,7 +11,7 @@ established a basic trust in the small units themselves, c) it serves as
 documentation about the expected behavior, d) enables easier code reuse because 
 code is already tested via two different code paths [Wikipedia].
 
-The unit test code is stored in cdb-pg/src/test/unit. The directory contains the 
+The unit test code is stored in src/test/unit. The directory contains the
 modified cmockery library, all mock source files currently in use (mock) and a 
 directory test, which contains all test code.
 

--- a/src/test/unit/mock/mocker.py
+++ b/src/test/unit/mock/mocker.py
@@ -121,7 +121,7 @@ class MockFile(object):
         self.outname = self.output_filename()
 
     def output_filename(self):
-        """outname is cdb-pg/src/test/unit/mock/backend/{path}/{stem}_mock.c
+        """outname is src/test/unit/mock/backend/{path}/{stem}_mock.c
         """
         src_dir = self.options.src_dir
         relpath = os.path.relpath(self.cfile.path, src_dir)


### PR DESCRIPTION
Spotted a reference to cdb-pg/ when looking at the unittest README and decided to fix up the other ones in src/ while at it (gpAux et.al are left for larger overhauls of these parts of the tree). The references to cdb-pg are from quite long ago when the source tree structure was different. Remove these references and clean up various file headers that were affected along the way.

Only affects comments and documentation, not code.