### PR TITLE
Check for possible overflow in filename generation

### DIFF
--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -890,10 +890,11 @@ ErrorLogDelete(Oid databaseId, Oid relationId)
 
 	if (!OidIsValid(relationId))
 	{
-		DIR	   *dir;
-		struct dirent *de;
-		char   *dirpath = ErrorLogDir;
-		char	prefix[MAXPGPATH];
+		DIR			   *dir;
+		struct dirent  *de;
+		char   		   *dirpath = ErrorLogDir;
+		char			prefix[MAXPGPATH];
+		int				len;
 
 		if (OidIsValid(databaseId))
 			snprintf(prefix, sizeof(prefix), "%u_", databaseId);
@@ -918,8 +919,16 @@ ErrorLogDelete(Oid databaseId, Oid relationId)
 			 */
 			if (!OidIsValid(databaseId))
 			{
+				len = snprintf(filename, MAXPGPATH, "%s/%s", dirpath, de->d_name);
+				if (len >= (MAXPGPATH - 1))
+				{
+					ereport(WARNING,
+						(errcode(ERRCODE_GP_INTERNAL_ERROR),
+						(errmsg("log filename truncation on \"%s\", unable to delete error log",
+								de->d_name))));
+					continue;
+				}
 				LWLockAcquire(ErrorLogLock, LW_EXCLUSIVE);
-				sprintf(filename, "%s/%s", dirpath, de->d_name);
 				unlink(filename);
 				LWLockRelease(ErrorLogLock);
 				continue;


### PR DESCRIPTION
The filename is defined as MAXPGPATH which can overflow on macOS when 64 bit inodes are used since the dirent struct can hold 1023 character dir entries (Linux has a dirent64 struct instead of overloading dirent). Guard against possible overflow and ereport a WARNING in case it happens. Use WARNING and not ERROR since that seems a bit harsh in this situation.

While perhaps not technically required on other platforms it's good practice to check for overflow either way.
