### PR TITLE
Use Wrapper function to call slot_getattr

### DIFF
--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -1443,41 +1443,6 @@ slot_deform_tuple(TupleTableSlot *slot, int natts)
 }
 
 /*
- * Get an attribute from the tuple table slot.
- */
-Datum slot_getattr(TupleTableSlot *slot, int attnum, bool *isnull)
-{
-  Assert(!TupIsNull(slot));
-  Assert(attnum <= slot->tts_tupleDescriptor->natts);
-
-  /* System attribute */
-  if(attnum <= 0)
-    return slot_getsysattr(slot, attnum, isnull);
-
-  /* fast path for virtual tuple */
-  if(TupHasVirtualTuple(slot) && slot->PRIVATE_tts_nvalid >= attnum)
-  {
-    *isnull = slot->PRIVATE_tts_isnull[attnum-1];
-    return slot->PRIVATE_tts_values[attnum-1];
-  }
-
-  /* Mem tuple: We do not even populate virtual tuple */
-  if(TupHasMemTuple(slot))
-  {
-    Assert(slot->tts_mt_bind);
-    return memtuple_getattr(slot->PRIVATE_tts_memtuple, slot->tts_mt_bind, attnum, isnull);
-  }
-
-  /* Slow: heap tuple */
-  Assert(TupHasHeapTuple(slot));
-
-  _slot_getsomeattrs(slot, attnum);
-  Assert(TupHasVirtualTuple(slot) && slot->PRIVATE_tts_nvalid >= attnum);
-  *isnull = slot->PRIVATE_tts_isnull[attnum-1];
-  return slot->PRIVATE_tts_values[attnum-1];
-}
-
-/*
  * slot_getsomeattrs
  *		This function forces the entries of the slot's Datum/isnull
  *		arrays to be valid at least up through the attnum'th entry.

--- a/src/backend/codegen/codegen_wrapper.cc
+++ b/src/backend/codegen/codegen_wrapper.cc
@@ -102,6 +102,11 @@ void SetActiveCodeGeneratorManager(void* manager) {
   ActiveCodeGeneratorManager = manager;
 }
 
+Datum
+slot_getattr_regular(TupleTableSlot *slot, int attnum, bool *isnull) {
+  return slot_getattr(slot, attnum, isnull);
+}
+
 void* ExecVariableListCodegenEnroll(
     ExecVariableListFn regular_func_ptr,
     ExecVariableListFn* ptr_to_chosen_func_ptr,

--- a/src/backend/codegen/exec_eval_expr_codegen.cc
+++ b/src/backend/codegen/exec_eval_expr_codegen.cc
@@ -123,8 +123,8 @@ bool ExecEvalExprCodegen::GenerateExecEvalExpr(
   if (nullptr == slot_getattr_codegen_ ||
       false == slot_getattr_codegen_->GenerateCode(codegen_utils)) {
     gen_info_.llvm_slot_getattr_func =
-        codegen_utils->GetOrRegisterExternalFunction(slot_getattr,
-                                                     "slot_getattr");
+        codegen_utils->GetOrRegisterExternalFunction(slot_getattr_regular,
+                                                     "slot_getattr_regular");
   } else {
     gen_info_.llvm_slot_getattr_func =
         slot_getattr_codegen_->GetGeneratedFunction();

--- a/src/backend/codegen/include/codegen/codegen_manager.h
+++ b/src/backend/codegen/include/codegen/codegen_manager.h
@@ -81,13 +81,12 @@ class CodegenManager {
       FuncType regular_func_ptr,
       FuncType* ptr_to_chosen_func_ptr,
       Args&&... args) {  // NOLINT(build/c++11)
-
-	assert(nullptr != regular_func_ptr);
-	assert(nullptr != ptr_to_chosen_func_ptr);
+    assert(nullptr != regular_func_ptr);
+    assert(nullptr != ptr_to_chosen_func_ptr);
 
     bool can_enroll =
         // manager may be NULL if ExecInitNode/ExecProcNode weren't previously
-    	// called. This happens e.g during gpinitsystem.
+        // called. This happens e.g during gpinitsystem.
         (nullptr != manager) &&
         codegen &&  // if codegen guc is false
         // if generator is disabled

--- a/src/backend/codegen/include/codegen/slot_getattr_codegen.h
+++ b/src/backend/codegen/include/codegen/slot_getattr_codegen.h
@@ -104,8 +104,7 @@ class SlotGetAttrCodegen : public BaseCodegen<SlotGetAttrFn> {
   SlotGetAttrCodegen(gpcodegen::CodegenManager* manager,
                      TupleTableSlot* slot,
                      int max_attr)
-  : BaseCodegen(
-      manager, kSlotGetAttrPrefix, slot_getattr, &dummy_func_),
+  : BaseCodegen(manager, kSlotGetAttrPrefix, slot_getattr, &dummy_func_),
     slot_(slot),
     max_attr_(max_attr),
     llvm_function_(nullptr) {

--- a/src/backend/codegen/include/codegen/slot_getattr_codegen.h
+++ b/src/backend/codegen/include/codegen/slot_getattr_codegen.h
@@ -104,7 +104,8 @@ class SlotGetAttrCodegen : public BaseCodegen<SlotGetAttrFn> {
   SlotGetAttrCodegen(gpcodegen::CodegenManager* manager,
                      TupleTableSlot* slot,
                      int max_attr)
-  : BaseCodegen(manager, kSlotGetAttrPrefix, slot_getattr, &dummy_func_),
+  : BaseCodegen(
+      manager, kSlotGetAttrPrefix, slot_getattr_regular, &dummy_func_),
     slot_(slot),
     max_attr_(max_attr),
     llvm_function_(nullptr) {

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -685,8 +685,8 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttr(
       llvm_error);
 
   codegen_utils->CreateFallback<SlotGetAttrFn>(
-      codegen_utils->GetOrRegisterExternalFunction(slot_getattr,
-                                                   "slot_getattr"),
+      codegen_utils->GetOrRegisterExternalFunction(slot_getattr_regular,
+                                                   "slot_getattr_regular"),
       slot_getattr_func);
   return true;
 }

--- a/src/include/codegen/codegen_wrapper.h
+++ b/src/include/codegen/codegen_wrapper.h
@@ -162,6 +162,12 @@ void
 SetActiveCodeGeneratorManager(void* manager);
 
 /*
+ * Wrapper function for slot_getattr.
+ */
+Datum
+slot_getattr_regular(struct TupleTableSlot *slot, int attnum, bool *isnull);
+
+/*
  * returns the pointer to the ExecVariableList
  */
 void*

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -316,8 +316,40 @@ static inline ItemPointer slot_get_ctid(TupleTableSlot *slot)
 	return &(slot->PRIVATE_tts_synthetic_ctid);
 }
 
-/* in access/common/heaptuple.c */
-extern Datum slot_getattr(TupleTableSlot *slot, int attnum, bool *isnull);
+/*
+ * Get an attribute from the tuple table slot.
+ */
+static inline Datum slot_getattr(TupleTableSlot *slot, int attnum, bool *isnull)
+{
+	Assert(!TupIsNull(slot));
+	Assert(attnum <= slot->tts_tupleDescriptor->natts);
+
+	/* System attribute */
+	if(attnum <= 0)
+		return slot_getsysattr(slot, attnum, isnull);
+
+	/* fast path for virtual tuple */
+	if(TupHasVirtualTuple(slot) && slot->PRIVATE_tts_nvalid >= attnum)
+	{
+		*isnull = slot->PRIVATE_tts_isnull[attnum-1];
+		return slot->PRIVATE_tts_values[attnum-1];
+	}
+
+	/* Mem tuple: We do not even populate virtual tuple */
+	if(TupHasMemTuple(slot))
+	{
+		Assert(slot->tts_mt_bind);
+		return memtuple_getattr(slot->PRIVATE_tts_memtuple, slot->tts_mt_bind, attnum, isnull);
+	}
+
+	/* Slow: heap tuple */
+	Assert(TupHasHeapTuple(slot));
+
+	_slot_getsomeattrs(slot, attnum);
+	Assert(TupHasVirtualTuple(slot) && slot->PRIVATE_tts_nvalid >= attnum);
+	*isnull = slot->PRIVATE_tts_isnull[attnum-1];
+	return slot->PRIVATE_tts_values[attnum-1];
+}
 
 static inline bool slot_attisnull(TupleTableSlot *slot, int attnum)
 {


### PR DESCRIPTION
Slot_getattr in header file cause to have a different pointer. This caused issue when we register as an external function. LLVM expect the name of the external function to be unique for each pointer. In order to fix it, we first moved the slot_getattr to `heaptuple.c`. But this introduces `memtuple` dependency in `heaptuple.c` which broke building `gp_filedump`. `gp_filedump` doesn't link with `SUBSYS.o` and hence linking with `memtuple.c` introduce a whole lot of undefined reference.

Hence we introduced wrapper function in codegen_wrapper.cc and use that instead of slot_getattr.
Also for the long term, from codegen perspective, it is good to have a wrapper function for each gpdb function we want to call. One of the advantages is to have a try/catch similar to `gpdbwrapper.cpp` for orca.

@foyzur @hardikar @armenatzoglou @danielgustafsson Please have a look when you get chance.