### PR TITLE
Set the upper bound on FTS Probe GUCs to 3600 seconds

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4116,7 +4116,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_UNIT_S
 		},
 		&gp_fts_probe_timeout,
-		20, 0, INT_MAX, NULL, NULL
+		20, 0, 3600, NULL, NULL
 	},
 
 	{
@@ -4126,7 +4126,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_UNIT_S
 		},
 		&gp_fts_probe_interval,
-		60, 10, INT_MAX, NULL, NULL
+		60, 10, 3600, NULL, NULL
 	},
 
 	{


### PR DESCRIPTION
Using INT_MAX is problematic in the case of gp_fts_probe_timeout since calculations on it can overflow at INT_MAX (as reported by Coverity scanning). Using INT_MAX gp_fts_probe_interval won't overflow with current usage but running the FTS probe every INT_MAX seconds is nonsensical.

 @deepesh1081, @schubert, @Eulerizeit 

@mkiyama if accepted this need a doc update (also note that the current docs are incorrect for the lower bound of gp_fts_probe_timeout which is allowed to be zero). 