### PR TITLE
Allow fsync=off, and use in the concourse pipeline

### DIFF
--- a/concourse/ic_gpdb.yml
+++ b/concourse/ic_gpdb.yml
@@ -8,7 +8,7 @@ inputs:
 outputs:
 params:
   MAKE_TEST_COMMAND: ""
-  BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
+  BLDWRAP_POSTGRES_CONF_ADDONS: ""
   TEST_OS: ""
 run:
   path: gpdb_src/concourse/scripts/ic_gpdb.bash

--- a/concourse/ic_gpdb.yml
+++ b/concourse/ic_gpdb.yml
@@ -8,7 +8,7 @@ inputs:
 outputs:
 params:
   MAKE_TEST_COMMAND: ""
-  BLDWRAP_POSTGRES_CONF_ADDONS: ""
+  BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
   TEST_OS: ""
 run:
   path: gpdb_src/concourse/scripts/ic_gpdb.bash

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -190,7 +190,7 @@ jobs:
     tags: ["worker-one"]
     params:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-good
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
 - name: icg_gporca_centos6
@@ -217,7 +217,7 @@ jobs:
     tags: ["worker-two"]
     params:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=off' installcheck-good
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
 - name: icg_planner_codegen_centos6
@@ -244,7 +244,7 @@ jobs:
     tags: ["worker-three"]
     params:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=on' installcheck-good
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
 - name: icg_gporca_codegen_centos6
@@ -271,7 +271,7 @@ jobs:
     tags: ["worker-four"]
     params:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=on' installcheck-good
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
 - name: icb_planner_centos6
@@ -298,7 +298,7 @@ jobs:
     tags: ["worker-one"]
     params:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
 - name: icb_gporca_centos6
@@ -325,7 +325,7 @@ jobs:
     tags: ["worker-two"]
     params:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=off' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
 - name: icb_planner_codegen_centos6
@@ -352,7 +352,7 @@ jobs:
     tags: ["worker-three"]
     params:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=on' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
 - name: icb_gporca_codegen_centos6
@@ -379,7 +379,7 @@ jobs:
     tags: ["worker-four"]
     params:
       MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=on' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
 # Stage 3: Packaging

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -131,7 +131,7 @@ jobs:
         gpdb_src: gpdb_pr
       params:
         MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-good
-        BLDWRAP_POSTGRES_CONF_ADDONS: ""
+        BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
         TEST_OS: centos
       timeout: 2h30m
       on_success:

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -33,7 +33,7 @@ function make_cluster() {
   source /usr/local/greenplum-db-devel/greenplum_path.sh
   workaround_before_concourse_stops_stripping_suid_bits
   pushd gpdb_src/gpAux/gpdemo
-      su gpadmin -c make cluster
+      su gpadmin -c 'BLDWRAP_POSTGRES_CONF_ADDONS=${BLDWRAP_POSTGRES_CONF_ADDONS} make cluster'
   popd
 }
 

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -31,9 +31,10 @@ function configure() {
 
 function make_cluster() {
   source /usr/local/greenplum-db-devel/greenplum_path.sh
+  export BLDWRAP_POSTGRES_CONF_ADDONS=${BLDWRAP_POSTGRES_CONF_ADDONS}
   workaround_before_concourse_stops_stripping_suid_bits
   pushd gpdb_src/gpAux/gpdemo
-      su gpadmin -c 'BLDWRAP_POSTGRES_CONF_ADDONS=${BLDWRAP_POSTGRES_CONF_ADDONS} make cluster'
+      su gpadmin -c make cluster
   popd
 }
 

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -75,9 +75,9 @@ function make_sync_tools() {
 function build_gpdb() {
   pushd gpdb_src/gpAux
     if [ -n "$1" ]; then
-      make "$1" GPROOT=/usr/local dist
+      make -j4 "$1" GPROOT=/usr/local dist
     else
-      make GPROOT=/usr/local dist
+      make -j4 GPROOT=/usr/local dist
     fi
   popd
 }

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -601,7 +601,7 @@ static struct config_bool ConfigureNamesBool[] =
 			"sure that updates are physically written to disk. This insures "
 						 "that a database cluster will recover to a consistent state after "
 						 "an operating system or hardware crash."),
-		  GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_DISALLOW_USER_SET
+		  GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
 		},
 		&enableFsync,
 		true, NULL, NULL


### PR DESCRIPTION
See discussion at gpdb-dev: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/0HjPmUk469o/Hg2CdamaCAAJ

I don't know if the pipeline yaml changes are correct, but we'll find out shortly..