### PR TITLE
Fix asynchronous gang creation bug which send startup packet to not connected connections

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -574,7 +574,7 @@ bool cdbconn_discardResults(SegmentDatabaseDescriptor *segdbDesc,
 /* Return if it's a bad connection */
 bool cdbconn_isBadConnection(SegmentDatabaseDescriptor *segdbDesc)
 {
-	return (PQsocket(segdbDesc->conn) < 0 ||
+	return (segdbDesc->conn == NULL || PQsocket(segdbDesc->conn) < 0 ||
 		    PQstatus(segdbDesc->conn) == CONNECTION_BAD);
 }
 


### PR DESCRIPTION
Existing asynchronous gang creation codes did not follow the standard routine to start and complete
a libpq connection, it called PQconnectPoll() with no restriction and did not wait expected polling
status was actually ready. This caused the status of connection was messed up and unexpected issues
occurred.