### PR TITLE
Move enrollment of codegened ExecVariableList to ExecInitNode

### DIFF
--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -342,6 +342,24 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			{
 			result = (PlanState *) ExecInitTableScan((TableScan *) node,
 													 estate, eflags);
+
+			/*
+			 * Enroll ExecVariableList in codegen_manager
+			 */
+			if (NULL != result)
+			{
+				ScanState *scanState = (ScanState *) result;
+				ProjectionInfo *projInfo = result->ps_ProjInfo;
+				if (NULL != projInfo &&
+					NULL != scanState &&
+					projInfo->pi_isVarList &&
+					NULL != projInfo->pi_targetlist)
+				{
+					enroll_ExecVariableList_codegen(ExecVariableList,
+							&projInfo->ExecVariableList_gen_info.ExecVariableList_fn, projInfo, scanState->ss_ScanTupleSlot);
+				}
+			}
+
 			/*
 			 * Enroll targetlist & quals' expression evaluation functions
 			 * in codegen_manager

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -350,10 +350,10 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			{
 				ScanState *scanState = (ScanState *) result;
 				ProjectionInfo *projInfo = result->ps_ProjInfo;
-				if (NULL != projInfo &&
-					NULL != scanState &&
-					projInfo->pi_isVarList &&
-					NULL != projInfo->pi_targetlist)
+				if (NULL != scanState &&
+				    NULL != projInfo &&
+				    projInfo->pi_isVarList &&
+				    NULL != projInfo->pi_targetlist)
 				{
 					enroll_ExecVariableList_codegen(ExecVariableList,
 							&projInfo->ExecVariableList_gen_info.ExecVariableList_fn, projInfo, scanState->ss_ScanTupleSlot);

--- a/src/backend/executor/execScan.c
+++ b/src/backend/executor/execScan.c
@@ -297,15 +297,6 @@ InitScanStateRelationDetails(ScanState *scanState, Plan *plan, EState *estate)
 	ExecAssignScanType(scanState, RelationGetDescr(currentRelation));
 	ExecAssignScanProjectionInfo(scanState);
 
-	ProjectionInfo *projInfo = scanState->ps.ps_ProjInfo;
-	if (NULL != projInfo &&
-	    projInfo->pi_isVarList &&
-	    NULL != projInfo->pi_targetlist)
-	{
-		enroll_ExecVariableList_codegen(ExecVariableList,
-				&projInfo->ExecVariableList_gen_info.ExecVariableList_fn, projInfo, scanState->ss_ScanTupleSlot);
-	}
-
 	scanState->tableType = getTableType(scanState->ss_currentRelation);
 }
 


### PR DESCRIPTION
Currently we enroll ExecVariableList in InitScanStateRelationDetails.
This is not the proper place to enroll it, since InitScanStateRelationDetails
is called from DynamicScan_InitSingleRelation DynamicScan_Begin
(i.e., Dynamic partition scan).

Existing codegen framework does not support ExecVariableList for Dynamic
Partition Scan. So, we move ExecVariableList's enrollment to ExecInitNode,
and we enroll it only if scan is one of the next types: T_SeqScan,
T_AppendOnlyScan, T_AOCSScan, or T_TableScan.