### PR TITLE
Preventing gpstart if there is an unknown configuration parameter in postgresql.conf.

### DIFF
--- a/src/backend/utils/misc/guc-file.l
+++ b/src/backend/utils/misc/guc-file.l
@@ -148,9 +148,6 @@ ProcessConfigFile(GucContext context)
 	const char *envvar;
 	int			i;
 
-	bool error = false;
-	const char* ConfFileWithError = ConfigFileName;
-
 	Assert(context == PGC_POSTMASTER || context == PGC_SIGHUP);
 
 	if (context == PGC_SIGHUP)
@@ -262,14 +259,7 @@ ProcessConfigFile(GucContext context)
 
 		if (!set_config_option(item->name, item->value, context,
 							   PGC_S_FILE, GUC_ACTION_SET, false))
-		{
-			/* 
-			 * If we fail to set one guc, we abort the process of updating other
-			 * gucs. Depending on the context, we may also abort the postmaster.
-			 */
-			error = true;
 			goto cleanup_list;
-		}
 	}
 
 	/*
@@ -350,18 +340,6 @@ ProcessConfigFile(GucContext context)
 	free_name_value_list(head);
 	if (cvc)
 		free(cvc);
-		
-	if (error)
-	{
-    	/* During postmaster startup, any error is fatal */
-    	if (context == PGC_POSTMASTER)
-    	{
-      		ereport(ERROR,
-          		(errcode(ERRCODE_CONFIG_FILE_ERROR),
-           		errmsg("configuration file \"%s\" contains errors",
-              	ConfFileWithError)));
-    	}
-  	}
 }
 
 /*

--- a/src/backend/utils/misc/guc-file.l
+++ b/src/backend/utils/misc/guc-file.l
@@ -148,6 +148,9 @@ ProcessConfigFile(GucContext context)
 	const char *envvar;
 	int			i;
 
+	bool error = false;
+	const char* ConfFileWithError = ConfigFileName;
+
 	Assert(context == PGC_POSTMASTER || context == PGC_SIGHUP);
 
 	if (context == PGC_SIGHUP)
@@ -259,7 +262,14 @@ ProcessConfigFile(GucContext context)
 
 		if (!set_config_option(item->name, item->value, context,
 							   PGC_S_FILE, GUC_ACTION_SET, false))
+		{
+			/* 
+			 * If we fail to set one guc, we abort the process of updating other
+			 * gucs. Depending on the context, we may also abort the postmaster.
+			 */
+			error = true;
 			goto cleanup_list;
+		}
 	}
 
 	/*
@@ -340,6 +350,18 @@ ProcessConfigFile(GucContext context)
 	free_name_value_list(head);
 	if (cvc)
 		free(cvc);
+		
+	if (error)
+	{
+    	/* During postmaster startup, any error is fatal */
+    	if (context == PGC_POSTMASTER)
+    	{
+      		ereport(ERROR,
+          		(errcode(ERRCODE_CONFIG_FILE_ERROR),
+           		errmsg("configuration file \"%s\" contains errors",
+              	ConfFileWithError)));
+    	}
+  	}
 }
 
 /*

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -4478,7 +4478,7 @@ set_config_option(const char *name, const char *value,
 	int			elevel;
 	bool		makeDefault;
 
-	if (context == PGC_SIGHUP || context == PGC_POSTMASTER || source == PGC_S_DEFAULT)
+	if (context == PGC_SIGHUP || source == PGC_S_DEFAULT)
 	{
 		/*
 		 * To avoid cluttering the log, only the postmaster bleats loudly


### PR DESCRIPTION
If there is an unknown configuration parameter in postgresql.conf,
currently we silently print a log message and skip reading any
configuration parameter from postgresql.conf. This does not prevent
database startup. As some of our gucs depend on explicitly mentioned
values on certain platforms (e.g., gp_vmem_protect_limit is set to 8GB
explicitly in postgresql.conf, and without explicit mention, it defaults
to 0 on darwin platforms), this can result in assertion failure and
confusing dtm errors as QEs fail to start with 0 vmem protect limit (and
potentially other invalid guc values).

This change prevent database startup if there is any unknown
configuration parameter.

This is relevant to Github issue #1201. However, for issue #1201 we will
need another fix to correct bugbuster test so that it doesn't put
unrecognized parameter in the postgresql.conf.