### PR TITLE
Explicitly mark abort() as an allowed API call for gpopt

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -13,6 +13,8 @@
 //
 //---------------------------------------------------------------------------
 
+#define ALLOW_abort
+
 #include "gpopt/CGPOptimizer.h"
 #include "gpopt/utils/COptTasks.h"
 

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -177,6 +177,7 @@
 #define ALLOW_has_subclass
 #define ALLOW_cdbhash_const
 #define ALLOW_cdbhash_const_list
+#define ALLOW_abort
 
 #define ALLOW_ExecCheckRTPerms
 #define ALLOW_evaluate_expr

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -14,6 +14,8 @@
 //
 //---------------------------------------------------------------------------
 
+#define ALLOW_abort
+
 #include "postgres.h"
 
 #include "access/sysattr.h"

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -27,6 +27,7 @@
 #define ALLOW_MemoryContextFreeImpl
 #define ALLOW_CharGetDatum
 #define ALLOW_list_head
+#define ALLOW_abort
 
 #include "postgres.h"
 #include "utils/array.h"

--- a/src/backend/gpopt/utils/CConstExprEvaluatorProxy.cpp
+++ b/src/backend/gpopt/utils/CConstExprEvaluatorProxy.cpp
@@ -14,6 +14,7 @@
 //
 //---------------------------------------------------------------------------
 
+#define ALLOW_abort
 
 #include "postgres.h"
 #include "executor/executor.h"

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -14,6 +14,7 @@
 //---------------------------------------------------------------------------
 
 #define ALLOW_strcasecmp
+#define ALLOW_abort
 
 #include "gpopt/utils/gpdbdefs.h"
 #include "gpopt/utils/CConstExprEvaluatorProxy.h"

--- a/src/backend/gpopt/utils/funcs.cpp
+++ b/src/backend/gpopt/utils/funcs.cpp
@@ -14,6 +14,7 @@
 //---------------------------------------------------------------------------
 
 #define ALLOW_appendStringInfo
+#define ALLOW_abort
 
 #include <sys/stat.h>
 #include "gpopt/utils/nodeutils.h"


### PR DESCRIPTION
libgpos has a set of banned API calls which needs to be allowed with the `ALLOW_xxx` macro in order for gpopt to compile (and thus run). The changes to `ereport()` brought a need for allowing `abort()` since it now invokes abort when building with `--enable-cassert`. Reported on -dev in https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/Mcw6JPav6h4

This adds the `ALLOW_` override where it's needed to allow gpopt to compile. While this could be more gracefully done it follows the current modus operandi for allowing api calls.