### PR TITLE
gprecoverseg shouldn't recover segments with persistent mirroring dis…

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -279,11 +279,14 @@ class GpRecoverSegmentProgram:
 
         segs = []
         segs_in_change_tracking_disabled = []
+        segs_with_persistent_mirroring_disabled = []
         for index, failedSegment in enumerate(failedSegments):
             peerForFailedSegment = peersForFailedSegments[index]
 
             peerForFailedSegmentDbId = peerForFailedSegment.getSegmentDbId()
-            if (not self.__options.forceFullResynchronization and
+            if self.is_segment_mirrored_with_PT_inconsistency(gpArray, peerForFailedSegment):
+                segs_with_persistent_mirroring_disabled.append(peerForFailedSegmentDbId)
+            elif (not self.__options.forceFullResynchronization and
                         peerForFailedSegmentDbId in segmentStates and
                     self.check_segment_change_tracking_disabled_state(segmentStates[peerForFailedSegmentDbId])):
 
@@ -293,6 +296,7 @@ class GpRecoverSegmentProgram:
                                              self.__options.forceFullResynchronization))
 
         self._output_segments_in_change_tracking_disabled(segs_in_change_tracking_disabled)
+        self._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
 
         return segs_in_change_tracking_disabled, GpMirrorListToBuild(segs, self.__pool, self.__options.quiet, self.__options.parallelDegree)
 
@@ -467,6 +471,7 @@ class GpRecoverSegmentProgram:
 
         segs = []
         segs_in_change_tracking_disabled = []
+        segs_with_persistent_mirroring_disabled = []
         for i in range(len(failedSegments)):
 
             failoverSegment = None
@@ -493,7 +498,10 @@ class GpRecoverSegmentProgram:
                 self.__applySpareDirectoryMapToSegment( gpEnv, gpArray, spareDirectoryMap, failoverSegment)
                 # we're failing over to different location on same host so we don't need to assign new ports
 
-            if (not forceFull and liveSegment.getSegmentDbId() in segmentStates and
+            if self.is_segment_mirrored_with_PT_inconsistency(gpArray, liveSegment):
+                segs_with_persistent_mirroring_disabled.append(liveSegment.getSegmentDbId())
+
+            elif (not forceFull and liveSegment.getSegmentDbId() in segmentStates and
                 self.check_segment_change_tracking_disabled_state(segmentStates[liveSegment.getSegmentDbId()])):
 
                 segs_in_change_tracking_disabled.append(liveSegment.getSegmentDbId())
@@ -502,6 +510,7 @@ class GpRecoverSegmentProgram:
                 segs.append(GpMirrorToBuild(failedSegment, liveSegment, failoverSegment, forceFull))
 
         self._output_segments_in_change_tracking_disabled(segs_in_change_tracking_disabled)
+        self._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
 
         return segs_in_change_tracking_disabled, GpMirrorListToBuild(segs, self.__pool, self.__options.quiet, self.__options.parallelDegree, interfaceHostnameWarnings)
 
@@ -511,10 +520,25 @@ class GpRecoverSegmentProgram:
             self.logger.warn('Segments with dbid %s in change tracking disabled state, need to run recoverseg with -F option.' %
                             (' ,'.join(str(id) for id in segs_in_change_tracking_disabled)))
 
-
     def check_segment_change_tracking_disabled_state(self, segmentState):
         if segmentState == gparray.SEGMENT_STATE_CHANGE_TRACKING_DISABLED:
             return True
+        return False
+
+    def _output_segments_with_persistent_mirroring_disabled(self, segs_persistent_mirroring_disabled=None):
+        if segs_persistent_mirroring_disabled:
+            self.logger.warn('Segments with dbid %s not recovered; persistent mirroring state is disabled.' %
+                            (', '.join(str(id) for id in segs_persistent_mirroring_disabled)))
+
+    def is_segment_mirrored_with_PT_inconsistency(self, gpArray, segment):
+        if gpArray.getFaultStrategy() == gparray.FAULT_STRATEGY_FILE_REPLICATION: # Determines whether cluster has mirrors
+            with dbconn.connect(dbconn.DbURL()) as conn:
+                res = dbconn.execSQL(conn, "SELECT mirror_existence_state from gp_dist_random('gp_persistent_relation_node') where gp_segment_id=%s group by 1;" % segment.getSegmentContentId()).fetchall()
+                # For a mirrored system, there should not be any mirror_existance_state entries with no mirrors.
+                # If any exist, the segment contains a PT inconsistency.
+                for state in res:
+                    if state[0] == 1: # 1 is the mirror_existence_state representing no mirrors
+                        return True
         return False
 
     # San-failback is handled separately from the Filerep-recovery operations.

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
@@ -196,3 +196,52 @@ class GpRecoverSegmentProgramTestCase(unittest.TestCase):
         gprecover_prog = GpRecoverSegmentProgram(options)
         res = gprecover_prog.check_segment_change_tracking_disabled_state(gparray.SEGMENT_STATE_READY)
         self.assertEquals(res, False)
+
+    def test_output_segments_with_persistent_mirroring_disabled_should_print_failed_segments(self):
+        segs_with_persistent_mirroring_disabled = [0, 1]
+        options = Mock()
+        gprecover_prog = GpRecoverSegmentProgram(options)
+        gprecover_prog.logger.warn = Mock()
+        gprecover_prog._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
+        gprecover_prog.logger.warn.assert_called_once_with('Segments with dbid 0, 1 not recovered; persistent mirroring state is disabled.')
+
+    def test_output_segments_with_persistent_mirroring_disabled_should_not_print_if_no_segments(self):
+        segs_with_persistent_mirroring_disabled = []
+        options = Mock()
+        gprecover_prog = GpRecoverSegmentProgram(options)
+        gprecover_prog.logger.warn = Mock()
+        gprecover_prog._output_segments_with_persistent_mirroring_disabled(segs_with_persistent_mirroring_disabled)
+        assert not gprecover_prog.logger.warn.called
+
+    @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[[3], [1]])
+    def test_is_segment_mirrored_with_PT_inconsistency_persistent_mirrors_disabled(self, mock_sql):
+        options = Mock()
+        gprecover_prog = GpRecoverSegmentProgram(options)
+        gparray_mock = Mock()
+        gparray_mock.getFaultStrategy.return_value = gparray.FAULT_STRATEGY_FILE_REPLICATION
+        segment_mock = Mock()
+        segment_mock.getSegmentContentId.return_value = 0
+        result = gprecover_prog.is_segment_mirrored_with_PT_inconsistency(gparray_mock, segment_mock)
+        self.assertTrue(result)
+
+    @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[[3]])
+    def test_is_segment_mirrored_with_PT_inconsistency_persistent_mirrors_enabled(self, mock_sql):
+        options = Mock()
+        gprecover_prog = GpRecoverSegmentProgram(options)
+        gparray_mock = Mock()
+        gparray_mock.getFaultStrategy.return_value = gparray.FAULT_STRATEGY_FILE_REPLICATION
+        segment_mock = Mock()
+        segment_mock.getSegmentContentId.return_value = 0
+        result = gprecover_prog.is_segment_mirrored_with_PT_inconsistency(gparray_mock, segment_mock)
+        self.assertFalse(result)
+
+    @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[[1]])
+    def test_is_segment_mirrored_with_PT_inconsistency_no_mirrors(self, mock_sql):
+        options = Mock()
+        gprecover_prog = GpRecoverSegmentProgram(options)
+        gparray_mock = Mock()
+        gparray_mock.getFaultStrategy.return_value = gparray.FAULT_STRATEGY_NONE
+        segment_mock = Mock()
+        segment_mock.getSegmentDbId.return_value = 0
+        result = gprecover_prog.is_segment_mirrored_with_PT_inconsistency(gparray_mock, segment_mock)
+        self.assertFalse(result)

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
@@ -214,34 +214,34 @@ class GpRecoverSegmentProgramTestCase(unittest.TestCase):
         assert not gprecover_prog.logger.warn.called
 
     @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[[3], [1]])
-    def test_is_segment_mirrored_with_PT_inconsistency_persistent_mirrors_disabled(self, mock_sql):
+    def test_is_segment_mirror_state_mismatched_cluster_mirroring_enabled_segment_mirroring_disabled(self, mock_sql):
         options = Mock()
         gprecover_prog = GpRecoverSegmentProgram(options)
         gparray_mock = Mock()
         gparray_mock.getFaultStrategy.return_value = gparray.FAULT_STRATEGY_FILE_REPLICATION
         segment_mock = Mock()
         segment_mock.getSegmentContentId.return_value = 0
-        result = gprecover_prog.is_segment_mirrored_with_PT_inconsistency(gparray_mock, segment_mock)
+        result = gprecover_prog.is_segment_mirror_state_mismatched(gparray_mock, segment_mock)
         self.assertTrue(result)
 
     @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[[3]])
-    def test_is_segment_mirrored_with_PT_inconsistency_persistent_mirrors_enabled(self, mock_sql):
+    def test_is_segment_mirror_state_mismatched_cluster_and_segments_mirroring_enabled(self, mock_sql):
         options = Mock()
         gprecover_prog = GpRecoverSegmentProgram(options)
         gparray_mock = Mock()
         gparray_mock.getFaultStrategy.return_value = gparray.FAULT_STRATEGY_FILE_REPLICATION
         segment_mock = Mock()
         segment_mock.getSegmentContentId.return_value = 0
-        result = gprecover_prog.is_segment_mirrored_with_PT_inconsistency(gparray_mock, segment_mock)
+        result = gprecover_prog.is_segment_mirror_state_mismatched(gparray_mock, segment_mock)
         self.assertFalse(result)
 
     @patch('pygresql.pgdb.pgdbCursor.fetchall', return_value=[[1]])
-    def test_is_segment_mirrored_with_PT_inconsistency_no_mirrors(self, mock_sql):
+    def test_is_segment_mirror_state_mismatched_cluster_and_segments_mirroring_disabled(self, mock_sql):
         options = Mock()
         gprecover_prog = GpRecoverSegmentProgram(options)
         gparray_mock = Mock()
         gparray_mock.getFaultStrategy.return_value = gparray.FAULT_STRATEGY_NONE
         segment_mock = Mock()
         segment_mock.getSegmentDbId.return_value = 0
-        result = gprecover_prog.is_segment_mirrored_with_PT_inconsistency(gparray_mock, segment_mock)
+        result = gprecover_prog.is_segment_mirror_state_mismatched(gparray_mock, segment_mock)
         self.assertFalse(result)

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -3,7 +3,7 @@ from gppylib.commands.base import Command, ExecutionError, REMOTE, WorkerPool
 from gppylib.db import dbconn
 from gppylib.commands import gp
 from gppylib.gparray import GpArray
-from gppylib.test.behave_utils.utils import run_gpcommand, getRows
+from gppylib.test.behave_utils.utils import run_gpcommand, getRows, getRow
 import platform
 
 @given('the information of a "{seg}" segment on a remote host is saved')
@@ -83,3 +83,105 @@ def impl(context):
     row_count = getRows('template1', qry)[0][0]
     if row_count != 1:
         raise Exception('Expected mirror segment %s on host %s to be down, but it is running.' % (context.remote_mirror_datadir, context.remote_mirror_segdbname))
+
+@given('the mirror with content id "{cid}" is marked down in config')
+@when('the mirror with content id "{cid}" is marked down in config')
+@then('the mirror with content id "{cid}" is marked down in config')
+def impl(context, cid):
+    qry = """select count(*) from gp_segment_configuration where status='d' and content='%s' and role='m'""" % (cid)
+    row_count = getRows('template1', qry)[0][0]
+    if row_count != 1:
+        raise Exception('Expected mirror segment cid %s to be down, but it is up.' % cid)
+
+@given('user runs the command "{cmd}" on segment "{cid}"')
+@when('user runs the command "{cmd}" on segment "{cid}"')
+@then('user runs the command "{cmd}" on segment "{cid}"')
+def impl(context, cmd, cid):
+    dbid = getPrimaryDbIdFromCid(context, cid)
+    cmdStr = '%s -s %s' % (cmd, int(dbid))
+    cmd=Command(name='user command', cmdStr=cmdStr)
+    cmd.run(validateAfter=True)
+
+@given('segment with content "{cid}" has persistent tables that were rebuilt with mirrors disabled')
+@when('segment with content "{cid}" has persistent tables that were rebuilt with mirrors disabled')
+@then('segment with content "{cid}" has persistent tables that were rebuilt with mirrors disabled')
+def impl(context, cid):
+    add_persistent_query = '''select
+    gp_add_persistent_relation_node_entry(NULL,tablespace_oid, database_oid,
+    relfilenode_oid, segment_file_num, relation_storage_manager,
+    persistent_state,create_mirror_data_loss_tracking_session_num, '1',
+    mirror_data_synchronization_state,
+    mirror_bufpool_marked_for_scan_incremental_resync,
+    mirror_bufpool_resync_changed_page_count, mirror_bufpool_resync_ckpt_loc,
+    mirror_bufpool_resync_ckpt_block_num, mirror_append_only_loss_eof,
+    mirror_append_only_new_eof, relation_bufpool_kind, parent_xid,
+    persistent_serial_num, previous_free_tid) from (select
+    ctid,tablespace_oid,database_oid,relfilenode_oid,
+    segment_file_num,relation_storage_manager,
+    persistent_state,create_mirror_data_loss_tracking_session_num,
+    mirror_existence_state, mirror_data_synchronization_state,
+    mirror_bufpool_marked_for_scan_incremental_resync,
+    mirror_bufpool_resync_changed_page_count, mirror_bufpool_resync_ckpt_loc,
+    mirror_bufpool_resync_ckpt_block_num, mirror_append_only_loss_eof,
+    mirror_append_only_new_eof, relation_bufpool_kind, parent_xid,
+    persistent_serial_num, previous_free_tid from gp_persistent_relation_node
+    limit 1) as test; '''
+    runCommandOnRemoteSegment(context, cid, add_persistent_query)
+
+@given('verify that segment with content "{cid}" is not recovered')
+@when('verify that segment with content "{cid}" is not recovered')
+@then('verify that segment with content "{cid}" is not recovered')
+def impl(context, cid):
+    primary_dbid = getPrimaryDbIdFromCid(context, cid)
+    mirror_dbid = getMirrorDbIdFromCid(context, cid)
+    output_msg ="Segments with dbid %s not recovered; persistent mirroring state is disabled." % primary_dbid
+    check_stdout_msg(context, output_msg)
+    if isSegmentUp(context, mirror_dbid):
+        raise Exception('Expected mirror segment with dbid %s to be down, but it is up.' % mirror_dbid)
+
+@given('verify that segment with content "{cid}" is recovered')
+@when('verify that segment with content "{cid}" is recovered')
+@then('verify that segment with content "{cid}" is recovered')
+def impl(context, cid):
+    primary_dbid = getPrimaryDbIdFromCid(context, cid)
+    mirror_dbid = getMirrorDbIdFromCid(context, cid)
+    output_msg ="Segments with dbid %s not recovered; persistent rebuild mirroring state is disabled." % primary_dbid
+    check_string_not_present_stdout(context, output_msg)
+    if not isSegmentUp(context, mirror_dbid):
+        raise Exception('Expected mirror segment with dbid %s to be up, but it is down.' % mirror_dbid)
+
+@given('delete extra tid persistent table entries on cid "{cid}"')
+@when('delete extra tid persistent table entries on cid "{cid}"')
+@then('delete extra tid persistent table entries on cid "{cid}"')
+def impl(context, cid):
+    remove_extra_tid_entry_sql = '''
+    select gp_delete_persistent_relation_node_entry(ctid) from (select ctid from gp_persistent_relation_node where mirror_existence_state=1) as ctid;
+    '''
+    runCommandOnRemoteSegment(context, cid, remove_extra_tid_entry_sql)
+
+def isSegmentUp(context, dbid):
+    qry = """select count(*) from gp_segment_configuration where status='d' and dbid=%s""" % dbid
+    row_count = getRows('template1', qry)[0][0]
+    if row_count == 0:
+        return True
+    else:
+        return False
+
+def getPrimaryDbIdFromCid(context, cid):
+    dbid_from_cid_sql = "SELECT dbid FROM gp_segment_configuration WHERE content=%s and role='p';" % cid
+    result = getRow('template1', dbid_from_cid_sql)
+    return result[0]
+
+def getMirrorDbIdFromCid(context, cid):
+    dbid_from_cid_sql = "SELECT dbid FROM gp_segment_configuration WHERE content=%s and role='m';" % cid
+    result = getRow('template1', dbid_from_cid_sql)
+    return result[0]
+
+def runCommandOnRemoteSegment(context, cid, sql_cmd):
+    local_cmd = 'psql template1 -t -c "SELECT port,hostname FROM gp_segment_configuration WHERE content=%s and role=\'p\';"' % cid
+    run_command(context, local_cmd)
+    port, host = context.stdout_message.split("|")
+    port = port.strip()
+    host = host.strip()
+    psql_cmd = "PGDATABASE=\'template1\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (host, port, sql_cmd)
+    Command(name='Running Remote command: %s' % psql_cmd, cmdStr = psql_cmd).run(validateAfter=True)

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -106,10 +106,11 @@ def impl(context, cmd, cid):
 @when('segment with content "{cid}" has persistent tables that were rebuilt with mirrors disabled')
 @then('segment with content "{cid}" has persistent tables that were rebuilt with mirrors disabled')
 def impl(context, cid):
+    mirror_state = '1' # 1 indicates mirrors are disabled
     add_persistent_query = '''select
     gp_add_persistent_relation_node_entry(NULL,tablespace_oid, database_oid,
     relfilenode_oid, segment_file_num, relation_storage_manager,
-    persistent_state,create_mirror_data_loss_tracking_session_num, '1',
+    persistent_state,create_mirror_data_loss_tracking_session_num, '%s',
     mirror_data_synchronization_state,
     mirror_bufpool_marked_for_scan_incremental_resync,
     mirror_bufpool_resync_changed_page_count, mirror_bufpool_resync_ckpt_loc,
@@ -125,7 +126,7 @@ def impl(context, cid):
     mirror_bufpool_resync_ckpt_block_num, mirror_append_only_loss_eof,
     mirror_append_only_new_eof, relation_bufpool_kind, parent_xid,
     persistent_serial_num, previous_free_tid from gp_persistent_relation_node
-    limit 1) as test; '''
+    limit 1) as test; ''' % mirror_state
     runCommandOnRemoteSegment(context, cid, add_persistent_query)
 
 @given('verify that segment with content "{cid}" is not recovered')


### PR DESCRIPTION
…abled

If a cluster with mirrors was rebuilt with the gp persistent rebuild tool without
mirrors, catalog inconsistencies may be present. gprecoverseg should
not attempt to recover these segment, but should still recover segments
without this inconsistency.

Authors: Chris Hajas, Chumki Roy, Karen Huddleston