### PR TITLE
Fix bugbuster tpch_query case

### DIFF
--- a/src/test/regress/bugbuster/expected/tpch_query.out
+++ b/src/test/regress/bugbuster/expected/tpch_query.out
@@ -2022,7 +2022,7 @@ order by
 (6 rows)
 
 	s_name, 
-	count(distinct(l1.l_orderkey||l1.l_linenumber)) as numwait 
+	count(distinct(l1.l_orderkey::text||l1.l_linenumber::text)) as numwait 
 from 
 	supplier, 
 	orders, 
@@ -4808,7 +4808,7 @@ order by
 (6 rows)
 
 	s_name, 
-	count(distinct(l1.l_orderkey||l1.l_linenumber)) as numwait 
+	count(distinct(l1.l_orderkey::text||l1.l_linenumber::text)) as numwait 
 from 
 	supplier, 
 	orders, 
@@ -7594,7 +7594,7 @@ order by
 (6 rows)
 
 	s_name, 
-	count(distinct(l1.l_orderkey||l1.l_linenumber)) as numwait 
+	count(distinct(l1.l_orderkey::text||l1.l_linenumber::text)) as numwait 
 from 
 	supplier, 
 	orders, 

--- a/src/test/regress/bugbuster/sql/tpch_query.sql
+++ b/src/test/regress/bugbuster/sql/tpch_query.sql
@@ -684,7 +684,7 @@ where
 order by
 	s_name;select  'tpch21',
 	s_name, 
-	count(distinct(l1.l_orderkey||l1.l_linenumber)) as numwait 
+	count(distinct(l1.l_orderkey::text||l1.l_linenumber::text)) as numwait 
 from 
 	supplier, 
 	orders, 
@@ -1526,7 +1526,7 @@ where
 order by
 	s_name;select  'tpch21',
 	s_name, 
-	count(distinct(l1.l_orderkey||l1.l_linenumber)) as numwait 
+	count(distinct(l1.l_orderkey::text||l1.l_linenumber::text)) as numwait 
 from 
 	supplier, 
 	orders, 
@@ -2367,7 +2367,7 @@ where
 order by
 	s_name;select  'tpch21',
 	s_name, 
-	count(distinct(l1.l_orderkey||l1.l_linenumber)) as numwait 
+	count(distinct(l1.l_orderkey::text||l1.l_linenumber::text)) as numwait 
 from 
 	supplier, 
 	orders, 


### PR DESCRIPTION
Due to 31edbadf4af45dd4eecebcb732702ec6d7ae1819, concatenating two
integers is not supported by both GPDB and latest PostgreSQL, so we need
to explicitly cast the integers in this tpch_query case.

Signed-off-by: Pengzhou Tang <ptang@pivotal.io>
Signed-off-by: Gang Xiong <gxiong@pivotal.io>