### PR TITLE
Fix gpcheckcat extraneous entry repair to use primary keys if oids not consistent across segments.

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2859,12 +2859,7 @@ def _checkAllTablesForMissingEntries():
         _, pk_name = getPrimaryKeyColumn(catalog_name, catalog_table_obj.getPrimaryKey())
         # We do this check in this function rather than getPrimaryKeyColumn as
         # it is used in checkACL and we do not want to modify that functionality
-        if pk_name is None and not catalog_table_obj.tableHasConsistentOids():
-            pk_names = catalog_table_obj.getPrimaryKey()
-            pk_names_tuple = tuple(pk_names)
-            catalog_issues[(catalog_name, pk_names_tuple)] = issues
-        else:
-            catalog_issues[(catalog_name, 'oid' if pk_name is None else pk_name )] = issues
+        catalog_issues[(catalog_table_obj, pk_name)] = issues
     return catalog_issues
 # -------------------------------------------------------------------------------
 
@@ -3661,10 +3656,12 @@ def do_repair(sql_repair_contents, issue_type, description):
 def do_repair_for_extra(catalog_issues):
     setError(ERROR_REMOVE)
     repair_dir_path = ""
-    for (catalog_name, pk_name), issues in catalog_issues.iteritems():
+    for (catalog_table_obj, pk_name), issues in catalog_issues.iteritems():
         try:
             repair_obj = Repair(context=GV, issue_type="extra", desc="Removing extra entries")
-            repair_dir_path = repair_obj.create_repair_for_extra_missing(catalog_name=catalog_name, issues=issues, pk_name=pk_name)
+            repair_dir_path = repair_obj.create_repair_for_extra_missing(catalog_table_obj=catalog_table_obj,
+                                                                         issues=issues,
+                                                                         pk_name=pk_name)
         except Exception, ex:
             logger.fatal(str(ex))
 

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2718,9 +2718,9 @@ def checkACL():
 
     for cat in sorted(tables):
         checkTableACL(cat)
-
-
 # -------------------------------------------------------------------------------
+
+
 def checkTableACL(cat):
     catname = cat.getTableName()
     pkey = cat.getPrimaryKey()
@@ -2794,9 +2794,9 @@ def checkTableACL(cat):
         myprint('[ERROR] executing: Cross consistency check for ' + catname)
         myprint('  Execution error: ' + str(e))
         myprint(qry)
-
-
 # -------------------------------------------------------------------------------
+
+
 def checkForeignKey(cat_tables=None):
     logger.info('-----------------------------------')
     logger.info('Performing foreign key tests')
@@ -2827,8 +2827,9 @@ def checkForeignKey(cat_tables=None):
         setError(ERROR_NOREPAIR)
         GV.foreignKeyStatus = False
         myprint('  Execution error: ' + str(ex))
-
 # -------------------------------------------------------------------------------
+
+
 def checkMissingEntry():
     logger.info('-----------------------------------')
     logger.info('Performing cross consistency tests: check for missing or extraneous issues')
@@ -2836,24 +2837,38 @@ def checkMissingEntry():
     if GV.missingEntryStatus == None:
         GV.missingEntryStatus = True
 
-    # looks up information in the catalog:
-    tables = GV.catalog.getCatalogTables()
+    catalog_issues = _checkAllTablesForMissingEntries()
 
+    if len(catalog_issues) == 0:
+        return
+
+    if GV.opt['-E']:
+        do_repair_for_extra(catalog_issues)
+    else:
+        setError(ERROR_NOREPAIR)
+
+
+def _checkAllTablesForMissingEntries():
     catalog_issues = {}
-
+    tables = GV.catalog.getCatalogTables()
     for catalog_table_obj in sorted(tables):
         issues = checkTableMissingEntry(catalog_table_obj)
         if not issues:
             continue
-
         catalog_name = catalog_table_obj.getTableName()
         _, pk_name = getPrimaryKeyColumn(catalog_name, catalog_table_obj.getPrimaryKey())
-        catalog_issues[(catalog_name, pk_name)] = issues
-
-    do_repair_for_extra(catalog_issues)
-
-
+        # We do this check in this function rather than getPrimaryKeyColumn as
+        # it is used in checkACL and we do not want to modify that functionality
+        if pk_name is None and not catalog_table_obj.tableHasConsistentOids():
+            pk_names = catalog_table_obj.getPrimaryKey()
+            pk_names_tuple = tuple(pk_names)
+            catalog_issues[(catalog_name, pk_names_tuple)] = issues
+        else:
+            catalog_issues[(catalog_name, 'oid' if pk_name is None else pk_name )] = issues
+    return catalog_issues
 # -------------------------------------------------------------------------------
+
+
 def checkTableMissingEntry(cat):
     catname = cat.getTableName()
     pkey = cat.getPrimaryKey()
@@ -2873,9 +2888,8 @@ def checkTableMissingEntry(cat):
             return
 
     # Skip catalogs without primary key
-    if pkey == []:
-        logger.warn("[WARN] Skipped missing/extra entry check for %s" %
-                    catname)
+    if len(pkey) == 0:
+        logger.warn("[WARN] Skipped missing/extra entry check for %s" % catname)
         return
 
     castedPkey = cat.getPrimaryKey()
@@ -2924,6 +2938,7 @@ def checkTableMissingEntry(cat):
         myprint('[ERROR] executing: Missing or extraneous entries check for ' + catname)
         myprint('  Execution error: ' + str(e))
         myprint(qry)
+
 
 def checkMirroringMatching():
     # check that PT rebuild has not left behind mismatched mirroring states in the segments
@@ -3644,12 +3659,6 @@ def do_repair(sql_repair_contents, issue_type, description):
 
 
 def do_repair_for_extra(catalog_issues):
-    if len(catalog_issues) == 0:
-        return
-    if not GV.opt['-E']:
-        setError(ERROR_NOREPAIR)
-        return
-
     setError(ERROR_REMOVE)
     repair_dir_path = ""
     for (catalog_name, pk_name), issues in catalog_issues.iteritems():

--- a/gpMgmt/bin/gpcheckcat_modules/repair.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair.py
@@ -36,10 +36,12 @@ class Repair:
 
         return repair_dir
 
-    def create_repair_for_extra_missing(self, catalog_name, issues, pk_name):
+    def create_repair_for_extra_missing(self, catalog_table_obj, issues, pk_name):
 
-        extra_missing_repair_obj = RepairMissingExtraneous(catalog_name=catalog_name,
-                                                           issues=issues, pk_name=pk_name)
+        catalog_name = catalog_table_obj.getTableName()
+        extra_missing_repair_obj = RepairMissingExtraneous(catalog_table_obj=catalog_table_obj,
+                                                           issues=issues,
+                                                           pk_name=pk_name)
         repair_dir = self.create_repair_dir()
         all_seg_ids = self._context.report_cfg.keys()
         segment_to_oid_map = extra_missing_repair_obj.get_segment_to_oid_mapping(all_seg_ids)

--- a/gpMgmt/bin/gpcheckcat_modules/repair_missing_extraneous.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair_missing_extraneous.py
@@ -32,13 +32,12 @@ class RepairMissingExtraneous:
         return delete_sql
 
     def get_delete_sql(self, oids):
-        if self._pk_name is None and not \
-           self.catalog_table_obj.tableHasConsistentOids():
-            pk_names = tuple(self.catalog_table_obj.getPrimaryKey())
-            return self._generate_delete_sql_for_pkeys(pk_names=pk_names)
+        if self.catalog_table_obj.tableHasConsistentOids():
+            pk_name = 'oid' if self._pk_name is None else self._pk_name
+            return self._generate_delete_sql_for_oid(pk_name=pk_name, oids=oids)
 
-        pk_name = 'oid' if self._pk_name is None else self._pk_name
-        return self._generate_delete_sql_for_oid(pk_name=pk_name, oids=oids)
+        pk_names = tuple(self.catalog_table_obj.getPrimaryKey())
+        return self._generate_delete_sql_for_pkeys(pk_names=pk_names)
 
     def get_segment_to_oid_mapping(self, all_seg_ids):
         if not self._issues:

--- a/gpMgmt/bin/gpcheckcat_modules/repair_missing_extraneous.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair_missing_extraneous.py
@@ -4,28 +4,27 @@ from gppylib.operations.backup_utils import escapeDoubleQuoteInSQLString
 
 class RepairMissingExtraneous:
 
-    def __init__(self, catalog_name,  issues, pk_name):
+    def __init__(self, catalog_table_obj,  issues, pk_name):
+        self.catalog_table_obj = catalog_table_obj
+        catalog_name = self.catalog_table_obj.getTableName()
         self._escaped_catalog_name = escapeDoubleQuoteInSQLString(catalog_name)
         self._issues = issues
         self._pk_name = pk_name
-        self._is_tuple = type(self._pk_name) is tuple
 
-    # TODO: figure out when to use "oid"
-
-    def _generate_delete_sql_for_oid(self, oids):
-        escaped_pk_name = escapeDoubleQuoteInSQLString(self._pk_name)
+    def _generate_delete_sql_for_oid(self, pk_name, oids):
+        escaped_pk_name = escapeDoubleQuoteInSQLString(pk_name)
         delete_sql = 'BEGIN;set allow_system_table_mods="dml";delete from {0} where {1} in ({2});COMMIT;'
         return delete_sql.format(self._escaped_catalog_name, escaped_pk_name, ','.join(str(oid) for oid in oids))
 
-    def _generate_delete_sql_for_pkeys(self):
+    def _generate_delete_sql_for_pkeys(self, pk_names):
         delete_sql = 'BEGIN;set allow_system_table_mods="dml";'
         for issue in self._issues:
             delete_issue_sql = 'delete from {0} where '
-            for pk, issue_col in zip(self._pk_name, issue):
-                operator = " and " if pk != self._pk_name[-1] else ";"
+            for pk, issue_col in zip(pk_names, issue):
+                operator = " and " if pk != pk_names[-1] else ";"
                 add_on = "{pk} = '{col}'{operator}".format(pk=pk,
-                                                            col=str(issue_col),
-                                                            operator=operator)
+                                                           col=str(issue_col),
+                                                           operator=operator)
                 delete_issue_sql += add_on
             delete_issue_sql = delete_issue_sql.format(self._escaped_catalog_name)
             delete_sql += delete_issue_sql
@@ -33,11 +32,13 @@ class RepairMissingExtraneous:
         return delete_sql
 
     def get_delete_sql(self, oids):
-        if self._is_tuple:
-            # create del sql for multiple pkeys
-            return self._generate_delete_sql_for_pkeys()
-        else:
-            return self._generate_delete_sql_for_oid(oids)
+        if self._pk_name is None and not \
+           self.catalog_table_obj.tableHasConsistentOids():
+            pk_names = tuple(self.catalog_table_obj.getPrimaryKey())
+            return self._generate_delete_sql_for_pkeys(pk_names=pk_names)
+
+        pk_name = 'oid' if self._pk_name is None else self._pk_name
+        return self._generate_delete_sql_for_oid(pk_name=pk_name, oids=oids)
 
     def get_segment_to_oid_mapping(self, all_seg_ids):
         if not self._issues:
@@ -73,4 +74,3 @@ class RepairMissingExtraneous:
                 oids_to_segment_mapping[seg_id].add(oid)
 
         return oids_to_segment_mapping
-

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -546,6 +546,9 @@ class GPCatalogTable():
     def __str__(self):
         return self._name
 
+    def __hash__(self):
+        return hash(self.__str__())
+
     def __repr__(self):
         return "GPCatalogTable: %s; pkey: %s; oids: %s; acl: %s" % (
             str(self._name), str(self._pkey), str(self._has_oid), str(self._acl),

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/add_operator.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gpcheckcat/add_operator.sql
@@ -1,0 +1,5 @@
+-- Create a function that will be added as an operator
+CREATE FUNCTION my_pk_schema.is_zero(int) RETURNS TABLE(f1 boolean)
+AS $$ select $1 = 0 $$  LANGUAGE SQL;
+
+CREATE OPERATOR my_pk_schema.!# (PROCEDURE = my_pk_schema.is_zero,LEFTARG = integer);

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -6,6 +6,7 @@ import sys
 from mock import *
 
 from gp_unittest import *
+from gppylib.gpcatalog import GPCatalogTable
 
 class GpCheckCatTestCase(GpTestCase):
     def setUp(self):
@@ -27,7 +28,7 @@ class GpCheckCatTestCase(GpTestCase):
             patch('pygresql.pgdb'),
         ])
 
-        self.subject.logger = Mock(spec=['log', 'info', 'debug', 'error'])
+        self.subject.logger = Mock(spec=['log', 'info', 'debug', 'error', 'fatal'])
         self.unique_index_violation_check.runCheck.return_value = []
         self.leaked_schema_dropper = Mock(spec=['drop_leaked_schemas'])
         self.leaked_schema_dropper.drop_leaked_schemas.return_value = []
@@ -43,6 +44,7 @@ class GpCheckCatTestCase(GpTestCase):
                                1:dict(hostname='host1', port=123, id=1, address='123', datadir='dir', content=1, dbid=1)}
         self.subject.GV.checkStatus = True
         self.subject.GV.foreignKeyStatus = True
+        self.subject.GV.missingEntryStatus = True
         self.subject.setError = Mock()
         self.subject.print_repair_issues = Mock()
 
@@ -156,17 +158,6 @@ class GpCheckCatTestCase(GpTestCase):
         # I am confused that .assert_any_call() did not seem to work as expected --Larry
         last_call = mock_log.call_args_list[0][0][2]
         self.assertEquals(last_call, "Truncated batch size to number of primaries: 50")
-
-
-    def test_do_repair_for_extra__no_issues(self):
-        issues = {}
-        self.subject.do_repair_for_extra(issues)
-        self.subject.setError.assert_not_called()
-
-    def test_do_repair_for_extra__issues_no_repair(self):
-        issues = {("pg_class", "oid"):"extra"}
-        self.subject.do_repair_for_extra(issues)
-        self.subject.setError.assert_any_call(self.subject.ERROR_NOREPAIR)
 
     @patch('gpcheckcat_modules.repair.Repair', return_value=Mock())
     @patch('gpcheckcat_modules.repair.Repair.create_repair_for_extra_missing', return_value="/tmp")
@@ -283,6 +274,53 @@ class GpCheckCatTestCase(GpTestCase):
         self.assertIn("  Execution error: Boom!", log_messages)
         self.assertFalse(self.subject.GV.checkStatus)
         self.subject.setError.assert_called_once_with(self.subject.ERROR_NOREPAIR)
+
+
+    @patch('gpcheckcat.checkTableMissingEntry', return_value = None)
+    def test_checkMissingEntry__no_issues(self, mock1):
+        cat_mock = Mock()
+        cat_tables = ["input1", "input2"]
+        cat_mock.getCatalogTables.return_value = cat_tables
+        self.subject.GV.catalog = cat_mock
+
+        self.subject.runOneCheck("missing_extraneous")
+
+        self.assertTrue(self.subject.GV.missingEntryStatus)
+        self.subject.setError.assert_not_called()
+
+    @patch('gpcheckcat.checkTableMissingEntry', return_value= {("pg_clas", "oid"): "extra"})
+    @patch('gpcheckcat.getPrimaryKeyColumn', return_value = (None,"oid"))
+    def test_checkMissingEntry__uses_oid(self, mock1, mock2):
+
+        self.subject.GV.opt['-E'] = True
+        aTable = Mock(spec=GPCatalogTable)
+
+        cat_mock = Mock()
+        cat_mock.getCatalogTables.return_value = [aTable]
+        self.subject.GV.catalog = cat_mock
+
+        self.subject.runOneCheck("missing_extraneous")
+
+        self.assertEquals(aTable.getPrimaryKey.call_count, 1)
+        self.subject.setError.assert_called_once_with(self.subject.ERROR_REMOVE)
+
+    @patch('gpcheckcat.checkTableMissingEntry', return_value= {("pg_operator", "typename, typenamespace"): "extra"})
+    @patch('gpcheckcat.getPrimaryKeyColumn', return_value = (None,None))
+    def test_checkMissingEntry__uses_pkeys(self, mock1, mock2):
+
+        self.subject.GV.opt['-E'] = True
+        aTable = MagicMock(spec=GPCatalogTable)
+        aTable.tableHasConsistentOids.return_value = False
+
+        cat_mock = Mock()
+        cat_mock.getCatalogTables.return_value = [aTable]
+        self.subject.GV.catalog = cat_mock
+
+        self.subject.runOneCheck("missing_extraneous")
+
+        self.assertEquals(aTable.getPrimaryKey.call_count, 2)
+        self.subject.setError.assert_called_once_with(self.subject.ERROR_REMOVE)
+
 
     ####################### PRIVATE METHODS #######################
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -318,7 +318,7 @@ class GpCheckCatTestCase(GpTestCase):
 
         self.subject.runOneCheck("missing_extraneous")
 
-        self.assertEquals(aTable.getPrimaryKey.call_count, 2)
+        self.assertEquals(aTable.getPrimaryKey.call_count, 1)
         self.subject.setError.assert_called_once_with(self.subject.ERROR_REMOVE)
 
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
@@ -53,8 +53,10 @@ class RepairTestCase(GpTestCase):
     def test_create_repair_extra__normal(self):
         self.subject = Repair(self.context, "extra", "some desc")
         self.subject.TIMESTAMP = "timestamp"
+        catalog_table_obj = Mock()
         catalog_table_name = "catalog"
-        repair_dir = self.subject.create_repair_for_extra_missing(catalog_table_name, issues=None, pk_name=None)
+        catalog_table_obj.getTableName.return_value = catalog_table_name
+        repair_dir = self.subject.create_repair_for_extra_missing(catalog_table_obj, issues=None, pk_name=None)
         self.assertEqual(repair_dir, self.repair_dir_path)
         bash_contents =[
                     "#!/bin/bash\n",


### PR DESCRIPTION
gpcheckcat missing/extraneous repair assumed oids are consistent across segments for a given catalog entry. This is not always guaranteed for all catalog tables (which are defined in gpcheckcat). Instead, we need to generate the repair based on the primary keys (the unique identifier in this case).

Authors: Marbin, Larry, Chris and Chumki