### PR TITLE
add gpcheckcat check for "mirroring_matching"

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -35,6 +35,7 @@ try:
     from gpcheckcat_modules.leaked_schema_dropper import LeakedSchemaDropper
     from gpcheckcat_modules.repair import Repair
     from gpcheckcat_modules.foreign_key_check import ForeignKeyCheck
+    from gpcheckcat_modules.mirror_matching_check import MirrorMatchingCheck
 
 
 except ImportError, e:
@@ -2924,6 +2925,18 @@ def checkTableMissingEntry(cat):
         myprint('  Execution error: ' + str(e))
         myprint(qry)
 
+def checkMirroringMatching():
+    # check that PT rebuild has not left behind mismatched mirroring states in the segments
+    db_connection = connect2(GV.cfg[1], utilityMode=True)
+    try:
+        mismatched_segments = MirrorMatchingCheck().run_check(db_connection, logger)
+        if len(mismatched_segments) > 0:
+            GV.checkStatus = False
+            setError(ERROR_NOREPAIR)
+    except Exception as ex:
+        setError(ERROR_NOREPAIR)
+        GV.checkStatus = False
+        myprint('  Execution error: ' + str(ex))
 
 # -------------------------------------------------------------------------------
 def missingEntryQuery(max_content, catname, pkey, castedPkey):
@@ -3494,6 +3507,14 @@ all_checks = {
             "fn": lambda: checkDuplicatePersistentEntry(),
             "version": 'main',
             "order": 15,
+            "online": True
+        },
+    "mirroring_matching":
+        {
+            "description": "Check that configured mirroring and segments' mirroring agree",
+            "fn": lambda: checkMirroringMatching(),
+            "version": 'main',
+            "order": 16,
             "online": True
         }
 }

--- a/gpMgmt/bin/gpcheckcat_modules/mirror_matching_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/mirror_matching_check.py
@@ -1,0 +1,36 @@
+from gppylib.gparray import FAULT_STRATEGY_FILE_REPLICATION, get_gparray_from_config
+
+
+class MirrorMatchingCheck:
+
+    def run_check(self, db_connection, logger):
+        logger.info('-----------------------------------')
+        logger.info('Checking mirroring_matching')
+
+        is_config_mirror_enabled = get_gparray_from_config().getFaultStrategy() == FAULT_STRATEGY_FILE_REPLICATION
+
+        # This query returns the mirroring status of all segments
+        mirroring_query = """SELECT gp_segment_id, mirror_existence_state FROM gp_dist_random('gp_persistent_relation_node') GROUP BY 1,2"""
+        segment_mirroring_result = db_connection.query(mirroring_query).getresult()
+
+        mismatching_segments = []
+        for (seg_id, mirror_state) in segment_mirroring_result:
+            is_segment_mirrored = mirror_state > 1
+            if mirror_state == 0:
+                continue  # 0 is considered a match in either situation
+            if is_segment_mirrored != is_config_mirror_enabled:
+                mismatching_segments.append((seg_id, mirror_state))
+
+        if mismatching_segments:
+            logger.info('[FAIL] Mirroring mismatch detected')
+            logger.info("The GP configuration reports mirror enabling is: %s" % is_config_mirror_enabled)
+            logger.error("The following segments are mismatched in PT:")
+            logger.error("")
+            logger.error("Segment ID:\tmirror_existence_state:")
+            for (seg_id, mirror_existence_state) in mismatching_segments:
+                label = "Enabled" if mirror_existence_state > 1 else "Disabled"
+                logger.error("%i\t\t%i (%s)" % (seg_id, mirror_existence_state, label))
+        else:
+            logger.info('[OK] %s' % "mirroring_matching")
+
+        return mismatching_segments

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -23,7 +23,7 @@ from gppylib    import gplog
 from gppylib.db import dbconn
 from gppylib.gpversion import GpVersion
 from gppylib.commands.unix import *
-
+import os
 
 SYSTEM_FILESPACE = 3052        # oid of the system filespace
 
@@ -2583,5 +2583,16 @@ def get_session_ids(master_port):
         conn.close()
 
 
+def get_gparray_from_config():
+    # imports below, when moved to the top, seem to cause an import error in a unit test because of dependency issue
+    from gppylib.system import configurationInterface
+    from gppylib.system import configurationImplGpdb
+    from gppylib.system.environment import GpMasterEnvironment
+    master_data_dir = os.environ['MASTER_DATA_DIRECTORY']
+    gpEnv = GpMasterEnvironment(master_data_dir, False)
+    configurationInterface.registerConfigurationProvider(
+        configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog())
+    confProvider = configurationInterface.getConfigurationProvider().initializeProvider(gpEnv.getMasterPort())
+    return confProvider.loadSystemConfig(useUtilityMode=True)
 
 # === EOF ====

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
@@ -26,7 +26,7 @@ class GpArrayTestCase(GpTestCase):
             patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog', return_value=self.gpConfigMock),
         ])
 
-def test_spreadmirror_layout(self):
+    def test_spreadmirror_layout(self):
         """ Basic spread mirroring """
         mirror_type = 'spread'
         primary_portbase = 5000

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
@@ -7,15 +7,26 @@
 
 """ Unittesting for gplog module
 """
-import unittest2 as unittest
+import os
 
-from gppylib.gparray import GpArray, GpDB, createSegmentRows
+from gppylib.gparray import GpArray, GpDB, createSegmentRows, FAULT_STRATEGY_NONE, get_gparray_from_config
 from gppylib import gplog
+from gp_unittest import *
+from mock import patch, Mock
+from gppylib.system.configurationInterface import GpConfigurationProvider
 
 logger = gplog.get_unittest_logger()
 
-class MyTestCase(unittest.TestCase):
-    def test_spreadmirror_layout(self):
+class GpArrayTestCase(GpTestCase):
+    # todo move to top
+    def setUp(self):
+        self.gpConfigMock = Mock()
+        self.apply_patches([
+            patch('os.environ', new={}),
+            patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog', return_value=self.gpConfigMock),
+        ])
+
+def test_spreadmirror_layout(self):
         """ Basic spread mirroring """
         mirror_type = 'spread'
         primary_portbase = 5000
@@ -45,31 +56,32 @@ class MyTestCase(unittest.TestCase):
         
         #now we have enough
         hostlist.append('host3')
-        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
+        self._validate_array(self._setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                                                 mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
         
         
         #enough
         hostlist = ['host1', 'host2', 'host3']
         primary_list = ['/db1', '/db2']
         mirror_list = ['/mir1', '/mir2']
-        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
+        self._validate_array(self._setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                                                 mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
 
         #typical thumper
         hostlist = ['sdw1', 'sdw2', 'sdw3', 'sdw4', 'sdw5']
         primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4']
         mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror']
-        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
+        self._validate_array(self._setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                                                 mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
 
         #typical Thor
         hostlist = ['sdw1', 'sdw2', 'sdw3', 'sdw4', 'sdw5', 'sdw6', 'sdw7', 'sdw8', 'sdw9']
         primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4', '/dbfast5', '/dbfast6', '/dbfast7', '/dbfast8']
         mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror',
                        '/dbfast5/mirror', '/dbfast6/mirror', '/dbfast7/mirror', '/dbfast8/mirror']
-        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
+        self._validate_array(self._setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                                                 mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
+
 
     def test_groupmirror_layout(self):
         """ Basic group mirroring """
@@ -105,16 +117,17 @@ class MyTestCase(unittest.TestCase):
         hostlist = ['sdw1', 'sdw2', 'sdw3', 'sdw4', 'sdw5']
         primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4']
         mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror']
-        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
+        self._validate_array(self._setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                                                 mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
 
         #typical Thor
         hostlist = ['sdw1', 'sdw2', 'sdw3', 'sdw4', 'sdw5', 'sdw6', 'sdw7', 'sdw8', 'sdw9']
         primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4', '/dbfast5', '/dbfast6', '/dbfast7', '/dbfast8']
         mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror',
                        '/dbfast5/mirror', '/dbfast6/mirror', '/dbfast7/mirror', '/dbfast8/mirror']
-        self._validate_array(self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
+        self._validate_array(self._setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                                                 mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase))
+
 
     def test_get_segment_list(self):
         mirror_type = 'grouped'
@@ -129,8 +142,8 @@ class MyTestCase(unittest.TestCase):
         primary_list = ['/dbfast1', '/dbfast2', '/dbfast3', '/dbfast4']
         mirror_list = ['/dbfast1/mirror', '/dbfast2/mirror', '/dbfast3/mirror', '/dbfast4/mirror']
 
-        gparray = self.setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
-                               mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)
+        gparray = self._setup_gparray(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                                      mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase)
         self._validate_array(gparray)
 
         # test without expansion segments
@@ -147,9 +160,31 @@ class MyTestCase(unittest.TestCase):
                                     'p' if convert_bool(row.isprimary) else 'm', row.host, row.address, row.port, row.fulldir, row.prPort)
         self._validate_get_segment_list(gparray, hostlist, expansion_hosts, primary_list)
 
+
+    @patch('gppylib.system.configurationInterface.getConfigurationProvider')
+    @patch('gppylib.system.environment.GpMasterEnvironment', return_value=Mock(), autospec=True)
+    def test_get_gparray_from_config(self, gpMasterEnvironmentMock, getConfigProviderFunctionMock):
+        os.environ['MASTER_DATA_DIRECTORY'] = "MY_TEST_DIR"
+        configProviderMock = Mock(spec=GpConfigurationProvider)
+        getConfigProviderFunctionMock.return_value = configProviderMock
+        configProviderMock.initializeProvider.return_value = configProviderMock
+        gpArrayMock = Mock(spec=GpArray)
+        gpArrayMock.getFaultStrategy.return_value = FAULT_STRATEGY_NONE
+        configProviderMock.loadSystemConfig.return_value = gpArrayMock
+        gpMasterEnvironmentMock.return_value.getMasterPort.return_value = 123456
+
+        gpArray = get_gparray_from_config()
+
+        self.assertEquals(gpArray.getFaultStrategy(), FAULT_STRATEGY_NONE)
+        gpMasterEnvironmentMock.assert_called_once_with("MY_TEST_DIR", False)
+        getConfigProviderFunctionMock.assert_any_call()
+        configProviderMock.initializeProvider.assert_called_once_with(123456)
+        configProviderMock.loadSystemConfig.assert_called_once_with(useUtilityMode=True)
+
+
 #------------------------------- non-test helpers --------------------------------
-    def setup_gparray(self, hostlist, interface_list, primary_list, primary_portbase, mirror_type, 
-                          mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase):
+    def _setup_gparray(self, hostlist, interface_list, primary_list, primary_portbase, mirror_type,
+                       mirror_list, mirror_portbase, dir_prefix, primary_replication_portbase, mirror_replication_portbase):
         master = GpDB(content = -1,
                     preferred_role = 'p',
                     dbid = 0,
@@ -231,4 +266,4 @@ def convert_bool(val):
 
 #------------------------------- Mainline --------------------------------
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -1,11 +1,11 @@
 import imp
+import logging
 import os
 import sys
 
 from mock import *
 
 from gp_unittest import *
-
 
 class GpCheckCatTestCase(GpTestCase):
     def setUp(self):
@@ -16,16 +16,22 @@ class GpCheckCatTestCase(GpTestCase):
         gpcheckcat_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpcheckcat")
         self.subject = imp.load_source('gpcheckcat', gpcheckcat_file)
 
-        self.subject.logger = Mock(spec=['log', 'info', 'debug', 'error'])
         self.db_connection = Mock(spec=['close', 'query'])
-
         self.unique_index_violation_check = Mock(spec=['runCheck'])
-        self.unique_index_violation_check.runCheck.return_value = []
+        self.foreign_key_check = Mock(spec=['runCheck', 'checkTableForeignKey'])
+        self.apply_patches([
+            patch("gpcheckcat.pg.connect", return_value=self.db_connection),
+            patch("gpcheckcat.UniqueIndexViolationCheck", return_value=self.unique_index_violation_check),
+            patch("gpcheckcat.ForeignKeyCheck", return_value=self.foreign_key_check),
+            patch('os.environ', new={}),
+            patch('pygresql.pgdb'),
+        ])
 
+        self.subject.logger = Mock(spec=['log', 'info', 'debug', 'error'])
+        self.unique_index_violation_check.runCheck.return_value = []
         self.leaked_schema_dropper = Mock(spec=['drop_leaked_schemas'])
         self.leaked_schema_dropper.drop_leaked_schemas.return_value = []
 
-        self.foreign_key_check = Mock(spec=['runCheck', 'checkTableForeignKey'])
         issues_list = dict()
         issues_list['cat1'] = [('pg_class', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')]),
                               ('arbitrary_catalog_table', ['pkey1', 'pkey2'], [('r1', 'r2'), ('r3', 'r4')])]
@@ -40,11 +46,6 @@ class GpCheckCatTestCase(GpTestCase):
         self.subject.setError = Mock()
         self.subject.print_repair_issues = Mock()
 
-        self.apply_patches([
-            patch("gpcheckcat.pg.connect", return_value=self.db_connection),
-            patch("gpcheckcat.UniqueIndexViolationCheck", return_value=self.unique_index_violation_check),
-            patch("gpcheckcat.ForeignKeyCheck", return_value=self.foreign_key_check),
-        ])
 
     def test_running_unknown_check__raises_exception(self):
         with self.assertRaises(LookupError):
@@ -252,6 +253,39 @@ class GpCheckCatTestCase(GpTestCase):
 
         self.subject.getCatObj.assert_called_once_with(' pg_class')
         self.subject.checkForeignKey.assert_called_once_with([cat_obj_mock])
+
+    def test_mirror_matching_success_sets_status_and_error(self):
+        with patch('gpcheckcat_modules.mirror_matching_check.MirrorMatchingCheck.run_check') as mirrorMatchingCheckMock:
+            mirrorMatchingCheckMock.return_value = []
+
+            self.subject.runOneCheck('mirroring_matching')
+
+            mirrorMatchingCheckMock.assert_called_once_with(self.db_connection, self.subject.logger)
+            self.assertTrue(self.subject.GV.checkStatus)
+            self.assertEqual(self.subject.setError.call_count, 0)
+            self.db_connection.close.assert_called_once_with()
+
+    def test_mirror_matching_failure_sets_status_and_error(self):
+        with patch('gpcheckcat_modules.mirror_matching_check.MirrorMatchingCheck.run_check') as mirrorMatchingCheckMock:
+            mirrorMatchingCheckMock.return_value = [1]  # failure, a list of segments that are mismatched
+
+            self.subject.runOneCheck('mirroring_matching')
+
+            mirrorMatchingCheckMock.assert_called_once_with(self.db_connection, self.subject.logger)
+            self.assertFalse(self.subject.GV.checkStatus)
+            self.subject.setError.assert_called_once_with(self.subject.ERROR_NOREPAIR)
+            self.db_connection.close.assert_called_once_with()
+
+    def test_mirror_matching_exception(self):
+        self.subject.logger.info.side_effect = Exception('Boom!')
+
+        self.subject.runOneCheck("mirroring_matching")
+
+        log_messages = [args[0][1] for args in self.subject.logger.log.call_args_list]
+        self.assertIn("  Execution error: Boom!", log_messages)
+        self.assertFalse(self.subject.GV.checkStatus)
+        self.subject.setError.assert_called_once_with(self.subject.ERROR_NOREPAIR)
+        self.db_connection.close.assert_called_once_with()
 
     ####################### PRIVATE METHODS #######################
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -263,7 +263,6 @@ class GpCheckCatTestCase(GpTestCase):
             mirrorMatchingCheckMock.assert_called_once_with(self.db_connection, self.subject.logger)
             self.assertTrue(self.subject.GV.checkStatus)
             self.assertEqual(self.subject.setError.call_count, 0)
-            self.db_connection.close.assert_called_once_with()
 
     def test_mirror_matching_failure_sets_status_and_error(self):
         with patch('gpcheckcat_modules.mirror_matching_check.MirrorMatchingCheck.run_check') as mirrorMatchingCheckMock:
@@ -274,7 +273,6 @@ class GpCheckCatTestCase(GpTestCase):
             mirrorMatchingCheckMock.assert_called_once_with(self.db_connection, self.subject.logger)
             self.assertFalse(self.subject.GV.checkStatus)
             self.subject.setError.assert_called_once_with(self.subject.ERROR_NOREPAIR)
-            self.db_connection.close.assert_called_once_with()
 
     def test_mirror_matching_exception(self):
         self.subject.logger.info.side_effect = Exception('Boom!')
@@ -285,7 +283,6 @@ class GpCheckCatTestCase(GpTestCase):
         self.assertIn("  Execution error: Boom!", log_messages)
         self.assertFalse(self.subject.GV.checkStatus)
         self.subject.setError.assert_called_once_with(self.subject.ERROR_NOREPAIR)
-        self.db_connection.close.assert_called_once_with()
 
     ####################### PRIVATE METHODS #######################
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_mirror_matching_check.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_mirror_matching_check.py
@@ -1,0 +1,139 @@
+import os
+
+from mock import *
+
+from gp_unittest import *
+from gpcheckcat_modules.mirror_matching_check import MirrorMatchingCheck
+
+from gppylib.gparray import FAULT_STRATEGY_FILE_REPLICATION, FAULT_STRATEGY_NONE
+
+class MirrorMatchingTestCase(GpTestCase):
+    def setUp(self):
+        self.subject = MirrorMatchingCheck()
+
+        self.logger = Mock(spec=['log', 'info', 'debug', 'error'])
+        self.db_connection = Mock(spec=['close', 'query'])
+
+        self.gpConfigMock = Mock()
+        self.apply_patches([
+           patch('gpcheckcat_modules.mirror_matching_check.get_gparray_from_config', return_value=self.gpConfigMock),
+        ])
+
+    def test_mirror_matching_permutations(self):
+        tests = self._get_list_of_tests_for_permutations_of_matching()
+        for test in tests:
+            segment_states = self._create_mirror_states(mirror_id_and_state_collection=test["segment_ids_and_states"])
+            config_mirror_strategy = FAULT_STRATEGY_FILE_REPLICATION if test["config"] else FAULT_STRATEGY_NONE
+            self.gpConfigMock.getFaultStrategy.return_value = config_mirror_strategy
+            self.db_connection.reset_mock()
+            self.logger.reset_mock()
+            self._setup_mirroring_matching(
+                database_mirror_states=segment_states
+            )
+
+            self.subject.run_check(self.db_connection, self.logger)
+            self._assert_mirroring_common()
+            if test["is_matched"]:
+                info_messages = self.logger.info.call_args_list
+                self.assertIn("[OK] mirroring_matching", info_messages[2][0])
+            else:
+                self._assert_mirroring_mismatch(segment_states, config_mirror_strategy)
+
+    ####################### PRIVATE METHODS #######################
+
+    def _setup_mirroring_matching(self, database_mirror_states=None):
+        self.db_connection.query.return_value.getresult.return_value = database_mirror_states
+
+    def _assert_mirroring_mismatch(self, segment_states, config_mirror_strategy):
+        info_messages = self.logger.info.call_args_list
+        self.assertIn('[FAIL] Mirroring mismatch detected', info_messages[2][0])
+
+        error_messages = self.logger.error.call_args_list
+        config_enabled = config_mirror_strategy == FAULT_STRATEGY_FILE_REPLICATION
+        self.assertIn("The GP configuration reports mirror enabling is: %s" % config_enabled, info_messages[3][0])
+        self.assertIn("The following segments are mismatched in PT:", error_messages[0][0])
+        self.assertIn("Segment ID:\tmirror_existence_state:", error_messages[2][0])
+
+        info_index = 3
+        for segment_state in segment_states:
+            segment_id = segment_state[0]
+            segment_mirroring_state = segment_state[1]
+            segment_enabled = segment_mirroring_state > 1
+            # 0 is considered a match in either situation
+            if segment_mirroring_state == 0:
+                segment_enabled = config_enabled
+            if segment_enabled != config_enabled:
+                label = "Enabled" if segment_enabled else "Disabled"
+                self.assertIn("%s\t\t%s (%s)" % (segment_id, segment_mirroring_state, label), error_messages[info_index][0])
+                info_index += 1
+
+    def _assert_mirroring_common(self):
+        expected_message1 = '-----------------------------------'
+        expected_message2 = 'Checking mirroring_matching'
+        info_messages = self.logger.info.call_args_list
+        error_messages = self.logger.error.call_args_list
+        self.assertIn(expected_message1, info_messages[0][0])
+        self.assertIn(expected_message2, info_messages[1][0])
+        self.db_connection.query.assert_called_once_with(
+            "SELECT gp_segment_id, mirror_existence_state FROM gp_dist_random('gp_persistent_relation_node') GROUP BY 1,2")
+        return error_messages, info_messages
+
+    def _get_list_of_tests_for_permutations_of_matching(self):
+        result = []
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 3)], is_matched=True))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 3)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 1)], is_matched=True))
+
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 3), (2, 3)], is_matched=True))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 3), (2, 3)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 1), (2, 3)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 1), (2, 4)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 3), (2, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 3), (2, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 1), (2, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 1), (2, 1)], is_matched=True))
+
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 4), (2, 3), (3, 3)], is_matched=True))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 3), (2, 3), (3, 5)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 1), (2, 3), (3, 3)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 1), (2, 4), (3, 3)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 3), (2, 1), (3, 3)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 3), (2, 1), (3, 7)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 3), (2, 6), (3, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 3), (2, 4), (3, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 1), (2, 1), (3, 3)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 1), (2, 1), (3, 3)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 1), (2, 6), (3, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 1), (2, 3), (3, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 3), (2, 1), (3, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 5), (2, 1), (3, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 1), (2, 1), (3, 1)], is_matched=False))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 1), (2, 1), (3, 1)], is_matched=True))
+
+        # A case to test for when one segment returns multiple mirror states
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 1), (2, 1), (2, 3), (3, 3)], is_matched=False))
+
+        # 0 matches enabled
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(2, 0), (2, 3), (3, 3)], is_matched=True))
+        result.append(self._create_test_permutation(config=True, segment_ids_and_states=[(1, 0), (1, 1), (2, 3), (2, 0)], is_matched=False))
+
+        # 0 matches disabled
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 1), (1, 0), (2, 1)], is_matched=True))
+        result.append(self._create_test_permutation(config=False, segment_ids_and_states=[(1, 1), (1, 0), (2, 0), (2, 3)], is_matched=False))
+
+        return result
+
+    # Convert the arguments to a dictionary
+    def _create_test_permutation(self, **permutation_args):
+        return permutation_args
+
+    # Convert a list of tuples to a list of lists
+    def _create_mirror_states(self, mirror_id_and_state_collection):
+        result = []
+        for (seg_id, mirror_state) in mirror_id_and_state_collection:
+            result.append([seg_id, mirror_state])
+        return result
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
-- compare the configuration setting that enables mirroring in the cluster versus each
segments' report of its "mirror_existence_state", which is part of its persistent-tables catalog info.
-- consider mirror_existence_state == 0 as a match with either config
setting (cluster mirroring enabled or disabled).
-- report any mismatch and list the segments with mismatches

Authors: Larry Hamel, Karen Huddleston, Chumki Roy