### PR TITLE
Fix codegen unittests using DatumCastGenerator

### DIFF
--- a/src/backend/codegen/tests/codegen_framework_unittest.cc
+++ b/src/backend/codegen/tests/codegen_framework_unittest.cc
@@ -242,15 +242,16 @@ class DatumToCppCastGenerator :
  public:
   explicit DatumToCppCastGenerator(
       gpcodegen::CodegenManager* manager,
-      DatumCastTemplateFn regular_func_ptr,
-      DatumCastTemplateFn* ptr_to_regular_func_ptr):
-      BaseCodegen<DatumCastTemplateFn>(manager,
+      DatumCastTemplateFn regular_func_ptr)
+  : BaseCodegen<DatumCastTemplateFn>(manager,
                   kDatumToCppCastFuncNamePrefix,
                   regular_func_ptr,
-                  ptr_to_regular_func_ptr) {
+                  &swappable_function_holder) {
   }
 
   virtual ~DatumToCppCastGenerator() = default;
+
+  DatumCastTemplateFn swappable_function_holder;
 
  protected:
   bool GenerateCodeInternal(gpcodegen::GpCodegenUtils* codegen_utils) final {
@@ -279,15 +280,16 @@ class CppToDatumCastGenerator :
  public:
   explicit CppToDatumCastGenerator(
       gpcodegen::CodegenManager* manager,
-      DatumCastTemplateFn regular_func_ptr,
-      DatumCastTemplateFn* ptr_to_regular_func_ptr):
-      BaseCodegen<DatumCastTemplateFn>(manager,
+      DatumCastTemplateFn regular_func_ptr)
+  : BaseCodegen<DatumCastTemplateFn>(manager,
                   kCppToDatumCastFuncNamePrefix,
                   regular_func_ptr,
-                  ptr_to_regular_func_ptr) {
+                  &swappable_function_holder) {
   }
 
   virtual ~CppToDatumCastGenerator() = default;
+
+  DatumCastTemplateFn swappable_function_holder;
 
  protected:
   bool GenerateCodeInternal(gpcodegen::GpCodegenUtils* codegen_utils) final {
@@ -354,16 +356,18 @@ class CodegenManagerTest : public ::testing::Test {
   void CheckDatumCast(DatumCastFn<Datum, CppType> CppToDatumReg,
                       DatumCastFn<CppType, Datum> DatumToCppReg,
                       const std::vector<CppType>& values) {
-    DatumCastFn<Datum, CppType> CppToDatumCgFn = CppToDatumReg;
     CppToDatumCastGenerator<CppType>* cpp_datum_gen =
         new CppToDatumCastGenerator<CppType>(
-            manager_.get(), CppToDatumReg, &CppToDatumCgFn);
+            manager_.get(), CppToDatumReg);
+    DatumCastFn<Datum, CppType>& CppToDatumCgFn =
+        cpp_datum_gen->swappable_function_holder;
 
 
-    DatumCastFn<CppType, Datum> DatumToCppCgFn = DatumToCppReg;
     DatumToCppCastGenerator<CppType>* datum_cpp_gen =
         new DatumToCppCastGenerator<CppType>(
-            manager_.get(), DatumToCppReg, &DatumToCppCgFn);
+            manager_.get(), DatumToCppReg);
+    DatumCastFn<CppType, Datum>& DatumToCppCgFn =
+        datum_cpp_gen->swappable_function_holder;
 
     ASSERT_TRUE(manager_->EnrollCodeGenerator(
         CodegenFuncLifespan_Parameter_Invariant, cpp_datum_gen));


### PR DESCRIPTION
The lifetime of double pointer passed to BaseCodegen must be strictly
longer than that of the CodegenManager in which it is enrolled. Using
a local variable can thus cause a SIGSEGV.

Signed-off-by: Karthikeyan Jambu Rajaraman <karthi.jrk@gmail.com>

On linux with debug builds of LLVM and clang
```
Test project /workspace/codegen/gpdb/src/backend/codegen
    Start 1: clang_compiler_unittest.t
1/5 Test #1: clang_compiler_unittest.t ..............   Passed    0.21 sec
    Start 2: codegen_utils_unittest.t
2/5 Test #2: codegen_utils_unittest.t ...............   Passed    0.72 sec
    Start 3: instance_method_wrappers_unittest.t
3/5 Test #3: instance_method_wrappers_unittest.t ....   Passed    0.01 sec
    Start 4: codegen_framework_unittest.t
4/5 Test #4: codegen_framework_unittest.t ...........   Passed    0.26 sec
    Start 5: codegen_pg_func_generator_unittest.t
5/5 Test #5: codegen_pg_func_generator_unittest.t ...   Passed    0.04 sec
```