### PR TITLE
Fix gpactivatestandby after CaQL removal.

### DIFF
--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -1169,7 +1169,7 @@ segment_config_activate_standby(int16 standbydbid, int16 newdbid)
 	ScanKeyInit(&scankey,
 				Anum_gp_segment_configuration_dbid,
 				BTEqualStrategyNumber, F_INT2EQ,
-				Int16GetDatum(newdbid));
+				Int16GetDatum(standbydbid));
 	sscan = systable_beginscan(rel, GpSegmentConfigDbidIndexId, true,
 							   SnapshotNow, 1, &scankey);
 


### PR DESCRIPTION
In commit 8df78e67f4de4bda603f021f573e81745102902b, there were some
CaQL removal. The scan that replaced the CaQL call was using the wrong
dbid.

Author: Jimmy Yih
Reported by @volkovandr in https://github.com/greenplum-db/gpdb/issues/1202