### PR TITLE
Fix gprecoverseg to correctly index the segment list

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -36,9 +36,16 @@ def validateFlexibleHeadersListAllFilespaces(configFileLabel, gpArray, fileData)
     """
     Verify that every filespace in the gpArray has exactly one entry in the flexible headers of fileData
     """
+    if not fileData:
+        return
+
+    flexibleHeaders = fileData.getFlexibleHeaders()
+    if not flexibleHeaders:
+        return
+
     filespaceNameToFilespace = dict([ (fs.getName(), fs) for fs in gpArray.getFilespaces(False)])
     specifiedFilespaces = {}
-    for fsName in fileData.getFlexibleHeaders():
+    for fsName in flexibleHeaders:
         if fsName not in filespaceNameToFilespace:
             raise Exception('%s refers to filespace that does not exist: "%s"' % (configFileLabel, fsName))
         if fsName in specifiedFilespaces:

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -279,15 +279,18 @@ class GpRecoverSegmentProgram:
 
         segs = []
         segs_in_change_tracking_disabled = []
-        for i in range(len(failedSegments)):
-            if (not self.__options.forceFullResynchronization and
-                peersForFailedSegments[i].getSegmentDbId() in segmentStates and
-                self.check_segment_change_tracking_disabled_state(segmentStates[peersForFailedSegments.getSegmentDbId()])):
+        for index, failedSegment in enumerate(failedSegments):
+            peerForFailedSegment = peersForFailedSegments[index]
 
-                segs_in_change_tracking_disabled.append(peersForFailedSegments.getSegmentDbId())
+            peerForFailedSegmentDbId = peerForFailedSegment.getSegmentDbId()
+            if (not self.__options.forceFullResynchronization and
+                        peerForFailedSegmentDbId in segmentStates and
+                    self.check_segment_change_tracking_disabled_state(segmentStates[peerForFailedSegmentDbId])):
+
+                segs_in_change_tracking_disabled.append(peerForFailedSegmentDbId)
             else:
-                segs.append( GpMirrorToBuild(failedSegments[i], peersForFailedSegments[i], failoverSegments[i], \
-                             self.__options.forceFullResynchronization))
+                segs.append( GpMirrorToBuild(failedSegment, peerForFailedSegment, failoverSegments[index], \
+                                             self.__options.forceFullResynchronization))
 
         self._output_segments_in_change_tracking_disabled(segs_in_change_tracking_disabled)
 
@@ -296,6 +299,7 @@ class GpRecoverSegmentProgram:
     def findAndValidatePeersForFailedSegments(self, gpArray, failedSegments):
         dbIdToPeerMap = gpArray.getDbIdToPeerMap()
         peersForFailedSegments = [ dbIdToPeerMap.get(seg.getSegmentDbId()) for seg in failedSegments]
+
         for i in range(len(failedSegments)):
             peer = peersForFailedSegments[i]
             if peer is None:


### PR DESCRIPTION
* If one or more segments are down and we use gprecoverseg -i input_file (which contains information about the failed segments), gprecoverseg fails with an exception because the code isn't indexing the failed segment list correctly.

* Fix exception in gprecoverseg if the input file is empty.