### PR TITLE
Fix DESTDIR option support for make install

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -55,35 +55,35 @@ SET_VERSION_SCRIPTS = \
 
 set_scripts_version : 
 	@for file in $(SET_VERSION_SCRIPTS); do \
-	    if [ -f $(prefix)/$${file} ]; then \
-	        perl $(top_builddir)/putversion $(prefix)/$${file} ; \
+	    if [ -f $(DESTDIR)$(prefix)/$${file} ]; then \
+	        perl $(top_builddir)/putversion $(DESTDIR)$(prefix)/$${file} ; \
 	    fi ; \
 	done
 
 generate_greenplum_path_file:
-	mkdir -p $(prefix)
+	mkdir -p $(DESTDIR)$(prefix)
 	unset LIBPATH; \
-	bin/generate-greenplum-path.sh $(prefix) > $(prefix)/greenplum_path.sh
+	bin/generate-greenplum-path.sh $(prefix) > $(DESTDIR)$(prefix)/greenplum_path.sh
 
 install: generate_greenplum_path_file
 	# Generate some python libraries
-	$(MAKE) -C bin all prefix=$(prefix)
+	$(MAKE) -C bin all prefix=$(DESTDIR)$(prefix)
 
 	# Copy the management utilities
-	mkdir -p $(prefix)/bin
-	mkdir -p $(prefix)/lib
-	mkdir -p $(prefix)/lib/python	
-	mkdir -p $(prefix)/sbin
+	mkdir -p $(DESTDIR)$(prefix)/bin
+	mkdir -p $(DESTDIR)$(prefix)/lib
+	mkdir -p $(DESTDIR)$(prefix)/lib/python	
+	mkdir -p $(DESTDIR)$(prefix)/sbin
 
 	# Setup /lib/python contents
-	cp -rp bin/gppylib $(prefix)/lib/python
-	cp -rp bin/ext/* $(prefix)/lib/python
+	cp -rp bin/gppylib $(DESTDIR)$(prefix)/lib/python
+	cp -rp bin/ext/* $(DESTDIR)$(prefix)/lib/python
 
 	# Setup /bin contents
-	cp -rp bin $(prefix)
+	cp -rp bin $(DESTDIR)$(prefix)
 	# Symlink gpcheckcat from bin to bin/lib to maintain backward compatibility
-	if [ -f $(prefix)/bin/gpcheckcat  ]; then \
-		ln -sf ../gpcheckcat $(prefix)/bin/lib/gpcheckcat; \
+	if [ -f $(DESTDIR)$(prefix)/bin/gpcheckcat  ]; then \
+		ln -sf ../gpcheckcat $(DESTDIR)$(prefix)/bin/lib/gpcheckcat; \
 	fi
 
 #ifeq "$(findstring $(BLD_ARCH),$(GPPKG_PLATFORMS))" ""
@@ -91,15 +91,15 @@ install: generate_greenplum_path_file
 #	rm -f $(prefix)/bin/gppkg
 #endif
 
-	cp -rp sbin/* $(prefix)/sbin/.
-	#cp -p extensions/gpfdist/gpfdist$(EXE_EXT) $(prefix)/bin/
-	cp $(top_builddir)/src/test/regress/*.pl $(prefix)/bin
-	cp $(top_builddir)/src/test/regress/*.pm $(prefix)/bin
-	if [ ! -d ${prefix}/docs ] ; then mkdir ${prefix}/docs ; fi
-	if [ -d doc ]; then cp -rp doc $(prefix)/docs/cli_help; fi
+	cp -rp sbin/* $(DESTDIR)$(prefix)/sbin/.
+	#cp -p extensions/gpfdist/gpfdist$(EXE_EXT) $(DESTDIR)$(prefix)/bin/
+	cp $(top_builddir)/src/test/regress/*.pl $(DESTDIR)$(prefix)/bin
+	cp $(top_builddir)/src/test/regress/*.pm $(DESTDIR)$(prefix)/bin
+	if [ ! -d ${DESTDIR}${prefix}/docs ] ; then mkdir ${DESTDIR}${prefix}/docs ; fi
+	if [ -d doc ]; then cp -rp doc $(DESTDIR)$(prefix)/docs/cli_help; fi
 	@if [ -d demo/gpmapreduce ]; then \
-	  mkdir -p $(prefix)/demo; \
-	  $(TAR) -C demo -czf $(prefix)/demo/gpmapreduce.tar.gz gpmapreduce; \
+	  mkdir -p $(DESTDIR)$(prefix)/demo; \
+	  $(TAR) -C demo -czf $(DESTDIR)$(prefix)/demo/gpmapreduce.tar.gz gpmapreduce; \
 	fi
 
 #	THIS NEEDS TO MOVE
@@ -110,10 +110,10 @@ install: generate_greenplum_path_file
 
 	$(MAKE) set_scripts_version prefix=$(prefix)
 	# Remove unwanted files.
-	rm -rf $(prefix)/bin/ext
-	rm -rf $(prefix)/bin/pythonSrc
-	rm -rf $(prefix)/bin/Makefile
-	rm -rf $(prefix)/bin/src
-	rm -f $(prefix)/bin/gpchecksubnetcfg
-	rm -rf $(prefix)/bin/gppylib
-	find $(prefix)/lib/python/gppylib -name test -type d | xargs rm -rf
+	rm -rf $(DESTDIR)$(prefix)/bin/ext
+	rm -rf $(DESTDIR)$(prefix)/bin/pythonSrc
+	rm -rf $(DESTDIR)$(prefix)/bin/Makefile
+	rm -rf $(DESTDIR)$(prefix)/bin/src
+	rm -f $(DESTDIR)$(prefix)/bin/gpchecksubnetcfg
+	rm -rf $(DESTDIR)$(prefix)/bin/gppylib
+	find $(DESTDIR)$(prefix)/lib/python/gppylib -name test -type d | xargs rm -rf

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -59,9 +59,9 @@ pygresql:
 	@echo "--- PyGreSQL"
 	. $(prefix)/greenplum_path.sh && unset PYTHONHOME && \
 	if [ `uname -s` = 'HP-UX' ]; then \
-	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && CC="$(CC)" LDFLAGS="-L../../../../gpAux/ext/hpux_ia64/python-2.5.6/lib" python setup.py build; \
+	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" LDFLAGS="-L../../../../gpAux/ext/hpux_ia64/python-2.5.6/lib" python setup.py build; \
 	else \
-	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && CC="$(CC)" python setup.py build; \
+	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python setup.py build; \
 	fi
 
 	mkdir -p $(PYLIB_DIR)/pygresql

--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/setup.py
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/setup.py
@@ -39,6 +39,7 @@ using distutils to install Python programs.
 version = "4.0"
 
 import sys
+import os
 
 if not (2, 2) < sys.version_info[:2] < (3, 0):
     raise Exception("PyGreSQL %s requires a Python 2 version"
@@ -62,7 +63,7 @@ def pg_config(s):
         raise Exception("pg_config tool is not available.")
     if not d:
         raise Exception("Could not get %s information." % s)
-    return d
+    return os.environ['DESTDIR']+d
 
 def mk_include():
     """Create a temporary local include directory.

--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/setup.py
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/setup.py
@@ -63,7 +63,7 @@ def pg_config(s):
         raise Exception("pg_config tool is not available.")
     if not d:
         raise Exception("Could not get %s information." % s)
-    return os.environ['DESTDIR']+d
+    return os.getenv('DESTDIR','')+d
 
 def mk_include():
     """Create a temporary local include directory.

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -43,7 +43,7 @@ gpfdist$(EXE_EXT): $(OBJS)
 	$(CC) $(LDFLAGS) $(CFLAGS) $(OBJS) $(LDLIBS) -o $@
 
 install: all
-	$(INSTALL) gpfdist$(EXE_EXT) $(prefix)/bin
+	$(INSTALL) gpfdist$(EXE_EXT) $(DESTDIR)$(prefix)/bin
 
 installcheck:
 	$(MAKE) -C regress installcheck


### PR DESCRIPTION
When building and then installing the last master gpdb by “make install DESTDIR=path_to_install_from_destdir” some files are being installed to “path_to_install_from_destdir”,  but the other part goes to “path_to_install_from_configure” from “./configure --prefix=path_to_install_from_configure” which is incorrect.