### PR TITLE
Set llvm_isNull to false when the result of codegened expression evaluation is not null

### DIFF
--- a/src/backend/codegen/include/codegen/pg_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_func_generator.h
@@ -285,6 +285,11 @@ class PGIRBuilderFuncGenerator
     llvm::BasicBlock* func_generation_last_block = irb->GetInsertBlock();
     assert(llvm_func_tmp_value->getType() ==
         codegen_utils->GetType<ReturnType>());
+    // Explicitly set isnull to false so that we can cover the case that isnull
+    // has not been initialized to false. This is useful because in codegen
+    // we do not use temporary struct fcinfo.
+    irb->CreateStore(codegen_utils->GetConstant<bool>(false),
+                     llvm_isnull_ptr);
     irb->CreateBr(set_llvm_out_value_block);
 
     // null_argument_block
@@ -502,6 +507,11 @@ class PGGenericFuncGenerator : public  PGFuncGeneratorInterface {
     llvm::BasicBlock* func_generation_last_block = irb->GetInsertBlock();
     assert(llvm_func_generation_tmp_value->getType() ==
            codegen_utils->GetType<ReturnType>());
+    // Explicitly set isnull to false so that we can cover the case that isnull
+    // has not been initialized to false. This is useful because in codegen
+    // we do not use temporary struct fcinfo.
+    irb->CreateStore(codegen_utils->GetConstant<bool>(false),
+                     llvm_isnull_ptr);
     irb->CreateBr(set_llvm_out_value_block);
 
     // set_llvm_out_value_block


### PR DESCRIPTION
So far we were assuming that the content of `llvm_isNull_ptr` variable, which is passed as input to expression evaluation, is always `false`. Consequently, if the result of the expression is not null, then we avoid setting `llvm_isNull_ptr` to `false`.

However, this assumption is not correct since in codegen we do not use a temporary `fcinfo` struct (for perfromance reasons), which initializes `fcinfo->isnull` to `false`. Instead, we pass a pointer to the isnull variable of the caller directly (which might not have been inititialized). For example, in `GenerateAdvanceAggregates` we pass a pointer to `transValueIsNull`.

In this commit, we explicitly set `llvm_isNull_ptr` to `false` when the result is not null. This will cover all cases that the input is not initialized to `false`.

Signed-off-by: Karthikeyan Jambu Rajaraman <karthi.jrk@gmail.com>