### PR TITLE
Protection for transactional stat updates only if in transaction

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -1636,12 +1636,16 @@ pgstat_count_heap_delete(Relation rel)
 		/* t_tuples_deleted is nontransactional, so just advance it */
 		pgstat_info->t_counts.t_tuples_deleted++;
 
-		/* We have to log the transactional effect at the proper level */
-		if (pgstat_info->trans == NULL ||
-			pgstat_info->trans->nest_level != nest_level)
-			add_tabstat_xact_level(pgstat_info, nest_level);
+		/* Only if in transaction record the transactional effect */
+		if (nest_level > 0)
+		{
+			/* We have to log the transactional effect at the proper level */
+			if (pgstat_info->trans == NULL ||
+				pgstat_info->trans->nest_level != nest_level)
+				add_tabstat_xact_level(pgstat_info, nest_level);
 
-		pgstat_info->trans->tuples_deleted++;
+			pgstat_info->trans->tuples_deleted++;
+		}
 	}
 }
 


### PR DESCRIPTION
Transactional stats for heap_delete must be updated only if in transaction,
which should always be the case. Except the issue was encountered now when we
started calling heap_delete for PT tables to free tuples instead of older
mechanism. During recovery based on object state if transaction was aborted the
tuple in PT needs to be deleted and was failing in this function as
TopTransactionContext is not allocated. Hence, added the protection that only if
nesting level if greater than 0 which will be the case if we are in transaction
collect stats else ignore the same. Which helps to fix the problem.