### PR TITLE
Use latest gpos and orca for codegen

### DIFF
--- a/concourse/gpcodegen_pipeline.yml
+++ b/concourse/gpcodegen_pipeline.yml
@@ -56,6 +56,18 @@ resources:
     secret_access_key: {{aws-secret-access-key}}
     regexp: bin_xerces_centos(6).tar.gz
 
+- name: orca
+  type: github-release
+  source:
+    user: greenplum-db
+    repository: gporca
+
+- name: gpos
+  type: github-release
+  source:
+    user: greenplum-db
+    repository: gpos
+
 ########
 # JOBS #
 ########
@@ -112,8 +124,17 @@ jobs:
         submodules: none
       trigger: true
     - get: bin_xerces
-  - task: prepare_orca_dependencies
-    file: gpdb_src/concourse/prepare_orca_dependencies.yml
+    - get: bin_orca
+      resource: orca
+      params:
+        globs:
+        - bin_orca_centos5_release.tar.gz
+    - get: bin_gpos
+      resource: gpos
+      params:
+        globs:
+        - bin_gpos_centos5_release.tar.gz
+
   - task: build_with_orca_and_codegen
     file: gpdb_src/concourse/build_with_orca_and_codegen.yml
     output_mapping: {bin_gpdb: bin_gpdb_orca}

--- a/concourse/gpcodegen_pipeline.yml
+++ b/concourse/gpcodegen_pipeline.yml
@@ -12,15 +12,6 @@ resources:
       - concourse/*
     uri: https://github.com/greenplum-db/gpdb.git
 
-- name: bin_gpdb_planner
-  type: s3
-  source:
-    access_key_id: {{aws-access-key-id}}
-    bucket: gporca-concourse-bucket
-    region_name: us-west-2
-    secret_access_key: {{aws-secret-access-key}}
-    versioned_file: bin_gpdb_with_codegen_centos6.tar.gz
-
 - name: bin_gpdb_orca
   type: s3
   source:
@@ -72,39 +63,22 @@ resources:
 # JOBS #
 ########
 jobs:
-- name: build_gpdb_planner
-  max_in_flight: 1
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      params:
-        submodules: none
-      trigger: true
-  - task: build_with_codegen
-    file: gpdb_src/concourse/build_with_codegen.yml
-    output_mapping: {bin_gpdb: bin_gpdb_planner}
-  - task: package_tarball
-    input_mapping: {bin_gpdb: bin_gpdb_planner}
-    file: gpdb_src/concourse/package_tarball.yml
-  - put: bin_gpdb_planner
-    params:
-      from: package_tarball/bin_gpdb.tar.gz
-
 - name: gpdb_icg_planner
   max_in_flight: 1
   plan:
   - aggregate:
     - get: gpdb_src
       passed:
-      - build_gpdb_planner
+      - build_gpdb_orca
       params:
         submodules: none
-    - get: bin_gpdb_planner
+    - get: bin_gpdb_orca
       passed:
-      - build_gpdb_planner
+      - build_gpdb_orca
       trigger: true
   - task: test_gpdb
-    input_mapping: {bin_gpdb: bin_gpdb_planner}
+    input_mapping:
+      bin_gpdb: bin_gpdb_orca
     file: gpdb_src/concourse/test_with_codegen.yml
     timeout: 1h30m
     on_failure:

--- a/concourse/gpcodegen_pipeline.yml
+++ b/concourse/gpcodegen_pipeline.yml
@@ -95,6 +95,8 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
+      passed:
+      - build_gpdb_planner
       params:
         submodules: none
     - get: bin_gpdb_planner
@@ -150,6 +152,8 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
+      passed:
+      - build_gpdb_orca
       params:
         submodules: none
     - get: bin_gpdb_orca


### PR DESCRIPTION
This Pull Request changes the following

0. It uses the latest ORCA to build codegen
0. It ensures that the binary fed into `installcheck` is actually built with the source code (`gpdb_src`)