### PR TITLE
Make dispatch testcases stable and independent of compile configuration

### DIFF
--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -121,10 +121,7 @@ s/^LOG.*\"Feature/\"Feature/
 m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
 s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)//
 
-# Mask out gp_debug_linger HINT message for dispatch
-m/^HINT:  Process \d+ will wait for gp_debug_linger=\d+ seconds before termination\./
-s/^HINT:  Process \d+ will wait for gp_debug_linger=\d+ seconds before termination\.//
-
+# Mask out whoami message for dispatch
 m/^ \(seg\d .*:\d+\)/
 s/^ \(seg\d .*:\d+\)//
 -- end_matchsubs

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -165,7 +165,7 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 select cleanupAllGangs();
 
 -- segment 0 report an error when get a request 
-\! gpfaultinjector -q -f process_startup_packet -y error --seg_dbid 2
+\! gpfaultinjector -q -f send_qe_details_init_backend -y error --seg_dbid 2
 
 -- expect failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
@@ -179,9 +179,9 @@ select * from v_hasBackendsOnSegment;
 -- cleanupAllGangs();
 select cleanupAllGangs();
 
-\! gpfaultinjector -q -f process_startup_packet -y reset --seg_dbid 2
+\! gpfaultinjector -q -f send_qe_details_init_backend -y reset --seg_dbid 2
 -- segment 0 report an error when get the second request (reader gang creation request)
-\! gpfaultinjector -q -f process_startup_packet -y error --seg_dbid 2 -o 3
+\! gpfaultinjector -q -f send_qe_details_init_backend -y error --seg_dbid 2 -o 3
 
 -- expect failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
@@ -192,7 +192,7 @@ select * from hasGangsExist();
 -- expect QEs exist.
 select * from v_hasBackendsOnSegment;
 
-\! gpfaultinjector -q -f process_startup_packet -y reset --seg_dbid 2
+\! gpfaultinjector -q -f send_qe_details_init_backend -y reset --seg_dbid 2
 
 -- Case 1.4
 -- Test createGang timeout.

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -218,14 +218,12 @@ select cleanupAllGangs();
 (1 row)
 
 -- segment 0 report an error when get a request 
-\! gpfaultinjector -q -f process_startup_packet -y error --seg_dbid 2
+\! gpfaultinjector -q -f send_qe_details_init_backend -y error --seg_dbid 2
 -- expect failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 ERROR:  failed to acquire resources on one or more segments
-DETAIL:  FATAL:  fault triggered, fault name:'process_startup_packet' fault type:'error' (faultinjector.c:683)
-HINT:  Process 8632 will wait for gp_debug_linger=120 seconds before termination.
-Note that its locks and other resources will not be released until then.
+DETAIL:  FATAL:  fault triggered, fault name:'send_qe_details_init_backend' fault type:'error' (faultinjector.c:683)
  (seg0 127.0.0.1:40000)
 -- expect no resuable gang exist
 select * from hasGangsExist();
@@ -248,16 +246,14 @@ select cleanupAllGangs();
  t
 (1 row)
 
-\! gpfaultinjector -q -f process_startup_packet -y reset --seg_dbid 2
+\! gpfaultinjector -q -f send_qe_details_init_backend -y reset --seg_dbid 2
 -- segment 0 report an error when get the second request (reader gang creation request)
-\! gpfaultinjector -q -f process_startup_packet -y error --seg_dbid 2 -o 3
+\! gpfaultinjector -q -f send_qe_details_init_backend -y error --seg_dbid 2 -o 3
 -- expect failure
 select * from dispatch_test_t1, dispatch_test_t2, dispatch_test_t3
 where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispatch_test_t3.c3;
 ERROR:  failed to acquire resources on one or more segments
-DETAIL:  FATAL:  fault triggered, fault name:'process_startup_packet' fault type:'error' (faultinjector.c:683)
-HINT:  Process 8685 will wait for gp_debug_linger=120 seconds before termination.
-Note that its locks and other resources will not be released until then.
+DETAIL:  FATAL:  fault triggered, fault name:'send_qe_details_init_backend' fault type:'error' (faultinjector.c:683)
  (seg0 127.0.0.1:40000)
 -- expect resuable gang exist
 select * from hasGangsExist();
@@ -273,7 +269,7 @@ select * from v_hasBackendsOnSegment;
  t
 (1 row)
 
-\! gpfaultinjector -q -f process_startup_packet -y reset --seg_dbid 2
+\! gpfaultinjector -q -f send_qe_details_init_backend -y reset --seg_dbid 2
 -- Case 1.4
 -- Test createGang timeout.
 -- gp_segment_connect_timeout = 0 : wait forever


### PR DESCRIPTION
When process_startup_packets is triggered, gp_debug_linger was not set to 0 which cause anoying message "HINT: process xxxx" exist in output file and make tests unstable. This commit change the fault injection location to send_qe_details_init_backend where gp_debug_linger has been set to 0, so no hint message is generated in output file.