### PR TITLE
Add support for binary COPY

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -186,6 +186,19 @@ cdbCopyStart(CdbCopy *c, char *copyCmd)
 }
 
 /*
+ * sends data to a copy command on all segments.
+ */
+void
+cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes)
+{
+	Gang *gp = c->primary_writer;
+	for (int i = 0; i < gp->size; ++i) {
+		int seg = gp->db_descriptors[i].segindex;
+		cdbCopySendData(c, seg, buffer, nbytes);
+	}
+}
+
+/*
  * sends data to a copy command on a specific segment (usually
  * the hash result of the data value).
  */

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -61,6 +61,7 @@ typedef struct CdbCopy
 CdbCopy    *makeCdbCopy(bool copy_in);
 int			cdbCopyGetDbCount(int total_segs, int seg);
 void		cdbCopyStart(CdbCopy *cdbCopy, char *copyCmd);
+void		cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes);
 void		cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer, int nbytes);
 bool		cdbCopyGetData(CdbCopy *c, bool cancel, uint64 *rows_processed);
 int			cdbCopyEnd(CdbCopy *c);

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -139,6 +139,7 @@ typedef struct CopyStateData
 	char	   *filename;		/* filename, or NULL for STDIN/STDOUT */
 	bool		custom;			/* custom format? */
 	bool		oids;			/* include OIDs? */
+	bool        binary;         /* binary format */
 	bool		csv_mode;		/* Comma Separated Value format? */
 	bool		header_line;	/* CSV header line? */
 	char	   *null_print;		/* NULL marker string (server encoding!) */
@@ -250,6 +251,9 @@ typedef CopyStateData *CopyState;
 
 #define ISOCTAL(c) (((c) >= '0') && ((c) <= '7'))
 #define OCTVALUE(c) ((c) - '0')
+
+#define htonll(x) ((1==htonl(1)) ? (x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#define ntohll(x) ((1==ntohl(1)) ? (x) : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
 
 extern void ValidateControlChars(bool copy, bool load, bool csv_mode, char *delim,
 								 char *null_print, char *quote, char *escape,

--- a/src/test/regress/input/misc.source
+++ b/src/test/regress/input/misc.source
@@ -69,12 +69,11 @@ COPY onek2 FROM '@abs_builddir@/results/onek.data';
 
 SELECT unique1 FROM onek2 WHERE unique1 < 2 ORDER BY unique1;
 
--- GPDB does not support BINARY-mode COPY.
---COPY BINARY stud_emp TO '@abs_builddir@/results/stud_emp.data';
+COPY BINARY stud_emp TO '@abs_builddir@/results/stud_emp.data';
 
---DELETE FROM stud_emp;
+DELETE FROM stud_emp;
 
---COPY BINARY stud_emp FROM '@abs_builddir@/results/stud_emp.data';
+COPY BINARY stud_emp FROM '@abs_builddir@/results/stud_emp.data';
 
 SELECT * FROM stud_emp;
 


### PR DESCRIPTION
Fixes #1162 

This change adds (back) support for binary COPY (in and out) without impacting the performance of text COPY (same code paths with a minimal amount of `cstate->binary` checks). The binary COPY code path in `CopyFromDispatch` follows the same partial-parsing optimization as text COPY.

Many new code snippets were copied from
https://github.com/postgres/postgres/blob/REL8_3_STABLE/src/backend/commands/copy.c

Tested with manual `psql` (copying in and out) and a superset of https://github.com/altaurog/pgcopy test cases.
