### PR TITLE
Refactor distributed transaction phase 2 retry logic.

### DIFF
--- a/src/backend/tcop/dest.c
+++ b/src/backend/tcop/dest.c
@@ -150,15 +150,6 @@ EndCommand(const char *commandTag, CommandDest dest)
 {
 	StringInfoData buf;
 
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		/*
-		 * Just before a successful reply, let's see if the DTM has
-		 * phase 2 retry work.
-		 */
-		doDtxPhase2Retry();
-	}
-	
 	switch (dest)
 	{
 		case DestRemote:

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4357,7 +4357,6 @@ PostgresMain(int argc, char *argv[],
 	StringInfoData input_message;
 	sigjmp_buf local_sigjmp_buf;
 	volatile bool send_ready_for_query = true;
-	int topErrLevel;
 
 	MemoryAccountIdType postgresMainMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;
 	
@@ -4753,16 +4752,6 @@ PostgresMain(int argc, char *argv[],
 
 		if (am_walsender)
 			WalSndErrorCleanup();
-
-		topErrLevel = elog_getelevel();
-		if (topErrLevel <= ERROR)
-		{
-			/*
-			 * Let's see if the DTM has phase 2 retry work.
-			 */
-			if (Gp_role == GP_ROLE_DISPATCH)
-				doDtxPhase2Retry();
-		}
 
 		/*
 		 * Now return to normal top-level context and clear ErrorContext for

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -223,6 +223,7 @@ bool		gp_temporary_files_filespace_repair = false;
 bool		gp_create_table_random_default_distribution = true;
 bool		gp_allow_non_uniform_partitioning_ddl = true;
 bool		gp_enable_exchange_default_partition = false;
+int			dtx_phase2_retry_count = 0;
 
 bool		log_dispatch_stats = false;
 
@@ -4782,6 +4783,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		0,
 #endif
 		0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"dtx_phase2_retry_count", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Maximum number of retries during two phase commit after which master PANICs."),
+			NULL,
+			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		&dtx_phase2_retry_count,
+		2, 0, 10, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -358,7 +358,6 @@ extern void performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 					int flags,
 					const char *loggingStr, const char *gid, 
 					DistributedTransactionId gxid, DtxContextInfo *contextInfo);
-extern void doDtxPhase2Retry(void);
 extern void UtilityModeFindOrCreateDtmRedoFile(void);
 extern void UtilityModeCloseDtmRedoFile(void);
 extern void PleaseDebugMe(char *caller);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -255,6 +255,7 @@ extern bool gp_crash_recovery_suppress_ao_eof;
 extern bool gp_create_table_random_default_distribution;
 extern bool gp_allow_non_uniform_partitioning_ddl;
 extern bool gp_enable_exchange_default_partition;
+extern int  dtx_phase2_retry_count;
 
 /* WAL replication debug gucs */
 extern bool debug_walrepl_snd;

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -73,6 +73,9 @@ pg_regress$(X): pg_regress.o pg_regress_main.o
 pg_regress.o: pg_regress.c $(top_builddir)/src/port/pg_config_paths.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) -I$(top_builddir)/src/port $(EXTRADEFS) -c -o $@ $<
 
+twophase_pqexecparams: twophase_pqexecparams.c
+	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq -lpq -o $@ $<
+
 $(top_builddir)/src/port/pg_config_paths.h: $(top_builddir)/src/Makefile.global
 	$(MAKE) -C $(top_builddir)/src/port pg_config_paths.h
 
@@ -172,7 +175,7 @@ check: all
 installcheck: all
 	$(pg_regress_call)  --psqldir=$(PSQLDIR) --schedule=$(srcdir)/serial_schedule --srcdir=$(abs_srcdir)
 
-installcheck-good: all
+installcheck-good: all twophase_pqexecparams
 	if [ -z "$(INSTALLCHECK_GOOD_KERBEROS)" ]; then \
 	$(pg_regress_call)  --psqldir=$(PSQLDIR) --schedule=$(srcdir)/parallel_schedule --schedule=$(srcdir)/greenplum_schedule --srcdir=$(abs_srcdir); \
 	else \
@@ -217,7 +220,7 @@ clean distclean maintainer-clean: clean-lib
 # things built by `all' target
 	rm -f $(NAME)$(DLSUFFIX) $(OBJS)
 	$(MAKE) -C $(contribdir)/spi clean
-	rm -f $(output_files) $(input_files) pg_regress_main.o pg_regress.o pg_regress$(X)
+	rm -f $(output_files) $(input_files) pg_regress_main.o pg_regress.o pg_regress$(X) twophase_pqexecparams
 	rm -f $(bb_output_files) $(bb_input_files)
 # things created by dynamic configs
 	find sql -type l | xargs rm -f

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -19,10 +19,23 @@
 -- We want to have an error between the point where all segments are prepared and our decision 
 -- to write the Distributed Commit record.
 --
+-- start_ignore
+BEGIN;
+DROP TABLE IF EXISTS distxact1_1;
+NOTICE:  table "distxact1_1" does not exist, skipping
+DROP TABLE IF EXISTS distxact1_2;
+NOTICE:  table "distxact1_2" does not exist, skipping
+DROP TABLE IF EXISTS distxact1_3;
+NOTICE:  table "distxact1_3" does not exist, skipping
+DROP TABLE IF EXISTS distxact1_4;
+NOTICE:  table "distxact1_4" does not exist, skipping
+CREATE TABLE distxact1_1 (a int) DISTRIBUTED BY (a);
+CREATE TABLE distxact1_2 (a int) DISTRIBUTED BY (a);
+CREATE TABLE distxact1_3 (a int) DISTRIBUTED BY (a);
+CREATE TABLE distxact1_4 (a int) DISTRIBUTED BY (a);
+COMMIT;
+-- end_ignore
 SET optimizer_disable_missing_stats_collection=true;
-CREATE TABLE distxact1_1 (a int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 BEGIN;
 INSERT INTO distxact1_1 VALUES (1);
 INSERT INTO distxact1_1 VALUES (2);
@@ -34,6 +47,7 @@ INSERT INTO distxact1_1 VALUES (7);
 INSERT INTO distxact1_1 VALUES (8);
 SET debug_abort_after_distributed_prepared = true;
 COMMIT;
+NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 RESET debug_abort_after_distributed_prepared;
 SELECT * FROM distxact1_1;
@@ -41,14 +55,10 @@ SELECT * FROM distxact1_1;
 ---
 (0 rows)
 
-DROP TABLE distxact1_1;
 --
 -- We want to have an error during the prepare which will cause a Abort-Some-Prepared broadcast 
 -- to cleanup.
 --
-CREATE TABLE distxact1_2 (a int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 BEGIN;
 INSERT INTO distxact1_2 VALUES (21);
 INSERT INTO distxact1_2 VALUES (22);
@@ -62,6 +72,7 @@ SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "prepare";
 COMMIT;
+NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1259106572-0000015083. (cdbtm.c:633)
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -71,14 +82,10 @@ SELECT * FROM distxact1_2;
 ---
 (0 rows)
 
-DROP TABLE distxact1_2;
 --
 -- We want to have an error during the commit-prepared broadcast which will cause a
 -- Retry-Commit-Prepared broadcast to cleanup.
 --
-CREATE TABLE distxact1_3 (a int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 BEGIN;
 INSERT INTO distxact1_3 VALUES (31);
 INSERT INTO distxact1_3 VALUES (32);
@@ -92,9 +99,8 @@ SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "commit_prepared";
 COMMIT;
-WARNING:  The distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1259106572-0000015090.
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid = 1477546849-0000000071.  Retrying ... try 1
 NOTICE:  Releasing segworker group to retry broadcast.
-NOTICE:  Retry of the distributed transaction 'Commit Prepared' broadcast succeeded to the segments for gid = 1259106572-0000015090.
 SELECT * FROM distxact1_3;
  a  
 ----
@@ -108,7 +114,6 @@ SELECT * FROM distxact1_3;
  37
 (8 rows)
 
-DROP TABLE distxact1_3;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
 RESET debug_dtm_action_protocol;
@@ -116,9 +121,6 @@ RESET debug_dtm_action_protocol;
 -- VARIANT of we want to have an error between the point where all segments are prepared and our decision 
 -- to write the Distributed Commit record.  Cause problem during abort-prepared broadcast.  
 --
-CREATE TABLE distxact1_4 (a int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 BEGIN;
 INSERT INTO distxact1_4 VALUES (41);
 INSERT INTO distxact1_4 VALUES (42);
@@ -133,16 +135,14 @@ SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "abort_prepared";
 COMMIT;
-WARNING:  The distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid = 1259106572-0000015097.
+WARNING:  the distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid = 1477546849-0000000078.  Retrying ... try 1
 NOTICE:  Releasing segworker groups to retry broadcast.
-NOTICE:  Retry of the distributed transaction 'Abort Prepared' broadcast succeeded to the segments for gid = 1259106572-0000015097.
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 SELECT * FROM distxact1_4;
  a 
 ---
 (0 rows)
 
-DROP TABLE distxact1_4;
 RESET debug_abort_after_distributed_prepared;
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -354,6 +354,14 @@ drop table if exists dtmcurse_bar;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP TABLE
+-- Test two phase commit for extended query
+\! ./twophase_pqexecparams dbname=regression
+WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments for gid DUMMY
+NOTICE:  Releasing segworker group to retry broadcast.
+tuple 0: got
+ i = (4 bytes) 1
+ t = (11 bytes) 'joe's place'
+
 --
 -- Subtransactions with partition table DDLs.
 --

--- a/src/test/regress/twophase_pqexecparams.c
+++ b/src/test/regress/twophase_pqexecparams.c
@@ -1,0 +1,148 @@
+/*
+ * twopase_pqexecparams.c
+ *
+ * This file tests the retry during phase 2 of two phase commit while running an
+ * extended query.
+ *
+ * This test program is modified from src/test/examples/testlibpq3.c.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include "libpq-fe.h"
+
+/* for ntohl/htonl */
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+
+static void
+exit_nicely(PGconn *conn)
+{
+	PQfinish(conn);
+	exit(1);
+}
+
+
+
+/*
+ * This function prints a query result that is a fetch from the test table.
+ */
+static void
+show_results(PGresult *res)
+{
+	int			i,
+				j;
+	int			i_fnum,
+				t_fnum;
+
+
+	/* Use PQfnumber to avoid assumptions about field order in result */
+	i_fnum = PQfnumber(res, "i");
+	t_fnum = PQfnumber(res, "t");
+
+	for (i = 0; i < PQntuples(res); i++)
+	{
+		char	   *iptr;
+		char	   *tptr;
+		int			ival;
+
+		/* Get the field values (we ignore possibility they are null!) */
+		iptr = PQgetvalue(res, i, i_fnum);
+		tptr = PQgetvalue(res, i, t_fnum);
+
+		/*
+		 * The binary representation of INT4 is in network byte order, which
+		 * we'd better coerce to the local byte order.
+		 */
+		ival = ntohl(*((uint32_t *) iptr));
+
+
+		printf("tuple %d: got\n", i);
+		printf(" i = (%d bytes) %d\n",
+			   PQgetlength(res, i, i_fnum), ival);
+		printf(" t = (%d bytes) '%s'\n",
+			   PQgetlength(res, i, t_fnum), tptr);
+		printf("\n");
+	}
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+	const char *conninfo;
+	PGconn	   *conn;
+	PGresult   *res;
+	const char *paramValues[1];
+
+	/*
+	 * If the user supplies a parameter on the command line, use it as the
+	 * conninfo string; otherwise default to setting dbname=postgres and using
+	 * environment variables or defaults for all other connection parameters.
+	 */
+	if (argc > 1)
+		conninfo = argv[1];
+	else
+		conninfo = "dbname = postgres";
+
+	/* Make a connection to the database */
+	conn = PQconnectdb(conninfo);
+
+	/* Check to see that the backend connection was successfully made */
+	if (PQstatus(conn) != CONNECTION_OK)
+	{
+		fprintf(stderr, "Connection to database failed: %s",
+				PQerrorMessage(conn));
+		exit_nicely(conn);
+	}
+
+	PQexec(conn, "DROP TABLE IF EXISTS test1"); 
+	PQexec(conn, "CREATE TABLE test1 (i int4, t text)");
+	PQexec(conn, "INSERT INTO test1 values (1, 'joe''s place')");
+	PQexec(conn, "INSERT INTO test1 values (2, 'ho there')");
+
+	/*
+	 * The following GUCs will cause the segment to error out while trying to
+	 * commit the prepared transaction.
+	 */
+
+	PQexec(conn, "SET debug_dtm_action_target = \"protocol\"");
+	PQexec(conn, "SET debug_dtm_action_protocol = \"commit_prepared\"");
+	PQexec(conn, "SET debug_dtm_action_segment = 0");
+	PQexec(conn, "SET debug_dtm_action = \"fail_begin_command\"");
+
+	paramValues[0] = "joe's place";
+
+	/* Upone receving the SELECT below, the segment will error out due to the
+	 * fault-injector GUCs set earlier.  However, the master will retry and we
+	 * should get a message saying that retry succeeded.
+	 */
+
+	res = PQexecParams(conn,
+					   "SELECT * FROM test1 WHERE t = $1",
+					   1,		/* one param */
+					   NULL,	/* let the backend deduce param type */
+					   paramValues,
+					   NULL,	/* don't need param lengths since text */
+					   NULL,	/* default to all text params */
+					   1);		/* ask for binary results */
+
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+	{
+		fprintf(stderr, "SELECT failed: %s", PQerrorMessage(conn));
+		PQclear(res);
+		exit_nicely(conn);
+	}
+
+	show_results(res);
+
+	PQclear(res);
+
+	PQfinish(conn);
+
+	return 0;
+}


### PR DESCRIPTION
Refactor the phase 2 retry logic of distributed transaction so that the retry happens
immediately after failure instead of happening inside EndCommand(). The patch also
increases the number of retries in case of failure to 2 and introduces a guc called
dtx_phase2_retry_count to control the number of retries.