### PR TITLE
pg_regress feature cleanup

### DIFF
--- a/gpAux/extensions/gps3ext/regress/Makefile
+++ b/gpAux/extensions/gps3ext/regress/Makefile
@@ -18,6 +18,6 @@ installcheck:
 	@echo "Regression ends:" `date` ]
 
 clean:
-	rm -rf source_replaced sql expected results regression.* optimizer_status.out
+	rm -rf source_replaced sql expected results regression.*
 
 .PHONY: installcheck clean

--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -3,7 +3,6 @@ current_good_schedule
 libregress.so
 libregress.so.0
 libregress.so.0.0
-optimizer_status.out
 regress.so
 regression.diffs
 regression.out

--- a/src/test/regress/bugbuster/.gitignore
+++ b/src/test/regress/bugbuster/.gitignore
@@ -1,1 +1,0 @@
-optimizer_status.out

--- a/src/test/regress/optfunctional/.gitignore
+++ b/src/test/regress/optfunctional/.gitignore
@@ -2,6 +2,5 @@ pg_regress
 results
 yml
 current_good_schedule
-optimizer_status.out
 regression.diffs
 regression.out

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2083,14 +2083,14 @@ check_feature_status(const char *feature_name, const char *on_msg, const char *o
 		char *trimmed = trim_white_space(line);
 		if (strncmp(trimmed, "on", 2) == 0)
 		{
-			status(_(on_msg));
+			status(_("%s"), on_msg);
 			isEnabled = true;
 			break;
 		}
 
 		if (strncmp(trimmed, "off", 3) == 0)
 		{
-			status(_(off_msg));
+			status(_("%s"), off_msg);
 			break;
 		}
 	}


### PR DESCRIPTION
Commit 96f22da expanded the feature check to handle more than just ORCA but when moving to using passed in string variables for printing on/off it generates a clang compiler warning on `-Wformat-security:`

    warning: format string is not a string literal (potentially insecure)

Move to using format strings rather than just passing the string variable to fix the warning and also avoid any theoretical issues with the passed string.

The second commit is a collection of small fixes to check_feature_status() that fell out when fixing the compiler warning in the code. The fixes are (listed in no specific order):

* Print tuples only in the `SHOW <feature>;` command since we know there is little point in reading the header rows when we're just hunting for the on/off
* Move to const char arguments since this function has no business altering the input
* Explicitly clean up temporary files from feature checking and remove them from .gitignore files to avoid littering the tree
* Check for overflow in command generation since we are appending a string with a theoretical limit of MAXPGPATH onto a string with MAXPGPATH size combined with additional content thus
risking a truncation. Also fix a minor related style issue to match the rest of the file