### PR TITLE
Index based memory accounting

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -257,12 +257,10 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 	Assert(queryDesc->estate == NULL);
 	Assert(queryDesc->plannedstmt != NULL);
 
-	if (NULL == queryDesc->memoryAccount)
-	{
-		queryDesc->memoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
-	}
+	Assert(queryDesc->memoryAccountId == MEMORY_OWNER_TYPE_Undefined);
+	queryDesc->memoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_EXECUTOR);
 
-	START_MEMORY_ACCOUNT(queryDesc->memoryAccount);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	Assert(queryDesc->plannedstmt->intoPolicy == NULL
 		   || queryDesc->plannedstmt->intoPolicy->ptype == POLICYTYPE_PARTITIONED);
@@ -830,9 +828,9 @@ ExecutorRun(QueryDesc *queryDesc,
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->memoryAccount);
+	Assert(MEMORY_OWNER_TYPE_Undefined != queryDesc->memoryAccountId);
 
-	START_MEMORY_ACCOUNT(queryDesc->memoryAccount);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	/*
 	 * Set dynamicTableScanInfo to the one in estate, and reset its value at
@@ -1030,9 +1028,9 @@ ExecutorEnd(QueryDesc *queryDesc)
 
 	Assert(estate != NULL);
 
-	Assert(queryDesc->memoryAccount);
+	Assert(MEMORY_OWNER_TYPE_Undefined != queryDesc->memoryAccountId);
 
-	START_MEMORY_ACCOUNT(queryDesc->memoryAccount);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	if (DEBUG1 >= log_min_messages)
 	{
@@ -1192,9 +1190,9 @@ ExecutorRewind(QueryDesc *queryDesc)
 
 	Assert(estate != NULL);
 
-	Assert(NULL != queryDesc->memoryAccount);
+	Assert(MEMORY_OWNER_TYPE_Undefined != queryDesc->memoryAccountId);
 
-	START_MEMORY_ACCOUNT(queryDesc->memoryAccount);
+	START_MEMORY_ACCOUNT(queryDesc->memoryAccountId);
 
 	/* It's probably not sensible to rescan updating queries */
 	Assert(queryDesc->operation == CMD_SELECT);

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -227,7 +227,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 	int origSliceIdInPlan = estate->currentSliceIdInPlan;
 	int origExecutingSliceId = estate->currentExecutingSliceId;
 
-	MemoryAccount* curMemoryAccount = NULL;
+	MemoryAccountIdType curMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
 
 	StringInfo codegenManagerName = makeStringInfo();
 	appendStringInfo(codegenManagerName, "%s-%d-%d", "execProcnode", node->plan_node_id, node->type);
@@ -273,9 +273,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			 * control nodes
 			 */
 		case T_Result:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Result);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Result);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitResult((Result *) node,
 												  estate, eflags);
@@ -284,9 +284,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Append:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Append);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Append);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitAppend((Append *) node,
 												  estate, eflags);
@@ -295,9 +295,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Sequence:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Sequence);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Sequence);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitSequence((Sequence *) node,
 													estate, eflags);
@@ -306,9 +306,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_BitmapAnd:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapAnd);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapAnd);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 
 			result = (PlanState *) ExecInitBitmapAnd((BitmapAnd *) node,
@@ -318,9 +318,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_BitmapOr:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapOr);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapOr);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitBitmapOr((BitmapOr *) node,
 													estate, eflags);
@@ -336,9 +336,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 		case T_AOCSScan:
 		case T_TableScan:
 			/* SeqScan, AppendOnlyScan and AOCSScan are defunct */
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, TableScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, TableScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitTableScan((TableScan *) node,
 													 estate, eflags);
@@ -356,9 +356,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_DynamicTableScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, DynamicTableScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, DynamicTableScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitDynamicTableScan((DynamicTableScan *) node,
 													 estate, eflags);
@@ -367,9 +367,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_ExternalScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, ExternalScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, ExternalScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitExternalScan((ExternalScan *) node,
 														estate, eflags);
@@ -378,9 +378,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_IndexScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, IndexScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, IndexScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitIndexScan((IndexScan *) node,
 													 estate, eflags);
@@ -389,9 +389,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_DynamicIndexScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, DynamicIndexScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, DynamicIndexScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitDynamicIndexScan((DynamicIndexScan *) node,
 													estate, eflags);
@@ -400,9 +400,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_BitmapIndexScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapIndexScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapIndexScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitBitmapIndexScan((BitmapIndexScan *) node,
 														   estate, eflags);
@@ -411,9 +411,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_BitmapHeapScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapHeapScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapHeapScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitBitmapHeapScan((BitmapHeapScan *) node,
 														  estate, eflags);
@@ -422,9 +422,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_BitmapAppendOnlyScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapAppendOnlyScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapAppendOnlyScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitBitmapAppendOnlyScan((BitmapAppendOnlyScan*) node,
 														        estate, eflags);
@@ -433,9 +433,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_BitmapTableScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapTableScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, BitmapTableScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitBitmapTableScan((BitmapTableScan*) node,
 														        estate, eflags);
@@ -444,9 +444,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_TidScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, TidScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, TidScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitTidScan((TidScan *) node,
 												   estate, eflags);
@@ -455,9 +455,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_SubqueryScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, SubqueryScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, SubqueryScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitSubqueryScan((SubqueryScan *) node,
 														estate, eflags);
@@ -466,9 +466,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_FunctionScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, FunctionScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, FunctionScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitFunctionScan((FunctionScan *) node,
 														estate, eflags);
@@ -477,9 +477,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_TableFunctionScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, TableFunctionScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, TableFunctionScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitTableFunction((TableFunctionScan *) node,
 														 estate, eflags);
@@ -488,9 +488,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_ValuesScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, ValuesScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, ValuesScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitValuesScan((ValuesScan *) node,
 													  estate, eflags);
@@ -499,9 +499,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_NestLoop:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, NestLoop);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, NestLoop);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitNestLoop((NestLoop *) node,
 													estate, eflags);
@@ -510,9 +510,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_MergeJoin:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, MergeJoin);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, MergeJoin);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitMergeJoin((MergeJoin *) node,
 													 estate, eflags);
@@ -521,9 +521,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_HashJoin:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, HashJoin);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, HashJoin);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitHashJoin((HashJoin *) node,
 													estate, eflags);
@@ -535,9 +535,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			 * share input nodes
 			 */
 		case T_ShareInputScan:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, ShareInputScan);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, ShareInputScan);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitShareInputScan((ShareInputScan *) node, estate, eflags);
 			}
@@ -548,9 +548,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			 * materialization nodes
 			 */
 		case T_Material:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Material);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Material);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitMaterial((Material *) node,
 													estate, eflags);
@@ -559,9 +559,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Sort:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Sort);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Sort);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitSort((Sort *) node,
 												estate, eflags);
@@ -570,9 +570,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Agg:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Agg);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Agg);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitAgg((Agg *) node,
 											   estate, eflags);
@@ -597,9 +597,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Window:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Window);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Window);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitWindow((Window *) node,
 											   estate, eflags);
@@ -608,9 +608,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Unique:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Unique);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Unique);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitUnique((Unique *) node,
 												  estate, eflags);
@@ -619,9 +619,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Hash:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Hash);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Hash);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitHash((Hash *) node,
 												estate, eflags);
@@ -630,9 +630,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_SetOp:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, SetOp);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, SetOp);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitSetOp((SetOp *) node,
 												 estate, eflags);
@@ -641,9 +641,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Limit:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Limit);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Limit);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitLimit((Limit *) node,
 												 estate, eflags);
@@ -652,9 +652,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Motion:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Motion);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Motion);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitMotion((Motion *) node,
 												  estate, eflags);
@@ -663,9 +663,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			break;
 
 		case T_Repeat:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Repeat);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, Repeat);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitRepeat((Repeat *) node,
 												  estate, eflags);
@@ -673,9 +673,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			END_MEMORY_ACCOUNT();
 			break;
 		case T_DML:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, DML);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, DML);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitDML((DML *) node,
 												  estate, eflags);
@@ -683,9 +683,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			END_MEMORY_ACCOUNT();
 			break;
 		case T_SplitUpdate:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, SplitUpdate);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, SplitUpdate);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitSplitUpdate((SplitUpdate *) node,
 												  estate, eflags);
@@ -693,9 +693,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			END_MEMORY_ACCOUNT();
 			break;
 		case T_AssertOp:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, AssertOp);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, AssertOp);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
  			result = (PlanState *) ExecInitAssertOp((AssertOp *) node,
  												  estate, eflags);
@@ -703,9 +703,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			END_MEMORY_ACCOUNT();
  			break;
 		case T_RowTrigger:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, RowTrigger);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, RowTrigger);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
  			result = (PlanState *) ExecInitRowTrigger((RowTrigger *) node,
  												   estate, eflags);
@@ -713,9 +713,9 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			END_MEMORY_ACCOUNT();
  			break;
 		case T_PartitionSelector:
-			curMemoryAccount = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, PartitionSelector);
+			curMemoryAccountId = CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, node, PartitionSelector);
 
-			START_MEMORY_ACCOUNT(curMemoryAccount);
+			START_MEMORY_ACCOUNT(curMemoryAccountId);
 			{
 			result = (PlanState *) ExecInitPartitionSelector((PartitionSelector *) node,
 															estate, eflags);
@@ -760,7 +760,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 
 	if (result != NULL)
 	{
-		SAVE_EXECUTOR_MEMORY_ACCOUNT(result, curMemoryAccount);
+		SAVE_EXECUTOR_MEMORY_ACCOUNT(result, curMemoryAccountId);
 		result->CodegenManager = CodegenManager;
 		/*
 		 * Generate code only if current node is not alien or
@@ -924,7 +924,7 @@ ExecProcNode(PlanState *node)
 
 	START_CODE_GENERATOR_MANAGER(node->CodegenManager);
 	{
-	START_MEMORY_ACCOUNT(node->memoryAccount);
+	START_MEMORY_ACCOUNT(node->plan->memoryAccountId);
 	{
 
 	CHECK_FOR_INTERRUPTS();
@@ -1184,7 +1184,7 @@ MultiExecProcNode(PlanState *node)
 
 	Assert(NULL != node->plan);
 
-	START_MEMORY_ACCOUNT(node->memoryAccount);
+	START_MEMORY_ACCOUNT(node->plan->memoryAccountId);
 	{
 		PG_TRACE5(execprocnode__enter, Gp_segment, currentSliceId, nodeTag(node), node->plan->plan_node_id, node->plan->plan_parent_node_id);
 

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -280,7 +280,7 @@ ExecHashTableCreate(HashState *hashState, HashJoinState *hjstate, List *hashOper
 	ListCell   *ho;
 	MemoryContext oldcxt;
 
-	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
 	{
 
 	Hash *node = (Hash *) hashState->ps.plan;
@@ -357,7 +357,7 @@ ExecHashTableCreate(HashState *hashState, HashJoinState *hjstate, List *hashOper
 	/*
 	 * Create temporary memory contexts in which to keep the hashtable working
 	 * storage.  See notes in executor/hashjoin.h.
-	 */
+     */
 	hashtable->hashCxt = AllocSetContextCreate(CurrentMemoryContext,
 											   "HashTableContext",
 											   ALLOCSET_DEFAULT_MINSIZE,
@@ -654,7 +654,7 @@ ExecHashTableDestroy(HashState *hashState, HashJoinTable hashtable)
 	Assert(hashtable);
 	Assert(!hashtable->eagerlyReleased);
 	
-	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
 	{
 
 	/*
@@ -924,7 +924,7 @@ ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
 	int			batchno;
 	int			hashTupleSize;
 
-	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
 	{
 	PlanState *ps = &hashState->ps;
 
@@ -1018,7 +1018,7 @@ ExecHashGetHashValue(HashState *hashState, HashJoinTable hashtable,
 	MemoryContext oldContext;
 	bool		result = true;
 
-	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
 	{
 
 	Assert(hashkeys_null);
@@ -1155,7 +1155,7 @@ ExecScanHashBucket(HashState *hashState, HashJoinState *hjstate,
 	HashJoinTuple hashTuple = hjstate->hj_CurTuple;
 	uint32		hashvalue = hjstate->hj_CurHashValue;
 
-	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
 	{
 	/*
 	 * hj_CurTuple is NULL to start scanning a new bucket, or the address of
@@ -1213,7 +1213,7 @@ ExecHashTableReset(HashState *hashState, HashJoinTable hashtable)
 	MemoryContext oldcxt;
 	int			nbuckets = 0;
 
-	START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
+	START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
 	{
 	Assert(hashtable);
 	Assert(!hashtable->eagerlyReleased);
@@ -1266,7 +1266,7 @@ ExecHashTableExplainInit(HashState *hashState, HashJoinState *hjstate,
     MemoryContext   oldcxt;
     int             nbatch = Max(hashtable->nbatch, 1);
 
-    START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
+    START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
     {
     /* Switch to a memory context that survives until ExecutorEnd. */
     oldcxt = MemoryContextSwitchTo(hjstate->js.ps.state->es_query_cxt);
@@ -1554,7 +1554,7 @@ ExecHashTableExplainBatchEnd(HashState *hashState, HashJoinTable hashtable)
     HashJoinBatchData  *batch = NULL;
     int                 i;
     
-    START_MEMORY_ACCOUNT(hashState->ps.memoryAccount);
+    START_MEMORY_ACCOUNT(hashState->ps.plan->memoryAccountId);
     {
     Assert(!hashtable->eagerlyReleased);
     Assert(hashtable->batches);

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4336,7 +4336,7 @@ PostgresMain(int argc, char *argv[],
 	volatile bool send_ready_for_query = true;
 	int topErrLevel;
 
-	MemoryAccount *postgresMainMemoryAccount = NULL;
+	MemoryAccountIdType postgresMainMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
 	
         /*
 	 * CDB: Catch program error signals.
@@ -4367,8 +4367,8 @@ PostgresMain(int argc, char *argv[],
 	 * In that case, we risk switching to a stale memoryAccount that is no
 	 * longer valid. This is because we reset the memory accounts frequently.
 	 */
-	postgresMainMemoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_MainEntry);
-	MemoryAccounting_SwitchAccount(postgresMainMemoryAccount);
+	postgresMainMemoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_MainEntry);
+	MemoryAccounting_SwitchAccount(postgresMainMemoryAccountId);
 
 	set_ps_display("startup", false);
 
@@ -4791,7 +4791,25 @@ PostgresMain(int argc, char *argv[],
 		MemoryContextSwitchTo(MessageContext);
 		MemoryContextResetAndDeleteChildren(MessageContext);
 		VmemTracker_ResetMaxVmemReserved();
-		MemoryAccounting_ResetPeakBalance();
+
+		/* Reset memory accounting */
+
+		/*
+		 * We finished processing the last query and currently we are not under
+		 * any transaction. So reset memory accounting. Note: any memory
+		 * allocated before resetting will go into the rollover memory account,
+		 * allocated under top memory context.
+		 */
+		MemoryAccounting_Reset();
+
+		postgresMainMemoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_MainEntry);
+		/*
+		 * Don't attempt to save previous memory account. This will be invalid by the time we attempt to restore.
+		 * This is why we are not using our START_MEMORY_ACCOUNT and END_MEMORY_ACCOUNT macros
+		 */
+		MemoryAccounting_SwitchAccount(postgresMainMemoryAccountId);
+
+		/* End of memory accounting setup */
 
 		initStringInfo(&input_message);
 
@@ -4882,28 +4900,6 @@ PostgresMain(int argc, char *argv[],
 		IdleTracker_DeactivateProcess();
 		firstchar = ReadCommand(&input_message);
 		IdleTracker_ActivateProcess();
-
-		if (!IsTransactionOrTransactionBlock())
-		{
-			/* Reset memory accounting */
-
-			/*
-			 * We finished processing the last query and currently we are not under
-			 * any transaction. So reset memory accounting. Note: any memory
-			 * allocated before resetting will go into the rollover memory account,
-			 * allocated under top memory context.
-			 */
-			MemoryAccounting_Reset();
-
-			postgresMainMemoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_MainEntry);
-			/*
-			 * Don't attempt to save previous memory account. This will be invalid by the time we attempt to restore.
-			 * This is why we are not using our START_MEMORY_ACCOUNT and END_MEMORY_ACCOUNT macros
-			 */
-			MemoryAccounting_SwitchAccount(postgresMainMemoryAccount);
-
-			/* End of memory accounting setup */
-		}
 
 		/*
 		 * (4) disable async signal conditions again.

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -101,13 +101,13 @@ CreateQueryDesc(PlannedStmt *plannedstmt,
 	qd->tupDesc = NULL;
 	qd->estate = NULL;
 	qd->planstate = NULL;
-	qd->memoryAccount = NULL;
 
 	qd->extended_query = false; /* default value */
 	qd->portal_name = NULL;
 
 	qd->ddesc = NULL;
 	qd->gpmon_pkt = NULL;
+	qd->memoryAccountId = MEMORY_OWNER_TYPE_Undefined;
 	
     if (Gp_role != GP_ROLE_EXECUTE)
 	{

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -442,7 +442,7 @@ MemoryContextError(int errorcode, MemoryContext context,
 		 *
 		 * XXX What is the right way of doing this?
 		 */
-		*(int *) NULL = errorcode;
+		((void(*)()) NULL)();
 	}
 
 	if(errorcode != ERRCODE_OUT_OF_MEMORY && errorcode != ERRCODE_INTERNAL_ERROR)
@@ -605,7 +605,7 @@ static void
 MemoryContext_LogContextStats(uint64 siblingCount, uint64 allAllocated,
 		uint64 allFreed, uint64 curAvailable, const char *contextName)
 {
-	write_stderr("context: %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %s\n", \
+	write_stderr("context: " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", %s\n", \
 	siblingCount, (allAllocated - allFreed), curAvailable, \
 	allAllocated, allFreed, contextName);
 }

--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -20,35 +20,52 @@
 #include "access/xact.h"
 #include "miscadmin.h"
 #include "utils/vmem_tracker.h"
+#include "utils/memaccounting_private.h"
 
 #define MEMORY_REPORT_FILE_NAME_LENGTH 255
+#define SHORT_LIVING_MEMORY_ACCOUNT_ARRAY_INIT_LEN 64
 
-/* Saves serializer context info during walking the memory account tree */
+/* Saves serializer context info during walking the memory account array */
 typedef struct MemoryAccountSerializerCxt
 {
 	/* How many was serialized in the buffer */
 	int memoryAccountCount;
 	/* Where to serialize */
 	StringInfoData *buffer;
-	char *prefix; /* Prefix to add before each line */
+	/* Prefix to add before each line */
+	char *prefix;
 } MemoryAccountSerializerCxt;
 
-/* Saves the deserializer context */
-typedef struct MemoryAccountDeserializerCxt
-{
-	/* total MemoryAccount to deserialize */
-	int memoryAccountCount;
-	/* The raw bytes from where to deserialize */
-	StringInfoData *buffer;
+/*
+ * A tree representation of the memory account array.
+ *
+ * Our existing "rendering" algorithms expect a tree. So, a quick way of
+ * reusing these functions is to convert the array to a tree.
+ */
+typedef struct MemoryAccountTree {
+	MemoryAccount *account;
+	struct MemoryAccountTree *firstChild;
+	struct MemoryAccountTree *nextSibling;
+} MemoryAccountTree;
 
-	/*
-	 * We build MemoryAccount array in-place, reusing the memory of "buffer".
-	 * The root will have a pseudo MemoryAccount (as we don't have a tree, and
-	 * RolloverMemoryAccount, and TopMemoryAccount both are top-level) and everything
-	 * will be direct/indirect children of it.
-	 */
-	MemoryAccount *root; /* Array of MemoryAccount [0...memoryAccountCount-1] */
-} MemoryAccountDeserializerCxt;
+/*
+ * Account Ids monotonically increases as new accounts are created. Many of these
+ * accounts may no longer exist as we drop accounts at the end of each statement.
+ * Therefore, we save a marker Id to indicate the start Id of "live" accounts. These
+ * live accounts are directly related to the currently executing statement.
+ *
+ * Note: only short-living accounts are tested with "liveness". Long living accounts
+ * have fixed Ids that run between MEMORY_OWNER_TYPE_START_LONG_LIVING and
+ * MEMORY_OWNER_TYPE_END_LONG_LIVING and these Ids are smaller than liveAccountStartId
+ * but are still considered live for the duration of a QE, across multiple statements
+ * and transactions.
+ */
+MemoryAccountIdType liveAccountStartId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
+/*
+ * A monotonically increasing counter to get the next Id at the time of creation of
+ * a new short-living account.
+ */
+MemoryAccountIdType nextAccountId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
 
 /*
  ******************************************************
@@ -59,13 +76,13 @@ CheckMemoryAccountingLeak(void);
 
 static void
 InitializeMemoryAccount(MemoryAccount *newAccount, long maxLimit,
-		MemoryOwnerType ownerType, MemoryAccount *parentAccount);
+		MemoryOwnerType ownerType, MemoryAccountIdType parentAccountId);
 
-static MemoryAccount*
+static MemoryAccountIdType
 CreateMemoryAccountImpl(long maxLimit,
-		MemoryOwnerType ownerType, MemoryAccount* parent);
+		MemoryOwnerType ownerType, MemoryAccountIdType parentId);
 
-typedef CdbVisitOpt (*MemoryAccountVisitor)(MemoryAccount *memoryAccount,
+typedef CdbVisitOpt (*MemoryAccountVisitor)(MemoryAccountTree *memoryAccountTreeNode,
 		void *context, const uint32 depth, uint32 parentWalkSerial,
 		uint32 curWalkSerial);
 
@@ -73,66 +90,74 @@ static void
 AdvanceMemoryAccountingGeneration(void);
 
 static void
-HandleMemoryAccountingGenerationOverflow(MemoryContext context);
-
-static void
-HandleMemoryAccountingGenerationOverflowChildren(MemoryContext context);
+MemoryAccounting_ToString(MemoryAccountTree *root, StringInfoData *str, uint32 indentation);
 
 static void
 InitMemoryAccounting(void);
 
+static MemoryAccountTree*
+ConvertMemoryAccountArrayToTree(MemoryAccount** longLiving, MemoryAccount** shortLiving, MemoryAccountIdType shortLivingCount);
+
 static CdbVisitOpt
-MemoryAccountWalkNode(MemoryAccount *memoryAccount,
+MemoryAccountTreeWalkNode(MemoryAccountTree *memoryAccountTreeNode,
 		MemoryAccountVisitor visitor, void *context, uint32 depth,
 		uint32 *totalWalked, uint32 parentWalkSerial);
 
 static CdbVisitOpt
-MemoryAccountWalkKids(MemoryAccount *memoryAccount,
+MemoryAccountTreeWalkKids(MemoryAccountTree *memoryAccountTreeNode,
 		MemoryAccountVisitor visitor, void *context, uint32 depth,
 		uint32 *totalWalked, uint32 parentWalkSerial);
 
 static CdbVisitOpt
-MemoryAccountToString(MemoryAccount *memoryAccount, void *context,
+MemoryAccountToString(MemoryAccountTree *memoryAccount, void *context,
 		uint32 depth, uint32 parentWalkSerial, uint32 curWalkSerial);
 
 static CdbVisitOpt
-SerializeMemoryAccount(MemoryAccount *memoryAccount, void *context,
+MemoryAccountToCSV(MemoryAccountTree *memoryAccount, void *context,
 		uint32 depth, uint32 parentWalkSerial, uint32 curWalkSerial);
 
-static CdbVisitOpt
-MemoryAccountToCSV(MemoryAccount *memoryAccount, void *context,
-		uint32 depth, uint32 parentWalkSerial, uint32 curWalkSerial);
+static void
+PsuedoAccountsToCSV(StringInfoData *str, char *prefix);
 
 static CdbVisitOpt
-MemoryAccountToLog(MemoryAccount *memoryAccount, void *context,
+MemoryAccountToLog(MemoryAccountTree *memoryAccountTreeNode, void *context,
 		uint32 depth, uint32 parentWalkSerial, uint32 curWalkSerial);
 
 static void
 SaveMemoryBufToDisk(struct StringInfoData *memoryBuf, char *prefix);
 
+static const char*
+MemoryAccounting_GetOwnerName(MemoryOwnerType ownerType);
+
+static void
+MemoryAccounting_ResetPeakBalance(void);
+
+static uint64
+MemoryAccounting_GetBalance(MemoryAccount* memoryAccount);
+
 /*****************************************************************************
- * Global memory accounting variables
+ * Global memory accounting variables, some are only visible via memaccounting_private.h
  */
 
 /*
- * This is the root of the memory accounting tree. All other accounts go
- * under this node. We call it "logical root" as no one should ever use it
- * or be aware of it. After creation of "logical root" to hold the root of
- * the tree, we immediately create other "useful" nodes such as "Rollover"
- * and "Top" and switch to "Top". Logical root can only have two children:
- * TopMemoryAccount and RolloverMemoryAccount
- */
-MemoryAccount *MemoryAccountTreeLogicalRoot = NULL;
-
-/* TopMemoryAccount is the father of all memory accounts EXCEPT RolloverMemoryAccount */
-MemoryAccount *TopMemoryAccount = NULL;
-/*
- * ActiveMemoryAccount is used by memory allocator to record the allocation.
+ * ActiveMemoryAccountId is used by memory allocator to record the allocation.
  * However, deallocation uses the allocator information and ignores ActiveMemoryAccount
  */
-MemoryAccount *ActiveMemoryAccount = NULL;
+MemoryAccountIdType ActiveMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
 /* MemoryAccountMemoryAccount saves the memory overhead of memory accounting itself */
 MemoryAccount *MemoryAccountMemoryAccount = NULL;
+
+// Array of accounts available
+MemoryAccountArray* shortLivingMemoryAccountArray = NULL;
+/*
+ * Long living accounts live during the entire lifespan of a QE across all the statements
+ * and have fixed Ids that run between MEMORY_OWNER_TYPE_START_LONG_LIVING
+ * and MEMORY_OWNER_TYPE_END_LONG_LIVING. They are also singleton per-owner. So,
+ * only one account exist per-owner type.
+ *
+ * Note: index 0 is saved for MEMORY_OWNER_TYPE_Undefined
+*/
+MemoryAccount* longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_END_LONG_LIVING + 1] = {NULL};
 
 /*
  * SharedChunkHeadersMemoryAccount is used to track all the allocations
@@ -163,19 +188,6 @@ uint64 MemoryAccountingOutstandingBalance = 0;
  */
 uint64 MemoryAccountingPeakBalance = 0;
 
-/*
- * The generation of current memory accounting tree.
- * Each allocation would save this generation in its
- * header. Later on during deallocation of memory if
- * the account generation of the memory does not match
- * the current generation, then we don't attempt to
- * release accounting for memory chunk's memory account.
- * Instead we release in bulk all the live allocations'
- * accounting into the RollOverMemoryAccount during
- * generation change.
- */
-uint16 MemoryAccountingCurrentGeneration = 0;
-
 /******************************************/
 /********** Public interface **************/
 
@@ -192,7 +204,7 @@ MemoryAccounting_Reset()
 	 * Attempt to reset only if we already have setup memory accounting
 	 * and the memory monitoring is ON
 	 */
-	if (MemoryAccountTreeLogicalRoot)
+	if (MemoryAccounting_IsInitialized())
 	{
 		/* No one should create child context under MemoryAccountMemoryContext */
 		Assert(MemoryAccountMemoryContext->firstchild == NULL);
@@ -200,27 +212,15 @@ MemoryAccounting_Reset()
 		AdvanceMemoryAccountingGeneration();
 		CheckMemoryAccountingLeak();
 
-		TopMemoryAccount = NULL;
-		AlienExecutorMemoryAccount = NULL;
-
 		/* Outstanding balance will come from either the rollover or the shared chunk header account */
 		Assert((RolloverMemoryAccount->allocated - RolloverMemoryAccount->freed) +
-				(SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed) ==
+				(SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed) +
+				(AlienExecutorMemoryAccount->allocated - AlienExecutorMemoryAccount->freed) ==
 				MemoryAccountingOutstandingBalance);
 		MemoryAccounting_ResetPeakBalance();
 	}
 
 	InitMemoryAccounting();
-}
-
-/*
- * MemoryAccounting_ResetPeakBalance
- *		Resets the peak memory account balance by setting it to the current balance.
- */
-void
-MemoryAccounting_ResetPeakBalance()
-{
-	MemoryAccountingPeakBalance = MemoryAccountingOutstandingBalance;
 }
 
 /*
@@ -234,10 +234,24 @@ MemoryAccounting_ResetPeakBalance()
  * 		accounts are hierarchical, so using the tree location we will differentiate
  * 		between owners of same type (e.g., two table scan owners).
  */
-MemoryAccount*
+MemoryAccountIdType
 MemoryAccounting_CreateAccount(long maxLimitInKB, MemoryOwnerType ownerType)
 {
-	return CreateMemoryAccountImpl(maxLimitInKB * 1024, ownerType, ActiveMemoryAccount);
+	MemoryAccountIdType parentId = MEMORY_OWNER_TYPE_Undefined;
+
+	if (MEMORY_OWNER_TYPE_Undefined == ActiveMemoryAccountId)
+	{
+		/*
+		 * If there is no active account, assign logical root as the parent.
+		 * This means the logical root will have itself as parent.
+		 */
+		parentId = MEMORY_OWNER_TYPE_LogicalRoot;
+	}
+	else
+	{
+		parentId = ActiveMemoryAccountId;
+	}
+	return CreateMemoryAccountImpl(maxLimitInKB * 1024, ownerType, parentId);
 }
 
 /*
@@ -248,28 +262,62 @@ MemoryAccounting_CreateAccount(long maxLimitInKB, MemoryOwnerType ownerType)
  *
  * desiredAccount: The account to switch to.
  */
-MemoryAccount*
-MemoryAccounting_SwitchAccount(MemoryAccount* desiredAccount)
+MemoryAccountIdType
+MemoryAccounting_SwitchAccount(MemoryAccountIdType desiredAccountId)
 {
-	/* If memory monitoring is not enabled, we only allow switching to internal accounts */
-	Assert(desiredAccount != NULL);
+	/*
+	 * We cannot validate the actual account pointer as there is no guarantee
+	 * that we will have live accounts all the time. We will dynamically
+	 * switch to Rollover for dead accounts. But, for now, we at least
+	 * assert that the passed accountId was "ever" created.
+	 *
+	 * Note: this assumes no overflow in the nextAccountId. For now, we don't have
+	 * overflow. But, in the future if we implement overflow for our 64 bit id
+	 * counter, we will need to get rid of this Assert or be more smart about it
+	 */
+	Assert(desiredAccountId < nextAccountId);
+	MemoryAccountIdType oldAccountId = ActiveMemoryAccountId;
 
-	MemoryAccount* oldAccount = ActiveMemoryAccount;
-
-	ActiveMemoryAccount = desiredAccount;
-	return oldAccount;
+	ActiveMemoryAccountId = desiredAccountId;
+	return oldAccountId;
 }
 
 /*
- * MemoryAccounting_GetPeak
- *		Returns peak memory
+ * MemoryAccounting_SizeOfAccountInBytes
+ *		Returns the number of bytes needed to hold a memory account.
  *
- * memoryAccount: The concerned account.
+ *		This method is useful to "outside" world to allocate appropriate buffer to
+ *		hold a memory account without having access to MemoryAccount struct.
+ */
+size_t
+MemoryAccounting_SizeOfAccountInBytes()
+{
+	return sizeof(MemoryAccount);
+}
+
+/*
+ * MemoryAccounting_GetAccountPeakBalance
+ *		Returns peak memory usage of an owner
+ *
+ * memoryAccountId: The concerned account.
  */
 uint64
-MemoryAccounting_GetPeak(MemoryAccount * memoryAccount)
+MemoryAccounting_GetAccountPeakBalance(MemoryAccountIdType memoryAccountId)
 {
-	return memoryAccount->peak;
+	return MemoryAccounting_ConvertIdToAccount(memoryAccountId)->peak;
+}
+
+/*
+ * MemoryAccounting_GetAccountCurrentBalance
+ *		Returns current memory usage of an owner
+ *
+ * memoryAccountId: The concerned account.
+ */
+uint64
+MemoryAccounting_GetAccountCurrentBalance(MemoryAccountIdType memoryAccountId)
+{
+	MemoryAccount *account = MemoryAccounting_ConvertIdToAccount(memoryAccountId);
+	return account->allocated - account->freed;
 }
 
 /*
@@ -279,39 +327,623 @@ MemoryAccounting_GetPeak(MemoryAccount * memoryAccount)
  * memoryAccount: The concerned account.
  */
 uint64
-MemoryAccounting_GetBalance(MemoryAccount * memoryAccount)
+MemoryAccounting_GetBalance(MemoryAccount* memoryAccount)
 {
-	return memoryAccount->allocated -
-			memoryAccount->freed;
+	return memoryAccount->allocated - memoryAccount->freed;
 }
 
 /*
- * MemoryAccounting_GetAccountName
- *		Converts MemoryAccount enum values to a descriptive string for reporting
- *		purpose.
- *
- *		We use a trick to save some coding. We currently set executor node's
- *		memory accounting enum values to the same one as their plan node's
- *		enum values. That way we can just pass the plan node's enum values in
- *		the CreateMemoryAccount() call.
- *
- * memoryAccount: The account whose name will be generated
+ * MemoryAccounting_GetGlobalPeak
+ *		Returns global peak balance across all accounts
  */
-const char*
-MemoryAccounting_GetAccountName(MemoryAccount *memoryAccount)
+uint64
+MemoryAccounting_GetGlobalPeak()
 {
-	switch (memoryAccount->ownerType)
+	return MemoryAccountingPeakBalance;
+}
+
+/*
+ * MemoryAccounting_Serialize
+ * 		Serializes the current memory accounting tree into the "buffer"
+ */
+uint32
+MemoryAccounting_Serialize(StringInfoData *buffer)
+{
+	START_MEMORY_ACCOUNT(MEMORY_OWNER_TYPE_MemAccount);
 	{
+		/* Ignore undefined account */
+		for (MemoryAccountIdType longIdx = MEMORY_OWNER_TYPE_LogicalRoot; longIdx <= MEMORY_OWNER_TYPE_END_LONG_LIVING; longIdx++)
+		{
+			MemoryAccount *longLivingAccount = MemoryAccounting_ConvertIdToAccount(longIdx);
+			appendBinaryStringInfo(buffer, longLivingAccount, sizeof(MemoryAccount));
+		}
+
+		for (int i = 0; i < shortLivingMemoryAccountArray->accountCount; i++)
+		{
+			MemoryAccount* shortLivingAccount = shortLivingMemoryAccountArray->allAccounts[i];
+			appendBinaryStringInfo(buffer, shortLivingAccount, sizeof(MemoryAccount));
+		}
+	}
+	END_MEMORY_ACCOUNT();
+	return MEMORY_OWNER_TYPE_END_LONG_LIVING + shortLivingMemoryAccountArray->accountCount;
+}
+
+/*
+ * MemoryAccounting_PrettyPrint
+ *    Prints (using elog-WARNING) the current memory accounting tree. Useful debugging
+ *    tool from inside gdb.
+ */
+void
+MemoryAccounting_PrettyPrint()
+{
+	StringInfoData memBuf;
+	initStringInfo(&memBuf);
+
+	MemoryAccountTree *tree = ConvertMemoryAccountArrayToTree(&longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Undefined],
+			shortLivingMemoryAccountArray->allAccounts, shortLivingMemoryAccountArray->accountCount);
+
+	MemoryAccounting_ToString(&tree[MEMORY_OWNER_TYPE_LogicalRoot], &memBuf, 0);
+
+	elog(WARNING, "%s\n", memBuf.data);
+
+	pfree(memBuf.data);
+}
+
+/*
+ * MemoryAccounting_CombinedAccountArrayToString
+ *    Converts a unified array of long and short living accounts to string.
+ */
+void
+MemoryAccounting_CombinedAccountArrayToString(void *accountArrayBytes,
+		MemoryAccountIdType accountCount, StringInfoData *str, uint32 indentation)
+{
+	MemoryAccount *combinedArray = (MemoryAccount *) accountArrayBytes;
+	/* 1 extra account pointer to reserve for undefined account */
+	MemoryAccount **combinedArrayOfPointers = palloc(sizeof(MemoryAccount *) * (accountCount + 1));
+	combinedArrayOfPointers[MEMORY_OWNER_TYPE_Undefined] = NULL;
+
+	for (MemoryAccountIdType idx = 0; idx < accountCount; idx++)
+	{
+		combinedArrayOfPointers[idx + 1] = &combinedArray[idx];
+	}
+	MemoryAccountTree *tree = ConvertMemoryAccountArrayToTree(&combinedArrayOfPointers[MEMORY_OWNER_TYPE_Undefined],
+			&combinedArrayOfPointers[MEMORY_OWNER_TYPE_START_SHORT_LIVING], accountCount - MEMORY_OWNER_TYPE_END_LONG_LIVING);
+
+	MemoryAccounting_ToString(&tree[MEMORY_OWNER_TYPE_LogicalRoot], str, indentation);
+
+	pfree(tree);
+	pfree(combinedArrayOfPointers);
+}
+
+/*
+ * MemoryAccounting_SaveToFile
+ *		Saves the current memory accounting tree into a CSV file
+ *
+ * currentSliceId: The currently executing slice ID
+ */
+void
+MemoryAccounting_SaveToFile(int currentSliceId)
+{
+	StringInfoData prefix;
+	StringInfoData memBuf;
+	initStringInfo(&prefix);
+	initStringInfo(&memBuf);
+
+	/* run_id, dataset_id, query_id, scale_factor, gp_session_id, current_statement_timestamp, slice_id, segment_idx, */
+	appendStringInfo(&prefix, "%s,%s,%s,%u,%u,%d," UINT64_FORMAT ",%d,%d",
+		memory_profiler_run_id, memory_profiler_dataset_id, memory_profiler_query_id,
+		memory_profiler_dataset_size, statement_mem, gp_session_id, GetCurrentStatementStartTimestamp(),
+		currentSliceId, GpIdentity.segindex);
+
+	MemoryAccountTree *tree = ConvertMemoryAccountArrayToTree(&longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Undefined],
+			shortLivingMemoryAccountArray->allAccounts, shortLivingMemoryAccountArray->accountCount);
+	PsuedoAccountsToCSV(&memBuf, prefix.data);
+
+	MemoryAccountSerializerCxt cxt;
+	cxt.buffer = &memBuf;
+	cxt.memoryAccountCount = 0;
+	cxt.prefix = prefix.data;
+
+	uint32 totalWalked = 0;
+
+	MemoryAccountTreeWalkNode(&tree[MEMORY_OWNER_TYPE_LogicalRoot], MemoryAccountToCSV, &cxt, 0, &totalWalked, totalWalked);
+	SaveMemoryBufToDisk(&memBuf, prefix.data);
+
+	pfree(prefix.data);
+	pfree(memBuf.data);
+	pfree(tree);
+}
+
+/*
+ * MemoryAccounting_SaveToLog
+ *		Saves the current memory accounting tree in the log.
+ *
+ * Returns the number of memory accounts written to log.
+ */
+uint32
+MemoryAccounting_SaveToLog()
+{
+	MemoryAccountSerializerCxt cxt;
+	cxt.buffer = NULL;
+	cxt.memoryAccountCount = 0;
+	cxt.prefix = NULL;
+
+	uint32 totalWalked = 0;
+
+	int64 vmem_reserved = VmemTracker_GetMaxReservedVmemBytes();
+
+	/* Write the header for the subsequent lines of memory usage information */
+    write_stderr("memory: account_name, child_id, parent_id, quota, peak, allocated, freed, current\n");
+
+    write_stderr("memory: %s, %u, %u, " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT "\n", "Vmem",
+    		totalWalked /* Child walk serial */, totalWalked /* Parent walk serial */,
+			(int64) 0 /* Quota */, vmem_reserved /* Peak */, vmem_reserved /* Allocated */, (int64) 0 /* Freed */, vmem_reserved /* Current */);
+
+    write_stderr("memory: %s, %u, %u, " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT "\n", "Peak",
+    		totalWalked /* Child walk serial */, totalWalked /* Parent walk serial */,
+			(int64) 0 /* Quota */, MemoryAccountingPeakBalance /* Peak */, MemoryAccountingPeakBalance /* Allocated */, (int64) 0 /* Freed */, MemoryAccountingPeakBalance /* Current */);
+
+	MemoryAccountTree *tree = ConvertMemoryAccountArrayToTree(&longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Undefined],
+			shortLivingMemoryAccountArray->allAccounts, shortLivingMemoryAccountArray->accountCount);
+
+	MemoryAccountTreeWalkNode(&tree[MEMORY_OWNER_TYPE_LogicalRoot], MemoryAccountToLog, &cxt, 0, &totalWalked, totalWalked);
+
+	pfree(tree);
+	return totalWalked;
+}
+
+/*****************************************************************************
+ *	  PRIVATE ROUTINES FOR MEMORY ACCOUNTING								 *
+ *****************************************************************************/
+
+/* Initializes all the long living accounts */
+static void
+InitLongLivingAccounts() {
+	/*
+	 * All the long living accounts are created together, so if logical root
+	 * is null, then other long-living accounts should be the null too
+	 */
+	Assert(SharedChunkHeadersMemoryAccount == NULL && RolloverMemoryAccount == NULL && MemoryAccountMemoryAccount == NULL && AlienExecutorMemoryAccount == NULL);
+	Assert(MemoryAccountMemoryContext == NULL);
+	/* Ensure we are in TopMemoryContext as we are creating long living accounts that don't die */
+	Assert(CurrentMemoryContext == TopMemoryContext);
+	for (int longLivingIdx = MEMORY_OWNER_TYPE_LogicalRoot;
+			longLivingIdx <= MEMORY_OWNER_TYPE_END_LONG_LIVING;
+			longLivingIdx++)
+	{
+		/* For long living account */
+		MemoryAccountIdType newAccountId = MemoryAccounting_CreateAccount(0, longLivingIdx);
+		Assert(longLivingIdx == newAccountId);
+	}
+	/* Now set all the global memory accounts */
+	SharedChunkHeadersMemoryAccount =
+			longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_SharedChunkHeader];
+	RolloverMemoryAccount =
+			longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Rollover];
+	MemoryAccountMemoryAccount =
+			longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_MemAccount];
+	AlienExecutorMemoryAccount =
+			longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Exec_AlienShared];
+}
+
+/* Initializes all the short living accounts */
+static void
+InitShortLivingMemoryAccounts()
+{
+	Assert(NULL == shortLivingMemoryAccountArray);
+	Assert(NULL != MemoryAccountMemoryContext && MemoryAccountMemoryAccount != NULL);
+
+	MemoryContext oldContext = MemoryContextSwitchTo(MemoryAccountMemoryContext);
+	MemoryAccountIdType oldAccountId = MemoryAccounting_SwitchAccount((MemoryAccountIdType)MEMORY_OWNER_TYPE_MemAccount);
+
+	shortLivingMemoryAccountArray = palloc0(sizeof(MemoryAccountArray));
+	shortLivingMemoryAccountArray->accountCount = 0;
+	shortLivingMemoryAccountArray->allAccounts = (MemoryAccount**) palloc0(SHORT_LIVING_MEMORY_ACCOUNT_ARRAY_INIT_LEN * sizeof(MemoryAccount*));
+	shortLivingMemoryAccountArray->arraySize = SHORT_LIVING_MEMORY_ACCOUNT_ARRAY_INIT_LEN;
+
+	MemoryAccounting_SwitchAccount(oldAccountId);
+	MemoryContextSwitchTo(oldContext);
+}
+
+/* Add a long living account to the longLivingMemoryAccountArray */
+static void
+AddToLongLivingAccountArray(MemoryAccount *newAccount)
+{
+	Assert(newAccount->id <= MEMORY_OWNER_TYPE_END_LONG_LIVING);
+	Assert(NULL == longLivingMemoryAccountArray[newAccount->id]);
+	longLivingMemoryAccountArray[newAccount->id] = newAccount;
+}
+
+/* Add a short living account to the shortLivingMemoryAccountArray */
+static void
+AddToShortLivingAccountArray(MemoryAccount *newAccount)
+{
+	Assert(shortLivingMemoryAccountArray->accountCount == newAccount->id - liveAccountStartId);
+	MemoryAccountIdType arraySize = shortLivingMemoryAccountArray->arraySize;
+	MemoryAccountIdType needAtleast = shortLivingMemoryAccountArray->accountCount + 1;
+
+	/* If we need more entries in the array, resize the array */
+	if (arraySize < needAtleast)
+	{
+		MemoryAccountIdType newArraySize = arraySize * 2;
+		shortLivingMemoryAccountArray->allAccounts = repalloc(shortLivingMemoryAccountArray->allAccounts,
+				sizeof(MemoryAccount*) * newArraySize);
+		shortLivingMemoryAccountArray->arraySize = newArraySize;
+
+		memset(&shortLivingMemoryAccountArray->allAccounts[shortLivingMemoryAccountArray->accountCount], 0,
+			(shortLivingMemoryAccountArray->arraySize - shortLivingMemoryAccountArray->accountCount) * sizeof(MemoryAccount*));
+	}
+
+	Assert(shortLivingMemoryAccountArray->arraySize > shortLivingMemoryAccountArray->accountCount);
+	Assert(NULL == shortLivingMemoryAccountArray->allAccounts[shortLivingMemoryAccountArray->accountCount]);
+	shortLivingMemoryAccountArray->allAccounts[shortLivingMemoryAccountArray->accountCount++] = newAccount;
+}
+
+/*
+ * InitializeMemoryAccount
+ *		Initialize the common data structures of a newly created memory account
+ *
+ * newAccount: the account to initialize
+ * maxLimit: quota of the account (0 means no quota)
+ * ownerType: the memory owner type for this account
+ * parentAccount: the parent account of this account
+ */
+static void
+InitializeMemoryAccount(MemoryAccount *newAccount, long maxLimit, MemoryOwnerType ownerType, MemoryAccountIdType parentAccountId)
+{
+	Assert(ownerType != MEMORY_OWNER_TYPE_Undefined && ownerType < MEMORY_OWNER_TYPE_EXECUTOR_END);
+
+	newAccount->ownerType = ownerType;
+
+	/*
+	 * Maximum targeted allocation for an owner. Peak usage can be
+	 * tracked to check if the allocation is overshooting
+	 */
+    newAccount->maxLimit = maxLimit;
+
+	newAccount->allocated = 0;
+	newAccount->freed = 0;
+	newAccount->peak = 0;
+    newAccount->parentId = parentAccountId;
+
+	if (ownerType <= MEMORY_OWNER_TYPE_END_LONG_LIVING)
+	{
+		newAccount->id = ownerType;
+		AddToLongLivingAccountArray(newAccount);
+	}
+	else
+	{
+		newAccount->id = nextAccountId++;
+		AddToShortLivingAccountArray(newAccount);
+	}
+}
+
+/*
+ * CreateMemoryAccountImpl
+ *		Allocates and initializes a memory account.
+ *
+ * maxLimit: The quota information of this account
+ * ownerType: Gross owner type (e.g., different executor nodes). The memory
+ * 		accounts are hierarchical, so using the tree location we will differentiate
+ * 		between owners of same gross type (e.g., two sequential scan owners).
+ * parent: The parent account of this account.
+ */
+static MemoryAccountIdType
+CreateMemoryAccountImpl(long maxLimit, MemoryOwnerType ownerType, MemoryAccountIdType parentId)
+{
+	Assert(liveAccountStartId > MEMORY_OWNER_TYPE_END_LONG_LIVING);
+
+	/* We don't touch the oldContext. We create all MemoryAccount in MemoryAccountMemoryContext */
+    MemoryContext oldContext = NULL;
+	MemoryAccount* newAccount = NULL; /* Return value */
+	/* Used for switching temporarily to MemoryAccountMemoryAccount ownership to account for the instrumentation overhead */
+	MemoryAccountIdType oldAccountId = MEMORY_OWNER_TYPE_Undefined;
+
+	/*
+	 * Rollover is a special MemoryAccount that resides at the
+	 * TopMemoryContext, and not under MemoryAccountMemoryContext
+	 */
+    Assert(ownerType == MEMORY_OWNER_TYPE_LogicalRoot || ownerType == MEMORY_OWNER_TYPE_SharedChunkHeader ||
+    		ownerType == MEMORY_OWNER_TYPE_Rollover || ownerType == MEMORY_OWNER_TYPE_MemAccount ||
+			ownerType == MEMORY_OWNER_TYPE_Exec_AlienShared ||
+    		(MemoryAccountMemoryContext != NULL && MemoryAccountMemoryAccount != NULL));
+
+    if (ownerType <= MEMORY_OWNER_TYPE_END_LONG_LIVING || ownerType == MEMORY_OWNER_TYPE_Top)
+    {
+    	/* Set the "logical root" as the parent of all long living accounts */
+    	parentId = MEMORY_OWNER_TYPE_LogicalRoot;
+    }
+
+    /*
+     * Other than logical root and AlienShared, no long-living account should have children
+     * and only logical root is allowed to have no parent
+     */
+    Assert((parentId == MEMORY_OWNER_TYPE_LogicalRoot || parentId == MEMORY_OWNER_TYPE_Exec_AlienShared
+    		|| parentId > MEMORY_OWNER_TYPE_END_LONG_LIVING));
+
+    /*
+     * Only SharedChunkHeadersMemoryAccount, Rollover, MemoryAccountMemoryAccount,
+     * AlienExecutorAccount and Top can be under "logical root"
+     */
+    AssertImply(parentId == MEMORY_OWNER_TYPE_LogicalRoot, ownerType <= MEMORY_OWNER_TYPE_END_LONG_LIVING ||
+    		ownerType == MEMORY_OWNER_TYPE_Top);
+
+    /* Long-living accounts need TopMemoryContext */
+    if (ownerType <= MEMORY_OWNER_TYPE_END_LONG_LIVING)
+    {
+    	oldContext = MemoryContextSwitchTo(TopMemoryContext);
+    }
+    else
+    {
+    	oldContext = MemoryContextSwitchTo(MemoryAccountMemoryContext);
+    	oldAccountId = MemoryAccounting_SwitchAccount((MemoryAccountIdType)MEMORY_OWNER_TYPE_MemAccount);
+    }
+
+	newAccount = makeNode(MemoryAccount);
+	InitializeMemoryAccount(newAccount, maxLimit, ownerType, parentId);
+
+	if (oldAccountId != MEMORY_OWNER_TYPE_Undefined)
+	{
+		MemoryAccounting_SwitchAccount(oldAccountId);
+	}
+
+    MemoryContextSwitchTo(oldContext);
+
+    return newAccount->id;
+}
+
+/*
+ * CheckMemoryAccountingLeak
+ *		Checks for leaks (i.e., memory accounts with balance) after everything
+ *		is reset.
+ */
+static void
+CheckMemoryAccountingLeak()
+{
+	/* Just an API. Not yet implemented. */
+}
+
+/*
+ * Returns a combined array index where the long and short living accounts are together.
+ * The first MEMORY_OWNER_TYPE_END_LONG_LIVING number of indices are reserved for long
+ * living accounts and short living accounts follow after that.
+ */
+static MemoryAccountIdType
+ConvertIdToUniversalArrayIndex(MemoryAccountIdType id, MemoryAccountIdType liveStartId,
+		MemoryAccountIdType shortLivingCount)
+{
+	if (id >= MEMORY_OWNER_TYPE_LogicalRoot && id <= MEMORY_OWNER_TYPE_END_LONG_LIVING)
+	{
+		return id;
+	}
+	else if (id >= liveStartId && id < liveStartId + shortLivingCount)
+	{
+		return id - liveStartId + MEMORY_OWNER_TYPE_END_LONG_LIVING + 1;
+	}
+	else
+	{
+		/* Note, we cannot map ID to rollover here as we expect a live account id */
+		elog(ERROR, "Cannot map id to array index");
+	}
+
+	/* Keep the compiler happy */
+	return MEMORY_OWNER_TYPE_Undefined;
+}
+
+static void
+AddChild(MemoryAccountTree *treeArray, MemoryAccount *childAccount, MemoryAccount* parentAccount,
+		MemoryAccountIdType liveStartId, MemoryAccountIdType shortLivingCount)
+{
+	MemoryAccountIdType childId = childAccount->id;
+	MemoryAccountIdType parentId = parentAccount->id;
+
+	Assert(parentId != MEMORY_OWNER_TYPE_Undefined && childId != MEMORY_OWNER_TYPE_Undefined);
+	AssertImply(childId == MEMORY_OWNER_TYPE_LogicalRoot, parentId == MEMORY_OWNER_TYPE_LogicalRoot);
+
+	MemoryAccountIdType childArrayIndex = ConvertIdToUniversalArrayIndex(childId, liveStartId, shortLivingCount);
+	MemoryAccountTree *childNode = &treeArray[childArrayIndex];
+	childNode->account = childAccount;
+
+	if (childId != MEMORY_OWNER_TYPE_LogicalRoot)
+	{
+		MemoryAccountIdType parentArrayIndex = ConvertIdToUniversalArrayIndex(parentId, liveStartId, shortLivingCount);
+
+		Assert(parentId == MEMORY_OWNER_TYPE_Undefined || childId == MEMORY_OWNER_TYPE_LogicalRoot ||
+				treeArray[parentArrayIndex].account != NULL);
+
+		MemoryAccountTree *parentNode = &treeArray[parentArrayIndex];
+		childNode->nextSibling = parentNode->firstChild;
+		parentNode->firstChild = childNode;
+	}
+}
+
+static MemoryAccountTree*
+ConvertMemoryAccountArrayToTree(MemoryAccount** longLiving, MemoryAccount** shortLiving, MemoryAccountIdType shortLivingCount)
+{
+	MemoryAccountTree *treeArray = palloc0(sizeof(MemoryAccountTree) *
+			(shortLivingCount + MEMORY_OWNER_TYPE_END_LONG_LIVING + 1));
+
+	/* Ignore "undefined" account in the tree */
+	for (MemoryAccountIdType longLivingArrayIdx = MEMORY_OWNER_TYPE_LogicalRoot;
+			longLivingArrayIdx <= MEMORY_OWNER_TYPE_END_LONG_LIVING; longLivingArrayIdx++)
+	{
+		MemoryAccount *longLivingAccount = longLiving[longLivingArrayIdx];
+		Assert(longLivingAccount->parentId <= MEMORY_OWNER_TYPE_END_LONG_LIVING);
+		MemoryAccount *parentAccount = longLiving[longLivingAccount->parentId];
+
+		/* Long living accounts don't care about liveStartId and shortLivingCount */
+		AddChild(treeArray, longLivingAccount, parentAccount, 0 /* liveStartId */, 0 /* shortLivingCount */);
+	}
+
+	if (shortLivingCount > 0)
+	{
+		Assert(NULL != shortLiving);
+		MemoryAccountIdType liveStartId = shortLiving[0]->id;
+		/* Ensure that the range of IDs for short living accounts are dense */
+		Assert(shortLiving[shortLivingCount - 1]->id == liveStartId + shortLivingCount - 1);
+
+		for (MemoryAccountIdType shortLivingArrayIdx = 0; shortLivingArrayIdx < shortLivingCount; shortLivingArrayIdx++)
+		{
+			MemoryAccount* shortLivingAccount = shortLiving[shortLivingArrayIdx];
+			MemoryAccount* parentAccount = NULL;
+			if (shortLivingAccount->parentId <= MEMORY_OWNER_TYPE_END_LONG_LIVING)
+			{
+				parentAccount = longLiving[shortLivingAccount->parentId];
+			}
+			else
+			{
+				parentAccount = shortLiving[shortLivingAccount->parentId - liveStartId];
+			}
+
+			Assert(NULL != parentAccount);
+			AddChild(treeArray, shortLivingAccount, parentAccount, liveStartId, shortLivingCount);
+		}
+	}
+
+	/* The children adding process shouldn't touch the reserved undefined account tree node */
+	Assert(treeArray[MEMORY_OWNER_TYPE_Undefined].account == NULL);
+	return treeArray;
+}
+
+/**
+ * MemoryAccountWalkNode:
+ * 		Walks one node of the MemoryAccount tree, and calls MemoryAccountWalkKids
+ * 		to walk children recursively (given the walk is sanctioned by the current node).
+ * 		For each walk it calls the provided function to do some "processing"
+ *
+ * memoryAccount: The current memory account to walk
+ * visitor: The function pointer that is interested to process this node
+ * context: context information to pass between successive "walker" call
+ * depth: The depth in the tree for current node
+ * totalWalked: An in/out parameter that will reflect how many nodes are walked
+ * 		so far. Useful to generate node serial ("walk serial") automatically
+ * parentWalkSerial: parent node's "walk serial".
+ *
+ * NB: totalWalked and parentWalkSerial can be used to generate a pointer
+ * agnostic representation of the tree.
+ */
+static CdbVisitOpt
+MemoryAccountTreeWalkNode(MemoryAccountTree *memoryAccountTreeNode, MemoryAccountVisitor visitor,
+			        void *context, uint32 depth, uint32 *totalWalked, uint32 parentWalkSerial)
+{
+    CdbVisitOpt     whatnext;
+
+    if (memoryAccountTreeNode == NULL)
+    {
+        whatnext = CdbVisit_Walk;
+    }
+    else
+    {
+    	uint32 curWalkSerial = *totalWalked;
+        whatnext = visitor(memoryAccountTreeNode, context, depth, parentWalkSerial, *totalWalked);
+        *totalWalked = *totalWalked + 1;
+
+        if (whatnext == CdbVisit_Walk)
+        {
+            whatnext = MemoryAccountTreeWalkKids(memoryAccountTreeNode, visitor, context, depth + 1, totalWalked, curWalkSerial);
+        }
+        else if (whatnext == CdbVisit_Skip)
+        {
+            whatnext = CdbVisit_Walk;
+        }
+    }
+    Assert(whatnext != CdbVisit_Skip);
+    return whatnext;
+}
+
+/**
+ * MemoryAccountWalkKids:
+ * 		Called from MemoryAccountWalkNode to recursively walk the children
+ *
+ * memoryAccount: The parent memory account whose children to walk
+ * visitor: The function pointer that is interested to process these nodes
+ * context: context information to pass between successive "walker" call
+ * depth: The depth in the tree for current node
+ * totalWalked: An in/out parameter that will reflect how many nodes are walked
+ * 		so far. Useful to generate node serial ("walk serial") automatically
+ * parentWalkSerial: parent node's "walk serial".
+ *
+ * NB: totalWalked and parentWalkSerial can be used to generate a pointer
+ * agnostic representation of the tree.
+ */
+static CdbVisitOpt
+MemoryAccountTreeWalkKids(MemoryAccountTree *memoryAccountTreeNode,
+			        MemoryAccountVisitor visitor,
+			        void           *context, uint32 depth, uint32 *totalWalked, uint32 parentWalkSerial)
+{
+    if (memoryAccountTreeNode == NULL)
+        return CdbVisit_Walk;
+
+    /* Traverse children accounts */
+    for (MemoryAccountTree *child = memoryAccountTreeNode->firstChild; child != NULL; child = child->nextSibling)
+    {
+    	MemoryAccountTreeWalkNode(child, visitor, context, depth, totalWalked, parentWalkSerial);
+    }
+
+    return CdbVisit_Walk;
+}
+
+/**
+ * MemoryAccountToString:
+ * 		A visitor function that can convert a memory account to string.
+ * 		Called repeatedly from the walker to convert the entire tree to string
+ * 		through MemoryAccountTreeToString.
+ *
+ * memoryAccount: The memory account which will be represented as string
+ * context: context information to pass between successive function call
+ * depth: The depth in the tree for current node. Used to generate indentation.
+ * parentWalkSerial: parent node's "walk serial". Not used right now. Part
+ * 		of the uniform "walker" function prototype
+ * curWalkSerial: current node's "walk serial". Not used right now. Part
+ * 		of the uniform "walker" function prototype
+ */
+static CdbVisitOpt
+MemoryAccountToString(MemoryAccountTree *memoryAccountTreeNode, void *context, uint32 depth,
+		uint32 parentWalkSerial, uint32 curWalkSerial)
+{
+	if (memoryAccountTreeNode == NULL) return CdbVisit_Walk;
+
+	MemoryAccount *memoryAccount = memoryAccountTreeNode->account;
+
+	MemoryAccountSerializerCxt *memAccountCxt = (MemoryAccountSerializerCxt*) context;
+
+    appendStringInfoFill(memAccountCxt->buffer, 2 * depth, ' ');
+
+    Assert(memoryAccount->peak >= MemoryAccounting_GetBalance(memoryAccount));
+    /* We print only integer valued memory consumption, in standard GPDB KB unit */
+    appendStringInfo(memAccountCxt->buffer, "%s: Peak/Cur " UINT64_FORMAT "/" UINT64_FORMAT "bytes. Quota: " UINT64_FORMAT "bytes.\n",
+    	MemoryAccounting_GetOwnerName(memoryAccount->ownerType),
+		memoryAccount->peak, MemoryAccounting_GetBalance(memoryAccount), memoryAccount->maxLimit);
+
+    memAccountCxt->memoryAccountCount++;
+
+    return CdbVisit_Walk;
+}
+
+/*
+ * MemoryAccounting_GetOwnerName
+ *		Returns the human readable name of an owner
+ */
+static const char*
+MemoryAccounting_GetOwnerName(MemoryOwnerType ownerType)
+{
+	switch (ownerType)
+	{
+		/* Long living accounts */
 		case MEMORY_OWNER_TYPE_LogicalRoot:
 			return "Root";
-		case MEMORY_OWNER_TYPE_Rollover:
-			return "Rollover";
 		case MEMORY_OWNER_TYPE_SharedChunkHeader:
 			return "SharedHeader";
-		case MEMORY_OWNER_TYPE_Top:
-			return "Top";
+		case MEMORY_OWNER_TYPE_Rollover:
+			return "Rollover";
 		case MEMORY_OWNER_TYPE_MemAccount:
 			return "MemAcc";
+		case MEMORY_OWNER_TYPE_Exec_AlienShared:
+			return "X_Alien";
+
+		/* Short living accounts */
+		case MEMORY_OWNER_TYPE_Top:
+			return "Top";
 		case MEMORY_OWNER_TYPE_MainEntry:
 			return "Main";
 		case MEMORY_OWNER_TYPE_Parser:
@@ -336,7 +968,7 @@ MemoryAccounting_GetAccountName(MemoryAccount *memoryAccount)
 		case MEMORY_OWNER_TYPE_Exec_Sequence:
 			return "X_Sequence";
 		case MEMORY_OWNER_TYPE_Exec_BitmapAnd:
-			return "X_Bitmap";
+			return "X_BitmapAnd";
 		case MEMORY_OWNER_TYPE_Exec_BitmapOr:
 			return "X_BitmapOr";
 		case MEMORY_OWNER_TYPE_Exec_SeqScan:
@@ -407,8 +1039,6 @@ MemoryAccounting_GetAccountName(MemoryAccount *memoryAccount)
 			return "X_RowTrigger";
 		case MEMORY_OWNER_TYPE_Exec_AssertOp:
 			return "X_AssertOp";
-		case MEMORY_OWNER_TYPE_Exec_AlienShared:
-			return "X_Alien";
 		case MEMORY_OWNER_TYPE_Exec_BitmapTableScan:
 			return "X_BitmapTableScan";
 		case MEMORY_OWNER_TYPE_Exec_PartitionSelector:
@@ -419,474 +1049,6 @@ MemoryAccounting_GetAccountName(MemoryAccount *memoryAccount)
 	}
 
 	return "Error";
-}
-
-/*
- * MemoryAccounting_Serialize
- * 		Serializes the current memory accounting tree into the "buffer"
- */
-uint32
-MemoryAccounting_Serialize(StringInfoData *buffer)
-{
-	MemoryAccountSerializerCxt cxt;
-	cxt.buffer = buffer;
-	cxt.prefix = NULL;
-
-	cxt.memoryAccountCount = 0;
-	uint32 totalWalked = 0;
-	MemoryAccountWalkNode(MemoryAccountTreeLogicalRoot, SerializeMemoryAccount, &cxt, 0, &totalWalked, totalWalked);
-
-	return totalWalked;
-}
-/*
- * MemoryAccounting_Deserialize:
- * 		Constructs the MemoryAccountTree in-place. NB: the function does not allocate
- * 		any new memory. Instead it assumes a binary set of bits that originally
- * 		represented the memory accounting tree. It updates the "serialized bits" to
- * 		correctly restores the original pointers that represents the tree.
- * 		Only the "logical root" is allocated in this function in the current memory context.
- * 		If the serialized bits have shorter life span than expected, it is callers
- * 		responsibility to correctly memcpy into the longer living context as appropriate.
- *
- * serializedBits: The array of bits that represents the serialized bits of the
- * 		memory accounting tree
- *
- * memoryAccountCount: Number of memory account node to expect in the serializedBits
- */
-SerializedMemoryAccount*
-MemoryAccounting_Deserialize(const void *serializedBits, uint32 memoryAccountCount)
-{
-    /*
-     * Array pointers to different memory accounts in the buffer for indexing to expedite
-     * tree construction
-     */
-    SerializedMemoryAccount **allAccounts = (SerializedMemoryAccount**)palloc0(memoryAccountCount * sizeof(SerializedMemoryAccount*));
-    MemoryAccount **lastSeenChildren = (MemoryAccount**)palloc0(memoryAccountCount * sizeof(MemoryAccount*));
-
-    SerializedMemoryAccount *memoryAccounts = (SerializedMemoryAccount*)serializedBits;
-    for (int memAccSerial = 0; memAccSerial < memoryAccountCount; memAccSerial++)
-    {
-    	SerializedMemoryAccount *curMemoryAccount = &memoryAccounts[memAccSerial];
-    	Assert(MemoryAccountIsValid(&curMemoryAccount->memoryAccount));
-
-    	curMemoryAccount->memoryAccount.firstChild = NULL;
-    	curMemoryAccount->memoryAccount.nextSibling = NULL;
-
-    	allAccounts[curMemoryAccount->memoryAccountSerial] = curMemoryAccount;
-
-    	if (curMemoryAccount->memoryAccountSerial == curMemoryAccount->parentMemoryAccountSerial)
-    	{
-			/* Only "logical root" can be parent less */
-			Assert(curMemoryAccount->memoryAccountSerial == 0);
-
-			/* We don't need to adjust parent and sibling pointers */
-			continue;
-    	}
-
-    	SerializedMemoryAccount *parentMemoryAccount = allAccounts[curMemoryAccount->parentMemoryAccountSerial];
-        	Assert(MemoryAccountIsValid(&parentMemoryAccount->memoryAccount));
-
-        MemoryAccount *lastSeenChild = lastSeenChildren[curMemoryAccount->parentMemoryAccountSerial];
-
-        if (!lastSeenChild)
-        {
-    		parentMemoryAccount->memoryAccount.firstChild = &(curMemoryAccount->memoryAccount);
-        }
-        else
-        {
-    		lastSeenChild->nextSibling = &curMemoryAccount->memoryAccount;
-        }
-
-		lastSeenChildren[curMemoryAccount->parentMemoryAccountSerial] = &(curMemoryAccount->memoryAccount);
-		curMemoryAccount->memoryAccount.parentAccount = &(parentMemoryAccount->memoryAccount);
-    }
-
-    pfree(allAccounts);
-    pfree(lastSeenChildren);
-
-    return memoryAccounts;
-}
-
-/*
- * MemoryAccounting_ToString
- *		Converts a memory account tree rooted at "root" to string using tree
- *		walker and repeated calls of MemoryAccountToString
- *
- * root: The root of the tree (used recursively)
- * str: The output buffer
- * indentation: The indentation of the root
- */
-void
-MemoryAccounting_ToString(MemoryAccount *root, StringInfoData *str, uint32 indentation)
-{
-	MemoryAccountSerializerCxt cxt;
-	cxt.buffer = str;
-	cxt.memoryAccountCount = 0;
-	cxt.prefix = NULL;
-
-	uint32 totalWalked = 0;
-	MemoryAccountWalkNode(root, MemoryAccountToString, &cxt, 0 + indentation, &totalWalked, totalWalked);
-}
-
-/*
- * MemoryAccounting_ToCSV
- *		Converts a memory account tree rooted at "root" to string using tree
- *		walker and repeated calls of MemoryAccountToCSV
- *
- * root: The root of the tree (used recursively)
- * str: The output buffer
- * prefix: A common prefix for each csv line
- */
-void
-MemoryAccounting_ToCSV(MemoryAccount *root, StringInfoData *str, char *prefix)
-{
-	MemoryAccountSerializerCxt cxt;
-	cxt.buffer = str;
-	cxt.memoryAccountCount = 0;
-	cxt.prefix = prefix;
-
-	uint32 totalWalked = 0;
-
-	int64 vmem_reserved = VmemTracker_GetMaxReservedVmemBytes();
-
-	/*
-	 * Add vmem reserved as reported by memprot. We report the vmem reserved in the
-	 * "allocated" and "peak" fields. We set the freed to 0.
-	 */
-	appendStringInfo(str, "%s,%d,%u,%u,%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "\n",
-			prefix, MEMORY_STAT_TYPE_VMEM_RESERVED,
-			totalWalked /* Child walk serial */, totalWalked /* Parent walk serial */,
-			(int64) 0 /* Quota */, vmem_reserved /* Peak */, vmem_reserved /* Allocated */, (int64) 0 /* Freed */);
-
-	/*
-	 * Add peak memory observed from inside memory accounting among all allocations.
-	 */
-	appendStringInfo(str, "%s,%d,%u,%u,%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "\n",
-			prefix, MEMORY_STAT_TYPE_MEMORY_ACCOUNTING_PEAK,
-			totalWalked /* Child walk serial */, totalWalked /* Parent walk serial */,
-			(int64) 0 /* Quota */, MemoryAccountingPeakBalance /* Peak */,
-			MemoryAccountingPeakBalance /* Allocated */, (int64) 0 /* Freed */);
-
-	MemoryAccountWalkNode(root, MemoryAccountToCSV, &cxt, 0, &totalWalked, totalWalked);
-}
-
-/*
- * MemoryAccounting_PrettyPrint
- *    Prints (using elog-WARNING) the current memory accounting tree. Useful debugging
- *    tool from inside gdb.
- */
-void
-MemoryAccounting_PrettyPrint()
-{
-	StringInfoData memBuf;
-	initStringInfo(&memBuf);
-
-	MemoryAccounting_ToString(MemoryAccountTreeLogicalRoot, &memBuf, 0);
-
-	elog(WARNING, "%s\n", memBuf.data);
-
-	pfree(memBuf.data);
-}
-
-/*
- * MemoryAccounting_SaveToFile
- *		Saves the current memory accounting tree into a CSV file
- *
- * currentSliceId: The currently executing slice ID
- */
-void
-MemoryAccounting_SaveToFile(int currentSliceId)
-{
-	StringInfoData prefix;
-	StringInfoData memBuf;
-	initStringInfo(&prefix);
-	initStringInfo(&memBuf);
-
-	/* run_id, dataset_id, query_id, scale_factor, gp_session_id, current_statement_timestamp, slice_id, segment_idx, */
-	appendStringInfo(&prefix, "%s,%s,%s,%u,%u,%d,%" PRIu64 ",%d,%d",
-		memory_profiler_run_id, memory_profiler_dataset_id, memory_profiler_query_id,
-		memory_profiler_dataset_size, statement_mem, gp_session_id, GetCurrentStatementStartTimestamp(),
-		currentSliceId, GpIdentity.segindex);
-	MemoryAccounting_ToCSV(MemoryAccountTreeLogicalRoot, &memBuf, prefix.data);
-	SaveMemoryBufToDisk(&memBuf, prefix.data);
-
-	pfree(prefix.data);
-	pfree(memBuf.data);
-}
-
-/*
- * MemoryAccounting_SaveToLog
- *		Saves the current memory accounting tree in the log.
- *
- * Returns the number of memory accounts written to log.
- */
-uint32
-MemoryAccounting_SaveToLog()
-{
-	MemoryAccountSerializerCxt cxt;
-	cxt.buffer = NULL;
-	cxt.memoryAccountCount = 0;
-	cxt.prefix = NULL;
-
-	uint32 totalWalked = 0;
-
-	int64 vmem_reserved = VmemTracker_GetMaxReservedVmemBytes();
-
-	/* Write the header for the subsequent lines of memory usage information */
-    write_stderr("memory: account_name, child_id, parent_id, quota, peak, allocated, freed, current\n");
-
-    write_stderr("memory: %s, %u, %u, %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n", "Vmem",
-    		totalWalked /* Child walk serial */, totalWalked /* Parent walk serial */,
-			(int64) 0 /* Quota */, vmem_reserved /* Peak */, vmem_reserved /* Allocated */, (int64) 0 /* Freed */, vmem_reserved /* Current */);
-
-    write_stderr("memory: %s, %u, %u, %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n", "Peak",
-    		totalWalked /* Child walk serial */, totalWalked /* Parent walk serial */,
-			(int64) 0 /* Quota */, MemoryAccountingPeakBalance /* Peak */, MemoryAccountingPeakBalance /* Allocated */, (int64) 0 /* Freed */, MemoryAccountingPeakBalance /* Current */);
-
-	MemoryAccountWalkNode(MemoryAccountTreeLogicalRoot, MemoryAccountToLog, &cxt, 0, &totalWalked, totalWalked);
-
-	return totalWalked;
-}
-
-/*****************************************************************************
- *	  PRIVATE ROUTINES FOR MEMORY ACCOUNTING								 *
- *****************************************************************************/
-
-/*
- * InitializeMemoryAccount
- *		Initialize the common data structures of a newly created memory account
- *
- * newAccount: the account to initialize
- * maxLimit: quota of the account (0 means no quota)
- * ownerType: the memory owner type for this account
- * parentAccount: the parent account of this account
- */
-static void
-InitializeMemoryAccount(MemoryAccount *newAccount, long maxLimit, MemoryOwnerType ownerType, MemoryAccount *parentAccount)
-{
-	newAccount->ownerType = ownerType;
-
-	/*
-	 * Maximum targeted allocation for an owner. Peak usage can be
-	 * tracked to check if the allocation is overshooting
-	 */
-    newAccount->maxLimit = maxLimit;
-
-	newAccount->allocated = 0;
-	newAccount->freed = 0;
-	newAccount->peak = 0;
-
-    newAccount->parentAccount = parentAccount;
-
-	/* We don't include sub-accounts in the main memory accounting tree */
-    if (parentAccount != NULL)
-    {
-		newAccount->nextSibling = parentAccount->firstChild;
-		parentAccount->firstChild = newAccount;
-    }
-}
-
-/*
- * CreateMemoryAccountImpl
- *		Allocates and initializes a memory account.
- *
- * maxLimit: The quota information of this account
- * ownerType: Gross owner type (e.g., different executor nodes). The memory
- * 		accounts are hierarchical, so using the tree location we will differentiate
- * 		between owners of same gross type (e.g., two sequential scan owners).
- * parent: The parent account of this account.
- */
-static MemoryAccount*
-CreateMemoryAccountImpl(long maxLimit, MemoryOwnerType ownerType, MemoryAccount* parent)
-{
-	/* We don't touch the oldContext. We create all MemoryAccount in MemoryAccountMemoryContext */
-    MemoryContext oldContext = NULL;
-	MemoryAccount* newAccount = NULL; /* Return value */
-	/* Used for switching temporarily to MemoryAccountMemoryAccount ownership to account for the instrumentation overhead */
-	MemoryAccount *oldAccount = NULL;
-
-	/*
-	 * Rollover is a special MemoryAccount that resides at the
-	 * TopMemoryContext, and not under MemoryAccountMemoryContext
-	 */
-    Assert(ownerType == MEMORY_OWNER_TYPE_LogicalRoot || ownerType == MEMORY_OWNER_TYPE_SharedChunkHeader ||
-    		ownerType == MEMORY_OWNER_TYPE_Rollover || ownerType == MEMORY_OWNER_TYPE_MemAccount ||
-    		(MemoryAccountMemoryContext != NULL && MemoryAccountMemoryAccount != NULL));
-
-    if (ownerType == MEMORY_OWNER_TYPE_SharedChunkHeader || ownerType == MEMORY_OWNER_TYPE_Rollover || ownerType == MEMORY_OWNER_TYPE_MemAccount || ownerType == MEMORY_OWNER_TYPE_Top)
-    {
-    	/* Set the "logical root" as the parent of two top account */
-    	parent = MemoryAccountTreeLogicalRoot;
-    }
-
-    /*
-     * Other than logical root, no long-living account should have children
-     * and only logical root is allowed to have no parent
-     */
-    Assert((parent == NULL && ownerType == MEMORY_OWNER_TYPE_LogicalRoot) ||
-    		(parent != RolloverMemoryAccount && parent != SharedChunkHeadersMemoryAccount &&
-    		parent != MemoryAccountMemoryAccount));
-
-    /*
-     * Only SharedChunkHeadersMemoryAccount, Rollover, MemoryAccountMemoryAccount
-     * and Top can be under "logical root"
-     */
-    Assert(parent != MemoryAccountTreeLogicalRoot ||
-    		ownerType == MEMORY_OWNER_TYPE_LogicalRoot ||
-    		ownerType == MEMORY_OWNER_TYPE_SharedChunkHeader ||
-    		ownerType == MEMORY_OWNER_TYPE_Rollover ||
-    		ownerType == MEMORY_OWNER_TYPE_MemAccount ||
-    		ownerType == MEMORY_OWNER_TYPE_Top);
-
-    /* Long-living accounts need TopMemoryContext */
-    if (ownerType == MEMORY_OWNER_TYPE_LogicalRoot ||
-    		ownerType == MEMORY_OWNER_TYPE_SharedChunkHeader ||
-    		ownerType == MEMORY_OWNER_TYPE_Rollover ||
-    		ownerType == MEMORY_OWNER_TYPE_MemAccount)
-    {
-    	oldContext = MemoryContextSwitchTo(TopMemoryContext);
-    }
-    else
-    {
-    	oldContext = MemoryContextSwitchTo(MemoryAccountMemoryContext);
-        oldAccount = MemoryAccounting_SwitchAccount(MemoryAccountMemoryAccount);
-    }
-
-	newAccount = makeNode(MemoryAccount);
-	InitializeMemoryAccount(newAccount, maxLimit, ownerType, parent);
-
-	if (oldAccount != NULL)
-	{
-		MemoryAccounting_SwitchAccount(oldAccount);
-	}
-
-    MemoryContextSwitchTo(oldContext);
-
-    return newAccount;
-}
-
-
-/*
- * CheckMemoryAccountingLeak
- *		Checks for leaks (i.e., memory accounts with balance) after everything
- *		is reset.
- */
-static void
-CheckMemoryAccountingLeak()
-{
-	/* Just an API. Not yet implemented. */
-}
-
-/**
- * MemoryAccountWalkNode:
- * 		Walks one node of the MemoryAccount tree, and calls MemoryAccountWalkKids
- * 		to walk children recursively (given the walk is sanctioned by the current node).
- * 		For each walk it calls the provided function to do some "processing"
- *
- * memoryAccount: The current memory account to walk
- * visitor: The function pointer that is interested to process this node
- * context: context information to pass between successive "walker" call
- * depth: The depth in the tree for current node
- * totalWalked: An in/out parameter that will reflect how many nodes are walked
- * 		so far. Useful to generate node serial ("walk serial") automatically
- * parentWalkSerial: parent node's "walk serial".
- *
- * NB: totalWalked and parentWalkSerial can be used to generate a pointer
- * agnostic representation of the tree.
- */
-static CdbVisitOpt
-MemoryAccountWalkNode(MemoryAccount *memoryAccount, MemoryAccountVisitor visitor,
-			        void *context, uint32 depth, uint32 *totalWalked, uint32 parentWalkSerial)
-{
-    CdbVisitOpt     whatnext;
-
-    if (memoryAccount == NULL)
-    {
-        whatnext = CdbVisit_Walk;
-    }
-    else
-    {
-    	uint32 curWalkSerial = *totalWalked;
-        whatnext = visitor(memoryAccount, context, depth, parentWalkSerial, *totalWalked);
-        *totalWalked = *totalWalked + 1;
-
-        if (whatnext == CdbVisit_Walk)
-        {
-            whatnext = MemoryAccountWalkKids(memoryAccount, visitor, context, depth + 1, totalWalked, curWalkSerial);
-        }
-        else if (whatnext == CdbVisit_Skip)
-        {
-            whatnext = CdbVisit_Walk;
-        }
-    }
-    Assert(whatnext != CdbVisit_Skip);
-    return whatnext;
-}
-
-/**
- * MemoryAccountWalkKids:
- * 		Called from MemoryAccountWalkNode to recursively walk the children
- *
- * memoryAccount: The parent memory account whose children to walk
- * visitor: The function pointer that is interested to process these nodes
- * context: context information to pass between successive "walker" call
- * depth: The depth in the tree for current node
- * totalWalked: An in/out parameter that will reflect how many nodes are walked
- * 		so far. Useful to generate node serial ("walk serial") automatically
- * parentWalkSerial: parent node's "walk serial".
- *
- * NB: totalWalked and parentWalkSerial can be used to generate a pointer
- * agnostic representation of the tree.
- */
-static CdbVisitOpt
-MemoryAccountWalkKids(MemoryAccount      *memoryAccount,
-			        MemoryAccountVisitor visitor,
-			        void           *context, uint32 depth, uint32 *totalWalked, uint32 parentWalkSerial)
-{
-    if (memoryAccount == NULL)
-        return CdbVisit_Walk;
-
-    /* Traverse children accounts */
-    for (MemoryAccount *child = memoryAccount->firstChild; child != NULL; child = child->nextSibling)
-    {
-    	MemoryAccountWalkNode(child, visitor, context, depth, totalWalked, parentWalkSerial);
-    }
-
-    return CdbVisit_Walk;
-}
-
-/**
- * MemoryAccountToString:
- * 		A visitor function that can convert a memory account to string.
- * 		Called repeatedly from the walker to convert the entire tree to string
- * 		through MemoryAccountTreeToString.
- *
- * memoryAccount: The memory account which will be represented as string
- * context: context information to pass between successive function call
- * depth: The depth in the tree for current node. Used to generate indentation.
- * parentWalkSerial: parent node's "walk serial". Not used right now. Part
- * 		of the uniform "walker" function prototype
- * curWalkSerial: current node's "walk serial". Not used right now. Part
- * 		of the uniform "walker" function prototype
- */
-static CdbVisitOpt
-MemoryAccountToString(MemoryAccount *memoryAccount, void *context, uint32 depth,
-		uint32 parentWalkSerial, uint32 curWalkSerial)
-{
-	if (memoryAccount == NULL) return CdbVisit_Walk;
-
-	MemoryAccountSerializerCxt *memAccountCxt = (MemoryAccountSerializerCxt*) context;
-
-    appendStringInfoFill(memAccountCxt->buffer, 2 * depth, ' ');
-
-    /* We print only integer valued memory consumption, in standard GPDB KB unit */
-    appendStringInfo(memAccountCxt->buffer, "%s: Peak %" PRIu64 "K bytes. Quota: %" PRIu64 "K bytes.\n",
-		MemoryAccounting_GetAccountName(memoryAccount),
-		memoryAccount->peak / 1024, memoryAccount->maxLimit / 1024);
-
-    memAccountCxt->memoryAccountCount++;
-
-    return CdbVisit_Walk;
 }
 
 /**
@@ -902,16 +1064,18 @@ MemoryAccountToString(MemoryAccount *memoryAccount, void *context, uint32 depth,
  * curWalkSerial: current node's "walk serial"
  */
 static CdbVisitOpt
-MemoryAccountToCSV(MemoryAccount *memoryAccount, void *context, uint32 depth, uint32 parentWalkSerial, uint32 curWalkSerial)
+MemoryAccountToCSV(MemoryAccountTree *memoryAccountTreeNode, void *context, uint32 depth, uint32 parentWalkSerial, uint32 curWalkSerial)
 {
-	if (memoryAccount == NULL) return CdbVisit_Walk;
+	if (memoryAccountTreeNode == NULL) return CdbVisit_Walk;
+
+	MemoryAccount *memoryAccount = memoryAccountTreeNode->account;
 
 	MemoryAccountSerializerCxt *memAccountCxt = (MemoryAccountSerializerCxt*) context;
 
 	/*
 	 * PREFIX, ownerType, curWalkSerial, parentWalkSerial, maxLimit, peak, allocated, freed
 	 */
-	appendStringInfo(memAccountCxt->buffer, "%s,%u,%u,%u,%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "\n",
+	appendStringInfo(memAccountCxt->buffer, "%s,%u,%u,%u," UINT64_FORMAT "," UINT64_FORMAT "," UINT64_FORMAT "," UINT64_FORMAT "\n",
 			memAccountCxt->prefix, memoryAccount->ownerType,
 			curWalkSerial, parentWalkSerial,
 			memoryAccount->maxLimit,
@@ -923,6 +1087,38 @@ MemoryAccountToCSV(MemoryAccount *memoryAccount, void *context, uint32 depth, ui
     memAccountCxt->memoryAccountCount++;
 
     return CdbVisit_Walk;
+}
+
+/*
+ * PsuedoAccountsToCSV
+ *		Formats pseudo accounts such as vmem reserved and overall peak to CSV
+ *
+ * root: The root of the tree (used recursively)
+ * str: The output buffer
+ * prefix: A common prefix for each csv line
+ */
+static void
+PsuedoAccountsToCSV(StringInfoData *str, char *prefix)
+{
+	int64 vmem_reserved = VmemTracker_GetMaxReservedVmemBytes();
+
+	/*
+	 * Add vmem reserved as reported by memprot. We report the vmem reserved in the
+	 * "allocated" and "peak" fields. We set the freed to 0.
+	 */
+	appendStringInfo(str, "%s,%d,%u,%u," UINT64_FORMAT "," UINT64_FORMAT "," UINT64_FORMAT "," UINT64_FORMAT "\n",
+			prefix, MEMORY_STAT_TYPE_VMEM_RESERVED,
+			0 /* Child walk serial */, 0 /* Parent walk serial */,
+			(int64) 0 /* Quota */, vmem_reserved /* Peak */, vmem_reserved /* Allocated */, (int64) 0 /* Freed */);
+
+	/*
+	 * Add peak memory observed from inside memory accounting among all allocations.
+	 */
+	appendStringInfo(str, "%s,%d,%u,%u," UINT64_FORMAT "," UINT64_FORMAT "," UINT64_FORMAT "," UINT64_FORMAT "\n",
+			prefix, MEMORY_STAT_TYPE_MEMORY_ACCOUNTING_PEAK,
+			0 /* Child walk serial */, 0 /* Parent walk serial */,
+			(int64) 0 /* Quota */, MemoryAccountingPeakBalance /* Peak */,
+			MemoryAccountingPeakBalance /* Allocated */, (int64) 0 /* Freed */);
 }
 
 /**
@@ -938,55 +1134,44 @@ MemoryAccountToCSV(MemoryAccount *memoryAccount, void *context, uint32 depth, ui
  * curWalkSerial: current node's "walk serial"
  */
 static CdbVisitOpt
-MemoryAccountToLog(MemoryAccount *memoryAccount, void *context, uint32 depth, uint32 parentWalkSerial, uint32 curWalkSerial)
+MemoryAccountToLog(MemoryAccountTree *memoryAccountTreeNode, void *context, uint32 depth, uint32 parentWalkSerial, uint32 curWalkSerial)
 {
-	if (memoryAccount == NULL) return CdbVisit_Walk;
+	if (memoryAccountTreeNode == NULL) return CdbVisit_Walk;
 
 	MemoryAccountSerializerCxt *memAccountCxt = (MemoryAccountSerializerCxt*) context;
 
-    write_stderr("memory: %s, %u, %u, %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n", MemoryAccounting_GetAccountName(memoryAccount),
+	MemoryAccount *memoryAccount = memoryAccountTreeNode->account;
+
+    write_stderr("memory: %s, %u, %u, " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT ", " UINT64_FORMAT "\n", MemoryAccounting_GetOwnerName(memoryAccount->ownerType),
     		curWalkSerial /* Child walk serial */, parentWalkSerial /* Parent walk serial */,
 			(int64) memoryAccount->maxLimit /* Quota */,
-	memoryAccount->peak /* Peak */,
-	memoryAccount->allocated /* Allocated */,
-	memoryAccount->freed /* Freed */, (memoryAccount->allocated - memoryAccount->freed) /* Current */);
+			memoryAccount->peak /* Peak */,
+			memoryAccount->allocated /* Allocated */,
+			memoryAccount->freed /* Freed */, (memoryAccount->allocated - memoryAccount->freed) /* Current */);
     memAccountCxt->memoryAccountCount++;
 
     return CdbVisit_Walk;
 }
 
-/**
- * SerializeMemoryAccount:
- * 		A visitor function that serializes a particular memory account. Called
- * 		from the walker to serialize the whole tree.
+/*
+ * MemoryAccounting_ToString
+ *		Converts a memory account tree rooted at "root" to string using tree
+ *		walker and repeated calls of MemoryAccountToString
  *
- * memoryAccount: The memory account which will be represented as CSV
- * context: context information to pass between successive function call
- * depth: The depth in the tree for current node. Used to generate indentation.
- * parentWalkSerial: parent node's "walk serial"
- * curWalkSerial: current node's "walk serial"
+ * root: The root of the tree (used recursively)
+ * str: The output buffer
+ * indentation: The indentation of the root
  */
-static CdbVisitOpt
-SerializeMemoryAccount(MemoryAccount *memoryAccount, void *context, uint32 depth,
-		uint32 parentWalkSerial, uint32 curWalkSerial)
+static void
+MemoryAccounting_ToString(MemoryAccountTree *root, StringInfoData *str, uint32 indentation)
 {
-	if (memoryAccount == NULL) return CdbVisit_Walk;
+	MemoryAccountSerializerCxt cxt;
+	cxt.buffer = str;
+	cxt.memoryAccountCount = 0;
+	cxt.prefix = NULL;
 
-	Assert(MemoryAccountIsValid(memoryAccount));
-
-	MemoryAccountSerializerCxt *memAccountCxt = (MemoryAccountSerializerCxt*) context;
-
-	SerializedMemoryAccount serializedMemoryAccount;
-	serializedMemoryAccount.type = T_SerializedMemoryAccount;
-	serializedMemoryAccount.memoryAccount = *memoryAccount;
-	serializedMemoryAccount.memoryAccountSerial = curWalkSerial;
-	serializedMemoryAccount.parentMemoryAccountSerial = parentWalkSerial;
-
-	appendBinaryStringInfo(memAccountCxt->buffer, &serializedMemoryAccount, sizeof(SerializedMemoryAccount));
-
-    memAccountCxt->memoryAccountCount++;
-
-    return CdbVisit_Walk;
+	uint32 totalWalked = 0;
+	MemoryAccountTreeWalkNode(root, MemoryAccountToString, &cxt, 0 + indentation, &totalWalked, totalWalked);
 }
 
 /*
@@ -998,41 +1183,35 @@ SerializeMemoryAccount(MemoryAccount *memoryAccount, void *context, uint32 depth
 static void
 InitMemoryAccounting()
 {
-	Assert(TopMemoryAccount == NULL);
-	Assert(AlienExecutorMemoryAccount == NULL);
+	/* Either we never initialized or we are re-initializing after reset and rollover should be the active owner */
+	Assert(ActiveMemoryAccountId == MEMORY_OWNER_TYPE_Undefined || ActiveMemoryAccountId == MEMORY_OWNER_TYPE_Rollover);
 
 	/*
-	 * Order of creation:
+	 * We have long and short living accounts. Long living accounts are created only
+	 * once and they live for the entire duration of a QE. We create all the long living
+	 * accounts first, only if they were never created before.
 	 *
-	 * 1. Root
-	 * 2. SharedChunkHeadersMemoryAccount
-	 * 3. RolloverMemoryAccount
-	 * 4. MemoryAccountMemoryAccount
-	 * 5. MemoryAccountMemoryContext
+	 * The memory accounting framework is a self-auditing framework in terms of memory usage.
+	 * All the accounts are created in MemoryAccountMemoryContext and tracked in a special
+	 * account MemoryAccountMemoryAccount. The MemoryAccountMemoryContext is created only
+	 * once, during the first initialization. Subsequently, this context is reset once per-statement
+	 * to prevent accumulating memory in accounting data structures.
 	 *
-	 * The above 5 survive reset (MemoryAccountMemoryContext
-	 * gets reset, but not deleted).
+	 * As MemoryAccountMemoryContext is reset once per-statement, we don't create the long living
+	 * accounts in that context. Rather the long living accounts are created in TopMemoryContext.
 	 *
-	 * Next set ActiveMemoryAccount = MemoryAccountMemoryAccount
+	 * Once the long living accounts are created we set the MemoryAccountMemoryAccount
+	 * as the ActiveMemoryAccount and proceed with the creation of short living accounts.
 	 *
-	 * Note, don't set MemoryAccountMemoryAccount before creating
-	 * MemoryAccuontMemoryContext, as that will put the balance
-	 * of MemoryAccountMemoryContext in the MemoryAccountMemoryAccount,
-	 * preventing it from going to 0, upon reset of MemoryAccountMemoryContext.
-	 * MemoryAccountMemoryAccount should only contain balance from actual
-	 * account creation, not the overhead of the context.
-	 *
-	 * Once the long living accounts are done and MemoryAccountMemoryAccount
-	 * is the ActiveMemoryAccount, we proceed to create TopMemoryAccount
-	 *
-	 * This ensures the following:
+	 * This process ensures the following:
 	 *
 	 * 1. Accounting is triggered only if the ActiveMemoryAccount is non-null
 	 *
 	 * 2. If the ActiveMemoryAccount is non-null, we are guaranteed to have
-	 * SharedChunkHeadersMemoryAccount, so that we can account shared chunk headers
+	 * SharedChunkHeadersMemoryAccount (which is a long living account), so that we can account
+	 * shared chunk headers.
 	 *
-	 * 3. All short-living accounts (including Top) are accounted in MemoryAccountMemoryAccount
+	 * 3. All short-living accounts are accounted in MemoryAccountMemoryAccount
 	 *
 	 * 4. All short-living accounts are allocated in MemoryAccountMemoryContext
 	 *
@@ -1042,76 +1221,52 @@ InitMemoryAccounting()
 	 * are very few and their overhead is already known).
 	 */
 
-	if (MemoryAccountTreeLogicalRoot == NULL)
+	if (!MemoryAccounting_IsInitialized())
 	{
 		/*
 		 * All the long living accounts are created together, so if logical root
 		 * is null, then other long-living accounts should be the null too
 		 */
-		Assert(SharedChunkHeadersMemoryAccount == NULL && RolloverMemoryAccount == NULL);
-		Assert(TopMemoryAccount == NULL && MemoryAccountMemoryAccount == NULL && MemoryAccountMemoryContext == NULL);
+		InitLongLivingAccounts();
 
-		MemoryAccountTreeLogicalRoot = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_LogicalRoot);
-
-		SharedChunkHeadersMemoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_SharedChunkHeader);
-
-		RolloverMemoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Rollover);
-
-		MemoryAccountMemoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_MemAccount);
-
-		/* Now initiate the memory accounting system. */
+		/*
+		 * Now create the context that contains all short-living accounts to ensure timely
+		 * free of all the short-living account memory.
+		 */
 		MemoryAccountMemoryContext = AllocSetContextCreate(TopMemoryContext,
 											 "MemoryAccountMemoryContext",
 											 ALLOCSET_DEFAULT_MINSIZE,
 											 ALLOCSET_DEFAULT_INITSIZE,
 											 ALLOCSET_DEFAULT_MAXSIZE);
 
-		/*
-		 * Temporarily active MemoryAccountMemoryAccount. Once
-		 * all the setup is done, TopMemoryAccount will become
-		 * the ActiveMemoryAccount
-		 */
-		ActiveMemoryAccount = MemoryAccountMemoryAccount;
 	}
 	else
 	{
 		/* Long-living setup is already done, so re-initialize those */
 		/* If "logical root" is pre-existing, "rollover" should also be pre-existing */
-		Assert(MemoryAccountTreeLogicalRoot->nextSibling == NULL &&
-				RolloverMemoryAccount != NULL && SharedChunkHeadersMemoryAccount != NULL &&
-				MemoryAccountMemoryAccount != NULL);
+		Assert(RolloverMemoryAccount != NULL && SharedChunkHeadersMemoryAccount != NULL &&
+				MemoryAccountMemoryAccount != NULL && AlienExecutorMemoryAccount != NULL);
 
 		/* Ensure tree integrity */
-		Assert(MemoryAccountMemoryAccount->firstChild == NULL &&
-				SharedChunkHeadersMemoryAccount->firstChild == NULL &&
-				RolloverMemoryAccount->firstChild == NULL);
-
-		/*
-		 * First child of MemoryAccountTreeLogicalRoot should be Top, which
-		 * had been obliterated during MemoryAccountMemoryContextReset. So,
-		 * we don't attempt to verify the first child of MeomryAccountTreeLogicalRoot
-		 */
-		Assert(MemoryAccountMemoryAccount->nextSibling == RolloverMemoryAccount &&
-				RolloverMemoryAccount->nextSibling == SharedChunkHeadersMemoryAccount &&
-				SharedChunkHeadersMemoryAccount->nextSibling == NULL);
-
-		/*
-		 * We will loose previous TopMemoryAccount during InitMemoryAccounting. So,
-		 * we need to readjust the "logical root" children pointers.
-		 */
-	 	MemoryAccountTreeLogicalRoot->firstChild = MemoryAccountMemoryAccount;
-	 	MemoryAccountMemoryAccount->nextSibling = RolloverMemoryAccount;
-	 	RolloverMemoryAccount->nextSibling = SharedChunkHeadersMemoryAccount;
-	 	SharedChunkHeadersMemoryAccount->nextSibling = NULL;
-	 	RolloverMemoryAccount->firstChild = NULL;
-	 	SharedChunkHeadersMemoryAccount->firstChild = NULL;
+		Assert(MemoryAccountMemoryAccount->parentId == MEMORY_OWNER_TYPE_LogicalRoot &&
+				SharedChunkHeadersMemoryAccount->parentId == MEMORY_OWNER_TYPE_LogicalRoot &&
+				RolloverMemoryAccount->parentId == MEMORY_OWNER_TYPE_LogicalRoot &&
+				AlienExecutorMemoryAccount->parentId == MEMORY_OWNER_TYPE_LogicalRoot);
 	}
 
-	TopMemoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Top);
-	/* For AlienExecutorMemoryAccount we need TopMemoryAccount as parent */
-	ActiveMemoryAccount = TopMemoryAccount;
+	InitShortLivingMemoryAccounts();
 
-	AlienExecutorMemoryAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_AlienShared);
+	/* For AlienExecutorMemoryAccount we need TopMemoryAccount as parent */
+	ActiveMemoryAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Top);
+}
+
+/* Clear out all the balance of an account */
+static void
+ClearAccount(MemoryAccount* memoryAccount)
+{
+	memoryAccount->allocated = 0;
+	memoryAccount->freed = 0;
+	memoryAccount->peak = 0;
 }
 
 /*
@@ -1128,23 +1283,22 @@ AdvanceMemoryAccountingGeneration()
 	 * is the only account to survive this MemoryAccountMemoryContext
 	 * reset.
 	 */
-	ActiveMemoryAccount = RolloverMemoryAccount;
+	MemoryAccounting_SwitchAccount((MemoryAccountIdType)MEMORY_OWNER_TYPE_Rollover);
 	MemoryContextReset(MemoryAccountMemoryContext);
-	Assert(MemoryAccountMemoryAccount->allocated == MemoryAccountMemoryAccount->freed &&
-			MemoryAccountMemoryAccount->firstChild == NULL);
+	Assert(MemoryAccountMemoryAccount->allocated == MemoryAccountMemoryAccount->freed);
+	shortLivingMemoryAccountArray = NULL;
 
 	/*
 	 * Reset MemoryAccountMemoryAccount so that one query doesn't take the blame
 	 * of another query. Note, this is different than RolloverMemoryAccount,
 	 * whose purpose is to carry balance between multiple reset
 	 */
-	MemoryAccountMemoryAccount->allocated = 0;
-	MemoryAccountMemoryAccount->freed = 0;
-	MemoryAccountMemoryAccount->peak = 0;
+	ClearAccount(MemoryAccountMemoryAccount);
 
-	/* Everything except the SharedChunkHeadersMemoryAccount rolls over */
+	/* Everything except the SharedChunkHeadersMemoryAccount and AlienExecutorMemoryAccount rolls over */
 	RolloverMemoryAccount->allocated = (MemoryAccountingOutstandingBalance -
-			(SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed));
+			(SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed) -
+			(AlienExecutorMemoryAccount->allocated - AlienExecutorMemoryAccount->freed));
 	RolloverMemoryAccount->freed = 0;
 
 	/*
@@ -1154,64 +1308,19 @@ AdvanceMemoryAccountingGeneration()
 	 */
 	RolloverMemoryAccount->peak = Max(RolloverMemoryAccount->peak, MemoryAccountingPeakBalance);
 
-	uint16 prevGeneration = MemoryAccountingCurrentGeneration;
-	MemoryAccountingCurrentGeneration = MemoryAccountingCurrentGeneration + 1;
+	liveAccountStartId = nextAccountId;
 
-	if (prevGeneration > MemoryAccountingCurrentGeneration)
-	{
-		/* Overflow happened, we need to adjust for generation */
-		elog(LOG, "Migrating all allocated memory chunks to generation %u due to generation counter exhaustion and QE recycling", MemoryAccountingCurrentGeneration);
-		HandleMemoryAccountingGenerationOverflow(TopMemoryContext);
-	}
-
-	Assert((RolloverMemoryAccount->allocated - RolloverMemoryAccount->freed) == (MemoryAccountingOutstandingBalance -
-			(SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed)));
 	Assert(RolloverMemoryAccount->peak >= MemoryAccountingPeakBalance);
 }
 
 /*
- * HandleMemoryAccountingGenerationOverflow
- * 		Descends the memory context tree rooted at "context" and calls update_generation
- * 		on each context. The update_generation is supposed to look for every active chunks
- * 		and set their ownership to RolloverAccount.The update_generation method will also
- * 		set the generation of every active chunk to MemoryAccountingCurrentGeneration.
- *
- * Parameters:
- * 		context: The memory context whose children will be descended
+ * MemoryAccounting_ResetPeakBalance
+ *		Resets the peak memory account balance by setting it to the current balance.
  */
 static void
-HandleMemoryAccountingGenerationOverflow(MemoryContext context)
+MemoryAccounting_ResetPeakBalance()
 {
-	AssertArg(MemoryContextIsValid(context));
-
-	/* save a function call in common case where there are no children */
-	if (context->firstchild != NULL)
-	{
-		HandleMemoryAccountingGenerationOverflowChildren(context);
-	}
-
-	(*context->methods.update_generation) (context);
-}
-
-/*
- * HandleMemoryAccountingGenerationOverflowChildren
- * 		Companion method for HandleMemoryAccountingGenerationOverflow(). Used for
- * 		walking the memory context tree.
- *
- * Parameters:
- * 		context: The memory context whose children will be descended
- */
-static void
-HandleMemoryAccountingGenerationOverflowChildren(MemoryContext context)
-{
-	MemoryContext child;
-
-	AssertArg(MemoryContextIsValid(context));
-
-	for (child = context->firstchild; child != NULL; child = child->nextchild)
-	{
-		HandleMemoryAccountingGenerationOverflow(child);
-	}
+	MemoryAccountingPeakBalance = MemoryAccountingOutstandingBalance;
 }
 
 /*

--- a/src/backend/utils/mmgr/test/aset_test.c
+++ b/src/backend/utils/mmgr/test/aset_test.c
@@ -7,9 +7,12 @@
 
 #define NEW_ALLOC_SIZE 1024
 
-extern MemoryAccount *MemoryAccountTreeLogicalRoot;
-extern MemoryAccount *TopMemoryAccount;
-extern MemoryAccount *MemoryAccountMemoryAccount;
+extern MemoryAccount* MemoryAccountMemoryAccount;
+extern MemoryAccount* RolloverMemoryAccount;
+extern MemoryAccount* AlienExecutorMemoryAccount;
+
+extern MemoryAccountIdType liveAccountStartId;
+extern MemoryAccountIdType nextAccountId;
 
 #define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
 
@@ -40,6 +43,14 @@ void SetupMemoryDataStructures(void **state)
 void
 TeardownMemoryDataStructures(void **state)
 {
+	/*
+	 * Ensure that no existing allocation refers to any short-living accounts. All
+	 * short living accounts live in MemoryAccountMemoryAccount which is soon going
+	 * to be reset via TopMemoryContext reset.
+	 */
+	MemoryAccounting_Reset();
+	MemoryAccounting_SwitchAccount(MEMORY_OWNER_TYPE_Rollover);
+
 	MemoryContextReset(TopMemoryContext); /* TopMemoryContext deletion is not supported */
 
 	/* These are needed to be NULL for calling MemoryContextInit() */
@@ -51,15 +62,25 @@ TeardownMemoryDataStructures(void **state)
 	 * try to setup memory account data structure again during the
 	 * execution of the next test.
 	 */
-	MemoryAccountTreeLogicalRoot = NULL;
-	TopMemoryAccount = NULL;
 	MemoryAccountMemoryAccount = NULL;
 	RolloverMemoryAccount = NULL;
 	SharedChunkHeadersMemoryAccount = NULL;
-	ActiveMemoryAccount = NULL;
 	AlienExecutorMemoryAccount = NULL;
 	MemoryAccountMemoryContext = NULL;
+
+	ActiveMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
+
+	for (int longLivingIdx = MEMORY_OWNER_TYPE_LogicalRoot; longLivingIdx <= MEMORY_OWNER_TYPE_END_LONG_LIVING; longLivingIdx++)
+	{
+		longLivingMemoryAccountArray[longLivingIdx] = NULL;
+	}
+
+	shortLivingMemoryAccountArray = NULL;
+
+	liveAccountStartId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
+	nextAccountId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
 }
+
 
 /*
  * Any change of global outstanding allocation balance should come
@@ -70,12 +91,12 @@ TeardownMemoryDataStructures(void **state)
 void
 test__MemoryAccounting_Allocate__ChargesOnlyActiveAccount(void **state)
 {
-	MemoryAccount *newActiveAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newActiveAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 
 	/* Make sure we have a new active account other than Rollover */
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount);
+	MemoryAccountIdType oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccountId);
 
-	assert_true(ActiveMemoryAccount == newActiveAccount);
+	assert_true(ActiveMemoryAccountId == newActiveAccountId);
 
 	uint64 prevOutstanding = MemoryAccountingOutstandingBalance;
 
@@ -83,10 +104,12 @@ test__MemoryAccounting_Allocate__ChargesOnlyActiveAccount(void **state)
 
 	void *testAlloc = palloc(NEW_ALLOC_SIZE);
 
+	MemoryAccount* newActiveAccount = MemoryAccounting_ConvertIdToAccount(newActiveAccountId);
 	/*
 	 * Any change of outstanding balance is coming from new allocation
 	 * and the associated shared header allocation
 	 */
+	assert_true(MemoryAccountingOutstandingBalance - prevOutstanding > 0);
 	assert_true((newActiveAccount->allocated - newActiveAccount->freed) +
 			(SharedChunkHeadersMemoryAccount->allocated - prevSharedHeaderAlloc) ==
 					(MemoryAccountingOutstandingBalance - prevOutstanding));
@@ -148,14 +171,15 @@ test__MemoryAccounting_Allocate__AdjustsPeak(void **state)
 void
 test__MemoryAccounting_Free__FreesOldGenFromRollover(void **state)
 {
-	assert_true(ActiveMemoryAccount == TopMemoryAccount);
+	assert_true(ActiveMemoryAccountId == MEMORY_OWNER_TYPE_Top);
 
-	uint64 activeBalance = ActiveMemoryAccount->allocated - ActiveMemoryAccount->freed;
+	MemoryAccount* activeAccount = MemoryAccounting_ConvertIdToAccount(ActiveMemoryAccountId);
+	uint64 activeBalance = activeAccount->allocated - activeAccount->freed;
 	uint64 oldRolloverBalance = RolloverMemoryAccount->allocated - RolloverMemoryAccount->freed;
 
 	void *testAlloc = palloc(NEW_ALLOC_SIZE);
 
-	assert_true(activeBalance < (ActiveMemoryAccount->allocated - ActiveMemoryAccount->freed));
+	assert_true(activeBalance < (activeAccount->allocated - activeAccount->freed));
 
 	MemoryAccounting_Reset();
 
@@ -245,10 +269,10 @@ test__AllocAllocInfo__SharesHeader(void **state)
 void
 test__AllocAllocInfo__ChargesSharedChunkHeadersMemoryAccount(void **state)
 {
-	MemoryAccount *newActiveAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newActiveAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 
 	/* Make sure we have a new active account to force a new shared header allocation */
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount);
+	MemoryAccountIdType oldActiveAccountId = MemoryAccounting_SwitchAccount(newActiveAccountId);
 
 	uint64 prevSharedBalance = SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed;
 
@@ -265,7 +289,7 @@ test__AllocAllocInfo__ChargesSharedChunkHeadersMemoryAccount(void **state)
 	pfree(testAlloc);
 }
 
-/* Tests whether we use null account header if there is no ActiveMemoryAccount */
+/* Tests whether we use null account header if there is ActiveMemoryAccountId is invalid */
 void
 test__AllocAllocInfo__UsesNullAccountHeader(void **state)
 {
@@ -279,12 +303,10 @@ test__AllocAllocInfo__UsesNullAccountHeader(void **state)
 	assert_true(newSet->sharedHeaderList == NULL);
 	assert_true(newSet->nullAccountHeader == NULL);
 
-	MemoryAccount *oldActive = ActiveMemoryAccount;
-	MemoryAccount *oldShared = SharedChunkHeadersMemoryAccount;
-
 	/* Turning off memory monitoring */
-	ActiveMemoryAccount = NULL;
-	/* Also make SharedChunkHeadersMemoryAccount NULL to avoid assert failure */
+	ActiveMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
+
+	/* Also make SharedChunkHeadersMemoryAccount undefined to avoid assert failure */
 	SharedChunkHeadersMemoryAccount = NULL;
 
 	/* Allocate from the new context which should trigger a nullAccountHeader creation*/
@@ -296,12 +318,11 @@ test__AllocAllocInfo__UsesNullAccountHeader(void **state)
 	/* The new chunk should use the nullAccountHeader of the Aset */
 	assert_true(header->sharedHeader != NULL && header->sharedHeader == newSet->nullAccountHeader);
 
-	ActiveMemoryAccount = oldActive;
-	SharedChunkHeadersMemoryAccount = oldShared;
-
 	pfree(testAlloc);
 
 	MemoryContextDelete(newContext);
+
+	SharedChunkHeadersMemoryAccount = MemoryAccounting_ConvertIdToAccount(MEMORY_OWNER_TYPE_SharedChunkHeader);
 }
 
 /*
@@ -319,11 +340,11 @@ test__AllocAllocInfo__LooksAheadInSharedHeaderList(void **state)
 	 */
 	void *testAlloc1 = palloc(NEW_ALLOC_SIZE);
 
-	MemoryAccount *newActiveAccount1 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newActiveAccount1 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 	/* Make sure we have a new active account to force a new shared header allocation */
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount1);
+	MemoryAccountIdType oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount1);
 
-	/* This will trigger a new sharedHeader creation because of the new ActiveMemoryAccount */
+	/* This will trigger a new sharedHeader creation because of the new ActiveMemoryAccountId */
 	void *testAlloc2 = palloc(NEW_ALLOC_SIZE);
 
 	StandardChunkHeader *header1 = (StandardChunkHeader *)
@@ -350,7 +371,7 @@ test__AllocAllocInfo__LooksAheadInSharedHeaderList(void **state)
 	assert_true(header3->sharedHeader == header1->sharedHeader);
 
 	/* Now we are triggering a third sharedHeader creation */
-	MemoryAccount *newActiveAccount2 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newActiveAccount2 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 	/* Make sure we have a new active account to force a new shared header allocation */
 	oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount2);
 
@@ -428,11 +449,11 @@ test__AllocAllocInfo__InsertsIntoSharedHeaderList(void **state)
 	 */
 	void *testAlloc1 = palloc(NEW_ALLOC_SIZE);
 
-	MemoryAccount *newActiveAccount1 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newActiveAccount1 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 	/* Make sure we have a new active account to force a new shared header allocation */
 	MemoryAccounting_SwitchAccount(newActiveAccount1);
 
-	/* This will trigger a new sharedHeader creation because of the new ActiveMemoryAccount */
+	/* This will trigger a new sharedHeader creation because of the new ActiveMemoryAccountId */
 	void *testAlloc2 = palloc(NEW_ALLOC_SIZE);
 
 	StandardChunkHeader *header1 = (StandardChunkHeader *)
@@ -442,7 +463,7 @@ test__AllocAllocInfo__InsertsIntoSharedHeaderList(void **state)
 		((char *) testAlloc2 - STANDARDCHUNKHEADERSIZE);
 
 	/* Now we are triggering a third sharedHeader creation */
-	MemoryAccount *newActiveAccount2 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newActiveAccount2 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 	/* Make sure we have a new active account to force a new shared header allocation */
 	MemoryAccounting_SwitchAccount(newActiveAccount2);
 
@@ -462,7 +483,7 @@ test__AllocAllocInfo__InsertsIntoSharedHeaderList(void **state)
 	 * look ahead up to depth 3, but we maintain all the sharedHeaders in the
 	 * sharedHeaderList
 	 */
-	MemoryAccount *newActiveAccount3 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newActiveAccount3 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 	MemoryAccounting_SwitchAccount(newActiveAccount3);
 
 	void *testAlloc4 = palloc(NEW_ALLOC_SIZE);
@@ -507,11 +528,11 @@ test__AllocFreeInfo__SharedChunkHeadersMemoryAccountIgnoresNullHeader(void **sta
 	assert_true(newSet->sharedHeaderList == NULL);
 	assert_true(newSet->nullAccountHeader == NULL);
 
-	MemoryAccount *oldActive = ActiveMemoryAccount;
-	MemoryAccount *oldShared = SharedChunkHeadersMemoryAccount;
+	MemoryAccountIdType oldActive = ActiveMemoryAccountId;
+	MemoryAccountIdType oldShared = SharedChunkHeadersMemoryAccount;
 
 	/* Turning off memory monitoring */
-	ActiveMemoryAccount = NULL;
+	ActiveMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
 
 	#ifdef USE_ASSERT_CHECKING
 	    expect_any(ExceptionalCondition,conditionName);
@@ -525,7 +546,7 @@ test__AllocFreeInfo__SharedChunkHeadersMemoryAccountIgnoresNullHeader(void **sta
 		PG_TRY();
 		{
 			/*
-			 * ActiveMemoryAccount is NULL, but SharedChunkHeadersMemoryAccount is
+			 * ActiveMemoryAccountId is invalid, but SharedChunkHeadersMemoryAccount is
 			 * *not* null. This should trigger an assertion
 			 */
 			void *testAlloc = MemoryContextAlloc(newContext, NEW_ALLOC_SIZE);
@@ -563,7 +584,7 @@ test__AllocFreeInfo__SharedChunkHeadersMemoryAccountIgnoresNullHeader(void **sta
 	 */
 	SharedChunkHeadersMemoryAccount = oldShared;
 	/* Activate the memory accounting */
-	ActiveMemoryAccount = oldActive;
+	ActiveMemoryAccountId = oldActive;
 
 	uint64 sharedBalance = SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed;
 
@@ -592,11 +613,11 @@ test__AllocFreeInfo__ReusesNullHeader(void **state)
 	assert_true(newSet->sharedHeaderList == NULL);
 	assert_true(newSet->nullAccountHeader == NULL);
 
-	MemoryAccount *oldActive = ActiveMemoryAccount;
-	MemoryAccount *oldShared = SharedChunkHeadersMemoryAccount;
+	MemoryAccountIdType oldActive = ActiveMemoryAccountId;
+	MemoryAccount* oldShared = SharedChunkHeadersMemoryAccount;
 
 	/* Turning off memory monitoring */
-	ActiveMemoryAccount = NULL;
+	ActiveMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
 	/* Also make SharedChunkHeadersMemoryAccount NULL to avoid assert failure */
 	SharedChunkHeadersMemoryAccount = NULL;
 
@@ -618,7 +639,7 @@ test__AllocFreeInfo__ReusesNullHeader(void **state)
 	assert_true(header1->sharedHeader != NULL && header1->sharedHeader == newSet->nullAccountHeader &&
 			header1->sharedHeader == header2->sharedHeader);
 
-	ActiveMemoryAccount = oldActive;
+	ActiveMemoryAccountId = oldActive;
 	SharedChunkHeadersMemoryAccount = oldShared;
 
 	pfree(testAlloc1);
@@ -631,10 +652,10 @@ test__AllocFreeInfo__ReusesNullHeader(void **state)
 void
 test__AllocFreeInfo__FreesObsoleteHeader(void **state)
 {
-	MemoryAccount *newActiveAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newActiveAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 
 	/* Make sure we have a new active account to force a new shared header allocation */
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount);
+	MemoryAccountIdType oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount);
 
 	uint64 prevSharedBalance = SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed;
 
@@ -671,17 +692,19 @@ test__AllocFreeInfo__FreesObsoleteHeader(void **state)
 void
 test__AllocFreeInfo__FreesOnlyOwnerAccount(void **state)
 {
-	MemoryAccount *newAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(newAccount);
+	MemoryAccountIdType newAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType oldActiveAccountId = MemoryAccounting_SwitchAccount(newAccountId);
 
 	/* This chunk should record newAccount as the owner */
 	void *testAlloc = palloc(NEW_ALLOC_SIZE);
 
-	MemoryAccounting_SwitchAccount(oldActiveAccount);
+	MemoryAccounting_SwitchAccount(oldActiveAccountId);
 
-	assert_true(ActiveMemoryAccount != newAccount);
+	assert_true(ActiveMemoryAccountId != newAccountId);
 
-	uint64 originalActiveBalance = ActiveMemoryAccount->allocated - ActiveMemoryAccount->freed;
+	MemoryAccount* activeAccount = MemoryAccounting_ConvertIdToAccount(ActiveMemoryAccountId);
+	MemoryAccount* newAccount = MemoryAccounting_ConvertIdToAccount(newAccountId);
+	uint64 originalActiveBalance = activeAccount->allocated - activeAccount->freed;
 	uint64 newAccountBalance = newAccount->allocated - newAccount->freed;
 	uint64 newAccountFreed = newAccount->freed;
 	uint64 sharedFreed = SharedChunkHeadersMemoryAccount->freed;
@@ -693,7 +716,7 @@ test__AllocFreeInfo__FreesOnlyOwnerAccount(void **state)
 	 * Make sure that the active account is unchanged while the owner account
 	 * balance was reduced
 	 */
-	assert_true(ActiveMemoryAccount->allocated - ActiveMemoryAccount->freed == originalActiveBalance);
+	assert_true(activeAccount->allocated - activeAccount->freed == originalActiveBalance);
 	/* Balance was released from newAccount */
 	assert_true(newAccount->allocated - newAccount->freed <= newAccountBalance - NEW_ALLOC_SIZE);
 
@@ -754,23 +777,24 @@ test__AllocSetAllocImpl__LargeAllocInOutstandingBalance(void **state)
 void
 test__AllocSetAllocImpl__LargeAllocInActiveMemoryAccount(void **state)
 {
-	MemoryAccount *newActiveAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newActiveAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 
 	/* Make sure we have a new active account other than Rollover */
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount);
+	MemoryAccountIdType oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccountId);
 
 	uint64 prevOutstanding = MemoryAccountingOutstandingBalance;
 
 	uint64 prevSharedHeaderAlloc = SharedChunkHeadersMemoryAccount->allocated;
 
-	uint64 prevActiveAlloc = ActiveMemoryAccount->allocated;
+	uint64 prevActiveAlloc = MemoryAccounting_GetAccountCurrentBalance(ActiveMemoryAccountId);
 
 	int chunkSize = ALLOC_CHUNK_LIMIT + 1;
 	/* This chunk should record newAccount as the owner */
 	void *testAlloc = palloc(chunkSize);
 
+	MemoryAccount *newActiveAccount = MemoryAccounting_ConvertIdToAccount(newActiveAccountId);
 	/*
-	 * All the new allocation should go to ActiveMemoryAccount, and the
+	 * All the new allocation should go to active memory account, and the
 	 * SharedChunkHeadersMemoryAccount should contribute to add up to
 	 * the outstanding balance change
 	 */

--- a/src/backend/utils/mmgr/test/memaccounting_test.c
+++ b/src/backend/utils/mmgr/test/memaccounting_test.c
@@ -20,11 +20,15 @@
 					((StandardChunkHeader *)(((char *)(ptr)) - ALLOC_CHUNKHDRSZ))
 
 static StringInfoData outputBuffer;
+int elevel;
 
+static void elog_mock(int elevel, const char *fmt,...);
 static void write_stderr_mock(const char *fmt,...);
 
 /* We will capture write_stderr output using write_stderr_mock */
 #define write_stderr write_stderr_mock
+
+#define elog elog_mock
 
 /* We will capture fwrite output using fwrite_mock */
 #undef fwrite
@@ -46,6 +50,8 @@ void write_stderr_mock(const char *fmt,...);
 
 #include "../memaccounting.c"
 
+#include "utils/memaccounting_private.h"
+
 #define EXPECT_EXCEPTION()     \
 	expect_any(ExceptionalCondition,conditionName); \
 	expect_any(ExceptionalCondition,errorType); \
@@ -53,12 +59,32 @@ void write_stderr_mock(const char *fmt,...);
 	expect_any(ExceptionalCondition,lineNumber); \
     will_be_called_with_sideeffect(ExceptionalCondition, &_ExceptionalCondition, NULL);\
 
+static void
+elog_mock(int passed_elevel, const char *fmt, ...)
+{
+    va_list		ap;
+
+    fmt = _(fmt);
+
+    va_start(ap, fmt);
+
+	char		buf[2048];
+
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+
+	appendStringInfo(&outputBuffer, buf);
+
+	elevel = passed_elevel;
+
+	va_end(ap);
+}
+
 /*
  * Mocks the function write_stderr and captures the output in
  * the global outputBuffer
  */
 static void
-write_stderr_mock(const char *fmt,...)
+write_stderr_mock(const char *fmt, ...)
 {
     va_list		ap;
 
@@ -108,25 +134,26 @@ void SetupMemoryDataStructures(void **state)
 	MemoryContextInit();
 
 	initStringInfoOfSize(&outputBuffer, MAX_OUTPUT_BUFFER_SIZE);
+
+	elevel = INT_MAX;
 }
 
 /*
  * This method cleans up MemoryContext tree and
  * the MemoryAccount data structures.
  */
-void TeardownMemoryDataStructures(void **state)
+void
+TeardownMemoryDataStructures(void **state)
 {
-	pfree(outputBuffer.data);
-
 	/*
-	 * TopMemoryContext deletion is not supported, so
-	 * we are just resetting it. Note: even reset
-	 * operation on TopMemoryContext is not supported,
-	 * but for our purpose (as we will not be running
-	 * anything after this call), it works to clean up
-	 * for the next unit test.
+	 * Ensure that no existing allocation refers to any short-living accounts. All
+	 * short living accounts live in MemoryAccountMemoryAccount which is soon going
+	 * to be reset via TopMemoryContext reset.
 	 */
-	MemoryContextReset(TopMemoryContext);
+	MemoryAccounting_Reset();
+	MemoryAccounting_SwitchAccount(MEMORY_OWNER_TYPE_Rollover);
+
+	MemoryContextReset(TopMemoryContext); /* TopMemoryContext deletion is not supported */
 
 	/* These are needed to be NULL for calling MemoryContextInit() */
 	TopMemoryContext = NULL;
@@ -137,20 +164,23 @@ void TeardownMemoryDataStructures(void **state)
 	 * try to setup memory account data structure again during the
 	 * execution of the next test.
 	 */
-	MemoryAccountTreeLogicalRoot = NULL;
-	TopMemoryAccount = NULL;
 	MemoryAccountMemoryAccount = NULL;
 	RolloverMemoryAccount = NULL;
 	SharedChunkHeadersMemoryAccount = NULL;
-	ActiveMemoryAccount = NULL;
 	AlienExecutorMemoryAccount = NULL;
 	MemoryAccountMemoryContext = NULL;
 
-	/*
-	 * We don't want to carry over peak to another test as this might
-	 * interfere during testing string conversion functions
-	 */
-	MemoryAccountingPeakBalance = MemoryAccountingOutstandingBalance;
+	ActiveMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
+
+	for (int longLivingIdx = MEMORY_OWNER_TYPE_LogicalRoot; longLivingIdx <= MEMORY_OWNER_TYPE_END_LONG_LIVING; longLivingIdx++)
+	{
+		longLivingMemoryAccountArray[longLivingIdx] = NULL;
+	}
+
+	shortLivingMemoryAccountArray = NULL;
+
+	liveAccountStartId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
+	nextAccountId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
 }
 
 /*
@@ -170,13 +200,14 @@ test__CreateMemoryAccountImpl__AccountProperties(void **state)
 		{
 			MemoryOwnerType curOwnerType = memoryOwnerTypes[j];
 
-			MemoryAccount *newAccount = CreateMemoryAccountImpl(curLimit, curOwnerType, ActiveMemoryAccount);
+			MemoryAccountIdType newAccountId = CreateMemoryAccountImpl(curLimit, curOwnerType, ActiveMemoryAccountId);
 
+			MemoryAccount* newAccount = MemoryAccounting_ConvertIdToAccount(newAccountId);
 			/*
 			 * Make sure we create account with valid tag, desired
 			 * ownerType and provided quota limit
 			 */
-			assert_true(MemoryAccountIsValid(newAccount));
+			assert_true(MemoryAccounting_IsLiveAccount(newAccountId));
 			assert_true(newAccount->ownerType == curOwnerType);
 			assert_true(newAccount->maxLimit == curLimit);
 			/*
@@ -184,43 +215,11 @@ test__CreateMemoryAccountImpl__AccountProperties(void **state)
 			 * RolloverMemoryAccount etc.). Therefore, the parent should be the
 			 * one we provided.
 			 */
-			assert_true(newAccount->parentAccount == ActiveMemoryAccount);
+			assert_true(newAccount->parentId == ActiveMemoryAccountId);
 
 			assert_true(0 == newAccount->allocated && 0 == newAccount->freed && 0 == newAccount->peak);
 		}
 	}
-}
-
-/*
- * Checks if a new account creation results in an expected memory accounting
- * tree.
- */
-void
-test__CreateMemoryAccountImpl__TreeStructure(void **state)
-{
-	MemoryAccount *topFirstChild = TopMemoryAccount->firstChild;
-	MemoryAccount *tempParentAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, TopMemoryAccount);
-
-	MemoryAccount *tempFirstChildAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_SeqScan, tempParentAccount);
-	MemoryAccount *tempSecondChildAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_SeqScan, tempParentAccount);
-
-	/*
-	 * The following assertions are validating the tree structure.
-	 * When we add a child to memory accounting tree, we point to
-	 * it via parent's firstChild pointer. We construct the tree
-	 * by using the nextSibling pointer of the child. So, if we
-	 * add a child, the child will become the firstChild of the
-	 * parent, and the child's nextSibling will point to whatever
-	 * the parent's firstChild was pointing previously
-	 */
-	assert_true(TopMemoryAccount->firstChild == tempParentAccount);
-	assert_true(topFirstChild == AlienExecutorMemoryAccount);
-	assert_true(tempParentAccount->nextSibling == topFirstChild);
-	assert_true(tempParentAccount->firstChild == tempSecondChildAccount);
-	assert_true(tempSecondChildAccount->nextSibling == tempFirstChildAccount);
-	assert_true(NULL == tempSecondChildAccount->firstChild);
-	assert_true(NULL == tempFirstChildAccount->firstChild);
-	assert_true(NULL == tempFirstChildAccount->nextSibling);
 }
 
 /*
@@ -231,89 +230,16 @@ test__CreateMemoryAccountImpl__TreeStructure(void **state)
 void
 test__CreateMemoryAccountImpl__ActiveVsParent(void **state)
 {
-	MemoryAccount *tempParentAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, TopMemoryAccount);
+	MemoryAccountIdType tempParentAccountId = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId);
+	assert_true(tempParentAccountId != ActiveMemoryAccountId);
 
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(TopMemoryAccount);
-
-	MemoryAccount *tempChildAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_SeqScan, tempParentAccount);
-
-	MemoryAccounting_SwitchAccount(oldActiveAccount);
+	MemoryAccountIdType tempChildAccountId = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_SeqScan, tempParentAccountId);
+	MemoryAccount *tempChildAccount = MemoryAccounting_ConvertIdToAccount(tempChildAccountId);
 
 	/* Make sure we are not blindly using ActiveMemoryAccount */
-	assert_true(tempChildAccount->parentAccount == tempParentAccount);
-}
-
-/*
- * Checks whether the core accounts have their pre-determined parents
- * regardless of the provided one.
- */
-void
-test__CreateMemoryAccountImpl__AutoDetectParent(void **state)
-{
-	assert_true(ActiveMemoryAccount == TopMemoryAccount);
-
-	/*
-	 * Only the short-living accounts' memory gets accounted against
-	 * MemoryAccountMemoryAccount. The long-living one doesn't
-	 * even attempt to change memory account. This causes a segv
-	 * for this test-case if we don't explicitly switch our
-	 * active memory account to something long-living account
-	 * (note: the active memory account is currently set to
-	 * TopMemoryAccount, which is short-living), as we are
-	 * creating long-living accounts. Therefore, we explicitly
-	 * switch to a long living account.
-	 */
-	MemoryAccounting_SwitchAccount(MemoryAccountMemoryAccount);
-
-	/* This will create a short-living account in MemoryAccountMemoryContext */
-	MemoryAccount *tempParentAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, TopMemoryAccount);
-
-	/*
-	 * Any short-living account should be created in MemoryAccountMemoryContext
-	 * to ensure timely release of memory upon MemoryAccounting_Reset()
-	 */
-	assert_true(MemoryContextContains(MemoryAccountMemoryContext, tempParentAccount));
-
-	/*
-	 * We must not switch to tempParentAccount, as we will end up creating a longer-living
-	 * account under short-living account
-	 */
-	MemoryAccount *tempShared = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_SharedChunkHeader, tempParentAccount);
-	/*
-	 * SharedChunkHeadersMemoryAccount is a long-living account, so it should be
-	 * created under TopMemoryContext to survive MemoryAccountMemoryContext reset
-	 */
-	assert_true(MemoryContextContains(TopMemoryContext, tempShared));
-
-	MemoryAccount *tempRollover = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Rollover, tempParentAccount);
-	/* Rollover is also a long-living account. Therefore it should reside in TopMemoryContext */
-	assert_true(MemoryContextContains(TopMemoryContext, tempRollover));
-
-	MemoryAccount *tempMemAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_MemAccount, tempParentAccount);
-	/* MemoryAccountMemoryAccount is another long-living account */
-	assert_true(MemoryContextContains(TopMemoryContext, tempMemAccount));
-
-	MemoryAccount *tempTop = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Top, tempParentAccount);
-	/*
-	 * TopMemoryAccount is not a long-living account, and therefore should
-	 * be created under MemoryAccountMemoryAccount
-	 */
-	assert_true(MemoryContextContains(MemoryAccountMemoryContext, tempTop));
-
-	/*
-	 * Verify that all the long living accounts have logical tree root
-	 * as their parent
-	 */
-	assert_true(tempShared->parentAccount == MemoryAccountTreeLogicalRoot);
-	assert_true(tempRollover->parentAccount == MemoryAccountTreeLogicalRoot);
-	assert_true(tempMemAccount->parentAccount == MemoryAccountTreeLogicalRoot);
-	/* Top is the only short-living account that goes under the logical root */
-	assert_true(tempTop->parentAccount == MemoryAccountTreeLogicalRoot);
-	/*
-	 * Any other short-living account other than Top should be a direct
-	 * or indirect descendant of Top
-	 */
-	assert_true(tempParentAccount->parentAccount == TopMemoryAccount);
+	assert_true(tempChildAccount->parentId == tempParentAccountId);
+	/* And we still have a different ActiveMemoryAccountId */
+	assert_true(tempChildAccount->parentId != ActiveMemoryAccountId);
 }
 
 /*
@@ -323,7 +249,9 @@ test__CreateMemoryAccountImpl__AutoDetectParent(void **state)
 void
 test__CreateMemoryAccountImpl__TracksMemoryOverhead(void **state)
 {
-	MemoryAccount *tempParentAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, TopMemoryAccount);
+	MemoryAccount *tempParentAccount = MemoryAccounting_ConvertIdToAccount(
+			CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId));
+
 
 	uint64 prevAllocated = MemoryAccountMemoryAccount->allocated;
 	uint64 prevFreed = MemoryAccountMemoryAccount->freed;
@@ -332,7 +260,7 @@ test__CreateMemoryAccountImpl__TracksMemoryOverhead(void **state)
 	uint64 prevSharedAllocated = SharedChunkHeadersMemoryAccount->allocated;
 	uint64 prevSharedFreed = SharedChunkHeadersMemoryAccount->freed;
 
-	MemoryAccount *tempChildAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, tempParentAccount);
+	MemoryAccountIdType tempChildAccountId = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, tempParentAccount);
 
 	/* Only MemoryAccountMemoryAccount changed, and nothing else changed */
 	assert_true((MemoryAccountMemoryAccount->allocated - prevAllocated) +
@@ -353,27 +281,21 @@ test__CreateMemoryAccountImpl__TracksMemoryOverhead(void **state)
 	assert_true(SharedChunkHeadersMemoryAccount->freed == prevSharedFreed);
 
 	/*
-	 * Now check SharedChunkHeadersMemoryAccount balance increase by advancing
-	 * account generation and invalidating the sharedHeaderList.
+	 * Now check SharedChunkHeadersMemoryAccount balance increase by ensuring we
+	 * cannot reuse an existing sharedChunkHeader.
 	 */
-	MemoryAccountingCurrentGeneration++;
-
-	tempChildAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, tempParentAccount);
+	MemoryAccounting_SwitchAccount(tempChildAccountId);
+	void * dummy = palloc(1);
 
 	/*
-	 * The new account cannot share any previous header due to generation
-	 * advancement. So, we should see a balance increase in SharedChunkHeadersMemoryAccount
+	 * The new allocation cannot share any previous header as we didn't have
+	 * any Hash account. So, we should have allocated new shared header, increasing
+	 * the balance of SharedChunkHeadersMemoryAccount
 	 */
 	assert_true(SharedChunkHeadersMemoryAccount->allocated > prevSharedAllocated);
+	assert_true(SharedChunkHeadersMemoryAccount->freed == prevSharedFreed);
 
-	/* Free this memory as we are going back to previous generation to ensure proper teardown */
-	pfree(tempChildAccount);
-
-	/*
-	 * Go back to previous generation to ensure proper teardown
-	 * (should subtract from the chunks' respective accounts, not the rollover)
-	 */
-	MemoryAccountingCurrentGeneration--;
+	pfree(dummy);
 }
 
 /*
@@ -397,7 +319,7 @@ test__CreateMemoryAccountImpl__AllocatesOnlyFromMemoryAccountMemoryContext(void 
 	 */
 	for (int i = 0; i <= ALLOCSET_DEFAULT_INITSIZE / sizeof(MemoryAccount); i++)
 	{
-		MemoryAccount *tempAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccount);
+		CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId);
 	}
 
 	/* Make sure the TopMemoryContext is reflecting the new allocations */
@@ -425,47 +347,17 @@ void
 test__MemoryAccounting_SwitchAccount__AccountIsSwitched(void **state)
 {
 	MemoryAccount *newAccount = 0xabcdefab;
-	ActiveMemoryAccount = 0xbafedcba;
-	MemoryAccount *oldActiveMemoryAccount = ActiveMemoryAccount;
-
-	MemoryAccount *oldAccount = MemoryAccounting_SwitchAccount(newAccount);
-
-	assert_true(oldAccount == oldActiveMemoryAccount);
-	assert_true(ActiveMemoryAccount == newAccount);
-}
-
-/*
- * This method tests whether MemoryAccounting_SwitchAccount
- * triggers an assertion failure in the event of a NULL input
- * account.
- */
-void
-test__MemoryAccounting_SwitchAccount__RequiresNonNullAccount(void **state)
-{
-	MemoryAccount *nullAccount = NULL;
-	ActiveMemoryAccount = makeNode(MemoryAccount);
-
-#ifdef USE_ASSERT_CHECKING
-    expect_any(ExceptionalCondition,conditionName);
-    expect_any(ExceptionalCondition,errorType);
-    expect_any(ExceptionalCondition,fileName);
-    expect_any(ExceptionalCondition,lineNumber);
-
-    will_be_called_with_sideeffect(ExceptionalCondition, &_ExceptionalCondition, NULL);
-
-    /* Test if within memory-limit strings cause assertion failure */
-	PG_TRY();
-	{
-		MemoryAccount *oldAccount = MemoryAccounting_SwitchAccount(nullAccount);
-		assert_true(false);
-	}
-	PG_CATCH();
-	{
-	}
-	PG_END_TRY();
-#endif
-
-	pfree(ActiveMemoryAccount);
+	/*
+	 * ActiveMemoryAccountId should be set to Top, but we don't care. We only
+	 * want to make sure if switching to an account will work
+	 */
+	assert_true(ActiveMemoryAccountId != MEMORY_OWNER_TYPE_MemAccount);
+	MemoryAccountIdType oldAccountId = MemoryAccounting_SwitchAccount(MEMORY_OWNER_TYPE_MemAccount);
+	assert_true(ActiveMemoryAccountId == MEMORY_OWNER_TYPE_MemAccount);
+	assert_true(oldAccountId == MEMORY_OWNER_TYPE_Top);
+	/* We are still in first gen. So, even for short-living account "Top" its id should equal to its enum */
+	MemoryAccounting_SwitchAccount(MEMORY_OWNER_TYPE_Top);
+	assert_true(ActiveMemoryAccountId == MEMORY_OWNER_TYPE_Top);
 }
 
 /*
@@ -475,34 +367,44 @@ test__MemoryAccounting_SwitchAccount__RequiresNonNullAccount(void **state)
 void
 test__MemoryAccountIsValid__ProperValidation(void **state)
 {
-	MemoryAccount *nullInvalidAccount = NULL;
+	int shortLivingCount = shortLivingMemoryAccountArray->accountCount;
+	/* The initialization already should populate at least Top memory account */
+	assert_true(NULL != shortLivingMemoryAccountArray);
+	assert_true(shortLivingMemoryAccountArray->accountCount > 0);
 
-	/* Create a valid node without the proper header (i.e., MemoryAccount header type) */
-	MemoryAccount *invalidAccountWithHeader = makeNode(SerializedMemoryAccount);
+	/* Create some short accounts */
+	MemoryAccountIdType extraShortAccountId1 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Append);
+	MemoryAccountIdType extraShortAccountId2 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType extraShortAccountId3 = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_SeqScan);
 
-	/* Create a MemoryAccount sized data structure without the header information */
-	MemoryAccount *invalidAccountWithoutHeader = palloc0(sizeof(MemoryAccount));
+	MemoryAccountArray* accountArray = shortLivingMemoryAccountArray;
 
-	/* Finally, the real one, where we create a MemoryAccount type node */
-	MemoryAccount *validAccount = makeNode(MemoryAccount);
+	/* Test when no short living account exists */
+	shortLivingMemoryAccountArray = NULL;
+	uint64 oldNext = nextAccountId;
+	/* Bypass the assertion that live is same as next if no short account */
+	nextAccountId = liveAccountStartId;
 
-	bool isNullValid = MemoryAccountIsValid(nullInvalidAccount);
-	bool isInvalidHeaderValid = MemoryAccountIsValid(invalidAccountWithHeader);
-	bool isNoHeaderValid = MemoryAccountIsValid(invalidAccountWithoutHeader);
-	bool isValidAccountValid = MemoryAccountIsValid(validAccount);
+	assert_true(MemoryAccounting_IsLiveAccount(MEMORY_OWNER_TYPE_END_LONG_LIVING));
+	/*
+	 * If shortLivingMemoryAccountArray is NULL, any ID beyond
+	 * MEMORY_OWNER_TYPE_END_LONG_LIVING will be considered invalid
+	 */
+	assert_false(MemoryAccounting_IsLiveAccount(MEMORY_OWNER_TYPE_END_LONG_LIVING + 1));
 
-	/* NULL account is not a valid account */
-	assert_false(isNullValid);
-	/* An account without proper header (T_MemoryAccount) is invalid */
-	assert_false(isInvalidHeaderValid);
-	/* An account without any header is invalid */
-	assert_false(isNoHeaderValid);
-	/* A valid account is one with the proper header */
-	assert_true(isValidAccountValid);
+	/* Restoring shortLivingAccountArray to check for valid accounts */
+	shortLivingMemoryAccountArray = accountArray;
+	nextAccountId = oldNext;
 
-	pfree(invalidAccountWithHeader);
-	pfree(invalidAccountWithoutHeader);
-	pfree(validAccount);
+	assert_true(MemoryAccounting_IsLiveAccount(MEMORY_OWNER_TYPE_Rollover));
+	/* liveAccountStartId should be the id of Top account */
+	assert_true(MemoryAccounting_IsLiveAccount(liveAccountStartId));
+	assert_true(MemoryAccounting_IsLiveAccount(MEMORY_OWNER_TYPE_END_LONG_LIVING + shortLivingMemoryAccountArray->accountCount - 1));
+
+	/* Check for a false return for boundary */
+	assert_false(MemoryAccounting_IsLiveAccount(
+			MEMORY_OWNER_TYPE_END_LONG_LIVING + shortLivingMemoryAccountArray->accountCount +
+			1 /* Reserved 1 for invalid */));
 }
 
 /*
@@ -514,7 +416,7 @@ test__MemoryAccountIsValid__ProperValidation(void **state)
 void
 test__MemoryAccounting_Reset__ReusesLongLivingAccounts(void **state)
 {
-	MemoryAccount *oldLogicalRoot = MemoryAccountTreeLogicalRoot;
+	MemoryAccount *oldLogicalRoot = MemoryAccounting_ConvertIdToAccount(MEMORY_OWNER_TYPE_LogicalRoot);
 	MemoryAccount *oldSharedChunkHeadersMemoryAccount = SharedChunkHeadersMemoryAccount;
 	MemoryAccount *oldRollover = RolloverMemoryAccount;
 	MemoryAccount *oldMemoryAccount = MemoryAccountMemoryAccount;
@@ -535,13 +437,15 @@ test__MemoryAccounting_Reset__ReusesLongLivingAccounts(void **state)
 	MemoryAccounting_Reset();
 
 	/* Make sure we have a valid set of accounts */
-	assert_true(MemoryAccountIsValid(MemoryAccountTreeLogicalRoot));
-	assert_true(MemoryAccountIsValid(SharedChunkHeadersMemoryAccount));
-	assert_true(MemoryAccountIsValid(RolloverMemoryAccount));
-	assert_true(MemoryAccountIsValid(MemoryAccountMemoryAccount));
+	assert_true(MemoryAccounting_IsLiveAccount(MEMORY_OWNER_TYPE_LogicalRoot));
+	assert_true(MemoryAccounting_IsLiveAccount(MEMORY_OWNER_TYPE_SharedChunkHeader));
+	assert_true(MemoryAccounting_IsLiveAccount(MEMORY_OWNER_TYPE_Rollover));
+	assert_true(MemoryAccounting_IsLiveAccount(MEMORY_OWNER_TYPE_MemAccount));
 
+	MemoryAccount *root = MemoryAccounting_ConvertIdToAccount(MEMORY_OWNER_TYPE_LogicalRoot);
 	/* MemoryAccountTreeLogicalRoot should be reused (i.e., MemoryAccountTreeLogicalRoot will survive the reset) */
-	assert_true(oldLogicalRoot && MemoryAccountTreeLogicalRoot && MemoryAccountTreeLogicalRoot->maxLimit == ULONG_LONG_MAX);
+	assert_true(oldLogicalRoot && root &&
+			root->maxLimit == ULONG_LONG_MAX);
 
 	/* SharedChunkHeadersMemoryAccount should be reused (i.e., SharedChunkHeadersMemoryAccount will survive the reset) */
 	assert_true(oldSharedChunkHeadersMemoryAccount && SharedChunkHeadersMemoryAccount &&
@@ -556,13 +460,17 @@ test__MemoryAccounting_Reset__ReusesLongLivingAccounts(void **state)
 
 /*
  * Tests if the MemoryAccounting_Reset() recreates all the short-living
- * basic accounts such as TopMemoryAccount and AlienExecutorMemoryAccount
+ * basic accounts such as TopMemoryAccount
  */
 void
 test__MemoryAccounting_Reset__RecreatesShortLivingAccounts(void **state)
 {
-	MemoryAccount *oldTop = TopMemoryAccount;
-	MemoryAccount *oldAlien = AlienExecutorMemoryAccount;
+	MemoryAccount *topAccount = MemoryAccounting_ConvertIdToAccount(liveAccountStartId);
+	/* The first account should be Top */
+	assert_true(topAccount->ownerType == MEMORY_OWNER_TYPE_Top);
+	MemoryAccount *oldTop = topAccount;
+	MemoryAccountIdType extraShortAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Append);
+	assert_true(shortLivingMemoryAccountArray->accountCount == 2);
 
 	/*
 	 * We want to make sure that the reset process re-creates
@@ -573,19 +481,15 @@ test__MemoryAccounting_Reset__RecreatesShortLivingAccounts(void **state)
 	 * or creating new ones.
 	 */
 	oldTop->maxLimit = ULONG_LONG_MAX;
-	oldAlien->maxLimit = ULONG_LONG_MAX;
+
+	MemoryAccountIdType oldLiveStart = liveAccountStartId;
 
 	MemoryAccounting_Reset();
+	assert_true(oldLiveStart + 2 == liveAccountStartId);
 
-	/* Make sure we have a valid set of accounts */
-	assert_true(MemoryAccountIsValid(TopMemoryAccount));
-	assert_true(MemoryAccountIsValid(AlienExecutorMemoryAccount));
- 	assert_true(ActiveMemoryAccount == TopMemoryAccount);
-
- 	/* TopMemoryAccount should be newly created */
-	assert_true(oldTop && TopMemoryAccount && TopMemoryAccount->maxLimit != ULONG_LONG_MAX);
-	/* AlienExecutorMemoryAccount should be newly created */
-	assert_true(oldAlien && AlienExecutorMemoryAccount && AlienExecutorMemoryAccount->maxLimit != ULONG_LONG_MAX);
+	MemoryAccount *newTop = MemoryAccounting_ConvertIdToAccount(liveAccountStartId);
+	assert_true(newTop->ownerType == MEMORY_OWNER_TYPE_Top);
+	assert_true(oldTop != newTop || newTop->maxLimit != ULONG_LONG_MAX);
 }
 
 /*
@@ -630,7 +534,8 @@ test__MemoryAccounting_Reset__ResetsMemoryAccountMemoryContext(void **state)
 	 */
 	for (int i = 0; i < numAccountsToCreate; i++)
 	{
-		MemoryAccount *tempAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccount);
+		MemoryAccount *tempAccount = MemoryAccounting_ConvertIdToAccount(CreateMemoryAccountImpl
+				(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId));
 	}
 
 	assert_true(oldMemContextBalance <
@@ -654,34 +559,37 @@ test__MemoryAccounting_Reset__ResetsMemoryAccountMemoryContext(void **state)
 void
 test__MemoryAccounting_Reset__TopIsActive(void **state)
 {
-	MemoryAccount *newActiveAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccount);
+	MemoryAccountIdType newActiveAccountId = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId);
 
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount);
-
-	assert_true(ActiveMemoryAccount == newActiveAccount);
+	MemoryAccountIdType oldActiveAccountId = MemoryAccounting_SwitchAccount(newActiveAccountId);
+	assert_true(ActiveMemoryAccountId == newActiveAccountId);
 
 	MemoryAccounting_Reset();
-
-	assert_true(ActiveMemoryAccount == TopMemoryAccount);
+	MemoryAccount* top = MemoryAccounting_ConvertIdToAccount(liveAccountStartId);
+	assert_true(MEMORY_OWNER_TYPE_Top == top->ownerType && ActiveMemoryAccountId == top->id);
 }
 
 /*
  * Tests if the MemoryAccounting_Reset() advances memory account
- * generation, so that previous generation accounts do not
- * cause segfault
+ * generation
  */
 void
 test__MemoryAccounting_Reset__AdvancesGeneration(void **state)
 {
-	uint16 oldGeneration = MemoryAccountingCurrentGeneration;
+	MemoryAccountIdType liveStart = liveAccountStartId;
+
+	MemoryAccountIdType extraShortAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Append);
+	MemoryAccounting_IsLiveAccount(extraShortAccountId);
+
+	MemoryAccountIdType nextId = nextAccountId;
+	assert_true(liveStart + 1 < nextId);
 
 	MemoryAccounting_Reset();
 
-	/*
-	 * We don't test for generation migration here, which will be handled
-	 * in the test case for AdvanceMemoryAccountingGeneration
-	 */
-	assert_true(oldGeneration < MemoryAccountingCurrentGeneration);
+	/* We already created top */
+	assert_true(liveAccountStartId == nextId && liveAccountStartId + 1 == nextAccountId);
+	/* Previous short account is no longer valid */
+	assert_false(MemoryAccounting_IsLiveAccount(extraShortAccountId));
 }
 
 /*
@@ -718,6 +626,27 @@ test__MemoryAccounting_Reset__TransferRemainingToRollover(void **state)
 }
 
 /*
+ * Tests if the MemoryAccounting_GetAccountCurrentBalance() returns the current
+ * balance of an account
+ */
+void
+test__MemoryAccounting_GetAccountCurrentBalance__ResetPeakBalance(void **state)
+{
+	MemoryAccountIdType newAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType oldAccountId = MemoryAccounting_SwitchAccount(newAccountId);
+
+	/* Tiny alloc that requires a new SharedChunkHeader, due to a new ActiveMemoryAccount */
+	assert_true(MemoryAccounting_GetAccountCurrentBalance(newAccountId) == 0);
+	void *testAlloc = palloc(sizeof(int));
+	MemoryAccount *memoryAccount = MemoryAccounting_ConvertIdToAccount(newAccountId);
+	assert_true(MemoryAccounting_GetAccountCurrentBalance(newAccountId) == memoryAccount->allocated - memoryAccount->freed);
+
+	pfree(testAlloc);
+	assert_true(MemoryAccounting_GetAccountCurrentBalance(newAccountId) == 0);
+	MemoryAccounting_SwitchAccount(oldAccountId);
+}
+
+/*
  * Tests if the MemoryAccounting_Reset() resets the high water
  * mark (i.e., peak balance)
  */
@@ -738,45 +667,6 @@ test__MemoryAccounting_Reset__ResetPeakBalance(void **state)
 
 	/* After reset, peak balance should be back to outstanding balance */
 	assert_true(MemoryAccountingPeakBalance == MemoryAccountingOutstandingBalance);
-}
-
-/*
- * This method tests that the memory accounting reset
- * process properly initializes the basic data structures.
- */
-void
-test__MemoryAccounting_Reset__TreeStructure(void **state)
-{
-	MemoryAccounting_Reset();
-
-	assert_true(NULL != MemoryAccountTreeLogicalRoot);
-	/* First child of logical root should be TopMemoryAccount */
-	assert_true(MemoryAccountTreeLogicalRoot->firstChild == TopMemoryAccount);
-	/*
-	 * nextSibling points to the parent's next child. As logical
-	 * root does not have any parent, so the next sibling should be NULL
-	 */
-	assert_true(NULL == MemoryAccountTreeLogicalRoot->nextSibling);
-	/* AlienExecutorMemoryAccount is the only child of TopMemoryAccount */
-	assert_true(TopMemoryAccount->firstChild == AlienExecutorMemoryAccount);
-	/* MemoryAccountMemoryAccount is the next child of logical root (first child is Top) */
-	assert_true(TopMemoryAccount->nextSibling == MemoryAccountMemoryAccount);
-	/* RolloverMemoryAccount is the next child of logical root */
-	assert_true(MemoryAccountMemoryAccount->nextSibling == RolloverMemoryAccount);
-	/* SharedChunkHeadersMemoryAccount is the next child of logical root */
-	assert_true(RolloverMemoryAccount->nextSibling == SharedChunkHeadersMemoryAccount);
-	/* SharedChunkHeadersMemoryAccount is the last child of logical root */
-	assert_true(SharedChunkHeadersMemoryAccount->nextSibling == NULL);
-
-	/* AlienExecutorMemoryAccount is a leaf node */
-	assert_true(NULL == AlienExecutorMemoryAccount->firstChild);
-	/* AlienExecutorAccount should not have any sibling */
-	assert_true(AlienExecutorMemoryAccount->nextSibling == NULL);
-
-	/* All long-living nodes except logical tree root should be leaf node */
-	assert_true(NULL == SharedChunkHeadersMemoryAccount->firstChild);
-	assert_true(NULL == RolloverMemoryAccount->firstChild);
-	assert_true(NULL == MemoryAccountMemoryAccount->firstChild);
 }
 
 /*
@@ -808,253 +698,17 @@ test__MemoryAccounting_AdvanceMemoryAccountingGeneration__TransfersBalanceToRoll
 
 /*
  * Tests if the MemoryAccounting_AdvanceMemoryAccountingGeneration()
- * transfers the entire outstanding balance to RolloverMemoryAccount
- * during generation overflow (i.e., migrates chunks from former
- * owner to Rollover)
- */
-void
-test__MemoryAccounting_AdvanceMemoryAccountingGeneration__TransfersBalanceToRolloverWithMigration(void **state)
-{
-	/* First allocate some memory so that we have something to rollover (do not free) */
-	palloc(NEW_ALLOC_SIZE);
-
-	uint64 oldRolloverBalance = RolloverMemoryAccount->allocated - RolloverMemoryAccount->freed;
-
-	assert_true(oldRolloverBalance < MemoryAccountingOutstandingBalance);
-
-	/*
-	 * Force a generation counter overflow (and trigger a migration)
-	 * upon next AdvanceMemoryAccountingGeneration() call
-	 */
-	MemoryAccountingCurrentGeneration = USHRT_MAX;
-
-	/* Prepare for a elog() call during migration */
-	will_be_called(elog_start);
-	expect_any(elog_start, filename);
-	expect_any(elog_start, lineno);
-	expect_any(elog_start, funcname);
-	will_be_called(elog_finish);
-	expect_any(elog_finish, elevel);
-	expect_any(elog_finish, fmt);
-
-	/*
-	 * Give all the balance to Rollover to pass the assertion check during MemoryAccounting_Free
-	 * where it subtracts any outstanding balance from Rollover because of generation mismatch
-	 * and expects to see a positive balance. Also, make sure that we pass the assertion check
-	 * in AdvanceMemoryAccountGeneration() where it checks that all the MemoryAccountMemoryAccount
-	 * balances have been freed (MemoryAccountMemoryAccount is not supposed to carry any balance
-	 * from previous generation, but due to artificial generation jump, it looks like it is carrying
-	 * from earlier generation. We want to fix this.)
-	 */
-	RolloverMemoryAccount->allocated = MemoryAccountMemoryAccount->allocated - MemoryAccountMemoryAccount->freed;
-	RolloverMemoryAccount->freed = 0;
-	/* Act as if we don't have any carryover */
-	MemoryAccountMemoryAccount->freed = MemoryAccountMemoryAccount->allocated;
-
-	AdvanceMemoryAccountingGeneration();
-
-	/* Generation counter should wrap around */
-	assert_true(MemoryAccountingCurrentGeneration == 0);
-
-	uint64 newRolloverBalance = RolloverMemoryAccount->allocated - RolloverMemoryAccount->freed;
-
-	/* The entire outstanding balance except SharedChunkHeadersMemoryAccount balance should now be in rollover's bucket */
-	assert_true((newRolloverBalance + (SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed)) ==
-			MemoryAccountingOutstandingBalance && newRolloverBalance > oldRolloverBalance);
-}
-
-/*
- * Tests if the MemoryAccounting_AdvanceMemoryAccountingGeneration()
  * sets RolloverMemoryAccount as the ActiveMemoryAccount
  */
 void
 test__MemoryAccounting_AdvanceMemoryAccountingGeneration__SetsActiveToRollover(void **state)
 {
-	MemoryAccounting_SwitchAccount(TopMemoryAccount);
+	MemoryAccounting_SwitchAccount(liveAccountStartId);
+	assert_true(MemoryAccounting_ConvertIdToAccount(ActiveMemoryAccountId)->ownerType == MEMORY_OWNER_TYPE_Top);
 
 	AdvanceMemoryAccountingGeneration();
 
-	assert_true(RolloverMemoryAccount == ActiveMemoryAccount);
-}
-
-/*
- * Tests if the MemoryAccounting_AdvanceMemoryAccountingGeneration()
- * advances generation in non-migration (no generation overflow) case
- */
-void
-test__MemoryAccounting_AdvanceMemoryAccountingGeneration__AdvancesGeneration(void **state)
-{
-	uint16 oldGeneration = MemoryAccountingCurrentGeneration;
-
-	AdvanceMemoryAccountingGeneration();
-
-	assert_true((oldGeneration + 1) == MemoryAccountingCurrentGeneration);
-}
-
-/*
- * Tests if the MemoryAccounting_AdvanceMemoryAccountingGeneration()
- * preserves the chunk header (for performance reason) if there
- * is no generation overflow
- */
-void
-test__MemoryAccounting_AdvanceMemoryAccountingGeneration__PreservesChunkHeader(void **state)
-{
-	MemoryAccount *newActiveAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccount);
-
-	/* Make sure we have a new active account other than Rollover */
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount);
-
-	assert_true(ActiveMemoryAccount == newActiveAccount);
-
-	/* Establish at least 3 level depths of tree (TopMemoryContext->ErrorContext->leafContext) */
-	MemoryContext *leafContext = AllocSetContextCreate(ErrorContext,
-			   "TestContext",
-			   ALLOCSET_DEFAULT_MINSIZE,
-			   ALLOCSET_DEFAULT_INITSIZE,
-			   ALLOCSET_DEFAULT_MAXSIZE);
-
-	/*
-	 * We created at least a depth 3 memory context tree, and we want to allocate
-	 * memory in all three levels. Then we want to make sure the AdvanceMemoryAccountingGeneration
-	 * doesn't change any of these chunks' headers
-	 */
-	int *topAlloc = MemoryContextAlloc(TopMemoryContext, NEW_ALLOC_SIZE);
-	int *errorAlloc = MemoryContextAlloc(ErrorContext, NEW_ALLOC_SIZE);
-	int *leafAlloc = MemoryContextAlloc(leafContext, NEW_ALLOC_SIZE);
-
-	StandardChunkHeader *topAllocChunk = AllocPointerGetChunk(topAlloc);
-	StandardChunkHeader *errorAllocChunk = AllocPointerGetChunk(errorAlloc);
-	StandardChunkHeader *leafAllocChunk = AllocPointerGetChunk(leafAlloc);
-
-	uint16 oldGeneration = MemoryAccountingCurrentGeneration;
-
-	/*
-	 * Make sure the chunks are from current generation and are owned
-	 * by an account that is soon to be extinct
-	 */
-	assert_true(topAllocChunk->sharedHeader->memoryAccountGeneration == MemoryAccountingCurrentGeneration &&
-			topAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-	assert_true(errorAllocChunk->sharedHeader->memoryAccountGeneration == MemoryAccountingCurrentGeneration &&
-			errorAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-	assert_true(leafAllocChunk->sharedHeader->memoryAccountGeneration == MemoryAccountingCurrentGeneration &&
-			leafAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-
-	AdvanceMemoryAccountingGeneration();
-
-	/* Now make sure that the chunks are unchanged, as this is a non-migration case */
-	assert_true(topAllocChunk->sharedHeader->memoryAccountGeneration == oldGeneration &&
-			topAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-	assert_true(errorAllocChunk->sharedHeader->memoryAccountGeneration == oldGeneration &&
-			errorAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-	assert_true(leafAllocChunk->sharedHeader->memoryAccountGeneration == oldGeneration &&
-			leafAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-}
-
-/*
- * Tests if the MemoryAccounting_AdvanceMemoryAccountingGeneration()
- * changes all shared chunk headers if there is a generation overflow
- */
-void
-test__MemoryAccounting_AdvanceMemoryAccountingGeneration__MigratesChunkHeaders(void **state)
-{
-	MemoryAccountingCurrentGeneration = 10;
-
-	/* Make sure we have a new active account other than Rollover */
-	MemoryAccount *newActiveAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccount);
-
-	MemoryAccount *oldActiveAccount = MemoryAccounting_SwitchAccount(newActiveAccount);
-
-	assert_true(ActiveMemoryAccount == newActiveAccount);
-
-	assert_true(TopMemoryContext != NULL && ErrorContext != NULL && ErrorContext->parent == TopMemoryContext);
-
-	/* Establish at least 3 level depths of tree (TopMemoryContext->ErrorContext->leafContext) */
-	MemoryContext *leafContext = AllocSetContextCreate(ErrorContext,
-			   "TestContext",
-			   ALLOCSET_DEFAULT_MINSIZE,
-			   ALLOCSET_DEFAULT_INITSIZE,
-			   ALLOCSET_DEFAULT_MAXSIZE);
-
-	/*
-	 * We created at least a depth 3 memory context tree, and we want to allocate
-	 * memory in all three levels. Then we want to make sure the AdvanceMemoryAccountingGeneration
-	 * recursively traverse the tree to change every allocated chunk's header
-	 */
-	int *topAlloc = MemoryContextAlloc(TopMemoryContext, NEW_ALLOC_SIZE);
-	int *errorAlloc = MemoryContextAlloc(ErrorContext, NEW_ALLOC_SIZE);
-	int *leafAlloc = MemoryContextAlloc(leafContext, NEW_ALLOC_SIZE);
-
-	StandardChunkHeader *topAllocChunk = AllocPointerGetChunk(topAlloc);
-	StandardChunkHeader *errorAllocChunk = AllocPointerGetChunk(errorAlloc);
-	StandardChunkHeader *leafAllocChunk = AllocPointerGetChunk(leafAlloc);
-
-	uint16 oldGeneration = MemoryAccountingCurrentGeneration;
-
-	/*
-	 * Make sure the chunks are from older generation and are owned
-	 * by an account that is soon to be extinct
-	 */
-	assert_true(topAllocChunk->sharedHeader->memoryAccountGeneration == MemoryAccountingCurrentGeneration &&
-			topAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-	assert_true(errorAllocChunk->sharedHeader->memoryAccountGeneration == MemoryAccountingCurrentGeneration &&
-			errorAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-	assert_true(leafAllocChunk->sharedHeader->memoryAccountGeneration == MemoryAccountingCurrentGeneration &&
-			leafAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-
-	/* Check the boundary, where we are just 1 short of generation migration */
-	MemoryAccountingCurrentGeneration = USHRT_MAX - 1;
-
-	/*
-	 * Give all the balance to Rollover to pass the assertion check during MemoryAccounting_Free
-	 * where it subtracts any outstanding balance from Rollover because of generation mismatch
-	 * and expects to see a positive balance. Also, make sure that we pass the assertion check
-	 * in AdvanceMemoryAccountGeneration() where it checks that all the MemoryAccountMemoryAccount
-	 * balances have been freed (MemoryAccountMemoryAccount is not supposed to carry any balance
-	 * from previous generation, but due to artificial generation jump, it looks like it is carrying
-	 * from earlier generation. We want to fix this.)
-	 */
-	RolloverMemoryAccount->allocated = MemoryAccountMemoryAccount->allocated - MemoryAccountMemoryAccount->freed;
-	/* Act as if we don't have any carryover */
-	MemoryAccountMemoryAccount->freed = MemoryAccountMemoryAccount->allocated;
-
-	AdvanceMemoryAccountingGeneration();
-
-	/* This should be a non-migration case and the chunk headers should be unchanged */
-	assert_false(topAllocChunk->sharedHeader->memoryAccountGeneration == 0 &&
-			topAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-	assert_false(errorAllocChunk->sharedHeader->memoryAccountGeneration == 0 &&
-			errorAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-	assert_false(leafAllocChunk->sharedHeader->memoryAccountGeneration == 0 &&
-			leafAllocChunk->sharedHeader->memoryAccount == newActiveAccount);
-
-	/*
-	 * Now push the generation to the max, so that the next generation advancement
-	 * triggers a migration
-	 */
-	MemoryAccountingCurrentGeneration = USHRT_MAX;
-
-	will_be_called(elog_start);
-	expect_any(elog_start, filename);
-	expect_any(elog_start, lineno);
-	expect_any(elog_start, funcname);
-	will_be_called(elog_finish);
-	expect_any(elog_finish, elevel);
-	expect_any(elog_finish, fmt);
-
-	AdvanceMemoryAccountingGeneration();
-
-	/*
-	 * Make sure that the generation migration process changed
-	 * headers of all levels of tree nodes. All the allocations
-	 * should now be owned by RolloverMemoryAccount and their
-	 * generation should be set to 0
-	 */
-	assert_true(topAllocChunk->sharedHeader->memoryAccountGeneration == 0 &&
-			topAllocChunk->sharedHeader->memoryAccount == RolloverMemoryAccount);
-	assert_true(errorAllocChunk->sharedHeader->memoryAccountGeneration == 0 &&
-			errorAllocChunk->sharedHeader->memoryAccount == RolloverMemoryAccount);
-	assert_true(leafAllocChunk->sharedHeader->memoryAccountGeneration == 0 &&
-			leafAllocChunk->sharedHeader->memoryAccount == RolloverMemoryAccount);
+	assert_true(ActiveMemoryAccountId == MEMORY_OWNER_TYPE_Rollover);
 }
 
 /*
@@ -1075,14 +729,14 @@ test__MemoryContextReset__ResetsSharedChunkHeadersMemoryAccountBalance(void **st
 	 * the MemoryAccountMemoryContext reset. So, we have to carefully set
 	 * to a long-living active memory account to prevent a crash in the teardown
 	 */
-	MemoryAccount *oldAccount = MemoryAccounting_SwitchAccount(MemoryAccountMemoryAccount);
+	MemoryAccountIdType oldAccountId = MemoryAccounting_SwitchAccount(MEMORY_OWNER_TYPE_Exec_AlienShared);
 	MemoryContext newContext = AllocSetContextCreate(TopMemoryContext,
 										   "TestContext",
 										   ALLOCSET_DEFAULT_MINSIZE,
 										   ALLOCSET_DEFAULT_INITSIZE,
 										   ALLOCSET_DEFAULT_MAXSIZE);
 
-	MemoryAccounting_SwitchAccount(oldAccount);
+	MemoryAccounting_SwitchAccount(oldAccountId);
 
 	MemoryContext oldContext = MemoryContextSwitchTo(newContext);
 
@@ -1093,14 +747,13 @@ test__MemoryContextReset__ResetsSharedChunkHeadersMemoryAccountBalance(void **st
 	 */
 	int64 initialSharedHeaderBalance = SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed;
 
-	/* This would trigger a new shared header with ActiveMemoryAccount */
+	/* This would trigger a new shared header with ActiveMemoryAccountId */
 	void *testAlloc1 = palloc(sizeof(int));
 
 	SharedChunkHeader *sharedHeader = ((AllocSet)newContext)->sharedHeaderList;
 
-	/* Make sure we got the right memory account, and the right generation */
-	assert_true(sharedHeader->memoryAccount == ActiveMemoryAccount &&
-			sharedHeader->memoryAccountGeneration == MemoryAccountingCurrentGeneration);
+	/* Make sure we got the right memory account */
+	assert_true(sharedHeader->memoryAccountId == ActiveMemoryAccountId);
 
 	/* Make sure we did adjust SharedChunkHeadersMemoryAccount balance */
 	assert_true(initialSharedHeaderBalance <
@@ -1108,7 +761,7 @@ test__MemoryContextReset__ResetsSharedChunkHeadersMemoryAccountBalance(void **st
 
 	int64 prevSharedHeaderBalance = SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed;
 
-	/* This would *not* trigger a new shared header (reuse header) */
+	/* This would *not* trigger a new shared	 header (reuse header) */
 	void *testAlloc2 = palloc(sizeof(int));
 
 	/* Make sure no shared header balance is increased */
@@ -1116,9 +769,9 @@ test__MemoryContextReset__ResetsSharedChunkHeadersMemoryAccountBalance(void **st
 			(SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed));
 
 	/* We need a new active account to make sure that we are forcing a new SharedChunkHeader */
-	MemoryAccount *newAccount = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
+	MemoryAccountIdType newAccountId = MemoryAccounting_CreateAccount(0, MEMORY_OWNER_TYPE_Exec_Hash);
 
-	oldAccount = MemoryAccounting_SwitchAccount(newAccount);
+	oldAccountId = MemoryAccounting_SwitchAccount(newAccountId);
 
 	/* Tiny alloc that requires a new SharedChunkHeader, due to a new ActiveMemoryAccount */
 	void *testAlloc3 = palloc(sizeof(int));
@@ -1136,112 +789,140 @@ test__MemoryContextReset__ResetsSharedChunkHeadersMemoryAccountBalance(void **st
 			(SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed));
 }
 
-/*
- * Compares two memory accounting trees (the original tree and
- * the deserialized version of that tree after it was serialized)
- * to see if they are identical
- *
- * Parameters:
- * 		deserializedRoot: the root of the deserialized memory accounting sub-tree
- * 		originalRoot: the root of the original memory accounting sub-tree
- *
- * 	Returns true if the sub-tree is identical in terms of ownerType and maxLimit
- */
-bool
-compareDeserializedVsOriginalMemoryAccountingTree(MemoryAccount *deserializedRoot, MemoryAccount *originalRoot)
-{
-	if (deserializedRoot == NULL && originalRoot == NULL)
+static void
+ValidateSerializedAccountArray(const char* bytes, uint32 totalSerialized, uint32 expectedSerialized) {
+    assert_true(totalSerialized == expectedSerialized);
+
+	MemoryAccount* combinedAccountArray = (MemoryAccount*) bytes;
+
+	for (int i = 0; i < MEMORY_OWNER_TYPE_END_LONG_LIVING; i++)
 	{
-		/* Identical tree */
-		return true;
+		MemoryAccount serializedAccount = combinedAccountArray[i];
+		/* Serialization throws out the reserved MEMORY_OWNER_TYPE_Undefined */
+		assert_true(serializedAccount.id == (i + 1));
+
 	}
-	else if (deserializedRoot == NULL || originalRoot == NULL)
+	assert_true(totalSerialized == MEMORY_OWNER_TYPE_END_LONG_LIVING
+							+ (nextAccountId - liveAccountStartId));
+
+	/* Make sure we can even verify if the liveAccountStartId is not contiguous (we already had some reset) */
+	assert_true(combinedAccountArray[MEMORY_OWNER_TYPE_END_LONG_LIVING].id == liveAccountStartId);
+	/* And verify that the end of the account Ids capture the entire set of accounts */
+	assert_true(combinedAccountArray[totalSerialized - 1].id == (nextAccountId - 1));
+
+	MemoryAccountIdType prevAccountId = liveAccountStartId;
+	for (int i = MEMORY_OWNER_TYPE_END_LONG_LIVING; i < totalSerialized; i++)
 	{
-		/* We exhausted one before the other */
-		return false;
+		MemoryAccount serializedAccount = combinedAccountArray[i];
+		assert_true(MemoryAccounting_IsLiveAccount(serializedAccount.id));
+
+		/* Ensure a set of contiguous account IDs */
+		assert_true(i == MEMORY_OWNER_TYPE_END_LONG_LIVING || prevAccountId == (i - 1));
+		prevAccountId = i;
 	}
-
-	/*
-	 * Cannot compare allocated and freed as the serialization process
-	 * might allocate/free additional memory while walking the tree,
-	 * introducing mismatch of allocated/freed between serialized and
-	 * original version of an account
-	 */
-	if (deserializedRoot->ownerType != originalRoot->ownerType ||
-			deserializedRoot->maxLimit != originalRoot->maxLimit)
-	{
-		return false;
-	}
-
-	bool identicalChildTree = compareDeserializedVsOriginalMemoryAccountingTree(deserializedRoot->firstChild, originalRoot->firstChild);
-
-	if (!identicalChildTree)
-	{
-		return false;
-	}
-
-	MemoryAccount *deserializedSibling = NULL;
-	MemoryAccount *originalSibling = NULL;
-
-	bool identicalSibling = true;
-
-	for (deserializedSibling = deserializedRoot->nextSibling,
-			originalSibling = originalRoot->nextSibling;
-			identicalSibling == true && deserializedSibling != NULL && originalSibling != NULL;
-			deserializedSibling = deserializedSibling->nextSibling,
-					originalSibling = originalSibling->nextSibling)
-	{
-		identicalSibling = compareDeserializedVsOriginalMemoryAccountingTree(deserializedSibling, originalSibling);
-	}
-
-	if (!identicalSibling || deserializedSibling != NULL || originalSibling != NULL)
-	{
-		return false;
-	}
-
-	return true;
 }
 
-/* Tests if the serialization and deserialization of the memory accounting tree is working */
+/* Tests if the serialization of the memory accounting tree is working */
 void
-test__MemoryAccounting_Serialize_Deserialize__Validate(void **state)
+test__MemoryAccounting_Serialize__Validate(void **state)
 {
 	StringInfoData buffer;
     initStringInfo(&buffer);
 
     uint32 totalSerialized = MemoryAccounting_Serialize(&buffer);
 
-    /*
-     * We haven't created any new account, so we should have
-     * MemoryAccountTreeLogicalRoot, SharedChunkHeadersMemoryAccount,
-     * RolloverMemoryAccount, TopMemoryAccount, and AlienExecutorMemoryAccount
-     */
-    assert_true(totalSerialized == 6);
+    /* Only top besides the long living accounts */
+	ValidateSerializedAccountArray(buffer.data, totalSerialized, MEMORY_OWNER_TYPE_END_LONG_LIVING + 1);
 
-    SerializedMemoryAccount *serializedTree = MemoryAccounting_Deserialize(buffer.data, totalSerialized);
+	MemoryAccountIdType newAccount1 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, liveAccountStartId /* Top */);
+	MemoryAccountIdType newAccount2 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_SeqScan, newAccount1);
+	MemoryAccountIdType newAccount3 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Sort, newAccount1);
 
-    assert_true(compareDeserializedVsOriginalMemoryAccountingTree(&serializedTree->memoryAccount, MemoryAccountTreeLogicalRoot));
-
-    /* This will also free serializedTree, as the deserialization is done in place */
-    pfree(buffer.data);
-
-	MemoryAccount *newAccount1 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, TopMemoryAccount);
-	MemoryAccount *newAccount2 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_SeqScan, newAccount1);
-	MemoryAccount *newAccount3 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Sort, newAccount1);
-
+	pfree(buffer.data);
 	initStringInfo(&buffer);
 
 	totalSerialized = MemoryAccounting_Serialize(&buffer);
+    /* Long living accounts + Top + 3 new accounts */
+	ValidateSerializedAccountArray(buffer.data, totalSerialized, MEMORY_OWNER_TYPE_END_LONG_LIVING + 1 + 3);
 
-	assert_true(totalSerialized == 9);
+	uint64 prevLiveStart = liveAccountStartId;
+	/* Ensure gap of Ids between end of long living and start of short living */
+	MemoryAccounting_Reset();
 
-    serializedTree = MemoryAccounting_Deserialize(buffer.data, totalSerialized);
-    assert_true(compareDeserializedVsOriginalMemoryAccountingTree(&serializedTree->memoryAccount, MemoryAccountTreeLogicalRoot));
+	/* Capture the fact that we have gap between start of short account Ids and end of long account Ids */
+	assert_true(prevLiveStart != liveAccountStartId && liveAccountStartId - MEMORY_OWNER_TYPE_END_LONG_LIVING > 1);
 
-    pfree(buffer.data);
-    pfree(newAccount1);
-    pfree(newAccount2);
-    pfree(newAccount3);
+	pfree(buffer.data);
+	initStringInfo(&buffer);
+	totalSerialized = MemoryAccounting_Serialize(&buffer);
+
+    /* Only top besides the long living accounts */
+	ValidateSerializedAccountArray(buffer.data, totalSerialized, MEMORY_OWNER_TYPE_END_LONG_LIVING + 1);
+
+	MemoryAccountIdType newAccount4 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, liveAccountStartId /* Top */);
+	MemoryAccountIdType newAccount5 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_SeqScan, newAccount1);
+	MemoryAccountIdType newAccount6 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Sort, newAccount1);
+
+	pfree(buffer.data);
+	initStringInfo(&buffer);
+	totalSerialized = MemoryAccounting_Serialize(&buffer);
+
+    /* Long living accounts + Top + 3 new accounts */
+	ValidateSerializedAccountArray(buffer.data, totalSerialized, MEMORY_OWNER_TYPE_END_LONG_LIVING + 1 + 3);
+	pfree(buffer.data);
+}
+
+
+/*
+ * Tests if the MemoryAccounting_CombinedAccountArrayToString of the memory accounting tree
+ *  produces expected output
+ */
+void
+test__MemoryAccounting_CombinedAccountArrayToString__Validate(void **state)
+{
+	StringInfoData serializedBytes;
+	initStringInfoOfSize(&serializedBytes, MAX_OUTPUT_BUFFER_SIZE);
+
+	MemoryAccount *topAccount = MemoryAccounting_ConvertIdToAccount(liveAccountStartId);
+
+	MemoryAccountIdType newAccount1 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, liveAccountStartId /* Top */);
+	MemoryAccountIdType newAccount2 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_SeqScan, newAccount1);
+	MemoryAccountIdType newAccount3 = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Sort, newAccount1);
+
+	StringInfoData str;
+	initStringInfoOfSize(&str, MAX_OUTPUT_BUFFER_SIZE);
+
+	size_t oldTopBalance = topAccount->allocated - topAccount->freed;
+	size_t oldTopPeak = topAccount->peak;
+
+	uint32 totalSerialized = MemoryAccounting_Serialize(&serializedBytes);
+
+	char *templateString = "Root: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  Top: Peak/Cur " UINT64_FORMAT "/" UINT64_FORMAT "bytes. Quota: 0bytes.\n\
+    X_Hash: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+      X_Sort: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+      X_SeqScan: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  X_Alien: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  MemAcc: Peak/Cur " UINT64_FORMAT "/" UINT64_FORMAT "bytes. Quota: 0bytes.\n\
+  Rollover: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  SharedHeader: Peak/Cur " UINT64_FORMAT "/" UINT64_FORMAT "bytes. Quota: 0bytes.\n";
+
+	char		buf[MAX_OUTPUT_BUFFER_SIZE];
+
+	snprintf(buf, sizeof(buf), templateString,
+			topAccount->peak, topAccount->allocated - topAccount->freed,
+			MemoryAccountMemoryAccount->peak, MemoryAccountMemoryAccount->allocated - MemoryAccountMemoryAccount->freed,
+			SharedChunkHeadersMemoryAccount->peak, SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed);
+
+	MemoryAccounting_CombinedAccountArrayToString(serializedBytes.data, totalSerialized, &str, 0);
+
+	size_t newTopBalance = topAccount->allocated - topAccount->freed;
+	size_t newTopPeak = topAccount->peak;
+
+    assert_true(strcmp(str.data, buf) == 0);
+
+    pfree(serializedBytes.data);
+	pfree(str.data);
 }
 
 
@@ -1253,49 +934,54 @@ test__MemoryAccounting_GetAccountName__Validate(void **state)
 #define SHORT_LIVING_NON_OPERATOR_START 101
 #define SHORT_LIVING_OPERATOR_START 1000
 
-	char* longLivingNames[] = {"Root", "SharedHeader", "Rollover", "MemAcc"};
+	char* longLivingNames[] = {"Root", "SharedHeader", "Rollover", "MemAcc", "X_Alien"};
 
-	char* shortLivingNonOpNames[] = {"Top", "Main", "Parser", "Planner", "Optimizer", "Dispatcher", "Serializer", "Deserializer"};
+	char* shortLivingNames[] = {"Top", "Main", "Parser", "Planner", "Optimizer", "Dispatcher", "Serializer", "Deserializer",
+			"Executor", "X_Result", "X_Append", "X_Sequence", "X_BitmapAnd", "X_BitmapOr", "X_SeqScan", "X_ExternalScan",
+			"X_AppendOnlyScan", "X_AOCSCAN", "X_TableScan", "X_DynamicTableScan", "X_IndexScan", "X_DynamicIndexScan", "X_BitmapIndexScan",
+			"X_BitmapHeapScan", "X_BitmapAppendOnlyScan", "X_TidScan", "X_SubqueryScan", "X_FunctionScan", "X_TableFunctionScan",
+			"X_ValuesScan", "X_NestLoop", "X_MergeJoin", "X_HashJoin", "X_Material", "X_Sort", "X_Agg", "X_Unique", "X_Hash", "X_SetOp",
+			"X_Limit", "X_Motion", "X_ShareInputScan", "X_Window", "X_Repeat", "X_DML", "X_SplitUpdate", "X_RowTrigger", "X_AssertOp",
+			"X_BitmapTableScan", "X_PartitionSelector"};
 
-	char* shortLivingOpNames[] = {"Executor", "X_Result", "X_Append", "X_Sequence", "X_Bitmap", "X_BitmapOr", "X_SeqScan", "X_ExternalScan", "X_AppendOnlyScan", "X_AOCSCAN", "X_TableScan", "X_DynamicTableScan", "X_IndexScan", "X_DynamicIndexScan", "X_BitmapIndexScan",
-			"X_BitmapHeapScan", "X_BitmapAppendOnlyScan", "X_TidScan", "X_SubqueryScan", "X_FunctionScan", "X_TableFunctionScan", "X_ValuesScan", "X_NestLoop", "X_MergeJoin", "X_HashJoin", "X_Material", "X_Sort", "X_Agg", "X_Unique", "X_Hash", "X_SetOp", "X_Limit",
-			"X_Motion", "X_ShareInputScan", "X_Window", "X_Repeat", "X_DML", "X_SplitUpdate", "X_RowTrigger", "X_AssertOp","X_Alien"};
-
-	for (int longLivingIndex = 0; longLivingIndex < sizeof(longLivingNames) / sizeof(char*); longLivingIndex++)
+	/* Ensure we have all the long living accounts in the longLivingNames array */
+	assert_true(sizeof(longLivingNames) / sizeof(char*) == MEMORY_OWNER_TYPE_END_LONG_LIVING);
+	for (int longLivingId = MEMORY_OWNER_TYPE_START_LONG_LIVING; longLivingId <= MEMORY_OWNER_TYPE_END_LONG_LIVING; longLivingId++)
 	{
-		int memoryOwnerType = LONG_LIVING_START + longLivingIndex;
-		MemoryAccount *newAccount = CreateMemoryAccountImpl(0, memoryOwnerType, ActiveMemoryAccount);
-
-		assert_true(strcmp(MemoryAccounting_GetAccountName(newAccount), longLivingNames[longLivingIndex]) == 0);
-
-		pfree(newAccount);
+		MemoryOwnerType memoryOwnerType = (MemoryOwnerType) longLivingId;
+		assert_true(strcmp(MemoryAccounting_GetOwnerName(memoryOwnerType), longLivingNames[longLivingId - 1]) == 0);
 	}
 
-	for (int shortLivingNonOpIndex = 0; shortLivingNonOpIndex < sizeof(shortLivingNonOpNames) / sizeof(char*); shortLivingNonOpIndex++)
+	assert_true(sizeof(shortLivingNames) / sizeof(char*) == MEMORY_OWNER_TYPE_END_SHORT_LIVING - MEMORY_OWNER_TYPE_START_SHORT_LIVING + 1);
+	for (int shortLivingOwnerTypeId = MEMORY_OWNER_TYPE_START_SHORT_LIVING;
+			shortLivingOwnerTypeId <= MEMORY_OWNER_TYPE_END_SHORT_LIVING; shortLivingOwnerTypeId++)
 	{
-		int memoryOwnerType = SHORT_LIVING_NON_OPERATOR_START + shortLivingNonOpIndex;
-		MemoryAccount *newAccount = CreateMemoryAccountImpl(0, memoryOwnerType, ActiveMemoryAccount);
-
-		assert_true(strcmp(MemoryAccounting_GetAccountName(newAccount), shortLivingNonOpNames[shortLivingNonOpIndex]) == 0);
-
-		pfree(newAccount);
-	}
-
-	for (int shortLivingOpIndex = 0; shortLivingOpIndex < sizeof(shortLivingOpNames) / sizeof(char*); shortLivingOpIndex++)
-	{
-		int memoryOwnerType = SHORT_LIVING_OPERATOR_START + shortLivingOpIndex;
-		MemoryAccount *newAccount = CreateMemoryAccountImpl(0, memoryOwnerType, ActiveMemoryAccount);
-
-		assert_true(strcmp(MemoryAccounting_GetAccountName(newAccount), shortLivingOpNames[shortLivingOpIndex]) == 0);
-
-		pfree(newAccount);
+		MemoryOwnerType shortLivingOwnerType = (MemoryOwnerType) shortLivingOwnerTypeId;
+		char* name = MemoryAccounting_GetOwnerName(shortLivingOwnerType);
+		char* expected = shortLivingNames[shortLivingOwnerTypeId - MEMORY_OWNER_TYPE_START_SHORT_LIVING];
+		assert_true(strcmp(name, expected) == 0);
 	}
 }
 
-
-/* Tests if the MemoryAccounting_GetPeak is returning the correct peak balance */
+/* Tests if the MemoryAccounting_SizeOfAccountInBytes returns correct size */
 void
-test__MemoryAccounting_GetPeak__Validate(void **state)
+test__MemoryAccounting_SizeOfAccountInBytes__Validate(void **state)
+{
+	size_t accountSize = MemoryAccounting_SizeOfAccountInBytes();
+	assert_true(accountSize == sizeof(MemoryAccount));
+}
+
+/* Tests if the MemoryAccounting_GetGlobalPeak returns correct global peak balance */
+void
+test__MemoryAccounting_GetGlobalPeak__Validate(void **state)
+{
+	uint64 peak = MemoryAccounting_GetGlobalPeak();
+	assert_true(peak == MemoryAccountingPeakBalance);
+}
+
+/* Tests if the MemoryAccounting_GetAccountPeakBalance is returning the correct peak balance */
+void
+test__MemoryAccounting_GetAccountPeakBalance__Validate(void **state)
 {
 	uint64 peakBalances[] = {0, UINT32_MAX, UINT64_MAX};
 
@@ -1303,11 +989,12 @@ test__MemoryAccounting_GetPeak__Validate(void **state)
 	{
 		uint64 peakBalance = peakBalances[accountIndex];
 
-		MemoryAccount *newAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccount);
+		MemoryAccount *newAccount = MemoryAccounting_ConvertIdToAccount(
+				CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId));
 
 		newAccount->peak = peakBalance;
 
-		assert_true(MemoryAccounting_GetPeak(newAccount) == peakBalance);
+		assert_true(MemoryAccounting_GetAccountPeakBalance(newAccount->id) == peakBalance);
 
 		pfree(newAccount);
 	}
@@ -1325,7 +1012,8 @@ test__MemoryAccounting_GetBalance__Validate(void **state)
 		uint64 allocated = allAllocated[accountIndex];
 		uint64 freed = allFreed[accountIndex];
 
-		MemoryAccount *newAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccount);
+		MemoryAccount *newAccount = MemoryAccounting_ConvertIdToAccount(
+				CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId));
 
 		newAccount->allocated = allocated;
 		newAccount->freed = freed;
@@ -1344,21 +1032,22 @@ void
 test__MemoryAccounting_ToString__Validate(void **state)
 {
 	char *templateString =
-"Root: Peak 0K bytes. Quota: 0K bytes.\n\
-  Top: Peak %" PRIu64 "K bytes. Quota: 0K bytes.\n\
-    X_Hash: Peak %" PRIu64 "K bytes. Quota: 0K bytes.\n\
-    X_Alien: Peak 0K bytes. Quota: 0K bytes.\n\
-  MemAcc: Peak 0K bytes. Quota: 0K bytes.\n\
-  Rollover: Peak 0K bytes. Quota: 0K bytes.\n\
-  SharedHeader: Peak 0K bytes. Quota: 0K bytes.\n";
+"Root: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  Top: Peak/Cur %" PRIu64 "/%" PRIu64 "bytes. Quota: 0bytes.\n\
+    X_Hash: Peak/Cur %" PRIu64 "/%" PRIu64 "bytes. Quota: 0bytes.\n\
+  X_Alien: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  MemAcc: Peak/Cur %" PRIu64 "/%" PRIu64 "bytes. Quota: 0bytes.\n\
+  Rollover: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  SharedHeader: Peak/Cur %" PRIu64 "/%" PRIu64 "bytes. Quota: 0bytes.\n";
 
 	/* ActiveMemoryAccount should be Top at this point */
-	MemoryAccount *newAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccount);
+	MemoryAccount *newAccount = MemoryAccounting_ConvertIdToAccount(CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId));
+	MemoryAccount *topAccount = MemoryAccounting_ConvertIdToAccount(liveAccountStartId);
 
 	void * dummy1 = palloc(NEW_ALLOC_SIZE);
 	void * dummy2 = palloc(NEW_ALLOC_SIZE);
 
-	MemoryAccounting_SwitchAccount(newAccount);
+	MemoryAccounting_SwitchAccount(newAccount->id);
 
 	void * dummy3 = palloc(NEW_ALLOC_SIZE);
 
@@ -1369,13 +1058,21 @@ test__MemoryAccounting_ToString__Validate(void **state)
 	StringInfoData buffer;
 	initStringInfoOfSize(&buffer, MAX_OUTPUT_BUFFER_SIZE);
 
-    MemoryAccounting_ToString(MemoryAccountTreeLogicalRoot, &buffer, 0 /* Indentation */);
+	MemoryAccountTree *tree = ConvertMemoryAccountArrayToTree(&longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Undefined],
+			shortLivingMemoryAccountArray->allAccounts, shortLivingMemoryAccountArray->accountCount);
+
+	MemoryAccounting_ToString(&tree[MEMORY_OWNER_TYPE_LogicalRoot], &buffer, 0 /* Indentation */);
 
 	char		buf[MAX_OUTPUT_BUFFER_SIZE];
-	snprintf(buf, sizeof(buf), templateString, TopMemoryAccount->peak / 1024, newAccount->peak / 1024);
+	snprintf(buf, sizeof(buf), templateString,
+			topAccount->peak, (topAccount->allocated - topAccount->freed), /* Top */
+			newAccount->peak, (newAccount->allocated - newAccount->freed), /* X_Hash */
+			MemoryAccountMemoryAccount->peak, (MemoryAccountMemoryAccount->allocated - MemoryAccountMemoryAccount->freed), /* MemoryAccountMemoryAccount */
+			SharedChunkHeadersMemoryAccount->peak, (SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed) /* SharedChunkHeadersMemoryAccount */);
 
     assert_true(strcmp(buffer.data, buf) == 0);
 
+    pfree(tree);
     pfree(buffer.data);
     pfree(newAccount);
 }
@@ -1397,37 +1094,102 @@ memory: Peak, 0, 0, 0, %" PRIu64 ", %" PRIu64 ", 0, %" PRIu64 "\n\
 memory: Root, 0, 0, 0, 0, 0, 0, 0\n\
 memory: Top, 1, 0, 0, %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n\
 memory: X_Hash, 2, 1, 0, %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n\
-memory: X_Alien, 3, 1, 0, 0, 0, 0, 0\n\
+memory: X_Alien, 3, 0, 0, 0, 0, 0, 0\n\
 memory: MemAcc, 4, 0, 0, %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n\
 memory: Rollover, 5, 0, 0, 0, 0, 0, 0\n\
 memory: SharedHeader, 6, 0, 0, %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n";
 
 	/* ActiveMemoryAccount should be Top at this point */
-	MemoryAccount *newAccount = CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccount);
+	MemoryAccount *newAccount = MemoryAccounting_ConvertIdToAccount(
+			CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId));
+	MemoryAccount *topAccount = MemoryAccounting_ConvertIdToAccount(liveAccountStartId);
 
 	void * dummy1 = palloc(NEW_ALLOC_SIZE);
+
+	MemoryAccountIdType oldAccountId = MemoryAccounting_SwitchAccount(newAccount->id);
+
 	void * dummy2 = palloc(NEW_ALLOC_SIZE);
-
-	MemoryAccounting_SwitchAccount(newAccount);
-
 	void * dummy3 = palloc(NEW_ALLOC_SIZE);
+	MemoryAccounting_SwitchAccount(oldAccountId);
 
-	pfree(dummy1);
-	pfree(dummy2);
+	/* Now free in Hash account, although Hash is no longer Active */
 	pfree(dummy3);
 
     MemoryAccounting_SaveToLog();
 
 	char		buf[MAX_OUTPUT_BUFFER_SIZE];
+	/* Hack to discount "tree" free in MemoryAccounting_SaveToLog which we did not count when walked the tree */
+	uint64 hackedFreed = topAccount->freed;
+	topAccount->freed = 0;
+
 	snprintf(buf, sizeof(buf), templateString,
 			MemoryAccountingPeakBalance, MemoryAccountingPeakBalance, MemoryAccountingPeakBalance,
-			TopMemoryAccount->peak, TopMemoryAccount->allocated, TopMemoryAccount->freed, TopMemoryAccount->allocated - TopMemoryAccount->freed,
+			topAccount->peak, topAccount->allocated, topAccount->freed, topAccount->allocated - topAccount->freed,
 			newAccount->peak, newAccount->allocated, newAccount->freed, newAccount->allocated - newAccount->freed,
 			MemoryAccountMemoryAccount->peak, MemoryAccountMemoryAccount->allocated, MemoryAccountMemoryAccount->freed, MemoryAccountMemoryAccount->allocated - MemoryAccountMemoryAccount->freed,
 			SharedChunkHeadersMemoryAccount->peak, SharedChunkHeadersMemoryAccount->allocated, SharedChunkHeadersMemoryAccount->freed, SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed);
 
+	/* Restore hacked counters */
+	topAccount->freed = hackedFreed;
+
     assert_true(strcmp(outputBuffer.data, buf) == 0);
 
+	pfree(dummy1);
+	pfree(dummy2);
+    pfree(newAccount);
+}
+
+/*
+ * Tests if the MemoryAccounting_PrettyPrint is generating the correct
+ * string representation of the memory accounting tree before printing.
+ */
+void
+test__MemoryAccounting_PrettyPrint__GeneratesCorrectString(void **state)
+{
+
+	char *templateString = "Root: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  Top: Peak/Cur " UINT64_FORMAT "/" UINT64_FORMAT "bytes. Quota: 0bytes.\n\
+    X_Hash: Peak/Cur " UINT64_FORMAT "/" UINT64_FORMAT "bytes. Quota: 0bytes.\n\
+  X_Alien: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  MemAcc: Peak/Cur " UINT64_FORMAT "/" UINT64_FORMAT "bytes. Quota: 0bytes.\n\
+  Rollover: Peak/Cur 0/0bytes. Quota: 0bytes.\n\
+  SharedHeader: Peak/Cur " UINT64_FORMAT "/" UINT64_FORMAT "bytes. Quota: 0bytes.\n\n";
+
+	/* ActiveMemoryAccount should be Top at this point */
+	MemoryAccount *newAccount = MemoryAccounting_ConvertIdToAccount(
+			CreateMemoryAccountImpl(0, MEMORY_OWNER_TYPE_Exec_Hash, ActiveMemoryAccountId));
+	MemoryAccount *topAccount = MemoryAccounting_ConvertIdToAccount(liveAccountStartId);
+
+	void * dummy1 = palloc(NEW_ALLOC_SIZE);
+
+	MemoryAccountIdType oldAccountId = MemoryAccounting_SwitchAccount(newAccount->id);
+
+	void * dummy2 = palloc(NEW_ALLOC_SIZE);
+	void * dummy3 = palloc(NEW_ALLOC_SIZE);
+	MemoryAccounting_SwitchAccount(oldAccountId);
+
+	/* Now free in Hash account, although Hash is no longer Active */
+	pfree(dummy3);
+
+	MemoryAccounting_PrettyPrint();
+
+	char		buf[MAX_OUTPUT_BUFFER_SIZE];
+	/* Hack to discount "tree" free in MemoryAccounting_SaveToLog which we did not count when walked the tree */
+	uint64 hackedFreed = topAccount->freed;
+	topAccount->freed = 0;
+	snprintf(buf, sizeof(buf), templateString,
+			topAccount->peak, topAccount->allocated - topAccount->freed,
+			newAccount->peak, newAccount->allocated - newAccount->freed,
+			MemoryAccountMemoryAccount->peak, MemoryAccountMemoryAccount->allocated - MemoryAccountMemoryAccount->freed,
+			SharedChunkHeadersMemoryAccount->peak, SharedChunkHeadersMemoryAccount->allocated - SharedChunkHeadersMemoryAccount->freed);
+
+	/* Restore hacked counters */
+	topAccount->freed = hackedFreed;
+
+    assert_true(strcmp(outputBuffer.data, buf) == 0);
+
+	pfree(dummy1);
+	pfree(dummy2);
     pfree(newAccount);
 }
 
@@ -1443,12 +1205,14 @@ test__MemoryAccounting_SaveToFile__GeneratesCorrectString(void **state)
 	MemoryOwnerType newAccountOwnerType = MEMORY_OWNER_TYPE_Exec_Hash;
 
 	/* ActiveMemoryAccount should be Top at this point */
-	MemoryAccount *newAccount = CreateMemoryAccountImpl(0, newAccountOwnerType, ActiveMemoryAccount);
+	MemoryAccount *newAccount = MemoryAccounting_ConvertIdToAccount(
+			CreateMemoryAccountImpl(0, newAccountOwnerType, ActiveMemoryAccountId));
+	MemoryAccount *topAccount = MemoryAccounting_ConvertIdToAccount(liveAccountStartId);
 
 	void * dummy1 = palloc(NEW_ALLOC_SIZE);
 	void * dummy2 = palloc(NEW_ALLOC_SIZE);
 
-	MemoryAccounting_SwitchAccount(newAccount);
+	MemoryAccounting_SwitchAccount(newAccount->id);
 
 	void * dummy3 = palloc(NEW_ALLOC_SIZE);
 
@@ -1470,7 +1234,10 @@ test__MemoryAccounting_SaveToFile__GeneratesCorrectString(void **state)
 	char *token = strtok(outputBuffer.data, "\n");
 	int lineNo = 0;
 
-	int memoryOwnerTypes[] = {-1, -2, 10, 101, 1029, 1040, 13, 12, 11};
+	int memoryOwnerTypes[] = {MEMORY_STAT_TYPE_VMEM_RESERVED, MEMORY_STAT_TYPE_MEMORY_ACCOUNTING_PEAK,
+			MEMORY_OWNER_TYPE_LogicalRoot, MEMORY_OWNER_TYPE_Top, MEMORY_OWNER_TYPE_Exec_Hash ,
+			MEMORY_OWNER_TYPE_Exec_AlienShared, MEMORY_OWNER_TYPE_MemAccount, MEMORY_OWNER_TYPE_Rollover,
+			MEMORY_OWNER_TYPE_SharedChunkHeader};
 
 	char runId[80];
 	char datasetId[80];
@@ -1515,12 +1282,13 @@ test__MemoryAccounting_SaveToFile__GeneratesCorrectString(void **state)
 		}
 		else if (ownerType == MEMORY_OWNER_TYPE_LogicalRoot)
 		{
-			assert_true(peak == MemoryAccountTreeLogicalRoot->peak &&
-					allocated == MemoryAccountTreeLogicalRoot->allocated && freed == MemoryAccountTreeLogicalRoot->freed);
+			MemoryAccount *root = MemoryAccounting_ConvertIdToAccount(MEMORY_OWNER_TYPE_LogicalRoot);
+			assert_true(peak == root->peak &&
+					allocated == root->allocated && freed == root->freed);
 		}
 		else if (ownerType == MEMORY_OWNER_TYPE_Top)
 		{
-			assert_true(peak == TopMemoryAccount->peak && allocated == TopMemoryAccount->allocated && freed == TopMemoryAccount->freed);
+			assert_true(peak == topAccount->peak && allocated == topAccount->allocated && freed == topAccount->freed);
 		}
 		else if (ownerType ==newAccountOwnerType)
 		{
@@ -1560,6 +1328,30 @@ test__MemoryAccounting_SaveToFile__GeneratesCorrectString(void **state)
     pfree(newAccount);
 }
 
+/*
+ * Tests if we correctly convert the short and long living indexes to a combined
+ * array index
+ */
+void
+test__ConvertIdToUniversalArrayIndex__Validate(void **state)
+{
+	// For long living number of short living accounts don't matter to resolve to a compact index
+	assert_true(ConvertIdToUniversalArrayIndex(MEMORY_OWNER_TYPE_MemAccount, MEMORY_OWNER_TYPE_START_SHORT_LIVING,
+			1) == MEMORY_OWNER_TYPE_MemAccount);
+
+	assert_true(ConvertIdToUniversalArrayIndex(MEMORY_OWNER_TYPE_MemAccount, MEMORY_OWNER_TYPE_START_SHORT_LIVING + 10,
+			4) == MEMORY_OWNER_TYPE_MemAccount);
+
+	// For gap of 10 we will still resolve to a compact index
+	assert_true(ConvertIdToUniversalArrayIndex(MEMORY_OWNER_TYPE_Top + 10, MEMORY_OWNER_TYPE_START_SHORT_LIVING + 10,
+			3) == MEMORY_OWNER_TYPE_Top);
+
+	// For out of range, we should get an error
+	//will_be_called(errstart);
+	ConvertIdToUniversalArrayIndex(100, MEMORY_OWNER_TYPE_START_SHORT_LIVING + 10, 3);
+	assert_true(elevel == ERROR && strcmp(outputBuffer.data, "Cannot map id to array index") == 0);
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -1567,15 +1359,11 @@ main(int argc, char* argv[])
 
 	const UnitTest tests[] = {
 		unit_test_setup_teardown(test__CreateMemoryAccountImpl__ActiveVsParent, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__CreateMemoryAccountImpl__TreeStructure, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__CreateMemoryAccountImpl__AutoDetectParent, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__CreateMemoryAccountImpl__AccountProperties, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__CreateMemoryAccountImpl__TracksMemoryOverhead, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__CreateMemoryAccountImpl__AllocatesOnlyFromMemoryAccountMemoryContext, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_SwitchAccount__AccountIsSwitched, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__MemoryAccounting_SwitchAccount__RequiresNonNullAccount, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccountIsValid__ProperValidation, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__MemoryAccounting_Reset__TreeStructure, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_Reset__ReusesLongLivingAccounts, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_Reset__RecreatesShortLivingAccounts, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_Reset__ReusesMemoryAccountMemoryContext, SetupMemoryDataStructures, TeardownMemoryDataStructures),
@@ -1584,20 +1372,22 @@ main(int argc, char* argv[])
 		unit_test_setup_teardown(test__MemoryAccounting_Reset__AdvancesGeneration, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_Reset__TransferRemainingToRollover, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_Reset__ResetPeakBalance, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__MemoryAccounting_AdvanceMemoryAccountingGeneration__AdvancesGeneration, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_AdvanceMemoryAccountingGeneration__SetsActiveToRollover, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__MemoryAccounting_AdvanceMemoryAccountingGeneration__MigratesChunkHeaders, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__MemoryAccounting_AdvanceMemoryAccountingGeneration__PreservesChunkHeader, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__MemoryAccounting_AdvanceMemoryAccountingGeneration__TransfersBalanceToRolloverWithMigration, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_AdvanceMemoryAccountingGeneration__TransfersBalanceToRolloverWithoutMigration, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryContextReset__ResetsSharedChunkHeadersMemoryAccountBalance, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__MemoryAccounting_Serialize_Deserialize__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__MemoryAccounting_Serialize__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_GetAccountName__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
-		unit_test_setup_teardown(test__MemoryAccounting_GetPeak__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__MemoryAccounting_SizeOfAccountInBytes__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__MemoryAccounting_GetGlobalPeak__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__MemoryAccounting_GetAccountPeakBalance__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_GetBalance__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_ToString__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_SaveToLog__GeneratesCorrectString, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 		unit_test_setup_teardown(test__MemoryAccounting_SaveToFile__GeneratesCorrectString, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__MemoryAccounting_PrettyPrint__GeneratesCorrectString, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__MemoryAccounting_CombinedAccountArrayToString__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__ConvertIdToUniversalArrayIndex__Validate, SetupMemoryDataStructures, TeardownMemoryDataStructures),
+		unit_test_setup_teardown(test__MemoryAccounting_GetAccountCurrentBalance__ResetPeakBalance, SetupMemoryDataStructures, TeardownMemoryDataStructures),
 	};
 
 	return run_tests(tests);

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -227,7 +227,7 @@ typedef struct QueryDesc
 	char		*portal_name;	/* NULL for unnamed portal */
 
 	/* The overall memory consumption account (i.e., outside of an operator) */
-	MemoryAccount *memoryAccount;
+	MemoryAccountIdType memoryAccountId;
 
 	QueryDispatchDesc *ddesc;
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1408,9 +1408,6 @@ typedef struct PlanState
 	void      (*cdbexplainfun)(struct PlanState *planstate, struct StringInfoData *buf);
 	/* callback before ExecutorEnd */
 
-	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
-	MemoryAccount* memoryAccount;
-
 	/*
 	 * GpMon packet
 	 */

--- a/src/include/nodes/memnodes.h
+++ b/src/include/nodes/memnodes.h
@@ -47,7 +47,6 @@ typedef struct MemoryContextMethods
 	bool		(*is_empty) (MemoryContext context);
 	void		(*stats) (MemoryContext context, uint64 *nBlocks, uint64 *nChunks, uint64 *currentAvailable, uint64 *allAllocated, uint64 *allFreed, uint64 *maxHeld);
 	void		(*release_accounting)(MemoryContext context);
-	void		(*update_generation)(MemoryContext context);
 #ifdef MEMORY_CONTEXT_CHECKING
 	void		(*check) (MemoryContext context);
 #endif

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -282,6 +282,9 @@ typedef struct Plan
 	 * How much memory (in KB) should be used to execute this plan node?
 	 */
 	uint64 operatorMemKB;
+
+	/* MemoryAccount to use for recording the memory usage of different plan nodes. */
+	MemoryAccountIdType memoryAccountId;
 } Plan;
 
 /* ----------------
@@ -744,7 +747,7 @@ typedef struct NestLoop
  *
  * The expected ordering of each mergeable column is described by a btree
  * opfamily OID, a direction (BTLessStrategyNumber or BTGreaterStrategyNumber)
- * and a nulls-first flag.	Note that the two sides of each mergeclause may
+ * and a nulls-first flag.  Note that the two sides of each mergeclause may
  * be of different datatypes, but they are ordered the same way according to
  * the common opfamily.  The operator in each mergeclause must be an equality
  * operator of the indicated opfamily.
@@ -753,9 +756,9 @@ typedef struct NestLoop
 typedef struct MergeJoin
 {
 	Join		join;
-	List	   *mergeclauses;	/* mergeclauses as expression trees */
+	List	   *mergeclauses;		/* mergeclauses as expression trees */
 	/* these are arrays, but have the same length as the mergeclauses list: */
-	Oid		   *mergeFamilies;	/* per-clause OIDs of btree opfamilies */
+	Oid		   *mergeFamilies;		/* per-clause OIDs of btree opfamilies */
 	int		   *mergeStrategies;	/* per-clause ordering (ASC or DESC) */
 	bool	   *mergeNullsFirst;	/* per-clause nulls ordering */
 	bool		unique_outer; /*CDB-OLAP true => outer is unique in merge key */

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -61,68 +61,79 @@ extern bool gp_dump_memory_usage;
  */
 typedef enum MemoryOwnerType
 {
+	/*
+	 * Undefined represents invalid account. We explicitly start from 0
+	 * as we use the long living accounts' enumeration to index into the
+	 * long living accounts array.
+	 */
+	MEMORY_OWNER_TYPE_Undefined = 0,
+
 	/* Long-living accounts that survive reset */
-	MEMORY_OWNER_TYPE_LogicalRoot = 10,
-	MEMORY_OWNER_TYPE_SharedChunkHeader = 11,
-	MEMORY_OWNER_TYPE_Rollover = 12,
-	MEMORY_OWNER_TYPE_MemAccount = 13,
+	MEMORY_OWNER_TYPE_START_LONG_LIVING,
+	MEMORY_OWNER_TYPE_LogicalRoot = MEMORY_OWNER_TYPE_START_LONG_LIVING,
+	MEMORY_OWNER_TYPE_SharedChunkHeader,
+	MEMORY_OWNER_TYPE_Rollover,
+	MEMORY_OWNER_TYPE_MemAccount,
+	MEMORY_OWNER_TYPE_Exec_AlienShared,
+	MEMORY_OWNER_TYPE_END_LONG_LIVING = MEMORY_OWNER_TYPE_Exec_AlienShared,
 	/* End of long-living accounts */
 
 	/* Short-living accounts */
-	MEMORY_OWNER_TYPE_Top = 101,
-	MEMORY_OWNER_TYPE_MainEntry = 102,
-	MEMORY_OWNER_TYPE_Parser = 103,
-	MEMORY_OWNER_TYPE_Planner = 104,
-	MEMORY_OWNER_TYPE_Optimizer = 105,
-	MEMORY_OWNER_TYPE_Dispatcher = 106,
-	MEMORY_OWNER_TYPE_Serializer = 107,
-	MEMORY_OWNER_TYPE_Deserializer = 108,
+	MEMORY_OWNER_TYPE_START_SHORT_LIVING,
+	MEMORY_OWNER_TYPE_Top = MEMORY_OWNER_TYPE_START_SHORT_LIVING,
+	MEMORY_OWNER_TYPE_MainEntry,
+	MEMORY_OWNER_TYPE_Parser,
+	MEMORY_OWNER_TYPE_Planner,
+	MEMORY_OWNER_TYPE_Optimizer,
+	MEMORY_OWNER_TYPE_Dispatcher,
+	MEMORY_OWNER_TYPE_Serializer,
+	MEMORY_OWNER_TYPE_Deserializer,
 
-	MEMORY_OWNER_TYPE_EXECUTOR = 1000,
-	MEMORY_OWNER_TYPE_Exec_Result = 1001,
-	MEMORY_OWNER_TYPE_Exec_Append = 1002,
-	MEMORY_OWNER_TYPE_Exec_Sequence = 1003,
-	MEMORY_OWNER_TYPE_Exec_BitmapAnd = 1004,
-	MEMORY_OWNER_TYPE_Exec_BitmapOr = 1005,
-	MEMORY_OWNER_TYPE_Exec_SeqScan = 1006,
-	MEMORY_OWNER_TYPE_Exec_ExternalScan = 1007,
-	MEMORY_OWNER_TYPE_Exec_AppendOnlyScan = 1008,
-	MEMORY_OWNER_TYPE_Exec_AOCSScan = 1009,
-	MEMORY_OWNER_TYPE_Exec_TableScan = 1010,
-	MEMORY_OWNER_TYPE_Exec_DynamicTableScan = 1011,
-	MEMORY_OWNER_TYPE_Exec_IndexScan = 1012,
-	MEMORY_OWNER_TYPE_Exec_DynamicIndexScan = 1013,
-	MEMORY_OWNER_TYPE_Exec_BitmapIndexScan = 1014,
-	MEMORY_OWNER_TYPE_Exec_BitmapHeapScan = 1015,
-	MEMORY_OWNER_TYPE_Exec_BitmapAppendOnlyScan = 1016,
-	MEMORY_OWNER_TYPE_Exec_TidScan = 1017,
-	MEMORY_OWNER_TYPE_Exec_SubqueryScan = 1018,
-	MEMORY_OWNER_TYPE_Exec_FunctionScan = 1019,
-	MEMORY_OWNER_TYPE_Exec_TableFunctionScan = 1020,
-	MEMORY_OWNER_TYPE_Exec_ValuesScan = 1021,
-	MEMORY_OWNER_TYPE_Exec_NestLoop = 1022,
-	MEMORY_OWNER_TYPE_Exec_MergeJoin = 1023,
-	MEMORY_OWNER_TYPE_Exec_HashJoin = 1024,
-	MEMORY_OWNER_TYPE_Exec_Material = 1025,
-	MEMORY_OWNER_TYPE_Exec_Sort = 1026,
-	MEMORY_OWNER_TYPE_Exec_Agg = 1027,
-	MEMORY_OWNER_TYPE_Exec_Unique = 1028,
-	MEMORY_OWNER_TYPE_Exec_Hash = 1029,
-	MEMORY_OWNER_TYPE_Exec_SetOp = 1030,
-	MEMORY_OWNER_TYPE_Exec_Limit = 1031,
-	MEMORY_OWNER_TYPE_Exec_Motion = 1032,
-	MEMORY_OWNER_TYPE_Exec_ShareInputScan = 1033,
-	MEMORY_OWNER_TYPE_Exec_Window = 1034,
-	MEMORY_OWNER_TYPE_Exec_Repeat = 1035,
-	MEMORY_OWNER_TYPE_Exec_DML = 1036,
-	MEMORY_OWNER_TYPE_Exec_SplitUpdate = 1037,
-	MEMORY_OWNER_TYPE_Exec_RowTrigger = 1038,
-	MEMORY_OWNER_TYPE_Exec_AssertOp = 1039,
-	MEMORY_OWNER_TYPE_Exec_AlienShared = 1040,
-	MEMORY_OWNER_TYPE_Exec_BitmapTableScan = 1041,
-	MEMORY_OWNER_TYPE_Exec_PartitionSelector = 1042,
-	MEMORY_OWNER_TYPE_Exec_Plan_End, /* No explicit number. Automatically gets the last of executor enumeration */
-
+	MEMORY_OWNER_TYPE_EXECUTOR_START,
+	MEMORY_OWNER_TYPE_EXECUTOR = MEMORY_OWNER_TYPE_EXECUTOR_START,
+	MEMORY_OWNER_TYPE_Exec_Result,
+	MEMORY_OWNER_TYPE_Exec_Append,
+	MEMORY_OWNER_TYPE_Exec_Sequence,
+	MEMORY_OWNER_TYPE_Exec_BitmapAnd,
+	MEMORY_OWNER_TYPE_Exec_BitmapOr,
+	MEMORY_OWNER_TYPE_Exec_SeqScan,
+	MEMORY_OWNER_TYPE_Exec_ExternalScan,
+	MEMORY_OWNER_TYPE_Exec_AppendOnlyScan,
+	MEMORY_OWNER_TYPE_Exec_AOCSScan,
+	MEMORY_OWNER_TYPE_Exec_TableScan,
+	MEMORY_OWNER_TYPE_Exec_DynamicTableScan,
+	MEMORY_OWNER_TYPE_Exec_IndexScan,
+	MEMORY_OWNER_TYPE_Exec_DynamicIndexScan,
+	MEMORY_OWNER_TYPE_Exec_BitmapIndexScan,
+	MEMORY_OWNER_TYPE_Exec_BitmapHeapScan,
+	MEMORY_OWNER_TYPE_Exec_BitmapAppendOnlyScan,
+	MEMORY_OWNER_TYPE_Exec_TidScan,
+	MEMORY_OWNER_TYPE_Exec_SubqueryScan,
+	MEMORY_OWNER_TYPE_Exec_FunctionScan,
+	MEMORY_OWNER_TYPE_Exec_TableFunctionScan,
+	MEMORY_OWNER_TYPE_Exec_ValuesScan,
+	MEMORY_OWNER_TYPE_Exec_NestLoop,
+	MEMORY_OWNER_TYPE_Exec_MergeJoin,
+	MEMORY_OWNER_TYPE_Exec_HashJoin,
+	MEMORY_OWNER_TYPE_Exec_Material,
+	MEMORY_OWNER_TYPE_Exec_Sort,
+	MEMORY_OWNER_TYPE_Exec_Agg,
+	MEMORY_OWNER_TYPE_Exec_Unique,
+	MEMORY_OWNER_TYPE_Exec_Hash,
+	MEMORY_OWNER_TYPE_Exec_SetOp,
+	MEMORY_OWNER_TYPE_Exec_Limit,
+	MEMORY_OWNER_TYPE_Exec_Motion,
+	MEMORY_OWNER_TYPE_Exec_ShareInputScan,
+	MEMORY_OWNER_TYPE_Exec_Window,
+	MEMORY_OWNER_TYPE_Exec_Repeat,
+	MEMORY_OWNER_TYPE_Exec_DML,
+	MEMORY_OWNER_TYPE_Exec_SplitUpdate,
+	MEMORY_OWNER_TYPE_Exec_RowTrigger,
+	MEMORY_OWNER_TYPE_Exec_AssertOp,
+	MEMORY_OWNER_TYPE_Exec_BitmapTableScan,
+	MEMORY_OWNER_TYPE_Exec_PartitionSelector,
+	MEMORY_OWNER_TYPE_EXECUTOR_END = MEMORY_OWNER_TYPE_Exec_PartitionSelector,
+	MEMORY_OWNER_TYPE_END_SHORT_LIVING = MEMORY_OWNER_TYPE_EXECUTOR_END
 } MemoryOwnerType;
 
 /****
@@ -135,87 +146,25 @@ typedef enum MemoryOwnerType
 #define MEMORY_STAT_TYPE_MEMORY_ACCOUNTING_PEAK -2
 /***************************************************************************/
 
-struct MemoryAccount;
+typedef uint64 MemoryAccountIdType;
 
-extern struct MemoryAccount* ActiveMemoryAccount;
-extern struct MemoryAccount* RolloverMemoryAccount;
-extern struct MemoryAccount* AlienExecutorMemoryAccount;
-extern struct MemoryAccount* SharedChunkHeadersMemoryAccount;
-
-extern uint64 MemoryAccountingOutstandingBalance;
-extern uint64 MemoryAccountingPeakBalance;
-
-extern uint16 MemoryAccountingCurrentGeneration;
-
-/* MemoryAccount is the fundamental data structure to record memory usage */
-typedef struct MemoryAccount {
-	NodeTag type;
-	MemoryOwnerType ownerType;
-
-	uint64 allocated;
-	uint64 freed;
-	uint64 peak;
-	/*
-	 * Maximum targeted allocation for an owner. Peak usage can be tracked to
-	 * check if the allocation is overshooting
-	 */
-	uint64 maxLimit;
-
-	/* If this account requests the privilege to "disown" some of the allocation
-	 * that would otherwise be charged to its account, then disownedMemoryAccount
-	 * holds a hidden account which will be used for allocation during a "disowned"
-	 * state (upon calling "DisownMemoryAccount()").
-	 */
-	//struct MemoryAccount *disownedMemoryAccount;
-	struct MemoryAccount *parentAccount;
-
-	/*
-	 * To traverse the tree of MemoryAccount, start from the Top. Read the firstChild and then read the
-	 * nextSibling of the firstChild. And continue this process. For each of the nextSibling, you can call
-	 * firstChild to descend the tree.
-	 */
-	struct MemoryAccount* firstChild;
-	struct MemoryAccount* nextSibling;
-} MemoryAccount;
-
-/*
- * Instead of pointers to construct the tree, the SerializedMemoryAccount
- * uses "serial" of each node and saves parent serial to construct the tree.
- * This is required as we cannot serialize pointers. As an optimization, we
- * can later on try to reuse the pointers themselves and treat them as integer
- * to save the "serial"
- */
-typedef struct SerializedMemoryAccount {
-	NodeTag type;
-	MemoryAccount memoryAccount;
-
-	/*
-	 * memoryAccountSerial and parentMemoryAccountSerial are used for serializing
-	 * MemoryAccount. Note: we cannot serialize the tree using the pointers.
-	 * Instead we serialize these "serial" and "parent serial" and construct the
-	 * tree at the destination (e.g., dispatcher or any reporting tool).
-	 */
-	uint32 memoryAccountSerial;
-	/* If memoryAccountSerial == parentMemoryAccountSerial, then the node has NO parent */
-	uint32 parentMemoryAccountSerial;
-} SerializedMemoryAccount;
+extern MemoryAccountIdType ActiveMemoryAccountId;
 
 /*
  * START_MEMORY_ACCOUNT would switch to the specified newMemoryAccount,
  * saving the oldActiveMemoryAccount. Must be paired with END_MEMORY_ACCOUNT
  */
-#define START_MEMORY_ACCOUNT(newMemoryAccount)  \
+#define START_MEMORY_ACCOUNT(newMemoryAccountId)  \
 	do { \
-		MemoryAccount *oldActiveMemoryAccount = NULL; \
-		Assert(newMemoryAccount != NULL); \
-		oldActiveMemoryAccount = ActiveMemoryAccount; \
-		ActiveMemoryAccount = newMemoryAccount;\
+		MemoryAccountIdType oldActiveMemoryAccountId = ActiveMemoryAccountId; \
+		ActiveMemoryAccountId = newMemoryAccountId;
+
 /*
  * END_MEMORY_ACCOUNT would restore the previous memory account that was
  * active at the time of START_MEMORY_ACCCOUNT call
  */
 #define END_MEMORY_ACCOUNT()  \
-		ActiveMemoryAccount = oldActiveMemoryAccount;\
+		ActiveMemoryAccountId = oldActiveMemoryAccountId;\
 	} while (0);
 
 /*
@@ -226,50 +175,49 @@ typedef struct SerializedMemoryAccount {
  * that will not be executed in current slice
  */
 #define CREATE_EXECUTOR_MEMORY_ACCOUNT(isAlienPlanNode, planNode, NodeType) \
-	(isAlienPlanNode ? AlienExecutorMemoryAccount :						\
-	 MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
-									work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType))
+		(MEMORY_OWNER_TYPE_Undefined != planNode->memoryAccountId) ?\
+			planNode->memoryAccountId : \
+			(isAlienPlanNode ? MEMORY_OWNER_TYPE_Exec_AlienShared : \
+				MemoryAccounting_CreateAccount(((Plan*)node)->operatorMemKB == 0 ? \
+				work_mem : ((Plan*)node)->operatorMemKB, MEMORY_OWNER_TYPE_Exec_##NodeType));
 
 /*
  * SAVE_EXECUTOR_MEMORY_ACCOUNT saves an operator specific memory account
  * into the PlanState of that operator
  */
-#define SAVE_EXECUTOR_MEMORY_ACCOUNT(execState, curMemoryAccount)\
-	do { \
-		Assert(NULL == ((PlanState *)execState)->memoryAccount || \
-			   AlienExecutorMemoryAccount == ((PlanState *)execState)->memoryAccount || \
-			   curMemoryAccount == ((PlanState *)execState)->memoryAccount); \
-		((PlanState *)execState)->memoryAccount = curMemoryAccount; \
-	} while(0)
+#define SAVE_EXECUTOR_MEMORY_ACCOUNT(execState, curMemoryAccountId)\
+		Assert(MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->plan->memoryAccountId || \
+		MEMORY_OWNER_TYPE_Undefined == ((PlanState *)execState)->plan->memoryAccountId || \
+		curMemoryAccountId == ((PlanState *)execState)->plan->memoryAccountId);\
+		((PlanState *)execState)->plan->memoryAccountId = curMemoryAccountId;
 
-extern struct MemoryAccount*
+extern MemoryAccountIdType
 MemoryAccounting_CreateAccount(long maxLimit, enum MemoryOwnerType ownerType);
 
-extern MemoryAccount*
-MemoryAccounting_SwitchAccount(struct MemoryAccount* desiredAccount);
+extern MemoryAccountIdType
+MemoryAccounting_SwitchAccount(MemoryAccountIdType desiredAccountId);
+
+extern size_t
+MemoryAccounting_SizeOfAccountInBytes(void);
 
 extern void
 MemoryAccounting_Reset(void);
 
-extern void
-MemoryAccounting_ResetPeakBalance(void);
-
 extern uint32
 MemoryAccounting_Serialize(StringInfoData* buffer);
 
-extern SerializedMemoryAccount*
-MemoryAccounting_Deserialize(const void *serializedBits,
-		uint32 memoryAccountCount);
+extern uint64
+MemoryAccounting_GetAccountPeakBalance(MemoryAccountIdType memoryAccountId);
 
 extern uint64
-MemoryAccounting_GetPeak(MemoryAccount *memoryAccount);
+MemoryAccounting_GetAccountCurrentBalance(MemoryAccountIdType memoryAccountId);
 
 extern uint64
-MemoryAccounting_GetBalance(MemoryAccount *memoryAccount);
+MemoryAccounting_GetGlobalPeak(void);
 
 extern void
-MemoryAccounting_ToString(MemoryAccount *root, StringInfoData *str,
-		uint32 indentation);
+MemoryAccounting_CombinedAccountArrayToString(void *accountArrayBytes,
+		MemoryAccountIdType accountCount, StringInfoData *str, uint32 indentation);
 
 extern void
 MemoryAccounting_SaveToFile(int currentSliceId);
@@ -277,20 +225,8 @@ MemoryAccounting_SaveToFile(int currentSliceId);
 extern uint32
 MemoryAccounting_SaveToLog(void);
 
-extern const char*
-MemoryAccounting_GetAccountName(MemoryAccount *memoryAccount);
-
-extern void
-MemoryAccounting_ToCSV(MemoryAccount *root, StringInfoData *str, char *prefix);
-
 extern void
 MemoryAccounting_PrettyPrint(void);
-/*
- * MemoryAccountIsValid
- *		True iff memory account is valid.
- */
-#define MemoryAccountIsValid(memoryAccount) \
-	((memoryAccount) != NULL && \
-	 ( IsA((memoryAccount), MemoryAccount) ))
+
 
 #endif   /* MEMACCOUNTING_H */

--- a/src/include/utils/memaccounting_private.h
+++ b/src/include/utils/memaccounting_private.h
@@ -1,0 +1,188 @@
+/*-------------------------------------------------------------------------
+ *
+ * memaccounting_private.h
+ *	  This file contains declarations for memory accounting functions that
+ *	  are only supposed to be used by privileged callers such a memory managers.
+ *	  Other files should not include this file.
+ *
+ * Copyright (c) 2016, Pivotal Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef MEMACCOUNTING_PRIVATE_H
+#define MEMACCOUNTING_PRIVATE_H
+
+#include "utils/memaccounting.h"
+
+extern MemoryAccountIdType liveAccountStartId;
+extern MemoryAccountIdType nextAccountId;
+
+/* MemoryAccount is the fundamental data structure to record memory usage */
+typedef struct MemoryAccount {
+	NodeTag type;
+	MemoryOwnerType ownerType;
+
+	uint64 allocated;
+	uint64 freed;
+	uint64 peak;
+	/*
+	 * Maximum targeted allocation for an owner. Peak usage can be tracked to
+	 * check if the allocation is overshooting
+	 */
+	uint64 maxLimit;
+
+	MemoryAccountIdType id;
+	MemoryAccountIdType parentId;
+} MemoryAccount;
+
+typedef struct MemoryAccountArray{
+	MemoryAccountIdType accountCount;
+	MemoryAccountIdType arraySize;
+	// array of pointers to memory accounts of size accountCount
+	MemoryAccount** allAccounts;
+} MemoryAccountArray;
+
+extern MemoryAccountArray* shortLivingMemoryAccountArray;
+/* We save index 0 for undefined null account. Therefore, we need an extra entry */
+extern MemoryAccount* longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_END_LONG_LIVING + 1];
+
+extern MemoryAccount *SharedChunkHeadersMemoryAccount;
+
+extern uint64 MemoryAccountingOutstandingBalance;
+extern uint64 MemoryAccountingPeakBalance;
+
+/*
+ * MemoryAccounting_IsLiveAccount
+ *    Checks if an account is live.
+ *
+ * id: the id of the account
+ */
+static inline bool
+MemoryAccounting_IsLiveAccount(MemoryAccountIdType id)
+{
+	AssertImply(NULL == shortLivingMemoryAccountArray, liveAccountStartId == nextAccountId);
+	bool isValidShortLivingAccount = (id >= liveAccountStartId &&
+      id < (liveAccountStartId + (NULL == shortLivingMemoryAccountArray ? 0 : shortLivingMemoryAccountArray->accountCount)));
+	return isValidShortLivingAccount ||
+	    ((id <= MEMORY_OWNER_TYPE_END_LONG_LIVING) && (id > MEMORY_OWNER_TYPE_Undefined)) /* Valid long living? */;
+}
+
+/*
+ * MemoryAccounting_ConvertIdToAccount
+ *    Converts an account ID to an account pointer.
+ *
+ * id: the id of the account
+ */
+static inline MemoryAccount*
+MemoryAccounting_ConvertIdToAccount(MemoryAccountIdType id)
+{
+	MemoryAccount *memoryAccount = NULL;
+
+	if (id >= liveAccountStartId)
+	{
+		Assert(NULL != shortLivingMemoryAccountArray);
+		Assert(id < liveAccountStartId + shortLivingMemoryAccountArray->accountCount);
+		memoryAccount = shortLivingMemoryAccountArray->allAccounts[id - liveAccountStartId];
+	}
+	else if (id <= MEMORY_OWNER_TYPE_END_LONG_LIVING)
+	{
+		Assert(NULL != longLivingMemoryAccountArray);
+		/* 0 is reserved as undefined. So, the array index is 1 behind */
+		memoryAccount = longLivingMemoryAccountArray[id];
+	}
+	else if (id < liveAccountStartId) /* Dead account; so use rollover */
+	{
+		Assert(NULL != longLivingMemoryAccountArray);
+		/*
+		 * For dead accounts we use a single rollover account to account for all
+		 * the long living allocations. Rollover is a long-living account, so it
+		 * doesn't get recreated and it accounts for all the past allocations that
+		 * outlived their owner accounts.
+		 */
+		memoryAccount = longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Rollover];
+	}
+
+	Assert(IsA(memoryAccount, MemoryAccount));
+
+	return memoryAccount;
+}
+
+/*
+ * MemoryAccounting_Allocate
+ *	 	When an allocation is made, this function will be called by the
+ *	 	underlying allocator to record allocation request.
+ *
+ * memoryAccountId: where to record this allocation
+ * allocatedSize: the final amount of memory returned by the allocator (with overhead)
+ *
+ * If the return value is false, the underlying memory allocator should fail.
+ */
+static inline bool
+MemoryAccounting_Allocate(MemoryAccountIdType memoryAccountId, Size allocatedSize)
+{
+	Assert(MemoryAccounting_IsLiveAccount(memoryAccountId));
+	MemoryAccount* memoryAccount = MemoryAccounting_ConvertIdToAccount(memoryAccountId);
+
+	Assert(memoryAccount->allocated + allocatedSize >=
+			memoryAccount->allocated);
+
+	memoryAccount->allocated += allocatedSize;
+
+	Size held = memoryAccount->allocated -
+			memoryAccount->freed;
+
+	memoryAccount->peak =
+			Max(memoryAccount->peak, held);
+
+	Assert(memoryAccount->allocated >=
+			memoryAccount->freed);
+
+	MemoryAccountingOutstandingBalance += allocatedSize;
+	MemoryAccountingPeakBalance = Max(MemoryAccountingPeakBalance, MemoryAccountingOutstandingBalance);
+
+	return true;
+}
+
+/*
+ * MemoryAccounting_Free
+ *		"One" implementation of free request handler. Each memory account
+ *		can customize its free request function. When memory is deallocated,
+ *		this function will be called by the underlying allocator to record deallocation.
+ *		This function records the amount of memory freed.
+ *
+ * memoryAccount: where to record this allocation
+ * context: the context where this memory belongs
+ * allocatedSize: the final amount of memory returned by the allocator (with overhead)
+ *
+ * Note: the memoryAccount can be an invalid pointer if the generation of
+ * the allocation is different than the current generation. In such case
+ * this method would automatically select RolloverMemoryAccount, instead
+ * of accessing an invalid pointer.
+ */
+static inline bool
+MemoryAccounting_Free(MemoryAccountIdType memoryAccountId, Size allocatedSize)
+{
+	MemoryAccount* memoryAccount = MemoryAccounting_ConvertIdToAccount(memoryAccountId);
+
+	Assert(memoryAccount->freed +
+			allocatedSize >= memoryAccount->freed);
+
+	Assert(memoryAccount->allocated >= memoryAccount->freed);
+
+	memoryAccount->freed += allocatedSize;
+
+	MemoryAccountingOutstandingBalance -= allocatedSize;
+
+	Assert(MemoryAccountingOutstandingBalance >= 0);
+
+	return true;
+}
+
+/* Is the memory accounting framework initialized? */
+static inline bool
+MemoryAccounting_IsInitialized()
+{
+	return (NULL != longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_LogicalRoot]);
+}
+
+#endif   /* MEMACCOUNTING_PRIVATE_H */

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -52,15 +52,7 @@ static inline bool AllocSizeIsValid(Size sz)
 typedef struct SharedChunkHeader
 {
 	MemoryContext context;		/* owning context */
-	struct MemoryAccount* memoryAccount; /* Which account to charge for this memory. */
-	/*
-	 * The generation of "memoryAccount" pointer. If the generation
-	 * is not equal to current memory account generation
-	 * (MemoryAccountingCurrentGeneration), we do not
-	 * release accounting through "memoryAccount". Instead, we
-	 * release the accounting of RolloverMemoryAccount.
-	 */
-	uint16 memoryAccountGeneration;
+	MemoryAccountIdType memoryAccountId; /* Which account to charge for this memory. */
 
 	/* Combined balance of all the chunks that are sharing this header */
 	int64 balance;
@@ -188,6 +180,7 @@ extern PGDLLIMPORT MemoryContext MessageContext;
 extern PGDLLIMPORT MemoryContext TopTransactionContext;
 extern PGDLLIMPORT MemoryContext CurTransactionContext;
 extern PGDLLIMPORT MemoryContext MemoryAccountMemoryContext;
+extern PGDLLIMPORT MemoryContext MemoryAccountDebugContext;
 
 /* This is a transient link to the active portal's memory context: */
 extern PGDLLIMPORT MemoryContext PortalContext;

--- a/src/include/utils/palloc.h
+++ b/src/include/utils/palloc.h
@@ -54,9 +54,8 @@
 #define CDB_PALLOC_CALLER_ID
 */
 
-#ifdef USE_ASSERT_CHECKING
 #define CDB_PALLOC_TAGS
-#endif
+#define ALLOC_SITE_KEY_SIZE 255
 
 /* CDB_PALLOC_TAGS implies CDB_PALLOC_CALLER_ID */
 #if defined(CDB_PALLOC_TAGS) && !defined(CDB_PALLOC_CALLER_ID)
@@ -85,6 +84,16 @@ typedef uint32 OOMTimeType;
  * do not provide the struct contents here.
  */
 typedef struct MemoryContextData *MemoryContext;
+
+typedef struct
+{
+	char hash_key[ALLOC_SITE_KEY_SIZE];
+	char* file_name;
+	int line_no;
+	int64 alloc_count;
+	int64 alloc_size;
+	uint64 gen_allocated; // which generations did we allocate from this site
+} AllocSiteInfo;
 
 /*
  * CurrentMemoryContext is the default allocation context for palloc().


### PR DESCRIPTION
Previously accounting tree and reference to accounts were pointer based. This prevents us from freeing accounts at the end of each statement as later statements of that transaction can potentially access memory and the corresponding accounts. This resulted in a perceived memory leak as the accounts were not freed per-statement.

In this implementation we convert pointers to index (or soft-pointers) that can refer to an array of accounts. There are two array of accounts: long-living account array (aka shared accounts across all the statements that we don't create once per-statement) and short living accounts array that contain one account per-operator. An unified index can refer to both long and short living accounts. We reserve the first set of index values for
long living account array and later values for short-living account array.

As we create short-living accounts, we allocate a monotonically increasing "serial" to these accounts similar to "ID". This ID can then be converted to a valid array index in the short-living account array by subtracting the lowest ID of the list of live short-living accounts. Using this "lowest" short-living ID we can also logically designate which past accounts are now dead and their memory is no longer accessible.

We save this logical ever increasing ID in all the places where we used to save account pointers. As this is a 64 bit counter, we don't perceive an overflow. But, we plan to implement an overflow support. We provide APIs to transform this logical ID to actual pointers by projecting this logical ID into actual array index (subtracting the start ID of currently live short-living accounts) and accessing the account at that array position.