### PR TITLE
Test gp-orafunk should use orafunc.sql in the install directory

### DIFF
--- a/gpAux/extensions/Makefile
+++ b/gpAux/extensions/Makefile
@@ -97,7 +97,7 @@ mkplr:
 mkorafce:
 	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C orafce install USE_PGXS=1
 
-installcheck: mkorafce
+installcheck:
 	if [ -d "$(ext_dir)" ]; then \
 		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C orafce installcheck USE_PGXS=1 && \
 		PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gphdfs installcheck USE_PGXS=1 ; \

--- a/gpAux/extensions/orafce/input/gp-orafunk.source
+++ b/gpAux/extensions/orafce/input/gp-orafunk.source
@@ -19,7 +19,7 @@
 -- *********************************************************************
 
 -- start_ignore
-\i orafunc.sql
+\i @bindir@/../share/postgresql/contrib/orafunc.sql
 -- end_ignore
 
 set search_path = oracompat;
@@ -170,6 +170,6 @@ SELECT dump('2008-10-10'::timestamp) ~ E'^Typ=1114 Len=8: \\d+(,\\d+){7}$' AS t;
 RESET DATESTYLE;
 
 -- start_ignore
-\i @abs_srcdir@/../../../contrib/orafce/uninstall_orafunc.sql
+\i @bindir@/../share/postgresql/contrib/uninstall_orafunc.sql
 -- end_ignore
 


### PR DESCRIPTION
Signed-off-by: Adam Lee <ali@pivotal.io>