### PR TITLE
Adding length checks for netbackup parameters in python and c code

### DIFF
--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -138,6 +138,9 @@ class GpCronDump(Operation):
             if not self.context.netbackup_schedule:
                 raise Exception("NetBackup schedule name (--netbackup-schedule) param should be provided in order to use NetBackup")
 
+        param_dict = {'Service Hostname':self.context.netbackup_service_host, 'Policy Name':self.context.netbackup_policy, 'Schedule Name':self.context.netbackup_schedule, 'Keyword':self.context.netbackup_keyword}
+        validate_netbackup_params(param_dict)
+
         if self.context.ddboost and self.context.netbackup_service_host:
             raise Exception('--ddboost is not supported with NetBackup')
 

--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -119,6 +119,9 @@ class GpdbRestore(Operation):
         if self.context.list_tables and self.context.netbackup_service_host:
             raise Exception('-L is not supported with NetBackup.')
 
+        if self.context.netbackup_service_host:
+            validate_netbackup_params({'Service Hostname':self.context.netbackup_service_host})
+
         if self.context.redirected_restore_db:
             check_funny_chars_in_names(self.context.redirected_restore_db, is_full_qualified_name = False)
 

--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -62,8 +62,6 @@ class Context(Values, object):
         if not self.output_options: self.output_options = []
         if not self.dump_schema: self.dump_schema = []
         if not self.exclude_dump_schema: self.exclude_dump_schema = []
-        if self.netbackup_keyword and (len(self.netbackup_keyword) > 100):
-            raise Exception('NetBackup Keyword provided has more than max limit (100) characters. Cannot proceed with backup.')
 
     def get_master_port(self):
         pgconf_dict = pgconf.readfile(self.master_datadir + "/postgresql.conf")
@@ -903,3 +901,10 @@ def get_table_info(line):
         tblspace_start.append(None)
     owner = temp[owner_start[0] + len(OWNER_EXPR) : tblspace_start[0]]
     return (name, type, schema, owner)
+
+def validate_netbackup_params(param_dict):
+    max_len = 127
+    for label, param in param_dict.items():
+        if param and len(param) > max_len:
+            raise Exception("Netbackup {0} ({1}) exceeds the maximum length of {2} characters".format(label, param, max_len))
+    

--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -904,7 +904,7 @@ def get_table_info(line):
 
 def validate_netbackup_params(param_dict):
     max_len = 127
-    for label, param in param_dict.items():
+    for label, param in param_dict.iteritems():
         if param and len(param) > max_len:
             raise Exception("Netbackup {0} ({1}) exceeds the maximum length of {2} characters".format(label, param, max_len))
     

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/netbackup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/netbackup.feature
@@ -168,14 +168,32 @@ Feature: NetBackup Integration with GPDB
         And verify that the data of "2" tables in "bkdb" is validated after restore
 
     @nbupartI
-    Scenario: Full Backup and Restore with keyword exceeding max limit of 100 characters
+    @foo2
+    Scenario: Test netbackup parameter lengths for full backup and restore (<=127 and >127)
         Given the test is initialized
         And the netbackup params have been parsed
         And there is a "ao" table "public.ao_table" in "bkdb" with data
         And there is a "co" table "public.co_table" in "bkdb" with data
-        When the user runs "gpcrondump -a -x bkdb --netbackup-block-size 2048 --netbackup-keyword Aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbcccccc" using netbackup
+        When the user runs "gpcrondump -a -x bkdb --netbackup-keyword aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127" using netbackup with long params
+        Then gpcrondump should return a return code of 0
+        And the timestamp from gpcrondump is stored
+        When the user runs "gpcrondump -a -x bkdb --netbackup-service-host aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128" using netbackup with long params
         Then gpcrondump should return a return code of 2
-        And gpcrondump should print NetBackup Keyword provided has more than max limit \(100\) characters. Cannot proceed with backup. to stdout
+        And gpcrondump should print Netbackup Service Hostname \(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128\) exceeds the maximum length of 127 characters to stdout
+        When the user runs "gpcrondump -a -x bkdb --netbackup-policy aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128" using netbackup with long params
+        Then gpcrondump should return a return code of 2
+        And gpcrondump should print Netbackup Policy Name \(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128\) exceeds the maximum length of 127 characters to stdout
+        When the user runs "gpcrondump -a -x bkdb --netbackup-schedule aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128" using netbackup with long params
+        Then gpcrondump should return a return code of 2
+        And gpcrondump should print Netbackup Schedule Name \(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128\) exceeds the maximum length of 127 characters to stdout
+        When the user runs "gpcrondump -a -x bkdb --netbackup-keyword aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128" using netbackup with long params
+        Then gpcrondump should return a return code of 2
+        And gpcrondump should print Netbackup Keyword \(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128\) exceeds the maximum length of 127 characters to stdout
+        When the user runs gpdbrestore with the stored timestamp and options "--netbackup-service-host netbackup-service-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127"
+        Then gpdbrestore should return a return code of 0
+        When the user runs gpdbrestore with the stored timestamp and options "--netbackup-service-host netbackup-service-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128"
+        Then gpdbrestore should return a return code of 2
+        And gpdbrestore should print Netbackup Service Hostname \(netbackup-service-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa128\) exceeds the maximum length of 127 characters to stdout
 
     @nbusmoke
     @nbupartI

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/netbackup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/netbackup.feature
@@ -168,7 +168,6 @@ Feature: NetBackup Integration with GPDB
         And verify that the data of "2" tables in "bkdb" is validated after restore
 
     @nbupartI
-    @foo2
     Scenario: Test netbackup parameter lengths for full backup and restore (<=127 and >127)
         Given the test is initialized
         And the netbackup params have been parsed

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/netbackup_mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/netbackup_mgmt_utils.py
@@ -25,6 +25,29 @@ def impl(context, ver):
                 remoteHost=host)
         cmd.run(validateAfter=True)
 
+@when('the user runs "{cmd_str}" using netbackup with long params')
+def impl(context, cmd_str):
+    netbackup_service_host = ""
+    netbackup_policy = ""
+    netbackup_schedule = ""
+    if "--netbackup-service-host" not in cmd_str:
+        netbackup_service_host = " --netbackup-service-host netbackup-service-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127 "
+    if "--netbackup-policy" not in cmd_str:
+        netbackup_policy = " --netbackup-policy netbackup-policy-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127 "
+    if "--netbackup-schedule" not in cmd_str:
+        netbackup_schedule = " --netbackup-schedule netbackup-schedule-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127 "
+    bnr_tool = cmd_str.split()[0].strip()
+    if bnr_tool == 'gpcrondump':
+        command_str = cmd_str + netbackup_service_host + netbackup_policy + netbackup_schedule
+    elif bnr_tool == 'gpdbrestore':
+        command_str = cmd_str + netbackup_service_host
+    elif bnr_tool == 'gp_dump':
+        command_str = cmd_str + netbackup_service_host + netbackup_policy + netbackup_schedule
+    elif bnr_tool == 'gp_restore':
+        command_str = cmd_str + netbackup_service_host
+
+    run_gpcommand(context, command_str)
+
 @when('the user runs "{cmd_str}" using netbackup')
 def impl(context, cmd_str):
     if hasattr(context, 'netbackup_service_host'):

--- a/src/bin/pg_dump/cdb/cdb_bsa_util.h
+++ b/src/bin/pg_dump/cdb/cdb_bsa_util.h
@@ -5,6 +5,11 @@
 #include "xbsa.h"
 #include "nbbsa.h"
 
+#define NBU_MAX_LABEL_LEN 20
+#define NBU_MAX_PARAM_LEN 127
+/* We add 2 to account for an '=' and the null terminator */
+#define NBU_BUFFER_SIZE (1 + NBU_MAX_LABEL_LEN + 1 + NBU_MAX_PARAM_LEN)
+
 /* Dump related functions to backup data to NetBackup */
 extern int initBSADumpSession(char *bsaServiceHost, char *nbbsaPolicy, char *nbbsaSchedule, char *nbbsaKeyword);
 extern int createBSADumpObject(char *BackupFilePathName);
@@ -23,5 +28,9 @@ extern int searchBSAObject(char *NetBackupQueryObject);
 
 /* Cleanup related function to delete objects on NetBackup server */
 extern int deleteBSAObjects(char *NetBackupDeleteObject);
+
+/* Helper function to validate parameters */
+extern int setNetbackupParam(char **envxPtr, char *label, char *nbbsaParam);
+
 
 #endif

--- a/src/bin/pg_dump/cdb/test/cdb_bsa_util_test.c
+++ b/src/bin/pg_dump/cdb/test/cdb_bsa_util_test.c
@@ -287,7 +287,8 @@ void
 test_initBSADumpSession_servicehost_len_too_long(void **state)
 {
 	int result = 0;
-	char* bsaServiceHost = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
+	char bsaServiceHost[130] = "";
+	memset(bsaServiceHost, 'a', 129);
 	char* nbbsaPolicy = "test_policy";
 	char* nbbsaSchedule = "test_schedule";
 	char* nbbsaKeyword = NULL;
@@ -300,7 +301,8 @@ test_initBSADumpSession_policy_len_too_long(void **state)
 {
 	int result = 0;
 	char* bsaServiceHost = "mdw";
-	char* nbbsaPolicy = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
+	char nbbsaPolicy[130] = "";
+	memset(nbbsaPolicy, 'a', 129);
 	char* nbbsaSchedule = "test_schedule";
 	char* nbbsaKeyword = NULL;
 	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
@@ -312,7 +314,8 @@ test_initBSADumpSession_schedule_len_too_long(void **state)
 	int result = 0;
 	char* bsaServiceHost = "mdw";
 	char* nbbsaPolicy = "test_policy";
-	char* nbbsaSchedule = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
+	char nbbsaSchedule[130] = "";
+	memset(nbbsaSchedule, 'a', 129);
 	char* nbbsaKeyword = NULL;
 	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
 	assert_true(result == -1);
@@ -325,7 +328,8 @@ test_initBSADumpSession_keyword_len_too_long(void **state)
 	char* bsaServiceHost = "mdw";
 	char* nbbsaPolicy = "test_policy";
 	char* nbbsaSchedule = "test_schedule";
-	char* nbbsaKeyword = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
+	char nbbsaKeyword[130] = "";
+	memset(nbbsaKeyword, 'a', 129);
 	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
 	assert_true(result == -1);
 }
@@ -334,7 +338,8 @@ void
 test_initBSADumpSession_servicehost_len_ok(void **state)
 {
 	int result = -1;
-	char* bsaServiceHost = "netbackup-service-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	char bsaServiceHost[128] = "";
+	memset(bsaServiceHost, 'a', 127);
 	char* nbbsaPolicy = "test_policy";
 	char* nbbsaSchedule = "test_schedule";
 	char* nbbsaKeyword = " ";
@@ -349,7 +354,8 @@ test_initBSADumpSession_policy_len_ok(void **state)
 {
 	int result = -1;
 	char* bsaServiceHost = "mdw";
-	char* nbbsaPolicy = "netbackup-policy-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	char nbbsaPolicy[128] = "";
+	memset(nbbsaPolicy, 'a', 127);
 	char* nbbsaSchedule = "test_schedule";
 	char* nbbsaKeyword = " ";
 	will_return(BSAInit, BSA_RC_SUCCESS);
@@ -364,7 +370,8 @@ test_initBSADumpSession_schedule_len_ok(void **state)
 	int result = -1;
 	char* bsaServiceHost = "mdw";
 	char* nbbsaPolicy = "test_policy";
-	char* nbbsaSchedule = "netbackup-schedule-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	char nbbsaSchedule[128] = "";
+	memset(nbbsaSchedule, 'a', 127);
 	char* nbbsaKeyword = " ";
 	will_return(BSAInit, BSA_RC_SUCCESS);
 	will_return(BSABeginTxn, BSA_RC_SUCCESS);
@@ -379,7 +386,8 @@ test_initBSADumpSession_keyword_len_ok(void **state)
 	char* bsaServiceHost = "mdw";
 	char* nbbsaPolicy = "test_policy";
 	char* nbbsaSchedule = "test_schedule";
-	char* nbbsaKeyword = "netbackup-keyword-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	char nbbsaKeyword[128] = "";
+	memset(nbbsaKeyword, 'a', 127);
 	will_return(BSAInit, BSA_RC_SUCCESS);
 	will_return(BSABeginTxn, BSA_RC_SUCCESS);
 	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
@@ -801,7 +809,8 @@ void
 test_initBSARestoreSession_servicehost_len_too_long(void **state)
 {
 	int result = 0;
-	char* bsaServiceHost = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
+	char bsaServiceHost[130] = "";
+	memset(bsaServiceHost, 'a', 129);
 	result = initBSARestoreSession(bsaServiceHost);
 	assert_true(result == -1);
 }
@@ -810,7 +819,8 @@ void
 test_initBSARestoreSession_servicehost_len_ok(void **state)
 {
 	int result = -1;
-	char* bsaServiceHost = "netbackup-service-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	char bsaServiceHost[128] = "";
+	memset(bsaServiceHost, 'a', 127);
 	will_return(BSAInit, BSA_RC_SUCCESS);
 	will_return(BSABeginTxn, BSA_RC_SUCCESS);
 	result = initBSARestoreSession(bsaServiceHost);

--- a/src/bin/pg_dump/cdb/test/cdb_bsa_util_test.c
+++ b/src/bin/pg_dump/cdb/test/cdb_bsa_util_test.c
@@ -25,7 +25,7 @@ int ferror(FILE *stream) {
 }
 
 /* Mock of BSAInit function. */
-int BSAInit(BSA_Handle *bsaHandlePtr, BSA_SecurityToken *tokenPtr, 
+int BSAInit(BSA_Handle *bsaHandlePtr, BSA_SecurityToken *tokenPtr,
 			BSA_ObjectOwner *objectOwnerPtr, char **environmentPtr) {
 	return (int)mock();
 }
@@ -282,18 +282,109 @@ test_initBSADumpSession14(void **state)
 	assert_true(result == 0);
 }
 
+
 void
-test_initBSADumpSession15(void **state)
+test_initBSADumpSession_servicehost_len_too_long(void **state)
+{
+	int result = 0;
+	char* bsaServiceHost = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
+	char* nbbsaPolicy = "test_policy";
+	char* nbbsaSchedule = "test_schedule";
+	char* nbbsaKeyword = NULL;
+	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
+	assert_true(result == -1);
+}
+
+void
+test_initBSADumpSession_policy_len_too_long(void **state)
+{
+	int result = 0;
+	char* bsaServiceHost = "mdw";
+	char* nbbsaPolicy = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
+	char* nbbsaSchedule = "test_schedule";
+	char* nbbsaKeyword = NULL;
+	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
+	assert_true(result == -1);
+}
+void
+test_initBSADumpSession_schedule_len_too_long(void **state)
+{
+	int result = 0;
+	char* bsaServiceHost = "mdw";
+	char* nbbsaPolicy = "test_policy";
+	char* nbbsaSchedule = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
+	char* nbbsaKeyword = NULL;
+	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
+	assert_true(result == -1);
+}
+
+void
+test_initBSADumpSession_keyword_len_too_long(void **state)
 {
 	int result = 0;
 	char* bsaServiceHost = "mdw";
 	char* nbbsaPolicy = "test_policy";
 	char* nbbsaSchedule = "test_schedule";
-	char* nbbsaKeyword = "Aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbcccccc";
+	char* nbbsaKeyword = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
 	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
 	assert_true(result == -1);
 }
 
+void
+test_initBSADumpSession_servicehost_len_ok(void **state)
+{
+	int result = -1;
+	char* bsaServiceHost = "netbackup-service-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	char* nbbsaPolicy = "test_policy";
+	char* nbbsaSchedule = "test_schedule";
+	char* nbbsaKeyword = " ";
+	will_return(BSAInit, BSA_RC_SUCCESS);
+	will_return(BSABeginTxn, BSA_RC_SUCCESS);
+	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
+	assert_true(result == 0);
+}
+
+void
+test_initBSADumpSession_policy_len_ok(void **state)
+{
+	int result = -1;
+	char* bsaServiceHost = "mdw";
+	char* nbbsaPolicy = "netbackup-policy-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	char* nbbsaSchedule = "test_schedule";
+	char* nbbsaKeyword = " ";
+	will_return(BSAInit, BSA_RC_SUCCESS);
+	will_return(BSABeginTxn, BSA_RC_SUCCESS);
+	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
+	assert_true(result == 0);
+}
+
+void
+test_initBSADumpSession_schedule_len_ok(void **state)
+{
+	int result = -1;
+	char* bsaServiceHost = "mdw";
+	char* nbbsaPolicy = "test_policy";
+	char* nbbsaSchedule = "netbackup-schedule-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	char* nbbsaKeyword = " ";
+	will_return(BSAInit, BSA_RC_SUCCESS);
+	will_return(BSABeginTxn, BSA_RC_SUCCESS);
+	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
+	assert_true(result == 0);
+}
+
+void
+test_initBSADumpSession_keyword_len_ok(void **state)
+{
+	int result = -1;
+	char* bsaServiceHost = "mdw";
+	char* nbbsaPolicy = "test_policy";
+	char* nbbsaSchedule = "test_schedule";
+	char* nbbsaKeyword = "netbackup-keyword-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	will_return(BSAInit, BSA_RC_SUCCESS);
+	will_return(BSABeginTxn, BSA_RC_SUCCESS);
+	result = initBSADumpSession(bsaServiceHost, nbbsaPolicy, nbbsaSchedule, nbbsaKeyword);
+	assert_true(result == 0);
+}
 /* Unit tests for createBSADumpObject() function */
 
 void
@@ -704,6 +795,26 @@ test_initBSARestoreSession12(void **state)
 	will_return(BSATerminate, BSA_RC_SUCCESS);
 	result = initBSARestoreSession(bsaServiceHost);
 	assert_true(result == -1);
+}
+
+void
+test_initBSARestoreSession_servicehost_len_too_long(void **state)
+{
+	int result = 0;
+	char* bsaServiceHost = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa129";
+	result = initBSARestoreSession(bsaServiceHost);
+	assert_true(result == -1);
+}
+
+void
+test_initBSARestoreSession_servicehost_len_ok(void **state)
+{
+	int result = -1;
+	char* bsaServiceHost = "netbackup-service-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa127";
+	will_return(BSAInit, BSA_RC_SUCCESS);
+	will_return(BSABeginTxn, BSA_RC_SUCCESS);
+	result = initBSARestoreSession(bsaServiceHost);
+	assert_true(result == 0);
 }
 
 /* Unit tests for getBSARestoreObject() function */
@@ -1408,8 +1519,8 @@ test_deleteBSAObjects11(void **state)
 	assert_true(result == -1);
 }
 
-int 
-main(int argc, char* argv[]) 
+int
+main(int argc, char* argv[])
 {
 	cmockery_parse_arguments(argc, argv);
 
@@ -1428,7 +1539,14 @@ main(int argc, char* argv[])
 			unit_test(test_initBSADumpSession12),
 			unit_test(test_initBSADumpSession13),
 			unit_test(test_initBSADumpSession14),
-			unit_test(test_initBSADumpSession15),
+			unit_test(test_initBSADumpSession_servicehost_len_too_long),
+			unit_test(test_initBSADumpSession_policy_len_too_long),
+			unit_test(test_initBSADumpSession_schedule_len_too_long),
+			unit_test(test_initBSADumpSession_keyword_len_too_long),
+			unit_test(test_initBSADumpSession_servicehost_len_ok),
+			unit_test(test_initBSADumpSession_policy_len_ok),
+			unit_test(test_initBSADumpSession_schedule_len_ok),
+			unit_test(test_initBSADumpSession_keyword_len_ok),
 			unit_test(test_createBSADumpObject1),
 			unit_test(test_createBSADumpObject2),
 			unit_test(test_createBSADumpObject3),
@@ -1465,6 +1583,8 @@ main(int argc, char* argv[])
 			unit_test(test_initBSARestoreSession10),
 			unit_test(test_initBSARestoreSession11),
 			unit_test(test_initBSARestoreSession12),
+			unit_test(test_initBSARestoreSession_servicehost_len_too_long),
+			unit_test(test_initBSARestoreSession_servicehost_len_ok),
 			unit_test(test_getBSARestoreObject1),
 			unit_test(test_getBSARestoreObject2),
 			unit_test(test_getBSARestoreObject3),
@@ -1536,6 +1656,6 @@ int main(int argc, char *argv[])
 	/* TODO: change printf() to mpp_err_msg() */
 	printf("\ngp_bsa_dump_agent is not supported on this platform\n\n");
 	return 0;
-}	
+}
 
 #endif


### PR DESCRIPTION
We have a limit of 127 characters for parameters passed to netbackup (--netbackup-service-host, --netbackup-policy, --netbackup-schedule, and --netbackup-keyword). We now allocate more memory for these parameters and have added code to check their length and throw errors if they are too long. These checks exist in both the python and c code for extra coverage. We also have unit and behave tests to ensure the new checks are working properly.