### PR TITLE
Resolving var from root->parse->rtable instead of simple_rte_array.

### DIFF
--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -3617,7 +3617,7 @@ examine_variable(PlannerInfo *root, Node *node, int varRelid,
 		vardata->atttype = var->vartype;
 		vardata->atttypmod = var->vartypmod;
 
-		rte = root->simple_rte_array[var->varno];
+		rte = rt_fetch(var->varno, root->parse->rtable);
 
 		/*
 		 * If this attribute has a foreign key relationship, then first look

--- a/src/test/regress/bugbuster/known_good_schedule
+++ b/src/test/regress/bugbuster/known_good_schedule
@@ -8,8 +8,7 @@ test: wrkloadadmin
 ignore: jdbc
 test: spi
 test: security
-ignore: view
-test: load_tpch xpath
+test: load_tpch view xpath
 # these tests depend on load_tpch
 test: tpch_query tpch_aopart hashagg gpsort
 test: mpp-11333


### PR DESCRIPTION
The optimization as introduced in
afcf09dd9034f24e34dd46f69938882ab5b103d2 breaks bugbuster view tests as
it appears to not have refreshed the simple_rte_array (by calling
rebuild_simple_rel_and_rte) properly. For now, we fix it by using the
root->parse->rtable.

This fixes #1250 

Signed-off-by: Foyzur Rahman <foyzur@gmail.com>