### PR TITLE
Fix an oversight in merge from upstream.

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsInjectFault.py
+++ b/gpMgmt/bin/gppylib/programs/clsInjectFault.py
@@ -411,7 +411,8 @@ class GpInjectFaultProgram:
 			      "runaway_cleanup (inject fault before starting the cleanup for a runaway query), " \
                   "opt_task_allocate_string_buffer (inject fault while allocating string buffer), " \
                   "opt_relcache_translator_catalog_access (inject fault while translating relcache entries), " \
-                  "send_qe_details_init_backend (inject fault before sending QE details during backend initialization)" \
+                  "send_qe_details_init_backend (inject fault before sending QE details during backend initialization) " \
+                  "load_relcache_init_file (inject fault before loading relcache init file during backend startup) " \
 			      "all (affects all faults injected, used for 'status' and 'reset'), ") 
         addTo.add_option("-c", "--ddl_statement", dest="ddlStatement", type="string",
                          metavar="ddlStatement",

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3413,14 +3413,14 @@ RelationCacheInitializePhase3(void)
 							AttributeRelationId);
 		load_critical_index(IndexRelidIndexId,
 							IndexRelationId);
-		load_critical_index(OpclassOidIndexId,
-							OperatorClassRelationId);
 		load_critical_index(AccessMethodStrategyIndexId,
 							AccessMethodOperatorRelationId);
 		load_critical_index(OpclassOidIndexId,
 							OperatorClassRelationId);
 		load_critical_index(AccessMethodProcedureIndexId,
 							AccessMethodProcedureRelationId);
+		load_critical_index(OperatorOidIndexId,
+							OperatorRelationId);
 		load_critical_index(RewriteRelRulenameIndexId,
 							RewriteRelationId);
 		load_critical_index(TriggerRelidNameIndexId,

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -65,6 +65,7 @@
 #include "storage/fd.h"
 #include "storage/smgr.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 #include "utils/fmgroids.h"
 #include "utils/inval.h"
 #include "utils/memutils.h"
@@ -4325,6 +4326,8 @@ load_relcache_init_file(bool shared)
 				nailed_indexes,
 				magic;
 	int			i;
+
+	SIMPLE_FAULT_INJECTOR(LoadRelcacheInitFile);
 
 	if (shared)
 		snprintf(initfilename, sizeof(initfilename), "global/%s",

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -321,6 +321,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault in quickdie*/
 	_("after_one_slice_dispatched"),
 		/* inject fault in cdbdisp_dispatchX*/
+	_("load_relcache_init_file"),
+		/* inject fault at the beginning of load_relcache_init_file */
 	_("not recognized"),
 };
 

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -213,6 +213,7 @@ typedef enum FaultInjectorIdentifier_e {
 	ProcessStartupPacketFault,
 	QuickDie,
 	AfterOneSliceDispatched,
+	LoadRelcacheInitFile,
 
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,


### PR DESCRIPTION
Relcache init file was failing to load because of this, causing relcache to be
built from scratch upon every child process startup.

Signed-off-by: Asim R P <apraveen@pivotal.io>