### PR TITLE
Fix relfilenode conflicts.

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -389,3 +389,55 @@ GetNewObjectId(void)
 
 	return result;
 }
+
+/*
+ * To avoid clashes on pg_class.relfilenode, we keep track of which
+ * OIDs have recently been used for a relfilenode. PostgreSQL doesn't
+ * need this, as they rely on the monotonicity of GetNewObjectId(),
+ * with checks for already-used relfilenodes in GetNewRelFileNode(),
+ * but that's not enough in GPDB. In a GPDB segment node, we try to use
+ * a table's OID as its relfilenode like in PostgreSQL, but because the
+ * OIDs are generated in the master node, it's possible that
+ * GetNewRelFileNode() chooses a value that has just been assigned for
+ * a different table in the master. To work around that, we have a
+ * small cache of values that have recently been used for relfilenodes,
+ * and refrain from choosing them again.
+ *
+ * If the given OID has recently been used as a relfilenode, returns
+ * false. Otherwise returns true, and marks the OID as used, so that
+ * subsequent calls with the same OID will return false.
+ *
+ * We use a small cache of 100 OIDs (NUM_RECENT_RELFILENODES). This is
+ * not bulletproof, but is good enough in practice to close the race
+ * condition. It is not enough by itself to ensure that a relfilenode
+ * value is unique, you still need to also check that there's no
+ * file in the data directory with the same name.
+ */
+bool
+UseOidForRelFileNode(Oid oid)
+{
+	int			i;
+	int			next;
+
+	LWLockAcquire(OidGenLock, LW_EXCLUSIVE);
+
+	for (i = 0; i < NUM_RECENT_RELFILENODES; i++)
+	{
+		if (ShmemVariableCache->recentRelfilenodes[i] == oid)
+		{
+			/* Already used. Not cool. */
+			LWLockRelease(OidGenLock);
+			return false;
+		}
+	}
+
+	next = ShmemVariableCache->nextRecentRelfilenode;
+	ShmemVariableCache->recentRelfilenodes[next] = oid;
+	if (++next >= NUM_RECENT_RELFILENODES)
+		next = 0;
+	ShmemVariableCache->nextRecentRelfilenode = next;
+
+	LWLockRelease(OidGenLock);
+
+	return true;
+}

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1576,6 +1576,9 @@ heap_create_with_catalog(const char *relname,
 	 *
 	 * The OID will be the relfilenode as well, so make sure it doesn't
 	 * collide with either pg_class OIDs or existing physical files.
+	 *
+	 * (In GPDB, heap_create can choose a different relfilenode, in a QE node,
+	 * if the one we choose is already in use.)
 	 */
 	if (!OidIsValid(relid) && Gp_role == GP_ROLE_EXECUTE)
 		relid = GetPreassignedOidForRelation(relnamespace, relname);
@@ -1583,12 +1586,6 @@ heap_create_with_catalog(const char *relname,
 	if (!OidIsValid(relid))
 		relid = GetNewRelFileNode(reltablespace, shared_relation,
 								  pg_class_desc);
-	else
-		if (IsUnderPostmaster)
-		{
-			CheckNewRelFileNodeIsOk(relid, reltablespace, shared_relation,
-									pg_class_desc);
-		}
 
 	/*
 	 * Create the relcache entry (mostly dummy at this point) and the physical

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1204,10 +1204,9 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 		 */
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
-			int 		i, j, nindexes;
+			int 		i, nindexes;
 			bool 		has_bitmap = false;
 			Relation   *i_rel = NULL;
-			Oid			newrelfilenode;
 
 			stats_context.ctx = vac_context;
 			stats_context.onerel = onerel;
@@ -1219,24 +1218,10 @@ vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
 			{
 				for (i = 0; i < nindexes; i++)
 				{
-					if (!RelationIsBitmapIndex(i_rel[i]))
-						continue;
-
-					has_bitmap = true;
-
-					/*
-					 * bitmap indexes require extra relfilenodes during vacuum,
-					 * the exact number is unknown so we err on the side of
-					 * caution. See comment on NUM_EXTRA_OIDS_FOR_BITMAP for
-					 * more information.
-					 */
-					for (j = 0; j < NUM_EXTRA_OIDS_FOR_BITMAP; j++)
+					if (RelationIsBitmapIndex(i_rel[i]))
 					{
-						newrelfilenode = GetNewRelFileNode(i_rel[i]->rd_rel->reltablespace,
-														   i_rel[i]->rd_rel->relisshared,
-														   NULL);
-						AddDispatchRelfilenodeForRelation(RelationGetRelid(i_rel[i]),
-														  newrelfilenode);
+						has_bitmap = true;
+						break;
 					}
 				}
 			}

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -59,6 +59,8 @@
 		(dest)--; \
 	} while ((dest) < FirstNormalTransactionId)
 
+#define NUM_RECENT_RELFILENODES		100
+
 /*
  * VariableCache is a data structure in shared memory that is used to track
  * OID and XID assignment state.  For largely historical reasons, there is
@@ -76,6 +78,10 @@ typedef struct VariableCacheData
 	 */
 	Oid			nextOid;		/* next OID to assign */
 	uint32		oidCount;		/* OIDs available before must do XLOG work */
+
+	/* cache of recently used relfilenodes, for UseOidForRelFileNode() */
+	Oid			recentRelfilenodes[NUM_RECENT_RELFILENODES];
+	int			nextRecentRelfilenode;
 
 	/*
 	 * These fields are protected by XidGenLock.
@@ -137,5 +143,6 @@ extern TransactionId ReadNewTransactionId(void);
 extern void SetTransactionIdLimit(TransactionId oldest_datfrozenxid,
 					  Name oldest_datname);
 extern Oid	GetNewObjectId(void);
+extern bool UseOidForRelFileNode(Oid oid);
 
 #endif   /* TRAMSAM_H */

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -45,6 +45,6 @@ extern Oid	GetNewOid(Relation relation);
 extern Oid	GetNewOidWithIndex(Relation relation, Relation indexrel);
 extern Oid GetNewRelFileNode(Oid reltablespace, bool relisshared,
 				  Relation pg_class);
-extern bool CheckNewRelFileNodeIsOk(Oid newOid, Oid reltablespace, bool relisshared, Relation pg_class);
+extern bool CheckNewRelFileNodeIsOk(Oid newOid, Oid reltablespace, bool relisshared);
 
 #endif   /* CATALOG_H */

--- a/src/include/catalog/oid_dispatch.h
+++ b/src/include/catalog/oid_dispatch.h
@@ -17,7 +17,6 @@
 
 /* Functions used in master */
 extern void AddDispatchOidFromTuple(Relation catalogrel, HeapTuple tuple);
-extern void AddDispatchRelfilenodeForRelation(Oid relid, Oid relfilenode);
 extern List *GetAssignedOidsForDispatch(void);
 
 /* Functions used in QE nodes */
@@ -26,7 +25,6 @@ extern Oid GetPreassignedOidForTuple(Relation catalogrel, HeapTuple tuple);
 extern Oid GetPreassignedOidForRelation(Oid namespaceOid, const char *relname);
 extern Oid GetPreassignedOidForType(Oid namespaceOid, const char *typname);
 extern Oid GetPreassignedOidForDatabase(const char *datname);
-extern Oid GetPreassignedRelfilenodeForRelation(Oid relid);
 
 extern void AtEOXact_DispatchOids(bool isCommit);
 

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -209,7 +209,7 @@ typedef struct
 	Oid			namespaceOid;	/* namespace OID for most objects */
 	Oid			keyOid2;		/* 2nd key OID field, meaning depends on object type */
 
-	Oid			oid;			/* OID (or relfilenode) to assign */
+	Oid			oid;			/* OID to assign */
 
 } OidAssignment;
 

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1286,40 +1286,6 @@ create table atsdb (i int, j text) distributed by (j);
 alter table atsdb set with(appendonly = true);
 ERROR:  option "appendonly" not supported
 drop table atsdb;
--- MPP-8474: Index relfilenode mismatch: entry db to segment db.
---
--- XXX This really belongs in alter_table.sql but this is not 
---     in use in current_good_schedule.
-drop table if exists mpp8474 cascade; --ignore
-NOTICE:  table "mpp8474" does not exist, skipping
-create table mpp8474(a int, b int, c text) 
-    with (appendonly=true) 
-    distributed by (b);
-create index mpp8474_a 
-    on mpp8474(a);
-alter table mpp8474 
-    add column d int default 10;
-select 
-    'Mismatched relfilenodes:' as oops,
-    e.oid::regclass as entry_oid,
-    e.relkind,
-    e.relfilenode as entry_relfilenode,
-    s.segid,
-    s.segfilenode as segment_relfilenode
-from 
-    pg_class e,
-    (   select gp_execution_segment(), oid, relfilenode
-        from gp_dist_random('pg_class')
-    ) s (segid, segoid, segfilenode)
-where 
-    e.oid = s.segoid 
-    and e.relfilenode != s.segfilenode
-    and e.relname ~ '^mpp8474.*';
- oops | entry_oid | relkind | entry_relfilenode | segid | segment_relfilenode 
-------+-----------+---------+-------------------+-------+---------------------
-(0 rows)
-
-drop table mpp8474;
 -- MPP-18660: duplicate entry in gp_distribution_policy
 set enable_indexscan=on;
 set enable_seqscan=off;


### PR DESCRIPTION
There was a race condition in the way relfilenodes were chosen, because
QE nodes chose relfilenodes for existing relations, e.g. at REINDEX or
TRUNCATE, independently of the master, while for newly created tables,
the relfilenode was chosen by the master. To fix:

1. If the OID of a newly-created table is already in use as relfilenode
   of a different table in a QE segment, use a different relfilenode.
   (This shouldn't happen in the dispatcher, for the same reasons it
   cannot happen in a single-server PostgreSQL instance)

2. Use a small cache of values recently used for a relfilenode, to close
   a race condition between checking if a relfilenode is in use, and
   actually creating the file