### PR TITLE
Making expression tree mutation unconditional

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1201,22 +1201,7 @@ fix_scan_expr(PlannerGlobal *glob, Node *node, int rtoffset)
 	context.glob = glob;
 	context.rtoffset = rtoffset;
 
-	if (rtoffset != 0)
-	{
-		return fix_scan_expr_mutator(node, &context);
-	}
-	else
-	{
-		/*
-		 * If rtoffset == 0, we don't need to change any Vars, which makes
-		 * it OK to just scribble on the input node tree instead of copying
-		 * (since the only change, filling in any unset opfuncid fields,
-		 * is harmless).  This saves just enough cycles to be noticeable on
-		 * trivial queries.
-		 */
-		(void) fix_scan_expr_walker(node, &context);
-		return node;
-	}
+	return fix_scan_expr_mutator(node, &context);
 }
 
 static Node *

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1201,6 +1201,15 @@ fix_scan_expr(PlannerGlobal *glob, Node *node, int rtoffset)
 	context.glob = glob;
 	context.rtoffset = rtoffset;
 
+	/*
+	 * Postgres has an optimization to mutate the expression tree only if
+	 * rtoffset is non-zero. However, this optimization does not work for
+	 * GPDB planner. The planner in GPDB produces plans where rtoffset
+	 * may be zero, but it uses gp_subplan_id as a pseudo column
+	 * to deduplicate all the partition scans. This pseudo var needs
+	 * to be unnested (i.e., the underlying expr needs to replace the Var)
+	 * using mutation. Therefore, in GPDB we need to unconditionally mutate the tree.
+	 */
 	return fix_scan_expr_mutator(node, &context);
 }
 


### PR DESCRIPTION
We previously did not consider that we need to mutate an expression
tree if there is a pseudo column. This introduces an executor crash in
non-assert build as executor does not know how to interpret a pseudo
column. Moreover, in assert build we fail an assert.

The conditional we are removing  was introduced to optimize performance
by commit a36436ea3f402293bc5484b83823eed8d6a8dfc3, but a quick performance
run shows that performance is not noticeably affected by removing the
optimization. [#131785597]

Signed-off-by: Foyzur Rahman <foyzur@gmail.com>