### PR TITLE
Process interrupts before reserving VMEM

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -413,6 +413,7 @@ static char *gp_test_deadlock_hazard_report_level_str;
 /* query cancellation GUC */
 bool		gp_cancel_query_print_log;
 int			gp_cancel_query_delay_time;
+bool		vmem_process_interrupt = false;
 
 /* partitioning GUC */
 bool		gp_partitioning_dynamic_selection_log;
@@ -3394,6 +3395,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 #endif
 		assign_codegen, NULL
 	},
+
+	{
+		{"vmem_process_interrupt", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Checks for interrupts before reserving VMEM"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		&vmem_process_interrupt,
+		false, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL

--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -184,6 +184,17 @@ VmemTracker_ResetMaxVmemReserved()
 	maxVmemChunksTracked = trackedVmemChunks;
 }
 
+/* Checks */
+static void
+VmemTracker_CheckForPendingCancellation()
+{
+  if (InterruptPending)
+  {
+    /* ProcessInterrupts should check for InterruptHoldoffCount and CritSectionCount */
+    ProcessInterrupts();
+  }
+}
+
 /*
  * Reserve 'num_chunks_to_reserve' number of chunks for current process. The
  * reservation is validated against segment level vmem quota.
@@ -495,6 +506,8 @@ VmemTracker_ReserveVmem(int64 newlyRequestedBytes)
 		 */
 		trackedBytes -= newlyRequestedBytes;
 		RedZoneHandler_DetectRunawaySession();
+		VmemTracker_CheckForPendingCancellation();
+
 		/*
 		 * Redo, as we returned from VmemTracker_TerminateRunawayQuery and
 		 * we are successfully reserving this vmem

--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -511,7 +511,7 @@ VmemTracker_ReserveVmem(int64 newlyRequestedBytes)
 		 * on CHECK_FOR_INTERRUPTS(). In a sense, this is a lightweight CHECK_FOR_INTERRUPTS
 		 * as we don't execute BackoffBackendTick() and some runaway detection code.
 		 */
-		if (InterruptPending)
+		if (vmem_process_interrupt && InterruptPending)
 		{
 			/* ProcessInterrupts should check for InterruptHoldoffCount and CritSectionCount */
 			ProcessInterrupts();

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -293,6 +293,7 @@ extern int ddboost_buf_size;
 
 extern bool gp_cancel_query_print_log;
 extern int gp_cancel_query_delay_time;
+extern bool vmem_process_interrupt;
 
 extern bool gp_partitioning_dynamic_selection_log;
 extern int gp_max_partition_level;


### PR DESCRIPTION
Traditionally we depend on voluntary CHECK_FOR_INTERRUPTS() call to process interrupts. This hinders timely enforcement of query cancellation during critical system resource consumption such as additional memory allocation. This PR is calling ProcessInterrupts() before reserving more VMEM to ensure that we don't gobble up unreasonable amount of memory from the system before checking to see if there is a cancellation request pending.
