### PR TITLE
Improve gpmmon manages connections to gpsmon.

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmonlib.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmonlib.h
@@ -182,6 +182,14 @@ struct multi_interface_holder_t
 	unsigned int counter;
 };
 
+#define CONM_INTERVAL (16)
+#define CONM_LOOP_LAUNCH_FRAME (1)
+#define CONM_LOOP_BROKEN_FRAME (9)
+#define CONM_LOOP_HANG_FRAME   (12)
+
+#define GPSMON_TIMEOUT_NONE     (0)
+#define GPSMON_TIMEOUT_RESTART  (1)
+#define GPSMON_TIMEOUT_DETECTED (2)
 
 /* segment host */ 
 typedef struct host_t
@@ -211,6 +219,7 @@ typedef struct host_t
 	unsigned char is_hdc;
 	unsigned char is_etl; 
 	char ever_connected; /* set to non-zero after first connection attempt */
+	char connect_timeout;
 } host_t;
 
 #define QEXEC_MAX_ROW_BUF_SIZE (2048)

--- a/gpAux/gpperfmon/src/gpmon/gpmonlib.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmonlib.h
@@ -220,6 +220,7 @@ typedef struct host_t
 	unsigned char is_etl; 
 	char ever_connected; /* set to non-zero after first connection attempt */
 	char connect_timeout;
+	apr_int32_t pid;
 } host_t;
 
 #define QEXEC_MAX_ROW_BUF_SIZE (2048)

--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -1350,6 +1350,7 @@ static void gx_accept(SOCKET sock, short event, void* arg)
 	}
 
 	/* echo the hello */
+	pkt.u.hello.pid = getpid();
 	TR2(("accepted pkt.magic = %x\n", (int) pkt.header.magic));
 	send_smon_to_mon_pkt(nsock, &pkt);
 

--- a/src/include/gpmon/gpmon.h
+++ b/src/include/gpmon/gpmon.h
@@ -360,6 +360,7 @@ struct gpmon_filerepinfo_t
 
 struct gpmon_hello_t {
     apr_int64_t signature;
+    apr_int32_t pid; /* pid of gpsmon */
 };
 
 


### PR DESCRIPTION
1. gpmmon detects timeout when connecting gpsmon
2. gpsmon sends command over SSH to kill hang gpsmon process and restart them
3. if still can't connect to remote gpsmon, print logs to explain the status
Before this change, gpmmon can never connect to a healthy remote gpsmon if there are timeout hosts before the healthy host. This fix improved the way gpmmon maintenance connections. Timeout hosts are pushed behind to ensure healthy host can get connected. Also for timeout hosts gpmmon will try to release "hang" gpsmon by kill them and start again.
@violet1986