### PR TITLE
Remove "-funroll-loops finline-limit=1800" from standard CFLAGS.

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -136,16 +136,8 @@ GPPKG_PLATFORMS=rhel5_x86_64 rhel6_x86_64 suse10_x86_64 suse11_x86_64
 # Compiler options
 #---------------------------------------------------------------------
 
-INLINE_FLAGS=-finline-limit=1800
-
-OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -funroll-loops -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(INLINE_FLAGS) $(TRACE_GCC_FLAG))"
-PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -funroll-loops -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(INLINE_FLAGS) $(TRACE_GCC_FLAG))"
-
-ifeq (on, ${GPDBGINLINE})
-CFLAGS_INLINE=$(INLINE_FLAGS)
-else
-CFLAGS_INLINE=-fno-inline
-endif
+OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(TRACE_GCC_FLAG))"
+PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer $(COPTX) -g $(TRACE_GCC_FLAG))"
 
 ifeq (on, ${GPDBGOPT})
 CFLAGS_OPT=-O1 -fno-omit-frame-pointer
@@ -159,7 +151,7 @@ else
 DEBUG_CFLAGS_OPT=-g3
 endif
 
-DEBUGFLAGS="$(strip $(BLD_CFLAGS) $(CFLAGS_INLINE) $(CFLAGS_OPT) $(DEBUG_CFLAGS_OPT) $(TRACE_GCC_FLAG))"
+DEBUGFLAGS="$(strip $(BLD_CFLAGS) $(CFLAGS_OPT) $(DEBUG_CFLAGS_OPT) $(TRACE_GCC_FLAG))"
 
 #---------------------------------------------------------------------
 # configure


### PR DESCRIPTION
Aggressive inlining can improve performance in hot spots, but when applied
indiscriminately, it makes binaries larger for little gain. For lack of
better evidence, let's trust the compiler defaults. This makes the build
faster, and the binaries smaller. If we find out that these options are
beneficial for some specific functions or source files, let's add them
back to those special cases.

In a quick test on my laptop, this makes the build about 2x faster, and
shrinks the binaries from about 14MB to 9MB (after running "strip").
