### PR TITLE
Use nonblocking mechanism to send data in async dispatcher.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -101,6 +101,18 @@ cdbdisp_dispatchToGang(struct CdbDispatcherState *ds,
 }
 
 /*
+ * For asynchronous dispatcher, we have to wait all dispatch to finish before we move on to query execution,
+ * otherwise we may get into a deadlock situation, e.g, gather motion node waiting for data,
+ * while segments waiting for plan. This is skipped in threaded dispatcher as data is sent in blocking style.
+ */
+void
+cdbdisp_waitDispatchFinish(struct CdbDispatcherState *ds)
+{
+	if (pDispatchFuncs->waitDispatchFinish != NULL)
+		(pDispatchFuncs->waitDispatchFinish)(ds);
+}
+
+/*
  * CdbCheckDispatchResult:
  *
  * Waits for completion of threads launched by cdbdisp_dispatchToGang().

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -134,6 +134,8 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	{
 		cdbdisp_dispatchToGang(&ds, primaryGang, -1, direct);
 
+		cdbdisp_waitDispatchFinish(&ds);
+
 		/*
 		 * Wait for all QEs to finish.	Don't cancel.
 		 */

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -515,6 +515,8 @@ cdbdisp_dispatchCommandInternal(const char *strCommand,
 	{
 		cdbdisp_dispatchToGang(&ds, primaryGang, -1, DEFAULT_DISP_DIRECT);
 
+		cdbdisp_waitDispatchFinish(&ds);
+
 		/*
 		 * Block until valid results is available or one or more QEs got errors.
 		 */
@@ -1323,6 +1325,8 @@ cdbdisp_dispatchX(DispatchCommandQueryParms *pQueryParms,
 
 	pfree(sliceVector);
 
+	cdbdisp_waitDispatchFinish(ds);
+
 	/*
 	 * If bailed before completely dispatched, stop QEs and throw error.
 	 */
@@ -1467,6 +1471,8 @@ cdbdisp_dispatchSetCommandToAllGangs(const char *strCommand,
 			cdbdisp_dispatchToGang(ds, rg, -1, DEFAULT_DISP_DIRECT);
 		}
 	}
+
+	cdbdisp_waitDispatchFinish(ds);
 }
 
 static int *

--- a/src/backend/cdb/dispatcher/cdbdisp_thread.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_thread.c
@@ -159,7 +159,8 @@ DispatcherInternalFuncs DispatcherSyncFuncs =
 	cdbdisp_shouldCancel,
 	cdbdisp_makeDispatchThreads,
 	CdbCheckDispatchResult_internal,
-	cdbdisp_dispatchToGang_internal
+	cdbdisp_dispatchToGang_internal,
+	NULL
 };
 
 /*
@@ -777,7 +778,7 @@ dispatchCommand(CdbDispatchResult * dispatchResult,
 	/*
 	 * Submit the command asynchronously.
 	 */
-	if (PQsendGpQuery_shared(dispatchResult->segdbDesc->conn, (char *) query_text, query_text_len) == 0)
+	if (PQsendGpQuery_shared(dispatchResult->segdbDesc->conn, (char *) query_text, query_text_len, false) == 0)
 		return false;
 
 	if (DEBUG1 >= log_min_messages)

--- a/src/backend/gp_libpq_fe/fe-misc.c
+++ b/src/backend/gp_libpq_fe/fe-misc.c
@@ -1005,7 +1005,7 @@ pqFlush(PGconn *conn)
 /*
  * pqFlushNonBlocking:
  *
- * wrapper for pqFlush, used by FileRep,
+ * wrapper for pqFlush, used by FileRep and dispatcher.
  * conn will be temporarily set to non-blocking mode,
  * so that if not all data could be sent on 1st attempt, 
  * pqFlushNonBlocking will return 1 instead of waiting/retrying.

--- a/src/backend/gp_libpq_fe/gp-libpq-fe.h
+++ b/src/backend/gp_libpq_fe/gp-libpq-fe.h
@@ -405,7 +405,8 @@ extern PGresult *PQexecPrepared(PGconn *conn,
  */
 extern int PQsendGpQuery_shared(PGconn       *conn,
 								 char         *query,
-								 int          query_len);
+								 int          query_len,
+								 bool         nonblock);
 
 /* Interface for multiple-result or asynchronous queries */
 extern int	PQsendQuery(PGconn *conn, const char *query);

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -55,6 +55,8 @@ typedef struct DispatcherInternalFuncs
 	void (*checkResults)(struct CdbDispatcherState *ds, DispatchWaitMode waitMode);
 	void (*dispatchToGang)(struct CdbDispatcherState *ds, struct Gang *gp,
 			int sliceIndex, CdbDispatchDirectDesc *direct);
+	void (*waitDispatchFinish)(struct CdbDispatcherState *ds);
+
 }DispatcherInternalFuncs;
 
 /*--------------------------------------------------------------------*/
@@ -92,6 +94,16 @@ cdbdisp_dispatchToGang(struct CdbDispatcherState *ds,
 					   struct Gang *gp,
 					   int sliceIndex,
 					   CdbDispatchDirectDesc *direct);
+
+/*
+ * cdbdisp_waitDispatchFinish:
+ *
+ * For asynchronous dispatcher, we have to wait all dispatch to finish before we move on to query execution,
+ * otherwise we may get into a deadlock situation, e.g, gather motion node waiting for data,
+ * while segments waiting for plan. This is skipped in threaded dispatcher as data is sent in blocking style.
+ */
+void
+cdbdisp_waitDispatchFinish(struct CdbDispatcherState *ds);
 
 /*
  * CdbCheckDispatchResult:


### PR DESCRIPTION
pqFlush is sending data synchronously though the socket is set
O_NONBLOCK, this incurs performance downgradation. This commit uses
pqFlushNonBlocking instead, and synchronizes the completion of
dispatching to all Gangs before query execution.

Signed-off-by: Kenan Yao<kyao@pivotal.io>