### PR TITLE
Stop make on error

### DIFF
--- a/gpAux/extensions/Makefile
+++ b/gpAux/extensions/Makefile
@@ -99,7 +99,7 @@ mkorafce:
 
 installcheck:
 	if [ -d "$(ext_dir)" ]; then \
-		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C orafce installcheck USE_PGXS=1 ; \
+		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C orafce installcheck USE_PGXS=1 && \
 		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gphdfs installcheck USE_PGXS=1 ; \
 	fi
 


### PR DESCRIPTION
The second command should not be executed after the first one failed.
Or else, the make command (e.g. installcheck) will return 0 even
when there's failure.

[#132692159]

Signed-off-by: Gang Xiong <gxiong@pivotal.io>