### PR TITLE
Ensure that codegen unittests pass with GCC 6.2.0

### DIFF
--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -34,7 +34,7 @@ export MPP_ARCH=$($(BLD_ARCH)_MPP_ARCH)
 endif
 
 # take over the gcc version we use
-BLD_CC=gcc
+BLD_CC=$(shell which gcc)
 hpux_ia64_CC=gcc
 osx106_x86_CC=gcc
 

--- a/src/backend/codegen/CMakeLists.txt
+++ b/src/backend/codegen/CMakeLists.txt
@@ -313,7 +313,7 @@ function(add_cmockery_gtest TEST_NAME TEST_SOURCES)
     )
     target_include_directories(${TEST_NAME} PUBLIC ${TEST_LIB_INC_DIRECTORIES})
     # Bring these from $ENV{LIBS}
-    target_link_libraries(${TEST_NAME} "-ldl -lbz2 -lxml2 -lz -lm -lcurl -L../../port -lpgport_srv" gpcodegen gtest)
+    target_link_libraries(${TEST_NAME} "-lnetsnmp -lpam -lxml2 -lpgport -lbz2 -lrt -lz -lreadline -lcrypt -ldl -lm -lcurl -L../../port -lpgport_srv" gpcodegen gtest)
     add_test(${TEST_NAME} ${TEST_NAME})
     add_dependencies(check ${TEST_NAME})
 endfunction(add_cmockery_gtest)


### PR DESCRIPTION
Update the CMakeLists.txt to include all the required libraries to make
codegen unittests pass.

Update the gpAux makefile.global to use the absolute gcc path.

This is a paired effort with @xinzweb and @kaknikhil.