### PR TITLE
Faultinjector to convey num times fault hit, fix pgtwophase tests using same

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1342,8 +1342,16 @@ RecordTransactionCommit(void)
 		}
 	}
 
-	SIMPLE_FAULT_INJECTOR(DtmXLogDistributedCommit);
-
+#ifdef FAULT_INJECTOR
+	if (isDtxPrepared)
+	{
+		FaultInjector_InjectFaultIfSet(DtmXLogDistributedCommit,
+									   DDLNotSpecified,
+									   "",  // databaseName
+									   ""); // tableName
+	}
+#endif
+	
 	/*
 	 * If we entered a commit critical section, leave it now, and let
 	 * checkpoints proceed.

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -1385,12 +1385,13 @@ FaultInjector_SetFaultInjection(
 			HASH_SEQ_STATUS			hash_status;
 			FaultInjectorEntry_s	*entryLocal;
 			bool					found = FALSE;
+			int                     length;
 			
 			if (faultInjectorShmem->hash == NULL) {
 				status = STATUS_ERROR;
 				break;
-			} 
-			snprintf(entry->bufOutput, sizeof(entry->bufOutput), "Success: ");
+			}
+			length = snprintf(entry->bufOutput, sizeof(entry->bufOutput), "Success: ");
 			
 			if (entry->faultInjectorIdentifier == ChangeTrackingCompactingReport)
 			{
@@ -1401,7 +1402,7 @@ FaultInjector_SetFaultInjection(
 			}
 			
 			hash_seq_init(&hash_status, faultInjectorShmem->hash);
-			
+
 			while ((entryLocal = (FaultInjectorEntry_s *) hash_seq_search(&hash_status)) != NULL) {
 				ereport(LOG,
 					(errmsg("fault injector status: "
@@ -1425,28 +1426,27 @@ FaultInjector_SetFaultInjection(
 						entryLocal->numTimesTriggered)));
 				
 				if (entry->faultInjectorIdentifier == entryLocal->faultInjectorIdentifier ||
-					entry->faultInjectorIdentifier == FaultInjectorIdAll) {
-						snprintf(entry->bufOutput, sizeof(entry->bufOutput), 
-								 "%s \n"
-								 "fault name:'%s' "
-								 "fault type:'%s' "
-								 "ddl statement:'%s' "
-								 "database name:'%s' "
-								 "table name:'%s' "
-								 "occurrence:'%d' "
-								 "sleep time:'%d' "
-								 "fault injection state:'%s' "
-								 "num times hit:'%d' ",
-								 entry->bufOutput,
-								 FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
-								 FaultInjectorTypeEnumToString[entryLocal->faultInjectorType],
-								 FaultInjectorDDLEnumToString[entryLocal->ddlStatement],
-								 entryLocal->databaseName,
-								 entryLocal->tableName,
-								 entryLocal->occurrence,
-								 entryLocal->sleepTime,
-								 FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
-							entryLocal->numTimesTriggered);
+					entry->faultInjectorIdentifier == FaultInjectorIdAll)
+				{
+					length = snprintf((entry->bufOutput + length), sizeof(entry->bufOutput) - length,
+									  "fault name:'%s' "
+									  "fault type:'%s' "
+									  "ddl statement:'%s' "
+									  "database name:'%s' "
+									  "table name:'%s' "
+									  "occurrence:'%d' "
+									  "sleep time:'%d' "
+									  "fault injection state:'%s'  "
+									  "num times hit:'%d' \n",
+									  FaultInjectorIdentifierEnumToString[entryLocal->faultInjectorIdentifier],
+									  FaultInjectorTypeEnumToString[entryLocal->faultInjectorType],
+									  FaultInjectorDDLEnumToString[entryLocal->ddlStatement],
+									  entryLocal->databaseName,
+									  entryLocal->tableName,
+									  entryLocal->occurrence,
+									  entryLocal->sleepTime,
+									  FaultInjectorStateEnumToString[entryLocal->faultInjectorState],
+									  entryLocal->numTimesTriggered);
 						found = TRUE;
 				}
 			}

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -337,8 +337,9 @@ typedef struct FaultInjectorEntry_s {
 	char					tableName[NAMEDATALEN];
 	
 	volatile	int			occurrence;
-	
+	volatile	 int	numTimesTriggered;
 	volatile	FaultInjectorState_e	faultInjectorState;
+
 		/* the state of the fault injection */
 	char					bufOutput[2500];
 	

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/__init__.py
@@ -169,7 +169,7 @@ class PgtwoPhaseClass(MPPTestCase):
             if not self.gprecover.wait_till_insync_transition():
                 raise Exception('Segments not in sync')                        
 
-    def get_trigger_status(self, trigger_count):
+    def get_trigger_status_old(self, trigger_count):
         '''Compare the pg_stat_activity count with the total number of trigger_sqls executed '''
         for i in range(1,50):
             psql_count = PSQL.run_sql_command('select count(*) from pg_stat_activity;', flags='-q -t', dbname='postgres')
@@ -179,17 +179,24 @@ class PgtwoPhaseClass(MPPTestCase):
             return False
         return True
 
-    def check_trigger_sql_hang(self, test_dir):
+    def get_trigger_status(self, trigger_count, fault_type):
+        if fault_type == None:
+            return self.get_trigger_status_old(trigger_count);
+
+        return self.filereputil.check_fault_status(fault_name=fault_type, status="triggered", seg_id='1', num_times_hit=trigger_count);
+
+    def check_trigger_sql_hang(self, test_dir, fault_type = None):
         '''
-        @param ddl_type : create/drop
-        @param fault_type : commit/abort/end_prepare_two_phase_sleep
         @description : Return the status of the trigger sqls: whether they are waiting on the fault 
         Since gpfaultinjector has no way to check if all the sqls are triggered, we are using 
         a count(*) on pg_stat_activity and compare the total number of trigger_sqls
-        '''    
-        trigger_dir = local_path('%s_tests/trigger_sql/' % (test_dir))
-        trigger_count = len(glob.glob1(trigger_dir,"*.ans"))
-        return self.get_trigger_status(trigger_count)
+        '''
+        trigger_count=0
+        for dir in test_dir.split(","):
+            trigger_dir = local_path('%s/trigger_sql/sql/' % (dir))
+            trigger_count += len(glob.glob1(trigger_dir,"*.sql"))
+        tinctest.logger.info('Total number of sqls to trigger %d in %s' % (trigger_count,test_dir));
+        return self.get_trigger_status(trigger_count, fault_type)
 
 
     def run_faults_before_pre(self, cluster_state):
@@ -232,6 +239,8 @@ class PgtwoPhaseClass(MPPTestCase):
 
         if cluster_state == 'resync':
             self.filereputil.inject_fault(f='filerep_resync', y='resume', r='primary')
+
+        PSQL.wait_for_database_up();
 
     def run_crash_and_recover(self, crash_type, fault_type, test_dir, cluster_state='sync', checkpoint='noskip'):
         '''
@@ -334,9 +343,9 @@ class PgtwoPhaseClass(MPPTestCase):
         @param fault_type : dtm_broadcast_prepare/dtm_broadcast_commit_prepared/dtm_xlog_distributed_commit
         @param test_dir : dir of the trigger_sqls
         '''
-        trigger_status = self.check_trigger_sql_hang(test_dir)
+        trigger_status = self.check_trigger_sql_hang(test_dir, fault_type)
         tinctest.logger.info('trigger_status %s' % trigger_status)
-        sleep(50) # This sleep is needed till we get a way to find the state of all suspended sqls
+
         if trigger_status == True:
             if cluster_state == 'resync':
                 self.filereputil.inject_fault(f='filerep_resync', y='resume', r='primary')

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_checkpoint.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_checkpoint.py
@@ -62,7 +62,7 @@ class SwitchCheckpointTestCase(ScenarioTestCase):
                 8. Validate using gpcheckcat and gpcheckmirrorseg
 
         '''
-        test_dir = {"dtm_broadcast_prepare":"switch_ckpt_b", "dtm_broadcast_commit_prepared":"switch_ckpt_b", "dtm_xlog_distributed_commit":"switch_ckpt_c"} 
+        test_dir = {"dtm_broadcast_prepare":"switch_ckpt_a,switch_ckpt_b", "dtm_broadcast_commit_prepared":"switch_ckpt_a,switch_ckpt_b", "dtm_xlog_distributed_commit":"switch_ckpt_c"}
 
         test_case_list0 = []
         test_case_list0.append('mpp.gpdb.tests.storage.lib.dbstate.DbStateClass.check_system')
@@ -110,19 +110,20 @@ class SwitchCheckpointTestCase(ScenarioTestCase):
         test_case_list5.append(('mpp.gpdb.tests.storage.pg_twophase.PgtwoPhaseClass.run_gprecover', [crash_type, cluster_state]))
         self.test_case_scenario.append(test_case_list5)
 
-        # No tables will be created for crash_type gpstop_i and failover_to_mirror
         test_case_list6 = []
-        if fault_type == 'dtm_broadcast_commit_prepared' and crash_type not in ('failover_to_mirror', 'gpstop_i'):
+        if fault_type == 'dtm_broadcast_commit_prepared':
             test_case_list6.append('mpp.gpdb.tests.storage.pg_twophase.switch_ckpt_a.post_sql.test_postsqls.TestPostSQLClass')
             test_case_list6.append('mpp.gpdb.tests.storage.pg_twophase.switch_ckpt_b.post_sql.test_postsqls.TestPostSQLClass')
-        
-        if fault_type == 'dtm_broadcast_prepare' and crash_type not in ('failover_to_mirror', 'gpstop_i'):
+
+        # No tables will be created for crash_type failover_to_mirror
+        if fault_type == 'dtm_broadcast_prepare' and crash_type not in ('gpstop_i'):
             test_case_list6.append('mpp.gpdb.tests.storage.pg_twophase.switch_ckpt_a.post_sql.test_postsqls.TestPostSQLClass')
             test_case_list6.append('mpp.gpdb.tests.storage.pg_twophase.checkpoint.test_checkpoint.TestCheckpointClass')
             test_case_list6.append('mpp.gpdb.tests.storage.pg_twophase.switch_ckpt_b.post_sql.test_postsqls.TestPostSQLClass')
          
-        if fault_type == 'dtm_xlog_distributed_commit' and crash_type not in ('failover_to_mirror', 'gpstop_i'):
+        if fault_type == 'dtm_xlog_distributed_commit':
             test_case_list6.append('mpp.gpdb.tests.storage.pg_twophase.switch_ckpt_c.post_sql.test_postsqls.TestPostSQLClass')
+
         self.test_case_scenario.append(test_case_list6)
 
         test_case_list7 = []
@@ -163,7 +164,7 @@ class SwitchCheckpointTestCase(ScenarioTestCase):
         test_case_list3.append('mpp.gpdb.tests.storage.pg_twophase.PgtwoPhaseClass.switch_ckpt_switch_xlog')
         self.test_case_scenario.append(test_case_list3)
         
-        test_dir = 'switch_ckpt_serial/trigger_sql'
+        test_dir = 'switch_ckpt_serial'
         test_case_list4 = []
         test_case_list4.append('mpp.gpdb.tests.storage.pg_twophase.switch_ckpt_serial.trigger_sql.test_triggersqls.TestTriggerSQLClass')
         test_case_list4.append(('mpp.gpdb.tests.storage.pg_twophase.PgtwoPhaseClass.switch_ckpt_crash_and_recover', [crash_type, fault_type, test_dir, cluster_state]))
@@ -177,7 +178,7 @@ class SwitchCheckpointTestCase(ScenarioTestCase):
         test_case_list6.append(('mpp.gpdb.tests.storage.pg_twophase.PgtwoPhaseClass.run_gprecover', [crash_type, cluster_state]))
         self.test_case_scenario.append(test_case_list6)
 
-        if fault_type not in ('dtm_xlog_distributed_commit', 'dtm_broadcast_prepare'):
+        if fault_type not in ('dtm_broadcast_prepare'):
             test_case_list7 = []
             test_case_list7.append('mpp.gpdb.tests.storage.pg_twophase.switch_ckpt_serial.post_sql.test_postsqls.TestPostSQLClass')
             self.test_case_scenario.append(test_case_list7)

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_a/trigger_sql/sql/checkpoint_template_a0.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_a/trigger_sql/sql/checkpoint_template_a0.sql
@@ -1,4 +1,0 @@
--- start_ignore
-SET gp_create_table_random_default_distribution=off;
--- end_ignore
-checkpoint;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_b/trigger_sql/sql/checkpoint_template_b0.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_b/trigger_sql/sql/checkpoint_template_b0.sql
@@ -1,4 +1,0 @@
--- start_ignore
-SET gp_create_table_random_default_distribution=off;
--- end_ignore
-checkpoint;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_c/trigger_sql/sql/checkpoint_template_c0.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_c/trigger_sql/sql/checkpoint_template_c0.sql
@@ -1,4 +1,0 @@
--- start_ignore
-SET gp_create_table_random_default_distribution=off;
--- end_ignore
-checkpoint;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/test_switch_25_33.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/test_switch_25_33.py
@@ -21,7 +21,6 @@ from mpp.gpdb.tests.storage.pg_twophase.switch_checkpoint import SwitchCheckpoin
 class SwitchCheckpoint25To33(SwitchCheckpointTestCase):
     '''
     Testing state of transactions with faults on master after crash-recovery
-    @gucs gp_create_table_random_default_distribution=off
     '''
 
     def __init__(self, methodName):

--- a/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
+++ b/src/test/tinc/tincrepo/mpp/lib/filerep_util.py
@@ -47,12 +47,11 @@ class Filerepe2e_Util():
         count = 0
         while(int(num_cl) < num_seg):
             tinctest.logger.info("waiting for DB to go into change tracking")
-            sleep(30)
+            sleep(10)
             num_cl = gpcfg.count_of_nodes_in_mode('c')
             count = count + 1
             if (count > 80):
                raise Exception("Timed out: cluster not in change tracking")
-            tinctest.logger.info("Cluster change tracking")
         return (True,num_cl)
 
     def inject_fault(self, y = None, f = None, r ='mirror', seg_id = None, H='ALL', m ='async', sleeptime = None,
@@ -110,7 +109,7 @@ class Filerepe2e_Util():
             return (ok,out)
        
     
-    def check_fault_status(self,fault_name = None, status = None, max_cycle=10, role='primary', seg_id=None):
+    def check_fault_status(self,fault_name = None, status = None, max_cycle=20, role='primary', seg_id=None, num_times_hit = None):
         ''' 
         Check whether a fault is triggered. Poll till the fault is triggered
         @param name : Fault name
@@ -126,11 +125,13 @@ class Filerepe2e_Util():
             poll +=1
             for line in out.splitlines():
                 if line.find(fault_name) > 0 and line.find(status) > 0 :
-                    tinctest.logger.info('Fault %s is %s ' % (fault_name,status))
+                    tinctest.logger.info('check_fault_status (%d): %s ' % (num_times_hit,line))
+                    if num_times_hit and line.find("num times hit:'%d'" % num_times_hit) < 0 :
+                        tinctest.logger.info('Fault not hit num of times %d line %s ' % (num_times_hit,line))
+                        continue
+                    tinctest.logger.info('Fault %s is %s num_times_hit %d' % (fault_name,status, num_times_hit))
                     poll = 0 
                     return True
             #sleep a while before start polling again
             sleep(10)
         return False
-
-


### PR DESCRIPTION
This PR contains bunch of commits to fix fault injector and current pg_twophase tests. 

- DtmXLogDistributedCommit fault to only hit for DTX
- Currently, fault injector framework doesn't convey how many times a given fault
has been hit. This is useful information to help optimize many tests which are
currently relying on sleep and select * from pg_stat_activity to figure out if
its time to trigger next step or not. Tests which need the fault to be triggered
for n number of commands and then perform some other activity, will now be able
to get this information in gpfaultinjector status message.
- Just fixing rough edges in current tests for now, no doubt whole mechanism needs
to be altered to how testing is done for this part. Using newly added mechanism
to check number of times fault triggered to remove sleeps and indeterministic
behavior of the tests. Also, fix the tests to correctly calculate number of
faults being trigered. Also, correctly run post sqls for
dtm_broadcast_commit_prepared and dtm_xlog_distributed_commit faults as
transactions would be committed for these situations.