### PR TITLE
Fixing assertion failures in indexed based memory accounting

### DIFF
--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -591,7 +591,11 @@ AddToShortLivingAccountArray(MemoryAccount *newAccount)
 static void
 InitializeMemoryAccount(MemoryAccount *newAccount, long maxLimit, MemoryOwnerType ownerType, MemoryAccountIdType parentAccountId)
 {
-	Assert(ownerType != MEMORY_OWNER_TYPE_Undefined && ownerType < MEMORY_OWNER_TYPE_EXECUTOR_END);
+	/*
+	 * MEMORY_OWNER_TYPE_EXECUTOR_END is set to the last valid executor account type.
+	 * I.e., it is inclusive in the valid values of ownerType
+	 */
+	Assert(ownerType != MEMORY_OWNER_TYPE_Undefined && ownerType <= MEMORY_OWNER_TYPE_EXECUTOR_END);
 
 	newAccount->ownerType = ownerType;
 

--- a/src/include/utils/memaccounting_private.h
+++ b/src/include/utils/memaccounting_private.h
@@ -120,7 +120,6 @@ MemoryAccounting_ConvertIdToAccount(MemoryAccountIdType id)
 static inline bool
 MemoryAccounting_Allocate(MemoryAccountIdType memoryAccountId, Size allocatedSize)
 {
-	Assert(MemoryAccounting_IsLiveAccount(memoryAccountId));
 	MemoryAccount* memoryAccount = MemoryAccounting_ConvertIdToAccount(memoryAccountId);
 
 	Assert(memoryAccount->allocated + allocatedSize >=


### PR DESCRIPTION
This PR fixes two assertion failures:

1. Removes an assertion that checks that a new allocation has to come from a live account. In reality, there is no such requirement. The sole purpose of a redesigned accounting is to handle such situations efficiently without hitting SEGV. For cursors, such as:

```
create table foo(a int, b int);
begin;
DECLARE cursor1 CURSOR FOR SELECT * FROM ONLY foo order by a;
fetch 1 from cursor1;
```

We will have a plan generated from previous statement and access that plan in next statement. We transparently handle such dead owners in RolloverMemoryAccount. So, no need to assert. (Side note: we do lose precision as such query will be entire executed in later statements and we only preserve RolloverMemoryAccount balance. This is for scalability, but in the future we can be clever to extend life of short-living accounts beyond one statement, depending on the type of statements.)

2. The MEMORY_OWNER_TYPE_EXECUTOR_END is a valid owner type as it assumes the owner type of the last executor owner type. So, we correct the assertion to make it inclusive.



