### PR TITLE
Multi-dimensional arrays can now be used as arguments to a PL/python …

### DIFF
--- a/src/pl/plpython/Makefile
+++ b/src/pl/plpython/Makefile
@@ -67,7 +67,7 @@ SHLIB_LINK = $(python_libspec) $(python_additional_libs) $(filter -lintl,$(LIBS)
 
 REGRESS_OPTS = --dbname=$(PL_TESTDB) --load-language=plpythonu
 REGRESS = plpython_schema plpython_populate plpython_function plpython_test \
-	plpython_subtransaction plpython_composite	\
+	plpython_subtransaction plpython_composite plpython_types \
 	plpython_returns plpython_error plpython_drop
 # where to find psql for running the tests
 PSQLDIR = $(bindir)

--- a/src/pl/plpython/expected/plpython_function.out
+++ b/src/pl/plpython/expected/plpython_function.out
@@ -158,67 +158,67 @@ CREATE TRIGGER show_trigger_data_trig
 BEFORE INSERT OR UPDATE OR DELETE ON trigger_test
 FOR EACH ROW EXECUTE PROCEDURE trigger_data(23,'skidoo');
 insert into trigger_test values(1,'insert');
-NOTICE:  TD[args] => ['23', 'skidoo']  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[args] => ['23', 'skidoo']  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[event] => INSERT  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[event] => INSERT  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[level] => ROW  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[level] => ROW  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[name] => show_trigger_data_trig  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[name] => show_trigger_data_trig  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[new] => {'i': 1, 'v': 'insert'}  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[new] => {'i': 1, 'v': 'insert'}  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[old] => None  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[old] => None  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[relid] => bogus:12345  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[relid] => bogus:12345  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[table_name] => trigger_test  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[table_name] => trigger_test  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[table_schema] => public  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[table_schema] => public  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[when] => BEFORE  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[when] => BEFORE  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
 update trigger_test set v = 'update' where i = 1;
-NOTICE:  TD[args] => ['23', 'skidoo']  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[args] => ['23', 'skidoo']  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[event] => UPDATE  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[event] => UPDATE  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[level] => ROW  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[level] => ROW  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[name] => show_trigger_data_trig  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[name] => show_trigger_data_trig  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[new] => {'i': 1, 'v': 'update'}  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[new] => {'i': 1, 'v': 'update'}  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[old] => {'i': 1, 'v': 'insert'}  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[old] => {'i': 1, 'v': 'insert'}  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[relid] => bogus:12345  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[relid] => bogus:12345  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[table_name] => trigger_test  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[table_name] => trigger_test  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[table_schema] => public  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[table_schema] => public  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[when] => BEFORE  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[when] => BEFORE  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
 delete from trigger_test;
-NOTICE:  TD[args] => ['23', 'skidoo']  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[args] => ['23', 'skidoo']  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[event] => DELETE  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[event] => DELETE  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[level] => ROW  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[level] => ROW  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[name] => show_trigger_data_trig  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[name] => show_trigger_data_trig  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[new] => None  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[new] => None  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[old] => {'i': 1, 'v': 'update'}  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[old] => {'i': 1, 'v': 'update'}  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[relid] => bogus:12345  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[relid] => bogus:12345  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[table_name] => trigger_test  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[table_name] => trigger_test  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[table_schema] => public  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[table_schema] => public  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
-NOTICE:  TD[when] => BEFORE  (seg0 gxymac.local:40000 pid=35258)
+NOTICE:  TD[when] => BEFORE  (seg0 192.168.1.138:25432 pid=54748)
 CONTEXT:  PL/Python function "trigger_data"
       
 DROP TRIGGER show_trigger_data_trig on trigger_test;
@@ -540,24 +540,6 @@ $$ LANGUAGE plpythonu;
 CREATE FUNCTION test_inout_params(first inout text) AS $$
 return first + '_inout';
 $$ LANGUAGE plpythonu;
-CREATE FUNCTION test_type_conversion_bool(x bool) returns bool AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_char(x char) returns char AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_int2(x int2) returns int2 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_int4(x int4) returns int4 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_int8(x int8) returns int8 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_float4(x float4) returns float4 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_float8(x float8) returns float8 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_numeric(x numeric) returns numeric AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_text(x text) returns text AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_bytea(x bytea) returns bytea AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_marshal() returns bytea AS $$ 
-import marshal
-return marshal.dumps('hello world')
-$$ language plpythonu;
-CREATE FUNCTION test_type_unmarshal(x bytea) returns text AS $$
-import marshal
-return marshal.loads(x)
-$$ language plpythonu;
 -- RETURN value testing
 CREATE FUNCTION test_return_void(s text) 
 RETURNS void AS $$
@@ -581,6 +563,16 @@ RETURNS bytea AS $$
 $$ language plpythonu;
 CREATE FUNCTION test_return_circle(s text) 
 RETURNS circle AS $$
+  exec('y = ' + s)
+  return y
+$$ language plpythonu;
+CREATE FUNCTION test_return_array_int(s text) 
+RETURNS int[] AS $$
+  exec('y = ' + s)
+  return y
+$$ language plpythonu;
+CREATE FUNCTION test_return_array_text(s text) 
+RETURNS text[] AS $$
   exec('y = ' + s)
   return y
 $$ language plpythonu;

--- a/src/pl/plpython/expected/plpython_returns.out
+++ b/src/pl/plpython/expected/plpython_returns.out
@@ -483,14 +483,14 @@ PL/Python function "test_return_text"
 SELECT test_return_text(
     E'1; exec("class Foo:\\n  def __str__(self): return None"); y = Foo()'
 );
-ERROR:  could not create string representation of Python object (plpython.c:4699)
+ERROR:  could not create string representation of Python object (plpython.c:4928)
 DETAIL:  TypeError: __str__ returned non-string (type NoneType)
 CONTEXT:  while creating return value
 PL/Python function "test_return_text"
 SELECT * FROM test_return_text(
     E'1; exec("class Foo:\\n  def __str__(self): return None"); y = Foo()'
 );
-ERROR:  could not create string representation of Python object (plpython.c:4699)
+ERROR:  could not create string representation of Python object (plpython.c:4928)
 DETAIL:  TypeError: __str__ returned non-string (type NoneType)
 CONTEXT:  while creating return value
 PL/Python function "test_return_text"
@@ -710,24 +710,24 @@ FROM gp_single_row;
 SELECT test_return_bytea(
     E'1; exec("class Foo:\\n  def __str__(self): return None"); y = Foo()'
 );
-ERROR:  could not create bytes representation of Python object (plpython.c:4699)
+ERROR:  could not create bytes representation of Python object (plpython.c:4928)
 DETAIL:  TypeError: __str__ returned non-string (type NoneType)
 CONTEXT:  while creating return value
 PL/Python function "test_return_bytea"
 SELECT * FROM test_return_bytea(
     E'1; exec("class Foo:\\n  def __str__(self): return None"); y = Foo()'
 );
-ERROR:  could not create bytes representation of Python object (plpython.c:4699)
+ERROR:  could not create bytes representation of Python object (plpython.c:4928)
 DETAIL:  TypeError: __str__ returned non-string (type NoneType)
 CONTEXT:  while creating return value
 PL/Python function "test_return_bytea"
 SELECT test_return_bytea(
     E'1; exec("class Foo:\\n  def __str__(self): return None"); y = Foo()'
 ) FROM gp_single_row;
-ERROR:  could not create bytes representation of Python object (plpython.c:4699)  (seg0 slice1 gxymac.local:40000 pid=35336) (cdbdisp.c:1462)
+ERROR:  could not create bytes representation of Python object (plpython.c:4928)  (seg0 slice1 192.168.1.138:25432 pid=43982)
 DETAIL:  
-	 TypeError: __str__ returned non-string (type NoneType)
-	 while creating return value
+TypeError: __str__ returned non-string (type NoneType)
+while creating return value
 PL/Python function "test_return_bytea"
 --
 -- Case 5: Return Circle
@@ -878,6 +878,180 @@ SELECT * FROM test_return_circle(E'"test\\0"');
 ERROR:  could not convert Python object into cstring: Python string representation appears to contain null bytes
 CONTEXT:  while creating return value
 PL/Python function "test_return_circle"
+--
+-- Case 5: Return array of integers
+--
+-- Test returning arrays of fixed-width elements from PL/Python functions
+--
+-- From Python None
+SELECT test_return_array_int('None');
+ test_return_array_int 
+-----------------------
+ 
+(1 row)
+
+SELECT * FROM test_return_array_int('None');
+ test_return_array_int 
+-----------------------
+ 
+(1 row)
+
+-- From Python empty list
+SELECT test_return_array_int('[]');
+ test_return_array_int 
+-----------------------
+ {}
+(1 row)
+
+SELECT * FROM test_return_array_int('[]');
+ test_return_array_int 
+-----------------------
+ {}
+(1 row)
+
+-- From Python non-empty list
+SELECT test_return_array_int('[1,2]');
+ test_return_array_int 
+-----------------------
+ {1,2}
+(1 row)
+
+SELECT * FROM test_return_array_int('[1,2]');
+ test_return_array_int 
+-----------------------
+ {1,2}
+(1 row)
+
+-- From Python multiple lists
+SELECT test_return_array_int('[[1,2,3],[4,5,6]]');
+ test_return_array_int 
+-----------------------
+ {{1,2,3},{4,5,6}}
+(1 row)
+
+SELECT * FROM test_return_array_int('[[1,2,3],[4,5,6]]');
+ test_return_array_int 
+-----------------------
+ {{1,2,3},{4,5,6}}
+(1 row)
+
+-- Error conditions
+-- Multi-dimensional array with non-fixed dimension sizes
+SELECT test_return_array_int('[[1,2,3],[1,2]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length 2 while expected 3 (plpython.c:4928)
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_int"
+SELECT * FROM test_return_array_int('[[1,2,3],[1,2]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length 2 while expected 3 (plpython.c:4928)
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_int"
+-- Multi-dimensional array with mix of arrays and atomic elements
+SELECT test_return_array_int('[[1,2,3],[1,[2,3],[4,5]]]');
+ERROR:  invalid input syntax for integer: "[2, 3]"
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_int"
+SELECT * FROM test_return_array_int('[[1,2,3],[1,[2,3],[4,5]]]');
+ERROR:  invalid input syntax for integer: "[2, 3]"
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_int"
+-- Multi-dimensional array with missing dimensions
+SELECT test_return_array_int('[[1,2,3],None,[4,5,6]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length -1 while expected 3 (plpython.c:4928)
+DETAIL:  TypeError: object of type 'NoneType' has no len()
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_int"
+SELECT * FROM test_return_array_int('[[1,2,3],None,[4,5,6]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length -1 while expected 3 (plpython.c:4928)
+DETAIL:  TypeError: object of type 'NoneType' has no len()
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_int"
+--
+-- Case 5: Return array of texts
+--
+-- Test returning arrays of variable-width elements from PL/Python functions
+--
+-- From Python None
+SELECT test_return_array_text('None');
+ test_return_array_text 
+------------------------
+ 
+(1 row)
+
+SELECT * FROM test_return_array_text('None');
+ test_return_array_text 
+------------------------
+ 
+(1 row)
+
+-- From Python empty list
+SELECT test_return_array_text('[]');
+ test_return_array_text 
+------------------------
+ {}
+(1 row)
+
+SELECT * FROM test_return_array_text('[]');
+ test_return_array_text 
+------------------------
+ {}
+(1 row)
+
+-- From Python non-empty list
+SELECT test_return_array_text('["abc","def"]');
+ test_return_array_text 
+------------------------
+ {abc,def}
+(1 row)
+
+SELECT * FROM test_return_array_text('["abc","def"]');
+ test_return_array_text 
+------------------------
+ {abc,def}
+(1 row)
+
+-- From Python multiple lists
+SELECT test_return_array_text('[["a","bcd","ef"],[None,"gh","ijklm"]]');
+    test_return_array_text    
+------------------------------
+ {{a,bcd,ef},{NULL,gh,ijklm}}
+(1 row)
+
+SELECT * FROM test_return_array_text('[["a","bcd","ef"],[None,"gh","ijklm"]]');
+    test_return_array_text    
+------------------------------
+ {{a,bcd,ef},{NULL,gh,ijklm}}
+(1 row)
+
+-- Error conditions
+-- Multi-dimensional array with non-fixed dimension sizes
+SELECT test_return_array_text('[["a","bcd","ef"],[None,"gh","ijklm","ERROR"]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length 4 while expected 3 (plpython.c:4928)
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_text"
+SELECT * FROM test_return_array_text('[["a","bcd","ef"],[None,"gh","ijklm","ERROR"]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length 4 while expected 3 (plpython.c:4928)
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_text"
+-- Multi-dimensional array with mix of arrays and atomic elements
+SELECT test_return_array_text('[[["a"],"b"],["c",["d","e"]]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length 2 while expected 1 (plpython.c:4928)
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_text"
+SELECT * FROM test_return_array_text('[[["a"],"b"],["c",["d","e"]]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length 2 while expected 1 (plpython.c:4928)
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_text"
+-- Multi-dimensional array with missing dimensions
+SELECT test_return_array_text('[["abc","def"],None,["ghij","k"]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length -1 while expected 2 (plpython.c:4928)
+DETAIL:  TypeError: object of type 'NoneType' has no len()
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_text"
+SELECT * FROM test_return_array_text('[["abc","def"],None,["ghij","k"]]');
+ERROR:  multidimensional arrays must have array expressions with matching dimensions. PL/Python function return value has sequence length -1 while expected 2 (plpython.c:4928)
+DETAIL:  TypeError: object of type 'NoneType' has no len()
+CONTEXT:  while creating return value
+PL/Python function "test_return_array_text"
 -- ===================================================
 -- TEST 2:  RETURN VALUE TESTING - SETOF scalar values
 -- ===================================================
@@ -2050,7 +2224,7 @@ SELECT test_return_table_record('{"first": "value", "second": 4, "third": "ignor
 (1 row)
 
 SELECT * FROM test_return_table_record('{"first": "value", "second": 4}, "third": "ignored"}');
-ERROR:  SyntaxError: invalid syntax (<string>, line 1) (plpython.c:4699)
+ERROR:  SyntaxError: invalid syntax (<string>, line 1) (plpython.c:4928)
 CONTEXT:  Traceback (most recent call last):
   PL/Python function "test_return_table_record", line 2, in <module>
     exec('y = ' + s)
@@ -2078,9 +2252,9 @@ CONTEXT:  while creating return value
 PL/Python function "test_return_setof_type_record"
 SELECT test_return_setof_type_record('[]')
 FROM gp_single_row;
-ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 gxymac.local:40000 pid=35336)
+ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 192.168.1.138:25432 pid=43982)
 DETAIL:  
-	 while creating return value
+while creating return value
 PL/Python function "test_return_setof_type_record"
 SELECT (test_return_setof_type_record('[]')).*;
 ERROR:  length of returned sequence did not match number of columns in row
@@ -2088,9 +2262,9 @@ CONTEXT:  while creating return value
 PL/Python function "test_return_setof_type_record"
 SELECT (test_return_setof_type_record('[]')).*
 FROM gp_single_row;
-ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 gxymac.local:40000 pid=35336)
+ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 192.168.1.138:25432 pid=43982)
 DETAIL:  
-	 while creating return value
+while creating return value
 PL/Python function "test_return_setof_type_record"
 -- From Python List
 SELECT test_return_setof_type_record('[ ("value", 4), {"first": "test", "second": 2} ]');
@@ -2103,9 +2277,9 @@ CONTEXT:  while creating return value
 PL/Python function "test_return_setof_type_record"
 SELECT test_return_setof_type_record('[ ("value", 4), {"first": "test", "second": 2} ]')
 FROM gp_single_row;
-ERROR:  invalid input syntax for integer: "{'second': 2, 'first': 'test'}"  (seg0 slice1 gxymac.local:40000 pid=35336)
+ERROR:  invalid input syntax for integer: "{'second': 2, 'first': 'test'}"  (seg0 slice1 192.168.1.138:25432 pid=43982)
 DETAIL:  
-	 while creating return value
+while creating return value
 PL/Python function "test_return_setof_type_record"
 SELECT (test_return_setof_type_record('[ ("value", 4), {"first": "test", "second": 2} ]')).*;
 ERROR:  invalid input syntax for integer: "{'second': 2, 'first': 'test'}"
@@ -2113,9 +2287,9 @@ CONTEXT:  while creating return value
 PL/Python function "test_return_setof_type_record"
 SELECT (test_return_setof_type_record('[ ("value", 4), {"first": "test", "second": 2} ]')).*
 FROM gp_single_row;
-ERROR:  invalid input syntax for integer: "{'second': 2, 'first': 'test'}"  (seg0 slice1 gxymac.local:40000 pid=35336)
+ERROR:  invalid input syntax for integer: "{'second': 2, 'first': 'test'}"  (seg0 slice1 192.168.1.138:25432 pid=43982)
 DETAIL:  
-	 while creating return value
+while creating return value
 PL/Python function "test_return_setof_type_record"
 -- Error conditions
 -- [ERROR] From Python None
@@ -2236,7 +2410,7 @@ ERROR:  length of returned sequence did not match number of columns in row
 CONTEXT:  while creating return value
 PL/Python function "test_return_setof_type_record"
 SELECT * FROM test_return_setof_type_record('[{"first": "value", "second": 4}, "third": "ignored"}]');
-ERROR:  SyntaxError: invalid syntax (<string>, line 1) (plpython.c:4699)
+ERROR:  SyntaxError: invalid syntax (<string>, line 1) (plpython.c:4928)
 CONTEXT:  Traceback (most recent call last):
   PL/Python function "test_return_setof_type_record", line 2, in <module>
     exec('y = ' + s)
@@ -2255,9 +2429,9 @@ CONTEXT:  while creating return value
 PL/Python function "test_return_setof_table_record"
 SELECT test_return_setof_table_record('[]')
 FROM gp_single_row;
-ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 gxymac.local:40000 pid=35336)
+ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 192.168.1.138:25432 pid=43982)
 DETAIL:  
-	 while creating return value
+while creating return value
 PL/Python function "test_return_setof_table_record"
 SELECT (test_return_setof_table_record('[]')).*;
 ERROR:  length of returned sequence did not match number of columns in row
@@ -2265,9 +2439,9 @@ CONTEXT:  while creating return value
 PL/Python function "test_return_setof_table_record"
 SELECT (test_return_setof_table_record('[]')).*
 FROM gp_single_row;
-ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 gxymac.local:40000 pid=35336)
+ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 192.168.1.138:25432 pid=43982)
 DETAIL:  
-	 while creating return value
+while creating return value
 PL/Python function "test_return_setof_table_record"
 -- From Python List
 SELECT test_return_setof_table_record('[ None, ("value", 4), {"first": "test", "second": 2} ]');
@@ -2280,9 +2454,9 @@ CONTEXT:  while creating return value
 PL/Python function "test_return_setof_table_record"
 SELECT test_return_setof_table_record('[ None, ("value", 4), {"first": "test", "second": 2} ]')
 FROM gp_single_row;
-ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 gxymac.local:40000 pid=35336)
+ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 192.168.1.138:25432 pid=43982)
 DETAIL:  
-	 while creating return value
+while creating return value
 PL/Python function "test_return_setof_table_record"
 SELECT (test_return_setof_table_record('[ None, ("value", 4), {"first": "test", "second": 2} ]')).*;
 ERROR:  length of returned sequence did not match number of columns in row
@@ -2290,9 +2464,9 @@ CONTEXT:  while creating return value
 PL/Python function "test_return_setof_table_record"
 SELECT (test_return_setof_table_record('[ None, ("value", 4), {"first": "test", "second": 2} ]')).*
 FROM gp_single_row;
-ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 gxymac.local:40000 pid=35336)
+ERROR:  length of returned sequence did not match number of columns in row  (seg0 slice1 192.168.1.138:25432 pid=43982)
 DETAIL:  
-	 while creating return value
+while creating return value
 PL/Python function "test_return_setof_table_record"
 -- Error conditions
 -- [ERROR] From Python None
@@ -2413,7 +2587,7 @@ ERROR:  length of returned sequence did not match number of columns in row
 CONTEXT:  while creating return value
 PL/Python function "test_return_setof_table_record"
 SELECT * FROM test_return_setof_table_record('[{"first": "value", "second": 4}, "third": "ignored"}]');
-ERROR:  SyntaxError: invalid syntax (<string>, line 1) (plpython.c:4699)
+ERROR:  SyntaxError: invalid syntax (<string>, line 1) (plpython.c:4928)
 CONTEXT:  Traceback (most recent call last):
   PL/Python function "test_return_setof_table_record", line 2, in <module>
     exec('y = ' + s)
@@ -2626,14 +2800,14 @@ PL/Python function "test_return_out_text"
 SELECT test_return_out_text(
     E'1; exec("class Foo:\\n  def __str__(self): return None"); y = Foo()'
 );
-ERROR:  could not create string representation of Python object (plpython.c:4699)
+ERROR:  could not create string representation of Python object (plpython.c:4928)
 DETAIL:  TypeError: __str__ returned non-string (type NoneType)
 CONTEXT:  while creating return value
 PL/Python function "test_return_out_text"
 SELECT * FROM test_return_out_text(
     E'1; exec("class Foo:\\n  def __str__(self): return None"); y = Foo()'
 );
-ERROR:  could not create string representation of Python object (plpython.c:4699)
+ERROR:  could not create string representation of Python object (plpython.c:4928)
 DETAIL:  TypeError: __str__ returned non-string (type NoneType)
 CONTEXT:  while creating return value
 PL/Python function "test_return_out_text"
@@ -2655,9 +2829,9 @@ SELECT * FROM test_return_out_record('None');
 
 SELECT test_return_out_record('None') 
 FROM gp_single_row;
-test_return_out_record 
+ test_return_out_record 
 ------------------------
-
+ 
 (1 row)
 
 SELECT (test_return_out_record('None')).*;
@@ -2688,9 +2862,9 @@ SELECT * FROM test_return_out_record('("value", 4)');
 
 SELECT test_return_out_record('("value", 4)')
 FROM gp_single_row;
-test_return_out_record 
+ test_return_out_record 
 ------------------------
-(value,4)
+ (value,4)
 (1 row)
 
 SELECT (test_return_out_record('("value", 4)')).*;
@@ -2721,9 +2895,9 @@ SELECT * FROM test_return_out_record('["value", 4]');
 
 SELECT test_return_out_record('["value", 4]')
 FROM gp_single_row;
-test_return_out_record 
+ test_return_out_record 
 ------------------------
-(value,4)
+ (value,4)
 (1 row)
 
 SELECT (test_return_out_record('["value", 4]')).*;
@@ -2754,9 +2928,9 @@ SELECT * FROM test_return_out_record('{"first": "value", "second": 4}');
 
 SELECT test_return_out_record('{"first": "value", "second": 4}')
 FROM gp_single_row;
-test_return_out_record 
+ test_return_out_record 
 ------------------------
-(value,4)
+ (value,4)
 (1 row)
 
 SELECT (test_return_out_record('{"first": "value", "second": 4}')).*;
@@ -3024,7 +3198,7 @@ SELECT * FROM test_return_out_setof_record('[]');
 
 SELECT test_return_out_setof_record('[]')
 FROM gp_single_row;
-test_return_out_setof_record 
+ test_return_out_setof_record 
 ------------------------------
 (0 rows)
 
@@ -3056,10 +3230,10 @@ SELECT * FROM test_return_out_setof_record('[ ("value", 4), {"first": "test", "s
 
 SELECT test_return_out_setof_record('[ ("value", 4), {"first": "test", "second": 2} ]')
 FROM gp_single_row;
-test_return_out_setof_record 
+ test_return_out_setof_record 
 ------------------------------
-(value,4)
-(test,2)
+ (value,4)
+ (test,2)
 (2 rows)
 
 SELECT (test_return_out_setof_record('[ ("value", 4), {"first": "test", "second": 2} ]')).*;
@@ -3183,7 +3357,7 @@ SELECT test_return_out_setof_record('[{"first": "value", "second": 4, "third": "
 (1 row)
 
 SELECT * FROM test_return_out_setof_record('[{"first": "value", "second": 4}, "third": "ignored"}]');
-ERROR:  SyntaxError: invalid syntax (<string>, line 1) (plpython.c:4699)
+ERROR:  SyntaxError: invalid syntax (<string>, line 1) (plpython.c:4928)
 CONTEXT:  Traceback (most recent call last):
   PL/Python function "test_return_out_setof_record", line 2, in <module>
     exec('y = ' + s)
@@ -3217,7 +3391,7 @@ SELECT * FROM test_return_table('[]');
 
 SELECT test_return_table('[]')
 FROM gp_single_row;
-test_return_table 
+ test_return_table 
 -------------------
 (0 rows)
 
@@ -3249,11 +3423,11 @@ SELECT * FROM test_return_table('[ ("value", 4), {"first": "test", "second": 2} 
 
 SELECT test_return_table('[ None, ("value", 4), {"first": "test", "second": 2} ]')
 FROM gp_single_row;
-test_return_table 
+ test_return_table 
 -------------------
-
-(value,4)
-(test,2)
+ 
+ (value,4)
+ (test,2)
 (3 rows)
 
 SELECT (test_return_table('[ ("value", 4), {"first": "test", "second": 2} ]')).*;

--- a/src/pl/plpython/expected/plpython_test.out
+++ b/src/pl/plpython/expected/plpython_test.out
@@ -182,7 +182,7 @@ NOTICE:  notice
 CONTEXT:  PL/Python function "elog_test"
 WARNING:  warning
 CONTEXT:  PL/Python function "elog_test"
-ERROR:  plpy.Error: error (plpython.c:4652)
+ERROR:  plpy.Error: error (plpython.c:4955)
 CONTEXT:  Traceback (most recent call last):
   PL/Python function "elog_test", line 10, in <module>
     plpy.error('error')
@@ -243,12 +243,12 @@ SELECT test_param_names1(1,'text');
 SELECT test_param_names2(users) from users;
                              test_param_names2                              
 ----------------------------------------------------------------------------
- {'lname': 'doe', 'username': 'johnd', 'userid': 2, 'fname': 'john'}
+ {'lname': 'doe', 'username': 'w_doe', 'userid': 3, 'fname': 'willem'}
  {'lname': 'smith', 'username': 'slash', 'userid': 4, 'fname': 'rick'}
+ {'lname': 'smith', 'username': 'w_smith', 'userid': 5, 'fname': 'willem'}
  {'lname': 'darwin', 'username': 'beagle', 'userid': 6, 'fname': 'charles'}
  {'lname': 'doe', 'username': 'j_doe', 'userid': 1, 'fname': 'jane'}
- {'lname': 'doe', 'username': 'w_doe', 'userid': 3, 'fname': 'willem'}
- {'lname': 'smith', 'username': 'w_smith', 'userid': 5, 'fname': 'willem'}
+ {'lname': 'doe', 'username': 'johnd', 'userid': 2, 'fname': 'john'}
 (6 rows)
 
 SELECT test_param_names3(1);
@@ -598,138 +598,6 @@ SELECT * FROM test_inout_params('test_in');
      first     
 ---------------
  test_in_inout
-(1 row)
-
-SELECT * FROM test_type_conversion_bool(true);
- test_type_conversion_bool 
----------------------------
- t
-(1 row)
-
-SELECT * FROM test_type_conversion_bool(false);
- test_type_conversion_bool 
----------------------------
- f
-(1 row)
-
-SELECT * FROM test_type_conversion_bool(null);
- test_type_conversion_bool 
----------------------------
- 
-(1 row)
-
-SELECT * FROM test_type_conversion_char('a');
- test_type_conversion_char 
----------------------------
- a
-(1 row)
-
-SELECT * FROM test_type_conversion_char(null);
- test_type_conversion_char 
----------------------------
- 
-(1 row)
-
-SELECT * FROM test_type_conversion_int2(100::int2);
- test_type_conversion_int2 
----------------------------
-                       100
-(1 row)
-
-SELECT * FROM test_type_conversion_int2(null);
- test_type_conversion_int2 
----------------------------
-                          
-(1 row)
-
-SELECT * FROM test_type_conversion_int4(100);
- test_type_conversion_int4 
----------------------------
-                       100
-(1 row)
-
-SELECT * FROM test_type_conversion_int4(null);
- test_type_conversion_int4 
----------------------------
-                          
-(1 row)
-
-SELECT * FROM test_type_conversion_int8(100);
- test_type_conversion_int8 
----------------------------
-                       100
-(1 row)
-
-SELECT * FROM test_type_conversion_int8(null);
- test_type_conversion_int8 
----------------------------
-                          
-(1 row)
-
-SELECT * FROM test_type_conversion_float4(100);
- test_type_conversion_float4 
------------------------------
-                         100
-(1 row)
-
-SELECT * FROM test_type_conversion_float4(null);
- test_type_conversion_float4 
------------------------------
-                            
-(1 row)
-
-SELECT * FROM test_type_conversion_float8(100);
- test_type_conversion_float8 
------------------------------
-                         100
-(1 row)
-
-SELECT * FROM test_type_conversion_float8(null);
- test_type_conversion_float8 
------------------------------
-                            
-(1 row)
-
-SELECT * FROM test_type_conversion_numeric(100);
- test_type_conversion_numeric 
-------------------------------
-                        100.0
-(1 row)
-
-SELECT * FROM test_type_conversion_numeric(null);
- test_type_conversion_numeric 
-------------------------------
-                             
-(1 row)
-
-SELECT * FROM test_type_conversion_text('hello world');
- test_type_conversion_text 
----------------------------
- hello world
-(1 row)
-
-SELECT * FROM test_type_conversion_text(null);
- test_type_conversion_text 
----------------------------
- 
-(1 row)
-
-SELECT * FROM test_type_conversion_bytea('hello world');
- test_type_conversion_bytea 
-----------------------------
- hello world
-(1 row)
-
-SELECT * FROM test_type_conversion_bytea(null);
- test_type_conversion_bytea 
-----------------------------
- 
-(1 row)
-
-SELECT test_type_unmarshal(x) FROM test_type_marshal() x;
- test_type_unmarshal 
----------------------
- hello world
 (1 row)
 
 SELECT (split(10)).*; 

--- a/src/pl/plpython/plpython.c
+++ b/src/pl/plpython/plpython.c
@@ -404,6 +404,8 @@ static PyObject *PLyLong_FromInt64(PLyDatumToOb *arg, Datum d);
 static PyObject *PLyBytes_FromBytea(PLyDatumToOb *arg, Datum d);
 static PyObject *PLyString_FromDatum(PLyDatumToOb *arg, Datum d);
 static PyObject *PLyList_FromArray(PLyDatumToOb *arg, Datum d);
+static PyObject *PLyList_FromArray_recurse(PLyDatumToOb *elm, int *dims, int ndim, int dim,
+						  char **dataptr_p, bits8 **bitmap_p, int *bitmask_p);
 
 static PyObject *PLyDict_FromTuple(PLyTypeInfo *, HeapTuple, TupleDesc);
 
@@ -411,7 +413,10 @@ static Datum PLyObject_ToBool(PLyObToDatum *, int32, PyObject *);
 static Datum PLyObject_ToBytea(PLyObToDatum *, int32, PyObject *);
 static Datum PLyObject_ToComposite(PLyObToDatum *, int32, PyObject *);
 static Datum PLyObject_ToDatum(PLyObToDatum *, int32, PyObject *);
-static Datum PLySequence_ToArray(PLyObToDatum *, int32, PyObject *);
+static Datum PLySequence_ToArray(PLyObToDatum *arg, int32 typmod, PyObject *plrv);
+static void PLySequence_ToArray_recurse(PLyObToDatum *elm, PyObject *list,
+							int *dims, int ndim, int dim,
+							Datum *elems, bool *nulls, int *currelem);
 
 static HeapTuple PLyObject_ToTuple(PLyTypeInfo *, TupleDesc, PyObject *);
 static HeapTuple PLyMapping_ToTuple(PLyTypeInfo *, TupleDesc, PyObject *);
@@ -2325,24 +2330,25 @@ PLy_output_datum_func2(PLyObToDatum *arg, HeapTuple typeTup)
 	 * Select a conversion function to convert Python objects to PostgreSQL
 	 * datums.	Most data types can go through the generic function.
 	 */
-	switch (getBaseType(element_type ? element_type : arg->typoid))
-	{
-		case BOOLOID:
-			arg->func = PLyObject_ToBool;
-			break;
-		case BYTEAOID:
-			arg->func = PLyObject_ToBytea;
-			break;
-		default:
-			arg->func = PLyObject_ToDatum;
-			break;
-	}
-
 	/* Composite types need their own input routine, though */
 	if (typeStruct->typtype == TYPTYPE_COMPOSITE)
 	{
 		arg->func = PLyObject_ToComposite;
 	}
+	else
+		switch (getBaseType(element_type ? element_type : arg->typoid))
+		{
+			case BOOLOID:
+				arg->func = PLyObject_ToBool;
+				break;
+			case BYTEAOID:
+				arg->func = PLyObject_ToBytea;
+				break;
+			default:
+				arg->func = PLyObject_ToDatum;
+				break;
+		}
+
 
 	if (element_type)
 	{
@@ -2350,11 +2356,7 @@ PLy_output_datum_func2(PLyObToDatum *arg, HeapTuple typeTup)
 		Oid			funcid;
 
 		if (type_is_rowtype(element_type))
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("PL/Python functions cannot return type %s",
-							format_type_be(arg->typoid)),
-					 errdetail("PL/Python does not support conversion to arrays of row types.")));
+			arg->func = PLyObject_ToComposite;
 
 		arg->elm = PLy_malloc0(sizeof(*arg->elm));
 		arg->elm->func = arg->func;
@@ -2552,59 +2554,104 @@ PLyList_FromArray(PLyDatumToOb *arg, Datum d)
 {
 	ArrayType  *array = DatumGetArrayTypeP(d);
 	PLyDatumToOb *elm = arg->elm;
-	PyObject   *list;
-	int			length;
-	int			lbound;
-	int			i;
-	char		*dataptr;
-	bits8		*bitmap;
+	int			ndim;
+	int		   *dims;
+	char	   *dataptr;
+	bits8	   *bitmap;
 	int			bitmask;
 
 	if (ARR_NDIM(array) == 0)
 		return PyList_New(0);
 
-	if (ARR_NDIM(array) != 1)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			  errmsg("cannot convert multidimensional array to Python list"),
-			  errdetail("PL/Python only supports one-dimensional arrays.")));
+	/* Array dimensions and left bounds */
+	ndim = ARR_NDIM(array);
+	dims = ARR_DIMS(array);
+	Assert(ndim < MAXDIM);
 
-	length = ARR_DIMS(array)[0];
-	lbound = ARR_LBOUND(array)[0];
-	list = PyList_New(length);
-
+	/*
+	 * We iterate the SQL array in the physical order it's stored in the
+	 * datum. For example, for a 3-dimensional array the order of iteration would
+	 * be the following: [0,0,0] elements through [0,0,k], then [0,1,0] through
+	 * [0,1,k] till [0,m,k], then [1,0,0] through [1,0,k] till [1,m,k], and so on.
+	 *
+	 * In Python, there are no multi-dimensional lists as such, but they are
+	 * represented as a list of lists. So a 3-d array of [n,m,k] elements is a
+	 * list of n m-element arrays, each element of which is k-element array.
+	 * PLyList_FromArray_recurse() builds the Python list for a single
+	 * dimension, and recurses for the next inner dimension.
+	 */
 	dataptr = ARR_DATA_PTR(array);
 	bitmap = ARR_NULLBITMAP(array);
 	bitmask = 1;
 
-	for (i = 0; i < length; i++)
+	return PLyList_FromArray_recurse(elm, dims, ndim, 0,
+									 &dataptr, &bitmap, &bitmask);
+}
+
+static PyObject *
+PLyList_FromArray_recurse(PLyDatumToOb *elm, int *dims, int ndim, int dim,
+						  char **dataptr_p, bits8 **bitmap_p, int *bitmask_p)
+{
+	int			i;
+	PyObject   *list;
+
+	list = PyList_New(dims[dim]);
+
+	if (dim < ndim - 1)
 	{
-		/* Get source element, checking for NULL */
-		if (bitmap && (*bitmap & bitmask) == 0)
+		/* Outer dimension. Recurse for each inner slice. */
+		for (i = 0; i < dims[dim]; i++)
 		{
-			Py_INCREF(Py_None);
-			PyList_SET_ITEM(list, i, Py_None);
-		}
-		else
-		{
-			Datum		itemvalue;
+			PyObject   *sublist;
 
-			itemvalue = fetch_att(dataptr, elm->typbyval, elm->typlen);
-			PyList_SET_ITEM(list, i, elm->func(elm, itemvalue));
-			dataptr = att_addlength_pointer(dataptr, elm->typlen, dataptr);
-			dataptr = (char *) att_align_nominal(dataptr, elm->typalign);
+			sublist = PLyList_FromArray_recurse(elm, dims, ndim, dim + 1,
+											 dataptr_p, bitmap_p, bitmask_p);
+			PyList_SET_ITEM(list, i, sublist);
 		}
+	}
+	else
+	{
+		/*
+		 * Innermost dimension. Fill the list with the values from the array
+		 * for this slice.
+		 */
+		char	   *dataptr = *dataptr_p;
+		bits8	   *bitmap = *bitmap_p;
+		int			bitmask = *bitmask_p;
 
-		/* advance bitmap pointer if any */
-		if (bitmap)
+		for (i = 0; i < dims[dim]; i++)
 		{
-			bitmask <<= 1;
-			if (bitmask == 0x100 /* (1<<8) */)
+			/* checking for NULL */
+			if (bitmap && (*bitmap & bitmask) == 0)
 			{
-				bitmap++;
-				bitmask = 1;
+				Py_INCREF(Py_None);
+				PyList_SET_ITEM(list, i, Py_None);
+			}
+			else
+			{
+				Datum		itemvalue;
+
+				itemvalue = fetch_att(dataptr, elm->typbyval, elm->typlen);
+				PyList_SET_ITEM(list, i, elm->func(elm, itemvalue));
+				dataptr = att_addlength_pointer(dataptr, elm->typlen, dataptr);
+				dataptr = (char *) att_align_nominal(dataptr, elm->typalign);
+			}
+
+			/* advance bitmap pointer if any */
+			if (bitmap)
+			{
+				bitmask <<= 1;
+				if (bitmask == 0x100 /* (1<<8) */ )
+				{
+					bitmap++;
+					bitmask = 1;
+				}
 			}
 		}
+
+		*dataptr_p = dataptr;
+		*bitmap_p = bitmap;
+		*bitmask_p = bitmask;
 	}
 
 	return list;
@@ -2855,41 +2902,156 @@ PLySequence_ToArray(PLyObToDatum *arg, int32 typmod, PyObject *plrv)
 	int			i;
 	Datum	   *elems;
 	bool	   *nulls;
-	int			len;
-	int			lbs;
+	int64		len;
+	int			ndim;
+	int			dims[MAXDIM];
+	int			lbs[MAXDIM];
+	int			currelem;
+	Datum		rv;
+	PyObject   *pyptr = plrv;
+	PyObject   *next;
 
 	Assert(plrv != Py_None);
 
-	if (!PySequence_Check(plrv))
-		PLy_elog(ERROR, "return value of function with array return type is not a Python sequence");
+	/*
+	 * Determine the number of dimensions, and their sizes.
+	 */
+	ndim = 0;
+	len = 1;
 
-	len = PySequence_Length(plrv);
-	elems = palloc(sizeof(*elems) * len);
-	nulls = palloc(sizeof(*nulls) * len);
+	Py_INCREF(plrv);
 
-	for (i = 0; i < len; i++)
+	for (;;)
 	{
-		PyObject   *obj = PySequence_GetItem(plrv, i);
+		if (!PyList_Check(pyptr))
+			break;
 
-		if (obj == Py_None)
-			nulls[i] = true;
-		else
+		if (ndim == MAXDIM)
+			PLy_elog(ERROR, "number of array dimensions exceeds the maximum allowed (%d)", MAXDIM);
+
+		dims[ndim] = PySequence_Length(pyptr);
+		if (dims[ndim] < 0)
+			PLy_elog(ERROR, "cannot determine sequence length for function return value");
+
+		if (dims[ndim] > MaxAllocSize)
+			PLy_elog(ERROR, "array size exceeds the maximum allowed");
+
+		len *= dims[ndim];
+		if (len > MaxAllocSize)
+			PLy_elog(ERROR, "array size exceeds the maximum allowed");
+
+		if (dims[ndim] == 0)
 		{
-			nulls[i] = false;
-
-			/*
-			 * We don't support arrays of row types yet, so the first argument
-			 * can be NULL.
-			 */
-			elems[i] = arg->elm->func(arg->elm, -1, obj);
+			/* empty sequence */
+			break;
 		}
-		Py_XDECREF(obj);
+
+		ndim++;
+
+		next = PySequence_GetItem(pyptr, 0);
+		Py_XDECREF(pyptr);
+		pyptr = next;
+	}
+	Py_XDECREF(pyptr);
+
+	/*
+	 * Check for zero dimensions. This happens if the object is a tuple or a
+	 * string, rather than a list, or is not a sequence at all. We don't map
+	 * tuples or strings to arrays in general, but in the first level, be
+	 * lenient, for historical reasons. So if the object is a sequence of any
+	 * kind, treat it as a one-dimensional array.
+	 */
+	if (ndim == 0)
+	{
+		if (!PySequence_Check(plrv))
+			PLy_elog(ERROR, "return value of function with array return type is not a Python sequence");
+
+		ndim = 1;
+		len = dims[0] = PySequence_Length(plrv);
 	}
 
-	lbs = 1;
-	array = construct_md_array(elems, nulls, 1, &len, &lbs,
-							   get_element_type(arg->typoid), arg->elm->typlen, arg->elm->typbyval, arg->elm->typalign);
-	return PointerGetDatum(array);
+	/*
+	 * Traverse the Python lists, in depth-first order, and collect all the
+	 * elements at the bottom level into 'elems'/'nulls' arrays.
+	 */
+	elems = palloc(sizeof(Datum) * len);
+	nulls = palloc(sizeof(bool) * len);
+	currelem = 0;
+	PLySequence_ToArray_recurse(arg->elm, plrv,
+								dims, ndim, 0,
+								elems, nulls, &currelem);
+
+	for (i = 0; i < ndim; i++)
+		lbs[i] = 1;
+
+	array = construct_md_array(elems,
+							   nulls,
+							   ndim,
+							   dims,
+							   lbs,
+							   get_base_element_type(arg->typoid),
+							   arg->elm->typlen,
+							   arg->elm->typbyval,
+							   arg->elm->typalign);
+
+	/*
+	 * If the result type is a domain of array, the resulting array must be
+	 * checked.
+	 */
+	rv = PointerGetDatum(array);
+	//if (get_typtype(arg->typoid) == TYPTYPE_DOMAIN)
+		//domain_check(rv, false, arg->typoid, &arg->typfunc.fn_extra, arg->typfunc.fn_mcxt);
+	return rv;
+}
+
+/*
+ * Helper function for PLySequence_ToArray. Traverse a Python list of lists in
+ * depth-first order, storing the elements in 'elems'.
+ */
+static void
+PLySequence_ToArray_recurse(PLyObToDatum *elm, PyObject *list,
+							int *dims, int ndim, int dim,
+							Datum *elems, bool *nulls, int *currelem)
+{
+	int			i;
+
+	if (PySequence_Length(list) != dims[dim])
+		PLy_elog(ERROR,
+				 "multidimensional arrays must have array expressions with matching dimensions. "
+				 "PL/Python function return value has sequence length %d while expected %d",
+				 (int) PySequence_Length(list), dims[dim]);
+
+	if (dim < ndim - 1)
+	{
+		for (i = 0; i < dims[dim]; i++)
+		{
+			PyObject   *sublist = PySequence_GetItem(list, i);
+
+			PLySequence_ToArray_recurse(elm, sublist, dims, ndim, dim + 1,
+										elems, nulls, currelem);
+			Py_XDECREF(sublist);
+		}
+	}
+	else
+	{
+		for (i = 0; i < dims[dim]; i++)
+		{
+			PyObject   *obj = PySequence_GetItem(list, i);
+
+			if (obj == Py_None)
+			{
+				nulls[*currelem] = true;
+				elems[*currelem] = (Datum) 0;
+			}
+			else
+			{
+				nulls[*currelem] = false;
+				elems[*currelem] = elm->func(elm, -1, obj);
+			}
+			Py_XDECREF(obj);
+			(*currelem)++;
+		}
+	}
 }
 
 static HeapTuple
@@ -2959,8 +3121,41 @@ PLyMapping_ToTuple(PLyTypeInfo *info, TupleDesc desc, PyObject *mapping)
 
 	return tuple;
 }
+#ifdef XXX
+static HeapTuple
+PLyString_ToComposite(PLyTypeInfo *info, TupleDesc desc, PyObject *string)
+{
+	Datum		result;
+	HeapTuple	typeTup;
+	PLyTypeInfo locinfo;
+	PLyExecutionContext *exec_ctx = PLy_current_execution_context();
+	MemoryContext cxt;
 
+	/* Create a dummy PLyTypeInfo */
+	cxt = AllocSetContextCreate(CurrentMemoryContext,
+								"PL/Python temp context",
+								ALLOCSET_DEFAULT_SIZES);
+	MemSet(&locinfo, 0, sizeof(PLyTypeInfo));
+	PLy_typeinfo_init(&locinfo, cxt);
 
+	typeTup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(desc->tdtypeid));
+	if (!HeapTupleIsValid(typeTup))
+		elog(ERROR, "cache lookup failed for type %u", desc->tdtypeid);
+
+	PLy_output_datum_func2(&locinfo.out.d, locinfo.mcxt, typeTup,
+						   exec_ctx->curr_proc->langid,
+						   exec_ctx->curr_proc->trftypes);
+
+	ReleaseSysCache(typeTup);
+
+	result = PLyObject_ToDatum(&locinfo.out.d, desc->tdtypmod, string);
+
+	MemoryContextDelete(cxt);
+
+	return result;
+}
+
+#endif
 static HeapTuple
 PLySequence_ToTuple(PLyTypeInfo *info, TupleDesc desc, PyObject *sequence)
 {

--- a/src/pl/plpython/sql/plpython_function.sql
+++ b/src/pl/plpython/sql/plpython_function.sql
@@ -566,24 +566,6 @@ CREATE FUNCTION test_inout_params(first inout text) AS $$
 return first + '_inout';
 $$ LANGUAGE plpythonu;
 
-CREATE FUNCTION test_type_conversion_bool(x bool) returns bool AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_char(x char) returns char AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_int2(x int2) returns int2 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_int4(x int4) returns int4 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_int8(x int8) returns int8 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_float4(x float4) returns float4 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_float8(x float8) returns float8 AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_numeric(x numeric) returns numeric AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_text(x text) returns text AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_conversion_bytea(x bytea) returns bytea AS $$ return x $$ language plpythonu;
-CREATE FUNCTION test_type_marshal() returns bytea AS $$ 
-import marshal
-return marshal.dumps('hello world')
-$$ language plpythonu;
-CREATE FUNCTION test_type_unmarshal(x bytea) returns text AS $$
-import marshal
-return marshal.loads(x)
-$$ language plpythonu;
 
 -- RETURN value testing
 CREATE FUNCTION test_return_void(s text) 
@@ -608,6 +590,16 @@ RETURNS bytea AS $$
 $$ language plpythonu;
 CREATE FUNCTION test_return_circle(s text) 
 RETURNS circle AS $$
+  exec('y = ' + s)
+  return y
+$$ language plpythonu;
+CREATE FUNCTION test_return_array_int(s text) 
+RETURNS int[] AS $$
+  exec('y = ' + s)
+  return y
+$$ language plpythonu;
+CREATE FUNCTION test_return_array_text(s text) 
+RETURNS text[] AS $$
   exec('y = ' + s)
   return y
 $$ language plpythonu;

--- a/src/pl/plpython/sql/plpython_returns.sql
+++ b/src/pl/plpython/sql/plpython_returns.sql
@@ -356,6 +356,77 @@ SELECT * FROM test_return_circle('{None: None}');
 SELECT test_return_circle(E'"test\\0"');
 SELECT * FROM test_return_circle(E'"test\\0"');
 
+--
+-- Case 5: Return array of integers
+--
+-- Test returning arrays of fixed-width elements from PL/Python functions
+--
+
+-- From Python None
+SELECT test_return_array_int('None');
+SELECT * FROM test_return_array_int('None');
+
+-- From Python empty list
+SELECT test_return_array_int('[]');
+SELECT * FROM test_return_array_int('[]');
+
+-- From Python non-empty list
+SELECT test_return_array_int('[1,2]');
+SELECT * FROM test_return_array_int('[1,2]');
+
+-- From Python multiple lists
+SELECT test_return_array_int('[[1,2,3],[4,5,6]]');
+SELECT * FROM test_return_array_int('[[1,2,3],[4,5,6]]');
+
+-- Error conditions
+
+-- Multi-dimensional array with non-fixed dimension sizes
+SELECT test_return_array_int('[[1,2,3],[1,2]]');
+SELECT * FROM test_return_array_int('[[1,2,3],[1,2]]');
+
+-- Multi-dimensional array with mix of arrays and atomic elements
+SELECT test_return_array_int('[[1,2,3],[1,[2,3],[4,5]]]');
+SELECT * FROM test_return_array_int('[[1,2,3],[1,[2,3],[4,5]]]');
+
+-- Multi-dimensional array with missing dimensions
+SELECT test_return_array_int('[[1,2,3],None,[4,5,6]]');
+SELECT * FROM test_return_array_int('[[1,2,3],None,[4,5,6]]');
+
+--
+-- Case 5: Return array of texts
+--
+-- Test returning arrays of variable-width elements from PL/Python functions
+--
+
+-- From Python None
+SELECT test_return_array_text('None');
+SELECT * FROM test_return_array_text('None');
+
+-- From Python empty list
+SELECT test_return_array_text('[]');
+SELECT * FROM test_return_array_text('[]');
+
+-- From Python non-empty list
+SELECT test_return_array_text('["abc","def"]');
+SELECT * FROM test_return_array_text('["abc","def"]');
+
+-- From Python multiple lists
+SELECT test_return_array_text('[["a","bcd","ef"],[None,"gh","ijklm"]]');
+SELECT * FROM test_return_array_text('[["a","bcd","ef"],[None,"gh","ijklm"]]');
+
+-- Error conditions
+
+-- Multi-dimensional array with non-fixed dimension sizes
+SELECT test_return_array_text('[["a","bcd","ef"],[None,"gh","ijklm","ERROR"]]');
+SELECT * FROM test_return_array_text('[["a","bcd","ef"],[None,"gh","ijklm","ERROR"]]');
+
+-- Multi-dimensional array with mix of arrays and atomic elements
+SELECT test_return_array_text('[[["a"],"b"],["c",["d","e"]]]');
+SELECT * FROM test_return_array_text('[[["a"],"b"],["c",["d","e"]]]');
+
+-- Multi-dimensional array with missing dimensions
+SELECT test_return_array_text('[["abc","def"],None,["ghij","k"]]');
+SELECT * FROM test_return_array_text('[["abc","def"],None,["ghij","k"]]');
 
 -- ===================================================
 -- TEST 2:  RETURN VALUE TESTING - SETOF scalar values

--- a/src/pl/plpython/sql/plpython_test.sql
+++ b/src/pl/plpython/sql/plpython_test.sql
@@ -166,29 +166,6 @@ SELECT * FROM test_in_out_params('test_in');
 SELECT * FROM test_in_out_params_multi('test_in');
 SELECT * FROM test_inout_params('test_in');
 
-SELECT * FROM test_type_conversion_bool(true);
-SELECT * FROM test_type_conversion_bool(false);
-SELECT * FROM test_type_conversion_bool(null);
-SELECT * FROM test_type_conversion_char('a');
-SELECT * FROM test_type_conversion_char(null);
-SELECT * FROM test_type_conversion_int2(100::int2);
-SELECT * FROM test_type_conversion_int2(null);
-SELECT * FROM test_type_conversion_int4(100);
-SELECT * FROM test_type_conversion_int4(null);
-SELECT * FROM test_type_conversion_int8(100);
-SELECT * FROM test_type_conversion_int8(null);
-SELECT * FROM test_type_conversion_float4(100);
-SELECT * FROM test_type_conversion_float4(null);
-SELECT * FROM test_type_conversion_float8(100);
-SELECT * FROM test_type_conversion_float8(null);
-SELECT * FROM test_type_conversion_numeric(100);
-SELECT * FROM test_type_conversion_numeric(null);
-SELECT * FROM test_type_conversion_text('hello world');
-SELECT * FROM test_type_conversion_text(null);
-SELECT * FROM test_type_conversion_bytea('hello world');
-SELECT * FROM test_type_conversion_bytea(null);
-SELECT test_type_unmarshal(x) FROM test_type_marshal() x;
-
 SELECT (split(10)).*; 
 
 SELECT * FROM split(100); 


### PR DESCRIPTION
…function

(used to throw an error), and they can be returned as nested Python lists.

This makes a backwards-incompatible change to the handling of composite
types in arrays. Previously, you could return an array of composite types
as "[[col1, col2], [col1, col2]]", but now that is interpreted as a two-
dimensional array. Composite types in arrays must now be returned as
Python tuples, not lists, to resolve the ambiguity. I.e. "[(col1, col2),
(col1, col2)]".

To avoid breaking backwards-compatibility, when not necessary, () is still
accepted for arrays at the top-level, but it is always treated as a
single-dimensional array. Likewise, [] is still accepted for composite types,
when they are not in an array. Update the documentation to recommend using []
for arrays, and () for composite types, with a mention that those other things
are also accepted in some contexts.

The upstream patch is 94aceed31773