### PR TITLE
Bump Orca version and update test output file due to plan changes

### DIFF
--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -172,7 +172,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	@echo "Resolve finished";
 
 	wget -O - https://github.com/greenplum-db/gpos/releases/download/v1.145/bin_gpos_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
-	wget -O - https://github.com/greenplum-db/gporca/releases/download/v1.674/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	wget -O - https://github.com/greenplum-db/gporca/releases/download/v1.675/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 
 clean_tools: opt_write_test
 	@cd releng/make/dependencies; \

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -8058,16 +8058,18 @@ explain select count(*) over (order by i), count(*) over (partition by i order b
    ->  Window  (cost=0.00..431.00 rows=1 width=16)
          Partition By: i
          Order By: j
-         ->  Sort  (cost=0.00..431.00 rows=1 width=24)
+         ->  Sort  (cost=0.00..431.00 rows=1 width=16)
                Sort Key: i, j
-               ->  Window  (cost=0.00..431.00 rows=1 width=24)
+               ->  Window  (cost=0.00..431.00 rows=1 width=16)
                      Order By: i
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=16)
-                           Sort Key: i
-                           ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=16)
-                                 ->  Table Scan on redundant_sort_check  (cost=0.00..431.00 rows=1 width=16)
- Settings:  gp_enable_sequential_window_plans=on; optimizer=on; optimizer_segments=3
-(13 rows)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           Merge Key: i
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                 Sort Key: i
+                                 ->  Table Scan on redundant_sort_check  (cost=0.00..431.00 rows=1 width=8)
+ Settings:  gp_enable_sequential_window_plans=on; optimizer=on
+ Optimizer status: PQO version 1.675
+(15 rows)
 
 -- End of MPP-13710
 -- MPP-13879

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1145,12 +1145,13 @@ from
  Result  (cost=0.00..862.00 rows=1 width=16)
    ->  Window  (cost=0.00..862.00 rows=1 width=16)
          Order By: t2_mpp_24563.seq
-         ->  Sort  (cost=0.00..862.00 rows=1 width=12)
-               Sort Key: t2_mpp_24563.seq
-               ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..862.00 rows=1 width=12)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+               Merge Key: t2_mpp_24563.seq
+               ->  Result  (cost=0.00..862.00 rows=1 width=12)
                      ->  Result  (cost=0.00..862.00 rows=1 width=12)
                            ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                                 ->  Result  (cost=0.00..862.00 rows=1 width=12)
+                                 ->  Sort  (cost=0.00..862.00 rows=1 width=12)
+                                       Sort Key: t2_mpp_24563.seq
                                        ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=12)
                                              Hash Cond: t2_mpp_24563.id = t1_mpp_24563.id
                                              ->  Table Scan on t2_mpp_24563  (cost=0.00..431.00 rows=1 width=8)
@@ -1162,8 +1163,8 @@ from
                                                                Sort Key: t1_mpp_24563.id
                                                                ->  Table Scan on t1_mpp_24563  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.621
-(21 rows)
+ Optimizer status: PQO version 1.675
+(22 rows)
 
 drop table t1_mpp_24563;
 drop table t2_mpp_24563;


### PR DESCRIPTION
In new version of Orca, broadcast motion is no longer requested from window operator unless it is requested explicitly from its parent operator.