### PR TITLE
Abort code generation of expression evaluation trees with unsupported ExprState types

### DIFF
--- a/src/backend/codegen/expr_tree_generator.cc
+++ b/src/backend/codegen/expr_tree_generator.cc
@@ -33,6 +33,13 @@ bool ExprTreeGenerator::VerifyAndCreateExprTree(
   assert(nullptr != expr_state &&
          nullptr != expr_state->expr &&
          nullptr != expr_tree);
+
+  if (expr_state->type != T_FuncExprState &&
+      expr_state->type != T_ExprState) {
+    elog(DEBUG1, "Input expression state type (%d) is not supported",
+         expr_state->type);
+    return false;
+  }
   expr_tree->reset(nullptr);
   bool supported_expr_tree = false;
   switch (nodeTag(expr_state->expr)) {

--- a/src/backend/codegen/expr_tree_generator.cc
+++ b/src/backend/codegen/expr_tree_generator.cc
@@ -34,8 +34,8 @@ bool ExprTreeGenerator::VerifyAndCreateExprTree(
          nullptr != expr_state->expr &&
          nullptr != expr_tree);
 
-  if (expr_state->type != T_FuncExprState &&
-      expr_state->type != T_ExprState) {
+  if (!(IsA(expr_state, FuncExprState) ||
+      IsA(expr_state, ExprState)) ){
     elog(DEBUG1, "Input expression state type (%d) is not supported",
          expr_state->type);
     return false;


### PR DESCRIPTION
Current codegen expression evaluation framework generates code based only on
`ExprState->Expr->type` (e.g., `T_Var`), without checking the `ExprState->type`.
In other words, it treats all nodes of the tree that have the same type
(e.g., `T_Var`) in the same way (i.e., generates the same code).

However, in GPDB the evaluation function (evalfunc) of a node depends
on `ExprState->Expr->type` and `ExprState->type`. For example, if
`ExprState->Expr->type = T_Var` and `ExprState->type = T_ExprState`, then 
`evalfunc  = ExecEvalScalarVar`. On the other hand, if
`ExprState->Expr->type = T_Var` and `ExprState->type =
T_WholeRowVarExprState`, then `evalfunc = ExecEvalWholeRowVar`.

We fix this issue by avoiding code generation for an expression tree
that contains nodes of unsupported `ExprState->type`.

Signed-off-by: Karen Huddleston <khuddleston@pivotal.io>