### PR TITLE
Ignore stdout that precede desired content.

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -1266,6 +1266,8 @@ class GpRecoverSegmentProgram:
             dataState    = None
             try:
                 lines = str(cmd.get_results().stderr).split("\n")
+                while not lines[0].startswith('mode: '):
+                    logger.info(lines.pop(0))
                 mode         = lines[0].split(": ")[1].strip()
                 segmentState = lines[1].split(": ")[1].strip()
                 dataState    = lines[2].split(": ")[1].strip()


### PR DESCRIPTION
When using a docker image, we noticed that gprecoverseg will fail due to
parsing stdout that has a SSH warning line such as "Warning: Permanently
added [host] to the list ...". We now ignore these lines until the
desired output begins.

Authors: Larry Hamel and Chris Hajas