### PR TITLE
Allow gptransfer to work if columns are dropped and re-added 

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gptransfer.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gptransfer.feature
@@ -256,7 +256,7 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print Cannot specify -F and --full options together to stdout 
 
-   @T886746
+    @T886746
     Scenario: gptransfer -T exclude non exist objects
         Given the database is running
         And the database "gptransfer_destdb" does not exist
@@ -324,7 +324,6 @@ Feature: gptransfer tests
         And verify that there is no table "t1" in "gptransfer_testdb1"
         And verify that table "t2" in "gptransfer_testdb1" has "300" rows
         And verify that there is no table "t3" in "gptransfer_testdb2"
-
 
     @T506747
     Scenario: gptransfer -t table level wildcard
@@ -395,7 +394,6 @@ Feature: gptransfer tests
         And verify that table "t4" in "gptransfer_testdb2" has "500" rows
         And verify that table "s1.t0" in "gptransfer_testdb3" has "800" rows
         And verify that table "s2.t0" in "gptransfer_testdb3" has "900" rows
-
 
     @T339948
     Scenario: gptransfer single table with skip
@@ -671,7 +669,6 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that function "test_function" exists in database "gptransfer_testdb1"
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -c 'drop table dependent_table; drop function test_function(int);' -d gptransfer_testdb1"
-        
 
     @T339838
     @T339961
@@ -949,8 +946,7 @@ Feature: gptransfer tests
         And verify that the file "/tmp/batch_size" contains the string "3"
         And the temporary file "/tmp/batch_size" is removed
         And the user runs "kill -9 `ps aux | grep test_gptransfer_batch_size.sh | awk '{print $2}'`"
-
-
+        
     @T339903
     Scenario:  gptransfer with --dry-run
         Given the database is running
@@ -1088,7 +1084,7 @@ Feature: gptransfer tests
         And the user runs "gptransfer --full --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
         Then gptransfer should return a return code of 0
 
-   @T432109
+    @T432109
     Scenario: gptransfer --full with user database exist in destination system
         Given the database is running
         And the database "gptest" does not exist
@@ -1498,7 +1494,7 @@ Feature: gptransfer tests
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
         And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/teardown.sql -d template1"
 
-   @T439821
+    @T439821
    Scenario: gptransfer filespace exists test with --full -t and -d options
         Given the database is running
         And the database "gptransfer_destdb" does not exist
@@ -1539,8 +1535,7 @@ Feature: gptransfer tests
         And verify that table "wide_row_16384" in "gptransfer_testdb5" has "10" rows
         And the temporary table file "wide_row_16384.sql" is removed
         And drop the table "wide_row_16384" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
-
-
+        
     @T339868
     Scenario: gptransfer with max-line-length of 32KB
         Given the database is running
@@ -1572,8 +1567,7 @@ Feature: gptransfer tests
         And verify that table "wide_row_267386880" in "gptransfer_testdb5" has "10" rows
         And the temporary table file "wide_row_267386880.sql" is removed
         And drop the table "wide_row_267386880" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
-
-
+        
     @T339871
     Scenario: gptransfer with max-line-length of 257MB
         Given the database is running
@@ -1659,7 +1653,7 @@ Feature: gptransfer tests
 
     @partition_transfer
     @prt_transfer_1
-    Scenario: gptransfer leaf partition -> leaf partition
+    Scenario: gptransfer leaf partition -> leaf partition basic transfer
         Given the database is running
         And database "gptest" exists
         And database "gptest" is created if not exists on host "GPTRANSFER_SOURCE_HOST" with port "GPTRANSFER_SOURCE_PORT" with user "GPTRANSFER_SOURCE_USER"
@@ -2203,6 +2197,35 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 0
         And verify that gptransfer is in order of "input_file" when partition transfer is "True"
 
+    @partition_transfer
+    @prt_transfer_47
+    Scenario: gptransfer leaf partition -> leaf partition drop and readd column before transfer
+        Given the database is running
+        And database "gptest" exists
+        And database "gptest" is created if not exists on host "GPTRANSFER_SOURCE_HOST" with port "GPTRANSFER_SOURCE_PORT" with user "GPTRANSFER_SOURCE_USER"
+        And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/one_level_range_prt_1.sql -d gptest"
+        And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/one_level_range_prt_1.sql -d gptest"
+        And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/drop_and_readd_column.sql -d gptest"
+        And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/insert_into_employee.sql -d gptest"
+        And there is a file "input_file" with tables "gptest.public.employee_1_prt_1, gptest.public.employee_1_prt_1"
+        When the user runs "gptransfer -f input_file --partition-transfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
+        Then gptransfer should return a return code of 0
+        And verify that table "public.employee_1_prt_1" in database "gptest" of source system has same data with table "public.employee_1_prt_1" in database "gptest" of destination system with options "-q"
+
+    @partition_transfer
+    @prt_transfer_48
+    Scenario: gptransfer leaf partition -> leaf partition different column order
+        Given the database is running
+        And database "gptest" exists
+        And database "gptest" is created if not exists on host "GPTRANSFER_SOURCE_HOST" with port "GPTRANSFER_SOURCE_PORT" with user "GPTRANSFER_SOURCE_USER"
+        And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/one_level_range_prt_1.sql -d gptest"
+        And the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/one_level_range_prt_1_different_col_order.sql -d gptest"
+        And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/insert_into_employee.sql -d gptest"
+        And there is a file "input_file" with tables "gptest.public.employee_1_prt_1, gptest.public.employee_1_prt_1"
+        When the user runs "gptransfer -f input_file --partition-transfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
+        Then gptransfer should return a return code of 2
+        And gptransfer should print Source partition table gptest.public.employee_1_prt_1 has different column layout or types from destination partition table gptest.public.employee_1_prt_1 to stdout
+
     @distribution_key
     Scenario: gptransfer is run with distribution key that has upper case characters
         Given the database is running
@@ -2211,8 +2234,7 @@ Feature: gptransfer tests
         And the user runs "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/distribution_test.sql -d gptest"
         And the user runs "gptransfer -t gptest.public.caps -t gptest.public.caps_with_dquote -t gptest.public.caps_with_dquote2 -t gptest.public.caps_with_dquote3 -t gptest.public.caps_with_dquote4 -t gptest.public.caps_with_squote -t gptest.public.randomkey --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --truncate -a"
         Then gptransfer should return a return code of 0
-
-
+        
     @gptransfer_help
     Scenario: use gptransfer --help with another gptransfer process already running.
         Given the database is running

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/drop_and_readd_column.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/drop_and_readd_column.sql
@@ -1,0 +1,3 @@
+-- partition table
+ALTER TABLE employee DROP COLUMN gender;
+ALTER TABLE employee ADD COLUMN gender char(1);

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/one_level_range_prt_1_different_col_order.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/one_level_range_prt_1_different_col_order.sql
@@ -1,6 +1,6 @@
 -- range partition type, column key: id
 DROP TABLE IF EXISTS employee;
-CREATE TABLE employee(id int, rank int, gender char(1))
+CREATE TABLE employee(id int, gender char(1), rank int)
 DISTRIBUTED BY (id)
 PARTITION BY RANGE (id)
 ( START (1) INCLUSIVE

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -189,7 +189,7 @@ class GpTransfer(GpTestCase):
         options = self.setup_partition_validation()
 
         additional = {
-            "select ordinal_position, is_nullable, data_type, character_maximum_length,": [[1, "t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"],
+            "select is_nullable, data_type, character_maximum_length,": [["t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"],
                                                                                            [2, "t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
         }
         self.cursor.side_effect = CursorSideEffect(additional).cursor_side_effect
@@ -201,7 +201,7 @@ class GpTransfer(GpTestCase):
         options = self.setup_partition_validation()
 
         additional = {
-            "select ordinal_position, is_nullable, data_type, character_maximum_length,": [[1, "t", "my_new_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
+            "select is_nullable, data_type, character_maximum_length,": [["t", "my_new_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
         }
         self.cursor.side_effect = CursorSideEffect(additional).cursor_side_effect
 
@@ -383,7 +383,7 @@ class CursorSideEffect:
         self.first_values = {
             "n.nspname, c.relname, c.relstorage": [["public", "my_table", ""]],
             "select relname from pg_class r": ["my_relname"],
-            "select ordinal_position, is_nullable, data_type, character_maximum_length,": [[1, "t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
+            "select is_nullable, data_type, character_maximum_length,": [["t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
             "select parkind, parlevel, parnatts, paratts": [["my_parkind", 1, "my_parnatts", "my_paratts"]],
             "SELECT fsname FROM pg_catalog.pg_filespace": ["public"],
         }
@@ -418,6 +418,9 @@ class FakeCursor:
 
     def close(self):
         pass
+
+    def fetchall(self):
+        return self.list
 
 class SingletonSideEffect:
     def __init__(self, additional=None, multi_list=None):

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -3644,28 +3644,16 @@ class GpTransfer(object):
         """
         src_tbl_columns = self._get_table_columns(table_pair.source, self._options.source_host, self._options.source_port, self._options.source_user)
         dest_tbl_columns = self._get_table_columns(table_pair.dest, self._options.dest_host, self._options.dest_port, self._options.dest_user)
-
-        if len(src_tbl_columns) != len(dest_tbl_columns):
-            return False
-        for ordinal_pos in src_tbl_columns:
-            if (ordinal_pos not in dest_tbl_columns) or (src_tbl_columns[ordinal_pos] != dest_tbl_columns[ordinal_pos]):
-                return False
-        return True
+        return src_tbl_columns == dest_tbl_columns
 
     def _get_table_columns(self, tbl, host, port, user):
-        column_types = dict()
-        get_columns_sql = ''' select ordinal_position, is_nullable, data_type, character_maximum_length,
+        get_columns_sql = ''' select is_nullable, data_type, character_maximum_length,
                              character_octet_length, numeric_precision, numeric_precision_radix, numeric_scale,
                              datetime_precision, interval_type, udt_name from information_schema.columns
-                             where table_schema = '%s' and table_name = '%s';''' % (pg.escape_string(tbl.schema), pg.escape_string(tbl.table))
+                             where table_schema = '%s' and table_name = '%s' order by ordinal_position asc;''' % (pg.escape_string(tbl.schema), pg.escape_string(tbl.table))
         with dbconn.connect(dbconn.DbURL(host, port, tbl.database, user)) as conn:
             cursor = execSQL(conn, get_columns_sql)
-            for row in cursor:
-                column_attrs = list()
-                ordinal_pos = row[0]
-                column_attrs.extend(row[1:])
-                column_types[ordinal_pos] = column_attrs
-        return column_types
+        return list(cursor.fetchall())
 
 
     def _has_same_partition_levels(self, table_pair):


### PR DESCRIPTION
When a column is dropped and readded, Postgres assigns the column the 
next unused ordinal number (not its original one). Previously we explicitly 
compared these ordinal numbers when doing validation between tables for 
gptransfer, but this caused gptransfer to fail if ordinal numbers were not 
the same, even if the actual column order was the same. We have removed 
the ordinal number check and now compare by the order to fix this. Now it
is not necessary for the columns to have matching ordinal numbers. As long 
as the column order is the same, the transfer can complete successfully.

Authors: Karen Huddleston and Stephen Wu