### PR TITLE
Changes to make compilation with gcc-6.2.0 successful

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -11,10 +11,10 @@ resources:
     uri: {{gpdb-git-remote}}
 
 
-- name: centos67-java7-gpdb-dev-image
+- name: centos67-gpdb-gcc6-llvm-image
   type: docker-image
   source:
-    repository: pivotaldata/centos67-java7-gpdb-dev-image
+    repository: pivotaldata/centos67-gpdb-gcc6-llvm-image
     username: {{docker_username}}
     password: {{docker_password}}
 
@@ -94,10 +94,10 @@ jobs:
   - aggregate:
     - get: gpdb_src
       trigger: true
-    - get: centos67-java7-gpdb-dev-image
+    - get: centos67-gpdb-gcc6-llvm-image
   - task: compile_gpdb
     file: gpdb_src/concourse/compile_gpdb.yml
-    image: centos67-java7-gpdb-dev-image
+    image: centos67-gpdb-gcc6-llvm-image
     params:
       IVYREPO_HOST: {{ivyrepo_host}}
       IVYREPO_REALM: {{ivyrepo_realm}}
@@ -120,10 +120,10 @@ jobs:
   - aggregate:
     - get: gpdb_src
       trigger: true
-    - get: centos67-java7-gpdb-dev-image
+    - get: centos67-gpdb-gcc6-llvm-image
   - task: compile_gpdb
     file: gpdb_src/concourse/compile_gpdb_custom_config.yml
-    image: centos67-java7-gpdb-dev-image
+    image: centos67-gpdb-gcc6-llvm-image
 
 # Stage 2: IC Tests
 - name: icg_planner_centos6
@@ -138,10 +138,10 @@ jobs:
       resource: bin_gpdb_centos
       passed: [compile_gpdb_centos6]
       trigger: true
-    - get: centos67-java7-gpdb-dev-image
+    - get: centos67-gpdb-gcc6-llvm-image
   - task: ic_gpdb
     file: gpdb_src/concourse/ic_gpdb.yml
-    image: centos67-java7-gpdb-dev-image
+    image: centos67-gpdb-gcc6-llvm-image
     params:
       MAKE_TEST_COMMAND: installcheck-good
       BLDWRAP_POSTGRES_CONF_ADDONS: ""
@@ -158,16 +158,16 @@ jobs:
       resource: bin_gpdb_centos
       passed: [icg_planner_centos6]
       trigger: true
-    - get: centos67-java7-gpdb-dev-image
+    - get: centos67-gpdb-gcc6-llvm-image
   - task: separate_qautils_files_for_rc
     file: gpdb_src/concourse/separate_qautils_files_for_rc.yml
-    image: centos67-java7-gpdb-dev-image
+    image: centos67-gpdb-gcc6-llvm-image
     params:
       QAUTILS_TARBALL: rc_bin_gpdb/QAUtils-rhel6-x86_64.tar.gz
   - aggregate:
     - task: gpdb_rc_packaging_centos
       file: gpdb_src/concourse/gpdb_packaging.yml
-      image: centos67-java7-gpdb-dev-image
+      image: centos67-gpdb-gcc6-llvm-image
       input_mapping:
         bin_gpdb: rc_bin_gpdb
       output_mapping:
@@ -178,7 +178,7 @@ jobs:
         ADD_README_INSTALL: true
     - task: gpdb_appliance_rhel6_rc_packaging
       file: gpdb_src/concourse/gpdb_packaging.yml
-      image: centos67-java7-gpdb-dev-image
+      image: centos67-gpdb-gcc6-llvm-image
       input_mapping:
         bin_gpdb: rc_bin_gpdb
       output_mapping:

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -23,6 +23,7 @@ function install_sync_tools() {
 }
 
 function configure() {
+  source /opt/gcc_env.sh
   pushd gpdb_src
       ./configure --prefix=/usr/local/greenplum-db-devel
   popd

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -18,7 +18,7 @@ function prep_env_for_centos() {
     6)
       BLDARCH=rhel6_x86_64
       export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk.x86_64
-
+      source /opt/gcc_env.sh
       # This is necessesary to build gphdfs.
       # It should be removed once the build image has this included.
       yum install -y ant-junit
@@ -62,6 +62,9 @@ function generate_build_number() {
 function make_sync_tools() {
   pushd gpdb_src/gpAux
     make IVYREPO_HOST=${IVYREPO_HOST} IVYREPO_REALM="${IVYREPO_REALM}" IVYREPO_USER=${IVYREPO_USER} IVYREPO_PASSWD=${IVYREPO_PASSWD} sync_tools
+    # Codegen fails to compile with the zlib downloaded from
+    # artifacts.  The native zlib on CentOS6 is good enough.
+    find ext -name 'libz.*' -exec rm -f {} \;
     tar -czf ../../sync_tools_gpdb/sync_tools_gpdb.tar.gz ext
   popd
 }

--- a/concourse/scripts/compile_gpdb_custom_config.bash
+++ b/concourse/scripts/compile_gpdb_custom_config.bash
@@ -7,6 +7,7 @@ CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 function prep_env_for_centos() {
   export JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-1.6.0.39.x86_64
   export PATH=${JAVA_HOME}/bin:${PATH}
+  source /opt/gcc_env.sh
   install_system_deps
 }
 
@@ -45,7 +46,8 @@ function install_system_deps() {
 
 function build_gpdb() {
   pushd gpdb_src
-    ./configure --enable-mapreduce --with-perl --with-libxml --with-python --disable-gpfdist --prefix=${GREENPLUM_INSTALL_DIR}
+    ./configure --enable-mapreduce --with-perl --with-libxml --with-python --disable-gpfdist \
+        --prefix=${GREENPLUM_INSTALL_DIR} --enable-codegen --with-codegen-prefix=/opt/llvm-3.7.1
     make
     make install
   popd

--- a/concourse/scripts/compile_gpdb_custom_config.bash
+++ b/concourse/scripts/compile_gpdb_custom_config.bash
@@ -7,7 +7,6 @@ CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 function prep_env_for_centos() {
   export JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-1.6.0.39.x86_64
   export PATH=${JAVA_HOME}/bin:${PATH}
-  source /opt/gcc_env.sh
   install_system_deps
 }
 
@@ -46,8 +45,10 @@ function install_system_deps() {
 
 function build_gpdb() {
   pushd gpdb_src
-    ./configure --enable-mapreduce --with-perl --with-libxml --with-python --disable-gpfdist \
-        --prefix=${GREENPLUM_INSTALL_DIR} --enable-codegen --with-codegen-prefix=/opt/llvm-3.7.1
+    source /opt/gcc_env.sh
+    CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --with-perl --with-libxml \
+    	--with-python --disable-gpfdist --prefix=${GREENPLUM_INSTALL_DIR} \
+	--enable-codegen --with-codegen-prefix=/opt/llvm-3.7.1
     make
     make install
   popd

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -176,15 +176,17 @@ else
 APR_CONFIG=--with-apr-config=$(BLD_THIRDPARTY_BIN_DIR)/apr-1-config
 endif
 
+CODEGEN_CONFIG=--disable-codegen --with-codegen-prefix=/opt/llvm-3.7.1
+
 win32_CONFIGFLAGS=--with-gssapi --without-libcurl $(APR_CONFIG)
 sol10_x86_64_CONFIGFLAGS=--enable-snmp --with-libxml $(APR_CONFIG)
 rhel5_x86_32_CONFIGFLAGS=--host=i686-pc-linux-gnu --enable-snmp --enable-ddboost --with-gssapi --enable-netbackup --with-libxml $(APR_CONFIG)
-rhel5_x86_64_CONFIGFLAGS=--enable-snmp --enable-connectemc --enable-ddboost --with-gssapi --enable-netbackup ${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
-rhel6_x86_64_CONFIGFLAGS=--enable-snmp --enable-connectemc --enable-ddboost --with-gssapi --enable-netbackup ${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
-suse10_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost ${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
-suse11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost ${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
-linux_x86_64_CONFIGFLAGS=--enable-snmp ${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
-osx106_x86_CONFIGFLAGS=--enable-snmp ${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
+rhel5_x86_64_CONFIGFLAGS=--enable-snmp --enable-connectemc --enable-ddboost --with-gssapi --enable-netbackup ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG)
+rhel6_x86_64_CONFIGFLAGS=--enable-snmp --enable-connectemc --enable-ddboost --with-gssapi --enable-netbackup ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG)
+suse10_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG)
+suse11_x86_64_CONFIGFLAGS=--enable-snmp --enable-ddboost ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG)
+linux_x86_64_CONFIGFLAGS=--enable-snmp ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG)
+osx106_x86_CONFIGFLAGS=--enable-snmp ${ORCA_CONFIG} ${CODEGEN_CONFIG} --with-libxml $(APR_CONFIG)
 
 BLD_CONFIGFLAGS=$($(BLD_ARCH)_CONFIGFLAGS)
 

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -176,7 +176,7 @@ else
 APR_CONFIG=--with-apr-config=$(BLD_THIRDPARTY_BIN_DIR)/apr-1-config
 endif
 
-CODEGEN_CONFIG=--disable-codegen --with-codegen-prefix=/opt/llvm-3.7.1
+CODEGEN_CONFIG=--enable-codegen --with-codegen-prefix=/opt/llvm-3.7.1
 
 win32_CONFIGFLAGS=--with-gssapi --without-libcurl $(APR_CONFIG)
 sol10_x86_64_CONFIGFLAGS=--enable-snmp --with-libxml $(APR_CONFIG)

--- a/gpAux/gpperfmon/src/gpmon/gpmonlib.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmonlib.h
@@ -81,7 +81,7 @@ extern int gpsmon_fatalx(const char* fline, int e, const char* fmt, ...);
 extern apr_status_t gpmon_ntohpkt(apr_int32_t magic, apr_int16_t version, apr_int16_t pkttype);
 
 /* get the size of the union packet for smon_to_mon packets*/
-inline size_t get_size_by_pkttype_smon_to_mmon(apr_int16_t pkttype);
+extern size_t get_size_by_pkttype_smon_to_mmon(apr_int16_t pkttype);
 
 /* strings */
 extern char* gpmon_trim(char* s);
@@ -286,7 +286,7 @@ double subtractTimeOfDay(struct timeval* begin, struct timeval* end);
 
 
 /* Set header*/
-inline void gp_smon_to_mmon_set_header(gp_smon_to_mmon_packet_t* pkt, apr_int16_t pkttype);
+extern void gp_smon_to_mmon_set_header(gp_smon_to_mmon_packet_t* pkt, apr_int16_t pkttype);
 
 unsigned int gpdb_getnode_number_metrics(PerfmonNodeType type);
 const char* gpdb_getnodename(PerfmonNodeType type);

--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -25,7 +25,7 @@
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="osx106_x86->osx106_x86_32;rhel5_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="OpenSSL"         name="openssl"         rev="0.9.8zg"        conf="osx106_x86->osx105_x86;aix5_ppc_32->aix5_ppc_32;aix5_ppc_64->aix5_ppc_64;hpux_ia64->hpux_ia64;rhel5_x86_32->rhel5_x86_32;rhel5_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;sol10_x86_32->sol10_x86_32;sol10_x86_64->sol10_x86_64;sol10_sparc_32->sol10_sparc_32;sol10_sparc_64->sol10_sparc_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="emc"             name="DDBoostSDK"      rev="3.0.0.3-446710" conf="rhel5_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
-      <dependency org="gnu"             name="libstdc"         rev="6.0.13"         conf="osx106_x86->osx106_x86;rhel5_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;sol10_x86_64->sol10_x86_64;suse11_x86_64->suse10_x86_64" />
+      <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse11_x86_64;sol10_x86_64->sol10_x86_64" />
       <dependency org="third-party"     name="ext"             rev="1.1"            conf="win32->win32" />
       <dependency org="third-party"     name="ext"             rev="2.0"            conf="aix5_ppc_32->aix5_ppc_32;aix5_ppc_64->aix5_ppc_64;hpux_ia64->hpux_ia64;rhel4_x86_32->rhel4_x86_32;rhel4_x86_64->rhel4_x86_64;rhel5_x86_32->rhel5_x86_32;rhel6_x86_64->rhel5_x86_64;sol10_x86_32->sol10_x86_32;sol10_sparc_32->sol10_sparc_32;sol10_sparc_64->sol10_sparc_64;sol10_x86_64->sol10_x86_64" />
       <dependency org="third-party"     name="ext"             rev="2.4"            conf="rhel5_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
@@ -49,7 +49,6 @@
       <dependency org="net-snmp"        name="net-snmp"        rev="5.5"            conf="osx106_x86->osx106_x86" />
       <dependency org="xmlsoft"         name="libxml2"         rev="2.7.8"          conf="osx106_x86->osx106_x86" />
       <dependency org="xmlsoft"         name="libxslt"         rev="1.1.24"         conf="osx106_x86->osx109_x86_32" />
-      <dependency org="zlib"            name="zlib"            rev="1.2.3"          conf="osx106_x86->osx106_x86" />
       <dependency org="Samba"           name="ccache"          rev="3.2.3"          conf="osx106_x86->osx106_x86;rhel5_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse10_x86_64->suse10_x86_64;suse11_x86_64->suse10_x86_64" />
     </dependencies>
 </ivy-module>

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -71,7 +71,7 @@ ifeq "$(BLD_ARCH)" "rhel5_x86_32"
 LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib
 endif
 
-ifeq "$(BLD_ARCH)" "rhel5_x86_64"
+ifeq "$(BLD_ARCH)" "rhel6_x86_64"
 LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib64
 endif
 

--- a/src/backend/codegen/tests/clang_compiler_unittest.cc
+++ b/src/backend/codegen/tests/clang_compiler_unittest.cc
@@ -329,10 +329,6 @@ TEST_F(ClangCompilerTest, GetLiteralConstantTest) {
   CheckGetLiteralConstant(UInt16Enum::kCaseC,
                           "static_cast<unsigned short>(2u)");
 
-  // Floats and doubles (using hex-float literals to avoid rounding errors).
-  CheckGetLiteralConstant(0x1.123efp-10f, "0x1.123ef00000000p-10f");
-  CheckGetLiteralConstant(0x1.123456789abcdp+999, "0x1.123456789abcdp+999");
-
   // Pointer literals.
   CheckGetLiteralConstant(nullptr, "nullptr");
   CheckGetLiteralConstant(static_cast<void*>(nullptr),

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -26,21 +26,9 @@
 #define ALLOW_pfree
 #define ALLOW_MemoryContextFreeImpl
 #define ALLOW_CharGetDatum
+#define ALLOW_list_head
 
 #include "postgres.h"
-#include "naucrates/md/CMDIdCast.h"
-#include "naucrates/md/CMDIdScCmp.h"
-
-#include "naucrates/dxl/gpdb_types.h"
-
-#include "naucrates/md/CMDCastGPDB.h"
-#include "naucrates/md/CMDScCmpGPDB.h"
-
-#include "gpopt/translate/CTranslatorUtils.h"
-#include "gpopt/translate/CTranslatorRelcacheToDXL.h"
-#include "gpopt/translate/CTranslatorScalarToDXL.h"
-#include "gpopt/mdcache/CMDAccessor.h"
-
 #include "utils/array.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
@@ -59,6 +47,19 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_statistic.h"
 
+#include "naucrates/md/CMDIdCast.h"
+#include "naucrates/md/CMDIdScCmp.h"
+
+#include "naucrates/dxl/gpdb_types.h"
+
+#include "naucrates/md/CMDCastGPDB.h"
+#include "naucrates/md/CMDScCmpGPDB.h"
+
+#include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/translate/CTranslatorRelcacheToDXL.h"
+#include "gpopt/translate/CTranslatorScalarToDXL.h"
+#include "gpopt/mdcache/CMDAccessor.h"
+
 #undef ALLOW_DatumGetPointer
 #undef ALLOW_ntohl
 #undef ALLOW_memset
@@ -72,6 +73,7 @@
 #undef ALLOW_pfree
 #undef ALLOW_MemoryContextAllocImpl
 #undef ALLOW_MemoryContextFreeImpl
+#undef ALLOW_list_head
 
 #include "gpos/base.h"
 #include "gpos/error/CException.h"

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -15,17 +15,17 @@
 
 #define ALLOW_isnan
 #include "postgres.h"
-#include "gpopt/translate/CTranslatorScalarToDXL.h"
-#include "gpopt/translate/CTranslatorQueryToDXL.h"
-#include "gpopt/translate/CTranslatorUtils.h"
-#include "gpopt/translate/CCTEListEntry.h"
-
 #include "nodes/plannodes.h"
 #include "nodes/parsenodes.h"
 #include "nodes/primnodes.h"
 #include "utils/datum.h"
 #include "utils/date.h"
 #include "utils/numeric.h"
+
+#include "gpopt/translate/CTranslatorScalarToDXL.h"
+#include "gpopt/translate/CTranslatorQueryToDXL.h"
+#include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/translate/CCTEListEntry.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CAutoP.h"


### PR DESCRIPTION
Orca translator changes reorder include statements so that system and
PostgreSQL headers are grouped at the top.  Including such headers
within a C++ namespace causes compilation to fail with the new GCC.

The gpmonlib change removes inline keyword.  The new compiler is not
happy with inlining a function defined in an external object.