### PR TITLE
Enroll codegened ExecVariableList only if GPDB scans a heap table

### DIFF
--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -350,6 +350,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 				ScanState *scanState = (ScanState *) result;
 				ProjectionInfo *projInfo = result->ps_ProjInfo;
 				if (NULL != scanState &&
+				    scanState->tableType == TableTypeHeap &&
 				    NULL != projInfo &&
 				    projInfo->pi_isVarList &&
 				    NULL != projInfo->pi_targetlist)


### PR DESCRIPTION
We currently support `slot_deform_tuple` only for heap tables. 
In this PR, we simply make sure that we enroll codegened `ExecVariableList` only when we scan a heap table.