### PR TITLE
Disable .psqlrc

### DIFF
--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -129,7 +129,8 @@ def dump_query(connectionInfo, query_file):
     with open(toolkit_sql, 'w') as toolkit_f:
         toolkit_f.write(query)
 
-    query_cmd = "psql %s --pset footer -Atq -h %s -p %s -U %s -f %s" % (db, host, port, user, toolkit_sql)
+    # disable .psqlrc to prevent unexpected timing and format output
+    query_cmd = "psql %s --pset footer --no-psqlrc -Atq -h %s -p %s -U %s -f %s" % (db, host, port, user, toolkit_sql)
     print query_cmd
 
     p = subprocess.Popen(query_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ)


### PR DESCRIPTION
.psqlrc can create unexpected output and changes in formatting that don't play nice with parse_oids().

```
psql database --pset footer -Atq -h localhost -p 5432 -U gpadmin -f /tmp/20161012232709/toolkit.sql

{"relids": "573615536", "funcids": ""}
Time: 2.973 ms
```

Generates an Exception:

```
Traceback (most recent call last):
  File "/usr/local/greenplum-db/./bin/minirepro", line 386, in <module>
    main()
  File "/usr/local/greenplum-db/./bin/minirepro", line 320, in main
    mr_query = parse_oids(cursor, json_str)
  File "/usr/local/greenplum-db/./bin/minirepro", line 151, in parse_oids
    result.relids = json.loads(json_oids)['relids']
  File "/usr/local/greenplum-db/ext/python/lib/python2.6/json/__init__.py", line 307, in loads
    return _default_decoder.decode(s)
  File "/usr/local/greenplum-db/ext/python/lib/python2.6/json/decoder.py", line 322, in decode
    raise ValueError(errmsg("Extra data", s, end, len(s)))
ValueError: Extra data: line 2 column 1 - line 3 column 1 (char 39 - 54)
```
