### PR TITLE
Don't fetch libstdc++ as part of the build. It's not needed.

### DIFF
--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -19,7 +19,6 @@
       <dependency org="xerces"          name="xerces-c"        rev="3.1.1-p1"       conf="osx106_x86->osx106_x86_32;rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64" />
       <dependency org="OpenSSL"         name="openssl"         rev="0.9.8zg"        conf="osx106_x86->osx105_x86;hpux_ia64->hpux_ia64;rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;sol10_x86_32->sol10_x86_32;sol10_x86_64->sol10_x86_64;sol10_sparc_32->sol10_sparc_32;sol10_sparc_64->sol10_sparc_64;suse11_x86_64->suse11_x86_64" />
       <dependency org="emc"             name="DDBoostSDK"      rev="3.0.0.3-446710" conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
-      <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse11_x86_64;sol10_x86_64->sol10_x86_64" />
       <dependency org="third-party"     name="ext"             rev="1.1"            conf="win32->win32" />
       <dependency org="third-party"     name="ext"             rev="2.0"            conf="hpux_ia64->hpux_ia64;sol10_x86_32->sol10_x86_32;sol10_sparc_32->sol10_sparc_32;sol10_sparc_64->sol10_sparc_64;sol10_x86_64->sol10_x86_64" />
       <dependency org="third-party"     name="ext"             rev="2.4"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->suse10_x86_64" />

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -53,47 +53,11 @@ XERCES_VER  = $(shell grep "\"xerces-c\""    $(GREP_SED_VAR))
 LIBGPOS_VER = $(shell grep "\"libgpos\""     $(GREP_SED_VAR))
 OPTIMIZER_VER = $(shell grep "\"optimizer\"" $(GREP_SED_VAR))
 
-LIBSTDC++_VER = $(shell grep "\"libstdc\""   $(GREP_SED_VAR))
-
 XERCES = $(BLD_TOP)/ext/$(BLD_ARCH)
 XERCES_LIBDIR = $(XERCES)/lib
 
 LIBGPOS = $(BLD_TOP)/ext/$(BLD_ARCH)/libgpos
 LIBGPOS_LIBDIR = $(LIBGPOS)/$(OBJDIR_DEFAULT)
-
-LIBSTDC++_BASEDIR = $(BLD_TOP)/ext/$(BLD_ARCH)
-
-ifeq (Darwin, $(UNAME))
-LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib
-endif
-
-ifeq "$(BLD_ARCH)" "rhel5_x86_32"
-LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib
-endif
-
-ifeq "$(BLD_ARCH)" "rhel6_x86_64"
-LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib64
-endif
-
-ifeq "$(BLD_ARCH)" "rhel7_x86_64"
-LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib64
-endif
-
-ifeq "$(BLD_ARCH)" "suse10_x86_64"
-LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib64
-endif
-
-ifeq "$(BLD_ARCH)" "suse11_x86_64"
-LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib64
-endif
-
-ifeq "$(BLD_ARCH)" "sol10_x86_32"
-LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib
-endif
-
-ifeq "$(BLD_ARCH)" "sol10_x86_64"
-LIBSTDC++_LIBDIR = $(LIBSTDC++_BASEDIR)/lib/amd64
-endif
 
 
 ## ---------------------------------------


### PR DESCRIPTION
I'm not sure why we did it, but AFAICS the LIBSTDC++_BASEDIR and
LIBSTDC++_LIBDIR variables were not used for anything.