### PR TITLE
Print filename and lineno in codegened CreateElog

### DIFF
--- a/src/backend/codegen/advance_aggregates_codegen.cc
+++ b/src/backend/codegen/advance_aggregates_codegen.cc
@@ -321,7 +321,8 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
   irb->SetInsertPoint(entry_block);
 
 #ifdef CODEGEN_DEBUG
-  codegen_utils->CreateElog(DEBUG1, "Codegen'ed advance_aggregates called!");
+  EXPAND_CREATE_ELOG(codegen_utils, DEBUG1,
+                     "Codegen'ed advance_aggregates called!");
 #endif
 
   // Compare aggstate given during code generation and the one passed
@@ -446,8 +447,8 @@ bool AdvanceAggregatesCodegen::GenerateAdvanceAggregates(
   // ---------------
   irb->SetInsertPoint(error_aggstate_block);
 
-  codegen_utils->CreateElog(ERROR, "Codegened advance_aggregates: "
-      "use of different aggstate.");
+  EXPAND_CREATE_ELOG(codegen_utils, ERROR, "Codegened advance_aggregates: "
+                     "use of different aggstate.");
 
   irb->CreateRetVoid();
 

--- a/src/backend/codegen/exec_eval_expr_codegen.cc
+++ b/src/backend/codegen/exec_eval_expr_codegen.cc
@@ -151,9 +151,9 @@ bool ExecEvalExprCodegen::GenerateExecEvalExpr(
   irb->SetInsertPoint(llvm_entry_block);
 
 #ifdef CODEGEN_DEBUG
-  codegen_utils->CreateElog(
-      DEBUG1,
-      "Codegen'ed expression evaluation called!");
+  EXPAND_CREATE_ELOG(codegen_utils,
+                     DEBUG1,
+                     "Codegen'ed expression evaluation called!");
 #endif
 
   // Generate code from expression tree generator

--- a/src/backend/codegen/exec_variable_list_codegen.cc
+++ b/src/backend/codegen/exec_variable_list_codegen.cc
@@ -164,9 +164,9 @@ bool ExecVariableListCodegen::GenerateExecVariableList(
   // -----------
   irb->SetInsertPoint(entry_block);
 #ifdef CODEGEN_DEBUG
-  codegen_utils->CreateElog(
-      DEBUG1,
-      "Codegen'ed ExecVariableList called!");
+  EXPAND_CREATE_ELOG(codegen_utils,
+                     DEBUG1,
+                     "Codegen'ed ExecVariableList called!");
 #endif
   irb->CreateBr(slot_check_block);
 
@@ -249,9 +249,9 @@ bool ExecVariableListCodegen::GenerateExecVariableList(
   // Fall back Block
   // ---------------
   irb->SetInsertPoint(fallback_block);
-  codegen_utils->CreateElog(
-      DEBUG1,
-      "Falling back to regular ExecVariableList");
+  EXPAND_CREATE_ELOG(codegen_utils,
+                     DEBUG1,
+                     "Falling back to regular ExecVariableList");
 
   codegen_utils->CreateFallback<ExecVariableListFn>(
       codegen_utils->GetOrRegisterExternalFunction(ExecVariableList,

--- a/src/backend/codegen/include/codegen/pg_arith_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_arith_func_generator.h
@@ -400,7 +400,7 @@ static bool CreateOverflowCheckLogic(
                       llvm_non_overflow_block);
 
     irb->SetInsertPoint(llvm_overflow_block);
-    codegen_utils->CreateElog(
+    EXPAND_CREATE_ELOG(codegen_utils,
         ERROR,
         "%s", llvm_error_msg);
     irb->CreateBr(pg_func_info.llvm_error_block);

--- a/src/backend/codegen/include/codegen/utils/gp_codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/gp_codegen_utils.h
@@ -25,6 +25,11 @@ extern "C" {
 #include "utils/elog.h"
 }
 
+#define EXPAND_CREATE_ELOG(codegen_utils, elevel, ...)  \
+  codegen_utils->CreateElog(__FILE__, __LINE__, PG_FUNCNAME_MACRO, \
+                            elevel, __VA_ARGS__)
+
+
 namespace gpcodegen {
 
 class GpCodegenUtils : public CodegenUtils {
@@ -50,18 +55,21 @@ class GpCodegenUtils : public CodegenUtils {
    *          straight out of the compiled module back to the last location in GPDB
    *          that setjump was called.
    *
+   * @param file_name   name of the file from which CreateElog is called
+   * @param lineno      number of the line in the file from which CreateElog is called
+   * @param func_name   name of the function that calls CreateElog
    * @param llvm_elevel llvm::Value pointer to an integer representing the error level
    * @param llvm_fmt    llvm::Value pointer to the format string
    * @tparam args       llvm::Value pointers to arguments to elog()
    */
   template<typename... V>
   void CreateElog(
-      llvm::Value* llvm_elevel,
-      llvm::Value* llvm_fmt,
+      const char* file_name,
+      int lineno,
+      const char* func_name,
+      int elevel,
+      const char* fmt,
       const V ... args ) {
-    assert(NULL != llvm_elevel);
-    assert(NULL != llvm_fmt);
-
     llvm::Function* llvm_elog_start =
         GetOrRegisterExternalFunction(elog_start, "elog_start");
     llvm::Function* llvm_elog_finish =
@@ -69,38 +77,16 @@ class GpCodegenUtils : public CodegenUtils {
 
     ir_builder()->CreateCall(
         llvm_elog_start, {
-            GetConstant(""),   // Filename
-            GetConstant(0),    // line number
-            GetConstant("")    // function name
-        });
+            GetConstant(file_name),   // Filename
+            GetConstant(lineno),    // line number
+            GetConstant(func_name)    // function name
+    });
     ir_builder()->CreateCall(
         llvm_elog_finish, {
-            llvm_elevel,
-            llvm_fmt,
+            GetConstant(elevel),
+            GetConstant(fmt),
             args...
-        });
-  }
-
-  /*
-   * @brief Create LLVM instructions to call elog_start() and elog_finish().
-   *        A convenient alternative that automatically converts an integer elevel and
-   *        format string to LLVM constants.
-   *
-   * @warning This method does not create instructions for any sort of exception
-   *          handling. In the case that elog throws an error, the code with jump
-   *          straight out of the compiled module back to the last location in GPDB
-   *          that setjump was called.
-   *
-   * @param elevel Integer representing the error level
-   * @param fmt    Format string
-   * @tparam args  llvm::Value pointers to arguments to elog()
-   */
-  template<typename... V>
-    void CreateElog(
-        int elevel,
-        const char* fmt,
-        const V ... args ) {
-    CreateElog(GetConstant(elevel), GetConstant(fmt), args...);
+    });
   }
 
   /**

--- a/src/backend/codegen/slot_getattr_codegen.cc
+++ b/src/backend/codegen/slot_getattr_codegen.cc
@@ -213,9 +213,9 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttr(
 
   irb->SetInsertPoint(entry_block);
 #ifdef CODEGEN_DEBUG
-  codegen_utils->CreateElog(
-      DEBUG1,
-      "Codegen'ed slot_getattr called!");
+  EXPAND_CREATE_ELOG(codegen_utils,
+                     DEBUG1,
+                     "Codegen'ed slot_getattr called!");
 #endif
   // Retrieve slot's PRIVATE variables
   llvm::Value* llvm_slot_PRIVATE_tts_isnull /* bool* */ =
@@ -701,10 +701,10 @@ bool SlotGetAttrCodegen::GenerateSlotGetAttr(
   llvm_error->addIncoming(codegen_utils->GetConstant("tuple check failed"),
       heap_tuple_check_block);
 
-  codegen_utils->CreateElog(
-      DEBUG1,
-      "Falling back to regular slot_getattr, reason = %s",
-      llvm_error);
+  EXPAND_CREATE_ELOG(codegen_utils,
+                     DEBUG1,
+                     "Falling back to regular slot_getattr, reason = %s",
+                     llvm_error);
 
   codegen_utils->CreateFallback<SlotGetAttrFn>(
       codegen_utils->GetOrRegisterExternalFunction(slot_getattr_regular,


### PR DESCRIPTION
Regular elog prints the filename and lineno of the caller at the end of the printed message. However, codegened CreateElog does not. Instead it prints (:0). This results to a broken icg test, where diff cannot identify and avoid the pattern "(filename:lineno)".