### PR TITLE
Fix Persistent Rebuild to use mirrors if mirrors are present.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/persistent_rebuild.py
+++ b/gpMgmt/bin/gppylib/operations/persistent_rebuild.py
@@ -905,7 +905,7 @@ class RebuildTable:
     def __init__(self, dbid_info, has_mirrors=False, batch_size=DEFAULT_BATCH_SIZE, backup_dir=None):
         self.gparray = None
         self.dbid_info = dbid_info
-        self.has_mirrors = False
+        self.has_mirrors = has_mirrors
         self.batch_size = batch_size
         self.backup_dir = backup_dir
         self.pool = None

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_persistent_rebuild.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_persistent_rebuild.py
@@ -961,6 +961,13 @@ class RebuildTableTestCase(unittest.TestCase):
     def setUp(self):
         self.rebuild_table = RebuildTable(dbid_info=None)
 
+    def test_initializer_captures_values(self):
+        self.rebuild_table = RebuildTable(dbid_info="abcd", has_mirrors="efg", batch_size=123, backup_dir=456)
+        self.assertEquals("abcd",self.rebuild_table.dbid_info)
+        self.assertEquals("efg",self.rebuild_table.has_mirrors)
+        self.assertEquals(123,self.rebuild_table.batch_size)
+        self.assertEquals(456,self.rebuild_table.backup_dir)
+
     def test_get_valid_dbids(self):
         content_ids = [1, 2]
         expected = [0, 1]

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gppersistent_rebuild.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gppersistent_rebuild.feature
@@ -14,3 +14,11 @@
     And user returns the data directory to the default location of the killed mirror
     And the user runs command "gprecoverseg -a"
     And gprecoverseg should return a return code of 0
+
+  Scenario: persistent_rebuild on mirrored systems should correctly rebuild persistent tables with mirrors
+    Given the database is running
+    And there is a "ao" table "public.ao_table" in "bkdb" with data
+    And the information of a "mirror" segment on any host is saved
+    Then run gppersistent_rebuild with the saved content id
+    And gppersistent_rebuild should return a return code of 0
+    And verify that mirror_existence_state of segment "0" is "3"

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3977,3 +3977,13 @@ def impl(context, table_name, db_name):
     with dbconn.connect(dbconn.DbURL(dbname=db_name)) as conn:
         dbconn.execSQL(conn, index_qry)
         conn.commit()
+
+@given('verify that mirror_existence_state of segment "{segc_id}" is "{mirror_existence_state}"')
+@when('verify that mirror_existence_state of segment "{segc_id}" is "{mirror_existence_state}"')
+@then('verify that mirror_existence_state of segment "{segc_id}" is "{mirror_existence_state}"')
+def impl(context, segc_id, mirror_existence_state):
+    with dbconn.connect(dbconn.DbURL(dbname='template1')) as conn:
+        sql = """SELECT mirror_existence_state from gp_dist_random('gp_persistent_relation_node') where gp_segment_id=%s group by 1;""" % segc_id
+        cluster_state = dbconn.execSQL(conn, sql).fetchone()
+        if cluster_state[0] != int(mirror_existence_state):
+            raise Exception("mirror_existence_state of segment %s is %s. Expected %s." % (segc_id, cluster_state[0], mirror_existence_state))


### PR DESCRIPTION
Previously the script had a constant false which caused the tool to
rebuild the cluster without mirrors even if mirrors were present.

Authors: Chris Hajas and Larry Hamel