### PR TITLE
GCC 6.2.0 generates code that causes incorrect number of index keys used

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1066,10 +1066,9 @@ CTranslatorRelcacheToDXL::Pmdindex
 
 	// extract the position of the key columns
 	DrgPul *pdrgpulKeyCols = GPOS_NEW(pmp) DrgPul(pmp);
-	ULONG ulKeys = pgIndex->indnatts;
-	for (ULONG ul = 0; ul < ulKeys; ul++)
+	for (USINT ui = 0; ui < pgIndex->indnatts; ui++)
 	{
-		INT iAttno = pgIndex->indkey.values[ul];
+		INT iAttno = pgIndex->indkey.values[ui];
 		GPOS_ASSERT(0 != iAttno && "Index expressions not supported");
 
 		pdrgpulKeyCols->Append(GPOS_NEW(pmp) ULONG(UlPosition(iAttno, pul)));


### PR DESCRIPTION
Fix this by using identical data type for the local variable and `pg_index->indnatts`.