### PR TITLE
Removing unrecognized gpperfmon guc (gp_gpperfmon_print_packet_info) from bugbuster setup

### DIFF
--- a/src/test/regress/bugbuster/bugbuster_setup.sh
+++ b/src/test/regress/bugbuster/bugbuster_setup.sh
@@ -9,7 +9,6 @@
 
 $GPHOME/bin/gpperfmon_install --enable --port 49999 > /dev/null
 gpconfig -c gpperfmon_port -v 49999 --masteronly
-gpconfig -c gp_gpperfmon_print_packet_info -v on --skipvalidation
 gpconfig -c gp_enable_gpperfmon -v on
 
 cat >> $MASTER_DATA_DIRECTORY/gpperfmon/conf/gpperfmon.conf <<EOF


### PR DESCRIPTION
Bugbuster runs a setup script to add some postgresql.conf parameters related to gpperfmon. One of the parameters (gp_gpperfmon_print_packet_info) is not valid and this causes aborted read of the rest of the postgresql.conf parameter parsing. I.e., all the parameters stay at default values.

On Mac OS X (darwin) the default value of gp_vmem_protect_limit is 0, which is invalid for QEs. This prevents QD to talk to QEs as they get stuck in assertion failures and raises a confusing DTM initialization failure message.

This CL is removing this invalid guc so that the guc reading process can parse and update all the guc values from postgresql.conf.

This fixes #1201 