### PR TITLE
Delete relcache init file at the end of crash recovery pass2.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -11327,6 +11327,19 @@ StartupProcessMain(int passNum)
 		if (passNum == 2)
 		{
 			StartupXLOG_Pass2();
+			/*
+			 * The cache init file created by
+			 * RelationCacheInitializePhase3() contains critical
+			 * relations and index entries from template1 database.
+			 * XLOG replay in pass 3 may invalidate these entries,
+			 * e.g. redo records for reindex operation on a system
+			 * table in template1.  Therefore, delete the file now
+			 * and let pass 4 rebuild it.  Note that pass 3 does not
+			 * need relcache to operate as it uses resource manager
+			 * redo (rm_redo()) methods to replay xlog rather than
+			 * regular access methods.
+			 */
+			RelationCacheInitFileRemove();
 		}
 		else
 		{


### PR DESCRIPTION
In certain rare cases, crash recovery may prevent start up due to stale
relfilenodes in relcache init file.  E.g. database crashes right after reindex
operation on critical system tables in "template1" database is committed.

This can happen only in case of "template1" database because MyDatabaseId is
set to "template1" during crash recovery.  Relcache needs to be initialized in
pass 2 of recovery so that heap access methods can be used to update persistent
tables.  Relcache init file written in pass 2 contains critical relations and
indexes from "template1" database.  Pass 3 applies redo records from xlog to
all relations other than persistent tables.  Relfilenodes in the relcache init
file may become out of date during pass 3.  Note that pass 3 does not need
relcache and therefore does not bother keeping it up to date.  Pass 4 should
initialize relcache from scratch rather than using a stale init file created by
pass 2.

Signed-off-by: Ashwin Agrawal <aagrawal@pivotal.io>