### PR TITLE
Add job to compile gpdb with custom configuration

### DIFF
--- a/ci/concourse/compile_gpdb_custom_config.yml
+++ b/ci/concourse/compile_gpdb_custom_config.yml
@@ -1,0 +1,7 @@
+platform: linux
+image_resource:
+  type: docker-image
+inputs:
+  - name: gpdb_src
+run:
+  path: gpdb_src/ci/concourse/scripts/compile_gpdb_custom_config.bash

--- a/ci/concourse/pipelines/pipeline.yml
+++ b/ci/concourse/pipelines/pipeline.yml
@@ -115,6 +115,16 @@ jobs:
       params:
         file: sync_tools_gpdb/sync_tools_gpdb.tar.gz
 
+- name: compile_gpdb_custom_config_centos6
+  public: true
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      trigger: true
+    - get: centos67-java7-gpdb-dev-image
+  - task: compile_gpdb
+    file: gpdb_src/ci/concourse/compile_gpdb_custom_config.yml
+    image: centos67-java7-gpdb-dev-image
 
 # Stage 2: Packaging
 

--- a/ci/concourse/scripts/compile_gpdb_custom_config.bash
+++ b/ci/concourse/scripts/compile_gpdb_custom_config.bash
@@ -1,0 +1,66 @@
+#!/bin/bash -l
+set -exo pipefail
+
+GREENPLUM_INSTALL_DIR=/usr/local/gpdb
+CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function prep_env_for_centos() {
+  export JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-1.6.0.39.x86_64
+  export PATH=${JAVA_HOME}/bin:${PATH}
+  install_system_deps
+}
+
+function install_system_deps() {
+  deps_list=" sudo 
+             passwd 
+             openssh-server 
+             ed 
+             readline-devel 
+             zlib-devel 
+             curl-devel 
+             bzip2-devel 
+             python-devel 
+             apr-devel 
+             libevent-devel 
+             openssl-libs 
+             openssl-devel 
+             libyaml 
+             libyaml-devel 
+             epel-release 
+             htop 
+             perl-Env 
+             perl-ExtUtils-Embed 
+             libxml2-devel 
+             libxslt-devel 
+             libffi-devel "
+  for dep in "$deps_list";
+  do
+    yum install -y $dep
+  done
+}
+
+# This is a canonical way to build GPDB. The intent is to validate that GPDB compiles 
+# with a fairly basic build. It is not meant to be exhasustive or include all features
+# and components available in GPDB.
+
+function build_gpdb() {
+  pushd gpdb_src
+    ./configure --enable-mapreduce --with-perl --with-libxml --with-python --disable-gpfdist --prefix=${GREENPLUM_INSTALL_DIR}
+    make
+    make install
+  popd
+}
+
+function unittest_check_gpdb() {
+  pushd gpdb_src/src/backend
+    make -s unittest-check
+  popd
+}
+
+function _main() {
+  prep_env_for_centos
+  build_gpdb
+  unittest_check_gpdb
+}
+
+_main "$@"


### PR DESCRIPTION
The intent is to validate that GPDB compiles with a fairly basic build. It is not meant to be exhaustive or include all features and components available in GPDB. There will be other jobs to perform compilation with full config.