### PR TITLE
Set persistentTid and persistentSerialNum in XLog record in log_newpa…

### DIFF
--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -126,12 +126,11 @@ _bitmap_create_lov_heapandindex(Relation rel,
 		{
 			// Fetch gp_persistent_relation_node information that will be added to XLOG record.
 			RelationFetchGpRelationNodeForXLog(lovIndex);
-			
-			log_newpage(&lovIndex->rd_node,
-						BufferGetBlockNumber(btree_metabuf),
+
+			log_newpage_rel(lovIndex, BufferGetBlockNumber(btree_metabuf),
 						btree_metapage);
 		}
-		
+
 		/* This cache value is not valid anymore. */
 		if (lovIndex->rd_amcache)
 		{

--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -267,9 +267,8 @@ end_heap_rewrite(RewriteState state)
 	if (state->rs_buffer_valid)
 	{
 		if (state->rs_use_wal)
-			log_newpage(&state->rs_new_rel->rd_node,
-						state->rs_blockno,
-						state->rs_buffer);
+			log_newpage_rel(state->rs_new_rel,state->rs_blockno, state->rs_buffer);
+
 		RelationOpenSmgr(state->rs_new_rel);
 		smgrextend(state->rs_new_rel->rd_smgr, state->rs_blockno,
 				   (char *) state->rs_buffer, true);
@@ -604,9 +603,7 @@ raw_heap_insert(RewriteState state, HeapTuple tup)
 
 			/* XLOG stuff */
 			if (state->rs_use_wal)
-				log_newpage(&state->rs_new_rel->rd_node,
-							state->rs_blockno,
-							page);
+				log_newpage_rel(state->rs_new_rel, state->rs_blockno, page);
 
 			/*
 			 * Now write the page. We say isTemp = true even if it's not a

--- a/src/backend/access/nbtree/nbtsort.c
+++ b/src/backend/access/nbtree/nbtsort.c
@@ -289,7 +289,7 @@ _bt_blwritepage(BTWriteState *wstate, Page page, BlockNumber blkno)
 	if (wstate->btws_use_wal)
 	{
 		/* We use the heap NEWPAGE record type for this */
-		log_newpage(&wstate->index->rd_node, blkno, page);
+		log_newpage_rel(wstate->index, blkno, page);
 	}
 
 	else
@@ -322,7 +322,7 @@ _bt_blwritepage(BTWriteState *wstate, Page page, BlockNumber blkno)
 		// -------- MirroredLock ----------
 	}
 
-	
+
 	// -------- MirroredLock ----------
 	// UNDONE: Unfortunately, I think we write temp relations to the mirror...
 	LWLockAcquire(MirroredLock, LW_SHARED);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -10593,7 +10593,10 @@ copy_buffer_pool_data(Relation rel, SMgrRelation dst,
 
 		/* XLOG stuff */
 		if (useWal)
-			log_newpage(&dst->smgr_rnode, blkno, page);
+		{
+			log_newpage_relFileNode(&dst->smgr_rnode, blkno, page, persistentTid,
+						persistentSerialNum);
+		}
 
 		// -------- MirroredLock ----------
 		LWLockAcquire(MirroredLock, LW_SHARED);

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -308,7 +308,14 @@ extern XLogRecPtr log_heap_clean(Relation reln, Buffer buffer,
 extern XLogRecPtr log_heap_freeze(Relation reln, Buffer buffer,
 				TransactionId cutoff_xid,
 				OffsetNumber *offsets, int offcnt);
-extern XLogRecPtr log_newpage(RelFileNode *rnode, BlockNumber blk, Page page);
+
+extern XLogRecPtr log_newpage_rel(Relation rel, BlockNumber blkno,
+								  Page page);
+
+extern XLogRecPtr log_newpage_relFileNode(RelFileNode *relFileNode,
+										  BlockNumber blkno, Page page,
+										  ItemPointer persistentTid,
+										  int64 persistentSerialNum);
 
 /* in common/heaptuple.c */
 extern Size heap_compute_data_size(TupleDesc tupleDesc,


### PR DESCRIPTION
…ge().

The log_newpage() routine allocates an XLog record on the stack with
uninitialized persistentTid and persistentSerialNum fields.  Insertion of these
XLog records causes problems in XLog replay during recovery.

This commit insures that the XLog records written by log_newpage() always have
the persistentTid and persistentSerial set correctly.

This commit also makes the test
src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_reindex_pg_class.py
pass.