### PR TITLE
Gpcrondump errors out if -h and -H options are specified together for…

### DIFF
--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -52,10 +52,11 @@ class GpCronDump(Operation):
         if args:
             logger.warn("please note that some of the arguments (%s) aren't valid and will be ignored.", args)
 
+        sys_args = sys.argv[1:]
         self.context = Context(options)
-        self.options_list = " ".join(sys.argv[1:])
+        self.options_list = " ".join(sys_args)
 
-        if "-h" in self.options_list and "-H" in self.options_list:
+        if "-h" in sys_args and "-H" in sys_args:
             raise Exception("-H option cannot be selected with -h option. ")
 
         self.interactive = options.interactive

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -1193,6 +1193,12 @@ Feature: Validate command line arguments
         Then gpcrondump should return a return code of 0
         Then verify that there is no table "public.gpcrondump_history" in "bkdb"
 
+    Scenario: Verify the gpcrondump -H and -h option can not be specified together with DDBoost
+        Given the test is initialized
+        When the user runs "gpcrondump -a -x bkdb -H -h --ddboost"
+        Then gpcrondump should return a return code of 2
+        And gpcrondump should print -H option cannot be selected with -h option to stdout
+
     @backupfire
     Scenario: Verify gpdbrestore -s option works with full backup
         Given the test is initialized

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/netbackup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/netbackup.feature
@@ -373,6 +373,23 @@ Feature: NetBackup Integration with GPDB
         And verify that the table "gpcrondump_history" in "bkdb" has dump info for the stored timestamp
 
     @nbupartI
+    Scenario: Verify the gpcrondump -H option should not create history table
+        Given the test is initialized
+        And the netbackup params have been parsed
+        And there is a "ao" table "public.ao_table" in "bkdb" with data
+        When the user runs "gpcrondump -a -x bkdb -H" using netbackup
+        Then gpcrondump should return a return code of 0
+        Then verify that there is no table "public.gpcrondump_history" in "bkdb"
+
+    @nbupartI
+    Scenario: Verify the gpcrondump -H and -h option can not be specified together
+        Given the test is initialized
+        And the netbackup params have been parsed
+        When the user runs "gpcrondump -a -x bkdb -H -h" using netbackup
+        Then gpcrondump should return a return code of 2
+        And gpcrondump should print -H option cannot be selected with -h option to stdout
+
+    @nbupartI
     Scenario: gpdbrestore -u option with full backup timestamp
         Given the test is initialized
         And the netbackup params have been parsed


### PR DESCRIPTION
… ddboost and netbackup

Add behave tests for netbackup and ddboost