### PR TITLE
Do not ignore NULLs in aggregates on DISTINCT values.

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -696,11 +696,7 @@ process_ordered_aggregate_single(AggState *aggstate,
 		/*
 		 * If DISTINCT mode, and not distinct from prior, skip it.
 		 */
-		if (isDistinct && *isNull ) 
-		{ 
-			/* per SQL, DISTINCT doesn't use nulls */
-		}
-		else if (isDistinct &&
+		if (isDistinct &&
 				 haveOldVal &&
 				 ((oldIsNull && *isNull) ||
 				  (!oldIsNull && !*isNull &&

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -562,8 +562,8 @@ select array_agg(b order by a desc)
 select array_agg(distinct a)
   from (values (1),(2),(1),(3),(null),(2)) v(a);
  array_agg 
------------
- {1,2,3}
+--------------
+ {1,2,3,NULL}
 (1 row)
 
 -- TODO: support distinct + order by


### PR DESCRIPTION
Fix for issue : https://github.com/greenplum-db/gpdb/issues/427

Currently GPDB and postgres 9.4, ignore NULLs in array_agg with DISTINCT.
```
$ ./build/bin/psql
psql (8.4.22)
Type "help" for help.

centos=# select array_agg(distinct a) from (values (1),(2),(3), (NULL), (2), (NULL)) v(a);
 array_agg
-----------
 {1,2,3}
(1 row)
```
 However this doesn't comply with the SQL-2008 (Refer https://www.postgresql.org/message-id/e08cc0400911150005r82bc48du726d02b680c7920c%40mail.gmail.com for context). This was fixed in postgres 9.0. This commit brings GPDB results to match that of current postgres.


```
postgres=# select array_agg(distinct a)
postgres-# from (values (1),(2),(1),(3),(null),(2)) v(a);
  array_agg
--------------
 {1,2,3,NULL}
(1 row)
```