### PR TITLE
Purge rather than rewrite error messages in atmsort diff

### DIFF
--- a/gpAux/extensions/gphdfs/regression/output/all_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/all_Extreadwrite.source
@@ -23,7 +23,7 @@ max_numeric numeric, min_numeric numeric, x_numeric numeric, reverse_numeric num
 col1_text text,col2_text text, nullcol_text text
 ) location ('gphdfs://10.152.10.234:8020/plaintext/all_20.txt')format 'TEXT';
 create writable external table all_writehdfs(like all_heap) location ('gphdfs://10.152.10.234:8020/extwrite/all_20')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table all_readhdfs(like all_heap) location ('gphdfs://10.152.10.234:8020/extwrite/all_20') format 'custom' (formatter='gphdfs_import');
 select count(*) from all_heap;
  count  

--- a/gpAux/extensions/gphdfs/regression/output/all_ExtwriteToHDFSText.source
+++ b/gpAux/extensions/gphdfs/regression/output/all_ExtwriteToHDFSText.source
@@ -30,7 +30,7 @@ max_numeric numeric, min_numeric numeric, x_numeric numeric, reverse_numeric num
 col1_text text,col2_text text, nullcol_text text
 ) location ('gphdfs://10.152.10.234:8020/plaintext/all.txt')format 'TEXT';
 create writable external table all_writehdfs(like all_heap) location ('gphdfs://10.152.10.234:8020/extwrite/all')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into all_writehdfs select * from all_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDBIn /extwrite/all /mapreduce/all_text/ 
 16/09/29 23:46:44 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/all_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/all_ExtwriteToHdfsToExtread.source
@@ -33,7 +33,7 @@ max_numeric numeric, min_numeric numeric, x_numeric numeric, reverse_numeric num
 col1_text text,col2_text text, nullcol_text text
 ) location ('gphdfs://10.152.10.234:8020/plaintext/all.txt')format 'TEXT';
 create writable external table all_writehdfs(like all_heap) location ('gphdfs://10.152.10.234:8020/extwrite/all')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into all_writehdfs select * from all_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/all /mapreduce/all_gpdb/ 
 16/09/29 23:49:56 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/bigint_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/bigint_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "bigint_readhdfs" does not exist
 -- end_ignore
 create readable external table bigint_heap(datatype_bigint varchar,xcount_bigint bigint, max_bigint bigint, min_bigint bigint, x_bigint bigint, reverse_bigint bigint, increment_bigint bigint, nullcol_bigint bigint) location ('gphdfs://10.152.10.234:8020/plaintext/bigint.txt')format 'TEXT';
 create writable external table bigint_writehdfs(like bigint_heap) location ('gphdfs://10.152.10.234:8020/extwrite/bigint')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table bigint_readhdfs(like bigint_heap) location ('gphdfs://10.152.10.234:8020/extwrite/bigint') format 'custom' (formatter='gphdfs_import');
 select count(*) from bigint_heap; 
  count 

--- a/gpAux/extensions/gphdfs/regression/output/bigint_ExtwriteToHDFSText.source
+++ b/gpAux/extensions/gphdfs/regression/output/bigint_ExtwriteToHDFSText.source
@@ -12,7 +12,7 @@ ERROR:  table "bigint_verification" does not exist
 --end_ignore
 create readable external table bigint_heap(datatype_bigint varchar,xcount_bigint bigint, max_bigint bigint, min_bigint bigint, x_bigint bigint, reverse_bigint bigint, increment_bigint bigint, nullcol_bigint bigint) location ('gphdfs://10.152.10.234:8020/plaintext/bigint.txt')format 'TEXT';
 create writable external table bigint_writehdfs(like bigint_heap) location ('gphdfs://10.152.10.234:8020/extwrite/bigint')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into bigint_writehdfs select * from bigint_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDBIn /extwrite/bigint /mapreduce/bigint_text/ 
 16/09/30 00:04:14 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/bigint_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/bigint_ExtwriteToHdfsToExtread.source
@@ -21,7 +21,7 @@ datatype_bigint varchar,xcount_bigint bigint, max_bigint bigint, min_bigint bigi
 --datatype_bigint varchar,xcount_bigint bigint, max_bigint bigint, min_bigint bigint, x_bigint bigint, reverse_bigint bigint, increment_bigint bigint
 ) location ('gphdfs://10.152.10.234:8020/plaintext/bigint.txt')format 'TEXT';
 create writable external table bigint_writehdfs(like bigint_heap) location ('gphdfs://10.152.10.234:8020/extwrite/bigint')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into bigint_writehdfs select * from bigint_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/bigint /mapreduce/bigint_gpdb/ >/dev/null
 16/09/30 00:06:56 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/boolean_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/boolean_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "boolean_readhdfs" does not exist
 -- end_ignore
 create readable external table boolean_heap(datatype_boolean varchar, x_boolean bigint, col1_boolean boolean, nullcol_boolean boolean) location ('gphdfs://10.152.10.234:8020/plaintext/boolean.txt')format 'TEXT';
 create writable external table boolean_writehdfs(like boolean_heap) location ('gphdfs://10.152.10.234:8020/extwrite/boolean')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table boolean_readhdfs(like boolean_heap) location ('gphdfs://10.152.10.234:8020/extwrite/boolean') format 'custom' (formatter='gphdfs_import');
 select count(*) from boolean_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/boolean_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/boolean_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table boolean_heap(
 datatype_boolean varchar, x_boolean bigint, col1_boolean boolean, nullcol_boolean boolean
 ) location ('gphdfs://10.152.10.234:8020/plaintext/boolean.txt')format 'TEXT';
 create writable external table boolean_writehdfs(like boolean_heap) location ('gphdfs://10.152.10.234:8020/extwrite/boolean')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into boolean_writehdfs select * from boolean_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/boolean /mapreduce/boolean_gpdb/ 
 16/09/30 00:12:57 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/bpchar_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/bpchar_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "bpchar_readhdfs" does not exist
 -- end_ignore
 create readable external table bpchar_heap(datatype_bpchar bpchar,x_bpchar bigint, col1_bpchar bpchar,col2_bpchar bpchar, nullcol_bpchar bpchar) location ('gphdfs://10.152.10.234:8020/plaintext/bpchar.txt')format 'TEXT';
 create writable external table bpchar_writehdfs(like bpchar_heap) location ('gphdfs://10.152.10.234:8020/extwrite/bpchar')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table bpchar_readhdfs(like bpchar_heap) location ('gphdfs://10.152.10.234:8020/extwrite/bpchar') format 'custom' (formatter='gphdfs_import');
 select count(*) from bpchar_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/bpchar_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/bpchar_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table bpchar_heap(
 datatype_bpchar bpchar,x_bpchar bigint, col1_bpchar bpchar,col2_bpchar bpchar, nullcol_bpchar bpchar
 ) location ('gphdfs://10.152.10.234:8020/plaintext/bpchar.txt')format 'TEXT';
 create writable external table bpchar_writehdfs(like bpchar_heap) location ('gphdfs://10.152.10.234:8020/extwrite/bpchar')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into bpchar_writehdfs select * from bpchar_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/bpchar /mapreduce/bpchar_gpdb/ 
 16/09/30 00:19:12 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/date_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/date_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "date_readhdfs" does not exist
 -- end_ignore
 create readable external table date_heap(datatype_date varchar,x_date bigint, col1_date date,col2_date date, col3_date date, col4_date date, col5_date date, col6_date date, col7_date date, nullcol_date date) location ('gphdfs://10.152.10.234:8020/plaintext/date.txt')format 'TEXT';
 create writable external table date_writehdfs(like date_heap) location ('gphdfs://10.152.10.234:8020/extwrite/date')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table date_readhdfs(like date_heap) location ('gphdfs://10.152.10.234:8020/extwrite/date') format 'custom' (formatter='gphdfs_import');
 select count(*) from date_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/date_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/date_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table date_heap(
 datatype_date varchar,x_date bigint, col1_date date,col2_date date, col3_date date, col4_date date, col5_date date, col6_date date, col7_date date, nullcol_date date
 ) location ('gphdfs://10.152.10.234:8020/plaintext/date.txt')format 'TEXT';
 create writable external table date_writehdfs(like date_heap) location ('gphdfs://10.152.10.234:8020/extwrite/date')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into date_writehdfs select * from date_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/date /mapreduce/date_gpdb/ 
 16/09/30 00:25:51 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/float_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/float_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "float_readhdfs" does not exist
 -- end_ignore
 create readable external table float_heap(datatype_float varchar, x_float bigint, max_float float, min_float float, pi_float float, piX_float float, nullcol_float float) location ('gphdfs://10.152.10.234:8020/plaintext/float.txt')format 'TEXT';
 create writable external table float_writehdfs(like float_heap) location ('gphdfs://10.152.10.234:8020/extwrite/float')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table float_readhdfs(like float_heap) location ('gphdfs://10.152.10.234:8020/extwrite/float') format 'custom' (formatter='gphdfs_import');
 select count(*) from float_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/float_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/float_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table float_heap(
 datatype_float varchar, x_float bigint, max_float float, min_float float, pi_float float, piX_float float, nullcol_float float
 ) location ('gphdfs://10.152.10.234:8020/plaintext/float.txt')format 'TEXT';
 create writable external table float_writehdfs(like float_heap) location ('gphdfs://10.152.10.234:8020/extwrite/float')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into float_writehdfs select * from float_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/float /mapreduce/float_gpdb/ 
 16/09/30 00:32:09 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/int_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/int_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "int_readhdfs" does not exist
 -- end_ignore
 create readable external table int_heap(datatype_int varchar,xcount_int bigint, max_int int, min_int int, x_int int, reverse_int int, increment_int int, nullcol_int int) location ('gphdfs://10.152.10.234:8020/plaintext/int.txt')format 'TEXT';
 create writable external table int_writehdfs(like int_heap) location ('gphdfs://10.152.10.234:8020/extwrite/int')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table int_readhdfs(like int_heap) location ('gphdfs://10.152.10.234:8020/extwrite/int') format 'custom' (formatter='gphdfs_import');
 select count(*) from int_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/int_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/int_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table int_heap(
 datatype_int varchar, xcount_int bigint, max_int int, min_int int, x_int int, reverse_int int, increment_int int, nullcol_int int
 ) location ('gphdfs://10.152.10.234:8020/plaintext/int.txt')format 'TEXT';
 create writable external table int_writehdfs(like int_heap) location ('gphdfs://10.152.10.234:8020/extwrite/int')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into int_writehdfs select * from int_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/int /mapreduce/int_gpdb/ 
 16/09/30 00:40:09 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/numeric_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/numeric_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "numeric_readhdfs" does not exist
 -- end_ignore
 create readable external table numeric_heap(datatype_numeric varchar, xcount_numeric bigint,max_numeric numeric, min_numeric numeric, x_numeric numeric, reverse_numeric numeric, increment_numeric numeric, nullcol_numeric numeric) location ('gphdfs://10.152.10.234:8020/plaintext/numeric.txt')format 'TEXT';
 create writable external table numeric_writehdfs(like numeric_heap) location ('gphdfs://10.152.10.234:8020/extwrite/numeric')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table numeric_readhdfs(like numeric_heap) location ('gphdfs://10.152.10.234:8020/extwrite/numeric') format 'custom' (formatter='gphdfs_import');
 select count(*) from numeric_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/numeric_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/numeric_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table numeric_heap(
 datatype_numeric varchar,xcount_numeric bigint, max_numeric numeric, min_numeric numeric, x_numeric numeric, reverse_numeric numeric, increment_numeric numeric, nullcol_numeric numeric
 ) location ('gphdfs://10.152.10.234:8020/plaintext/numeric.txt')format 'TEXT';
 create writable external table numeric_writehdfs(like numeric_heap) location ('gphdfs://10.152.10.234:8020/extwrite/numeric')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into numeric_writehdfs select * from numeric_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/numeric /mapreduce/numeric_gpdb/ 
 16/09/30 00:46:25 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/real_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/real_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "real_readhdfs" does not exist
 -- end_ignore
 create readable external table real_heap(datatype_real varchar,x_real bigint, max_real real, min_real real, pi_real real, piX_real real, nullcol_real real) location ('gphdfs://10.152.10.234:8020/plaintext/real.txt')format 'TEXT';
 create writable external table real_writehdfs(like real_heap) location ('gphdfs://10.152.10.234:8020/extwrite/real')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table real_readhdfs(like real_heap) location ('gphdfs://10.152.10.234:8020/extwrite/real') format 'custom' (formatter='gphdfs_import');
 select count(*) from real_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/real_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/real_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table real_heap(
 datatype_real varchar,x_real bigint, max_real real, min_real real, pi_real real, piX_real real, nullcol_real real
 ) location ('gphdfs://10.152.10.234:8020/plaintext/real.txt')format 'TEXT';
 create writable external table real_writehdfs(like real_heap) location ('gphdfs://10.152.10.234:8020/extwrite/real')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into real_writehdfs select * from real_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/real /mapreduce/real_gpdb/ 
 16/09/30 00:53:19 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/rescan.source
+++ b/gpAux/extensions/gphdfs/regression/output/rescan.source
@@ -33,7 +33,7 @@ L_SHIPMODE     CHAR(10) ,
 L_COMMENT      VARCHAR(44) 
 ) location ('gphdfs://10.152.10.234:8020/plaintext/lineitem.txt')format 'text' (delimiter as '|');
 create writable external table rescan_lineitem_writeHDFS (like rescan_lineitem) location ('gphdfs://10.152.10.234:8020/extwrite/lineitem') format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into rescan_lineitem_writeHDFS select * from rescan_lineitem;
 create readable external table rescan_lineitem_readHDFS (like rescan_lineitem) location ('gphdfs://10.152.10.234:8020/extwrite/lineitem') format 'custom' (formatter='gphdfs_import');
 create readable external table rescan_orders(
@@ -48,7 +48,7 @@ O_SHIPPRIORITY   INTEGER ,
 O_COMMENT        VARCHAR(79) 
 ) location ('gphdfs://10.152.10.234:8020/plaintext/orders.txt')format 'text' (delimiter as '|');
 create writable external table rescan_orders_writeHDFS (like rescan_orders ) location ('gphdfs://10.152.10.234:8020/extwrite/orders') format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into rescan_orders_writeHDFS select * from rescan_orders;
 create readable external table rescan_orders_readHDFS (like rescan_orders ) location ('gphdfs://10.152.10.234:8020/extwrite/orders') format 'custom' (formatter='gphdfs_import');
 select * from rescan_lineitem order by l_partkey;

--- a/gpAux/extensions/gphdfs/regression/output/smallint_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/smallint_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "smallint_readhdfs" does not exist
 -- end_ignore
 create readable external table smallint_heap(datatype_smallint varchar, xcount_smallint bigint, max_smallint smallint, min_smallint smallint, x_smallint smallint, reverse_smallint smallint, increment_smallint smallint, nullcol_smallint smallint) location ('gphdfs://10.152.10.234:8020/plaintext/smallint.txt')format 'TEXT';
 create writable external table smallint_writehdfs(like smallint_heap) location ('gphdfs://10.152.10.234:8020/extwrite/smallint')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table smallint_readhdfs(like smallint_heap) location ('gphdfs://10.152.10.234:8020/extwrite/smallint') format 'custom' (formatter='gphdfs_import');
 select count(*) from smallint_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/smallint_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/smallint_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table smallint_heap(
 datatype_smallint varchar, xcount_smallint bigint, max_smallint smallint, min_smallint smallint, x_smallint smallint, reverse_smallint smallint, increment_smallint smallint, nullcol_smallint smallint
 ) location ('gphdfs://10.152.10.234:8020/plaintext/smallint.txt')format 'TEXT';
 create writable external table smallint_writehdfs(like smallint_heap) location ('gphdfs://10.152.10.234:8020/extwrite/smallint')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into smallint_writehdfs select * from smallint_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/smallint /mapreduce/smallint_gpdb/ 
 16/09/30 01:01:19 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/text_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/text_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "text_readhdfs" does not exist
 -- end_ignore
 create readable external table text_heap(datatype_text text,x_text bigint, col1_text text,col2_text text, nullcol_text text) location ('gphdfs://10.152.10.234:8020/plaintext/text.txt')format 'TEXT';
 create writable external table text_writehdfs(like text_heap) location ('gphdfs://10.152.10.234:8020/extwrite/text')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table text_readhdfs(like text_heap) location ('gphdfs://10.152.10.234:8020/extwrite/text') format 'custom' (formatter='gphdfs_import');
 select count(*) from text_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/text_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/text_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table text_heap(
 datatype_text text,x_text bigint, col1_text text,col2_text text, nullcol_text text
 ) location ('gphdfs://10.152.10.234:8020/plaintext/text.txt')format 'TEXT';
 create writable external table text_writehdfs(like text_heap) location ('gphdfs://10.152.10.234:8020/extwrite/text')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into text_writehdfs select * from text_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/text /mapreduce/text_gpdb/ 
 16/09/30 01:07:39 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/time_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/time_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "time_readhdfs" does not exist
 -- end_ignore
 create readable external table time_heap(datatype_time varchar,x_time bigint, col1_time time,col2_time time, col3_time time, col4_time time, col5_time time, col6_time time, col7_time time, col8_time time, col9_time time, nullcol_time time) location ('gphdfs://10.152.10.234:8020/plaintext/time.txt')format 'TEXT';
 create writable external table time_writehdfs(like time_heap) location ('gphdfs://10.152.10.234:8020/extwrite/time')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table time_readhdfs(like time_heap) location ('gphdfs://10.152.10.234:8020/extwrite/time') format 'custom' (formatter='gphdfs_import');
 select count(*) from time_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/time_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/time_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table time_heap(
 datatype_time varchar,x_time bigint, col1_time time,col2_time time, col3_time time, col4_time time, col5_time time, col6_time time, col7_time time, col8_time time, col9_time time, nullcol_time time
 ) location ('gphdfs://10.152.10.234:8020/plaintext/time.txt')format 'TEXT';
 create writable external table time_writehdfs(like time_heap) location ('gphdfs://10.152.10.234:8020/extwrite/time')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into time_writehdfs select * from time_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/time /mapreduce/time_gpdb/ 
 16/09/30 01:13:58 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/timestamp_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/timestamp_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "timestamp_readhdfs" does not exist
 -- end_ignore
 create readable external table timestamp_heap(datatype_timestamp varchar,x_timestamp bigint, col1_timestamp timestamp,col2_timestamp timestamp, col3_timestamp timestamp, nullcol_timestamp timestamp) location ('gphdfs://10.152.10.234:8020/plaintext/timestamp.txt')format 'TEXT';
 create writable external table timestamp_writehdfs(like timestamp_heap) location ('gphdfs://10.152.10.234:8020/extwrite/timestamp')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table timestamp_readhdfs(like timestamp_heap) location ('gphdfs://10.152.10.234:8020/extwrite/timestamp') format 'custom' (formatter='gphdfs_import');
 select count(*) from timestamp_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/timestamp_ExtwriteToHDFSText.source
+++ b/gpAux/extensions/gphdfs/regression/output/timestamp_ExtwriteToHDFSText.source
@@ -12,7 +12,7 @@ ERROR:  table "timestamp_verification" does not exist
 --end_ignore
 create readable external table timestamp_heap(datatype_timestamp varchar,xcount_timestamp bigint, col1_timestamp timestamp,col2_timestamp timestamp, col3_timestamp timestamp, nullcol_timestamp timestamp) location ('gphdfs://10.152.10.234:8020/plaintext/timestamp.txt')format 'TEXT';
 create writable external table timestamp_writehdfs(like timestamp_heap) location ('gphdfs://10.152.10.234:8020/extwrite/timestamp')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into timestamp_writehdfs select * from timestamp_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDBIn /extwrite/timestamp /mapreduce/timestamp_text/ 
 16/09/30 01:20:28 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/timestamp_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/timestamp_ExtwriteToHdfsToExtread.source
@@ -18,7 +18,7 @@ ERROR:  table "timestamp_verification_recordcomp_mapred" does not exist
 --end_ignore
 create readable external table timestamp_heap(datatype_timestamp varchar,xcount_timestamp bigint, col1_timestamp timestamp,col2_timestamp timestamp, col3_timestamp timestamp, nullcol_timestamp timestamp) location ('gphdfs://10.152.10.234:8020/plaintext/timestamp.txt')format 'TEXT';
 create writable external table timestamp_writehdfs(like timestamp_heap) location ('gphdfs://10.152.10.234:8020/extwrite/timestamp')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into timestamp_writehdfs select * from timestamp_heap;
 \!/home/gpadmin/gpdb/gpAux/extensions/gphdfs/regression/runcmd -DcompressionType=none javaclasses/TestHadoopIntegration mapreduce Mapreduce_mapper_GPDB_INOUT /extwrite/timestamp /mapreduce/timestamp_gpdb/ 
 16/09/30 01:23:14 INFO Configuration.deprecation: fs.default.name is deprecated. Instead, use fs.defaultFS

--- a/gpAux/extensions/gphdfs/regression/output/typemismatch.source
+++ b/gpAux/extensions/gphdfs/regression/output/typemismatch.source
@@ -15,7 +15,7 @@ datatype_bigint varchar,xcount_bigint bigint, max_bigint bigint, min_bigint bigi
 --datatype_bigint varchar,xcount_bigint bigint, max_bigint bigint, min_bigint bigint, x_bigint bigint, reverse_bigint bigint, increment_bigint bigint
 ) location ('gphdfs://10.152.10.234:8020/plaintext/bigint_text.txt')format 'TEXT';
 create writable external table bigint_writehdfs(like bigint_heap) location ('gphdfs://10.152.10.234:8020/extwrite/bigint')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into bigint_writehdfs select * from bigint_heap;
 \echo --start_ignore
 --start_ignore

--- a/gpAux/extensions/gphdfs/regression/output/userDefinedTypes_withHDFS.source
+++ b/gpAux/extensions/gphdfs/regression/output/userDefinedTypes_withHDFS.source
@@ -16,7 +16,7 @@ NOTICE:  drop cascades to external table writeudt column composit
 CREATE TYPE mytype AS (f1 int, f2 text);
 create readable external table readgpfdist_compositeType (type varchar, id bigint, composite mytype) location ('gphdfs://10.152.10.234:8020/plaintext/compositeType.txt') format 'text';
 create writable external table composite_write_hdfs(like readgpfdist_compositeType) location ('gphdfs://10.152.10.234:8020/extwrite/composite') format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into composite_write_hdfs select * from readgpfdist_compositeType;
 \echo --start_ignore
 --start_ignore

--- a/gpAux/extensions/gphdfs/regression/output/varchar_Extreadwrite.source
+++ b/gpAux/extensions/gphdfs/regression/output/varchar_Extreadwrite.source
@@ -10,7 +10,7 @@ ERROR:  table "varchar_readhdfs" does not exist
 -- end_ignore
 create readable external table varchar_heap(datatype_varchar varchar,x_varchar bigint, col1_varchar varchar,col2_varchar varchar, nullcol_varchar varchar) location ('gphdfs://10.152.10.234:8020/plaintext/varchar.txt')format 'TEXT';
 create writable external table varchar_writehdfs(like varchar_heap) location ('gphdfs://10.152.10.234:8020/extwrite/varchar')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table varchar_readhdfs(like varchar_heap) location ('gphdfs://10.152.10.234:8020/extwrite/varchar') format 'custom' (formatter='gphdfs_import');
 select count(*) from varchar_heap;
  count 

--- a/gpAux/extensions/gphdfs/regression/output/varchar_ExtwriteToHdfsToExtread.source
+++ b/gpAux/extensions/gphdfs/regression/output/varchar_ExtwriteToHdfsToExtread.source
@@ -20,7 +20,7 @@ create readable external table varchar_heap(
 datatype_varchar varchar,x_varchar bigint, col1_varchar varchar,col2_varchar varchar, nullcol_varchar varchar
 ) location ('gphdfs://10.152.10.234:8020/plaintext/varchar.txt')format 'TEXT';
 create writable external table varchar_writehdfs(like varchar_heap) location ('gphdfs://10.152.10.234:8020/extwrite/varchar')format 'custom' (formatter='gphdfs_export');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into varchar_writehdfs select * from varchar_heap;
 \echo --start_ignore
 --start_ignore

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -837,7 +837,7 @@ CTranslatorQueryToDXL::PdxlnCTAS()
 	}
 	else
 	{
-		elog(NOTICE, "Table doesn't have 'distributed by' clause. Creating a NULL policy entry.");
+		elog(NOTICE, "Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.");
 	}
 	
 	GPOS_ASSERT(IMDRelation::EreldistrMasterOnly != ereldistrpolicy);

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1505,7 +1505,7 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 	{
 		distributedBy = likeDistributedBy;
 		if (!bQuiet)
-			elog(NOTICE, "Table doesn't have 'distributed by' clause, "
+			elog(NOTICE, "Table doesn't have 'DISTRIBUTED BY' clause, "
 				 "defaulting to distribution columns from LIKE table");
 	}
 
@@ -1638,7 +1638,7 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 			 */
 			policy->nattrs = 0;
 			if (!bQuiet)
-				elog(NOTICE, "Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.");
+				elog(NOTICE, "Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.");
 		}
 
 	}
@@ -1839,7 +1839,7 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 						heap_close(rel, NoLock);
 
 						if (found)
-							elog(DEBUG1, "'distributed by' clause refers to "
+							elog(DEBUG1, "'DISTRIBUTED BY' clause refers to "
 								 "columns of inherited table");
 
 						if (found)
@@ -1937,7 +1937,7 @@ transformDistributedBy(ParseState *pstate, CreateStmtContext *cxt,
 						}
 						heap_close(rel, NoLock);
 						if (found)
-							elog(NOTICE, "'distributed by' clause refers to columns of inherited table");
+							elog(NOTICE, "'DISTRIBUTED BY' clause refers to columns of inherited table");
 
 						if (found)
 							break;

--- a/src/backend/utils/gpmon/gpmon.c
+++ b/src/backend/utils/gpmon/gpmon.c
@@ -193,7 +193,7 @@ void gpmon_send(gpmon_packet_t* p)
 		if (n != sendto(gpmon.gxsock, (const char *)p, n, 0, 
 						(struct sockaddr*) &gpmon.gxaddr, 
 						sizeof(gpmon.gxaddr))) {
-			elog(WARNING, "gpmon: cannot send (%m socket %d)", gpmon.gxsock);
+			elog(LOG, "gpmon: cannot send (%m socket %d)", gpmon.gxsock);
 		}
 	}
 }

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -699,7 +699,7 @@ create writable external table wet_pos2(a text, b text) location('gpfdist://@hos
 create writable external table wet_pos3(like wet_pos2) location('gpfdist://@hostname@:7070/wet.out') format 'text' distributed by(a,b);
 create writable external web table wet_pos4(a text, b text) execute 'some command' format 'text';
 create writable external table wet_region(like reg_region) location('gpfdist://@hostname@:7070/wet_region.out') format 'text';
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table ret_region(like wet_region) location('gpfdist://@hostname@:7070/wet_region.out') format 'text';
 -- negative
 create writable external table wet_neg1(a text, b text) location('file://@hostname@@abs_srcdir@/badt1.tbl') format 'text';
@@ -894,6 +894,8 @@ select count(*) from pg_catalog.pg_exttable where reloid in (select r.oid from p
 
 COPY (VALUES('1,2'),('1,2,3'),('1,'),('1')) TO '@abs_srcdir@/data/tableless.csv';
 CREATE TABLE tableless_heap(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 COPY tableless_heap FROM '@abs_srcdir@/data/tableless.csv' CSV LOG ERRORS SEGMENT REJECT LIMIT 10;
 NOTICE:  Found 2 data formatting errors (2 or more input rows). Rejected related input data.
 SELECT relname, linenum, errmsg FROM gp_read_error_log('tableless_heap');
@@ -904,6 +906,8 @@ SELECT relname, linenum, errmsg FROM gp_read_error_log('tableless_heap');
 (2 rows)
 
 create table errlog_save as select * from gp_read_error_log('tableless_heap');
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'cmdtime' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew
 select count(*) from errlog_save;
  count 
 -------

--- a/src/bin/gpfdist/regress/output/exttab1_optimizer.source
+++ b/src/bin/gpfdist/regress/output/exttab1_optimizer.source
@@ -699,7 +699,7 @@ create writable external table wet_pos2(a text, b text) location('gpfdist://@hos
 create writable external table wet_pos3(like wet_pos2) location('gpfdist://@hostname@:7070/wet.out') format 'text' distributed by(a,b);
 create writable external web table wet_pos4(a text, b text) execute 'some command' format 'text';
 create writable external table wet_region(like reg_region) location('gpfdist://@hostname@:7070/wet_region.out') format 'text';
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 create readable external table ret_region(like wet_region) location('gpfdist://@hostname@:7070/wet_region.out') format 'text';
 -- negative
 create writable external table wet_neg1(a text, b text) location('file://@hostname@@abs_srcdir@/badt1.tbl') format 'text';
@@ -893,6 +893,8 @@ select count(*) from pg_catalog.pg_exttable where reloid in (select r.oid from p
 
 COPY (VALUES('1,2'),('1,2,3'),('1,'),('1')) TO '@abs_srcdir@/data/tableless.csv';
 CREATE TABLE tableless_heap(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 COPY tableless_heap FROM '@abs_srcdir@/data/tableless.csv' CSV LOG ERRORS SEGMENT REJECT LIMIT 10;
 NOTICE:  Found 2 data formatting errors (2 or more input rows). Rejected related input data.
 SELECT relname, linenum, errmsg FROM gp_read_error_log('tableless_heap');
@@ -903,6 +905,8 @@ SELECT relname, linenum, errmsg FROM gp_read_error_log('tableless_heap');
 (2 rows)
 
 create table errlog_save as select * from gp_read_error_log('tableless_heap');
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'cmdtime' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew
 select count(*) from errlog_save;
  count 
 -------

--- a/src/pl/plpython/init_file
+++ b/src/pl/plpython/init_file
@@ -1,4 +1,4 @@
--- start_matchignore
+-- start_matchsubs
 m/\(plpython\.c:\d+\)/
 s/\(plpython\.c:\d+\)//
 -- end_matchsubs

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -410,9 +410,6 @@ m/^HINT:  The \'DISTRIBUTED BY\' clause determines the distribution of data/
 
 m/^WARNING:  Referential integrity \(.*\) constraints are not supported in Greenplum Database/
 
-
-m/^\s*Distributed by:\s+\(.*\)\s*$/
-
         # ignore notices for DROP sqlobject IF EXISTS "objectname"
         # eg NOTICE:  table "foo" does not exist, skipping
         #

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -397,16 +397,9 @@ sub init_matchignores
 
     $here_matchignores = << 'EOF_matchignores';
 
-        # XXX XXX: note the discrepancy in the NOTICE messages
-        # 'distributed by' vs 'DISTRIBUTED BY'
-m/^NOTICE:  Table doesn\'t have \'distributed by\' clause/
-m/^NOTICE:  Table doesn\'t have \'DISTRIBUTED BY\' clause/
-
 m/^NOTICE:  Dropping a column that is part of the distribution policy/
 
 m/^NOTICE:  Table has parent\, setting distribution columns to match parent table/
-
-m/^HINT:  The \'DISTRIBUTED BY\' clause determines the distribution of data/
 
 m/^WARNING:  Referential integrity \(.*\) constraints are not supported in Greenplum Database/
 

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -268,8 +268,8 @@ sub init_match_subs
     $here_matchsubs = << 'EOF_matchsubs';
 
 # some cleanup of greenplum-specific messages
-m/\s+(?:\W)?(?:\W)?\(seg.*pid.*\)/
-s/\s+(\W)?(\W)?\(seg.*pid.*\)//
+m/\s+\(seg.*pid.*\)/
+s/\s+\(seg.*pid.*\)//
 
 # distributed transactions
 m/^(?:ERROR|WARNING|CONTEXT|NOTICE):.*gid\s+=\s+(?:\d+)/

--- a/src/test/regress/bugbuster/expected/aoco_compr_sanity.out
+++ b/src/test/regress/bugbuster/expected/aoco_compr_sanity.out
@@ -3340,7 +3340,7 @@ DROP TABLE
 Create table parent_like1 (a1 int ENCODING (compresstype=zlib,compresslevel=9,blocksize=32768),a2 char(5),a3  date)  with (appendonly=true,orientation=column) distributed by (a1);
 CREATE TABLE
 Create table child_like1 (like parent_like1) with (appendonly = true, orientation = column);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
                                 Append-Only Columnar Table "public.parent_like1"
  Column |     Type     | Modifiers | Storage  | Compression Type | Compression Level | Block Size | Description 
@@ -3373,7 +3373,7 @@ DROP TABLE
 Create table parent_like2 (a1 int ,a2 char(5),a3  date, column a1 ENCODING (compresstype=zlib,compresslevel=9,blocksize=32768))  with (appendonly=true,orientation=column) distributed by (a1);
 CREATE TABLE
 Create table child_like2  (like parent_like2) with (appendonly = true, orientation = column);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
                                 Append-Only Columnar Table "public.parent_like2"
  Column |     Type     | Modifiers | Storage  | Compression Type | Compression Level | Block Size | Description 
@@ -3411,7 +3411,7 @@ NOTICE:  CREATE TABLE will create partition "parent_like3_1_prt_1" for table "pa
 NOTICE:  CREATE TABLE will create partition "parent_like3_1_prt_2" for table "parent_like3"
 CREATE TABLE
 Create table child_like3  (like parent_like3) with (appendonly = true, orientation = column) Partition by range(a1) (start(1) end(1000) every(500));
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "child_like3_1_prt_1" for table "child_like3"
 NOTICE:  CREATE TABLE will create partition "child_like3_1_prt_2" for table "child_like3"
 CREATE TABLE
@@ -3469,7 +3469,7 @@ Create table child_like4  (like parent_like4) with (appendonly = true, orientati
         ( subpartition part1 values('M') ,
           subpartition part2 values('F')) 
         (start(1) end(1000) every(500));
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "child_like4_1_prt_1" for table "child_like4"
 NOTICE:  CREATE TABLE will create partition "child_like4_1_prt_2" for table "child_like4"
 NOTICE:  CREATE TABLE will create partition "child_like4_1_prt_1_2_prt_part1" for table "child_like4_1_prt_1"
@@ -3522,7 +3522,7 @@ CREATE TABLE
 Insert into parent_like5 values(generate_series(1,100),'asd','2011-02-11');
 INSERT 0 100
 Create table child_like5  (like parent_like5) with (appendonly = true, orientation = column,compresstype=zlib,compresslevel=1);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
                                 Append-Only Columnar Table "public.parent_like5"
  Column |     Type     | Modifiers | Storage  | Compression Type | Compression Level | Block Size | Description 

--- a/src/test/regress/bugbuster/expected/schema_topology.out
+++ b/src/test/regress/bugbuster/expected/schema_topology.out
@@ -899,7 +899,7 @@ PARTITION BY RANGE (date)
 ( START (date '2008-01-01') INCLUSIVE 
    END (date '2009-01-01') EXCLUSIVE 
    EVERY (INTERVAL '1 month') );
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "sales1_1_prt_1" for table "sales1"
 NOTICE:  CREATE TABLE will create partition "sales1_1_prt_2" for table "sales1"
 NOTICE:  CREATE TABLE will create partition "sales1_1_prt_3" for table "sales1"
@@ -1133,7 +1133,7 @@ PARTITION BY RANGE (date)
    END (date '2009-01-01') EXCLUSIVE 
    EVERY (INTERVAL '1 month')
    WITH (appendonly=true, compresslevel=5));
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "sales_ao1_1_prt_1" for table "sales_ao1"
 NOTICE:  CREATE TABLE will create partition "sales_ao1_1_prt_2" for table "sales_ao1"
 NOTICE:  CREATE TABLE will create partition "sales_ao1_1_prt_3" for table "sales_ao1"
@@ -1365,7 +1365,7 @@ PARTITION BY RANGE (date)
 ( START (date '2008-01-01') INCLUSIVE 
    END (date '2009-01-01') EXCLUSIVE 
    EVERY (INTERVAL '1 month'));
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "sales_hybrid1_1_prt_1" for table "sales_hybrid1"
 NOTICE:  CREATE TABLE will create partition "sales_hybrid1_1_prt_2" for table "sales_hybrid1"
 NOTICE:  CREATE TABLE will create partition "sales_hybrid1_1_prt_3" for table "sales_hybrid1"

--- a/src/test/regress/bugbuster/expected/schema_topology_optimizer.out
+++ b/src/test/regress/bugbuster/expected/schema_topology_optimizer.out
@@ -897,7 +897,7 @@ PARTITION BY RANGE (date)
 ( START (date '2008-01-01') INCLUSIVE 
    END (date '2009-01-01') EXCLUSIVE 
    EVERY (INTERVAL '1 month') );
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "sales1_1_prt_1" for table "sales1"
 NOTICE:  CREATE TABLE will create partition "sales1_1_prt_2" for table "sales1"
 NOTICE:  CREATE TABLE will create partition "sales1_1_prt_3" for table "sales1"
@@ -1131,7 +1131,7 @@ PARTITION BY RANGE (date)
    END (date '2009-01-01') EXCLUSIVE 
    EVERY (INTERVAL '1 month')
    WITH (appendonly=true, compresslevel=5));
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "sales_ao1_1_prt_1" for table "sales_ao1"
 NOTICE:  CREATE TABLE will create partition "sales_ao1_1_prt_2" for table "sales_ao1"
 NOTICE:  CREATE TABLE will create partition "sales_ao1_1_prt_3" for table "sales_ao1"
@@ -1363,7 +1363,7 @@ PARTITION BY RANGE (date)
 ( START (date '2008-01-01') INCLUSIVE 
    END (date '2009-01-01') EXCLUSIVE 
    EVERY (INTERVAL '1 month'));
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "sales_hybrid1_1_prt_1" for table "sales_hybrid1"
 NOTICE:  CREATE TABLE will create partition "sales_hybrid1_1_prt_2" for table "sales_hybrid1"
 NOTICE:  CREATE TABLE will create partition "sales_hybrid1_1_prt_3" for table "sales_hybrid1"

--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -1151,7 +1151,7 @@ ERROR:  function insertmanyintosales(integer, character varying) does not exist
 create table r (a int, b int) distributed by (a);
 create table s (a int, b int) distributed by (a);
 create table m ();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 	alter table m add column a int;
 	alter table m add column b int;
 create table t (region text, id int) distributed by (region);

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -1139,7 +1139,7 @@ ERROR:  function insertmanyintosales(integer, character varying) does not exist
 create table r (a int, b int) distributed by (a);
 create table s (a int, b int) distributed by (a);
 create table m ();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 	alter table m add column a int;
 	alter table m add column b int;
 create table t (region text, id int) distributed by (region);

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -102,7 +102,7 @@ select 1, to_char(col1, 'YYYY'), median(col2) from d group by 1, 2;
 ---
 -- SETUP
 create table toy(id,val) as select i,i from generate_series(1,5) i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create aggregate mysum1(int4) (sfunc = int4_sum, prefunc=int8pl, stype=bigint);
 create aggregate mysum2(int4) (sfunc = int4_sum, stype=bigint);
 -- TEST

--- a/src/test/regress/expected/bfv_cte.out
+++ b/src/test/regress/expected/bfv_cte.out
@@ -20,9 +20,9 @@ DROP TABLE test_group_window;
 -- Set up
 --
 CREATE TABLE bfv_cte_foo AS SELECT i as a, i+1 as b from generate_series(1,10)i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE TABLE bfv_cte_bar AS SELECT i as c, i+1 as d from generate_series(1,10)i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 --
 -- Test with CTE inlining disabled
 --

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -22,11 +22,11 @@ END
 $$ LANGUAGE plpgsql;
 create table z(x int) distributed by (x);
 CREATE TABLE bfv_joins_foo AS SELECT i as a, i+1 as b from generate_series(1,10)i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE TABLE bfv_joins_bar AS SELECT i as c, i+1 as d from generate_series(1,10)i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE TABLE t AS SELECT bfv_joins_foo.a,bfv_joins_foo.b,bfv_joins_bar.d FROM bfv_joins_foo,bfv_joins_bar WHERE bfv_joins_foo.a = bfv_joins_bar.d;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE FUNCTION my_equality(a int, b int) RETURNS BOOL
     AS $$ SELECT $1 < $2 $$
     LANGUAGE SQL;

--- a/src/test/regress/expected/bfv_legacy_optimizer.out
+++ b/src/test/regress/expected/bfv_legacy_optimizer.out
@@ -100,7 +100,7 @@ col_with_constraint numeric UNIQUE
 ) distributed BY (col_with_constraint);
 NOTICE:  CREATE TABLE / UNIQUE will create implicit index "bfv_legacy_a_col_with_constraint_key" for table "bfv_legacy_a"
 create table bfv_legacy_B as select * from bfv_legacy_A;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 select localoid::regclass, attrnums from gp_distribution_policy p left join pg_class c on (p.localoid = c.oid) where c.relname in ('bfv_legacy_a', 'bfv_legacy_b') order by 1,2;
    localoid   | attrnums 
 --------------+----------

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -13,7 +13,7 @@ drop aggregate if exists mysum2(int4);
 NOTICE:  aggregate mysum2(int4) does not exist, skipping
 -- end_ignore
 create table toy(id,val) as select i,i from generate_series(1,5) i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create aggregate mysum1(int4) (sfunc = int4_sum, prefunc=int8pl, stype=bigint);
 create aggregate mysum2(int4) (sfunc = int4_sum, stype=bigint);
 -- TEST

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -13,7 +13,7 @@ CREATE TABLE bfv_planner_x(i integer);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE bfv_planner_foo AS SELECT i as a, i+1 as b from generate_series(1,10)i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 --
 -- Test unexpected internal error (execQual.c:4413) when using subquery+window function+union in 4.2.6.x
 --

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -255,7 +255,7 @@ NOTICE:  table "mpp_t3" does not exist, skipping
 create table mpp_t1(a int,b int) distributed by (a); 
 create table mpp_t2(a int,b int) distributed by (b);
 create table mpp_t3(like mpp_t1);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- end_ignore
 select * from mpp_t1 where a=1 and a=2 and a > (select mpp_t2.b from mpp_t2);
  a | b 

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -255,7 +255,7 @@ NOTICE:  table "mpp_t3" does not exist, skipping
 create table mpp_t1(a int,b int) distributed by (a); 
 create table mpp_t2(a int,b int) distributed by (b);
 create table mpp_t3(like mpp_t1);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- end_ignore
 select * from mpp_t1 where a=1 and a=2 and a > (select mpp_t2.b from mpp_t2);
  a | b 
@@ -330,7 +330,7 @@ NOTICE:  table "t_coalesce_count_subquery_empty" does not exist, skipping
 drop table if exists t_coalesce_count_subquery_empty2;
 NOTICE:  table "t_coalesce_count_subquery_empty2" does not exist, skipping
 CREATE TABLE t_coalesce_count_subquery(a, b) AS VALUES (1, 1);
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE TABLE t_coalesce_count_subquery_empty(c int, d int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -398,7 +398,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table ccddl_co(LIKE ccddl)
   with (appendonly = true, orientation=column);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 execute ccddlcheck;
  relname  | attnum |                     attoptions                      
 ----------+--------+-----------------------------------------------------
@@ -408,7 +408,7 @@ execute ccddlcheck;
 drop table ccddl_co;
 create table ccddl_co(LIKE ccddl)
   with (appendonly = true, orientation=column, compresstype=zlib);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 execute ccddlcheck;
  relname  | attnum |                     attoptions                      
 ----------+--------+-----------------------------------------------------
@@ -514,7 +514,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table ccddl_co (like ccddl, column i encoding(compresstype=RLE_TYPE))
 with (appendonly=true, orientation=column, compresstype=zlib);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 execute ccddlcheck;
  relname  | attnum |                       attoptions                        
 ----------+--------+---------------------------------------------------------
@@ -1724,7 +1724,7 @@ select typoptions from pg_type_encoding where typid='public.int42'::regtype;
 (1 row)
 
 create table ccddl (i int42) with(appendonly = true, orientation=column);
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
  relname | attnum |                     attoptions                      
 ---------+--------+-----------------------------------------------------
@@ -1743,7 +1743,7 @@ execute ccddlcheck;
 drop table ccddl;
 -- Shouldn't apply type default encoding in these cases
 create table ccddl (i int42);
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
  relname | attnum | attoptions 
 ---------+--------+------------
@@ -1751,7 +1751,7 @@ execute ccddlcheck;
 
 drop table ccddl;
 create table ccddl (i int42) with (appendonly = true);
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
  relname | attnum | attoptions 
 ---------+--------+------------
@@ -1760,7 +1760,7 @@ execute ccddlcheck;
 drop table ccddl;
 create table ccddl (i int42) with (appendonly = true, orientation=column,
 compresstype=none);
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
  relname | attnum |                     attoptions                      
 ---------+--------+-----------------------------------------------------

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -444,7 +444,7 @@ Indexes:
     "concur_index5" btree (f2) WHERE f1 = 'x'::text
     "concur_index6" btree ((f2 || f1))
     "std_index" btree (f2)
-Distributed by: (f1)
+Distributed by: (dk)
 
 DROP TABLE concur_heap;
 --

--- a/src/test/regress/expected/create_table.out
+++ b/src/test/regress/expected/create_table.out
@@ -118,11 +118,11 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE TABLE slow_emp4000 (
 	home_base	 box
 );
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 CREATE TABLE fast_emp4000 (
 	home_base	 box
 );
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 CREATE TABLE road (
 	name		text,
 	thepath 	path

--- a/src/test/regress/expected/create_type.out
+++ b/src/test/regress/expected/create_type.out
@@ -72,7 +72,7 @@ CREATE TYPE text_w_default (
    default = 'zippo'
 );
 CREATE TABLE default_test (f1 text_w_default, f2 int42);
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 INSERT INTO default_test DEFAULT VALUES;
 SELECT * FROM default_test;
   f1   | f2 

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -14,7 +14,7 @@ set optimizer_enable_master_only_queries = on;
 -- master only tables
 create schema orca;
 create table orca.r();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 set allow_system_table_mods='DML';
 delete from gp_distribution_policy where localoid='orca.r'::regclass;
 reset allow_system_table_mods;
@@ -22,7 +22,7 @@ alter table orca.r add column a int;
 alter table orca.r add column b int;
 insert into orca.r select i, i/3 from generate_series(1,20) i;
 create table orca.s();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 set allow_system_table_mods='DML';
 delete from gp_distribution_policy where localoid='orca.s'::regclass;
 reset allow_system_table_mods;
@@ -3145,11 +3145,11 @@ select r.* from orca.r, orca.s where s.c=2;
 ----------------------------------------------------------------------
 set optimizer=off;
 create table orca.m();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 alter table orca.m add column a int;
 alter table orca.m add column b int;
 create table orca.m1();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 alter table orca.m1 add column a int;
 alter table orca.m1 add column b int;
 insert into orca.m select i-1, i%2 from generate_series(1,35) i;
@@ -8704,9 +8704,9 @@ select * from (select 2.2 AS two UNION select 1) x(a), (select 1.0 AS two UNION 
 
 -- window functions inside inline CTE
 CREATE TABLE orca.twf1 AS SELECT i as a, i+1 as b from generate_series(1,10)i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE TABLE orca.twf2 AS SELECT i as c, i+1 as d from generate_series(1,10)i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 SET optimizer_cte_inlining_bound=1000;
 SET optimizer_cte_inlining = on;
 WITH CTE(a,b) AS
@@ -8741,9 +8741,9 @@ drop table if exists orca.tab1;
 drop table if exists orca.tab2;
 NOTICE:  table "tab2" does not exist, skipping
 create table orca.tab1 (i, j) as select i,i%2 from generate_series(1,10) i;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table orca.tab2 (a, b) as select 1, 2;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 select * from orca.tab1 where 0 < (select count(*) from generate_series(1,i)) order by 1;
  i  | j 
 ----+---

--- a/src/test/regress/expected/gp_optimizer_1.out
+++ b/src/test/regress/expected/gp_optimizer_1.out
@@ -14,7 +14,7 @@ set optimizer_enable_master_only_queries = on;
 -- master only tables
 create schema orca;
 create table orca.r();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 set allow_system_table_mods='DML';
 delete from gp_distribution_policy where localoid='orca.r'::regclass;
 reset allow_system_table_mods;
@@ -22,7 +22,7 @@ alter table orca.r add column a int;
 alter table orca.r add column b int;
 insert into orca.r select i, i/3 from generate_series(1,20) i;
 create table orca.s();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 set allow_system_table_mods='DML';
 delete from gp_distribution_policy where localoid='orca.s'::regclass;
 reset allow_system_table_mods;
@@ -3148,11 +3148,11 @@ select r.* from orca.r, orca.s where s.c=2;
 ----------------------------------------------------------------------
 set optimizer=off;
 create table orca.m();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 alter table orca.m add column a int;
 alter table orca.m add column b int;
 create table orca.m1();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 alter table orca.m1 add column a int;
 alter table orca.m1 add column b int;
 insert into orca.m select i-1, i%2 from generate_series(1,35) i;

--- a/src/test/regress/expected/gpcopy.out
+++ b/src/test/regress/expected/gpcopy.out
@@ -192,7 +192,7 @@ DROP TABLE copy_regression_out1;
 -- Zero column table
 -- ######################################################
 CREATE TABLE copy_regression_nocol();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 -- copy in and out of zero column table..
 COPY copy_regression_nocol from stdin;
 COPY copy_regression_nocol from stdin;

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -24,9 +24,9 @@ NOTICE:  table "ctas_bar" does not exist, skipping
 drop table if exists ctas_baz;
 NOTICE:  table "ctas_baz" does not exist, skipping
 create table ctas_foo as select * from generate_series(1, 100);
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table ctas_bar as select a.generate_series as a, b.generate_series as b from ctas_foo a, ctas_foo b;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table ctas_baz as select 'delete me' as action, * from ctas_bar distributed by (a);
 WARNING:  column "action" has type "unknown"
 DETAIL:  Proceeding with relation creation anyway.

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -701,7 +701,7 @@ NOTICE:  CREATE TABLE will create partition "d_1_prt_abc" for table "d"
 NOTICE:  CREATE TABLE will create partition "d_1_prt_a" for table "d"
 NOTICE:  CREATE TABLE will create partition "d_1_prt_b" for table "d"
 create table exh_abc (like d);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 alter table d exchange default partition with table exh_abc;
 ERROR:  cannot exchange DEFAULT partition
 set gp_enable_exchange_default_partition = on;
@@ -744,7 +744,7 @@ NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_subothers" 
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_sub1" for table "sto_ao_ao_1_prt_5"
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_sub2" for table "sto_ao_ao_1_prt_5"
 create table exh_ao_ao (like sto_ao_ao) with (appendonly=true);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- Exchange default sub-partition, should fail
 alter table sto_ao_ao alter partition for (rank(3)) exchange default partition with table exh_ao_ao;
 ERROR:  cannot exchange DEFAULT partition
@@ -3073,7 +3073,7 @@ select * from rank;
 
 --exchange test
 create table r (like rank);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into rank values(3, 3, 2004, 'F', 100);
 insert into r values(3, 3, 2004, 'F', 100000);
 alter table rank alter partition girls exchange partition year4 with table r;
@@ -3406,7 +3406,7 @@ NOTICE:  CREATE TABLE will create partition "rank_1_prt_9" for table "rank"
 alter table rank_1_prt_1 no inherit rank;
 ERROR:  can't alter inheritance on "rank_1_prt_1"; it is a partitioned table or part thereof
 create table rank2(like rank);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 alter table rank_1_prt_1 inherit rank2;
 ERROR:  can't alter inheritance on "rank_1_prt_1"; it is a partitioned table or part thereof
 alter table rank_1_prt_1 alter column i type bigint;
@@ -6098,7 +6098,7 @@ NOTICE:  CREATE TABLE will create partition "mpp6979part_1_prt_8" for table "mpp
 NOTICE:  CREATE TABLE will create partition "mpp6979part_1_prt_9" for table "mpp6979part"
 -- append-only table in new schema 
 create table mpp6979dummy.mpp6979tab(like mpp6979part) with (appendonly=true);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- check that table and all parts in public schema
 select schemaname, tablename, partitionschemaname, partitiontablename
 from pg_partitions 

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -702,7 +702,7 @@ NOTICE:  CREATE TABLE will create partition "d_1_prt_abc" for table "d"
 NOTICE:  CREATE TABLE will create partition "d_1_prt_a" for table "d"
 NOTICE:  CREATE TABLE will create partition "d_1_prt_b" for table "d"
 create table exh_abc (like d);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 alter table d exchange default partition with table exh_abc;
 ERROR:  cannot exchange DEFAULT partition
 set gp_enable_exchange_default_partition = on;
@@ -745,7 +745,7 @@ NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_subothers" 
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_sub1" for table "sto_ao_ao_1_prt_5"
 NOTICE:  CREATE TABLE will create partition "sto_ao_ao_1_prt_5_2_prt_sub2" for table "sto_ao_ao_1_prt_5"
 create table exh_ao_ao (like sto_ao_ao) with (appendonly=true);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- Exchange default sub-partition, should fail
 alter table sto_ao_ao alter partition for (rank(3)) exchange default partition with table exh_ao_ao;
 ERROR:  cannot exchange DEFAULT partition
@@ -3073,7 +3073,7 @@ select * from rank;
 
 --exchange test
 create table r (like rank);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 insert into rank values(3, 3, 2004, 'F', 100);
 insert into r values(3, 3, 2004, 'F', 100000);
 alter table rank alter partition girls exchange partition year4 with table r;
@@ -3406,7 +3406,7 @@ NOTICE:  CREATE TABLE will create partition "rank_1_prt_9" for table "rank"
 alter table rank_1_prt_1 no inherit rank;
 ERROR:  can't alter inheritance on "rank_1_prt_1"; it is a partitioned table or part thereof
 create table rank2(like rank);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 alter table rank_1_prt_1 inherit rank2;
 ERROR:  can't alter inheritance on "rank_1_prt_1"; it is a partitioned table or part thereof
 alter table rank_1_prt_1 alter column i type bigint;
@@ -6098,7 +6098,7 @@ NOTICE:  CREATE TABLE will create partition "mpp6979part_1_prt_8" for table "mpp
 NOTICE:  CREATE TABLE will create partition "mpp6979part_1_prt_9" for table "mpp6979part"
 -- append-only table in new schema 
 create table mpp6979dummy.mpp6979tab(like mpp6979part) with (appendonly=true);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- check that table and all parts in public schema
 select schemaname, tablename, partitionschemaname, partitiontablename
 from pg_partitions 

--- a/src/test/regress/expected/qp_functions.out
+++ b/src/test/regress/expected/qp_functions.out
@@ -1195,7 +1195,7 @@ CREATE AGGREGATE agg_point_add1(
                                 STYPE=point
                         );
 create table agg_point_tbl (p point);
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 insert into agg_point_tbl values (POINT(3,5));
 insert into agg_point_tbl values (POINT(30,50));
 -- end_ignore

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -1294,7 +1294,7 @@ select * from qp_misc_jiras.tbl_694_1;
 (0 rows)
 
 create table qp_misc_jiras.tbl_694_2 (like qp_misc_jiras.tbl_694_1);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 select * from qp_misc_jiras.tbl_694_2;
  c1 | b1 
 ----+----

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -77,7 +77,7 @@ SELECT a FROM qp_misc_jiras.tbl3403_tab ORDER BY a;
 drop table qp_misc_jiras.tbl3403_tab;
 -- Check that CTAS chooses a sensible distribution key.
 create table qp_misc_jiras.tbl2788 as select * from generate_series(1, 1000);
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 \d qp_misc_jiras.tbl2788;
      Table "qp_misc_jiras.tbl2788"
      Column      |  Type   | Modifiers 
@@ -488,9 +488,9 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into qp_misc_jiras.tbl3183_t1 values (1), (1);
 select * into qp_misc_jiras.tbl3183_t2 from qp_misc_jiras.tbl3183_t1;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 select * into qp_misc_jiras.tbl3183_t3 from qp_misc_jiras.tbl3183_t1;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 select i from (select i from qp_misc_jiras.tbl3183_t2 union all select i from qp_misc_jiras.tbl3183_t3) tmpt where i in (select i from qp_misc_jiras.tbl3183_t2 union all select i from qp_misc_jiras.tbl3183_t3);
  i 
 ---
@@ -1291,7 +1291,7 @@ select * from qp_misc_jiras.tbl_694_1;
 (0 rows)
 
 create table qp_misc_jiras.tbl_694_2 (like qp_misc_jiras.tbl_694_1);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 select * from qp_misc_jiras.tbl_694_2;
  c1 | b1 
 ----+----
@@ -1756,11 +1756,11 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into qp_misc_jiras.tbl7126_ao select i, 'abcd'||i, '1981-10-02' from generate_series(1,100000)i;
 create table qp_misc_jiras.tbl7126_ao_zlib3 with (appendonly=true, compresstype = zlib, compresslevel=3 ) as select * from qp_misc_jiras.tbl7126_ao;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table qp_misc_jiras.tbl7126_co with (appendonly=true,orientation=column) as select * from qp_misc_jiras.tbl7126_ao_zlib3;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table qp_misc_jiras.tbl7126_co_zlib3  with (appendonly=true,orientation=column, compresstype=zlib, compresslevel=3) as select * from qp_misc_jiras.tbl7126_co;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- selects
 select count(*) from qp_misc_jiras.tbl7126_ao;
  count  
@@ -1921,7 +1921,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'visit
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 copy pre_visitor_ca_event_ao from STDIN with delimiter '~' null '';
 create table pre_visitor_ca_event_cao with (appendonly=true,orientation=column) as select * from pre_visitor_ca_event_ao;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 select count(*) from pre_visitor_ca_event_ao;
  count 
 -------
@@ -2118,7 +2118,7 @@ select count(*) from qp_misc_jiras.tbl7161_co;
 
 drop table qp_misc_jiras.tbl7161_co;
 select i, j into qp_misc_jiras.tbl6535_table from generate_series(1, 200) i, generate_series(1, 201) j;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
@@ -2461,7 +2461,7 @@ create table qp_misc_jiras.tbl7268_foo (a varchar(15), b varchar(15)) distribute
 Distributed by: (b)
 
 create table qp_misc_jiras.tbl7268_bar as select * from qp_misc_jiras.tbl7268_foo;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 \d qp_misc_jiras.tbl7268_bar; 
      Table "qp_misc_jiras.tbl7268_bar"
  Column |         Type          | Modifiers 
@@ -2482,7 +2482,7 @@ Table "qp_misc_jiras.tbl7268_foo"
 Distributed by: (b)
 
 create table qp_misc_jiras.tbl7268_bar as select * from qp_misc_jiras.tbl7268_foo;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 \d qp_misc_jiras.tbl7268_bar; 
 Table "qp_misc_jiras.tbl7268_bar"
  Column |  Type   | Modifiers 
@@ -2503,7 +2503,7 @@ create table qp_misc_jiras.tbl7268_foo (a varchar(15), b int) distributed by (b)
 Distributed by: (b)
 
 create table qp_misc_jiras.tbl7268_bar as select * from qp_misc_jiras.tbl7268_foo;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 \d qp_misc_jiras.tbl7268_bar; 
      Table "qp_misc_jiras.tbl7268_bar"
  Column |         Type          | Modifiers 
@@ -2524,7 +2524,7 @@ create table qp_misc_jiras.tbl7268_foo (a int, b varchar(15)) distributed by (b)
 Distributed by: (b)
 
 create table qp_misc_jiras.tbl7268_bar as select * from qp_misc_jiras.tbl7268_foo;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 \d qp_misc_jiras.tbl7268_bar; 
      Table "qp_misc_jiras.tbl7268_bar"
  Column |         Type          | Modifiers 
@@ -2549,7 +2549,7 @@ drop table if exists qp_misc_jiras.tbl6775_bar;
 --
 set optimizer_segments=3;
 create table qp_misc_jiras.sample as select generate_series(1,1000);
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table qp_misc_jiras.fim1 (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -2826,18 +2826,18 @@ set gp_autostats_mode=none;
 create table qp_misc_jiras.tbl_7498_t1(x int, y text) distributed by (x);
 insert into qp_misc_jiras.tbl_7498_t1 select x, 'foo' from generate_series(1,70000) x;
 create table qp_misc_jiras.tbl_7498_t2 as select * from qp_misc_jiras.tbl_7498_t1;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table qp_misc_jiras.tbl_7498_t3 as select * from qp_misc_jiras.tbl_7498_t1;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 drop table qp_misc_jiras.tbl_7498_t2;
 drop table if exists qp_misc_jiras.tbl_7498_t1, qp_misc_jiras.tbl_7498_t2, qp_misc_jiras.tbl_7498_t3 cascade;
 NOTICE:  table "tbl_7498_t2" does not exist, skipping
 create table qp_misc_jiras.tbl_7498_t1(x int, y text) distributed by (x);
 insert into qp_misc_jiras.tbl_7498_t1 select x, 'foo' from generate_series(1,70000) x;
 create table qp_misc_jiras.tbl_7498_t2 as select * from qp_misc_jiras.tbl_7498_t1;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table qp_misc_jiras.tbl_7498_t3 as select * from qp_misc_jiras.tbl_7498_t1;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- clean up all the test tables
 -- start_ignore
 drop table if exists qp_misc_jiras.tbl_7498_t1, qp_misc_jiras.tbl_7498_t2, qp_misc_jiras.tbl_7498_t3 cascade;

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1258,7 +1258,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into TblUp1 values(1,2),(3,4),(5,6);
 create table TblUp2 as select * from TblUp1;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table TblUp3(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -917,7 +917,7 @@ insert into mpp7620 values (200, 'horse');
 -- enable printing of printing info
 set test_print_direct_dispatch_info=on;
 Create table zoompp7620 as select * from mpp7620 where key=200;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to ALL contents

--- a/src/test/regress/expected/qp_with_clause.out
+++ b/src/test/regress/expected/qp_with_clause.out
@@ -8138,7 +8138,7 @@ group by region ) OUTERMOST_FOO,bad_headofstates,country
 where country.code = bad_headofstates.code and country.region = OUTERMOST_FOO.region
 order by OUTERMOST_FOO.region,bad_headofstates.headofstate LIMIT 40
 );
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 select * from bad_headofstates order by region,headofstate;
        avg        |          region           |           headofstate            
 ------------------+---------------------------+----------------------------------

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -332,7 +332,7 @@ drop table if exists mrs_u2;
 drop table if exists csq_m1;
 NOTICE:  table "csq_m1" does not exist, skipping
 create table csq_m1();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 set allow_system_table_mods='DML';
 delete from gp_distribution_policy where localoid='csq_m1'::regclass;
 reset allow_system_table_mods;
@@ -415,7 +415,7 @@ ORDER BY a.attnum
 --
 drop table if exists csq_m1;
 create table csq_m1();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 set allow_system_table_mods='DML';
 delete from gp_distribution_policy where localoid='csq_m1'::regclass;
 reset allow_system_table_mods;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -262,7 +262,7 @@ drop table if exists mrs_u2;
 drop table if exists csq_m1;
 NOTICE:  table "csq_m1" does not exist, skipping
 create table csq_m1();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 set allow_system_table_mods='DML';
 delete from gp_distribution_policy where localoid='csq_m1'::regclass;
 reset allow_system_table_mods;
@@ -345,7 +345,7 @@ ORDER BY a.attnum
 --
 drop table if exists csq_m1;
 create table csq_m1();
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 set allow_system_table_mods='DML';
 delete from gp_distribution_policy where localoid='csq_m1'::regclass;
 reset allow_system_table_mods;
@@ -992,11 +992,11 @@ NOTICE:  table "t3" does not exist, skipping
 drop table if exists t4; 
 NOTICE:  table "t4" does not exist, skipping
 CREATE TABLE t1 AS (SELECT generate_series(1, 5000) AS i, generate_series(5001, 10000) AS j);
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE TABLE t2 AS (SELECT * FROM t1 WHERE gp_segment_id = 0);
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE TABLE t3 AS (SELECT * FROM t1 WHERE gp_segment_id = 1);
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 CREATE TABLE t4 (i1 int, i2 int); 
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/uao_ddl/create_ao_tables_optimizer.out
+++ b/src/test/regress/expected/uao_ddl/create_ao_tables_optimizer.out
@@ -436,7 +436,7 @@ select count(*) from sto_uao_1;
 set gp_select_invisible=false;
 -- Select into
 select * into sto_heap_10 from sto_uao_8;
-NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 select count(*) from sto_heap_10;
  count 
 -------

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -7,20 +7,20 @@ m/^WARNING:  gpmon:.*No buffer space available socket.*/
 
 m/^ Optimizer status:.*/
 
-# We have disabled ignoring NOTICE statements because some tests rely on these
-# NOTICEs to verify that the test is correct e.g (vacuum). Ignoring them would
-# cause these tests to pass even when there is some discrepancy in the NOTICE
-# statements when they should actually fail. We would still like to ignore some
-# NOTICE statements which are harmless and show up regulary, will make it
-# easier to merge postgres tests and which keep changing with test runs.
-
-# The following NOTICE is generated when the user does not explicitly specify a
-# distribution policy for a table. It is to inform the user that the database
-# will pick a particular column in order to distribute the data. Merging tests
-# from postgres will cause the tests to output these messages and we would need
-# to manually modify the corresponding expected output. Hence we want to ignore
-# these.
-m/^NOTICE:.*Table doesn't have 'DISTRIBUTED BY' clause -- Using column named '.*' as the Greenplum Database data distribution key for this table./
+# There are a number of NOTICE and HINT messages around table distribution,
+# for example to inform the user that the database will pick a particular
+# column in order to distribute the data. Merging tests from postgres will
+# cause the tests to output these messages and we would need to manually
+# modify the corresponding expected output. Hence we want to ignore these.
+# Some of the messages include:
+#
+# NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named '<colname>' as the Greenplum Database data distribution key for this table.
+# NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+# HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+#
+# The following regex is intended to cover all permutations of the above set
+# of messages.
+m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
 
 # The following NOTICE is generated when a partitioned table is created. For
 # each child partition that gets created, it will generate a NOTICE saying that

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -2,9 +2,6 @@
 # match ignore the gpmon WARNING message
 m/^WARNING:  gpmon:.*Connection refused.*/
 
-# MPP-20400
-m/^WARNING:  gpmon:.*No buffer space available socket.*/
-
 m/^ Optimizer status:.*/
 
 # There are a number of NOTICE and HINT messages around table distribution,

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -633,7 +633,7 @@ CREATE EXTERNAL TABLE exttab_basic_4( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_more_errors.data') FORMAT 'TEXT' (DELIMITER '|') 
 LOG ERRORS SEGMENT REJECT LIMIT 100;
 CREATE TABLE exttab_insert_1 (LIKE exttab_basic_4);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 -- Insert should go through fine
 INSERT INTO exttab_insert_1 SELECT * FROM exttab_basic_4;
 NOTICE:  Found 6 data formatting errors (6 or more input rows). Rejected related input data.
@@ -1900,7 +1900,7 @@ SELECT * FROM gp_read_error_log('exttab_udfs_2')
 DROP TABLE IF EXISTS exttab_udfs_insert_2;
 NOTICE:  table "exttab_udfs_insert_2" does not exist, skipping
 CREATE TABLE exttab_udfs_insert_2 (LIKE exttab_udfs_1);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE OR REPLACE FUNCTION exttab_udfs_func2 ()
 RETURNS boolean
 AS $$
@@ -2112,7 +2112,7 @@ SELECT * FROM gp_read_error_log('exttab_union_2')
 DROP TABLE IF EXISTS exttab_union_insert_1;
 NOTICE:  table "exttab_union_insert_1" does not exist, skipping
 CREATE TABLE exttab_union_insert_1 (LIKE exttab_union_1);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 SELECT gp_truncate_error_log('exttab_union_1');
  gp_truncate_error_log 
 -----------------------

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -106,7 +106,7 @@ CREATE FUNCTION error(a anytable DEFAULT TABLE(select 1,'test')) RETURNS TABLE(a
 ERROR:  anytable parameter cannot have default value
 /* Negative test cases around the "anytable" type */
 CREATE TABLE fail(x anytable);
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 ERROR:  column "x" has pseudo-type anytable
 CREATE TYPE  fail AS (x anytable);
 ERROR:  column "x" has pseudo-type anytable

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -106,7 +106,7 @@ CREATE FUNCTION error(a anytable DEFAULT TABLE(select 1,'test')) RETURNS TABLE(a
 ERROR:  anytable parameter cannot have default value
 /* Negative test cases around the "anytable" type */
 CREATE TABLE fail(x anytable);
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 ERROR:  column "x" has pseudo-type anytable
 CREATE TYPE  fail AS (x anytable);
 ERROR:  column "x" has pseudo-type anytable

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/oid_inconsistency/pg_attrdef/expected/pg_attrdef.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/oid_inconsistency/pg_attrdef/expected/pg_attrdef.ans
@@ -44,7 +44,7 @@ drop table if exists t_like;
 psql:/path/sql_file:1: NOTICE:  table "t_like" does not exist, skipping
 DROP TABLE
 create table t_like (like t including defaults);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 select verify('t_like');
  verify 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/etablefunc_gppc/expected/query13.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/etablefunc_gppc/expected/query13.ans
@@ -1,5 +1,5 @@
 CREATE TABLE tmpTable1 (a anytable);
-NOTICE:  Table doesn't have 'distributed by' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 ERROR:  column "a" has pseudo-type anytable
 select * from transform( TABLE(
         select * from intable 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/etablefunc_gppc/sql/query13.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/etablefunc_gppc/sql/query13.sql
@@ -1,5 +1,5 @@
 -- Negative: using anytable as general data type should fail
--- NOTICE:  Table doesn't have 'distributed by' clause, 
+-- NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, 
 --          and no column type is suitable for a distribution key. 
 --          Creating a NULL policy entry.
     CREATE TABLE tmpTable1 (a anytable);

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_add_part1.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_add_part1.ans
@@ -17,7 +17,7 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_add_1_prt_2_2_prt_sp2" for table "mdt_part_tbl_add_1_prt_2"
 CREATE TABLE
 alter table mdt_part_tbl_add add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_add_1_prt_p1" for table "mdt_part_tbl_add"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_add_1_prt_p1_2_prt_sp1" for table "mdt_part_tbl_add_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_add_1_prt_p1_2_prt_sp2" for table "mdt_part_tbl_add_1_prt_p1"

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_add_part2.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_add_part2.ans
@@ -20,7 +20,7 @@ alter table mdt_part_tbl_add set subpartition template ();
 psql:/path/sql_file:1: NOTICE:  dropped level 1 subpartition template specification for relation "mdt_part_tbl_add"
 ALTER TABLE
 alter table mdt_part_tbl_add add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_add_1_prt_p3" for table "mdt_part_tbl_add"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_add_1_prt_p3_2_prt_sp3" for table "mdt_part_tbl_add_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_add_part3.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_add_part3.ans
@@ -5,7 +5,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_add_1_prt_foo" for table "mdt_part_tbl_add"
 CREATE TABLE
 alter table mdt_part_tbl_add add partition a1 start ('2007-01-01') end ('2007-02-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_add_1_prt_a1" for table "mdt_part_tbl_add"
 ALTER TABLE
 select classname,schemaname, objname, usestatus, usename, actionname, subtype, partitionlevel, parenttablename, parentschemaname  from pg_stat_partition_operations  where statime > ( select statime from pg_stat_partition_operations where objname ='my_first_table' and actionname ='CREATE') and objname  not in ('pg_stat_operations','pg_stat_partition_operations') order by statime;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_drop_default_part1.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_drop_default_part1.ans
@@ -14,7 +14,7 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_test_par
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_test_part1_1_prt_2_2_prt_1" for table "mdt_test_part1_1_prt_2"
 CREATE TABLE
 alter table mdt_test_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_test_part1_1_prt_default_part" for table "mdt_test_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_test_part1_1_prt_default_part_2_prt_1" for table "mdt_test_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_drop_default_part2.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_drop_default_part2.ans
@@ -14,7 +14,7 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_test_par
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_test_part1_1_prt_2_2_prt_1" for table "mdt_test_part1_1_prt_2"
 CREATE TABLE
 alter table mdt_test_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_test_part1_1_prt_default_part" for table "mdt_test_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_test_part1_1_prt_default_part_2_prt_1" for table "mdt_test_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_drop_part1.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_drop_part1.ans
@@ -5,7 +5,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_1_prt_foo" for table "mdt_part_tbl"
 CREATE TABLE
 alter table mdt_part_tbl add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_1_prt_a2" for table "mdt_part_tbl"
 ALTER TABLE
 alter table mdt_part_tbl DROP partition a2;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_drop_part2.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/alter_part_table_drop_part2.ans
@@ -5,7 +5,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_1_prt_foo" for table "mdt_part_tbl"
 CREATE TABLE
 alter table mdt_part_tbl add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "mdt_part_tbl_1_prt_a2" for table "mdt_part_tbl"
 ALTER TABLE
 alter table mdt_part_tbl DROP partition a2;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/setup/create_table_external.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/metadata_track/expected/setup/create_table_external.ans
@@ -15,7 +15,7 @@ CREATE external web TABLE mdt_e_REGION  ( R_REGIONKEY  INTEGER ,
                         on 1 format 'text' (delimiter '|');
 CREATE EXTERNAL TABLE
 CREATE WRITABLE EXTERNAL TABLE mdt_wet_region ( like mdt_region_1) LOCATION ('gpfdist://10.1.2.10:8088/view/wet_region.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 CREATE EXTERNAL TABLE mdt_ret_region ( like mdt_region_1) LOCATION ('gpfdist://10.1.2.10:8088/view/wet_region.tbl') FORMAT 'TEXT' (DELIMITER AS
 '|');

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/alter_table_exchange_partition.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/alter_table_exchange_partition.ans
@@ -48,7 +48,7 @@ drop table ret;
 DROP TABLE
 --end_ignore
 create table pt_ext_heap(like pt_ext);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table pt_ext exchange partition part1 with table pt_ext_heap;
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/distributed_randomly.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/external_partition/expected/distributed_randomly.ans.orca
@@ -34,7 +34,7 @@ CREATE TABLE
 insert into pt_ext select i,i,'test',true from generate_series(1,50) i;
 INSERT 0 50
 create temp table tmp as select * from pt_ext where col1 < 11;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 SELECT 10
 \! rm /tmp/exttab_list
 copy tmp to '/tmp/exttab_list' csv;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/basic.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/basic.ans
@@ -93,7 +93,7 @@ LOCATION ('gpfdist://@host@:@port@/exttab_basic_4.tbl') FORMAT 'TEXT' (DELIMITER
 LOG ERRORS SEGMENT REJECT LIMIT 100;
 CREATE EXTERNAL TABLE
 CREATE TABLE exttab_insert_1 (LIKE exttab_basic_4);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 -- Insert should go through fine
 INSERT INTO exttab_insert_1 SELECT * FROM exttab_basic_4;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/cte_43.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/cte_43.ans
@@ -96,7 +96,7 @@ DROP TABLE IF EXISTS exttab_cte_insert_1;
 psql:/path/sql_file:1: NOTICE:  table "exttab_cte_insert_1" does not exist, skipping
 DROP TABLE
 CREATE TABLE exttab_cte_insert_1 (LIKE exttab_cte_1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 SELECT gp_truncate_error_log('exttab_cte_1');
  gp_truncate_error_log 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/cte_master.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/cte_master.ans
@@ -94,7 +94,7 @@ DROP TABLE IF EXISTS exttab_cte_insert_1;
 psql:/path/sql_file:1: NOTICE:  table "exttab_cte_insert_1" does not exist, skipping
 DROP TABLE
 CREATE TABLE exttab_cte_insert_1 (LIKE exttab_cte_1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 SELECT gp_truncate_error_log('exttab_cte_1');
  gp_truncate_error_log 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/mpp22974.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/mpp22974.ans
@@ -106,7 +106,7 @@ SELECT COUNT(*) from gp_read_error_log('exttab_first_reject_limit_2');
 DROP TABLE IF EXISTS test_first_segment_reject_limit;
 DROP TABLE
 CREATE TABLE test_first_segment_reject_limit (LIKE exttab_first_reject_limit_1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 SET gp_initial_bad_row_limit = 500;
 SET

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/udfs.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/udfs.ans
@@ -130,7 +130,7 @@ DROP TABLE IF EXISTS exttab_udfs_insert_2;
 psql:/path/sql_file:1: NOTICE:  table "exttab_udfs_insert_2" does not exist, skipping
 DROP TABLE
 CREATE TABLE exttab_udfs_insert_2 (LIKE exttab_udfs_1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 CREATE OR REPLACE FUNCTION exttab_udfs_func2 ()
 RETURNS boolean

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/unions.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/queries/basic/exttab/errlog/expected/unions.ans
@@ -57,7 +57,7 @@ SELECT * FROM gp_read_error_log('exttab_union_2')
 DROP TABLE IF EXISTS exttab_union_insert_1;
 DROP TABLE
 CREATE TABLE exttab_union_insert_1 (LIKE exttab_union_1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 SELECT gp_truncate_error_log('exttab_union_1');
  gp_truncate_error_log 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/gpctas.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/gpctas.ans.orca
@@ -39,13 +39,13 @@ DROP TABLE
 drop table if exists ctas_baz;
 DROP TABLE
 create table ctas_foo as select * from generate_series(1, 100);
-psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:35: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:35: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 SELECT 100
 create table ctas_bar as select a.generate_series as a, b.generate_series as b from ctas_foo a, ctas_foo b;
-psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:36: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:36: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 SELECT 10000
 create table ctas_baz as select 'delete me' as action, * from ctas_bar;
-psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:38: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:38: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:38: WARNING:  column "action" has type "unknown"
 DETAIL:  Proceeding with relation creation anyway.
 SELECT 10000

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/strings.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/strings.ans.orca
@@ -951,7 +951,7 @@ select * from (select 'a' as a, 'b' as b, 'c' as c, 1 as d)d union select 'a' as
 -- Make sure we can convert unknown to other useful types (MPP-4298)
 create table t as select j as a, 'abc' as i from
 generate_series(1, 10) j;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 psql:/path/sql_file:1: WARNING:  column "i" has type "unknown"
 DETAIL:  Proceeding with relation creation anyway.
 SELECT 10

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/expected/ctas_tables.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/access_methods/storage_parameters/expected/ctas_tables.ans.orca
@@ -48,7 +48,7 @@ Drop table if exists ao_db_ap_ctas;
 psql:/path/sql_file:1: NOTICE:  table "ao_db_ap_ctas" does not exist, skipping
 DROP TABLE
 Create table ao_db_ap_ctas as select * from ao_db_ap_base;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 SELECT 10
 \d+ ao_db_ap_ctas;
        Append-Only Table "public.ao_db_ap_ctas"
@@ -96,7 +96,7 @@ Drop table if exists ao_db_ap_ctas;
 psql:/path/sql_file:1: NOTICE:  table "ao_db_ap_ctas" does not exist, skipping
 DROP TABLE
 Create table ao_db_ap_ctas as select * from ao_db_ap_base;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 SELECT 10
 \d+ ao_db_ap_ctas;
                             Append-Only Columnar Table "public.ao_db_ap_ctas"
@@ -130,7 +130,7 @@ Drop table if exists ao_db_ap_ctas;
 psql:/path/sql_file:1: NOTICE:  table "ao_db_ap_ctas" does not exist, skipping
 DROP TABLE
 Create table ao_db_ap_ctas as select * from ao_db_ap_base;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 SELECT 10
 \d+ ao_db_ap_ctas;
        Append-Only Table "public.ao_db_ap_ctas"
@@ -159,7 +159,7 @@ Drop table if exists ao_db_ap_ctas;
 psql:/path/sql_file:1: NOTICE:  table "ao_db_ap_ctas" does not exist, skipping
 DROP TABLE
 Create table ao_db_ap_ctas with( appendonly=true, orientation=column) as select * from ao_db_ap_base;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 SELECT 10
 \d+ ao_db_ap_ctas;
                             Append-Only Columnar Table "public.ao_db_ap_ctas"

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/expected/other_tests/ao_co_alter_table.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/expected/other_tests/ao_co_alter_table.ans
@@ -267,7 +267,7 @@ LINE 2:  FROM carpe_diem
 -- without specifying whether the table should be column-oriented.  
 -- Should it automatically acquire the column-orientedness of the parent?
 CREATE TABLE like1 (LIKE carp_die);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 INSERT INTO like1 SELECT * FROM carp_die;
 INSERT 0 5
@@ -305,7 +305,7 @@ SELECT id, wealth
 -- Create a table with the same structure as carp_die, using the LIKE clause, 
 -- but this time specify that the table should be column-oriented.  
 CREATE TABLE like2 (LIKE carp_die) WITH (appendonly=True, orientation='column');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 INSERT INTO like2 SELECT * FROM carp_die;
 INSERT 0 5

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/expected/other_tests/negative_tests_1.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/expected/other_tests/negative_tests_1.ans
@@ -230,7 +230,7 @@ DROP TABLE
 Create table parent_like1 (a1 int ENCODING (compresstype=zlib,compresslevel=9,blocksize=32768),a2 char(5),a3  date)  with (appendonly=true,orientation=column) distributed by (a1);
 CREATE TABLE
 Create table child_like1 (like parent_like1) with (appendonly = true, orientation = column);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 \d+ parent_like1
                                 Append-Only Columnar Table "public.parent_like1"
@@ -264,7 +264,7 @@ DROP TABLE
 Create table parent_like2 (a1 int ,a2 char(5),a3  date, column a1 ENCODING (compresstype=zlib,compresslevel=9,blocksize=32768))  with (appendonly=true,orientation=column) distributed by (a1);
 CREATE TABLE
 Create table child_like2  (like parent_like2) with (appendonly = true, orientation = column);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 \d+ parent_like2
                                 Append-Only Columnar Table "public.parent_like2"
@@ -303,7 +303,7 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "parent_like3
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "parent_like3_1_prt_2" for table "parent_like3"
 CREATE TABLE
 Create table child_like3  (like parent_like3) with (appendonly = true, orientation = column) Partition by range(a1) (start(1) end(1000) every(500));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "child_like3_1_prt_1" for table "child_like3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "child_like3_1_prt_2" for table "child_like3"
 CREATE TABLE
@@ -362,7 +362,7 @@ Create table child_like4  (like parent_like4) with (appendonly = true, orientati
         ( subpartition part1 values('M') ,
           subpartition part2 values('F')) 
         (start(1) end(1000) every(500));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "child_like4_1_prt_1" for table "child_like4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "child_like4_1_prt_2" for table "child_like4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "child_like4_1_prt_1_2_prt_part1" for table "child_like4_1_prt_1"
@@ -416,7 +416,7 @@ CREATE TABLE
 Insert into parent_like5 values(generate_series(1,100),'asd','2011-02-11');
 INSERT 0 100
 Create table child_like5  (like parent_like5) with (appendonly = true, orientation = column,compresstype=quicklz,compresslevel=1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 \d+ parent_like5
                                 Append-Only Columnar Table "public.parent_like5"

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/exttableext/expected/exttableext.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/exttableext/expected/exttableext.ans
@@ -909,7 +909,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE exttabtest_w_invalid(like exttabtest)
         LOCATION('demoprot://exttabtest_invalid.txt') 
     FORMAT 'text';
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     -- Drop a column (id) from WET
     ALTER EXTERNAL TABLE exttabtest_w_invalid DROP COLUMN id;
@@ -1012,7 +1012,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_w(like formatsource) 
     LOCATION ('demoprot://exttabtest_test63') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_i');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_r;
 psql:/path/sql_file:1: NOTICE:  table "format_r" does not exist, skipping
@@ -1030,7 +1030,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_w(like formatsource) 
     LOCATION ('demoprot://exttabtest_test63') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_r;
 DROP EXTERNAL TABLE
@@ -1217,7 +1217,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_w_s1(like formatsource) 
         LOCATION ('demoprot://exttabtest_test67_s1') 
         FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_r_s1;
 psql:/path/sql_file:1: NOTICE:  table "format_r_s1" does not exist, skipping
@@ -1234,7 +1234,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_w_s2(like formatsource) 
         LOCATION ('demoprot://exttabtest_test67_s2') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_r_s2;
 psql:/path/sql_file:1: NOTICE:  table "format_r_s2" does not exist, skipping
@@ -1319,7 +1319,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_long_w(like format_long) 
     LOCATION ('demoprot://exttabtest_test71.txt') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_long_r;
 psql:/path/sql_file:1: NOTICE:  table "format_long_r" does not exist, skipping
@@ -1404,7 +1404,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_long_w(like format_long) 
     LOCATION ('demoprot://exttabtest_test72.txt') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_long_r;
 DROP EXTERNAL TABLE
@@ -1463,7 +1463,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_long_w(like format_long) 
     LOCATION ('demoprot://exttabtest_test73.txt') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_long_r;
 DROP EXTERNAL TABLE
@@ -1521,7 +1521,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_long_w(like format_long) 
     LOCATION ('demoprot://format_long_test14') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_long_r;
 DROP EXTERNAL TABLE
@@ -1570,7 +1570,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_w(like formatsource) 
     LOCATION ('demoprot://format_test15') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_r;
 DROP EXTERNAL TABLE
@@ -1625,7 +1625,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_w(like formatsource) 
     LOCATION ('demoprot://exttabtest_test76.txt') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_r;
 DROP EXTERNAL TABLE
@@ -1683,7 +1683,7 @@ DROP EXTERNAL TABLE
     CREATE WRITABLE EXTERNAL TABLE format_w(like formatsource) 
     LOCATION ('demoprot://exttabtest_test77.txt') 
     FORMAT 'CUSTOM' (FORMATTER='formatter_export_s');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
     DROP EXTERNAL TABLE IF EXISTS format_r;
 DROP EXTERNAL TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional.ans
@@ -16,7 +16,7 @@ INSERT 0 1
 insert into all_types values ('1','0','t','c','varchar5','char5','varchar5','2005-11-11',234.23234,23,'24',234,23,4,'12:12:12',2,3,'d','10.1.3.45',1,'10.1.3.45','EE:EE:EE:EE:EE:EE','34.23',5,'text5','00:00:00','00:00:00+1359','2005-12-13 01:51:15','2005-12-13 01:51:15+1359');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_all_types ( like all_types) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_alltypes.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_all_types SELECT * FROM all_types;
 INSERT 0 5
@@ -30,7 +30,7 @@ INSERT 0 1
 insert into ao_table values (3,'test_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_ao ( like ao_table) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_ao.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_ao SELECT * FROM ao_table;
 INSERT 0 3
@@ -44,7 +44,7 @@ INSERT 0 1
 insert into co_table values (3,'test_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_co ( like co_table) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_co.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_co SELECT * FROM co_table;
 INSERT 0 3
@@ -68,7 +68,7 @@ INSERT 0 1
 INSERT INTO table_with_default_constraint  (col_with_default_numeric,col_with_constraint) VALUES (35,4);
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_non_supported_sql ( like table_with_default_constraint) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_non_supported_sql.tbl') FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_non_supported_sql SELECT * FROM table_with_default_constraint;
 INSERT 0 6
@@ -89,7 +89,7 @@ psql:/path/sql_file:1: ERROR:  cannot create indexes on external tables.
 CREATE INDEX test_index ON table_with_default_constraint (col_with_constraint);
 CREATE INDEX
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_non_supported_sql_idx ( like table_with_default_constraint) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_non_supported_sql_idx.tbl') FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 CREATE INDEX test_index ON tbl_wet_non_supported_sql_idx (col_with_constraint);
 psql:/path/sql_file:1: ERROR:  cannot create indexes on external tables.
@@ -107,7 +107,7 @@ INSERT 0 1
 INSERT INTO table_constraint  VALUES (300,'name_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet ( like table_constraint) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_ctas.tbl' ) FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 CREATE TABLE tbl_wet_ctas AS SELECT * from tbl_wet_non_supported_sql;
 psql:/path/sql_file:1: ERROR:  it is not possible to read from a WRITABLE external table.
@@ -128,7 +128,7 @@ INSERT 0 1
 INSERT INTO table_distributed_randomly VALUES ('2_zero', 2, '2_zero', 2);
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_select ( like table_distributed_randomly) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_select.tbl' ) FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_select SELECT * FROM table_distributed_randomly;
 INSERT 0 3
@@ -163,7 +163,7 @@ insert into region_1 select * from e_region;
 INSERT 0 5
 -- create WET with similiar schema def as the original heap table 
 CREATE WRITABLE EXTERNAL TABLE wet_region ( like region_1) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_region.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- insert data into the WET selecting from original table
 INSERT INTO wet_region SELECT * FROM region_1;
@@ -173,7 +173,7 @@ CREATE EXTERNAL TABLE ret_region ( like region_1) LOCATION ('gpfdist://@hostname
 CREATE EXTERNAL TABLE
 -- create second table with same schema def
 CREATE TABLE region_2 (like region_1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 -- insert into the second table reading from the RET
 INSERT INTO region_2 SELECT * FROM ret_region;
@@ -212,7 +212,7 @@ INSERT 0 1
 INSERT INTO table_execute  VALUES (300,'name_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_execute ( like table_execute) EXECUTE ' cat > wet_execute.tbl' FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO  tbl_wet_execute SELECT * from table_execute ;
 INSERT 0 3
@@ -235,28 +235,28 @@ insert into all_types_csv values ('1','0','t','e','varchar5','char5','varchar5',
 INSERT 0 1
 -- with AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv1 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- without AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv2 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS ',' NULL 'null' ESCAPE ' ');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with header
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv3 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  HEADER ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  HEADER is not yet supported for writable external tables
 -- with double quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv4 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with single quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv5 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL
  AS 'null' ESCAPE AS ' '  QUOTE AS '''') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with force quote
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv6 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"' FORCE QUOTE char1) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --Table with all data types
     CREATE TABLE all_types_text ( bit1 bit(1), bit2 bit varying(50), boolean1 boolean, char1 char(1), charvar1 character varying(50), char2 character(50),
@@ -277,32 +277,32 @@ insert into all_types_text values ('1','0','t','e','varchar5','char5','varchar5'
 INSERT 0 1
 -- with AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text1 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- without AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text2 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS ',' NULL 'null' ESCAPE ' ');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with ESCAPE OFF
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text3 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|'
 NULL AS 'null' ESCAPE 'OFF') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with header
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text4 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  HEADER ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  HEADER is not yet supported for writable external tables
 -- with double quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text5 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  quote available only in CSV mode
 -- with single quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text6 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '''') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  quote available only in CSV mode
 -- with force quote
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text7 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ' FORCE QUOTE char1) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  force quote available only in CSV mode
 create table test_tbl_for_view1 (a int, b text);
 psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -313,7 +313,7 @@ INSERT 0 5
 create view test_view1 as select * from test_tbl_for_view1;
 CREATE VIEW
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_view1 (like  test_tbl_for_view1) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_view.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 insert into tbl_wet_view1 select * from test_view1;
 INSERT 0 5
@@ -343,7 +343,7 @@ CREATE TABLE
 INSERT INTO test_order_by VALUES ( generate_series(1,5), 'test_1');
 INSERT 0 5
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_order_by(like  test_order_by) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_tbl_order_by.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO  tbl_wet_order_by SELECT * FROM  test_order_by ORDER BY a;
 INSERT 0 5
@@ -354,7 +354,7 @@ CREATE TABLE
 INSERT INTO test_tran VALUES ( generate_series(1,5), 'test_1');
 INSERT 0 5
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_tran(like  test_tran) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_tbl_tran.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 BEGIN;
 BEGIN

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional.ans.orca
@@ -18,7 +18,7 @@ INSERT 0 1
 insert into all_types values ('1','0','t','c','varchar5','char5','varchar5','2005-11-11',234.23234,23,'24',234,23,4,'12:12:12',2,3,'d','0.0.0.0',1,'0.0.0.0','EE:EE:EE:EE:EE:EE','34.23',5,'text5','00:00:00','00:00:00+1359','2005-12-13 01:51:15','2005-12-13 01:51:15+1359');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_all_types ( like all_types) LOCATION ('gpfdist://test1:8080/output/wet_alltypes.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_all_types SELECT * FROM all_types;
 INSERT 0 5
@@ -32,7 +32,7 @@ INSERT 0 1
 insert into ao_table values (3,'test_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_ao ( like ao_table) LOCATION ('gpfdist://test1:8080/output/wet_ao.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_ao SELECT * FROM ao_table;
 INSERT 0 3
@@ -46,7 +46,7 @@ INSERT 0 1
 insert into co_table values (3,'test_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_co ( like co_table) LOCATION ('gpfdist://test1:8080/output/wet_co.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_co SELECT * FROM co_table;
 INSERT 0 3
@@ -70,7 +70,7 @@ INSERT 0 1
 INSERT INTO table_with_default_constraint  (col_with_default_numeric,col_with_constraint) VALUES (35,4);
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_non_supported_sql ( like table_with_default_constraint) LOCATION ('gpfdist://test1:8080/output/wet_non_supported_sql.tbl') FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_non_supported_sql SELECT * FROM table_with_default_constraint;
 INSERT 0 6
@@ -91,7 +91,7 @@ psql:/path/sql_file:1: ERROR:  cannot create indexes on external tables.
 CREATE INDEX test_index ON table_with_default_constraint (col_with_constraint);
 CREATE INDEX
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_non_supported_sql_idx ( like table_with_default_constraint) LOCATION ('gpfdist://test1:8080/output/wet_non_supported_sql_idx.tbl') FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 CREATE INDEX test_index ON tbl_wet_non_supported_sql_idx (col_with_constraint);
 psql:/path/sql_file:1: ERROR:  cannot create indexes on external tables.
@@ -109,10 +109,10 @@ INSERT 0 1
 INSERT INTO table_constraint  VALUES (300,'name_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet ( like table_constraint) LOCATION ('gpfdist://test1:8080/output/wet_ctas.tbl' ) FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 CREATE TABLE tbl_wet_ctas AS SELECT * from tbl_wet_non_supported_sql;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 psql:/path/sql_file:1: ERROR:  External scan error: It is not possible to read from a WRITABLE external table. Create the table as READABLE instead. (COptTasks.cpp:1679)
 --negative testing
 -- selecting from WET should error
@@ -130,7 +130,7 @@ INSERT 0 1
 INSERT INTO table_distributed_randomly VALUES ('2_zero', 2, '2_zero', 2);
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_select ( like table_distributed_randomly) LOCATION ('gpfdist://test1:8080/output/wet_select.tbl' ) FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_select SELECT * FROM table_distributed_randomly;
 INSERT 0 3
@@ -164,7 +164,7 @@ insert into region_1 select * from e_region;
 INSERT 0 5
 -- create WET with similiar schema def as the original heap table 
 CREATE WRITABLE EXTERNAL TABLE wet_region ( like region_1) LOCATION ('gpfdist://test1:8080/output/wet_region.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- insert data into the WET selecting from original table
 INSERT INTO wet_region SELECT * FROM region_1;
@@ -174,7 +174,7 @@ CREATE EXTERNAL TABLE ret_region ( like region_1) LOCATION ('gpfdist://test1:808
 CREATE EXTERNAL TABLE
 -- create second table with same schema def
 CREATE TABLE region_2 (like region_1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 -- insert into the second table reading from the RET
 INSERT INTO region_2 SELECT * FROM ret_region;
@@ -213,7 +213,7 @@ INSERT 0 1
 INSERT INTO table_execute  VALUES (300,'name_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_execute ( like table_execute) EXECUTE ' cat > wet_execute.tbl' FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO  tbl_wet_execute SELECT * from table_execute ;
 INSERT 0 3
@@ -236,28 +236,28 @@ insert into all_types_csv values ('1','0','t','e','varchar5','char5','varchar5',
 INSERT 0 1
 -- with AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv1 (like all_types_csv)LOCATION ('gpfdist://test1:8080/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- without AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv2 (like all_types_csv)LOCATION ('gpfdist://test1:8080/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS ',' NULL 'null' ESCAPE ' ');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with header
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv3 (like all_types_csv)LOCATION ('gpfdist://test1:8080/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  HEADER ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  HEADER is not yet supported for writable external tables
 -- with double quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv4 (like all_types_csv)LOCATION ('gpfdist://test1:8080/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with single quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv5 (like all_types_csv)LOCATION ('gpfdist://test1:8080/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL
  AS 'null' ESCAPE AS ' '  QUOTE AS '''') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with force quote
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv6 (like all_types_csv)LOCATION ('gpfdist://test1:8080/output/wet_csv.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"' FORCE QUOTE char1) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --Table with all data types
     CREATE TABLE all_types_text ( bit1 bit(1), bit2 bit varying(50), boolean1 boolean, char1 char(1), charvar1 character varying(50), char2 character(50),
@@ -278,32 +278,32 @@ insert into all_types_text values ('1','0','t','e','varchar5','char5','varchar5'
 INSERT 0 1
 -- with AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text1 (like all_types_text)LOCATION ('gpfdist://test1:8080/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- without AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text2 (like all_types_text)LOCATION ('gpfdist://test1:8080/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS ',' NULL 'null' ESCAPE ' ');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with ESCAPE OFF
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text3 (like all_types_text)LOCATION ('gpfdist://test1:8080/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|'
 NULL AS 'null' ESCAPE 'OFF') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with header
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text4 (like all_types_text)LOCATION ('gpfdist://test1:8080/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  HEADER ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  HEADER is not yet supported for writable external tables
 -- with double quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text5 (like all_types_text)LOCATION ('gpfdist://test1:8080/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  quote available only in CSV mode
 -- with single quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text6 (like all_types_text)LOCATION ('gpfdist://test1:8080/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '''') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  quote available only in CSV mode
 -- with force quote
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text7 (like all_types_text)LOCATION ('gpfdist://test1:8080/output/wet_text.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ' FORCE QUOTE char1) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  force quote available only in CSV mode
 create table test_tbl_for_view1 (a int, b text);
 psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -314,7 +314,7 @@ INSERT 0 5
 create view test_view1 as select * from test_tbl_for_view1;
 CREATE VIEW
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_view1 (like  test_tbl_for_view1) LOCATION ('gpfdist://test1:8080/output/wet_view.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 insert into tbl_wet_view1 select * from test_view1;
 INSERT 0 5
@@ -344,7 +344,7 @@ CREATE TABLE
 INSERT INTO test_order_by VALUES ( generate_series(1,5), 'test_1');
 INSERT 0 5
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_order_by(like  test_order_by) LOCATION ('gpfdist://test1:8080/output/wet_tbl_order_by.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO  tbl_wet_order_by SELECT * FROM  test_order_by ORDER BY a;
 INSERT 0 5
@@ -355,7 +355,7 @@ CREATE TABLE
 INSERT INTO test_tran VALUES ( generate_series(1,5), 'test_1');
 INSERT 0 5
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_tran(like  test_tran) LOCATION ('gpfdist://test1:8080/output/wet_tbl_tran.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 BEGIN;
 BEGIN

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional_dsp.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional_dsp.ans
@@ -26,7 +26,7 @@ INSERT 0 1
 insert into all_types values ('1','0','t','c','varchar5','char5','varchar5','2005-11-11',234.23234,23,'24',234,23,4,'12:12:12',2,3,'d','0.0.0.0',1,'0.0.0.0','EE:EE:EE:EE:EE:EE','34.23',5,'text5','00:00:00','00:00:00+1359','2005-12-13 01:51:15','2005-12-13 01:51:15+1359');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_all_types ( like all_types) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_alltypes_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_all_types SELECT * FROM all_types;
 INSERT 0 5
@@ -42,7 +42,7 @@ INSERT 0 1
 insert into ao_table values (3,'test_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_ao ( like ao_table) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_ao_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 \d+ tbl_wet_ao
           External table "dsp_ext.tbl_wet_ao"
@@ -70,7 +70,7 @@ INSERT 0 1
 insert into co_table values (3,'test_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_co ( like co_table) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_co_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_co SELECT * FROM co_table;
 INSERT 0 3
@@ -98,7 +98,7 @@ INSERT 0 1
 set gp_default_storage_options='appendonly=true, orientation=column';
 SET
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_non_supported_sql ( like table_with_default_constraint) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_non_supported_sql_dsp.tbl') FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_non_supported_sql SELECT * FROM table_with_default_constraint;
 INSERT 0 6
@@ -119,7 +119,7 @@ psql:/path/sql_file:1: ERROR:  cannot create indexes on external tables.
 CREATE INDEX test_index ON table_with_default_constraint (col_with_constraint);
 CREATE INDEX
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_non_supported_sql_idx ( like table_with_default_constraint) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_non_supported_sql_idx_dsp.tbl') FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 CREATE INDEX test_index ON tbl_wet_non_supported_sql_idx (col_with_constraint);
 psql:/path/sql_file:1: ERROR:  cannot create indexes on external tables.
@@ -137,7 +137,7 @@ INSERT 0 1
 INSERT INTO table_constraint  VALUES (300,'name_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet ( like table_constraint) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_ctas_dsp.tbl' ) FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 CREATE TABLE tbl_wet_ctas AS SELECT * from tbl_wet_non_supported_sql;
 psql:/path/sql_file:1: ERROR:  it is not possible to read from a WRITABLE external table.
@@ -158,7 +158,7 @@ INSERT 0 1
 INSERT INTO table_distributed_randomly VALUES ('2_zero', 2, '2_zero', 2);
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_select ( like table_distributed_randomly) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_select_dsp.tbl' ) FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_select SELECT * FROM table_distributed_randomly;
 INSERT 0 3
@@ -193,7 +193,7 @@ insert into region_1 select * from e_region;
 INSERT 0 5
 -- create WET with similiar schema def as the original heap table 
 CREATE WRITABLE EXTERNAL TABLE wet_region ( like region_1) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_region_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- insert data into the WET selecting from original table
 INSERT INTO wet_region SELECT * FROM region_1;
@@ -203,7 +203,7 @@ CREATE EXTERNAL TABLE ret_region ( like region_1) LOCATION ('gpfdist://@hostname
 CREATE EXTERNAL TABLE
 -- create second table with same schema def
 CREATE TABLE region_2 (like region_1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 -- insert into the second table reading from the RET
 INSERT INTO region_2 SELECT * FROM ret_region;
@@ -242,7 +242,7 @@ INSERT 0 1
 INSERT INTO table_execute  VALUES (300,'name_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_execute ( like table_execute) EXECUTE ' cat > wet_execute_dsp.tbl' FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO  tbl_wet_execute SELECT * from table_execute ;
 INSERT 0 3
@@ -265,28 +265,28 @@ insert into all_types_csv values ('1','0','t','e','varchar5','char5','varchar5',
 INSERT 0 1
 -- with AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv1 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- without AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv2 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS ',' NULL 'null' ESCAPE ' ');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with header
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv3 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  HEADER ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  HEADER is not yet supported for writable external tables
 -- with double quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv4 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with single quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv5 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL
  AS 'null' ESCAPE AS ' '  QUOTE AS '''') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with force quote
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv6 (like all_types_csv)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"' FORCE QUOTE char1) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --Table with all data types
     CREATE TABLE all_types_text ( bit1 bit(1), bit2 bit varying(50), boolean1 boolean, char1 char(1), charvar1 character varying(50), char2 character(50),
@@ -307,32 +307,32 @@ insert into all_types_text values ('1','0','t','e','varchar5','char5','varchar5'
 INSERT 0 1
 -- with AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text1 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- without AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text2 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS ',' NULL 'null' ESCAPE ' ');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with ESCAPE OFF
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text3 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|'
 NULL AS 'null' ESCAPE 'OFF') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with header
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text4 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  HEADER ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  HEADER is not yet supported for writable external tables
 -- with double quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text5 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  quote available only in CSV mode
 -- with single quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text6 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '''') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  quote available only in CSV mode
 -- with force quote
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text7 (like all_types_text)LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ' FORCE QUOTE char1) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  force quote available only in CSV mode
 create table test_tbl_for_view1 (a int, b text);
 psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -343,7 +343,7 @@ INSERT 0 5
 create view test_view1 as select * from test_tbl_for_view1;
 CREATE VIEW
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_view1 (like  test_tbl_for_view1) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_view.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 insert into tbl_wet_view1 select * from test_view1;
 INSERT 0 5
@@ -373,7 +373,7 @@ CREATE TABLE
 INSERT INTO test_order_by VALUES ( generate_series(1,5), 'test_1');
 INSERT 0 5
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_order_by(like  test_order_by) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_tbl_order_by.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO  tbl_wet_order_by SELECT * FROM  test_order_by ORDER BY a;
 INSERT 0 5
@@ -384,7 +384,7 @@ CREATE TABLE
 INSERT INTO test_tran VALUES ( generate_series(1,5), 'test_1');
 INSERT 0 5
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_tran(like  test_tran) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_tbl_tran.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 BEGIN;
 BEGIN

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional_dsp.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional_dsp.ans.orca
@@ -27,7 +27,7 @@ INSERT 0 1
 insert into all_types values ('1','0','t','c','varchar5','char5','varchar5','2005-11-11',234.23234,23,'24',234,23,4,'12:12:12',2,3,'d','0.0.0.0',1,'0.0.0.0','EE:EE:EE:EE:EE:EE','34.23',5,'text5','00:00:00','00:00:00+1359','2005-12-13 01:51:15','2005-12-13 01:51:15+1359');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_all_types ( like all_types) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_alltypes_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_all_types SELECT * FROM all_types;
 INSERT 0 5
@@ -43,7 +43,7 @@ INSERT 0 1
 insert into ao_table values (3,'test_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_ao ( like ao_table) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_ao_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 \d+ tbl_wet_ao
           External table "dsp_ext.tbl_wet_ao"
@@ -71,7 +71,7 @@ INSERT 0 1
 insert into co_table values (3,'test_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_co ( like co_table) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_co_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_co SELECT * FROM co_table;
 INSERT 0 3
@@ -99,7 +99,7 @@ INSERT 0 1
 set gp_default_storage_options='appendonly=true, orientation=column';
 SET
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_non_supported_sql ( like table_with_default_constraint) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_non_supported_sql_dsp.tbl') FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_non_supported_sql SELECT * FROM table_with_default_constraint;
 INSERT 0 6
@@ -120,7 +120,7 @@ psql:/path/sql_file:1: ERROR:  cannot create indexes on external tables.
 CREATE INDEX test_index ON table_with_default_constraint (col_with_constraint);
 CREATE INDEX
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_non_supported_sql_idx ( like table_with_default_constraint) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_non_supported_sql_idx_dsp.tbl') FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 CREATE INDEX test_index ON tbl_wet_non_supported_sql_idx (col_with_constraint);
 psql:/path/sql_file:1: ERROR:  cannot create indexes on external tables.
@@ -138,10 +138,10 @@ INSERT 0 1
 INSERT INTO table_constraint  VALUES (300,'name_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet ( like table_constraint) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_ctas_dsp.tbl' ) FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 CREATE TABLE tbl_wet_ctas AS SELECT * from tbl_wet_non_supported_sql;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 psql:/path/sql_file:1: ERROR:  External scan error: It is not possible to read from a WRITABLE external table. Create the table as READABLE instead. (COptTasks.cpp:1731)
 --negative testing
 -- selecting from WET should error
@@ -159,7 +159,7 @@ INSERT 0 1
 INSERT INTO table_distributed_randomly VALUES ('2_zero', 2, '2_zero', 2);
 INSERT 0 1
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_select ( like table_distributed_randomly) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_select_dsp.tbl' ) FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_select SELECT * FROM table_distributed_randomly;
 INSERT 0 3
@@ -193,7 +193,7 @@ insert into region_1 select * from e_region;
 INSERT 0 5
 -- create WET with similiar schema def as the original heap table 
 CREATE WRITABLE EXTERNAL TABLE wet_region ( like region_1) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_region_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- insert data into the WET selecting from original table
 INSERT INTO wet_region SELECT * FROM region_1;
@@ -203,7 +203,7 @@ CREATE EXTERNAL TABLE ret_region ( like region_1) LOCATION ('gpfdist://vraghavan
 CREATE EXTERNAL TABLE
 -- create second table with same schema def
 CREATE TABLE region_2 (like region_1);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 -- insert into the second table reading from the RET
 INSERT INTO region_2 SELECT * FROM ret_region;
@@ -242,7 +242,7 @@ INSERT 0 1
 INSERT INTO table_execute  VALUES (300,'name_3');
 INSERT 0 1
 CREATE WRITABLE EXTERNAL WEB TABLE tbl_wet_execute ( like table_execute) EXECUTE ' cat > wet_execute_dsp.tbl' FORMAT 'TEXT'  (DELIMITER '|' ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO  tbl_wet_execute SELECT * from table_execute ;
 INSERT 0 3
@@ -265,28 +265,28 @@ insert into all_types_csv values ('1','0','t','e','varchar5','char5','varchar5',
 INSERT 0 1
 -- with AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv1 (like all_types_csv)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- without AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv2 (like all_types_csv)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS ',' NULL 'null' ESCAPE ' ');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with header
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv3 (like all_types_csv)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  HEADER ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  HEADER is not yet supported for writable external tables
 -- with double quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv4 (like all_types_csv)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with single quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv5 (like all_types_csv)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL
  AS 'null' ESCAPE AS ' '  QUOTE AS '''') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with force quote
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_csv6 (like all_types_csv)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_csv_dsp.tbl') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"' FORCE QUOTE char1) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --Table with all data types
     CREATE TABLE all_types_text ( bit1 bit(1), bit2 bit varying(50), boolean1 boolean, char1 char(1), charvar1 character varying(50), char2 character(50),
@@ -307,32 +307,32 @@ insert into all_types_text values ('1','0','t','e','varchar5','char5','varchar5'
 INSERT 0 1
 -- with AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text1 (like all_types_text)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- without AS for DELIMITER , NULL, ESCAPE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text2 (like all_types_text)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS ',' NULL 'null' ESCAPE ' ');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with ESCAPE OFF
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text3 (like all_types_text)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|'
 NULL AS 'null' ESCAPE 'OFF') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 -- with header
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text4 (like all_types_text)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  HEADER ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  HEADER is not yet supported for writable external tables
 -- with double quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text5 (like all_types_text)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '"') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  quote available only in CSV mode
 -- with single quotes
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text6 (like all_types_text)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '  QUOTE AS '''') ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  quote available only in CSV mode
 -- with force quote
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_text7 (like all_types_text)LOCATION ('gpfdist://vraghavan.local:8080/output/wet_text_dsp.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ' FORCE QUOTE char1) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: ERROR:  force quote available only in CSV mode
 create table test_tbl_for_view1 (a int, b text);
 psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -343,7 +343,7 @@ INSERT 0 5
 create view test_view1 as select * from test_tbl_for_view1;
 CREATE VIEW
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_view1 (like  test_tbl_for_view1) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_view.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 insert into tbl_wet_view1 select * from test_view1;
 INSERT 0 5
@@ -373,7 +373,7 @@ CREATE TABLE
 INSERT INTO test_order_by VALUES ( generate_series(1,5), 'test_1');
 INSERT 0 5
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_order_by(like  test_order_by) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_tbl_order_by.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO  tbl_wet_order_by SELECT * FROM  test_order_by ORDER BY a;
 INSERT 0 5
@@ -384,7 +384,7 @@ CREATE TABLE
 INSERT INTO test_tran VALUES ( generate_series(1,5), 'test_1');
 INSERT 0 5
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_tran(like  test_tran) LOCATION ('gpfdist://vraghavan.local:8080/output/wet_tbl_tran.txt') FORMAT 'CSV' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' '   ) ;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 BEGIN;
 BEGIN

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional_seg2.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional_seg2.ans
@@ -18,7 +18,7 @@ CREATE EXTERNAL TABLE E_LINEITEM ( L_ORDERKEY    INT8 ,
                               FORMAT 'CSV' (DELIMITER '|');
 CREATE EXTERNAL TABLE
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_lineitem1 ( like e_lineitem) LOCATION ('gpfdist://@hostname@:@gp_port@/output/new_lineitem.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_lineitem1 SELECT * FROM e_lineitem limit 1000;
 INSERT 0 1000
@@ -68,7 +68,7 @@ CREATE EXTERNAL TABLE
 INSERT INTO lineitem SELECT * FROM e_lineitem limit 1000; 
 INSERT 0 1000
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_lineitem2 ( like lineitem) location ('gpfdist://@hostname@:@gp_port@/output/new_lineitem.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 INSERT INTO tbl_wet_lineitem2 SELECT * FROM lineitem limit 1000;
 INSERT 0 1000

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp12775.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp12775.ans
@@ -15,7 +15,7 @@ CREATE TABLE
 alter table sales drop column amt;
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales exchange partition for ('2011-01-01') with table newpart;
 ALTER TABLE
@@ -38,7 +38,7 @@ CREATE TABLE
 alter table sales add column tax float;
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales exchange partition for ('2011-01-01') with table newpart;
 ALTER TABLE
@@ -63,7 +63,7 @@ ALTER TABLE
 alter table sales drop column tax ;
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales exchange partition for ('2011-01-01') with table newpart;
 ALTER TABLE
@@ -86,7 +86,7 @@ CREATE TABLE
 alter table sales rename COLUMN id to id_change;
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales exchange partition for ('2011-01-01') with table newpart;
 ALTER TABLE
@@ -109,7 +109,7 @@ CREATE TABLE
 alter table sales alter COLUMN id TYPE numeric(10,2);
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales exchange partition for ('2011-01-01') with table newpart;
 ALTER TABLE
@@ -144,7 +144,7 @@ ALTER TABLE
 alter table sales drop column tax ;
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales exchange partition for ('2011-01-01') with table newpart;
 ALTER TABLE
@@ -177,7 +177,7 @@ CREATE TABLE
 alter table sales add column tax float;
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales split partition for(1) at (50) into (partition aa1, partition aa2);
 psql:/path/sql_file:1: NOTICE:  exchanged partition "aa" of relation "sales" with relation "pg_temp_2371071"
@@ -230,7 +230,7 @@ CREATE TABLE
 alter table sales drop column option2;
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales split partition for(1) at (50) into (partition aa1, partition aa2);
 psql:/path/sql_file:1: NOTICE:  exchanged partition "aa" of relation "sales" with relation "pg_temp_2371574"
@@ -281,7 +281,7 @@ CREATE TABLE
 alter table sales rename COLUMN pkid to id_change;
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales split partition for(1) at (50) into (partition aa1, partition aa2);
 psql:/path/sql_file:1: NOTICE:  exchanged partition "aa" of relation "sales" with relation "pg_temp_2372044"
@@ -333,7 +333,7 @@ CREATE TABLE
 alter table sales alter COLUMN option1 TYPE numeric(10,2);
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales split partition for(1) at (50) into (partition aa1, partition aa2);
 psql:/path/sql_file:1: NOTICE:  exchanged partition "aa" of relation "sales" with relation "pg_temp_2372503"
@@ -438,7 +438,7 @@ ALTER TABLE
 alter table sales drop column tax;
 ALTER TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table newpart add constraint partable_pkey primary key(pkid, option3);
 psql:/path/sql_file:1: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "newpart_pkey" for table "newpart"
@@ -506,7 +506,7 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "sales_1_prt_cc_pkey" for table "sales_1_prt_cc"
 CREATE TABLE
 create table newpart(like sales);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 alter table sales drop column option2;
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp13750.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp13750.ans
@@ -137,7 +137,7 @@ NOTICE:  table "dcl_candidate" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table dcl_candidate(like dcl_messaging_test) with (appendonly=true);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into dcl_candidate(message_create_date) values (timestamp '2011-09-06');
 INSERT 0 1

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-1.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-1.ans
@@ -120,13 +120,13 @@ drop table if exists co_can cascade;
 DROP TABLE
 --end_ignore
  create table heap_can(like pt_heap_tab);  
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  create table ao_can(like pt_heap_tab) with (appendonly=true);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  create table co_can(like pt_heap_tab)  with (appendonly=true,orientation=column);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  -- Exchange
  alter table pt_heap_tab exchange partition for ('abc') with table ao_can ; -- Heap exchanged with  AO

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-2.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-2.ans
@@ -120,13 +120,13 @@ drop table if exists co_can cascade;
 DROP TABLE
 --end_ignore
  create table heap_can(like pt_ao_tab);  
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  create table ao_can(like pt_ao_tab) with (appendonly=true);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  create table co_can(like pt_ao_tab)  with (appendonly=true,orientation=column);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  -- Exchange
  alter table pt_ao_tab add partition pqr values ('pqr','pqr1','pqr2') WITH (appendonly=true,orientation=column,compresslevel=5);-- CO

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-3.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-3.ans
@@ -120,13 +120,13 @@ drop table if exists co_can cascade;
 DROP TABLE
 --end_ignore
  create table heap_can(like pt_co_tab);  
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  create table ao_can(like pt_co_tab) with (appendonly=true);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  create table co_can(like pt_co_tab)  with (appendonly=true,orientation=column);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  -- Exchange
  alter table pt_co_tab add partition pqr values ('pqr','pqr1','pqr2') WITH (appendonly=true,compresslevel=5);-- AO

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-4.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-4.ans
@@ -106,13 +106,13 @@ DROP TABLE
 DROP TABLE
 --end_ignore
   create table heap_can(like pt_heap_tab_rng);  
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
   create table ao_can(like pt_heap_tab_rng) with (appendonly=true);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
   create table co_can(like pt_heap_tab_rng)  with (appendonly=true,orientation=column);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  alter table pt_heap_tab_rng add partition newco start(36) end(40) with (appendonly= true, orientation = column);
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "pt_heap_tab_rng_1_prt_newco" for table "pt_heap_tab_rng"

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-5.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-5.ans
@@ -106,13 +106,13 @@ drop table if exists co_can cascade;
 DROP TABLE
 --end_ignore
   create table heap_can(like pt_ao_tab_rng);  
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
   create table ao_can(like pt_ao_tab_rng) with (appendonly=true);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
   create table co_can(like pt_ao_tab_rng)  with (appendonly=true,orientation=column);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  alter table pt_ao_tab_rng add partition newco start(36) end(40) with (appendonly= true, orientation = column);
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "pt_ao_tab_rng_1_prt_newco" for table "pt_ao_tab_rng"

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-6.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp17707-6.ans
@@ -106,13 +106,13 @@ drop table if exists co_can cascade;
 DROP TABLE
 --end_ignore
   create table heap_can(like pt_co_tab_rng);  
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
   create table ao_can(like pt_co_tab_rng) with (appendonly=true);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
   create table co_can(like pt_co_tab_rng)  with (appendonly=true,orientation=column);   
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
  alter table pt_co_tab_rng add partition newao start(36) end(40) with (appendonly= true);
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "pt_co_tab_rng_1_prt_newao" for table "pt_co_tab_rng"

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp6589.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp6589.ans
@@ -13,12 +13,12 @@ PARTITION BY RANGE(day_dt)
 NOTICE:  CREATE TABLE will create partition "mpp6589_1_prt_p20090312" for table "mpp6589"
 CREATE TABLE
 ALTER TABLE mpp6589.mpp6589 SPLIT PARTITION p20090312 AT( '20090310' ) INTO( PARTITION p20090309, PARTITION p20090312_tmp);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  exchanged partition "p20090312" of relation "mpp6589" with relation "pg_temp_21969"
 NOTICE:  dropped partition "p20090312" for relation "mpp6589"
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "mpp6589_1_prt_p20090309" for table "mpp6589"
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "mpp6589_1_prt_p20090312_tmp" for table "mpp6589"
 ALTER TABLE
 drop schema mpp6589 cascade;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp6979.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp6979.ans
@@ -47,7 +47,7 @@ PARTITION BY RANGE (ad_impsn_dttm)
   -- p1 derived from: (mpp6979_child.ad_impsn_fact2_c_d_1_m_1_1610396_month)
   PARTITION p1  START ('2007-10-01 00:00:00'::timestamp without time zone) INCLUSIVE END ('2007-11-01 00:00:00'::timestamp without time zone) EXCLUSIVE
 );
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ad_impsn_fact_xnewx_1_prt_p1" for table "ad_impsn_fact_xnewx"
 CREATE TABLE
 -- EXCHANGE DATA TO PARTITIONED TABLES

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp7863.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp7863.ans
@@ -47,12 +47,12 @@ select count(*) from mpp7863;
 (1 row)
 
 alter table mpp7863 split default partition start (201001) inclusive end (201002) exclusive into (partition jan10,default partition);
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  exchanged partition "extra" of relation "mpp7863" with relation "pg_temp_17362"
 NOTICE:  dropped partition "extra" for relation "mpp7863"
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "mpp7863_1_prt_jan10" for table "mpp7863"
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "mpp7863_1_prt_extra" for table "mpp7863"
 ALTER TABLE
 select count(*) from mpp7863_1_prt_extra where dat is null;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp9548.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/partition/expected/mpp9548.ans
@@ -38,18 +38,18 @@ ALTER TABLE
 alter table mpp9548 add partition drop1 
     start('2010-06-02') 
     end('2010-06-03');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "mpp9548_1_prt_drop1" for table "mpp9548"
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 ALTER TABLE
 alter table mpp9548 drop column drop2a, drop column drop2b;
 ALTER TABLE
 alter table mpp9548 add partition drop2 
     start('2010-06-03') 
     end('2010-06-04');
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 NOTICE:  CREATE TABLE will create partition "mpp9548_1_prt_drop2" for table "mpp9548"
-NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 ALTER TABLE
 insert into mpp9548 
 values

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_ao_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_ao_alter_part_add_default_part.ans
@@ -168,7 +168,7 @@ INSERT 0 100
 -- ALTER SYNC1 AO Part Add Default Parition
 --
 alter table sync1_ao_alter_part_add_default_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part2_1_prt_default_part" for table "sync1_ao_alter_part_add_default_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part2_1_prt_default_par_2_prt_1" for table "sync1_ao_alter_part_add_default_part2_1_prt_default_part"
 ALTER TABLE
@@ -181,7 +181,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 AO Part Add Default Parition
 --
 alter table ck_sync1_ao_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_default_part1_1_prt_default_part" for table "ck_sync1_ao_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_default_part1_1_prt_default__2_prt_1" for table "ck_sync1_ao_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_ao_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_ao_alter_part_add_part.ans
@@ -191,7 +191,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_ao_alter_part_add_part2 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part2_1_prt_p1" for table "sync1_ao_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part2_1_prt_p1_2_prt_sp1" for table "sync1_ao_alter_part_add_part2_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part2_1_prt_p1_2_prt_sp2" for table "sync1_ao_alter_part_add_part2_1_prt_p1"
@@ -211,7 +211,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_ao_alter_part_add_part2 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part2_1_prt_p3" for table "sync1_ao_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part2_1_prt_p3_2_prt_sp3" for table "sync1_ao_alter_part_add_part2_1_prt_p3"
 ALTER TABLE
@@ -226,7 +226,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_ao_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part1_1_prt_p1" for table "ck_sync1_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "ck_sync1_ao_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "ck_sync1_ao_alter_part_add_part1_1_prt_p1"
@@ -246,7 +246,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_ao_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part1_1_prt_p3" for table "ck_sync1_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "ck_sync1_ao_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_ao_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_ao_alter_part_drop_part.ans
@@ -128,7 +128,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_ao_alter_part_drop_part2 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part2_1_prt_a2" for table "sync1_ao_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -146,7 +146,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_ao_alter_part_drop_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part2_1_prt_default_part" for table "sync1_ao_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -179,7 +179,7 @@ select count(*) from sync1_ao_alter_part_drop_part2;
 -- Add partition 
 --
 alter table ck_sync1_ao_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_drop_part1_1_prt_a2" for table "ck_sync1_ao_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -197,7 +197,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_ao_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_drop_part1_1_prt_default_part" for table "ck_sync1_ao_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_ao_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_ao_alter_part_rename.ans
@@ -229,7 +229,7 @@ select count(*) from ck_sync1_ao_alter_part_rn7;
 -- Add default Partition
 --
 alter table sync1_ao_alter_part_rn2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_rn2_1_prt_default_part" for table "sync1_ao_alter_part_rn2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_rn2_1_prt_default_part_2_prt_1" for table "sync1_ao_alter_part_rn2_1_prt_default_part"
 ALTER TABLE
@@ -279,7 +279,7 @@ select count(*) from sync1_ao_alter_part_rn2_0;
 -- Add default Partition
 --
 alter table ck_sync1_ao_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_rn1_1_prt_default_part" for table "ck_sync1_ao_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_rn1_1_prt_default_part_2_prt_1" for table "ck_sync1_ao_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_alter_part_add_default_part.ans
@@ -168,7 +168,7 @@ INSERT 0 100
 -- ALTER SYNC1 CO Part Add Default Parition
 --
 alter table sync1_co_alter_part_add_default_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part2_1_prt_default_part" for table "sync1_co_alter_part_add_default_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part2_1_prt_default_par_2_prt_1" for table "sync1_co_alter_part_add_default_part2_1_prt_default_part"
 ALTER TABLE
@@ -181,7 +181,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 CO Part Add Default Parition
 --
 alter table ck_sync1_co_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_default_part1_1_prt_default_part" for table "ck_sync1_co_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_default_part1_1_prt_default__2_prt_1" for table "ck_sync1_co_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_alter_part_add_part.ans
@@ -191,7 +191,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_co_alter_part_add_part2 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part2_1_prt_p1" for table "sync1_co_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part2_1_prt_p1_2_prt_sp1" for table "sync1_co_alter_part_add_part2_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part2_1_prt_p1_2_prt_sp2" for table "sync1_co_alter_part_add_part2_1_prt_p1"
@@ -211,7 +211,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_co_alter_part_add_part2 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part2_1_prt_p3" for table "sync1_co_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part2_1_prt_p3_2_prt_sp3" for table "sync1_co_alter_part_add_part2_1_prt_p3"
 ALTER TABLE
@@ -226,7 +226,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_co_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part1_1_prt_p1" for table "ck_sync1_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "ck_sync1_co_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "ck_sync1_co_alter_part_add_part1_1_prt_p1"
@@ -246,7 +246,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_co_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part1_1_prt_p3" for table "ck_sync1_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "ck_sync1_co_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_alter_part_drop_part.ans
@@ -128,7 +128,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_co_alter_part_drop_part2 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part2_1_prt_a2" for table "sync1_co_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -146,7 +146,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_co_alter_part_drop_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part2_1_prt_default_part" for table "sync1_co_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -179,7 +179,7 @@ select count(*) from sync1_co_alter_part_drop_part2;
 -- Add partition 
 --
 alter table ck_sync1_co_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_drop_part1_1_prt_a2" for table "ck_sync1_co_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -197,7 +197,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_co_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_drop_part1_1_prt_default_part" for table "ck_sync1_co_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_alter_part_rename.ans
@@ -229,7 +229,7 @@ select count(*) from ck_sync1_co_alter_part_rn7;
 -- Add default Partition
 --
 alter table sync1_co_alter_part_rn2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn2_1_prt_default_part" for table "sync1_co_alter_part_rn2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn2_1_prt_default_part_2_prt_1" for table "sync1_co_alter_part_rn2_1_prt_default_part"
 ALTER TABLE
@@ -279,7 +279,7 @@ select count(*) from sync1_co_alter_part_rn2_0;
 -- Add default Partition
 --
 alter table ck_sync1_co_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_rn1_1_prt_default_part" for table "ck_sync1_co_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_rn1_1_prt_default_part_2_prt_1" for table "ck_sync1_co_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_create_wet_ret.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_create_wet_ret.ans
@@ -32,7 +32,7 @@ INSERT 0 5
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE sync1_wet_region2 ( like sync1_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region2.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -48,7 +48,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE sync1_new_region2 (like sync1_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -85,7 +85,7 @@ select * from sync1_new_region2 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE ck_sync1_wet_region1 ( like ck_sync1_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region1.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -101,7 +101,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE ck_sync1_new_region1 (like ck_sync1_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_heap_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_heap_alter_part_add_default_part.ans
@@ -168,7 +168,7 @@ INSERT 0 100
 -- ALTER SYNC1 Heap Part Add Default Parition
 --
 alter table sync1_heap_alter_part_add_default_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part2_1_prt_default_part" for table "sync1_heap_alter_part_add_default_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part2_1_prt_default_p_2_prt_1" for table "sync1_heap_alter_part_add_default_part2_1_prt_default_part"
 ALTER TABLE
@@ -181,7 +181,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 Heap Part Add Default Parition
 --
 alter table ck_sync1_heap_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_default_part1_1_prt_default_part" for table "ck_sync1_heap_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_default_part1_1_prt_defaul_2_prt_1" for table "ck_sync1_heap_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_heap_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_heap_alter_part_add_part.ans
@@ -191,7 +191,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_heap_alter_part_add_part2 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part2_1_prt_p1" for table "sync1_heap_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part2_1_prt_p1_2_prt_sp1" for table "sync1_heap_alter_part_add_part2_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part2_1_prt_p1_2_prt_sp2" for table "sync1_heap_alter_part_add_part2_1_prt_p1"
@@ -211,7 +211,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_heap_alter_part_add_part2 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part2_1_prt_p3" for table "sync1_heap_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part2_1_prt_p3_2_prt_sp3" for table "sync1_heap_alter_part_add_part2_1_prt_p3"
 ALTER TABLE
@@ -226,7 +226,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_heap_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part1_1_prt_p1" for table "ck_sync1_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "ck_sync1_heap_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "ck_sync1_heap_alter_part_add_part1_1_prt_p1"
@@ -246,7 +246,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_heap_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part1_1_prt_p3" for table "ck_sync1_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "ck_sync1_heap_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_heap_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_heap_alter_part_drop_part.ans
@@ -128,7 +128,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_heap_alter_part_drop_part2 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part2_1_prt_a2" for table "sync1_heap_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -146,7 +146,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_heap_alter_part_drop_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part2_1_prt_default_part" for table "sync1_heap_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -179,7 +179,7 @@ select count(*) from sync1_heap_alter_part_drop_part2;
 -- Add partition 
 --
 alter table ck_sync1_heap_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_drop_part1_1_prt_a2" for table "ck_sync1_heap_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -197,7 +197,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_heap_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_drop_part1_1_prt_default_part" for table "ck_sync1_heap_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_heap_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_heap_alter_part_rename.ans
@@ -229,7 +229,7 @@ select count(*) from ck_sync1_heap_alter_part_rn7;
 -- Add default Partition
 --
 alter table sync1_heap_alter_part_rn2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn2_1_prt_default_part" for table "sync1_heap_alter_part_rn2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn2_1_prt_default_part_2_prt_1" for table "sync1_heap_alter_part_rn2_1_prt_default_part"
 ALTER TABLE
@@ -279,7 +279,7 @@ select count(*) from sync1_heap_alter_part_rn2_0;
 -- Add default Partition
 --
 alter table ck_sync1_heap_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_rn1_1_prt_default_part" for table "ck_sync1_heap_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_rn1_1_prt_default_part_2_prt_1" for table "ck_sync1_heap_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_ao_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_ao_alter_part_split_default_part.ans
@@ -200,11 +200,11 @@ select count(*) from ck_sync1_ao_alter_part_split_default_part7;
 -- split default partition
 --
 alter table sync1_ao_alter_part_split_default_part2 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_ao_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part2_1_prt_bing" for table "sync1_ao_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part2_1_prt_baz" for table "sync1_ao_alter_part_split_default_part2"
 ALTER TABLE
 --
@@ -231,11 +231,11 @@ select count(*) from sync1_ao_alter_part_split_default_part2;
 -- split default partition
 --
 alter table ck_sync1_ao_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_default_part1_1_prt_bing" for table "ck_sync1_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_default_part1_1_prt_baz" for table "ck_sync1_ao_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_ao_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_ao_alter_part_split_partlist.ans
@@ -180,11 +180,11 @@ select count(*) from ck_sync1_ao_alter_part_split_partlist7;
 -- split partition
 --
 alter table sync1_ao_alter_part_split_partlist2 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_ao_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist2_1_prt_f1a" for table "sync1_ao_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist2_1_prt_f1b" for table "sync1_ao_alter_part_split_partlist2"
 ALTER TABLE
 --
@@ -213,11 +213,11 @@ select count(*) from sync1_ao_alter_part_split_partlist2;
 -- split partition
 --
 alter table ck_sync1_ao_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partlist1_1_prt_f1a" for table "ck_sync1_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partlist1_1_prt_f1b" for table "ck_sync1_ao_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_ao_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_ao_alter_part_split_partrange.ans
@@ -166,10 +166,10 @@ select count(*) from ck_sync1_ao_alter_part_split_partrange7;
 -- Split Partition Range
 --
 alter table sync1_ao_alter_part_split_partrange2 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange2_1_prt_aa" for table "sync1_ao_alter_part_split_partrange2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange2_1_prt_bb" for table "sync1_ao_alter_part_split_partrange2"
 ALTER TABLE
 --
@@ -193,10 +193,10 @@ select count(*) from sync1_ao_alter_part_split_partrange2;
 -- Split Partition Range
 --
 alter table ck_sync1_ao_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partrange1_1_prt_aa" for table "ck_sync1_ao_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partrange1_1_prt_bb" for table "ck_sync1_ao_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_co_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_co_alter_part_split_default_part.ans
@@ -200,11 +200,11 @@ select count(*) from ck_sync1_co_alter_part_split_default_part7;
 -- split default partition
 --
 alter table sync1_co_alter_part_split_default_part2 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_co_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part2_1_prt_bing" for table "sync1_co_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part2_1_prt_baz" for table "sync1_co_alter_part_split_default_part2"
 ALTER TABLE
 --
@@ -231,11 +231,11 @@ select count(*) from sync1_co_alter_part_split_default_part2;
 -- split default partition
 --
 alter table ck_sync1_co_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_default_part1_1_prt_bing" for table "ck_sync1_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_default_part1_1_prt_baz" for table "ck_sync1_co_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_co_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_co_alter_part_split_partlist.ans
@@ -180,11 +180,11 @@ select count(*) from ck_sync1_co_alter_part_split_partlist7;
 -- split partition
 --
 alter table sync1_co_alter_part_split_partlist2 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_co_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist2_1_prt_f1a" for table "sync1_co_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist2_1_prt_f1b" for table "sync1_co_alter_part_split_partlist2"
 ALTER TABLE
 --
@@ -213,11 +213,11 @@ select count(*) from sync1_co_alter_part_split_partlist2;
 -- split partition
 --
 alter table ck_sync1_co_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partlist1_1_prt_f1a" for table "ck_sync1_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partlist1_1_prt_f1b" for table "ck_sync1_co_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_co_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_co_alter_part_split_partrange.ans
@@ -166,10 +166,10 @@ select count(*) from ck_sync1_co_alter_part_split_partrange7;
 -- Split Partition Range
 --
 alter table sync1_co_alter_part_split_partrange2 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partrange2_1_prt_aa" for table "sync1_co_alter_part_split_partrange2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partrange2_1_prt_bb" for table "sync1_co_alter_part_split_partrange2"
 ALTER TABLE
 --
@@ -193,10 +193,10 @@ select count(*) from sync1_co_alter_part_split_partrange2;
 -- Split Partition Range
 --
 alter table ck_sync1_co_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partrange1_1_prt_aa" for table "ck_sync1_co_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partrange1_1_prt_bb" for table "ck_sync1_co_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_heap_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_heap_alter_part_split_default_part.ans
@@ -200,11 +200,11 @@ select count(*) from ck_sync1_heap_alter_part_split_default_part7;
 -- split default partition
 --
 alter table sync1_heap_alter_part_split_default_part2 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_heap_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part2_1_prt_bing" for table "sync1_heap_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part2_1_prt_baz" for table "sync1_heap_alter_part_split_default_part2"
 ALTER TABLE
 --
@@ -231,11 +231,11 @@ select count(*) from sync1_heap_alter_part_split_default_part2;
 -- split default partition
 --
 alter table ck_sync1_heap_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_default_part1_1_prt_bing" for table "ck_sync1_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_default_part1_1_prt_baz" for table "ck_sync1_heap_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_heap_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_heap_alter_part_split_partlist.ans
@@ -180,11 +180,11 @@ select count(*) from ck_sync1_heap_alter_part_split_partlist7;
 -- split partition
 --
 alter table sync1_heap_alter_part_split_partlist2 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_heap_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist2_1_prt_f1a" for table "sync1_heap_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist2_1_prt_f1b" for table "sync1_heap_alter_part_split_partlist2"
 ALTER TABLE
 --
@@ -213,11 +213,11 @@ select count(*) from sync1_heap_alter_part_split_partlist2;
 -- split partition
 --
 alter table ck_sync1_heap_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partlist1_1_prt_f1a" for table "ck_sync1_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partlist1_1_prt_f1b" for table "ck_sync1_heap_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_heap_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/skip/ck_sync1_heap_alter_part_split_partrange.ans
@@ -166,10 +166,10 @@ select count(*) from ck_sync1_heap_alter_part_split_partrange7;
 -- Split Partition Range
 --
 alter table sync1_heap_alter_part_split_partrange2 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange2_1_prt_aa" for table "sync1_heap_alter_part_split_partrange2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange2_1_prt_bb" for table "sync1_heap_alter_part_split_partrange2"
 ALTER TABLE
 --
@@ -193,10 +193,10 @@ select count(*) from sync1_heap_alter_part_split_partrange2;
 -- Split Partition Range
 --
 alter table ck_sync1_heap_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partrange1_1_prt_aa" for table "ck_sync1_heap_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partrange1_1_prt_bb" for table "ck_sync1_heap_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_ao_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_ao_alter_part_add_default_part.ans
@@ -122,7 +122,7 @@ INSERT 0 100
 -- ALTER SYNC1 AO Part Add Default Parition
 --
 alter table sync1_ao_alter_part_add_default_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part4_1_prt_default_part" for table "sync1_ao_alter_part_add_default_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part4_1_prt_default_par_2_prt_1" for table "sync1_ao_alter_part_add_default_part4_1_prt_default_part"
 ALTER TABLE
@@ -135,7 +135,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 AO Part Add Default Parition
 --
 alter table ck_sync1_ao_alter_part_add_default_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_default_part3_1_prt_default_part" for table "ck_sync1_ao_alter_part_add_default_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_default_part3_1_prt_default__2_prt_1" for table "ck_sync1_ao_alter_part_add_default_part3_1_prt_default_part"
 ALTER TABLE
@@ -148,7 +148,7 @@ INSERT 0 100
 -- ALTER CT AO Part Add Default Parition
 --
 alter table ct_ao_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_default_part1_1_prt_default_part" for table "ct_ao_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_default_part1_1_prt_default_part_2_prt_1" for table "ct_ao_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_ao_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_ao_alter_part_add_part.ans
@@ -139,7 +139,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_ao_alter_part_add_part4 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part4_1_prt_p1" for table "sync1_ao_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part4_1_prt_p1_2_prt_sp1" for table "sync1_ao_alter_part_add_part4_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part4_1_prt_p1_2_prt_sp2" for table "sync1_ao_alter_part_add_part4_1_prt_p1"
@@ -159,7 +159,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_ao_alter_part_add_part4 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part4_1_prt_p3" for table "sync1_ao_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part4_1_prt_p3_2_prt_sp3" for table "sync1_ao_alter_part_add_part4_1_prt_p3"
 ALTER TABLE
@@ -174,7 +174,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_ao_alter_part_add_part3 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part3_1_prt_p1" for table "ck_sync1_ao_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part3_1_prt_p1_2_prt_sp1" for table "ck_sync1_ao_alter_part_add_part3_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part3_1_prt_p1_2_prt_sp2" for table "ck_sync1_ao_alter_part_add_part3_1_prt_p1"
@@ -194,7 +194,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_ao_alter_part_add_part3 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part3_1_prt_p3" for table "ck_sync1_ao_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part3_1_prt_p3_2_prt_sp3" for table "ck_sync1_ao_alter_part_add_part3_1_prt_p3"
 ALTER TABLE
@@ -209,7 +209,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_ao_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part1_1_prt_p1" for table "ct_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "ct_ao_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "ct_ao_alter_part_add_part1_1_prt_p1"
@@ -229,7 +229,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_ao_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part1_1_prt_p3" for table "ct_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "ct_ao_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_ao_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_ao_alter_part_drop_part.ans
@@ -94,7 +94,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_ao_alter_part_drop_part4 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part4_1_prt_a2" for table "sync1_ao_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -112,7 +112,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_ao_alter_part_drop_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part4_1_prt_default_part" for table "sync1_ao_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -145,7 +145,7 @@ select count(*) from sync1_ao_alter_part_drop_part4;
 -- Add partition 
 --
 alter table ck_sync1_ao_alter_part_drop_part3 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_drop_part3_1_prt_a2" for table "ck_sync1_ao_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -163,7 +163,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_ao_alter_part_drop_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_drop_part3_1_prt_default_part" for table "ck_sync1_ao_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -197,7 +197,7 @@ select count(*) from ck_sync1_ao_alter_part_drop_part3;
 -- Add partition 
 --
 alter table ct_ao_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_drop_part1_1_prt_a2" for table "ct_ao_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -215,7 +215,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ct_ao_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_drop_part1_1_prt_default_part" for table "ct_ao_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_alter_part_add_default_part.ans
@@ -122,7 +122,7 @@ INSERT 0 100
 -- ALTER SYNC1 CO Part Add Default Parition
 --
 alter table sync1_co_alter_part_add_default_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part4_1_prt_default_part" for table "sync1_co_alter_part_add_default_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part4_1_prt_default_par_2_prt_1" for table "sync1_co_alter_part_add_default_part4_1_prt_default_part"
 ALTER TABLE
@@ -135,7 +135,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 CO Part Add Default Parition
 --
 alter table ck_sync1_co_alter_part_add_default_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_default_part3_1_prt_default_part" for table "ck_sync1_co_alter_part_add_default_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_default_part3_1_prt_default__2_prt_1" for table "ck_sync1_co_alter_part_add_default_part3_1_prt_default_part"
 ALTER TABLE
@@ -148,7 +148,7 @@ INSERT 0 100
 -- ALTER CT CO Part Add Default Parition
 --
 alter table ct_co_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_default_part1_1_prt_default_part" for table "ct_co_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_default_part1_1_prt_default_part_2_prt_1" for table "ct_co_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_alter_part_add_part.ans
@@ -139,7 +139,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_co_alter_part_add_part4 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part4_1_prt_p1" for table "sync1_co_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part4_1_prt_p1_2_prt_sp1" for table "sync1_co_alter_part_add_part4_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part4_1_prt_p1_2_prt_sp2" for table "sync1_co_alter_part_add_part4_1_prt_p1"
@@ -159,7 +159,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_co_alter_part_add_part4 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part4_1_prt_p3" for table "sync1_co_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part4_1_prt_p3_2_prt_sp3" for table "sync1_co_alter_part_add_part4_1_prt_p3"
 ALTER TABLE
@@ -174,7 +174,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_co_alter_part_add_part3 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part3_1_prt_p1" for table "ck_sync1_co_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part3_1_prt_p1_2_prt_sp1" for table "ck_sync1_co_alter_part_add_part3_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part3_1_prt_p1_2_prt_sp2" for table "ck_sync1_co_alter_part_add_part3_1_prt_p1"
@@ -194,7 +194,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_co_alter_part_add_part3 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part3_1_prt_p3" for table "ck_sync1_co_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part3_1_prt_p3_2_prt_sp3" for table "ck_sync1_co_alter_part_add_part3_1_prt_p3"
 ALTER TABLE
@@ -209,7 +209,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_co_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part1_1_prt_p1" for table "ct_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "ct_co_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "ct_co_alter_part_add_part1_1_prt_p1"
@@ -229,7 +229,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_co_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part1_1_prt_p3" for table "ct_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "ct_co_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_alter_part_drop_part.ans
@@ -94,7 +94,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_co_alter_part_drop_part4 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part4_1_prt_a2" for table "sync1_co_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -112,7 +112,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_co_alter_part_drop_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part4_1_prt_default_part" for table "sync1_co_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -145,7 +145,7 @@ select count(*) from sync1_co_alter_part_drop_part4;
 -- Add partition 
 --
 alter table ck_sync1_co_alter_part_drop_part3 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_drop_part3_1_prt_a2" for table "ck_sync1_co_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -163,7 +163,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_co_alter_part_drop_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_drop_part3_1_prt_default_part" for table "ck_sync1_co_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -196,7 +196,7 @@ select count(*) from ck_sync1_co_alter_part_drop_part3;
 -- Add partition 
 --
 alter table ct_co_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_drop_part1_1_prt_a2" for table "ct_co_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -214,7 +214,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ct_co_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_drop_part1_1_prt_default_part" for table "ct_co_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_alter_part_rename.ans
@@ -165,7 +165,7 @@ select count(*) from ct_co_alter_part_rn5;
 -- Add default Partition
 --
 alter table sync1_co_alter_part_rn4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn4_1_prt_default_part" for table "sync1_co_alter_part_rn4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn4_1_prt_default_part_2_prt_1" for table "sync1_co_alter_part_rn4_1_prt_default_part"
 ALTER TABLE
@@ -215,7 +215,7 @@ select count(*) from sync1_co_alter_part_rn4_0;
 -- Add default Partition
 --
 alter table ck_sync1_co_alter_part_rn3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_rn3_1_prt_default_part" for table "ck_sync1_co_alter_part_rn3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_rn3_1_prt_default_part_2_prt_1" for table "ck_sync1_co_alter_part_rn3_1_prt_default_part"
 ALTER TABLE
@@ -265,7 +265,7 @@ select count(*) from ck_sync1_co_alter_part_rn3_0;
 -- Add default Partition
 --
 alter table ct_co_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_rn1_1_prt_default_part" for table "ct_co_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_rn1_1_prt_default_part_2_prt_1" for table "ct_co_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_create_wet_ret.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_create_wet_ret.ans
@@ -32,7 +32,7 @@ INSERT 0 5
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE sync1_wet_region4 ( like sync1_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region4.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -48,7 +48,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE sync1_new_region4 (like sync1_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -85,7 +85,7 @@ select * from sync1_new_region4 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE ck_sync1_wet_region3 ( like ck_sync1_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region3.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -101,7 +101,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE ck_sync1_new_region3 (like ck_sync1_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -138,7 +138,7 @@ select * from ck_sync1_new_region3 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE ct_wet_region1 ( like ct_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region1.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -154,7 +154,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE ct_new_region1 (like ct_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_heap_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_heap_alter_part_add_default_part.ans
@@ -122,7 +122,7 @@ INSERT 0 100
 -- ALTER SYNC1 Heap Part Add Default Parition
 --
 alter table sync1_heap_alter_part_add_default_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part4_1_prt_default_part" for table "sync1_heap_alter_part_add_default_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part4_1_prt_default_p_2_prt_1" for table "sync1_heap_alter_part_add_default_part4_1_prt_default_part"
 ALTER TABLE
@@ -135,7 +135,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 Heap Part Add Default Parition
 --
 alter table ck_sync1_heap_alter_part_add_default_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_default_part3_1_prt_default_part" for table "ck_sync1_heap_alter_part_add_default_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_default_part3_1_prt_defaul_2_prt_1" for table "ck_sync1_heap_alter_part_add_default_part3_1_prt_default_part"
 ALTER TABLE
@@ -148,7 +148,7 @@ INSERT 0 100
 -- ALTER CT Heap Part Add Default Parition
 --
 alter table ct_heap_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_default_part1_1_prt_default_part" for table "ct_heap_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_default_part1_1_prt_default_part_2_prt_1" for table "ct_heap_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_heap_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_heap_alter_part_add_part.ans
@@ -139,7 +139,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_heap_alter_part_add_part4 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part4_1_prt_p1" for table "sync1_heap_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part4_1_prt_p1_2_prt_sp1" for table "sync1_heap_alter_part_add_part4_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part4_1_prt_p1_2_prt_sp2" for table "sync1_heap_alter_part_add_part4_1_prt_p1"
@@ -159,7 +159,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_heap_alter_part_add_part4 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part4_1_prt_p3" for table "sync1_heap_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part4_1_prt_p3_2_prt_sp3" for table "sync1_heap_alter_part_add_part4_1_prt_p3"
 ALTER TABLE
@@ -174,7 +174,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_heap_alter_part_add_part3 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part3_1_prt_p1" for table "ck_sync1_heap_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part3_1_prt_p1_2_prt_sp1" for table "ck_sync1_heap_alter_part_add_part3_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part3_1_prt_p1_2_prt_sp2" for table "ck_sync1_heap_alter_part_add_part3_1_prt_p1"
@@ -194,7 +194,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_heap_alter_part_add_part3 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part3_1_prt_p3" for table "ck_sync1_heap_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part3_1_prt_p3_2_prt_sp3" for table "ck_sync1_heap_alter_part_add_part3_1_prt_p3"
 ALTER TABLE
@@ -209,7 +209,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_heap_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part1_1_prt_p1" for table "ct_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "ct_heap_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "ct_heap_alter_part_add_part1_1_prt_p1"
@@ -229,7 +229,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_heap_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part1_1_prt_p3" for table "ct_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "ct_heap_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_heap_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_heap_alter_part_drop_part.ans
@@ -94,7 +94,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_heap_alter_part_drop_part4 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part4_1_prt_a2" for table "sync1_heap_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -112,7 +112,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_heap_alter_part_drop_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part4_1_prt_default_part" for table "sync1_heap_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -145,7 +145,7 @@ select count(*) from sync1_heap_alter_part_drop_part4;
 -- Add partition 
 --
 alter table ck_sync1_heap_alter_part_drop_part3 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_drop_part3_1_prt_a2" for table "ck_sync1_heap_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -163,7 +163,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_heap_alter_part_drop_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_drop_part3_1_prt_default_part" for table "ck_sync1_heap_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -197,7 +197,7 @@ select count(*) from ck_sync1_heap_alter_part_drop_part3;
 -- Add partition 
 --
 alter table ct_heap_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_drop_part1_1_prt_a2" for table "ct_heap_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -215,7 +215,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ct_heap_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_drop_part1_1_prt_default_part" for table "ct_heap_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_heap_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_heap_alter_part_rename.ans
@@ -165,7 +165,7 @@ select count(*) from ct_heap_alter_part_rn5;
 -- Add default Partition
 --
 alter table sync1_heap_alter_part_rn4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn4_1_prt_default_part" for table "sync1_heap_alter_part_rn4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn4_1_prt_default_part_2_prt_1" for table "sync1_heap_alter_part_rn4_1_prt_default_part"
 ALTER TABLE
@@ -215,7 +215,7 @@ select count(*) from sync1_heap_alter_part_rn4_0;
 -- Add default Partition
 --
 alter table ck_sync1_heap_alter_part_rn3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_rn3_1_prt_default_part" for table "ck_sync1_heap_alter_part_rn3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_rn3_1_prt_default_part_2_prt_1" for table "ck_sync1_heap_alter_part_rn3_1_prt_default_part"
 ALTER TABLE
@@ -266,7 +266,7 @@ select count(*) from ck_sync1_heap_alter_part_rn3_0;
 -- Add default Partition
 --
 alter table ct_heap_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_rn1_1_prt_default_part" for table "ct_heap_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_rn1_1_prt_default_part_2_prt_1" for table "ct_heap_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_ao_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_ao_alter_part_split_default_part.ans
@@ -144,11 +144,11 @@ select count(*) from ct_ao_alter_part_split_default_part5;
 -- split default partition
 --
 alter table sync1_ao_alter_part_split_default_part4 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_ao_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part4_1_prt_bing" for table "sync1_ao_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part4_1_prt_baz" for table "sync1_ao_alter_part_split_default_part4"
 ALTER TABLE
 --
@@ -175,11 +175,11 @@ select count(*) from sync1_ao_alter_part_split_default_part4;
 -- split default partition
 --
 alter table ck_sync1_ao_alter_part_split_default_part3 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_ao_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_default_part3_1_prt_bing" for table "ck_sync1_ao_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_default_part3_1_prt_baz" for table "ck_sync1_ao_alter_part_split_default_part3"
 ALTER TABLE
 --
@@ -206,11 +206,11 @@ select count(*) from ck_sync1_ao_alter_part_split_default_part3;
 -- split default partition
 --
 alter table ct_ao_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ct_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_default_part1_1_prt_bing" for table "ct_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_default_part1_1_prt_baz" for table "ct_ao_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_ao_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_ao_alter_part_split_partlist.ans
@@ -130,11 +130,11 @@ select count(*) from ct_ao_alter_part_split_partlist5;
 -- split partition
 --
 alter table sync1_ao_alter_part_split_partlist4 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_ao_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist4_1_prt_f1a" for table "sync1_ao_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist4_1_prt_f1b" for table "sync1_ao_alter_part_split_partlist4"
 ALTER TABLE
 --
@@ -163,11 +163,11 @@ select count(*) from sync1_ao_alter_part_split_partlist4;
 -- split partition
 --
 alter table ck_sync1_ao_alter_part_split_partlist3 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_ao_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partlist3_1_prt_f1a" for table "ck_sync1_ao_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partlist3_1_prt_f1b" for table "ck_sync1_ao_alter_part_split_partlist3"
 ALTER TABLE
 --
@@ -196,11 +196,11 @@ select count(*) from ck_sync1_ao_alter_part_split_partlist3;
 -- split partition
 --
 alter table ct_ao_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ct_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partlist1_1_prt_f1a" for table "ct_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partlist1_1_prt_f1b" for table "ct_ao_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_ao_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_ao_alter_part_split_partrange.ans
@@ -120,10 +120,10 @@ select count(*) from ct_ao_alter_part_split_partrange5;
 -- Split Partition Range
 --
 alter table sync1_ao_alter_part_split_partrange4 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange4_1_prt_aa" for table "sync1_ao_alter_part_split_partrange4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange4_1_prt_bb" for table "sync1_ao_alter_part_split_partrange4"
 ALTER TABLE
 --
@@ -147,10 +147,10 @@ select count(*) from sync1_ao_alter_part_split_partrange4;
 -- Split Partition Range
 --
 alter table ck_sync1_ao_alter_part_split_partrange3 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partrange3_1_prt_aa" for table "ck_sync1_ao_alter_part_split_partrange3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partrange3_1_prt_bb" for table "ck_sync1_ao_alter_part_split_partrange3"
 ALTER TABLE
 --
@@ -174,10 +174,10 @@ select count(*) from ck_sync1_ao_alter_part_split_partrange3;
 -- Split Partition Range
 --
 alter table ct_ao_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partrange1_1_prt_aa" for table "ct_ao_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partrange1_1_prt_bb" for table "ct_ao_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_co_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_co_alter_part_split_default_part.ans
@@ -144,11 +144,11 @@ select count(*) from ct_co_alter_part_split_default_part5;
 -- split default partition
 --
 alter table sync1_co_alter_part_split_default_part4 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_co_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part4_1_prt_bing" for table "sync1_co_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part4_1_prt_baz" for table "sync1_co_alter_part_split_default_part4"
 ALTER TABLE
 --
@@ -175,11 +175,11 @@ select count(*) from sync1_co_alter_part_split_default_part4;
 -- split default partition
 --
 alter table ck_sync1_co_alter_part_split_default_part3 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_co_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_default_part3_1_prt_bing" for table "ck_sync1_co_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_default_part3_1_prt_baz" for table "ck_sync1_co_alter_part_split_default_part3"
 ALTER TABLE
 --
@@ -206,11 +206,11 @@ select count(*) from ck_sync1_co_alter_part_split_default_part3;
 -- split default partition
 --
 alter table ct_co_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ct_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_default_part1_1_prt_bing" for table "ct_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_default_part1_1_prt_baz" for table "ct_co_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_co_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_co_alter_part_split_partlist.ans
@@ -130,11 +130,11 @@ select count(*) from ct_co_alter_part_split_partlist5;
 -- split partition
 --
 alter table sync1_co_alter_part_split_partlist4 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_co_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist4_1_prt_f1a" for table "sync1_co_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist4_1_prt_f1b" for table "sync1_co_alter_part_split_partlist4"
 ALTER TABLE
 --
@@ -163,11 +163,11 @@ select count(*) from sync1_co_alter_part_split_partlist4;
 -- split partition
 --
 alter table ck_sync1_co_alter_part_split_partlist3 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_co_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partlist3_1_prt_f1a" for table "ck_sync1_co_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partlist3_1_prt_f1b" for table "ck_sync1_co_alter_part_split_partlist3"
 ALTER TABLE
 --
@@ -196,11 +196,11 @@ select count(*) from ck_sync1_co_alter_part_split_partlist3;
 -- split partition
 --
 alter table ct_co_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ct_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partlist1_1_prt_f1a" for table "ct_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partlist1_1_prt_f1b" for table "ct_co_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_co_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_co_alter_part_split_partrange.ans
@@ -120,10 +120,10 @@ select count(*) from ct_co_alter_part_split_partrange5;
 -- Split Partition Range
 --
 alter table sync1_co_alter_part_split_partrange4 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partrange4_1_prt_aa" for table "sync1_co_alter_part_split_partrange4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partrange4_1_prt_bb" for table "sync1_co_alter_part_split_partrange4"
 ALTER TABLE
 --
@@ -147,10 +147,10 @@ select count(*) from sync1_co_alter_part_split_partrange4;
 -- Split Partition Range
 --
 alter table ck_sync1_co_alter_part_split_partrange3 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partrange3_1_prt_aa" for table "ck_sync1_co_alter_part_split_partrange3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partrange3_1_prt_bb" for table "ck_sync1_co_alter_part_split_partrange3"
 ALTER TABLE
 --
@@ -174,10 +174,10 @@ select count(*) from ck_sync1_co_alter_part_split_partrange3;
 -- Split Partition Range
 --
 alter table ct_co_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partrange1_1_prt_aa" for table "ct_co_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partrange1_1_prt_bb" for table "ct_co_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_heap_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_heap_alter_part_split_default_part.ans
@@ -144,11 +144,11 @@ select count(*) from ct_heap_alter_part_split_default_part5;
 -- split default partition
 --
 alter table sync1_heap_alter_part_split_default_part4 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_heap_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part4_1_prt_bing" for table "sync1_heap_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part4_1_prt_baz" for table "sync1_heap_alter_part_split_default_part4"
 ALTER TABLE
 --
@@ -175,11 +175,11 @@ select count(*) from sync1_heap_alter_part_split_default_part4;
 -- split default partition
 --
 alter table ck_sync1_heap_alter_part_split_default_part3 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_heap_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_default_part3_1_prt_bing" for table "ck_sync1_heap_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_default_part3_1_prt_baz" for table "ck_sync1_heap_alter_part_split_default_part3"
 ALTER TABLE
 --
@@ -206,11 +206,11 @@ select count(*) from ck_sync1_heap_alter_part_split_default_part3;
 -- split default partition
 --
 alter table ct_heap_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ct_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_default_part1_1_prt_bing" for table "ct_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_default_part1_1_prt_baz" for table "ct_heap_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_heap_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_heap_alter_part_split_partlist.ans
@@ -130,11 +130,11 @@ select count(*) from ct_heap_alter_part_split_partlist5;
 -- split partition
 --
 alter table sync1_heap_alter_part_split_partlist4 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_heap_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist4_1_prt_f1a" for table "sync1_heap_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist4_1_prt_f1b" for table "sync1_heap_alter_part_split_partlist4"
 ALTER TABLE
 --
@@ -163,11 +163,11 @@ select count(*) from sync1_heap_alter_part_split_partlist4;
 -- split partition
 --
 alter table ck_sync1_heap_alter_part_split_partlist3 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_heap_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partlist3_1_prt_f1a" for table "ck_sync1_heap_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partlist3_1_prt_f1b" for table "ck_sync1_heap_alter_part_split_partlist3"
 ALTER TABLE
 --
@@ -196,11 +196,11 @@ select count(*) from ck_sync1_heap_alter_part_split_partlist3;
 -- split partition
 --
 alter table ct_heap_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ct_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partlist1_1_prt_f1a" for table "ct_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partlist1_1_prt_f1b" for table "ct_heap_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_heap_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/skip/ct_heap_alter_part_split_partrange.ans
@@ -120,10 +120,10 @@ select count(*) from ct_heap_alter_part_split_partrange5;
 -- Split Partition Range
 --
 alter table sync1_heap_alter_part_split_partrange4 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange4_1_prt_aa" for table "sync1_heap_alter_part_split_partrange4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange4_1_prt_bb" for table "sync1_heap_alter_part_split_partrange4"
 ALTER TABLE
 --
@@ -147,10 +147,10 @@ select count(*) from sync1_heap_alter_part_split_partrange4;
 -- Split Partition Range
 --
 alter table ck_sync1_heap_alter_part_split_partrange3 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partrange3_1_prt_aa" for table "ck_sync1_heap_alter_part_split_partrange3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partrange3_1_prt_bb" for table "ck_sync1_heap_alter_part_split_partrange3"
 ALTER TABLE
 --
@@ -174,10 +174,10 @@ select count(*) from ck_sync1_heap_alter_part_split_partrange3;
 -- Split Partition Range
 --
 alter table ct_heap_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partrange1_1_prt_aa" for table "ct_heap_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partrange1_1_prt_bb" for table "ct_heap_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_ao_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_ao_alter_part_add_default_part.ans
@@ -76,7 +76,7 @@ INSERT 0 100
 -- ALTER SYNC1 AO Part Add Default Parition
 --
 alter table sync1_ao_alter_part_add_default_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part6_1_prt_default_part" for table "sync1_ao_alter_part_add_default_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part6_1_prt_default_par_2_prt_1" for table "sync1_ao_alter_part_add_default_part6_1_prt_default_part"
 ALTER TABLE
@@ -89,7 +89,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 AO Part Add Default Parition
 --
 alter table ck_sync1_ao_alter_part_add_default_part5 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_default_part5_1_prt_default_part" for table "ck_sync1_ao_alter_part_add_default_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_default_part5_1_prt_default__2_prt_1" for table "ck_sync1_ao_alter_part_add_default_part5_1_prt_default_part"
 ALTER TABLE
@@ -102,7 +102,7 @@ INSERT 0 100
 -- ALTER CT AO Part Add Default Parition
 --
 alter table ct_ao_alter_part_add_default_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_default_part3_1_prt_default_part" for table "ct_ao_alter_part_add_default_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_default_part3_1_prt_default_part_2_prt_1" for table "ct_ao_alter_part_add_default_part3_1_prt_default_part"
 ALTER TABLE
@@ -115,7 +115,7 @@ INSERT 0 100
 -- ALTER RESYNC AO Part Add Default Parition
 --
 alter table resync_ao_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_default_part1_1_prt_default_part" for table "resync_ao_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_default_part1_1_prt_default_pa_2_prt_1" for table "resync_ao_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_ao_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_ao_alter_part_add_part.ans
@@ -87,7 +87,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_ao_alter_part_add_part6 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part6_1_prt_p1" for table "sync1_ao_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part6_1_prt_p1_2_prt_sp1" for table "sync1_ao_alter_part_add_part6_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part6_1_prt_p1_2_prt_sp2" for table "sync1_ao_alter_part_add_part6_1_prt_p1"
@@ -107,7 +107,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_ao_alter_part_add_part6 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part6_1_prt_p3" for table "sync1_ao_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part6_1_prt_p3_2_prt_sp3" for table "sync1_ao_alter_part_add_part6_1_prt_p3"
 ALTER TABLE
@@ -122,7 +122,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_ao_alter_part_add_part5 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part5_1_prt_p1" for table "ck_sync1_ao_alter_part_add_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part5_1_prt_p1_2_prt_sp1" for table "ck_sync1_ao_alter_part_add_part5_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part5_1_prt_p1_2_prt_sp2" for table "ck_sync1_ao_alter_part_add_part5_1_prt_p1"
@@ -142,7 +142,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_ao_alter_part_add_part5 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part5_1_prt_p3" for table "ck_sync1_ao_alter_part_add_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part5_1_prt_p3_2_prt_sp3" for table "ck_sync1_ao_alter_part_add_part5_1_prt_p3"
 ALTER TABLE
@@ -157,7 +157,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_ao_alter_part_add_part3 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part3_1_prt_p1" for table "ct_ao_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part3_1_prt_p1_2_prt_sp1" for table "ct_ao_alter_part_add_part3_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part3_1_prt_p1_2_prt_sp2" for table "ct_ao_alter_part_add_part3_1_prt_p1"
@@ -177,7 +177,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_ao_alter_part_add_part3 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part3_1_prt_p3" for table "ct_ao_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part3_1_prt_p3_2_prt_sp3" for table "ct_ao_alter_part_add_part3_1_prt_p3"
 ALTER TABLE
@@ -192,7 +192,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table resync_ao_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part1_1_prt_p1" for table "resync_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "resync_ao_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "resync_ao_alter_part_add_part1_1_prt_p1"
@@ -212,7 +212,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table resync_ao_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part1_1_prt_p3" for table "resync_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "resync_ao_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_ao_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_ao_alter_part_drop_part.ans
@@ -60,7 +60,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_ao_alter_part_drop_part6 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part6_1_prt_a2" for table "sync1_ao_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -78,7 +78,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_ao_alter_part_drop_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part6_1_prt_default_part" for table "sync1_ao_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -111,7 +111,7 @@ select count(*) from sync1_ao_alter_part_drop_part6;
 -- Add partition 
 --
 alter table ck_sync1_ao_alter_part_drop_part5 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_drop_part5_1_prt_a2" for table "ck_sync1_ao_alter_part_drop_part5"
 ALTER TABLE
 --
@@ -129,7 +129,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_ao_alter_part_drop_part5 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_drop_part5_1_prt_default_part" for table "ck_sync1_ao_alter_part_drop_part5"
 ALTER TABLE
 --
@@ -163,7 +163,7 @@ select count(*) from ck_sync1_ao_alter_part_drop_part5;
 -- Add partition 
 --
 alter table ct_ao_alter_part_drop_part3 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_drop_part3_1_prt_a2" for table "ct_ao_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -181,7 +181,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ct_ao_alter_part_drop_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_drop_part3_1_prt_default_part" for table "ct_ao_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -215,7 +215,7 @@ select count(*) from ct_ao_alter_part_drop_part3;
 -- Add partition 
 --
 alter table resync_ao_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_drop_part1_1_prt_a2" for table "resync_ao_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -233,7 +233,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table resync_ao_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_drop_part1_1_prt_default_part" for table "resync_ao_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_ao_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_ao_alter_part_rename.ans
@@ -101,7 +101,7 @@ select count(*) from resync_ao_alter_part_rn3;
 -- Add default Partition
 --
 alter table sync1_ao_alter_part_rn6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_rn6_1_prt_default_part" for table "sync1_ao_alter_part_rn6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_rn6_1_prt_default_part_2_prt_1" for table "sync1_ao_alter_part_rn6_1_prt_default_part"
 ALTER TABLE
@@ -151,7 +151,7 @@ select count(*) from sync1_ao_alter_part_rn6_0;
 -- Add default Partition
 --
 alter table ck_sync1_ao_alter_part_rn5 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_rn5_1_prt_default_part" for table "ck_sync1_ao_alter_part_rn5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_rn5_1_prt_default_part_2_prt_1" for table "ck_sync1_ao_alter_part_rn5_1_prt_default_part"
 ALTER TABLE
@@ -202,7 +202,7 @@ select count(*) from ck_sync1_ao_alter_part_rn5_0;
 -- Add default Partition
 --
 alter table ct_ao_alter_part_rn3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_rn3_1_prt_default_part" for table "ct_ao_alter_part_rn3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_rn3_1_prt_default_part_2_prt_1" for table "ct_ao_alter_part_rn3_1_prt_default_part"
 ALTER TABLE
@@ -253,7 +253,7 @@ select count(*) from ct_ao_alter_part_rn3_0;
 -- Add default Partition
 --
 alter table resync_ao_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_rn1_1_prt_default_part" for table "resync_ao_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_rn1_1_prt_default_part_2_prt_1" for table "resync_ao_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_alter_part_add_default_part.ans
@@ -76,7 +76,7 @@ INSERT 0 100
 -- ALTER SYNC1 CO Part Add Default Parition
 --
 alter table sync1_co_alter_part_add_default_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part6_1_prt_default_part" for table "sync1_co_alter_part_add_default_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part6_1_prt_default_par_2_prt_1" for table "sync1_co_alter_part_add_default_part6_1_prt_default_part"
 ALTER TABLE
@@ -89,7 +89,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 CO Part Add Default Parition
 --
 alter table ck_sync1_co_alter_part_add_default_part5 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_default_part5_1_prt_default_part" for table "ck_sync1_co_alter_part_add_default_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_default_part5_1_prt_default__2_prt_1" for table "ck_sync1_co_alter_part_add_default_part5_1_prt_default_part"
 ALTER TABLE
@@ -102,7 +102,7 @@ INSERT 0 100
 -- ALTER CT CO Part Add Default Parition
 --
 alter table ct_co_alter_part_add_default_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_default_part3_1_prt_default_part" for table "ct_co_alter_part_add_default_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_default_part3_1_prt_default_part_2_prt_1" for table "ct_co_alter_part_add_default_part3_1_prt_default_part"
 ALTER TABLE
@@ -115,7 +115,7 @@ INSERT 0 100
 -- ALTER RESYNC CO Part Add Default Parition
 --
 alter table resync_co_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_default_part1_1_prt_default_part" for table "resync_co_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_default_part1_1_prt_default_pa_2_prt_1" for table "resync_co_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_alter_part_add_part.ans
@@ -87,7 +87,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_co_alter_part_add_part6 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part6_1_prt_p1" for table "sync1_co_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part6_1_prt_p1_2_prt_sp1" for table "sync1_co_alter_part_add_part6_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part6_1_prt_p1_2_prt_sp2" for table "sync1_co_alter_part_add_part6_1_prt_p1"
@@ -107,7 +107,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_co_alter_part_add_part6 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part6_1_prt_p3" for table "sync1_co_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part6_1_prt_p3_2_prt_sp3" for table "sync1_co_alter_part_add_part6_1_prt_p3"
 ALTER TABLE
@@ -122,7 +122,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_co_alter_part_add_part5 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part5_1_prt_p1" for table "ck_sync1_co_alter_part_add_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part5_1_prt_p1_2_prt_sp1" for table "ck_sync1_co_alter_part_add_part5_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part5_1_prt_p1_2_prt_sp2" for table "ck_sync1_co_alter_part_add_part5_1_prt_p1"
@@ -142,7 +142,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_co_alter_part_add_part5 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part5_1_prt_p3" for table "ck_sync1_co_alter_part_add_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part5_1_prt_p3_2_prt_sp3" for table "ck_sync1_co_alter_part_add_part5_1_prt_p3"
 ALTER TABLE
@@ -157,7 +157,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_co_alter_part_add_part3 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part3_1_prt_p1" for table "ct_co_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part3_1_prt_p1_2_prt_sp1" for table "ct_co_alter_part_add_part3_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part3_1_prt_p1_2_prt_sp2" for table "ct_co_alter_part_add_part3_1_prt_p1"
@@ -177,7 +177,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_co_alter_part_add_part3 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part3_1_prt_p3" for table "ct_co_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part3_1_prt_p3_2_prt_sp3" for table "ct_co_alter_part_add_part3_1_prt_p3"
 ALTER TABLE
@@ -192,7 +192,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table resync_co_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part1_1_prt_p1" for table "resync_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "resync_co_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "resync_co_alter_part_add_part1_1_prt_p1"
@@ -212,7 +212,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table resync_co_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part1_1_prt_p3" for table "resync_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "resync_co_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_alter_part_drop_part.ans
@@ -60,7 +60,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_co_alter_part_drop_part6 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part6_1_prt_a2" for table "sync1_co_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -78,7 +78,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_co_alter_part_drop_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part6_1_prt_default_part" for table "sync1_co_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -111,7 +111,7 @@ select count(*) from sync1_co_alter_part_drop_part6;
 -- Add partition 
 --
 alter table ck_sync1_co_alter_part_drop_part5 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_drop_part5_1_prt_a2" for table "ck_sync1_co_alter_part_drop_part5"
 ALTER TABLE
 --
@@ -129,7 +129,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_co_alter_part_drop_part5 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_drop_part5_1_prt_default_part" for table "ck_sync1_co_alter_part_drop_part5"
 ALTER TABLE
 --
@@ -162,7 +162,7 @@ select count(*) from ck_sync1_co_alter_part_drop_part5;
 -- Add partition 
 --
 alter table ct_co_alter_part_drop_part3 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_drop_part3_1_prt_a2" for table "ct_co_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -180,7 +180,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ct_co_alter_part_drop_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_drop_part3_1_prt_default_part" for table "ct_co_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -213,7 +213,7 @@ select count(*) from ct_co_alter_part_drop_part3;
 -- Add partition 
 --
 alter table resync_co_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_drop_part1_1_prt_a2" for table "resync_co_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -231,7 +231,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table resync_co_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_drop_part1_1_prt_default_part" for table "resync_co_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_alter_part_rename.ans
@@ -101,7 +101,7 @@ select count(*) from resync_co_alter_part_rn3;
 -- Add default Partition
 --
 alter table sync1_co_alter_part_rn6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn6_1_prt_default_part" for table "sync1_co_alter_part_rn6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn6_1_prt_default_part_2_prt_1" for table "sync1_co_alter_part_rn6_1_prt_default_part"
 ALTER TABLE
@@ -151,7 +151,7 @@ select count(*) from sync1_co_alter_part_rn6_0;
 -- Add default Partition
 --
 alter table ck_sync1_co_alter_part_rn5 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_rn5_1_prt_default_part" for table "ck_sync1_co_alter_part_rn5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_rn5_1_prt_default_part_2_prt_1" for table "ck_sync1_co_alter_part_rn5_1_prt_default_part"
 ALTER TABLE
@@ -202,7 +202,7 @@ select count(*) from ck_sync1_co_alter_part_rn5_0;
 -- Add default Partition
 --
 alter table ct_co_alter_part_rn3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_rn3_1_prt_default_part" for table "ct_co_alter_part_rn3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_rn3_1_prt_default_part_2_prt_1" for table "ct_co_alter_part_rn3_1_prt_default_part"
 ALTER TABLE
@@ -253,7 +253,7 @@ select count(*) from ct_co_alter_part_rn3_0;
 -- Add default Partition
 --
 alter table resync_co_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_rn1_1_prt_default_part" for table "resync_co_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_rn1_1_prt_default_part_2_prt_1" for table "resync_co_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_create_wet_ret.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_create_wet_ret.ans
@@ -32,7 +32,7 @@ INSERT 0 5
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE sync1_wet_region6 ( like sync1_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region6.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -48,7 +48,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE sync1_new_region6 (like sync1_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -85,7 +85,7 @@ select * from sync1_new_region6 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE ck_sync1_wet_region5 ( like ck_sync1_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region5.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -101,7 +101,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE ck_sync1_new_region5 (like ck_sync1_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -139,7 +139,7 @@ select * from ck_sync1_new_region5 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE ct_wet_region3 ( like ct_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region3.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -155,7 +155,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE ct_new_region3 (like ct_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -192,7 +192,7 @@ select * from ct_new_region3 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE resync_wet_region1 ( like resync_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region1.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -208,7 +208,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE resync_new_region1 (like resync_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_add_default_part.ans
@@ -76,7 +76,7 @@ INSERT 0 100
 -- ALTER SYNC1 Heap Part Add Default Parition
 --
 alter table sync1_heap_alter_part_add_default_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part6_1_prt_default_part" for table "sync1_heap_alter_part_add_default_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part6_1_prt_default_p_2_prt_1" for table "sync1_heap_alter_part_add_default_part6_1_prt_default_part"
 ALTER TABLE
@@ -89,7 +89,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 Heap Part Add Default Parition
 --
 alter table ck_sync1_heap_alter_part_add_default_part5 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_default_part5_1_prt_default_part" for table "ck_sync1_heap_alter_part_add_default_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_default_part5_1_prt_defaul_2_prt_1" for table "ck_sync1_heap_alter_part_add_default_part5_1_prt_default_part"
 ALTER TABLE
@@ -102,7 +102,7 @@ INSERT 0 100
 -- ALTER CT Heap Part Add Default Parition
 --
 alter table ct_heap_alter_part_add_default_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_default_part3_1_prt_default_part" for table "ct_heap_alter_part_add_default_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_default_part3_1_prt_default_part_2_prt_1" for table "ct_heap_alter_part_add_default_part3_1_prt_default_part"
 ALTER TABLE
@@ -115,7 +115,7 @@ INSERT 0 100
 -- ALTER RESYNC Heap Part Add Default Parition
 --
 alter table resync_heap_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_default_part1_1_prt_default_part" for table "resync_heap_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_default_part1_1_prt_default__2_prt_1" for table "resync_heap_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_add_part..ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_add_part..ans
@@ -87,7 +87,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_heap_alter_part_add_part6 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p1" for table "sync1_heap_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p1_2_prt_sp1" for table "sync1_heap_alter_part_add_part6_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p1_2_prt_sp2" for table "sync1_heap_alter_part_add_part6_1_prt_p1"
@@ -107,7 +107,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_heap_alter_part_add_part6 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p3" for table "sync1_heap_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p3_2_prt_sp3" for table "sync1_heap_alter_part_add_part6_1_prt_p3"
 ALTER TABLE
@@ -122,7 +122,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_heap_alter_part_add_part5 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p1" for table "ck_sync1_heap_alter_part_add_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p1_2_prt_sp1" for table "ck_sync1_heap_alter_part_add_part5_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p1_2_prt_sp2" for table "ck_sync1_heap_alter_part_add_part5_1_prt_p1"
@@ -142,7 +142,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_heap_alter_part_add_part5 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p3" for table "ck_sync1_heap_alter_part_add_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p3_2_prt_sp3" for table "ck_sync1_heap_alter_part_add_part5_1_prt_p3"
 ALTER TABLE
@@ -157,7 +157,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table fault_ct_heap_alter_part_add_part4 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "fault_ct_heap_alter_part_add_part4_1_prt_p1" for table "fault_ct_heap_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "fault_ct_heap_alter_part_add_part4_1_prt_p1_2_prt_sp1" for table "fault_ct_heap_alter_part_add_part4_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "fault_ct_heap_alter_part_add_part4_1_prt_p1_2_prt_sp2" for table "fault_ct_heap_alter_part_add_part4_1_prt_p1"
@@ -177,7 +177,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table fault_ct_heap_alter_part_add_part4 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "fault_ct_heap_alter_part_add_part4_1_prt_p3" for table "fault_ct_heap_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "fault_ct_heap_alter_part_add_part4_1_prt_p3_2_prt_sp3" for table "fault_ct_heap_alter_part_add_part4_1_prt_p3"
 ALTER TABLE
@@ -192,7 +192,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_heap_alter_part_add_part3 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p1" for table "ct_heap_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p1_2_prt_sp1" for table "ct_heap_alter_part_add_part3_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p1_2_prt_sp2" for table "ct_heap_alter_part_add_part3_1_prt_p1"
@@ -212,7 +212,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_heap_alter_part_add_part3 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p3" for table "ct_heap_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p3_2_prt_sp3" for table "ct_heap_alter_part_add_part3_1_prt_p3"
 ALTER TABLE
@@ -227,7 +227,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_ct_heap_alter_part_add_part2 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_ct_heap_alter_part_add_part2_1_prt_p1" for table "ck_ct_heap_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_ct_heap_alter_part_add_part2_1_prt_p1_2_prt_sp1" for table "ck_ct_heap_alter_part_add_part2_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_ct_heap_alter_part_add_part2_1_prt_p1_2_prt_sp2" for table "ck_ct_heap_alter_part_add_part2_1_prt_p1"
@@ -247,7 +247,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_ct_heap_alter_part_add_part2 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_ct_heap_alter_part_add_part2_1_prt_p3" for table "ck_ct_heap_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_ct_heap_alter_part_add_part2_1_prt_p3_2_prt_sp3" for table "ck_ct_heap_alter_part_add_part2_1_prt_p3"
 ALTER TABLE
@@ -262,7 +262,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table resync_heap_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p1" for table "resync_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "resync_heap_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "resync_heap_alter_part_add_part1_1_prt_p1"
@@ -282,7 +282,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table resync_heap_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p3" for table "resync_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "resync_heap_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_add_part.ans
@@ -87,7 +87,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_heap_alter_part_add_part6 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p1" for table "sync1_heap_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p1_2_prt_sp1" for table "sync1_heap_alter_part_add_part6_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p1_2_prt_sp2" for table "sync1_heap_alter_part_add_part6_1_prt_p1"
@@ -107,7 +107,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_heap_alter_part_add_part6 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p3" for table "sync1_heap_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part6_1_prt_p3_2_prt_sp3" for table "sync1_heap_alter_part_add_part6_1_prt_p3"
 ALTER TABLE
@@ -122,7 +122,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_heap_alter_part_add_part5 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p1" for table "ck_sync1_heap_alter_part_add_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p1_2_prt_sp1" for table "ck_sync1_heap_alter_part_add_part5_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p1_2_prt_sp2" for table "ck_sync1_heap_alter_part_add_part5_1_prt_p1"
@@ -142,7 +142,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_heap_alter_part_add_part5 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p3" for table "ck_sync1_heap_alter_part_add_part5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part5_1_prt_p3_2_prt_sp3" for table "ck_sync1_heap_alter_part_add_part5_1_prt_p3"
 ALTER TABLE
@@ -157,7 +157,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_heap_alter_part_add_part3 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p1" for table "ct_heap_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p1_2_prt_sp1" for table "ct_heap_alter_part_add_part3_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p1_2_prt_sp2" for table "ct_heap_alter_part_add_part3_1_prt_p1"
@@ -177,7 +177,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_heap_alter_part_add_part3 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p3" for table "ct_heap_alter_part_add_part3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part3_1_prt_p3_2_prt_sp3" for table "ct_heap_alter_part_add_part3_1_prt_p3"
 ALTER TABLE
@@ -192,7 +192,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table resync_heap_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p1" for table "resync_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "resync_heap_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "resync_heap_alter_part_add_part1_1_prt_p1"
@@ -212,7 +212,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table resync_heap_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p3" for table "resync_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "resync_heap_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_drop_part.ans
@@ -60,7 +60,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_heap_alter_part_drop_part6 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part6_1_prt_a2" for table "sync1_heap_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -78,7 +78,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_heap_alter_part_drop_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part6_1_prt_default_part" for table "sync1_heap_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -111,7 +111,7 @@ select count(*) from sync1_heap_alter_part_drop_part6;
 -- Add partition 
 --
 alter table ck_sync1_heap_alter_part_drop_part5 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_drop_part5_1_prt_a2" for table "ck_sync1_heap_alter_part_drop_part5"
 ALTER TABLE
 --
@@ -129,7 +129,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_heap_alter_part_drop_part5 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_drop_part5_1_prt_default_part" for table "ck_sync1_heap_alter_part_drop_part5"
 ALTER TABLE
 --
@@ -162,7 +162,7 @@ select count(*) from ck_sync1_heap_alter_part_drop_part5;
 -- Add partition 
 --
 alter table ct_heap_alter_part_drop_part3 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_drop_part3_1_prt_a2" for table "ct_heap_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -180,7 +180,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ct_heap_alter_part_drop_part3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_drop_part3_1_prt_default_part" for table "ct_heap_alter_part_drop_part3"
 ALTER TABLE
 --
@@ -213,7 +213,7 @@ select count(*) from ct_heap_alter_part_drop_part3;
 -- Add partition 
 --
 alter table resync_heap_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_drop_part1_1_prt_a2" for table "resync_heap_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -231,7 +231,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table resync_heap_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_drop_part1_1_prt_default_part" for table "resync_heap_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_heap_alter_part_rename.ans
@@ -101,7 +101,7 @@ select count(*) from resync_heap_alter_part_rn3;
 -- Add default Partition
 --
 alter table sync1_heap_alter_part_rn6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn6_1_prt_default_part" for table "sync1_heap_alter_part_rn6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn6_1_prt_default_part_2_prt_1" for table "sync1_heap_alter_part_rn6_1_prt_default_part"
 ALTER TABLE
@@ -151,7 +151,7 @@ select count(*) from sync1_heap_alter_part_rn6_0;
 -- Add default Partition
 --
 alter table ck_sync1_heap_alter_part_rn5 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_rn5_1_prt_default_part" for table "ck_sync1_heap_alter_part_rn5"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_rn5_1_prt_default_part_2_prt_1" for table "ck_sync1_heap_alter_part_rn5_1_prt_default_part"
 ALTER TABLE
@@ -201,7 +201,7 @@ select count(*) from ck_sync1_heap_alter_part_rn5_0;
 -- Add default Partition
 --
 alter table ct_heap_alter_part_rn3 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_rn3_1_prt_default_part" for table "ct_heap_alter_part_rn3"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_rn3_1_prt_default_part_2_prt_1" for table "ct_heap_alter_part_rn3_1_prt_default_part"
 ALTER TABLE
@@ -251,7 +251,7 @@ select count(*) from ct_heap_alter_part_rn3_0;
 -- Add default Partition
 --
 alter table resync_heap_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_rn1_1_prt_default_part" for table "resync_heap_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_rn1_1_prt_default_part_2_prt_1" for table "resync_heap_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_ao_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_ao_alter_part_split_default_part.ans
@@ -88,11 +88,11 @@ select count(*) from resync_ao_alter_part_split_default_part3;
 -- split default partition
 --
 alter table sync1_ao_alter_part_split_default_part6 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_ao_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part6_1_prt_bing" for table "sync1_ao_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part6_1_prt_baz" for table "sync1_ao_alter_part_split_default_part6"
 ALTER TABLE
 --
@@ -119,11 +119,11 @@ select count(*) from sync1_ao_alter_part_split_default_part6;
 -- split default partition
 --
 alter table ck_sync1_ao_alter_part_split_default_part5 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_ao_alter_part_split_default_part5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_default_part5_1_prt_bing" for table "ck_sync1_ao_alter_part_split_default_part5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_default_part5_1_prt_baz" for table "ck_sync1_ao_alter_part_split_default_part5"
 ALTER TABLE
 --
@@ -151,11 +151,11 @@ select count(*) from ck_sync1_ao_alter_part_split_default_part5;
 -- split default partition
 --
 alter table ct_ao_alter_part_split_default_part3 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ct_ao_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_default_part3_1_prt_bing" for table "ct_ao_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_default_part3_1_prt_baz" for table "ct_ao_alter_part_split_default_part3"
 ALTER TABLE
 --
@@ -182,11 +182,11 @@ select count(*) from ct_ao_alter_part_split_default_part3;
 -- split default partition
 --
 alter table resync_ao_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "resync_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_default_part1_1_prt_bing" for table "resync_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_default_part1_1_prt_baz" for table "resync_ao_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_ao_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_ao_alter_part_split_partlist.ans
@@ -80,11 +80,11 @@ select count(*) from resync_ao_alter_part_split_partlist3;
 -- split partition
 --
 alter table sync1_ao_alter_part_split_partlist6 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_ao_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist6_1_prt_f1a" for table "sync1_ao_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist6_1_prt_f1b" for table "sync1_ao_alter_part_split_partlist6"
 ALTER TABLE
 --
@@ -113,11 +113,11 @@ select count(*) from sync1_ao_alter_part_split_partlist6;
 -- split partition
 --
 alter table ck_sync1_ao_alter_part_split_partlist5 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_ao_alter_part_split_partlist5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partlist5_1_prt_f1a" for table "ck_sync1_ao_alter_part_split_partlist5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partlist5_1_prt_f1b" for table "ck_sync1_ao_alter_part_split_partlist5"
 ALTER TABLE
 --
@@ -146,11 +146,11 @@ select count(*) from ck_sync1_ao_alter_part_split_partlist5;
 -- split partition
 --
 alter table ct_ao_alter_part_split_partlist3 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ct_ao_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partlist3_1_prt_f1a" for table "ct_ao_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partlist3_1_prt_f1b" for table "ct_ao_alter_part_split_partlist3"
 ALTER TABLE
 --
@@ -179,11 +179,11 @@ select count(*) from ct_ao_alter_part_split_partlist3;
 -- split partition
 --
 alter table resync_ao_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "resync_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_partlist1_1_prt_f1a" for table "resync_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_partlist1_1_prt_f1b" for table "resync_ao_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_ao_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_ao_alter_part_split_partrange.ans
@@ -74,10 +74,10 @@ select count(*) from resync_ao_alter_part_split_partrange3;
 -- Split Partition Range
 --
 alter table sync1_ao_alter_part_split_partrange6 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange6_1_prt_aa" for table "sync1_ao_alter_part_split_partrange6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange6_1_prt_bb" for table "sync1_ao_alter_part_split_partrange6"
 ALTER TABLE
 --
@@ -101,10 +101,10 @@ select count(*) from sync1_ao_alter_part_split_partrange6;
 -- Split Partition Range
 --
 alter table ck_sync1_ao_alter_part_split_partrange5 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partrange5_1_prt_aa" for table "ck_sync1_ao_alter_part_split_partrange5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partrange5_1_prt_bb" for table "ck_sync1_ao_alter_part_split_partrange5"
 ALTER TABLE
 --
@@ -129,10 +129,10 @@ select count(*) from ck_sync1_ao_alter_part_split_partrange5;
 -- Split Partition Range
 --
 alter table ct_ao_alter_part_split_partrange3 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partrange3_1_prt_aa" for table "ct_ao_alter_part_split_partrange3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partrange3_1_prt_bb" for table "ct_ao_alter_part_split_partrange3"
 ALTER TABLE
 --
@@ -157,10 +157,10 @@ select count(*) from ct_ao_alter_part_split_partrange3;
 -- Split Partition Range
 --
 alter table resync_ao_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_partrange1_1_prt_aa" for table "resync_ao_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_partrange1_1_prt_bb" for table "resync_ao_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_co_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_co_alter_part_split_default_part.ans
@@ -88,11 +88,11 @@ select count(*) from resync_co_alter_part_split_default_part3;
 -- split default partition
 --
 alter table sync1_co_alter_part_split_default_part6 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_co_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part6_1_prt_bing" for table "sync1_co_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part6_1_prt_baz" for table "sync1_co_alter_part_split_default_part6"
 ALTER TABLE
 --
@@ -119,11 +119,11 @@ select count(*) from sync1_co_alter_part_split_default_part6;
 -- split default partition
 --
 alter table ck_sync1_co_alter_part_split_default_part5 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_co_alter_part_split_default_part5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_default_part5_1_prt_bing" for table "ck_sync1_co_alter_part_split_default_part5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_default_part5_1_prt_baz" for table "ck_sync1_co_alter_part_split_default_part5"
 ALTER TABLE
 --
@@ -151,11 +151,11 @@ select count(*) from ck_sync1_co_alter_part_split_default_part5;
 -- split default partition
 --
 alter table ct_co_alter_part_split_default_part3 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ct_co_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_default_part3_1_prt_bing" for table "ct_co_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_default_part3_1_prt_baz" for table "ct_co_alter_part_split_default_part3"
 ALTER TABLE
 --
@@ -182,11 +182,11 @@ select count(*) from ct_co_alter_part_split_default_part3;
 -- split default partition
 --
 alter table resync_co_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "resync_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_default_part1_1_prt_bing" for table "resync_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_default_part1_1_prt_baz" for table "resync_co_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_co_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_co_alter_part_split_partlist.ans
@@ -80,11 +80,11 @@ select count(*) from resync_co_alter_part_split_partlist3;
 -- split partition
 --
 alter table sync1_co_alter_part_split_partlist6 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_co_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist6_1_prt_f1a" for table "sync1_co_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist6_1_prt_f1b" for table "sync1_co_alter_part_split_partlist6"
 ALTER TABLE
 --
@@ -113,11 +113,11 @@ select count(*) from sync1_co_alter_part_split_partlist6;
 -- split partition
 --
 alter table ck_sync1_co_alter_part_split_partlist5 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_co_alter_part_split_partlist5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partlist5_1_prt_f1a" for table "ck_sync1_co_alter_part_split_partlist5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partlist5_1_prt_f1b" for table "ck_sync1_co_alter_part_split_partlist5"
 ALTER TABLE
 --
@@ -147,11 +147,11 @@ select count(*) from ck_sync1_co_alter_part_split_partlist5;
 -- split partition
 --
 alter table ct_co_alter_part_split_partlist3 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ct_co_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partlist3_1_prt_f1a" for table "ct_co_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partlist3_1_prt_f1b" for table "ct_co_alter_part_split_partlist3"
 ALTER TABLE
 --
@@ -180,11 +180,11 @@ select count(*) from ct_co_alter_part_split_partlist3;
 -- split partition
 --
 alter table resync_co_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "resync_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_partlist1_1_prt_f1a" for table "resync_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_partlist1_1_prt_f1b" for table "resync_co_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_heap_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_heap_alter_part_split_default_part.ans
@@ -88,11 +88,11 @@ select count(*) from resync_heap_alter_part_split_default_part3;
 -- split default partition
 --
 alter table sync1_heap_alter_part_split_default_part6 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_heap_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part6_1_prt_bing" for table "sync1_heap_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part6_1_prt_baz" for table "sync1_heap_alter_part_split_default_part6"
 ALTER TABLE
 --
@@ -119,11 +119,11 @@ select count(*) from sync1_heap_alter_part_split_default_part6;
 -- split default partition
 --
 alter table ck_sync1_heap_alter_part_split_default_part5 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_heap_alter_part_split_default_part5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_default_part5_1_prt_bing" for table "ck_sync1_heap_alter_part_split_default_part5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_default_part5_1_prt_baz" for table "ck_sync1_heap_alter_part_split_default_part5"
 ALTER TABLE
 --
@@ -150,11 +150,11 @@ select count(*) from ck_sync1_heap_alter_part_split_default_part5;
 -- split default partition
 --
 alter table ct_heap_alter_part_split_default_part3 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ct_heap_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_default_part3_1_prt_bing" for table "ct_heap_alter_part_split_default_part3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_default_part3_1_prt_baz" for table "ct_heap_alter_part_split_default_part3"
 ALTER TABLE
 --
@@ -181,11 +181,11 @@ select count(*) from ct_heap_alter_part_split_default_part3;
 -- split default partition
 --
 alter table resync_heap_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "resync_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_default_part1_1_prt_bing" for table "resync_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_default_part1_1_prt_baz" for table "resync_heap_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_heap_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_heap_alter_part_split_partlist.ans
@@ -80,11 +80,11 @@ select count(*) from resync_heap_alter_part_split_partlist3;
 -- split partition
 --
 alter table sync1_heap_alter_part_split_partlist6 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_heap_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist6_1_prt_f1a" for table "sync1_heap_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist6_1_prt_f1b" for table "sync1_heap_alter_part_split_partlist6"
 ALTER TABLE
 --
@@ -113,11 +113,11 @@ select count(*) from sync1_heap_alter_part_split_partlist6;
 -- split partition
 --
 alter table ck_sync1_heap_alter_part_split_partlist5 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_heap_alter_part_split_partlist5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partlist5_1_prt_f1a" for table "ck_sync1_heap_alter_part_split_partlist5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partlist5_1_prt_f1b" for table "ck_sync1_heap_alter_part_split_partlist5"
 ALTER TABLE
 --
@@ -146,11 +146,11 @@ select count(*) from ck_sync1_heap_alter_part_split_partlist5;
 -- split partition
 --
 alter table ct_heap_alter_part_split_partlist3 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ct_heap_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partlist3_1_prt_f1a" for table "ct_heap_alter_part_split_partlist3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partlist3_1_prt_f1b" for table "ct_heap_alter_part_split_partlist3"
 ALTER TABLE
 --
@@ -179,11 +179,11 @@ select count(*) from ct_heap_alter_part_split_partlist3;
 -- split partition
 --
 alter table resync_heap_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "resync_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_partlist1_1_prt_f1a" for table "resync_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_partlist1_1_prt_f1b" for table "resync_heap_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_heap_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/skip/resync_heap_alter_part_split_partrange.ans
@@ -74,10 +74,10 @@ select count(*) from resync_heap_alter_part_split_partrange3;
 -- Split Partition Range
 --
 alter table sync1_heap_alter_part_split_partrange6 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange6_1_prt_aa" for table "sync1_heap_alter_part_split_partrange6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange6_1_prt_bb" for table "sync1_heap_alter_part_split_partrange6"
 ALTER TABLE
 --
@@ -101,10 +101,10 @@ select count(*) from sync1_heap_alter_part_split_partrange6;
 -- Split Partition Range
 --
 alter table ck_sync1_heap_alter_part_split_partrange5 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partrange5_1_prt_aa" for table "ck_sync1_heap_alter_part_split_partrange5"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partrange5_1_prt_bb" for table "ck_sync1_heap_alter_part_split_partrange5"
 ALTER TABLE
 --
@@ -128,10 +128,10 @@ select count(*) from ck_sync1_heap_alter_part_split_partrange5;
 -- Split Partition Range
 --
 alter table ct_heap_alter_part_split_partrange3 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partrange3_1_prt_aa" for table "ct_heap_alter_part_split_partrange3"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partrange3_1_prt_bb" for table "ct_heap_alter_part_split_partrange3"
 ALTER TABLE
 --
@@ -155,10 +155,10 @@ select count(*) from ct_heap_alter_part_split_partrange3;
 -- Split Partition Range
 --
 alter table resync_heap_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_partrange1_1_prt_aa" for table "resync_heap_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_partrange1_1_prt_bb" for table "resync_heap_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_ao_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_ao_alter_part_split_default_part.ans
@@ -228,11 +228,11 @@ select count(*) from sync1_ao_alter_part_split_default_part8;
 -- split default partition
 --
 alter table sync1_ao_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part1_1_prt_bing" for table "sync1_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part1_1_prt_baz" for table "sync1_ao_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_ao_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_ao_alter_part_split_partlist.ans
@@ -205,11 +205,11 @@ select count(*) from sync1_ao_alter_part_split_partlist8;
 -- split partition
 --
 alter table sync1_ao_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist1_1_prt_f1a" for table "sync1_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist1_1_prt_f1b" for table "sync1_ao_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_ao_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_ao_alter_part_split_partrange.ans
@@ -189,10 +189,10 @@ select count(*) from sync1_ao_alter_part_split_partrange8;
 -- Split Partition Range
 --
 alter table sync1_ao_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange1_1_prt_aa" for table "sync1_ao_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange1_1_prt_bb" for table "sync1_ao_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_co_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_co_alter_part_split_default_part.ans
@@ -228,11 +228,11 @@ select count(*) from sync1_co_alter_part_split_default_part8;
 -- split default partition
 --
 alter table sync1_co_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part1_1_prt_bing" for table "sync1_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part1_1_prt_baz" for table "sync1_co_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_co_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_co_alter_part_split_partlist.ans
@@ -205,11 +205,11 @@ select count(*) from sync1_co_alter_part_split_partlist8;
 -- split partition
 --
 alter table sync1_co_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist1_1_prt_f1a" for table "sync1_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist1_1_prt_f1b" for table "sync1_co_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_co_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_co_alter_part_split_partrange.ans
@@ -189,10 +189,10 @@ select count(*) from sync1_co_alter_part_split_partrange8;
 -- Split Partition Range
 --
 alter table sync1_co_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partrange1_1_prt_aa" for table "sync1_co_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partrange1_1_prt_bb" for table "sync1_co_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_heap_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_heap_alter_part_split_default_part.ans
@@ -228,11 +228,11 @@ select count(*) from sync1_heap_alter_part_split_default_part8;
 -- split default partition
 --
 alter table sync1_heap_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part1_1_prt_bing" for table "sync1_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part1_1_prt_baz" for table "sync1_heap_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_heap_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_heap_alter_part_split_partlist.ans
@@ -205,11 +205,11 @@ select count(*) from sync1_heap_alter_part_split_partlist8;
 -- split partition
 --
 alter table sync1_heap_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist1_1_prt_f1a" for table "sync1_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist1_1_prt_f1b" for table "sync1_heap_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_heap_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/skip/sync1_heap_alter_part_split_partrange.ans
@@ -189,10 +189,10 @@ select count(*) from sync1_heap_alter_part_split_partrange8;
 -- Split Partition Range
 --
 alter table sync1_heap_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange1_1_prt_aa" for table "sync1_heap_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange1_1_prt_bb" for table "sync1_heap_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_ao_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_ao_alter_part_add_default_part.ans
@@ -191,7 +191,7 @@ INSERT 0 100
 -- ALTER SYNC1 AO Part Add Default Parition
 --
 alter table sync1_ao_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part1_1_prt_default_part" for table "sync1_ao_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part1_1_prt_default_par_2_prt_1" for table "sync1_ao_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_ao_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_ao_alter_part_add_part.ans
@@ -217,7 +217,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_ao_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part1_1_prt_p1" for table "sync1_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "sync1_ao_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "sync1_ao_alter_part_add_part1_1_prt_p1"
@@ -237,7 +237,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_ao_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part1_1_prt_p3" for table "sync1_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "sync1_ao_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_ao_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_ao_alter_part_drop_part.ans
@@ -145,7 +145,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_ao_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part1_1_prt_a2" for table "sync1_ao_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -163,7 +163,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_ao_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part1_1_prt_default_part" for table "sync1_ao_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_ao_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_ao_alter_part_rename.ans
@@ -261,7 +261,7 @@ select count(*) from sync1_ao_alter_part_rn8;
 -- Add default Partition
 --
 alter table sync1_ao_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_rn1_1_prt_default_part" for table "sync1_ao_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_rn1_1_prt_default_part_2_prt_1" for table "sync1_ao_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_alter_part_add_default_part.ans
@@ -191,7 +191,7 @@ INSERT 0 100
 -- ALTER SYNC1 CO Part Add Default Parition
 --
 alter table sync1_co_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part1_1_prt_default_part" for table "sync1_co_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part1_1_prt_default_par_2_prt_1" for table "sync1_co_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_alter_part_add_part.ans
@@ -217,7 +217,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_co_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part1_1_prt_p1" for table "sync1_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "sync1_co_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "sync1_co_alter_part_add_part1_1_prt_p1"
@@ -237,7 +237,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_co_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part1_1_prt_p3" for table "sync1_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "sync1_co_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_alter_part_drop_part.ans
@@ -145,7 +145,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_co_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part1_1_prt_a2" for table "sync1_co_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -163,7 +163,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_co_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part1_1_prt_default_part" for table "sync1_co_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_alter_part_rename.ans
@@ -261,7 +261,7 @@ select count(*) from sync1_co_alter_part_rn8;
 -- Add default Partition
 --
 alter table sync1_co_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn1_1_prt_default_part" for table "sync1_co_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn1_1_prt_default_part_2_prt_1" for table "sync1_co_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_create_wet_ret.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_create_wet_ret.ans
@@ -32,7 +32,7 @@ INSERT 0 5
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE sync1_wet_region1 ( like sync1_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region1.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -48,7 +48,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE sync1_new_region1 (like sync1_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_heap_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_heap_alter_part_add_default_part.ans
@@ -191,7 +191,7 @@ INSERT 0 100
 -- ALTER SYNC1 Heap Part Add Default Parition
 --
 alter table sync1_heap_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part1_1_prt_default_part" for table "sync1_heap_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part1_1_prt_default_p_2_prt_1" for table "sync1_heap_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_heap_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_heap_alter_part_add_part.ans
@@ -217,7 +217,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_heap_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part1_1_prt_p1" for table "sync1_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "sync1_heap_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "sync1_heap_alter_part_add_part1_1_prt_p1"
@@ -237,7 +237,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_heap_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part1_1_prt_p3" for table "sync1_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "sync1_heap_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_heap_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_heap_alter_part_drop_part.ans
@@ -145,7 +145,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_heap_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part1_1_prt_a2" for table "sync1_heap_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -163,7 +163,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_heap_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part1_1_prt_default_part" for table "sync1_heap_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_heap_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_heap_alter_part_rename.ans
@@ -261,7 +261,7 @@ select count(*) from sync1_heap_alter_part_rn8;
 -- Add default Partition
 --
 alter table sync1_heap_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn1_1_prt_default_part" for table "sync1_heap_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn1_1_prt_default_part_2_prt_1" for table "sync1_heap_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_ao_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_ao_alter_part_split_default_part.ans
@@ -60,11 +60,11 @@ select count(*) from sync2_ao_alter_part_split_default_part2;
 -- split default partition
 --
 alter table sync1_ao_alter_part_split_default_part7 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_ao_alter_part_split_default_part7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part7_1_prt_bing" for table "sync1_ao_alter_part_split_default_part7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_default_part7_1_prt_baz" for table "sync1_ao_alter_part_split_default_part7"
 ALTER TABLE
 --
@@ -91,11 +91,11 @@ select count(*) from sync1_ao_alter_part_split_default_part7;
 -- split default partition
 --
 alter table ck_sync1_ao_alter_part_split_default_part6 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_ao_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_default_part6_1_prt_bing" for table "ck_sync1_ao_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_default_part6_1_prt_baz" for table "ck_sync1_ao_alter_part_split_default_part6"
 ALTER TABLE
 --
@@ -122,11 +122,11 @@ select count(*) from ck_sync1_ao_alter_part_split_default_part6;
 -- split default partition
 --
 alter table ct_ao_alter_part_split_default_part4 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ct_ao_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_default_part4_1_prt_bing" for table "ct_ao_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_default_part4_1_prt_baz" for table "ct_ao_alter_part_split_default_part4"
 ALTER TABLE
 --
@@ -153,11 +153,11 @@ select count(*) from ct_ao_alter_part_split_default_part4;
 -- split default partition
 --
 alter table resync_ao_alter_part_split_default_part2 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "resync_ao_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_default_part2_1_prt_bing" for table "resync_ao_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_default_part2_1_prt_baz" for table "resync_ao_alter_part_split_default_part2"
 ALTER TABLE
 --
@@ -184,11 +184,11 @@ select count(*) from resync_ao_alter_part_split_default_part2;
 -- split default partition
 --
 alter table sync2_ao_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync2_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_split_default_part1_1_prt_bing" for table "sync2_ao_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_split_default_part1_1_prt_baz" for table "sync2_ao_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_ao_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_ao_alter_part_split_partlist.ans
@@ -55,11 +55,11 @@ select count(*) from sync2_ao_alter_part_split_partlist2;
 -- split partition
 --
 alter table sync1_ao_alter_part_split_partlist7 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_ao_alter_part_split_partlist7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist7_1_prt_f1a" for table "sync1_ao_alter_part_split_partlist7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partlist7_1_prt_f1b" for table "sync1_ao_alter_part_split_partlist7"
 ALTER TABLE
 --
@@ -88,11 +88,11 @@ select count(*) from sync1_ao_alter_part_split_partlist7;
 -- split partition
 --
 alter table ck_sync1_ao_alter_part_split_partlist6 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_ao_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partlist6_1_prt_f1a" for table "ck_sync1_ao_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partlist6_1_prt_f1b" for table "ck_sync1_ao_alter_part_split_partlist6"
 ALTER TABLE
 --
@@ -121,11 +121,11 @@ select count(*) from ck_sync1_ao_alter_part_split_partlist6;
 -- split partition
 --
 alter table ct_ao_alter_part_split_partlist4 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ct_ao_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partlist4_1_prt_f1a" for table "ct_ao_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partlist4_1_prt_f1b" for table "ct_ao_alter_part_split_partlist4"
 ALTER TABLE
 --
@@ -154,11 +154,11 @@ select count(*) from ct_ao_alter_part_split_partlist4;
 -- split partition
 --
 alter table resync_ao_alter_part_split_partlist2 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "resync_ao_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_partlist2_1_prt_f1a" for table "resync_ao_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_partlist2_1_prt_f1b" for table "resync_ao_alter_part_split_partlist2"
 ALTER TABLE
 --
@@ -187,11 +187,11 @@ select count(*) from resync_ao_alter_part_split_partlist2;
 -- split partition
 --
 alter table sync2_ao_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync2_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_split_partlist1_1_prt_f1a" for table "sync2_ao_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_split_partlist1_1_prt_f1b" for table "sync2_ao_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_ao_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_ao_alter_part_split_partrange.ans
@@ -51,10 +51,10 @@ select count(*) from sync2_ao_alter_part_split_partrange2;
 -- Split Partition Range
 --
 alter table sync1_ao_alter_part_split_partrange7 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange7_1_prt_aa" for table "sync1_ao_alter_part_split_partrange7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_split_partrange7_1_prt_bb" for table "sync1_ao_alter_part_split_partrange7"
 ALTER TABLE
 --
@@ -78,10 +78,10 @@ select count(*) from sync1_ao_alter_part_split_partrange7;
 -- Split Partition Range
 --
 alter table ck_sync1_ao_alter_part_split_partrange6 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partrange6_1_prt_aa" for table "ck_sync1_ao_alter_part_split_partrange6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_split_partrange6_1_prt_bb" for table "ck_sync1_ao_alter_part_split_partrange6"
 ALTER TABLE
 --
@@ -105,10 +105,10 @@ select count(*) from ck_sync1_ao_alter_part_split_partrange6;
 -- Split Partition Range
 --
 alter table ct_ao_alter_part_split_partrange4 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partrange4_1_prt_aa" for table "ct_ao_alter_part_split_partrange4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_split_partrange4_1_prt_bb" for table "ct_ao_alter_part_split_partrange4"
 ALTER TABLE
 --
@@ -132,10 +132,10 @@ select count(*) from ct_ao_alter_part_split_partrange4;
 -- Split Partition Range
 --
 alter table resync_ao_alter_part_split_partrange2 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_partrange2_1_prt_aa" for table "resync_ao_alter_part_split_partrange2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_split_partrange2_1_prt_bb" for table "resync_ao_alter_part_split_partrange2"
 ALTER TABLE
 --
@@ -159,10 +159,10 @@ select count(*) from resync_ao_alter_part_split_partrange2;
 -- Split Partition Range
 --
 alter table sync2_ao_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_split_partrange1_1_prt_aa" for table "sync2_ao_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_split_partrange1_1_prt_bb" for table "sync2_ao_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_co_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_co_alter_part_split_default_part.ans
@@ -60,11 +60,11 @@ select count(*) from sync2_co_alter_part_split_default_part2;
 -- split default partition
 --
 alter table sync1_co_alter_part_split_default_part7 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_co_alter_part_split_default_part7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part7_1_prt_bing" for table "sync1_co_alter_part_split_default_part7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_default_part7_1_prt_baz" for table "sync1_co_alter_part_split_default_part7"
 ALTER TABLE
 --
@@ -91,11 +91,11 @@ select count(*) from sync1_co_alter_part_split_default_part7;
 -- split default partition
 --
 alter table ck_sync1_co_alter_part_split_default_part6 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_co_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_default_part6_1_prt_bing" for table "ck_sync1_co_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_default_part6_1_prt_baz" for table "ck_sync1_co_alter_part_split_default_part6"
 ALTER TABLE
 --
@@ -122,11 +122,11 @@ select count(*) from ck_sync1_co_alter_part_split_default_part6;
 -- split default partition
 --
 alter table ct_co_alter_part_split_default_part4 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ct_co_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_default_part4_1_prt_bing" for table "ct_co_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_default_part4_1_prt_baz" for table "ct_co_alter_part_split_default_part4"
 ALTER TABLE
 --
@@ -153,11 +153,11 @@ select count(*) from ct_co_alter_part_split_default_part4;
 -- split default partition
 --
 alter table resync_co_alter_part_split_default_part2 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "resync_co_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_default_part2_1_prt_bing" for table "resync_co_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_default_part2_1_prt_baz" for table "resync_co_alter_part_split_default_part2"
 ALTER TABLE
 --
@@ -184,11 +184,11 @@ select count(*) from resync_co_alter_part_split_default_part2;
 -- split default partition
 --
 alter table sync2_co_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync2_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_split_default_part1_1_prt_bing" for table "sync2_co_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_split_default_part1_1_prt_baz" for table "sync2_co_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_co_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_co_alter_part_split_partlist.ans
@@ -55,11 +55,11 @@ select count(*) from sync2_co_alter_part_split_partlist2;
 -- split partition
 --
 alter table sync1_co_alter_part_split_partlist7 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_co_alter_part_split_partlist7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist7_1_prt_f1a" for table "sync1_co_alter_part_split_partlist7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partlist7_1_prt_f1b" for table "sync1_co_alter_part_split_partlist7"
 ALTER TABLE
 --
@@ -88,11 +88,11 @@ select count(*) from sync1_co_alter_part_split_partlist7;
 -- split partition
 --
 alter table ck_sync1_co_alter_part_split_partlist6 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_co_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partlist6_1_prt_f1a" for table "ck_sync1_co_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partlist6_1_prt_f1b" for table "ck_sync1_co_alter_part_split_partlist6"
 ALTER TABLE
 --
@@ -121,11 +121,11 @@ select count(*) from ck_sync1_co_alter_part_split_partlist6;
 -- split partition
 --
 alter table ct_co_alter_part_split_partlist4 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ct_co_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partlist4_1_prt_f1a" for table "ct_co_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partlist4_1_prt_f1b" for table "ct_co_alter_part_split_partlist4"
 ALTER TABLE
 --
@@ -154,11 +154,11 @@ select count(*) from ct_co_alter_part_split_partlist4;
 -- split partition
 --
 alter table resync_co_alter_part_split_partlist2 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "resync_co_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_partlist2_1_prt_f1a" for table "resync_co_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_partlist2_1_prt_f1b" for table "resync_co_alter_part_split_partlist2"
 ALTER TABLE
 --
@@ -187,11 +187,11 @@ select count(*) from resync_co_alter_part_split_partlist2;
 -- split partition
 --
 alter table sync2_co_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync2_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_split_partlist1_1_prt_f1a" for table "sync2_co_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_split_partlist1_1_prt_f1b" for table "sync2_co_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_co_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_co_alter_part_split_partrange.ans
@@ -51,10 +51,10 @@ select count(*) from sync2_co_alter_part_split_partrange2;
 -- Split Partition Range
 --
 alter table sync1_co_alter_part_split_partrange7 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partrange7_1_prt_aa" for table "sync1_co_alter_part_split_partrange7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_split_partrange7_1_prt_bb" for table "sync1_co_alter_part_split_partrange7"
 ALTER TABLE
 --
@@ -78,10 +78,10 @@ select count(*) from sync1_co_alter_part_split_partrange7;
 -- Split Partition Range
 --
 alter table ck_sync1_co_alter_part_split_partrange6 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partrange6_1_prt_aa" for table "ck_sync1_co_alter_part_split_partrange6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_split_partrange6_1_prt_bb" for table "ck_sync1_co_alter_part_split_partrange6"
 ALTER TABLE
 --
@@ -105,10 +105,10 @@ select count(*) from ck_sync1_co_alter_part_split_partrange6;
 -- Split Partition Range
 --
 alter table ct_co_alter_part_split_partrange4 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partrange4_1_prt_aa" for table "ct_co_alter_part_split_partrange4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_split_partrange4_1_prt_bb" for table "ct_co_alter_part_split_partrange4"
 ALTER TABLE
 --
@@ -132,10 +132,10 @@ select count(*) from ct_co_alter_part_split_partrange4;
 -- Split Partition Range
 --
 alter table resync_co_alter_part_split_partrange2 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_partrange2_1_prt_aa" for table "resync_co_alter_part_split_partrange2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_split_partrange2_1_prt_bb" for table "resync_co_alter_part_split_partrange2"
 ALTER TABLE
 --
@@ -159,10 +159,10 @@ select count(*) from resync_co_alter_part_split_partrange2;
 -- Split Partition Range
 --
 alter table sync2_co_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_split_partrange1_1_prt_aa" for table "sync2_co_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_split_partrange1_1_prt_bb" for table "sync2_co_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_heap_alter_part_split_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_heap_alter_part_split_default_part.ans
@@ -60,11 +60,11 @@ select count(*) from sync2_heap_alter_part_split_default_part2;
 -- split default partition
 --
 alter table sync1_heap_alter_part_split_default_part7 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync1_heap_alter_part_split_default_part7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part7_1_prt_bing" for table "sync1_heap_alter_part_split_default_part7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_default_part7_1_prt_baz" for table "sync1_heap_alter_part_split_default_part7"
 ALTER TABLE
 --
@@ -91,11 +91,11 @@ select count(*) from sync1_heap_alter_part_split_default_part7;
 -- split default partition
 --
 alter table ck_sync1_heap_alter_part_split_default_part6 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ck_sync1_heap_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_default_part6_1_prt_bing" for table "ck_sync1_heap_alter_part_split_default_part6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_default_part6_1_prt_baz" for table "ck_sync1_heap_alter_part_split_default_part6"
 ALTER TABLE
 --
@@ -122,11 +122,11 @@ select count(*) from ck_sync1_heap_alter_part_split_default_part6;
 -- split default partition
 --
 alter table ct_heap_alter_part_split_default_part4 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "ct_heap_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_default_part4_1_prt_bing" for table "ct_heap_alter_part_split_default_part4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_default_part4_1_prt_baz" for table "ct_heap_alter_part_split_default_part4"
 ALTER TABLE
 --
@@ -154,11 +154,11 @@ select count(*) from ct_heap_alter_part_split_default_part4;
 -- split default partition
 --
 alter table resync_heap_alter_part_split_default_part2 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "resync_heap_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_default_part2_1_prt_bing" for table "resync_heap_alter_part_split_default_part2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_default_part2_1_prt_baz" for table "resync_heap_alter_part_split_default_part2"
 ALTER TABLE
 --
@@ -185,11 +185,11 @@ select count(*) from resync_heap_alter_part_split_default_part2;
 -- split default partition
 --
 alter table sync2_heap_alter_part_split_default_part1 split default partition at ('baz') into (partition bing, default partition);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "baz" for relation "sync2_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_split_default_part1_1_prt_bing" for table "sync2_heap_alter_part_split_default_part1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_split_default_part1_1_prt_baz" for table "sync2_heap_alter_part_split_default_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_heap_alter_part_split_partlist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_heap_alter_part_split_partlist.ans
@@ -55,11 +55,11 @@ select count(*) from sync2_heap_alter_part_split_partlist2;
 -- split partition
 --
 alter table sync1_heap_alter_part_split_partlist7 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync1_heap_alter_part_split_partlist7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist7_1_prt_f1a" for table "sync1_heap_alter_part_split_partlist7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partlist7_1_prt_f1b" for table "sync1_heap_alter_part_split_partlist7"
 ALTER TABLE
 --
@@ -88,11 +88,11 @@ select count(*) from sync1_heap_alter_part_split_partlist7;
 -- split partition
 --
 alter table ck_sync1_heap_alter_part_split_partlist6 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ck_sync1_heap_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partlist6_1_prt_f1a" for table "ck_sync1_heap_alter_part_split_partlist6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partlist6_1_prt_f1b" for table "ck_sync1_heap_alter_part_split_partlist6"
 ALTER TABLE
 --
@@ -121,11 +121,11 @@ select count(*) from ck_sync1_heap_alter_part_split_partlist6;
 -- split partition
 --
 alter table ct_heap_alter_part_split_partlist4 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "ct_heap_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partlist4_1_prt_f1a" for table "ct_heap_alter_part_split_partlist4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partlist4_1_prt_f1b" for table "ct_heap_alter_part_split_partlist4"
 ALTER TABLE
 --
@@ -154,11 +154,11 @@ select count(*) from ct_heap_alter_part_split_partlist4;
 -- split partition
 --
 alter table resync_heap_alter_part_split_partlist2 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "resync_heap_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_partlist2_1_prt_f1a" for table "resync_heap_alter_part_split_partlist2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_partlist2_1_prt_f1b" for table "resync_heap_alter_part_split_partlist2"
 ALTER TABLE
 --
@@ -187,11 +187,11 @@ select count(*) from resync_heap_alter_part_split_partlist2;
 -- split partition
 --
 alter table sync2_heap_alter_part_split_partlist1 split partition for(1) at (1,2) into (partition f1a, partition f1b);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  dropped partition "a" for relation "sync2_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_split_partlist1_1_prt_f1a" for table "sync2_heap_alter_part_split_partlist1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_split_partlist1_1_prt_f1b" for table "sync2_heap_alter_part_split_partlist1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_heap_alter_part_split_partrange.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/skip/sync2_heap_alter_part_split_partrange.ans
@@ -51,10 +51,10 @@ select count(*) from sync2_heap_alter_part_split_partrange2;
 -- Split Partition Range
 --
 alter table sync1_heap_alter_part_split_partrange7 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange7_1_prt_aa" for table "sync1_heap_alter_part_split_partrange7"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_split_partrange7_1_prt_bb" for table "sync1_heap_alter_part_split_partrange7"
 ALTER TABLE
 --
@@ -78,10 +78,10 @@ select count(*) from sync1_heap_alter_part_split_partrange7;
 -- Split Partition Range
 --
 alter table ck_sync1_heap_alter_part_split_partrange6 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partrange6_1_prt_aa" for table "ck_sync1_heap_alter_part_split_partrange6"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_split_partrange6_1_prt_bb" for table "ck_sync1_heap_alter_part_split_partrange6"
 ALTER TABLE
 --
@@ -105,10 +105,10 @@ select count(*) from ck_sync1_heap_alter_part_split_partrange6;
 -- Split Partition Range
 --
 alter table ct_heap_alter_part_split_partrange4 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partrange4_1_prt_aa" for table "ct_heap_alter_part_split_partrange4"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_split_partrange4_1_prt_bb" for table "ct_heap_alter_part_split_partrange4"
 ALTER TABLE
 --
@@ -132,10 +132,10 @@ select count(*) from ct_heap_alter_part_split_partrange4;
 -- Split Partition Range
 --
 alter table resync_heap_alter_part_split_partrange2 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_partrange2_1_prt_aa" for table "resync_heap_alter_part_split_partrange2"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_split_partrange2_1_prt_bb" for table "resync_heap_alter_part_split_partrange2"
 ALTER TABLE
 --
@@ -159,10 +159,10 @@ select count(*) from resync_heap_alter_part_split_partrange2;
 -- Split Partition Range
 --
 alter table sync2_heap_alter_part_split_partrange1 split partition for(1) at (5) into (partition aa, partition bb);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_split_partrange1_1_prt_aa" for table "sync2_heap_alter_part_split_partrange1"
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_split_partrange1_1_prt_bb" for table "sync2_heap_alter_part_split_partrange1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_ao_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_ao_alter_part_add_default_part.ans
@@ -53,7 +53,7 @@ INSERT 0 100
 -- ALTER SYNC1 AO Part Add Default Parition
 --
 alter table sync1_ao_alter_part_add_default_part7 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part7_1_prt_default_part" for table "sync1_ao_alter_part_add_default_part7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_default_part7_1_prt_default_par_2_prt_1" for table "sync1_ao_alter_part_add_default_part7_1_prt_default_part"
 ALTER TABLE
@@ -66,7 +66,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 AO Part Add Default Parition
 --
 alter table ck_sync1_ao_alter_part_add_default_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_default_part6_1_prt_default_part" for table "ck_sync1_ao_alter_part_add_default_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_default_part6_1_prt_default__2_prt_1" for table "ck_sync1_ao_alter_part_add_default_part6_1_prt_default_part"
 ALTER TABLE
@@ -79,7 +79,7 @@ INSERT 0 100
 -- ALTER CT AO Part Add Default Parition
 --
 alter table ct_ao_alter_part_add_default_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_default_part4_1_prt_default_part" for table "ct_ao_alter_part_add_default_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_default_part4_1_prt_default_part_2_prt_1" for table "ct_ao_alter_part_add_default_part4_1_prt_default_part"
 ALTER TABLE
@@ -92,7 +92,7 @@ INSERT 0 100
 -- ALTER RESYNC AO Part Add Default Parition
 --
 alter table resync_ao_alter_part_add_default_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_default_part2_1_prt_default_part" for table "resync_ao_alter_part_add_default_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_default_part2_1_prt_default_pa_2_prt_1" for table "resync_ao_alter_part_add_default_part2_1_prt_default_part"
 ALTER TABLE
@@ -105,7 +105,7 @@ INSERT 0 100
 -- ALTER SYNC2 AO Part Add Default Parition
 --
 alter table sync2_ao_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_add_default_part1_1_prt_default_part" for table "sync2_ao_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_add_default_part1_1_prt_default_par_2_prt_1" for table "sync2_ao_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_ao_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_ao_alter_part_add_part.ans
@@ -61,7 +61,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_ao_alter_part_add_part7 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part7_1_prt_p1" for table "sync1_ao_alter_part_add_part7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part7_1_prt_p1_2_prt_sp1" for table "sync1_ao_alter_part_add_part7_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part7_1_prt_p1_2_prt_sp2" for table "sync1_ao_alter_part_add_part7_1_prt_p1"
@@ -81,7 +81,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_ao_alter_part_add_part7 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part7_1_prt_p3" for table "sync1_ao_alter_part_add_part7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_add_part7_1_prt_p3_2_prt_sp3" for table "sync1_ao_alter_part_add_part7_1_prt_p3"
 ALTER TABLE
@@ -96,7 +96,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_ao_alter_part_add_part6 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part6_1_prt_p1" for table "ck_sync1_ao_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part6_1_prt_p1_2_prt_sp1" for table "ck_sync1_ao_alter_part_add_part6_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part6_1_prt_p1_2_prt_sp2" for table "ck_sync1_ao_alter_part_add_part6_1_prt_p1"
@@ -116,7 +116,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_ao_alter_part_add_part6 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part6_1_prt_p3" for table "ck_sync1_ao_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_add_part6_1_prt_p3_2_prt_sp3" for table "ck_sync1_ao_alter_part_add_part6_1_prt_p3"
 ALTER TABLE
@@ -131,7 +131,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_ao_alter_part_add_part4 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part4_1_prt_p1" for table "ct_ao_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part4_1_prt_p1_2_prt_sp1" for table "ct_ao_alter_part_add_part4_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part4_1_prt_p1_2_prt_sp2" for table "ct_ao_alter_part_add_part4_1_prt_p1"
@@ -151,7 +151,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_ao_alter_part_add_part4 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part4_1_prt_p3" for table "ct_ao_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_add_part4_1_prt_p3_2_prt_sp3" for table "ct_ao_alter_part_add_part4_1_prt_p3"
 ALTER TABLE
@@ -166,7 +166,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table resync_ao_alter_part_add_part2 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part2_1_prt_p1" for table "resync_ao_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part2_1_prt_p1_2_prt_sp1" for table "resync_ao_alter_part_add_part2_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part2_1_prt_p1_2_prt_sp2" for table "resync_ao_alter_part_add_part2_1_prt_p1"
@@ -186,7 +186,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table resync_ao_alter_part_add_part2 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part2_1_prt_p3" for table "resync_ao_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_add_part2_1_prt_p3_2_prt_sp3" for table "resync_ao_alter_part_add_part2_1_prt_p3"
 ALTER TABLE
@@ -201,7 +201,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync2_ao_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_add_part1_1_prt_p1" for table "sync2_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "sync2_ao_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "sync2_ao_alter_part_add_part1_1_prt_p1"
@@ -221,7 +221,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync2_ao_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_add_part1_1_prt_p3" for table "sync2_ao_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "sync2_ao_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_ao_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_ao_alter_part_drop_part.ans
@@ -43,7 +43,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_ao_alter_part_drop_part7 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part7_1_prt_a2" for table "sync1_ao_alter_part_drop_part7"
 ALTER TABLE
 --
@@ -61,7 +61,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_ao_alter_part_drop_part7 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_drop_part7_1_prt_default_part" for table "sync1_ao_alter_part_drop_part7"
 ALTER TABLE
 --
@@ -94,7 +94,7 @@ select count(*) from sync1_ao_alter_part_drop_part7;
 -- Add partition 
 --
 alter table ck_sync1_ao_alter_part_drop_part6 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_drop_part6_1_prt_a2" for table "ck_sync1_ao_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -112,7 +112,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_ao_alter_part_drop_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_drop_part6_1_prt_default_part" for table "ck_sync1_ao_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -145,7 +145,7 @@ select count(*) from ck_sync1_ao_alter_part_drop_part6;
 -- Add partition 
 --
 alter table ct_ao_alter_part_drop_part4 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_drop_part4_1_prt_a2" for table "ct_ao_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -163,7 +163,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ct_ao_alter_part_drop_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_drop_part4_1_prt_default_part" for table "ct_ao_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -196,7 +196,7 @@ select count(*) from ct_ao_alter_part_drop_part4;
 -- Add partition 
 --
 alter table resync_ao_alter_part_drop_part2 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_drop_part2_1_prt_a2" for table "resync_ao_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -214,7 +214,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table resync_ao_alter_part_drop_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_drop_part2_1_prt_default_part" for table "resync_ao_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -247,7 +247,7 @@ select count(*) from resync_ao_alter_part_drop_part2;
 -- Add partition 
 --
 alter table sync2_ao_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_drop_part1_1_prt_a2" for table "sync2_ao_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -265,7 +265,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync2_ao_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_drop_part1_1_prt_default_part" for table "sync2_ao_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_ao_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_ao_alter_part_rename.ans
@@ -69,7 +69,7 @@ select count(*) from sync2_ao_alter_part_rn2;
 -- Add default Partition
 --
 alter table sync1_ao_alter_part_rn7 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_rn7_1_prt_default_part" for table "sync1_ao_alter_part_rn7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_ao_alter_part_rn7_1_prt_default_part_2_prt_1" for table "sync1_ao_alter_part_rn7_1_prt_default_part"
 ALTER TABLE
@@ -119,7 +119,7 @@ select count(*) from sync1_ao_alter_part_rn7_0;
 -- Add default Partition
 --
 alter table ck_sync1_ao_alter_part_rn6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_rn6_1_prt_default_part" for table "ck_sync1_ao_alter_part_rn6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_ao_alter_part_rn6_1_prt_default_part_2_prt_1" for table "ck_sync1_ao_alter_part_rn6_1_prt_default_part"
 ALTER TABLE
@@ -169,7 +169,7 @@ select count(*) from ck_sync1_ao_alter_part_rn6_0;
 -- Add default Partition
 --
 alter table ct_ao_alter_part_rn4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_rn4_1_prt_default_part" for table "ct_ao_alter_part_rn4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_ao_alter_part_rn4_1_prt_default_part_2_prt_1" for table "ct_ao_alter_part_rn4_1_prt_default_part"
 ALTER TABLE
@@ -219,7 +219,7 @@ select count(*) from ct_ao_alter_part_rn4_0;
 -- Add default Partition
 --
 alter table resync_ao_alter_part_rn2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_rn2_1_prt_default_part" for table "resync_ao_alter_part_rn2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_ao_alter_part_rn2_1_prt_default_part_2_prt_1" for table "resync_ao_alter_part_rn2_1_prt_default_part"
 ALTER TABLE
@@ -269,7 +269,7 @@ select count(*) from resync_ao_alter_part_rn2_0;
 -- Add default Partition
 --
 alter table sync2_ao_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_rn1_1_prt_default_part" for table "sync2_ao_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_ao_alter_part_rn1_1_prt_default_part_2_prt_1" for table "sync2_ao_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_alter_part_add_default_part.ans
@@ -53,7 +53,7 @@ INSERT 0 100
 -- ALTER SYNC1 CO Part Add Default Parition
 --
 alter table sync1_co_alter_part_add_default_part7 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part7_1_prt_default_part" for table "sync1_co_alter_part_add_default_part7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_default_part7_1_prt_default_par_2_prt_1" for table "sync1_co_alter_part_add_default_part7_1_prt_default_part"
 ALTER TABLE
@@ -66,7 +66,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 CO Part Add Default Parition
 --
 alter table ck_sync1_co_alter_part_add_default_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_default_part6_1_prt_default_part" for table "ck_sync1_co_alter_part_add_default_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_default_part6_1_prt_default__2_prt_1" for table "ck_sync1_co_alter_part_add_default_part6_1_prt_default_part"
 ALTER TABLE
@@ -79,7 +79,7 @@ INSERT 0 100
 -- ALTER CT CO Part Add Default Parition
 --
 alter table ct_co_alter_part_add_default_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_default_part4_1_prt_default_part" for table "ct_co_alter_part_add_default_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_default_part4_1_prt_default_part_2_prt_1" for table "ct_co_alter_part_add_default_part4_1_prt_default_part"
 ALTER TABLE
@@ -92,7 +92,7 @@ INSERT 0 100
 -- ALTER RESYNC CO Part Add Default Parition
 --
 alter table resync_co_alter_part_add_default_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_default_part2_1_prt_default_part" for table "resync_co_alter_part_add_default_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_default_part2_1_prt_default_pa_2_prt_1" for table "resync_co_alter_part_add_default_part2_1_prt_default_part"
 ALTER TABLE
@@ -105,7 +105,7 @@ INSERT 0 100
 -- ALTER SYNC2 CO Part Add Default Parition
 --
 alter table sync2_co_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_add_default_part1_1_prt_default_part" for table "sync2_co_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_add_default_part1_1_prt_default_par_2_prt_1" for table "sync2_co_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_alter_part_add_part.ans
@@ -61,7 +61,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_co_alter_part_add_part7 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part7_1_prt_p1" for table "sync1_co_alter_part_add_part7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part7_1_prt_p1_2_prt_sp1" for table "sync1_co_alter_part_add_part7_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part7_1_prt_p1_2_prt_sp2" for table "sync1_co_alter_part_add_part7_1_prt_p1"
@@ -81,7 +81,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_co_alter_part_add_part7 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part7_1_prt_p3" for table "sync1_co_alter_part_add_part7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_add_part7_1_prt_p3_2_prt_sp3" for table "sync1_co_alter_part_add_part7_1_prt_p3"
 ALTER TABLE
@@ -96,7 +96,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_co_alter_part_add_part6 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part6_1_prt_p1" for table "ck_sync1_co_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part6_1_prt_p1_2_prt_sp1" for table "ck_sync1_co_alter_part_add_part6_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part6_1_prt_p1_2_prt_sp2" for table "ck_sync1_co_alter_part_add_part6_1_prt_p1"
@@ -116,7 +116,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_co_alter_part_add_part6 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part6_1_prt_p3" for table "ck_sync1_co_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_add_part6_1_prt_p3_2_prt_sp3" for table "ck_sync1_co_alter_part_add_part6_1_prt_p3"
 ALTER TABLE
@@ -131,7 +131,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_co_alter_part_add_part4 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part4_1_prt_p1" for table "ct_co_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part4_1_prt_p1_2_prt_sp1" for table "ct_co_alter_part_add_part4_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part4_1_prt_p1_2_prt_sp2" for table "ct_co_alter_part_add_part4_1_prt_p1"
@@ -151,7 +151,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_co_alter_part_add_part4 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part4_1_prt_p3" for table "ct_co_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_add_part4_1_prt_p3_2_prt_sp3" for table "ct_co_alter_part_add_part4_1_prt_p3"
 ALTER TABLE
@@ -167,7 +167,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table resync_co_alter_part_add_part2 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part2_1_prt_p1" for table "resync_co_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part2_1_prt_p1_2_prt_sp1" for table "resync_co_alter_part_add_part2_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part2_1_prt_p1_2_prt_sp2" for table "resync_co_alter_part_add_part2_1_prt_p1"
@@ -187,7 +187,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table resync_co_alter_part_add_part2 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part2_1_prt_p3" for table "resync_co_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_add_part2_1_prt_p3_2_prt_sp3" for table "resync_co_alter_part_add_part2_1_prt_p3"
 ALTER TABLE
@@ -202,7 +202,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync2_co_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_add_part1_1_prt_p1" for table "sync2_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "sync2_co_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "sync2_co_alter_part_add_part1_1_prt_p1"
@@ -222,7 +222,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync2_co_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_add_part1_1_prt_p3" for table "sync2_co_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "sync2_co_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_alter_part_drop_part.ans
@@ -43,7 +43,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_co_alter_part_drop_part7 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part7_1_prt_a2" for table "sync1_co_alter_part_drop_part7"
 ALTER TABLE
 --
@@ -61,7 +61,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_co_alter_part_drop_part7 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_drop_part7_1_prt_default_part" for table "sync1_co_alter_part_drop_part7"
 ALTER TABLE
 --
@@ -94,7 +94,7 @@ select count(*) from sync1_co_alter_part_drop_part7;
 -- Add partition 
 --
 alter table ck_sync1_co_alter_part_drop_part6 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_drop_part6_1_prt_a2" for table "ck_sync1_co_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -112,7 +112,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_co_alter_part_drop_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_drop_part6_1_prt_default_part" for table "ck_sync1_co_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -145,7 +145,7 @@ select count(*) from ck_sync1_co_alter_part_drop_part6;
 -- Add partition 
 --
 alter table ct_co_alter_part_drop_part4 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_drop_part4_1_prt_a2" for table "ct_co_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -163,7 +163,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ct_co_alter_part_drop_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_drop_part4_1_prt_default_part" for table "ct_co_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -196,7 +196,7 @@ select count(*) from ct_co_alter_part_drop_part4;
 -- Add partition 
 --
 alter table resync_co_alter_part_drop_part2 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_drop_part2_1_prt_a2" for table "resync_co_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -214,7 +214,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table resync_co_alter_part_drop_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_drop_part2_1_prt_default_part" for table "resync_co_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -247,7 +247,7 @@ select count(*) from resync_co_alter_part_drop_part2;
 -- Add partition 
 --
 alter table sync2_co_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_drop_part1_1_prt_a2" for table "sync2_co_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -265,7 +265,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync2_co_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_drop_part1_1_prt_default_part" for table "sync2_co_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_alter_part_rename.ans
@@ -69,7 +69,7 @@ select count(*) from sync2_co_alter_part_rn2;
 -- Add default Partition
 --
 alter table sync1_co_alter_part_rn7 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn7_1_prt_default_part" for table "sync1_co_alter_part_rn7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_co_alter_part_rn7_1_prt_default_part_2_prt_1" for table "sync1_co_alter_part_rn7_1_prt_default_part"
 ALTER TABLE
@@ -119,7 +119,7 @@ select count(*) from sync1_co_alter_part_rn7_0;
 -- Add default Partition
 --
 alter table ck_sync1_co_alter_part_rn6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_rn6_1_prt_default_part" for table "ck_sync1_co_alter_part_rn6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_co_alter_part_rn6_1_prt_default_part_2_prt_1" for table "ck_sync1_co_alter_part_rn6_1_prt_default_part"
 ALTER TABLE
@@ -169,7 +169,7 @@ select count(*) from ck_sync1_co_alter_part_rn6_0;
 -- Add default Partition
 --
 alter table ct_co_alter_part_rn4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_rn4_1_prt_default_part" for table "ct_co_alter_part_rn4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_co_alter_part_rn4_1_prt_default_part_2_prt_1" for table "ct_co_alter_part_rn4_1_prt_default_part"
 ALTER TABLE
@@ -219,7 +219,7 @@ select count(*) from ct_co_alter_part_rn4_0;
 -- Add default Partition
 --
 alter table resync_co_alter_part_rn2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_rn2_1_prt_default_part" for table "resync_co_alter_part_rn2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_co_alter_part_rn2_1_prt_default_part_2_prt_1" for table "resync_co_alter_part_rn2_1_prt_default_part"
 ALTER TABLE
@@ -269,7 +269,7 @@ select count(*) from resync_co_alter_part_rn2_0;
 -- Add default Partition
 --
 alter table sync2_co_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_rn1_1_prt_default_part" for table "sync2_co_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_co_alter_part_rn1_1_prt_default_part_2_prt_1" for table "sync2_co_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_create_wet_ret.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_create_wet_ret.ans
@@ -32,7 +32,7 @@ INSERT 0 5
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE sync1_wet_region7 ( like sync1_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region7.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -48,7 +48,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE sync1_new_region7 (like sync1_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -85,7 +85,7 @@ select * from sync1_new_region7 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE ck_sync1_wet_region6 ( like ck_sync1_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region6.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -101,7 +101,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE ck_sync1_new_region6 (like ck_sync1_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -138,7 +138,7 @@ select * from ck_sync1_new_region6 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE ct_wet_region4 ( like ct_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region4.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -154,7 +154,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE ct_new_region4 (like ct_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -191,7 +191,7 @@ select * from ct_new_region4 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE resync_wet_region2 ( like resync_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region2.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -207,7 +207,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE resync_new_region2 (like resync_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET
@@ -244,7 +244,7 @@ select * from resync_new_region2 order by r_regionkey;
 -- create WET with similiar schema def as the original heap table
 --
 CREATE WRITABLE EXTERNAL TABLE sync2_wet_region1 ( like sync2_region) LOCATION ('gpfdist://10.110.120.92:8088/wet_region1.tbl') FORMAT 'TEXT' (DELIMITER AS '|');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE EXTERNAL TABLE
 --
 -- insert data into the WET selecting from original table
@@ -260,7 +260,7 @@ CREATE EXTERNAL TABLE
 -- create second table with same schema def
 --
 CREATE TABLE sync2_new_region1 (like sync2_region);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 --
 -- insert into the second table reading from the RET

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_heap_alter_part_add_default_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_heap_alter_part_add_default_part.ans
@@ -53,7 +53,7 @@ INSERT 0 100
 -- ALTER SYNC1 Heap Part Add Default Parition
 --
 alter table sync1_heap_alter_part_add_default_part7 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part7_1_prt_default_part" for table "sync1_heap_alter_part_add_default_part7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_default_part7_1_prt_default_p_2_prt_1" for table "sync1_heap_alter_part_add_default_part7_1_prt_default_part"
 ALTER TABLE
@@ -66,7 +66,7 @@ INSERT 0 100
 -- ALTER CK_SYNC1 Heap Part Add Default Parition
 --
 alter table ck_sync1_heap_alter_part_add_default_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_default_part6_1_prt_default_part" for table "ck_sync1_heap_alter_part_add_default_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_default_part6_1_prt_defaul_2_prt_1" for table "ck_sync1_heap_alter_part_add_default_part6_1_prt_default_part"
 ALTER TABLE
@@ -79,7 +79,7 @@ INSERT 0 100
 -- ALTER CT Heap Part Add Default Parition
 --
 alter table ct_heap_alter_part_add_default_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_default_part4_1_prt_default_part" for table "ct_heap_alter_part_add_default_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_default_part4_1_prt_default_part_2_prt_1" for table "ct_heap_alter_part_add_default_part4_1_prt_default_part"
 ALTER TABLE
@@ -92,7 +92,7 @@ INSERT 0 100
 -- ALTER RESYNC Heap Part Add Default Parition
 --
 alter table resync_heap_alter_part_add_default_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_default_part2_1_prt_default_part" for table "resync_heap_alter_part_add_default_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_default_part2_1_prt_default__2_prt_1" for table "resync_heap_alter_part_add_default_part2_1_prt_default_part"
 ALTER TABLE
@@ -105,7 +105,7 @@ INSERT 0 100
 -- ALTER SYNC2 Heap Part Add Default Parition
 --
 alter table sync2_heap_alter_part_add_default_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_add_default_part1_1_prt_default_part" for table "sync2_heap_alter_part_add_default_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_add_default_part1_1_prt_default_p_2_prt_1" for table "sync2_heap_alter_part_add_default_part1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_heap_alter_part_add_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_heap_alter_part_add_part.ans
@@ -61,7 +61,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync1_heap_alter_part_add_part7 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part7_1_prt_p1" for table "sync1_heap_alter_part_add_part7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part7_1_prt_p1_2_prt_sp1" for table "sync1_heap_alter_part_add_part7_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part7_1_prt_p1_2_prt_sp2" for table "sync1_heap_alter_part_add_part7_1_prt_p1"
@@ -81,7 +81,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync1_heap_alter_part_add_part7 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part7_1_prt_p3" for table "sync1_heap_alter_part_add_part7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_add_part7_1_prt_p3_2_prt_sp3" for table "sync1_heap_alter_part_add_part7_1_prt_p3"
 ALTER TABLE
@@ -96,7 +96,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ck_sync1_heap_alter_part_add_part6 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part6_1_prt_p1" for table "ck_sync1_heap_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part6_1_prt_p1_2_prt_sp1" for table "ck_sync1_heap_alter_part_add_part6_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part6_1_prt_p1_2_prt_sp2" for table "ck_sync1_heap_alter_part_add_part6_1_prt_p1"
@@ -116,7 +116,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ck_sync1_heap_alter_part_add_part6 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part6_1_prt_p3" for table "ck_sync1_heap_alter_part_add_part6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_add_part6_1_prt_p3_2_prt_sp3" for table "ck_sync1_heap_alter_part_add_part6_1_prt_p3"
 ALTER TABLE
@@ -131,7 +131,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table ct_heap_alter_part_add_part4 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part4_1_prt_p1" for table "ct_heap_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part4_1_prt_p1_2_prt_sp1" for table "ct_heap_alter_part_add_part4_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part4_1_prt_p1_2_prt_sp2" for table "ct_heap_alter_part_add_part4_1_prt_p1"
@@ -151,7 +151,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table ct_heap_alter_part_add_part4 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part4_1_prt_p3" for table "ct_heap_alter_part_add_part4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_add_part4_1_prt_p3_2_prt_sp3" for table "ct_heap_alter_part_add_part4_1_prt_p3"
 ALTER TABLE
@@ -166,7 +166,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table resync_heap_alter_part_add_part2 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part2_1_prt_p1" for table "resync_heap_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part2_1_prt_p1_2_prt_sp1" for table "resync_heap_alter_part_add_part2_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part2_1_prt_p1_2_prt_sp2" for table "resync_heap_alter_part_add_part2_1_prt_p1"
@@ -186,7 +186,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table resync_heap_alter_part_add_part2 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part2_1_prt_p3" for table "resync_heap_alter_part_add_part2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_add_part2_1_prt_p3_2_prt_sp3" for table "resync_heap_alter_part_add_part2_1_prt_p3"
 ALTER TABLE
@@ -201,7 +201,7 @@ INSERT 0 5
 -- Add partition
 --
 alter table sync2_heap_alter_part_add_part1 add partition p1 end (11);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_add_part1_1_prt_p1" for table "sync2_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_add_part1_1_prt_p1_2_prt_sp1" for table "sync2_heap_alter_part_add_part1_1_prt_p1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_add_part1_1_prt_p1_2_prt_sp2" for table "sync2_heap_alter_part_add_part1_1_prt_p1"
@@ -221,7 +221,7 @@ ALTER TABLE
 -- Add Partition
 --
 alter table sync2_heap_alter_part_add_part1 add partition p3 end (13) (subpartition sp3 values ('c'));
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_add_part1_1_prt_p3" for table "sync2_heap_alter_part_add_part1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_add_part1_1_prt_p3_2_prt_sp3" for table "sync2_heap_alter_part_add_part1_1_prt_p3"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_heap_alter_part_drop_part.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_heap_alter_part_drop_part.ans
@@ -43,7 +43,7 @@ INSERT 0 1
 -- Add partition 
 --
 alter table sync1_heap_alter_part_drop_part7 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part7_1_prt_a2" for table "sync1_heap_alter_part_drop_part7"
 ALTER TABLE
 --
@@ -61,7 +61,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync1_heap_alter_part_drop_part7 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_drop_part7_1_prt_default_part" for table "sync1_heap_alter_part_drop_part7"
 ALTER TABLE
 --
@@ -94,7 +94,7 @@ select count(*) from sync1_heap_alter_part_drop_part7;
 -- Add partition 
 --
 alter table ck_sync1_heap_alter_part_drop_part6 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_drop_part6_1_prt_a2" for table "ck_sync1_heap_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -112,7 +112,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ck_sync1_heap_alter_part_drop_part6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_drop_part6_1_prt_default_part" for table "ck_sync1_heap_alter_part_drop_part6"
 ALTER TABLE
 --
@@ -146,7 +146,7 @@ select count(*) from ck_sync1_heap_alter_part_drop_part6;
 -- Add partition 
 --
 alter table ct_heap_alter_part_drop_part4 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_drop_part4_1_prt_a2" for table "ct_heap_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -164,7 +164,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table ct_heap_alter_part_drop_part4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_drop_part4_1_prt_default_part" for table "ct_heap_alter_part_drop_part4"
 ALTER TABLE
 --
@@ -198,7 +198,7 @@ select count(*) from ct_heap_alter_part_drop_part4;
 -- Add partition 
 --
 alter table resync_heap_alter_part_drop_part2 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_drop_part2_1_prt_a2" for table "resync_heap_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -216,7 +216,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table resync_heap_alter_part_drop_part2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_drop_part2_1_prt_default_part" for table "resync_heap_alter_part_drop_part2"
 ALTER TABLE
 --
@@ -249,7 +249,7 @@ select count(*) from resync_heap_alter_part_drop_part2;
 -- Add partition 
 --
 alter table sync2_heap_alter_part_drop_part1 add partition a2 start ('2007-02-01') end ('2007-03-01');
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_drop_part1_1_prt_a2" for table "sync2_heap_alter_part_drop_part1"
 ALTER TABLE
 --
@@ -267,7 +267,7 @@ ALTER TABLE
 -- Add default partition
 --
 alter table sync2_heap_alter_part_drop_part1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_drop_part1_1_prt_default_part" for table "sync2_heap_alter_part_drop_part1"
 ALTER TABLE
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_heap_alter_part_rename.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_heap_alter_part_rename.ans
@@ -69,7 +69,7 @@ select count(*) from sync2_heap_alter_part_rn2;
 -- Add default Partition
 --
 alter table sync1_heap_alter_part_rn7 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn7_1_prt_default_part" for table "sync1_heap_alter_part_rn7"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync1_heap_alter_part_rn7_1_prt_default_part_2_prt_1" for table "sync1_heap_alter_part_rn7_1_prt_default_part"
 ALTER TABLE
@@ -119,7 +119,7 @@ select count(*) from sync1_heap_alter_part_rn7_0;
 -- Add default Partition
 --
 alter table ck_sync1_heap_alter_part_rn6 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_rn6_1_prt_default_part" for table "ck_sync1_heap_alter_part_rn6"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ck_sync1_heap_alter_part_rn6_1_prt_default_part_2_prt_1" for table "ck_sync1_heap_alter_part_rn6_1_prt_default_part"
 ALTER TABLE
@@ -170,7 +170,7 @@ select count(*) from ck_sync1_heap_alter_part_rn6_0;
 -- Add default Partition
 --
 alter table ct_heap_alter_part_rn4 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_rn4_1_prt_default_part" for table "ct_heap_alter_part_rn4"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "ct_heap_alter_part_rn4_1_prt_default_part_2_prt_1" for table "ct_heap_alter_part_rn4_1_prt_default_part"
 ALTER TABLE
@@ -221,7 +221,7 @@ select count(*) from ct_heap_alter_part_rn4_0;
 -- Add default Partition
 --
 alter table resync_heap_alter_part_rn2 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_rn2_1_prt_default_part" for table "resync_heap_alter_part_rn2"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "resync_heap_alter_part_rn2_1_prt_default_part_2_prt_1" for table "resync_heap_alter_part_rn2_1_prt_default_part"
 ALTER TABLE
@@ -271,7 +271,7 @@ select count(*) from resync_heap_alter_part_rn2_0;
 -- Add default Partition
 --
 alter table sync2_heap_alter_part_rn1 add default partition default_part;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_rn1_1_prt_default_part" for table "sync2_heap_alter_part_rn1"
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create partition "sync2_heap_alter_part_rn1_1_prt_default_part_2_prt_1" for table "sync2_heap_alter_part_rn1_1_prt_default_part"
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/alter_co_part_exch_co_ao.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/alter_co_part_exch_co_ao.ans
@@ -66,7 +66,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_co_ao" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_co_ao (like sto_co_ao) with (appendonly=true);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_co_ao values (1, '2008-03-20', 'two'),  (2, '2008-03-21', 'two');
 INSERT 0 2

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/alter_co_part_exch_co_co.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/alter_co_part_exch_co_co.ans
@@ -66,7 +66,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_co_co" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_co_co (like sto_co_co) with (appendonly=true, orientation=column);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_co_co values (1, '2008-04-20', 'two'),  (2, '2008-04-21', 'two');
 INSERT 0 2

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/alter_co_part_exch_co_heap.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/alter_co_part_exch_co_heap.ans
@@ -66,7 +66,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_co_heap" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_co_heap (like sto_co_heap);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_co_heap values (1, '2008-03-20', 'two'),  (2, '2008-03-21', 'two');
 INSERT 0 2

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/alter_co_part_exch_heap_co.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/alter_co_part_exch_heap_co.ans
@@ -48,7 +48,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_heap_co" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_heap_co (like sto_heap_co) with (appendonly=true, orientation=column);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_heap_co values (1, '2008-01-20', 'three'),  (2, '2008-01-21', 'two');
 INSERT 0 2

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/expected/alter_subpart_exch_tables.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/expected/alter_subpart_exch_tables.ans
@@ -97,7 +97,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_ac" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_ac (like sto_altmsp1) with(appendonly=true, compresstype=zlib);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_ac values(1, '2008-02-02', 'newtwo');
 INSERT 0 1
@@ -111,7 +111,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_cc" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_cc (like sto_altmsp1) with(appendonly=true, compresstype=zlib);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_cc values(1, '2008-02-02', 'newfive');
 INSERT 0 1
@@ -125,7 +125,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_cc1" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_cc1 (like sto_altmsp1) with(appendonly=true, orientation=column, compresstype=quicklz);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_cc1 values(1, '2008-02-02', 'newone');
 INSERT 0 1
@@ -139,7 +139,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_ac1" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_ac1 (like sto_altmsp1) with(appendonly=true, orientation=column, compresstype=quicklz);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_ac1 values(1, '2008-02-02', 'newfour');
 INSERT 0 1
@@ -153,7 +153,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_cc2" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_cc2 (like sto_altmsp1) with(appendonly=true,orientation= column, compresstype=zlib);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_cc2 values(1, '2008-02-02', 'newthree');
 INSERT 0 1
@@ -167,7 +167,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_ac2" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_ac2 (like sto_altmsp1) with(appendonly=true,orientation= column, compresstype=zlib);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_ac2 values(1, '2008-02-02', 'newsix');
 INSERT 0 1
@@ -181,7 +181,7 @@ psql:/path/sql_file:1: NOTICE:  table "exh_def" does not exist, skipping
 DROP TABLE
 --end_ignore
 create table exh_def (like sto_altmsp1) with(appendonly=true);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_def values(1, '2008-02-01', 'ten');
 INSERT 0 1

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_subpart_exch_tables.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_subpart_exch_tables.ans
@@ -88,7 +88,7 @@ Drop table if exists exh_ac;
 DROP TABLE
 --end_ignore
 create table exh_ac (like sto_altmsp1) with(appendonly=true, compresstype=zlib);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_ac values(1, '2008-02-02', 'newtwo');
 INSERT 0 1
@@ -101,7 +101,7 @@ Drop table if exists exh_cc;
 DROP TABLE
 --end_ignore
 create table exh_cc (like sto_altmsp1) with(appendonly=true, compresstype=zlib);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_cc values(1, '2008-02-02', 'newfive');
 INSERT 0 1
@@ -114,7 +114,7 @@ Drop table if exists exh_cc1;
 DROP TABLE
 --end_ignore
 create table exh_cc1 (like sto_altmsp1) with(appendonly=true, orientation=column, compresstype=quicklz);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_cc1 values(1, '2008-02-02', 'newone');
 INSERT 0 1
@@ -127,7 +127,7 @@ Drop table if exists exh_ac1;
 DROP TABLE
 --end_ignore
 create table exh_ac1 (like sto_altmsp1) with(appendonly=true, orientation=column, compresstype=quicklz);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_ac1 values(1, '2008-02-02', 'newfour');
 INSERT 0 1
@@ -140,7 +140,7 @@ Drop table if exists exh_cc2;
 DROP TABLE
 --end_ignore
 create table exh_cc2 (like sto_altmsp1) with(appendonly=true,orientation= column, compresstype=zlib);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_cc2 values(1, '2008-02-02', 'newthree');
 INSERT 0 1
@@ -153,7 +153,7 @@ Drop table if exists exh_ac2;
 DROP TABLE
 --end_ignore
 create table exh_ac2 (like sto_altmsp1) with(appendonly=true,orientation= column, compresstype=zlib);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_ac2 values(1, '2008-02-02', 'newsix');
 INSERT 0 1
@@ -166,7 +166,7 @@ Drop table if exists exh_def;
 DROP TABLE
 --end_ignore
 create table exh_def (like sto_altmsp1) with(appendonly=true);
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause, defaulting to distribution columns from LIKE table
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 CREATE TABLE
 insert into exh_def values(1, '2008-02-01', 'ten');
 INSERT 0 1


### PR DESCRIPTION
Rather than rewriting the error message output to account for diffs in file line numbers, delete the mention entirely as we cleared out the rewrite artifact with an init_file rule anyways. Each init_file rule make gpdiff slower so removing as many as we can will speed up testing. Also teach atmsort about C++ source files and remove the bespoke filename rules which shouldn't be required anymore.

This PR has been updated from WIP to final version and is ready for review.
