### PR TITLE
Adding explicit casting for concatenation operator with integer operands

### DIFF
--- a/src/test/regress/bugbuster/expected/opperf.out
+++ b/src/test/regress/bugbuster/expected/opperf.out
@@ -86,7 +86,7 @@ select max(l_partkey) from lineitem;
 
 -- Scan test2:
 -- select several columns from lineitem
-select max(length(l_linenumber) + length(l_linestatus) + length(l_comment))
+select max(length(l_linenumber::text) + length(l_linestatus) + length(l_comment))
 from lineitem;
  max 
 -----

--- a/src/test/regress/bugbuster/expected/tpch_aopart.out
+++ b/src/test/regress/bugbuster/expected/tpch_aopart.out
@@ -1567,7 +1567,7 @@ select 'TPCH QUERY 20',s_name,s_address
  TPCH QUERY 20 | Supplier#000000013        | HK71HQyWoqRWOX8GI FpgAifW,2PoH
 (1 row)
 
-select 'TPCH QUERY 21',s_name, count( distinct (l1.l_orderkey||l1.l_linenumber)) as numwait
+select 'TPCH QUERY 21',s_name, count( distinct (l1.l_orderkey::text || l1.l_linenumber::text)) as numwait
     from aopart_supplier, aopart_orders, aopart_nation, aopart_lineitem l1 left join aopart_lineitem l2 on (l2.l_orderkey = l1.l_orderkey
          and l2.l_suppkey <> l1.l_suppkey) left join (
         select l3.l_orderkey,l3.l_suppkey

--- a/src/test/regress/bugbuster/sql/opperf.sql
+++ b/src/test/regress/bugbuster/sql/opperf.sql
@@ -36,7 +36,7 @@ select * from opperfscale;
 select max(l_partkey) from lineitem;
 -- Scan test2:
 -- select several columns from lineitem
-select max(length(l_linenumber) + length(l_linestatus) + length(l_comment))
+select max(length(l_linenumber::text) + length(l_linestatus) + length(l_comment))
 from lineitem;
 
 -- Sort test 1: 

--- a/src/test/regress/bugbuster/sql/tpch_aopart.sql
+++ b/src/test/regress/bugbuster/sql/tpch_aopart.sql
@@ -299,7 +299,7 @@ select 'TPCH QUERY 20',s_name,s_address
         where g.l_partkey = ps_partkey and g.l_suppkey = ps_suppkey and ps_availqty > 0.5*g.qty_sum and ps_partkey in (select p_partkey
               from aopart_part where p_name like 'forest%' )) and s_nationkey = n_nationkey and n_name = 'CANADA' order by s_name;
 
-select 'TPCH QUERY 21',s_name, count( distinct (l1.l_orderkey||l1.l_linenumber)) as numwait
+select 'TPCH QUERY 21',s_name, count( distinct (l1.l_orderkey::text || l1.l_linenumber::text)) as numwait
     from aopart_supplier, aopart_orders, aopart_nation, aopart_lineitem l1 left join aopart_lineitem l2 on (l2.l_orderkey = l1.l_orderkey
          and l2.l_suppkey <> l1.l_suppkey) left join (
         select l3.l_orderkey,l3.l_suppkey


### PR DESCRIPTION
Parser support to implicitly cast arguments to text was 
removed in GPDB open source. Therefore, we are adding explicit 
casts to these test queries so we only use supported operations.

Signed-off-by: Foyzur Rahman <foyzur@gmail.com>