### PR TITLE
Fix assertions which have accidental side effects

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -289,7 +289,7 @@ isPrimaryWriterGangAlive(void)
 	int size = primaryWriterGang->size;
 	int i = 0;
 
-	Assert(size = getgpsegmentCount());
+	Assert(size == getgpsegmentCount());
 
 	for (i = 0; i < size; i++)
 	{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -942,7 +942,7 @@ ProcessUtility(Node *parsetree,
 							{
 								case RELKIND_VIEW:
 								case RELKIND_COMPOSITE_TYPE:
-									Assert(relStorage = RELSTORAGE_VIRTUAL);
+									Assert(relStorage == RELSTORAGE_VIRTUAL);
 									break;
 								default:
 									Assert(relStorage == RELSTORAGE_HEAP ||


### PR DESCRIPTION
Asserting that an assignment isn't zero is a valid use of Assert() but these instances look more like accidental assignments due to a missing '='. getgpsegmentCount() is already internally asserting that the count is > 0 so we would never reach here in case it was.