### PR TITLE
Improve codegen stability

### DIFF
--- a/src/backend/codegen/codegen_wrapper.cc
+++ b/src/backend/codegen/codegen_wrapper.cc
@@ -16,6 +16,7 @@
 #include <string>
 #include <type_traits>
 
+#include "codegen/codegen_config.h"
 #include "codegen/base_codegen.h"
 #include "codegen/codegen_manager.h"
 #include "codegen/exec_eval_expr_codegen.h"
@@ -36,9 +37,6 @@ using gpcodegen::AdvanceAggregatesCodegen;
 
 // Current code generator manager that oversees all code generators
 static void* ActiveCodeGeneratorManager = nullptr;
-
-extern bool codegen;  // defined from guc
-extern bool init_codegen;  // defined from guc
 
 // Perform global set-up tasks for code generation. Returns 0 on
 // success, nonzero on error.
@@ -104,51 +102,20 @@ void SetActiveCodeGeneratorManager(void* manager) {
   ActiveCodeGeneratorManager = manager;
 }
 
-/**
- * @brief Template function to facilitate enroll for any type of
- *        codegen
- *
- * @tparam ClassType Type of Code Generator class
- * @tparam FuncType Type of the regular function
- * @tparam Args Variable argument that ClassType will take in its constructor
- *
- * @param regular_func_ptr Regular version of the target function.
- * @param ptr_to_chosen_func_ptr Reference to the function pointer that the caller will call.
- * @param args Variable length argument for ClassType
- *
- * @return Pointer to ClassType
- **/
-template <typename ClassType, typename FuncType, typename ...Args>
-ClassType* CodegenEnroll(FuncType regular_func_ptr,
-                          FuncType* ptr_to_chosen_func_ptr,
-                          Args&&... args) {  // NOLINT(build/c++11)
-  CodegenManager* manager = static_cast<CodegenManager*>(
-        GetActiveCodeGeneratorManager());
-  if (nullptr == manager ||
-      !codegen) {  // if codegen guc is false
-      BaseCodegen<FuncType>::SetToRegular(
-          regular_func_ptr, ptr_to_chosen_func_ptr);
-      return nullptr;
-    }
-
-  ClassType* generator = new ClassType(
-      manager,
-      regular_func_ptr,
-      ptr_to_chosen_func_ptr,
-      std::forward<Args>(args)...);
-    bool is_enrolled = manager->EnrollCodeGenerator(
-        CodegenFuncLifespan_Parameter_Invariant, generator);
-    assert(is_enrolled);
-    return generator;
-}
-
 void* ExecVariableListCodegenEnroll(
     ExecVariableListFn regular_func_ptr,
     ExecVariableListFn* ptr_to_chosen_func_ptr,
     ProjectionInfo* proj_info,
     TupleTableSlot* slot) {
-  ExecVariableListCodegen* generator = CodegenEnroll<ExecVariableListCodegen>(
-      regular_func_ptr, ptr_to_chosen_func_ptr, proj_info, slot);
+  CodegenManager* manager = static_cast<CodegenManager*>(
+      GetActiveCodeGeneratorManager());
+  ExecVariableListCodegen* generator =
+      CodegenManager::CreateAndEnrollGenerator<ExecVariableListCodegen>(
+          manager,
+          regular_func_ptr,
+          ptr_to_chosen_func_ptr,
+          proj_info,
+          slot);
   return generator;
 }
 
@@ -158,12 +125,16 @@ void* ExecEvalExprCodegenEnroll(
     ExprState *exprstate,
     ExprContext *econtext,
     PlanState* plan_state) {
-  ExecEvalExprCodegen* generator = CodegenEnroll<ExecEvalExprCodegen>(
-      regular_func_ptr,
-      ptr_to_chosen_func_ptr,
-      exprstate,
-      econtext,
-      plan_state);
+  CodegenManager* manager = static_cast<CodegenManager*>(
+      GetActiveCodeGeneratorManager());
+  ExecEvalExprCodegen* generator =
+      CodegenManager::CreateAndEnrollGenerator<ExecEvalExprCodegen>(
+          manager,
+          regular_func_ptr,
+          ptr_to_chosen_func_ptr,
+          exprstate,
+          econtext,
+          plan_state);
   return generator;
 }
 
@@ -171,8 +142,14 @@ void* AdvanceAggregatesCodegenEnroll(
     AdvanceAggregatesFn regular_func_ptr,
     AdvanceAggregatesFn* ptr_to_chosen_func_ptr,
     AggState *aggstate) {
-  AdvanceAggregatesCodegen* generator = CodegenEnroll<AdvanceAggregatesCodegen>(
-      regular_func_ptr, ptr_to_chosen_func_ptr, aggstate);
+  CodegenManager* manager = static_cast<CodegenManager*>(
+      GetActiveCodeGeneratorManager());
+  AdvanceAggregatesCodegen* generator =
+      CodegenManager::CreateAndEnrollGenerator<AdvanceAggregatesCodegen>(
+          manager,
+          regular_func_ptr,
+          ptr_to_chosen_func_ptr,
+          aggstate);
   return generator;
 }
 

--- a/src/backend/codegen/exec_eval_expr_codegen.cc
+++ b/src/backend/codegen/exec_eval_expr_codegen.cc
@@ -118,16 +118,17 @@ bool ExecEvalExprCodegen::GenerateExecEvalExpr(
     return false;
   }
 
-  // In case the generation above either failed or was not needed,
+  // If slot_getattr_codegen_ is not set or generation fails
   // we revert to use the external slot_getattr()
-  if (nullptr == slot_getattr_codegen_) {
+  if (nullptr == slot_getattr_codegen_ ||
+      false == slot_getattr_codegen_->GenerateCode(codegen_utils)) {
     gen_info_.llvm_slot_getattr_func =
         codegen_utils->GetOrRegisterExternalFunction(slot_getattr,
                                                      "slot_getattr");
   } else {
-    slot_getattr_codegen_->GenerateCode(codegen_utils);
     gen_info_.llvm_slot_getattr_func =
-      slot_getattr_codegen_->GetGeneratedFunction();
+        slot_getattr_codegen_->GetGeneratedFunction();
+    assert(nullptr != gen_info_.llvm_slot_getattr_func);
   }
 
   llvm::Function* exec_eval_expr_func = CreateFunction<ExecEvalExprFn>(

--- a/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
+++ b/src/backend/codegen/include/codegen/advance_aggregates_codegen.h
@@ -94,7 +94,7 @@ class AdvanceAggregatesCodegen: public BaseCodegen<AdvanceAggregatesFn> {
       gpcodegen::GpCodegenUtils* codegen_utils,
       llvm::Value* llvm_pergroup_arg,
       int aggno,
-      gpcodegen::PGFuncGeneratorInfo& pg_func_info);
+      gpcodegen::PGFuncGeneratorInfo* pg_func_info);
 };
 
 /** @} */

--- a/src/backend/codegen/include/codegen/base_codegen.h
+++ b/src/backend/codegen/include/codegen/base_codegen.h
@@ -19,19 +19,21 @@ extern "C" {
 #include <string>
 #include <vector>
 #include "codegen/utils/gp_codegen_utils.h"
-#include "codegen/codegen_manager.h"
+#include "codegen/codegen_config.h"
 #include "codegen/codegen_interface.h"
 
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Verifier.h"
 
-extern bool codegen_validate_functions;
 
 namespace gpcodegen {
 
 /** \addtogroup gpcodegen
  *  @{
  */
+
+// Forward declaration
+class CodegenManager;
 
 /**
  * @brief Base code generator with common implementation that other

--- a/src/backend/codegen/include/codegen/codegen_config.h
+++ b/src/backend/codegen/include/codegen/codegen_config.h
@@ -1,0 +1,81 @@
+//---------------------------------------------------------------------------
+//  Greenplum Database
+//  Copyright (C) 2016 Pivotal Software, Inc.
+//
+//  @filename:
+//    codegen_config.h
+//
+//  @doc:
+//    Configure Class to handle gucs in gpdb
+//
+//---------------------------------------------------------------------------
+#ifndef GPCODEGEN_CODEGEN_CONFIG_H_  // NOLINT(build/header_guard)
+#define GPCODEGEN_CODEGEN_CONFIG_H_
+
+extern "C" {
+// Variables that are defined in guc
+extern bool init_codegen;
+extern bool codegen;
+extern bool codegen_validate_functions;
+extern bool codegen_exec_variable_list;
+extern bool codegen_slot_getattr;
+extern bool codegen_exec_eval_expr;
+extern bool codegen_advance_aggregate;
+// TODO(shardikar): Retire this GUC after performing experiments to find the
+// tradeoff of codegen-ing slot_getattr() (potentially by measuring the
+// difference in the number of instructions) when one of the first few
+// attributes is varlen.
+extern int codegen_varlen_tolerance;
+}
+
+namespace gpcodegen {
+
+/** \addtogroup gpcodegen
+ *  @{
+ */
+
+// Forward declaration
+class ExecVariableListCodegen;
+class SlotGetAttrCodegen;
+class ExecEvalExprCodegen;
+class AdvanceAggregatesCodegen;
+
+class CodegenConfig {
+ public:
+  /**
+   * @brief Template function to check if generator enabled.
+   *
+   * @tparam ClassType Type of Code Generator class
+   *
+   * @return true if respective generator is enabled with gpdb guc.
+   **/
+  template <class ClassType>
+  inline static bool IsGeneratorEnabled();
+};
+
+template<>
+inline bool CodegenConfig::IsGeneratorEnabled<ExecVariableListCodegen>() {
+  return codegen_exec_variable_list;
+}
+
+template<>
+inline bool CodegenConfig::IsGeneratorEnabled<SlotGetAttrCodegen>() {
+  return codegen_slot_getattr;
+}
+
+template<>
+inline bool CodegenConfig::IsGeneratorEnabled<ExecEvalExprCodegen>() {
+  return codegen_exec_eval_expr;
+}
+
+template<>
+inline bool CodegenConfig::IsGeneratorEnabled<AdvanceAggregatesCodegen>() {
+  return codegen_advance_aggregate;
+}
+
+
+/** @} */
+
+}  // namespace gpcodegen
+
+#endif  // GPCODEGEN_CODEGEN_CONFIG_H_

--- a/src/backend/codegen/include/codegen/codegen_manager.h
+++ b/src/backend/codegen/include/codegen/codegen_manager.h
@@ -18,7 +18,9 @@
 #include <string>
 
 #include "codegen/utils/macros.h"
-#include "codegen/codegen_wrapper.h"
+#include "codegen/codegen_config.h"
+#include "codegen/codegen_interface.h"
+#include "codegen/base_codegen.h"
 
 namespace gpcodegen {
 /** \addtogroup gpcodegen
@@ -45,6 +47,67 @@ class CodegenManager {
   explicit CodegenManager(const std::string& module_name);
 
   ~CodegenManager() = default;
+
+  /**
+   * @brief Template function to facilitate enroll for any type of
+   *        CodegenInterface that CodegenManager wants to keep track of.
+   *
+   * @tparam ClassType Type of Code Generator class that derives from
+   *                   CodegenInterface.
+   * @tparam FuncType Type of the function pointer that CodegenManager swaps.
+   * @tparam Args Variable argument that ClassType will take in its constructor
+   *
+   * @param manager Current Codegen Manager
+   * @param regular_func_ptr Regular version of the target function.
+   * @param ptr_to_chosen_func_ptr Pointer to the function pointer that the
+   *                               caller will call.
+   * @param args Variable length argument for ClassType
+   *
+   * This function creates a new code generator object of type ClassType using
+   * the passed-in args, and enrolls it in the given codegen manager.
+   *
+   * It does not create a generator when codegen or manager is unset, or the
+   * code generator ClassType is disabled (with the appropriate GUC).
+   * It always initializes the given double function pointer
+   * (ptr_to_chosen_func_ptr) to the regular_func_ptr.
+   *
+   * This transfers the ownership of the code generator to the manager.
+   *
+   * @return Pointer to ClassType
+   **/
+  template <typename ClassType, typename FuncType, typename ...Args>
+  static ClassType* CreateAndEnrollGenerator(
+      CodegenManager* manager,
+      FuncType regular_func_ptr,
+      FuncType* ptr_to_chosen_func_ptr,
+      Args&&... args) {  // NOLINT(build/c++11)
+
+	assert(nullptr != regular_func_ptr);
+	assert(nullptr != ptr_to_chosen_func_ptr);
+
+    bool can_enroll =
+        // manager may be NULL if ExecInitNode/ExecProcNode weren't previously
+    	// called. This happens e.g during gpinitsystem.
+        (nullptr != manager) &&
+        codegen &&  // if codegen guc is false
+        // if generator is disabled
+        CodegenConfig::IsGeneratorEnabled<ClassType>();
+    if (!can_enroll) {
+      gpcodegen::BaseCodegen<FuncType>::SetToRegular(
+          regular_func_ptr, ptr_to_chosen_func_ptr);
+      return nullptr;
+    }
+
+    ClassType* generator = new ClassType(
+        manager,
+        regular_func_ptr,
+        ptr_to_chosen_func_ptr,
+        std::forward<Args>(args)...);
+    bool is_enrolled = manager->EnrollCodeGenerator(
+        CodegenFuncLifespan_Parameter_Invariant, generator);
+    assert(is_enrolled);
+    return generator;
+  }
 
   /**
    * @brief Enroll a code generator with manager

--- a/src/backend/codegen/include/codegen/slot_getattr_codegen.h
+++ b/src/backend/codegen/include/codegen/slot_getattr_codegen.h
@@ -104,7 +104,8 @@ class SlotGetAttrCodegen : public BaseCodegen<SlotGetAttrFn> {
   SlotGetAttrCodegen(gpcodegen::CodegenManager* manager,
                      TupleTableSlot* slot,
                      int max_attr)
-  : BaseCodegen(manager, kSlotGetAttrPrefix, slot_getattr, &dummy_func_),
+  : BaseCodegen(
+      manager, kSlotGetAttrPrefix, slot_getattr, &dummy_func_),
     slot_(slot),
     max_attr_(max_attr),
     llvm_function_(nullptr) {

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -445,16 +445,21 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttr(
                          irb->CreateAnd(llvm_attnum,
                                         codegen_utils->GetConstant(0x07))),
                                         codegen_utils->GetType<int8>());
-      // !(Exp_1 & Expr_2)
-      llvm::Value* llvm_att_isnull = irb->CreateNot(
-          irb->CreateTrunc(irb->CreateAnd(llvm_expr_1, llvm_expr_2),
-                           codegen_utils->GetType<bool>()));
+      // (Exp_1 & Expr_2)
+      llvm::Value* llvm_expr1_and_expr2 = irb->CreateICmpNE(
+          irb->CreateAnd(llvm_expr_1, llvm_expr_2),
+          codegen_utils->GetConstant<int8>(0));
+
+      // !(Expr_1 & Expr_2)
+      llvm::Value* llvm_att_isnull = irb->CreateNot(llvm_expr1_and_expr2,
+                                                    "llvm_att_isnull");
       // }}
 
-      llvm::Value* llvm_hasnulls = irb->CreateTrunc(
+      llvm::Value* llvm_hasnulls = irb->CreateICmpNE(
           irb->CreateAnd(llvm_heaptuple_t_data_t_infomask,
                          codegen_utils->GetConstant<uint16>(HEAP_HASNULL)),
-                         codegen_utils->GetType<bool>());
+                         codegen_utils->GetConstant<uint16>(0),
+                         "llvm_hasnulls");
 
       // hasnulls && att_isnull(attnum, bp)
       llvm::Value* llvm_is_null = irb->CreateAnd(

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -577,6 +577,10 @@ bool		optimizer_array_constraints;
 bool		init_codegen;
 bool		codegen;
 bool		codegen_validate_functions;
+bool		codegen_exec_variable_list;
+bool		codegen_slot_getattr;
+bool		codegen_exec_eval_expr;
+bool		codegen_advance_aggregate;
 int		codegen_varlen_tolerance;
 int		codegen_optimization_level;
 static char 	*codegen_optimization_level_str = NULL;
@@ -3335,7 +3339,12 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&codegen,
-		false, assign_codegen, NULL
+#ifdef USE_CODEGEN
+		true,
+#else
+		false,
+#endif
+		assign_codegen, NULL
 	},
 
 	{
@@ -3347,6 +3356,62 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&codegen_validate_functions,
 #if defined(USE_ASSERT_CHECKING) && defined(USE_CODEGEN)
 		true, 	/* true by default on debug builds. */
+#else
+		false,
+#endif
+		assign_codegen, NULL
+	},
+	{
+		{"codegen_exec_variable_list", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable codegen for ExecVariableList"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		&codegen_exec_variable_list,
+#ifdef USE_CODEGEN
+		true,
+#else
+		false,
+#endif
+		assign_codegen, NULL
+	},
+	{
+		{"codegen_slot_getattr", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable codegen for slot_get_attr"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		&codegen_slot_getattr,
+#ifdef USE_CODEGEN
+		true,
+#else
+		false,
+#endif
+		assign_codegen, NULL
+	},
+	{
+		{"codegen_exec_eval_expr", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable codegen for ExecEvalExpr"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		&codegen_exec_eval_expr,
+#ifdef USE_CODEGEN
+		true,
+#else
+		false,
+#endif
+		assign_codegen, NULL
+	},
+	{
+		{"codegen_advance_aggregate", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable codegen for AdvanceAggregate"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		&codegen_advance_aggregate,
+#ifdef USE_CODEGEN
+		true,
 #else
 		false,
 #endif
@@ -4734,7 +4799,12 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&codegen_varlen_tolerance,
-		5, 0, INT_MAX, NULL, NULL
+#ifdef USE_CODEGEN
+		5,
+#else
+		0,
+#endif
+		0, INT_MAX, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -316,40 +316,8 @@ static inline ItemPointer slot_get_ctid(TupleTableSlot *slot)
 	return &(slot->PRIVATE_tts_synthetic_ctid);
 }
 
-/*
- * Get an attribute from the tuple table slot.
- */
-static inline Datum slot_getattr(TupleTableSlot *slot, int attnum, bool *isnull)
-{
-	Assert(!TupIsNull(slot));
-	Assert(attnum <= slot->tts_tupleDescriptor->natts);
-
-	/* System attribute */
-	if(attnum <= 0)
-		return slot_getsysattr(slot, attnum, isnull);
-
-	/* fast path for virtual tuple */
-	if(TupHasVirtualTuple(slot) && slot->PRIVATE_tts_nvalid >= attnum)
-	{
-		*isnull = slot->PRIVATE_tts_isnull[attnum-1];
-		return slot->PRIVATE_tts_values[attnum-1];
-	}
-
-	/* Mem tuple: We do not even populate virtual tuple */
-	if(TupHasMemTuple(slot))
-	{
-		Assert(slot->tts_mt_bind);
-		return memtuple_getattr(slot->PRIVATE_tts_memtuple, slot->tts_mt_bind, attnum, isnull);
-	}
-
-	/* Slow: heap tuple */
-	Assert(TupHasHeapTuple(slot));
-
-	_slot_getsomeattrs(slot, attnum);
-	Assert(TupHasVirtualTuple(slot) && slot->PRIVATE_tts_nvalid >= attnum);
-	*isnull = slot->PRIVATE_tts_isnull[attnum-1];
-	return slot->PRIVATE_tts_values[attnum-1];
-}
+/* in access/common/heaptuple.c */
+extern Datum slot_getattr(TupleTableSlot *slot, int attnum, bool *isnull);
 
 static inline bool slot_attisnull(TupleTableSlot *slot, int attnum)
 {


### PR DESCRIPTION
In this PR, we addressed the following issues that came out as a result of improving the codegen stability.

1. Introduced guc to enable / disable generators. 
```
codegen_exec_variable_list;
codegen_slot_getattr;
codegen_exec_eval_expression;
codegen_advance_aggregate;
```
2. `slot_getattr` is moved to .h with 8.3 merge. This cause issue when we register as external function. LLVM expect the name of the external function to be unique for each pointer. In order to fix it, we introduced wrapper function in codegen_wrapper.cc and use that instead of slot_getattr.

3. In `slot_getattr_codegen`, we found that IR code for logic `!(Expr1 & Expr2)` and `hasnull` is wrong. We fixed in this PR. 

4. We fixed the issue of `slot_getattr` function pointer being null for expression evaluation code generation.

5. Cpplint was red due to a couple of violation in `advance_aggregate`. This has been fixed in this PR.

Existing ICG `join.sql` covers pretty much what we fixed here.

@foyzur @hardikar @armenatzoglou @xinzweb Please take a look when you get a chance.


