### PR TITLE
Fix memory leak in dispatcher.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -623,6 +623,8 @@ void setQEIdentifier(SegmentDatabaseDescriptor *segdbDesc,
 	if (segdbDesc->backendPid != 0)
 		appendStringInfo(&string, " pid=%d", segdbDesc->backendPid);
 
+	if (segdbDesc->whoami != NULL)
+		pfree(segdbDesc->whoami);
 	segdbDesc->whoami = string.data;
 	MemoryContextSwitchTo(oldContext);
 }


### PR DESCRIPTION
About 3KB * cluster_size * slice_number memory is leaked per query execution,
if the GUC gp_vmem_idle_resource_timeout is set to 0.

Reproduction is easy by using following script:
pgbench -c 1 -n -f query.sql -t 100000 test
where query.sql contains statement 'SELECT 1 FROM gp_dist_random(gp_id);',
then by monitoring the VIRT consumption of QD, we can see the memory leak.