### PR TITLE
Add ICG jobs to run all 4 flavors for enterprise build.

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -147,6 +147,69 @@ jobs:
       BLDWRAP_POSTGRES_CONF_ADDONS: ""
       TEST_OS: centos
 
+- name: icg_gporca_centos6
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+    - get: sync_tools_gpdb_centos
+      resource: sync_tools_gpdb_centos
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos67-gpdb-gcc6-llvm-image
+  - task: ic_gpdb
+    file: gpdb_src/concourse/ic_gpdb.yml
+    image: centos67-gpdb-gcc6-llvm-image
+    params:
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-good
+      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      TEST_OS: centos
+
+- name: icg_planner_codegen_centos6
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+    - get: sync_tools_gpdb_centos
+      resource: sync_tools_gpdb_centos
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos67-gpdb-gcc6-llvm-image
+  - task: ic_gpdb
+    file: gpdb_src/concourse/ic_gpdb.yml
+    image: centos67-gpdb-gcc6-llvm-image
+    params:
+      MAKE_TEST_COMMAND: PGOPTIONS='-c codegen=on' installcheck-good
+      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      TEST_OS: centos
+
+- name: icg_gporca_codegen_centos6
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+    - get: sync_tools_gpdb_centos
+      resource: sync_tools_gpdb_centos
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos67-gpdb-gcc6-llvm-image
+  - task: ic_gpdb
+    file: gpdb_src/concourse/ic_gpdb.yml
+    image: centos67-gpdb-gcc6-llvm-image
+    params:
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=on' installcheck-good
+      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      TEST_OS: centos
+
 # Stage 3: Packaging
 
 - name: gpdb_rc_packaging_centos

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -30,6 +30,7 @@ function gen_env(){
 		    exit 1
 		}
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
+		source /opt/gcc_env.sh
 		cd "\${1}/gpdb_src/gpAux"
 		source gpdemo/gpdemo-env.sh
 		make ${MAKE_TEST_COMMAND}


### PR DESCRIPTION
GPORCA on/off
CODEGEN on/off

Also patch up a bug in ic_gpdb.bash to use GCC 6.2.0.

[#129755219]

Signed-off-by: Nikhil Kak <nkak@pivotal.io>