### PR TITLE
Use relpath for ReadBuffer_common error messages.

### DIFF
--- a/src/backend/cdb/cdbfilerepresyncworker.c
+++ b/src/backend/cdb/cdbfilerepresyncworker.c
@@ -249,7 +249,7 @@ FileRepPrimary_ResyncWrite(FileRepResyncHashEntry_s	*entry)
 #endif				
 						
 						FileRepResync_SetReadBufferRequest();
-						buf = ReadBuffer_Resync(smgr_relation, blkno, relidstr);
+						buf = ReadBuffer_Resync(smgr_relation, blkno);
 						FileRepResync_ResetReadBufferRequest();
 						
 						LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
@@ -617,8 +617,7 @@ FileRepPrimary_ResyncBufferPoolIncrementalWrite(ChangeTrackingRequest *request)
 				/* allow flushing buffers from buffer pool during scan */
 				FileRepResync_SetReadBufferRequest();
 				buf = ReadBuffer_Resync(smgr_relation,
-										result->entries[ii].block_num,
-										relidstr);
+										result->entries[ii].block_num);
 				FileRepResync_ResetReadBufferRequest();
 				
 				Assert(result->entries[ii].block_num < numBlocks);

--- a/src/include/storage/bufmgr.h
+++ b/src/include/storage/bufmgr.h
@@ -293,8 +293,7 @@ extern Buffer ReadBuffer(Relation reln, BlockNumber blockNum);
 extern Buffer ReadBufferWithStrategy(Relation reln, BlockNumber blockNum,
 					   BufferAccessStrategy strategy);
 extern Buffer ReadOrZeroBuffer(Relation reln, BlockNumber blockNum);
-extern Buffer ReadBuffer_Resync(SMgrRelation reln, BlockNumber blockNum,
-				  const char *relidstr);
+extern Buffer ReadBuffer_Resync(SMgrRelation reln, BlockNumber blockNum);
 
 extern void ReleaseBuffer(Buffer buffer);
 extern void UnlockReleaseBuffer(Buffer buffer);


### PR DESCRIPTION
This patch refactors ReadBuffer_common to remove relErrMsgString
argument and use relpath of reln->smgr_rnode instead.

Author: Jimmy Yih