### PR TITLE
Set user and fix SIGSEGV for incremental filerep resync.

### DIFF
--- a/src/backend/access/transam/gp_changetracking_log.c
+++ b/src/backend/access/transam/gp_changetracking_log.c
@@ -233,19 +233,13 @@ gp_changetracking_log(PG_FUNCTION_ARGS)
              * the calling code will copy our tuple data, so reuse our template one
              */
             HeapTupleHeader td = context->heapTuple->t_data;
-			int data_len = heap_compute_data_size(funcctx->tuple_desc, context->tupleValuesToCopy, NULL);
-#ifdef USE_ASSERT_CHECKING
-            int len =
-#endif
-                heap_fill_tuple(funcctx->tuple_desc,
-                            context->tupleValuesToCopy,
-                            NULL /* isnull */,
-                            (char *) td + td->t_hoff,
-							data_len,
-                            &td->t_infomask,
-                            NULL /* bits -- NULL is okay because we have no nulls */);
-
-            Assert(len == context->tupleDataLen);
+			heap_fill_tuple(funcctx->tuple_desc,
+							context->tupleValuesToCopy,
+							NULL /* isnull */,
+							(char *) td + td->t_hoff,
+							context->tupleDataLen,
+							&td->t_infomask,
+							NULL /* bits -- NULL is okay because we have no nulls */);
         }
 
 		Datum result = HeapTupleGetDatum(context->heapTuple);

--- a/src/backend/cdb/cdbresynchronizechangetracking.c
+++ b/src/backend/cdb/cdbresynchronizechangetracking.c
@@ -1348,6 +1348,7 @@ ChangeTracking_GetIncrementalChangeList(void)
 		/* must be in a transaction in order to use SPI */
 		StartTransactionCommand();
 		ActiveSnapshot = CopySnapshot(GetTransactionSnapshot());
+		SetSessionUserId(BOOTSTRAP_SUPERUSERID, true);
 
 		if (SPI_OK_CONNECT != SPI_connect())
 		{
@@ -1633,6 +1634,7 @@ ChangeTrackingResult* ChangeTracking_GetChanges(ChangeTrackingRequest *request)
 		/* must be in a transaction in order to use SPI */
 		StartTransactionCommand();
 		ActiveSnapshot = CopySnapshot(GetTransactionSnapshot());
+		SetSessionUserId(BOOTSTRAP_SUPERUSERID, true);
 
 		if (SPI_OK_CONNECT != SPI_connect())
 		{
@@ -3082,6 +3084,7 @@ int ChangeTracking_CompactLogFile(CTFType source, CTFType dest, XLogRecPtr*	upto
 		/* must be in a transaction in order to use SPI */
 		StartTransactionCommand();
 		ActiveSnapshot = CopySnapshot(GetTransactionSnapshot());
+		SetSessionUserId(BOOTSTRAP_SUPERUSERID, true);
 
 		if (SPI_OK_CONNECT != SPI_connect())
 		{


### PR DESCRIPTION
Commit fixes issues for incremental recoverseg
reported by @zeromax007 and @volkovandr.
- as part of commit 7d639c3016d3bf2d7ba1c834e7f0cc88c0e7cdca,
function FtsFindSuperuser was removed. But it deep inside was
setting the user. Missing to set the same causes the error
for queries to compact change tracking logs.
- Also, as part of commit a453004ea1946b5c141bd26ac871ac6edde64f37,
function gp_changetracking_log was broken, resulting in SIGSEGV
on incremental gprecoverseg. Fixed to avoid passing NULL to
heap_compute_data_size.

Fixes #1161 and Fixes #1207.