### PR TITLE
Add "installcheck-world" target (and sync plperl with upstream)

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -103,11 +103,28 @@ distclean maintainer-clean:
 # Garbage from autoconf:
 	@rm -rf autom4te.cache/
 
-check: all
+# This is a top-level target that runs "all" regression test suites against
+# a running server. This is what the CI pipeline runs.
+installcheck-world:
+	$(MAKE) -C src/test installcheck-good
+	$(MAKE) -C src/test installcheck-bugbuster
+	$(MAKE) -C src/test/isolation installcheck
+	$(MAKE) -C src/pl installcheck
+	#$(MAKE) -C src/interfaces/ecpg installcheck
+	#$(MAKE) -C contrib installcheck
+	$(MAKE) -C gpAux/extensions installcheck
+	$(MAKE) -C src/bin/gpfdist installcheck
 
-check installcheck installcheck-parallel installcheck-good:
-	$(MAKE) -C src/test $@
-	$(MAKE) -C gpAux/extensions $@
+
+# Run mock tests, that don't require a running server. Arguably these should
+# be part of [install]check-world, but we treat them more like part of
+# compilation than regression testing, in the CI. But they are too heavy-weight
+# to put into "make all", either.
+.PHONY : unittest-check
+unittest-check:
+	$(MAKE) -C src/backend unittest-check
+	$(MAKE) -C src/bin unittest-check
+
 
 GNUmakefile: GNUmakefile.in $(top_builddir)/config.status
 	./config.status $@

--- a/concourse/pipelines/dev_pipeline.yml
+++ b/concourse/pipelines/dev_pipeline.yml
@@ -169,8 +169,8 @@ jobs:
       TARGET_OS_VERSION: 7
       BLD_TARGETS: ""
 
-# Stage 2: IC Tests
-- name: icg_planner_centos6
+# Stage 2: Run regression tests (make installcheck-world)
+- name: icw_planner_centos6
   serial: true
   plan:
   - aggregate:
@@ -188,11 +188,11 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: centos67-gpdb-gcc6-llvm-image
     params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-good
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
-- name: icg_gporca_centos6
+- name: icw_gporca_centos6
   serial: true
   plan:
   - aggregate:
@@ -210,11 +210,11 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: centos67-gpdb-gcc6-llvm-image
     params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=off' installcheck-good
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=off' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
-- name: icg_planner_codegen_centos6
+- name: icw_planner_codegen_centos6
   serial: true
   plan:
   - aggregate:
@@ -232,11 +232,11 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: centos67-gpdb-gcc6-llvm-image
     params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=on' installcheck-good
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=on' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
-- name: icg_gporca_codegen_centos6
+- name: icw_gporca_codegen_centos6
   serial: true
   plan:
   - aggregate:
@@ -254,95 +254,7 @@ jobs:
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: centos67-gpdb-gcc6-llvm-image
     params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=on' installcheck-good
-      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
-      TEST_OS: centos
-
-- name: icb_planner_centos6
-  serial: true
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [icg_planner_centos6]
-    - get: sync_tools_gpdb_centos
-      resource: sync_tools_gpdb_centos
-      passed: [icg_planner_centos6]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos
-      passed: [icg_planner_centos6]
-      trigger: true
-    - get: centos67-gpdb-gcc6-llvm-image
-  - task: ic_gpdb
-    file: gpdb_src/concourse/tasks/ic_gpdb.yml
-    image: centos67-gpdb-gcc6-llvm-image
-    params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
-      TEST_OS: centos
-
-- name: icb_gporca_centos6
-  serial: true
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [icg_gporca_centos6]
-    - get: sync_tools_gpdb_centos
-      resource: sync_tools_gpdb_centos
-      passed: [icg_gporca_centos6]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos
-      passed: [icg_gporca_centos6]
-      trigger: true
-    - get: centos67-gpdb-gcc6-llvm-image
-  - task: ic_gpdb
-    file: gpdb_src/concourse/tasks/ic_gpdb.yml
-    image: centos67-gpdb-gcc6-llvm-image
-    params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=off' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
-      TEST_OS: centos
-
-- name: icb_planner_codegen_centos6
-  serial: true
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [icg_planner_codegen_centos6]
-    - get: sync_tools_gpdb_centos
-      resource: sync_tools_gpdb_centos
-      passed: [icg_planner_codegen_centos6]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos
-      passed: [icg_planner_codegen_centos6]
-      trigger: true
-    - get: centos67-gpdb-gcc6-llvm-image
-  - task: ic_gpdb
-    file: gpdb_src/concourse/tasks/ic_gpdb.yml
-    image: centos67-gpdb-gcc6-llvm-image
-    params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=on' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
-      TEST_OS: centos
-
-- name: icb_gporca_codegen_centos6
-  serial: true
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [icg_gporca_codegen_centos6]
-    - get: sync_tools_gpdb_centos
-      resource: sync_tools_gpdb_centos
-      passed: [icg_gporca_codegen_centos6]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos
-      passed: [icg_gporca_codegen_centos6]
-      trigger: true
-    - get: centos67-gpdb-gcc6-llvm-image
-  - task: ic_gpdb
-    file: gpdb_src/concourse/tasks/ic_gpdb.yml
-    image: centos67-gpdb-gcc6-llvm-image
-    params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=on' installcheck-bugbuster
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=on' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
@@ -353,11 +265,11 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: [icb_planner_centos6, icb_gporca_centos6, icb_planner_codegen_centos6, icb_gporca_codegen_centos6]
+      passed: [icw_planner_centos6, icw_gporca_centos6, icw_planner_codegen_centos6, icw_gporca_codegen_centos6]
     - get: gpaddon_src
     - get: bin_gpdb
       resource: bin_gpdb_centos
-      passed: [icb_planner_centos6, icb_gporca_centos6, icb_planner_codegen_centos6, icb_gporca_codegen_centos6]
+      passed: [icw_planner_centos6, icw_gporca_centos6, icw_planner_codegen_centos6, icw_gporca_codegen_centos6]
       trigger: true
     - get: centos67-gpdb-gcc6-llvm-image
   - task: separate_qautils_files_for_rc

--- a/concourse/pipelines/dev_pr_pipeline.yml
+++ b/concourse/pipelines/dev_pr_pipeline.yml
@@ -111,7 +111,7 @@ jobs:
         gpdb_src: gpdb_pr
 
   # Stage 2: IC Tests
-  - name: icg_planner_centos6
+  - name: icw_planner_centos6
     plan:
     - aggregate:
       - get: gpdb_pr
@@ -130,7 +130,7 @@ jobs:
       input_mapping:
         gpdb_src: gpdb_pr
       params:
-        MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-good
+        MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-world
         BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
         TEST_OS: centos
       timeout: 2h30m
@@ -142,11 +142,11 @@ jobs:
     plan:
     - aggregate:
       - get: gpdb_pr
-        passed: [icg_planner_centos6]
+        passed: [icw_planner_centos6]
       - get: gpaddon_src
       - get: bin_gpdb
         resource: bin_gpdb_centos
-        passed: [icg_planner_centos6]
+        passed: [icw_planner_centos6]
         trigger: true
       - get: centos67-gpdb-gcc6-llvm-image
     - task: separate_qautils_files_for_rc

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -180,8 +180,8 @@ jobs:
       TARGET_OS_VERSION: 7
       BLD_TARGETS: ""
 
-# Stage 2: IC Tests
-- name: icg_planner_centos6
+# Stage 2: Run regression tests (make installcheck-world)
+- name: icw_planner_centos6
   serial: true
   plan:
   - aggregate:
@@ -204,11 +204,11 @@ jobs:
     image: centos67-gpdb-gcc6-llvm-image
     tags: ["worker-one"]
     params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-good
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
-- name: icg_gporca_centos6
+- name: icw_gporca_centos6
   serial: true
   plan:
   - aggregate:
@@ -231,11 +231,11 @@ jobs:
     image: centos67-gpdb-gcc6-llvm-image
     tags: ["worker-two"]
     params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=off' installcheck-good
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=off' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
-- name: icg_planner_codegen_centos6
+- name: icw_planner_codegen_centos6
   serial: true
   plan:
   - aggregate:
@@ -258,11 +258,11 @@ jobs:
     image: centos67-gpdb-gcc6-llvm-image
     tags: ["worker-three"]
     params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=on' installcheck-good
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=on' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
-- name: icg_gporca_codegen_centos6
+- name: icw_gporca_codegen_centos6
   serial: true
   plan:
   - aggregate:
@@ -285,115 +285,7 @@ jobs:
     image: centos67-gpdb-gcc6-llvm-image
     tags: ["worker-four"]
     params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=on' installcheck-good
-      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
-      TEST_OS: centos
-
-- name: icb_planner_centos6
-  serial: true
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      tags: ["worker-one"]
-      passed: [icg_planner_centos6]
-    - get: sync_tools_gpdb_centos
-      tags: ["worker-one"]
-      resource: sync_tools_gpdb_centos
-      passed: [icg_planner_centos6]
-    - get: bin_gpdb
-      tags: ["worker-one"]
-      resource: bin_gpdb_centos
-      passed: [icg_planner_centos6]
-      trigger: true
-    - get: centos67-gpdb-gcc6-llvm-image
-      tags: ["worker-one"]
-  - task: ic_gpdb
-    file: gpdb_src/concourse/tasks/ic_gpdb.yml
-    image: centos67-gpdb-gcc6-llvm-image
-    tags: ["worker-one"]
-    params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
-      TEST_OS: centos
-
-- name: icb_gporca_centos6
-  serial: true
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      tags: ["worker-two"]
-      passed: [icg_gporca_centos6]
-    - get: sync_tools_gpdb_centos
-      tags: ["worker-two"]
-      resource: sync_tools_gpdb_centos
-      passed: [icg_gporca_centos6]
-    - get: bin_gpdb
-      tags: ["worker-two"]
-      resource: bin_gpdb_centos
-      passed: [icg_gporca_centos6]
-      trigger: true
-    - get: centos67-gpdb-gcc6-llvm-image
-      tags: ["worker-two"]
-  - task: ic_gpdb
-    file: gpdb_src/concourse/tasks/ic_gpdb.yml
-    image: centos67-gpdb-gcc6-llvm-image
-    tags: ["worker-two"]
-    params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=off' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
-      TEST_OS: centos
-
-- name: icb_planner_codegen_centos6
-  serial: true
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      tags: ["worker-three"]
-      passed: [icg_planner_codegen_centos6]
-    - get: sync_tools_gpdb_centos
-      tags: ["worker-three"]
-      resource: sync_tools_gpdb_centos
-      passed: [icg_planner_codegen_centos6]
-    - get: bin_gpdb
-      tags: ["worker-three"]
-      resource: bin_gpdb_centos
-      passed: [icg_planner_codegen_centos6]
-      trigger: true
-    - get: centos67-gpdb-gcc6-llvm-image
-      tags: ["worker-three"]
-  - task: ic_gpdb
-    file: gpdb_src/concourse/tasks/ic_gpdb.yml
-    image: centos67-gpdb-gcc6-llvm-image
-    tags: ["worker-three"]
-    params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=on' installcheck-bugbuster
-      BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
-      TEST_OS: centos
-
-- name: icb_gporca_codegen_centos6
-  serial: true
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      tags: ["worker-four"]
-      passed: [icg_gporca_codegen_centos6]
-    - get: sync_tools_gpdb_centos
-      tags: ["worker-four"]
-      resource: sync_tools_gpdb_centos
-      passed: [icg_gporca_codegen_centos6]
-    - get: bin_gpdb
-      tags: ["worker-four"]
-      resource: bin_gpdb_centos
-      passed: [icg_gporca_codegen_centos6]
-      trigger: true
-    - get: centos67-gpdb-gcc6-llvm-image
-      tags: ["worker-four"]
-  - task: ic_gpdb
-    file: gpdb_src/concourse/tasks/ic_gpdb.yml
-    image: centos67-gpdb-gcc6-llvm-image
-    tags: ["worker-four"]
-    params:
-      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=on' installcheck-bugbuster
+      MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on -c codegen=on' installcheck-world
       BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
       TEST_OS: centos
 
@@ -405,13 +297,13 @@ jobs:
   - aggregate:
     - get: gpdb_src
       tags: ["worker-three"]
-      passed: [icb_planner_centos6, icb_gporca_centos6, icb_planner_codegen_centos6, icb_gporca_codegen_centos6]
+      passed: [icw_planner_centos6, icw_gporca_centos6, icw_planner_codegen_centos6, icw_gporca_codegen_centos6]
     - get: gpaddon_src
       tags: ["worker-three"]
     - get: bin_gpdb
       tags: ["worker-three"]
       resource: bin_gpdb_centos
-      passed: [icb_planner_centos6, icb_gporca_centos6, icb_planner_codegen_centos6, icb_gporca_codegen_centos6]
+      passed: [icw_planner_centos6, icw_gporca_centos6, icw_planner_codegen_centos6, icw_gporca_codegen_centos6]
       trigger: true
     - get: centos67-gpdb-gcc6-llvm-image
       tags: ["worker-three"]

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -139,8 +139,8 @@ jobs:
           path: gpdb_pr
           status: failure
 
-  # Stage 2: IC Tests
-  - name: icg_planner_centos6
+  # Stage 2: Run regression tests (make installcheck-world)
+  - name: icw_planner_centos6
     plan:
     - aggregate:
       - get: gpdb_pr
@@ -164,7 +164,7 @@ jobs:
       input_mapping:
         gpdb_src: gpdb_pr
       params:
-        MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-good
+        MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off -c codegen=off' installcheck-world
         BLDWRAP_POSTGRES_CONF_ADDONS: "fsync=off"
         TEST_OS: centos
       timeout: 2h30m
@@ -188,11 +188,11 @@ jobs:
     - aggregate:
       - get: gpdb_pr
         tags: ["worker-three"]
-        passed: [icg_planner_centos6]
+        passed: [icw_planner_centos6]
       - get: bin_gpdb
         tags: ["worker-three"]
         resource: bin_gpdb_centos
-        passed: [icg_planner_centos6]
+        passed: [icw_planner_centos6]
         trigger: true
       - get: centos67-gpdb-gcc6-llvm-image
         tags: ["worker-three"]

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -89,7 +89,7 @@ function build_gppkg() {
 }
 
 function unittest_check_gpdb() {
-  pushd gpdb_src/gpAux
+  pushd gpdb_src
     source $GREENPLUM_INSTALL_DIR/greenplum_path.sh
     make GPROOT=/usr/local unittest-check
   popd

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -11,8 +11,7 @@ function gen_env(){
 
 		function look4diffs() {
 
-		    diff_files="../src/test/regress/regression.diffs
-				../src/test/regress/bugbuster/regression.diffs"
+		    diff_files=`find .. -name regression.diffs`
 
 		    for diff_file in \${diff_files}; do
 			if [ -f "\${diff_file}" ]; then
@@ -31,8 +30,8 @@ function gen_env(){
 		}
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
 		source /opt/gcc_env.sh
-		cd "\${1}/gpdb_src/gpAux"
-		source gpdemo/gpdemo-env.sh
+		cd "\${1}/gpdb_src"
+		source gpAux/gpdemo/gpdemo-env.sh
 		make ${MAKE_TEST_COMMAND}
 	EOF
 

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -19,10 +19,6 @@ all : devel
 # Targets recognized by the PostgreSQL makefile (GNUmakefile)
 .PHONY : all install installdirs uninstall distprep
 .PHONY : clean distclean maintainer-clean
-.PHONY : check installcheck installcheck-parallel
-
-# Targets for running regression tests
-.PHONY : installcheck-good installcheck-bugbuster
 
 # The pvk target builds a subset of the GPDB package that includes just the
 # tools used to verify the configuration of a set of GPDB servers.
@@ -361,8 +357,6 @@ endif
 
 ifeq "$(BLD_GPDB_BUILDSET)" "partial"
 define BUILD_STEPS
-	rm -f installcheck-good_SKIP
-	rm -f installcheck-bugbuster_SKIP
 	rm -rf $(INSTLOC)
 	@if [ "$(findstring win,$(BLD_ARCH))" = "win" ]; then \
 	    echo "Modifying timezone Makefile for crosscompile."; \
@@ -399,8 +393,6 @@ define BUILD_STEPS
 	  cd $(GPMGMT)/bin && $(MAKE) pygresql INSTLOC=$(INSTLOC) ; \
 	fi
 	$(MAKE) loaders INSTLOC=$(INSTLOC) LOADERSINSTLOC=$(LOADERSINSTLOC)
-	touch installcheck-good_SKIP
-	touch installcheck-bugbuster_SKIP
 endef
 endif
 
@@ -1217,28 +1209,6 @@ distprep : $(ISCONFIG)
 	@cd $(BUILDDIR) && $(MAKE) distprep
 
 #---------------------------------------------------------------------
-# Regression tests
-#---------------------------------------------------------------------
-
-bouncer:
-	@cd $(BUILDDIR)/src/test/regress && $(MAKE) testbouncer
-
-installcheck-good :
-	@if [ ! -f $(ISCONFIG) ]; then echo "not configured, cannot check"; exit 1; fi
-	@cd $(BUILDDIR)/src/test/regress && $(MAKE) installcheck-good
-	@#cd $(BUILDDIR)/src/test/regress && $(MAKE) testbouncer
-	@cd extensions && $(MAKE) installcheck
-
-installcheck-parallel :
-	@if [ ! -f $(ISCONFIG) ]; then echo "not configured, cannot check"; exit 1; fi
-	@cd $(BUILDDIR)/src/test/regress && $(MAKE) installcheck-parallel
-	@cd extensions && $(MAKE) installcheck
-
-installcheck-bugbuster :
-	@if [ ! -f $(ISCONFIG) ]; then echo "not configured, cannot check"; exit 1; fi
-	@cd $(BUILDDIR)/src/test/regress && $(MAKE) installcheck-bugbuster
-
-#---------------------------------------------------------------------
 # More internal functions
 #---------------------------------------------------------------------
 
@@ -1378,10 +1348,3 @@ else
 	done
 endif
 endif
-
-## ----------------------------------------------------------------------
-
-.PHONY : unittest-check
-unittest-check:
-	$(MAKE) -C ../src/backend unittest-check
-	$(MAKE) -C ../src/bin unittest-check

--- a/src/bin/gpfdist/regress/output/exttab1_optimizer.source
+++ b/src/bin/gpfdist/regress/output/exttab1_optimizer.source
@@ -713,7 +713,7 @@ ERROR:  ON clause may not be used with a writable external table
 -- SELECT from WET (negative)
 --
 select * from wet_pos1;
-ERROR:  External scan error: It is not possible to read from a WRITABLE external table. Create the table as READABLE instead. (COptTasks.cpp:1289)
+ERROR:  External scan error: It is not possible to read from a WRITABLE external table. Create the table as READABLE instead. (CTranslatorDXLToPlStmt.cpp:973)
 --
 -- WET: export some data with INSERT SELECT, INSERT and COPY. 
 --
@@ -894,7 +894,7 @@ select count(*) from pg_catalog.pg_exttable where reloid in (select r.oid from p
 COPY (VALUES('1,2'),('1,2,3'),('1,'),('1')) TO '@abs_srcdir@/data/tableless.csv';
 CREATE TABLE tableless_heap(a int, b int);
 COPY tableless_heap FROM '@abs_srcdir@/data/tableless.csv' CSV LOG ERRORS SEGMENT REJECT LIMIT 10;
-NOTICE:  Found 3 data formatting errors (3 or more input rows). Rejected related input data.
+NOTICE:  Found 2 data formatting errors (2 or more input rows). Rejected related input data.
 SELECT relname, linenum, errmsg FROM gp_read_error_log('tableless_heap');
     relname     | linenum |                errmsg                 
 ----------------+---------+---------------------------------------

--- a/src/pl/plperl/GNUmakefile
+++ b/src/pl/plperl/GNUmakefile
@@ -1,5 +1,5 @@
 # Makefile for PL/Perl
-# PostgreSQL: pgsql/src/pl/plperl/GNUmakefile
+# src/pl/plperl/GNUmakefile
 
 subdir = src/pl/plperl
 top_builddir = ../../..
@@ -44,8 +44,7 @@ PERLCHUNKS = plc_perlboot.pl plc_trusted.pl
 SHLIB_LINK = $(perl_embed_ldflags)
 
 REGRESS_OPTS = --dbname=$(PL_TESTDB) --load-language=plperl --load-language=plperlu
-REGRESS = plperl plperl_trigger plperl_shared plperl_elog plperl_util plperl_init plperlu plperl_array
-STRESS = plperl_stress
+REGRESS = plperl plperl_lc plperl_trigger plperl_shared plperl_elog plperl_util plperl_init plperlu plperl_array
 # if Perl can support two interpreters in one backend,
 # test plperl-and-plperlu cases
 ifneq ($(PERL),)
@@ -61,34 +60,48 @@ XSUBPPDIR = $(shell $(PERL) -e 'use List::Util qw(first); print first { -r "$$_/
 
 include $(top_srcdir)/src/Makefile.shlib
 
-plperl.o: perlchunks.h plperl_opmask.h
+plperl.o: perlchunks.h plperl_opmask.h plperl_helpers.h
 
 plperl_opmask.h: plperl_opmask.pl
+	@if [ x"$(perl_privlibexp)" = x"" ]; then echo "configure switch --with-perl was not specified."; exit 1; fi
 	$(PERL) $< $@
 
 perlchunks.h: $(PERLCHUNKS)
+	@if [ x"$(perl_privlibexp)" = x"" ]; then echo "configure switch --with-perl was not specified."; exit 1; fi
 	$(PERL) $(srcdir)/text2macro.pl --strip='^(\#.*|\s*)$$' $^ > $@
 
 all: all-lib
 
-SPI.c: SPI.xs
+SPI.c: SPI.xs plperl_helpers.h
+	@if [ x"$(perl_privlibexp)" = x"" ]; then echo "configure switch --with-perl was not specified."; exit 1; fi
 	$(PERL) $(XSUBPPDIR)/ExtUtils/xsubpp -typemap $(perl_privlibexp)/ExtUtils/typemap $< >$@
 
-Util.c: Util.xs
+Util.c: Util.xs plperl_helpers.h
+	@if [ x"$(perl_privlibexp)" = x"" ]; then echo "configure switch --with-perl was not specified."; exit 1; fi
 	$(PERL) $(XSUBPPDIR)/ExtUtils/xsubpp -typemap $(perl_privlibexp)/ExtUtils/typemap $< >$@
 
-install: all installdirs install-lib
+
+install: all install-lib install-data
 
 installdirs: installdirs-lib
+	$(MKDIR_P) '$(DESTDIR)$(datadir)/extension'
 
-uninstall: uninstall-lib
+uninstall: uninstall-lib uninstall-data
+
+install-data: installdirs
+	$(INSTALL_DATA) $(addprefix $(srcdir)/, $(DATA)) '$(DESTDIR)$(datadir)/extension/'
+
+uninstall-data:
+	rm -f $(addprefix '$(DESTDIR)$(datadir)/extension'/, $(notdir $(DATA)))
+
+.PHONY: install-data uninstall-data
+
+
+check: submake
+	$(top_builddir)/src/test/regress/pg_regress --init-file=init_file $(REGRESS_OPTS) $(REGRESS)
 
 installcheck: submake
-	$(top_builddir)/src/test/regress/pg_regress --inputdir=$(srcdir) --psqldir=$(PSQLDIR) $(REGRESS_OPTS) $(REGRESS)
-
-installcheck-stress: submake
-	$(top_builddir)/src/test/regress/pg_regress --inputdir=$(srcdir) --psqldir=$(PSQLDIR) $(REGRESS_OPTS) $(STRESS)
-
+	$(top_builddir)/src/test/regress/pg_regress --init-file=init_file $(REGRESS_OPTS) $(REGRESS)
 
 .PHONY: submake
 submake:
@@ -96,8 +109,7 @@ submake:
 
 clean distclean maintainer-clean: clean-lib
 	rm -f SPI.c Util.c $(OBJS) perlchunks.h plperl_opmask.h
-	rm -rf results
-	rm -f regression.diffs regression.out
+	rm -rf $(pg_regress_clean_files)
 
 else # can't build
 

--- a/src/pl/plperl/README
+++ b/src/pl/plperl/README
@@ -1,4 +1,4 @@
-$PostgreSQL: pgsql/src/pl/plperl/README,v 1.4 2008/03/21 13:23:29 momjian Exp $
+src/pl/plperl/README
 
 PL/Perl allows you to write PostgreSQL functions and procedures in
 Perl.  To include PL/Perl in the build use './configure --with-perl'.

--- a/src/pl/plperl/SPI.xs
+++ b/src/pl/plperl/SPI.xs
@@ -41,7 +41,7 @@ do_plperl_return_next(SV *sv)
 		FlushErrorState();
 
 		/* Punt the error to Perl */
-		croak("%s", edata->message);
+		croak_cstr(edata->message);
 	}
 	PG_END_TRY();
 }
@@ -183,4 +183,3 @@ spi_spi_cursor_close(sv)
 
 BOOT:
     items = 0;  /* avoid 'unused variable' warning */
-

--- a/src/pl/plperl/Util.xs
+++ b/src/pl/plperl/Util.xs
@@ -58,7 +58,7 @@ do_util_elog(int level, SV *msg)
 			pfree(cmsg);
 
 		/* Punt the error to Perl */
-		croak("%s", edata->message);
+		croak_cstr(edata->message);
 	}
 	PG_END_TRY();
 }
@@ -67,8 +67,11 @@ static text *
 sv2text(SV *sv)
 {
 	char	   *str = sv2cstr(sv);
+	text	   *text;
 
-	return cstring_to_text(str);
+	text = cstring_to_text(str);
+	pfree(str);
+	return text;
 }
 
 MODULE = PostgreSQL::InServer::Util PREFIX = util_
@@ -113,8 +116,11 @@ util_quote_literal(sv)
     }
     else {
         text *arg = sv2text(sv);
-        text *ret = DatumGetTextP(DirectFunctionCall1(quote_literal, PointerGetDatum(arg)));
-		char *str = text_to_cstring(ret);
+		text *quoted = DatumGetTextP(DirectFunctionCall1(quote_literal, PointerGetDatum(arg)));
+		char *str;
+
+		pfree(arg);
+		str = text_to_cstring(quoted);
 		RETVAL = cstr2sv(str);
 		pfree(str);
     }
@@ -132,8 +138,11 @@ util_quote_nullable(sv)
     else
 	{
         text *arg = sv2text(sv);
-        text *ret = DatumGetTextP(DirectFunctionCall1(quote_nullable, PointerGetDatum(arg)));
-		char *str = text_to_cstring(ret);
+		text *quoted = DatumGetTextP(DirectFunctionCall1(quote_nullable, PointerGetDatum(arg)));
+		char *str;
+
+		pfree(arg);
+		str = text_to_cstring(quoted);
 		RETVAL = cstr2sv(str);
 		pfree(str);
     }
@@ -145,12 +154,14 @@ util_quote_ident(sv)
     SV *sv
     PREINIT:
         text *arg;
-        text *ret;
+		text *quoted;
 		char *str;
     CODE:
         arg = sv2text(sv);
-        ret = DatumGetTextP(DirectFunctionCall1(quote_ident, PointerGetDatum(arg)));
-		str = text_to_cstring(ret);
+		quoted = DatumGetTextP(DirectFunctionCall1(quote_ident, PointerGetDatum(arg)));
+
+		pfree(arg);
+		str = text_to_cstring(quoted);
 		RETVAL = cstr2sv(str);
 		pfree(str);
     OUTPUT:

--- a/src/pl/plperl/expected/plperl.out
+++ b/src/pl/plperl/expected/plperl.out
@@ -101,6 +101,16 @@ SELECT * FROM perl_row();
   1 | hello | world | ({{1}})
 (1 row)
 
+-- test returning a composite literal
+CREATE OR REPLACE FUNCTION perl_row_lit() RETURNS testrowperl AS $$
+    return '(1,hello,world,"({{1}})")';
+$$ LANGUAGE plperl;
+SELECT perl_row_lit();
+       perl_row_lit        
+---------------------------
+ (1,hello,world,"({{1}})")
+(1 row)
+
 CREATE OR REPLACE FUNCTION perl_set() RETURNS SETOF testrowperl AS $$
     return undef;
 $$  LANGUAGE plperl;
@@ -204,8 +214,8 @@ CREATE OR REPLACE FUNCTION perl_record_set() RETURNS SETOF record AS $$
     return undef;
 $$  LANGUAGE plperl;
 SELECT perl_record_set();
-ERROR:  Unsupported Perl function "perl_record_set"
-DETAIL:  function returning record called in context that cannot accept type record
+ERROR:  set-valued function called in context that cannot accept a set
+CONTEXT:  PL/Perl function "perl_record_set"
 SELECT * FROM perl_record_set();
 ERROR:  a column definition list is required for functions returning "record"
 LINE 1: SELECT * FROM perl_record_set();
@@ -223,8 +233,7 @@ CREATE OR REPLACE FUNCTION perl_record_set() RETURNS SETOF record AS $$
     ];
 $$  LANGUAGE plperl;
 SELECT perl_record_set();
-ERROR:  Unsupported Perl function "perl_record_set"
-DETAIL:  function returning record called in context that cannot accept type record
+ERROR:  set-valued function called in context that cannot accept a set
 CONTEXT:  PL/Perl function "perl_record_set"
 SELECT * FROM perl_record_set();
 ERROR:  a column definition list is required for functions returning "record"
@@ -241,8 +250,7 @@ CREATE OR REPLACE FUNCTION perl_record_set() RETURNS SETOF record AS $$
     ];
 $$  LANGUAGE plperl;
 SELECT perl_record_set();
-ERROR:  Unsupported Perl function "perl_record_set"
-DETAIL:  function returning record called in context that cannot accept type record
+ERROR:  set-valued function called in context that cannot accept a set
 CONTEXT:  PL/Perl function "perl_record_set"
 SELECT * FROM perl_record_set();
 ERROR:  a column definition list is required for functions returning "record"
@@ -338,7 +346,8 @@ CREATE OR REPLACE FUNCTION foo_bad() RETURNS footype AS $$
 return 42;
 $$ LANGUAGE plperl;
 SELECT * FROM foo_bad();
-ERROR:  composite-returning PL/Perl function must return reference to hash
+ERROR:  malformed record literal: "42"
+DETAIL:  Missing left parenthesis.
 CONTEXT:  PL/Perl function "foo_bad"
 CREATE OR REPLACE FUNCTION foo_bad() RETURNS footype AS $$
 return [
@@ -347,7 +356,7 @@ return [
 ];
 $$ LANGUAGE plperl;
 SELECT * FROM foo_bad();
-ERROR:  composite-returning PL/Perl function must return reference to hash
+ERROR:  cannot convert Perl array to non-array type footype
 CONTEXT:  PL/Perl function "foo_bad"
 CREATE OR REPLACE FUNCTION foo_set_bad() RETURNS SETOF footype AS $$
     return 42;
@@ -571,8 +580,7 @@ CREATE OR REPLACE FUNCTION perl_spi_prepared_bad(double precision) RETURNS doubl
   return $result;
 $$ LANGUAGE plperl;
 SELECT perl_spi_prepared_bad(4.35) as "double precision";
-ERROR:  Perl function "perl_spi_prepared_bad" failed (SOMEFILE:SOMEFUNC)
-DETAIL:  type "does_not_exist" does not exist at line 2.
+ERROR:  type "does_not_exist" does not exist at line 2.
 CONTEXT:  PL/Perl function "perl_spi_prepared_bad"
 -- Test with a row type
 CREATE OR REPLACE FUNCTION perl_spi_prepared() RETURNS INTEGER AS $$
@@ -598,12 +606,93 @@ SELECT * from perl_spi_prepared_row('(1, 2)');
  x | y 
 ---+---
  1 | 2
---
--- Test detection of unsafe operations
-CREATE OR REPLACE FUNCTION perl_unsafe1() RETURNS void AS $$
-	my $fd = fileno STDERR;
+(1 row)
+
+-- simple test of a DO block
+DO $$
+  $a = 'This is a test';
+  elog(NOTICE, $a);
 $$ LANGUAGE plperl;
-ERROR:  creation of Perl function "perl_unsafe1" failed: 'fileno' trapped by operation mask at line 2.
+NOTICE:  This is a test
+CONTEXT:  PL/Perl anonymous code block
+-- check that restricted operations are rejected in a plperl DO block
+DO $$ system("/nonesuch"); $$ LANGUAGE plperl;
+ERROR:  'system' trapped by operation mask at line 1.
+CONTEXT:  PL/Perl anonymous code block
+DO $$ qx("/nonesuch"); $$ LANGUAGE plperl;
+ERROR:  'quoted execution (``, qx)' trapped by operation mask at line 1.
+CONTEXT:  PL/Perl anonymous code block
+DO $$ open my $fh, "</nonesuch"; $$ LANGUAGE plperl;
+ERROR:  'open' trapped by operation mask at line 1.
+CONTEXT:  PL/Perl anonymous code block
+-- check that eval is allowed and eval'd restricted ops are caught
+DO $$ eval q{chdir '.';}; warn "Caught: $@"; $$ LANGUAGE plperl;
+WARNING:  Caught: 'chdir' trapped by operation mask at line 1.
+CONTEXT:  PL/Perl anonymous code block
+-- check that compiling do (dofile opcode) is allowed
+-- but that executing it for a file not already loaded (via require) dies
+DO $$ warn do "/dev/null"; $$ LANGUAGE plperl;
+ERROR:  Unable to load /dev/null into plperl at line 1.
+CONTEXT:  PL/Perl anonymous code block
+-- check that we can't "use" a module that's not been loaded already
+-- compile-time error: "Unable to load blib.pm into plperl"
+DO $$ use blib; $$ LANGUAGE plperl;
+ERROR:  Unable to load blib.pm into plperl at line 1.
+DETAIL:  BEGIN failed--compilation aborted at line 1.
+CONTEXT:  PL/Perl anonymous code block
+-- check that we can "use" a module that has already been loaded
+-- runtime error: "Can't use string ("foo") as a SCALAR ref while "strict refs" in use
+DO $do$ use strict; my $name = "foo"; my $ref = $$name; $do$ LANGUAGE plperl;
+ERROR:  Can't use string ("foo") as a SCALAR ref while "strict refs" in use at line 1.
+CONTEXT:  PL/Perl anonymous code block
+-- check that we can "use warnings" (in this case to turn a warn into an error)
+-- yields "ERROR:  Useless use of sort in scalar context."
+DO $do$ use warnings FATAL => qw(void) ; my @y; my $x = sort @y; 1; $do$ LANGUAGE plperl;
+ERROR:  Useless use of sort in scalar context at line 1.
+CONTEXT:  PL/Perl anonymous code block
+-- make sure functions marked as VOID without an explicit return work
+CREATE OR REPLACE FUNCTION myfuncs() RETURNS void AS $$
+   $_SHARED{myquote} = sub {
+       my $arg = shift;
+       $arg =~ s/(['\\])/\\$1/g;
+       return "'$arg'";
+   };
+$$ LANGUAGE plperl;
+SELECT myfuncs();
+ myfuncs 
+---------
+ 
+(1 row)
+
+-- make sure we can't return an array as a scalar
+CREATE OR REPLACE FUNCTION text_arrayref() RETURNS text AS $$
+	return ['array'];
+$$ LANGUAGE plperl;
+SELECT text_arrayref();
+ERROR:  cannot convert Perl array to non-array type text
+CONTEXT:  PL/Perl function "text_arrayref"
+--- make sure we can't return a hash as a scalar
+CREATE OR REPLACE FUNCTION text_hashref() RETURNS text AS $$
+	return {'hash'=>1};
+$$ LANGUAGE plperl;
+SELECT text_hashref();
+ERROR:  cannot convert Perl hash to non-composite type text
+CONTEXT:  PL/Perl function "text_hashref"
+---- make sure we can't return a blessed object as a scalar
+CREATE OR REPLACE FUNCTION text_obj() RETURNS text AS $$
+	return bless({}, 'Fake::Object');
+$$ LANGUAGE plperl;
+SELECT text_obj();
+ERROR:  cannot convert Perl hash to non-composite type text
+CONTEXT:  PL/Perl function "text_obj"
+----- make sure we can't return a scalar ref
+CREATE OR REPLACE FUNCTION text_scalarref() RETURNS text AS $$
+	my $str = 'str';
+	return \$str;
+$$ LANGUAGE plperl;
+SELECT text_scalarref();
+ERROR:  PL/Perl function must return reference to hash or array
+CONTEXT:  PL/Perl function "text_scalarref"
 -- check safe behavior when a function body is replaced during execution
 CREATE OR REPLACE FUNCTION self_modify(INTEGER) RETURNS INTEGER AS $$
    spi_exec_query('CREATE OR REPLACE FUNCTION self_modify(INTEGER) RETURNS INTEGER AS \'return $_[0] * 3;\' LANGUAGE plperl;');
@@ -622,16 +711,3 @@ SELECT self_modify(42);
          126
 (1 row)
 
--- simple test of a DO block
-DO $$
-  $a = 'This is a test';
-  elog(NOTICE, $a);
-$$ LANGUAGE plperl;
-NOTICE:  This is a test
-CONTEXT:  PL/Perl anonymous code block
--- check that restricted operations are rejected in a plperl DO block
-DO $$ use Config; $$ LANGUAGE plperl;
-ERROR:  creation of Perl function failed
-DETAIL:  Unable to load Config.pm into plperl at line 1.
-BEGIN failed--compilation aborted at line 1.
-CONTEXT:  PL/Perl anonymous code block

--- a/src/pl/plperl/expected/plperl_array.out
+++ b/src/pl/plperl/expected/plperl_array.out
@@ -102,6 +102,24 @@ select plperl_concat('{"hello"," ","world!"}');
  hello world! {hello," ",world!}
 (1 row)
 
+-- array of rows --
+CREATE TYPE foo AS (bar INTEGER, baz TEXT);
+CREATE OR REPLACE FUNCTION plperl_array_of_rows(foo[]) RETURNS TEXT AS $$
+	my $array_arg = shift;
+	my $result = "";
+	
+	for my $row_ref (@$array_arg) {
+		die "not a hash reference" unless (ref $row_ref eq "HASH");
+			$result .= $row_ref->{bar}." items of ".$row_ref->{baz}.";";
+	}
+	return $result .' '. $array_arg;
+$$ LANGUAGE plperl;
+select plperl_array_of_rows(ARRAY[ ROW(2, 'coffee'), ROW(0, 'sugar')]::foo[]);
+                      plperl_array_of_rows                      
+----------------------------------------------------------------
+ 2 items of coffee;0 items of sugar; {"(2,coffee)","(0,sugar)"}
+(1 row)
+
 -- composite type containing arrays
 CREATE TYPE rowfoo AS (bar INTEGER, baz INTEGER[]);
 CREATE OR REPLACE FUNCTION plperl_sum_row_elements(rowfoo) RETURNS TEXT AS $$
@@ -128,6 +146,44 @@ select plperl_sum_row_elements(ROW(1, ARRAY[2,3,4,5,6,7,8,9,10])::rowfoo);
  55
 (1 row)
 
+-- composite type containing array of another composite type, which, in order,
+-- contains an array of integers.
+CREATE TYPE rowbar AS (foo rowfoo[]);
+CREATE OR REPLACE FUNCTION plperl_sum_array_of_rows(rowbar) RETURNS TEXT AS $$
+	my $rowfoo_ref = shift;
+	my $result = 0;
+	
+	if (ref $rowfoo_ref eq 'HASH') {
+		my $row_array_ref = $rowfoo_ref->{foo};
+		if (is_array_ref($row_array_ref)) {
+			foreach my $row_ref (@{$row_array_ref}) {
+				if (ref $row_ref eq 'HASH') {
+					$result += $row_ref->{bar};
+					die "not an array reference".ref ($row_ref->{baz}) 
+					unless (is_array_ref($row_ref->{baz}));
+					foreach my $elem (@{$row_ref->{baz}}) {
+						$result += $elem unless ref $elem;
+					}
+				}
+				else {
+					die "element baz is not a reference to a rowfoo";
+				}
+			}
+		} else {
+			die "not a reference to an array of rowfoo elements"
+		}
+	} else {
+		die "not a reference to type rowbar";
+	}
+	return $result;
+$$ LANGUAGE plperl;
+select plperl_sum_array_of_rows(ROW(ARRAY[ROW(1, ARRAY[2,3,4,5,6,7,8,9,10])::rowfoo, 
+ROW(11, ARRAY[12,13,14,15,16,17,18,19,20])::rowfoo])::rowbar);
+ plperl_sum_array_of_rows 
+--------------------------
+ 210
+(1 row)
+
 -- check arrays as out parameters
 CREATE OR REPLACE FUNCTION plperl_arrays_out(OUT INTEGER[]) AS $$
 	return [[1,2,3],[4,5,6]];
@@ -145,6 +201,16 @@ $$ LANGUAGE plperl;
 select plperl_arrays_inout('{{1}, {2}, {3}}');
  plperl_arrays_inout 
 ---------------------
+ {{1},{2},{3}}
+(1 row)
+
+-- check that we can return an array literal
+CREATE OR REPLACE FUNCTION plperl_arrays_inout_l(INTEGER[]) returns INTEGER[] AS $$
+	return shift.''; # stringify it
+$$ LANGUAGE plperl;
+select plperl_arrays_inout_l('{{1}, {2}, {3}}');
+ plperl_arrays_inout_l 
+-----------------------
  {{1},{2},{3}}
 (1 row)
 

--- a/src/pl/plperl/expected/plperl_elog.out
+++ b/src/pl/plperl/expected/plperl_elog.out
@@ -36,9 +36,9 @@ create or replace function uses_global() returns text language plperl as $$
   return 'uses_global worked';
 
 $$;
-ERROR:  creation of Perl function failed
-DETAIL:  Global symbol "$global" requires explicit package name at line 3.
-Global symbol "$other_global" requires explicit package name at line 4.
+ERROR:  Global symbol "$global" requires explicit package name at line 3.
+DETAIL:  Global symbol "$other_global" requires explicit package name at line 4.
+CONTEXT:  compilation of PL/Perl function "uses_global"
 select uses_global();
 ERROR:  function uses_global() does not exist
 LINE 1: select uses_global();
@@ -58,3 +58,62 @@ select uses_global();
  uses_global worked
 (1 row)
 
+-- make sure we don't choke on readonly values
+do language plperl $$ elog(NOTICE, ${^TAINT}); $$;
+NOTICE:  0
+CONTEXT:  PL/Perl anonymous code block
+-- test recovery after "die"
+create or replace function just_die() returns void language plperl AS $$
+die "just die";
+$$;
+select just_die();
+ERROR:  just die at line 2.
+CONTEXT:  PL/Perl function "just_die"
+create or replace function die_caller() returns int language plpgsql as $$
+BEGIN
+  BEGIN
+    PERFORM just_die();
+  EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'caught die';
+  END;
+  RETURN 1;
+END;
+$$;
+select die_caller();
+NOTICE:  caught die
+ die_caller 
+------------
+          1
+(1 row)
+
+create or replace function indirect_die_caller() returns int language plperl as $$
+my $prepared = spi_prepare('SELECT die_caller() AS fx');
+my $a = spi_exec_prepared($prepared)->{rows}->[0]->{fx};
+my $b = spi_exec_prepared($prepared)->{rows}->[0]->{fx};
+return $a + $b;
+$$;
+select indirect_die_caller();
+NOTICE:  caught die
+CONTEXT:  SQL statement "SELECT die_caller() AS fx"
+PL/Perl function "indirect_die_caller"
+NOTICE:  caught die
+CONTEXT:  SQL statement "SELECT die_caller() AS fx"
+PL/Perl function "indirect_die_caller"
+ indirect_die_caller 
+---------------------
+                   2
+(1 row)
+
+-- Test non-ASCII error messages
+--
+-- Note: this test case is known to fail if the database encoding is
+-- EUC_CN, EUC_JP, EUC_KR, or EUC_TW, for lack of any equivalent to
+-- U+00A0 (no-break space) in those encodings.  However, testing with
+-- plain ASCII data would be rather useless, so we must live with that.
+SET client_encoding TO UTF8;
+create or replace function error_with_nbsp() returns void language plperl as $$
+  elog(ERROR, "this message contains a no-break space");
+$$;
+select error_with_nbsp();
+ERROR:  this message contains a no-break space at line 2.
+CONTEXT:  PL/Perl function "error_with_nbsp"

--- a/src/pl/plperl/expected/plperl_elog_1.out
+++ b/src/pl/plperl/expected/plperl_elog_1.out
@@ -1,13 +1,17 @@
 -- test warnings and errors from plperl
-
 create or replace function perl_elog(text) returns void language plperl as $$
 
   my $msg = shift;
   elog(NOTICE,$msg);
 
 $$;
-
 select perl_elog('explicit elog');
+NOTICE:  explicit elog
+CONTEXT:  PL/Perl function "perl_elog"
+ perl_elog 
+-----------
+ 
+(1 row)
 
 create or replace function perl_warn(text) returns void language plperl as $$
 
@@ -15,13 +19,16 @@ create or replace function perl_warn(text) returns void language plperl as $$
   warn($msg);
 
 $$;
-
 select perl_warn('implicit elog via warn');
+WARNING:  implicit elog via warn at line 4.
+CONTEXT:  PL/Perl function "perl_warn"
+ perl_warn 
+-----------
+ 
+(1 row)
 
 -- test strict mode on/off
-
 SET plperl.use_strict = true;
-
 create or replace function uses_global() returns text language plperl as $$
 
   $global = 1;
@@ -29,11 +36,15 @@ create or replace function uses_global() returns text language plperl as $$
   return 'uses_global worked';
 
 $$;
-
+ERROR:  Global symbol "$global" requires explicit package name (did you forget to declare "my $global"?) at line 3.
+DETAIL:  Global symbol "$other_global" requires explicit package name (did you forget to declare "my $other_global"?) at line 4.
+CONTEXT:  compilation of PL/Perl function "uses_global"
 select uses_global();
-
+ERROR:  function uses_global() does not exist
+LINE 1: select uses_global();
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SET plperl.use_strict = false;
-
 create or replace function uses_global() returns text language plperl as $$
 
   $global = 1;
@@ -41,20 +52,23 @@ create or replace function uses_global() returns text language plperl as $$
   return 'uses_global worked';
 
 $$;
-
 select uses_global();
+    uses_global     
+--------------------
+ uses_global worked
+(1 row)
 
 -- make sure we don't choke on readonly values
 do language plperl $$ elog(NOTICE, ${^TAINT}); $$;
-
+NOTICE:  0
+CONTEXT:  PL/Perl anonymous code block
 -- test recovery after "die"
-
 create or replace function just_die() returns void language plperl AS $$
 die "just die";
 $$;
-
 select just_die();
-
+ERROR:  just die at line 2.
+CONTEXT:  PL/Perl function "just_die"
 create or replace function die_caller() returns int language plpgsql as $$
 BEGIN
   BEGIN
@@ -65,8 +79,12 @@ BEGIN
   RETURN 1;
 END;
 $$;
-
 select die_caller();
+NOTICE:  caught die
+ die_caller 
+------------
+          1
+(1 row)
 
 create or replace function indirect_die_caller() returns int language plperl as $$
 my $prepared = spi_prepare('SELECT die_caller() AS fx');
@@ -74,8 +92,17 @@ my $a = spi_exec_prepared($prepared)->{rows}->[0]->{fx};
 my $b = spi_exec_prepared($prepared)->{rows}->[0]->{fx};
 return $a + $b;
 $$;
-
 select indirect_die_caller();
+NOTICE:  caught die
+CONTEXT:  SQL statement "SELECT die_caller() AS fx"
+PL/Perl function "indirect_die_caller"
+NOTICE:  caught die
+CONTEXT:  SQL statement "SELECT die_caller() AS fx"
+PL/Perl function "indirect_die_caller"
+ indirect_die_caller 
+---------------------
+                   2
+(1 row)
 
 -- Test non-ASCII error messages
 --
@@ -83,11 +110,10 @@ select indirect_die_caller();
 -- EUC_CN, EUC_JP, EUC_KR, or EUC_TW, for lack of any equivalent to
 -- U+00A0 (no-break space) in those encodings.  However, testing with
 -- plain ASCII data would be rather useless, so we must live with that.
-
 SET client_encoding TO UTF8;
-
 create or replace function error_with_nbsp() returns void language plperl as $$
   elog(ERROR, "this message contains a no-break space");
 $$;
-
 select error_with_nbsp();
+ERROR:  this message contains a no-break space at line 2.
+CONTEXT:  PL/Perl function "error_with_nbsp"

--- a/src/pl/plperl/expected/plperl_init.out
+++ b/src/pl/plperl/expected/plperl_init.out
@@ -1,10 +1,14 @@
 -- test plperl.on_plperl_init errors are fatal
 -- Avoid need for custom_variable_classes = 'plperl'
 LOAD 'plperl';
-SET SESSION plperl.on_plperl_init = ' system("/nonesuch") ';
+SET SESSION plperl.on_plperl_init = ' system("/nonesuch"); ';
 SHOW plperl.on_plperl_init;
- plperl.on_plperl_init 
------------------------
-  system("/nonesuch") 
+ plperl.on_plperl_init  
+------------------------
+  system("/nonesuch"); 
 (1 row)
 
+DO $$ warn 42 $$ language plperl;
+ERROR:  'system' trapped by operation mask at line 1.
+CONTEXT:  while executing plperl.on_plperl_init
+PL/Perl anonymous code block

--- a/src/pl/plperl/expected/plperl_lc.out
+++ b/src/pl/plperl/expected/plperl_lc.out
@@ -1,0 +1,10 @@
+--
+-- Make sure strings are validated
+-- Should fail for all encodings, as nul bytes are never permitted.
+--
+CREATE OR REPLACE FUNCTION perl_zerob() RETURNS TEXT AS $$
+  return "abcd\0efg";
+$$ LANGUAGE plperl;
+SELECT perl_zerob();
+ERROR:  invalid byte sequence for encoding "UTF8": 0x00
+CONTEXT:  PL/Perl function "perl_zerob"

--- a/src/pl/plperl/expected/plperl_lc_1.out
+++ b/src/pl/plperl/expected/plperl_lc_1.out
@@ -1,0 +1,10 @@
+--
+-- Make sure strings are validated
+-- Should fail for all encodings, as nul bytes are never permitted.
+--
+CREATE OR REPLACE FUNCTION perl_zerob() RETURNS TEXT AS $$
+  return "abcd\0efg";
+$$ LANGUAGE plperl;
+SELECT perl_zerob();
+ERROR:  invalid byte sequence for encoding "SQL_ASCII": 0x00
+CONTEXT:  PL/Perl function "perl_zerob"

--- a/src/pl/plperl/expected/plperl_plperlu.out
+++ b/src/pl/plperl/expected/plperl_plperlu.out
@@ -10,12 +10,10 @@ CREATE OR REPLACE FUNCTION foo() RETURNS integer AS $$
     return 1;
 $$ LANGUAGE plperlu; -- compile plperlu code
 SELECT * FROM bar(); -- throws exception normally (running plperl)
-ERROR:  Perl function "bar" failed (plperl.c:1961)
-DETAIL:  syntax error at or near "invalid" at line 4.
+ERROR:  syntax error at or near "invalid" at line 4.
 CONTEXT:  PL/Perl function "bar"
 SELECT * FROM foo(); -- used to cause backend crash (after switching to plperlu)
-ERROR:  Perl function "foo" failed (plperl.c:1961)
-DETAIL:  Perl function "bar" failed at line 2.
+ERROR:  syntax error at or near "invalid" at line 4. at line 2.
 CONTEXT:  PL/Perl function "foo"
 -- test redefinition of specific SP switching languages
 -- http://archives.postgresql.org/pgsql-bugs/2010-01/msg00116.php
@@ -74,9 +72,8 @@ CREATE OR REPLACE FUNCTION use_plperl() RETURNS void LANGUAGE plperl
 AS $$
 use Errno;
 $$;
-ERROR:  creation of Perl function failed
-DETAIL:  Unable to load Errno.pm into plperl at line 2.
-BEGIN failed--compilation aborted at line 2.
+ERROR:  Unable to load Errno.pm into plperl at line 2.
+DETAIL:  BEGIN failed--compilation aborted at line 2.
 CONTEXT:  compilation of PL/Perl function "use_plperl"
 -- make sure our overloaded require op gets restored/set correctly
 select use_plperlu();
@@ -89,7 +86,6 @@ CREATE OR REPLACE FUNCTION use_plperl() RETURNS void LANGUAGE plperl
 AS $$
 use Errno;
 $$;
-ERROR:  creation of Perl function failed
-DETAIL:  Unable to load Errno.pm into plperl at line 2.
-BEGIN failed--compilation aborted at line 2.
+ERROR:  Unable to load Errno.pm into plperl at line 2.
+DETAIL:  BEGIN failed--compilation aborted at line 2.
 CONTEXT:  compilation of PL/Perl function "use_plperl"

--- a/src/pl/plperl/expected/plperl_shared.out
+++ b/src/pl/plperl/expected/plperl_shared.out
@@ -1,3 +1,9 @@
+-- test plperl.on_plperl_init via the shared hash
+-- (must be done before plperl is first used)
+-- Avoid need for custom_variable_classes = 'plperl'
+LOAD 'plperl';
+-- testing on_plperl_init gets run, and that it can alter %_SHARED
+SET plperl.on_plperl_init = '$_SHARED{on_init} = 42';
 -- test the shared hash
 create function setme(key text, val text) returns void language plperl as $$
 
@@ -22,5 +28,30 @@ select getme('ourkey');
  getme  
 --------
  ourval
+(1 row)
+
+select getme('on_init');
+ getme 
+-------
+ 42
+(1 row)
+
+-- verify that we can use $_SHARED in strict mode
+create or replace function perl_shared() returns int as $$
+use strict;
+my $val = $_SHARED{'stuff'};
+$_SHARED{'stuff'} = '1';
+return $val;
+$$ language plperl;
+select perl_shared();
+ perl_shared 
+-------------
+            
+(1 row)
+
+select perl_shared();
+ perl_shared 
+-------------
+           1
 (1 row)
 

--- a/src/pl/plperl/expected/plperl_trigger.out
+++ b/src/pl/plperl/expected/plperl_trigger.out
@@ -5,7 +5,7 @@ CREATE TABLE trigger_test (
         i int,
         v varchar,
 		foo rowcompnest
-) distributed by (i);
+);
 CREATE OR REPLACE FUNCTION trigger_data() RETURNS trigger LANGUAGE plperl AS $$
 
   # make sure keys are sorted for consistent results - perl no longer
@@ -173,10 +173,39 @@ ERROR:  Cannot parallelize an UPDATE statement that updates the distribution col
 SELECT * FROM trigger_test;
  i |                v                 |   foo   
 ---+----------------------------------+---------
- 2 | second line(modified by trigger) | ("(3)")
- 4 | immortal                         | ("(4)")
  1 | first line(modified by trigger)  | ("(2)")
+ 2 | second line(modified by trigger) | ("(3)")
  3 | third line(modified by trigger)  | ("(4)")
+ 4 | immortal                         | ("(4)")
+(4 rows)
+
+DROP TRIGGER "test_valid_id_trig" ON trigger_test;
+CREATE OR REPLACE FUNCTION trigger_recurse() RETURNS trigger AS $$
+	use strict;
+
+	if ($_TD->{new}{i} == 10000)
+	{
+		spi_exec_query("insert into trigger_test (i, v) values (20000, 'child');");
+
+		if ($_TD->{new}{i} != 10000)
+		{
+			die "recursive trigger modified: ". $_TD->{new}{i};
+		}
+	}
+    return;
+$$ LANGUAGE plperl;
+CREATE TRIGGER "test_trigger_recurse" BEFORE INSERT ON trigger_test
+FOR EACH ROW EXECUTE PROCEDURE "trigger_recurse"();
+INSERT INTO trigger_test (i, v) values (10000, 'top');
+ERROR:  function cannot execute on segment because it issues a non-SELECT statement at line 6.
+DETAIL:  PL/Perl function "trigger_recurse"
+SELECT * FROM trigger_test;
+ i |                v                 |   foo   
+---+----------------------------------+---------
+ 1 | first line(modified by trigger)  | ("(2)")
+ 2 | second line(modified by trigger) | ("(3)")
+ 3 | third line(modified by trigger)  | ("(4)")
+ 4 | immortal                         | ("(4)")
 (4 rows)
 
 CREATE OR REPLACE FUNCTION immortal() RETURNS trigger AS $$

--- a/src/pl/plperl/expected/plperl_util.out
+++ b/src/pl/plperl/expected/plperl_util.out
@@ -73,6 +73,23 @@ select perl_decode_bytea();
  : 
 (4 rows)
 
+-- test encode_bytea
+create or replace function perl_encode_bytea() returns setof text language plperl as $$
+	return_next encode_bytea(undef); # generates undef warning if warnings enabled
+	return_next encode_bytea($_)
+		for q{@}, qq{@\x01@}, qq{@\x00@}, q{};
+	return undef;
+$$;
+select perl_encode_bytea();
+ perl_encode_bytea 
+-------------------
+ 
+ @
+ @\001@
+ @\000@
+ 
+(5 rows)
+
 -- test encode_array_literal
 create or replace function perl_encode_array_literal() returns setof text language plperl as $$
 	return_next encode_array_literal(undef);

--- a/src/pl/plperl/expected/plperlu.out
+++ b/src/pl/plperl/expected/plperlu.out
@@ -4,6 +4,9 @@
 LOAD 'plperl';
 -- Test plperl.on_plperlu_init gets run
 SET plperl.on_plperlu_init = '$_SHARED{init} = 42';
+DO $$ warn $_SHARED{init} $$ language plperlu;
+WARNING:  42 at line 1.
+CONTEXT:  PL/Perl anonymous code block
 --
 -- Test compilation of unicode regex - regardless of locale.
 -- This code fails in plain plperl in a non-UTF8 database.

--- a/src/pl/plperl/nls.mk
+++ b/src/pl/plperl/nls.mk
@@ -1,5 +1,5 @@
-# $PostgreSQL: pgsql/src/pl/plperl/nls.mk,v 1.7.2.1 2009/09/03 21:01:21 petere Exp $
+# src/pl/plperl/nls.mk
 CATALOG_NAME	:= plperl
-AVAIL_LANGUAGES	:= de es fr it ja pt_BR tr
+AVAIL_LANGUAGES	:= cs de es fr it ja pl pt_BR ro ru tr zh_CN zh_TW
 GETTEXT_FILES	:= plperl.c SPI.c
 GETTEXT_TRIGGERS:= errmsg errmsg_plural:1,2 errdetail errdetail_log errdetail_plural:1,2 errhint errcontext

--- a/src/pl/plperl/plc_perlboot.pl
+++ b/src/pl/plperl/plc_perlboot.pl
@@ -1,7 +1,7 @@
 #  src/pl/plperl/plc_perlboot.pl
 
 use 5.008001;
-use vars qw(%_SHARED);
+use vars qw(%_SHARED $_TD);
 
 PostgreSQL::InServer::Util::bootstrap();
 

--- a/src/pl/plperl/plperl--1.0.sql
+++ b/src/pl/plperl/plperl--1.0.sql
@@ -7,3 +7,5 @@
  */
 
 CREATE PROCEDURAL LANGUAGE plperl;
+
+COMMENT ON PROCEDURAL LANGUAGE plperl IS 'PL/Perl procedural language';

--- a/src/pl/plperl/plperl.h
+++ b/src/pl/plperl/plperl.h
@@ -44,18 +44,11 @@
 #undef vsnprintf
 #endif
 
-#define list_head sys_list_head
-#define list_tail sys_list_tail
 
 /* required for perl API */
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
-#include "ppport.h"
-
-#undef list_head
-#undef list_tail
-
 
 /* put back our snprintf and vsnprintf */
 #ifdef USE_REPL_SNPRINTF
@@ -66,18 +59,19 @@
 #undef vsnprintf
 #endif
 #ifdef __GNUC__
-#define vsnprintf(...)  pg_vsnprintf(__VA_ARGS__)
-#define snprintf(...)   pg_snprintf(__VA_ARGS__)
+#define vsnprintf(...)	pg_vsnprintf(__VA_ARGS__)
+#define snprintf(...)	pg_snprintf(__VA_ARGS__)
 #else
-#define vsnprintf       pg_vsnprintf
-#define snprintf        pg_snprintf
-#endif /* __GNUC__ */
-#endif /*  USE_REPL_SNPRINTF */
+#define vsnprintf		pg_vsnprintf
+#define snprintf		pg_snprintf
+#endif   /* __GNUC__ */
+#endif   /* USE_REPL_SNPRINTF */
 
 /* perl version and platform portability */
 #define NEED_eval_pv
 #define NEED_newRV_noinc
 #define NEED_sv_2pv_flags
+#include "ppport.h"
 
 /* perl may have a different width of "bool", don't buy it */
 #ifdef bool
@@ -89,6 +83,11 @@
 #define HeUTF8(he)			   ((HeKLEN(he) == HEf_SVKEY) ?			   \
 								SvUTF8(HeKEY_sv(he)) :				   \
 								(U32)HeKUTF8(he))
+#endif
+
+/* supply GvCV_set if it's missing - ppport.h doesn't supply it, unfortunately */
+#ifndef GvCV_set
+#define GvCV_set(gv, cv)		(GvCV(gv) = cv)
 #endif
 
 /* declare routines from plperl.c for access by .xs files */
@@ -103,9 +102,6 @@ void		plperl_spi_freeplan(char *);
 void		plperl_spi_cursor_close(char *);
 char	   *plperl_sv_to_literal(SV *, char *);
 
-/*  supply GvCV_set if it's missing - ppport.h doesn't supply it, unfortunately */
-#ifndef GvCV_set
-#define GvCV_set(gv, cv)		(GvCV(gv) = cv)
-#endif
+
 
 #endif   /* PL_PERL_H */

--- a/src/pl/plperl/plperl_helpers.h
+++ b/src/pl/plperl/plperl_helpers.h
@@ -3,24 +3,47 @@
 
 /*
  * convert from utf8 to database encoding
+ *
+ * Returns a palloc'ed copy of the original string
  */
 static inline char *
-utf_u2e(const char *utf8_str, size_t len)
+utf_u2e(char *utf8_str, size_t len)
 {
-	char	   *ret = (char *) pg_do_encoding_conversion((unsigned char *) utf8_str, len, PG_UTF8, GetDatabaseEncoding());
+	int			enc = GetDatabaseEncoding();
+	char	   *ret;
+
+	/*
+	 * When we are in a PG_UTF8 or SQL_ASCII database
+	 * pg_do_encoding_conversion() will not do any conversion (which is good)
+	 * or verification (not so much), so we need to run the verification step
+	 * separately.
+	 */
+	if (enc == PG_UTF8 || enc == PG_SQL_ASCII)
+	{
+		pg_verify_mbstr_len(enc, utf8_str, len, false);
+		ret = utf8_str;
+	}
+	else
+		ret = (char *) pg_do_encoding_conversion((unsigned char *) utf8_str,
+												 len, PG_UTF8, enc);
 
 	if (ret == utf8_str)
 		ret = pstrdup(ret);
+
 	return ret;
 }
 
 /*
  * convert from database encoding to utf8
+ *
+ * Returns a palloc'ed copy of the original string
  */
 static inline char *
 utf_e2u(const char *str)
 {
-	char	   *ret = (char *) pg_do_encoding_conversion((unsigned char *) str, strlen(str), GetDatabaseEncoding(), PG_UTF8);
+	char	   *ret =
+		(char *) pg_do_encoding_conversion((unsigned char *) str, strlen(str),
+										   GetDatabaseEncoding(), PG_UTF8);
 
 	if (ret == str)
 		ret = pstrdup(ret);
@@ -30,42 +53,120 @@ utf_e2u(const char *str)
 
 /*
  * Convert an SV to a char * in the current database encoding
+ *
+ * Returns a palloc'ed copy of the original string
  */
 static inline char *
 sv2cstr(SV *sv)
 {
-	char	   *val;
+	char	   *val, *res;
 	STRLEN		len;
 
 	/*
 	 * get a utf8 encoded char * out of perl. *note* it may not be valid utf8!
 	 */
-	val = SvPVutf8(sv, len);
 
 	/*
-	 * we use perls length in the event we had an embedded null byte to ensure
-	 * we error out properly
+	 * SvPVutf8() croaks nastily on certain things, like typeglobs and
+	 * readonly objects such as $^V. That's a perl bug - it's not supposed to
+	 * happen. To avoid crashing the backend, we make a copy of the sv before
+	 * passing it to SvPVutf8(). The copy is garbage collected 
+	 * when we're done with it.
 	 */
-	return utf_u2e(val, len);
+	if (SvREADONLY(sv) ||
+		isGV_with_GP(sv) ||
+		(SvTYPE(sv) > SVt_PVLV && SvTYPE(sv) != SVt_PVFM))
+		sv = newSVsv(sv);
+	else
+	{
+		/*
+		 * increase the reference count so we can just SvREFCNT_dec() it when
+		 * we are done
+		 */
+		SvREFCNT_inc_simple_void(sv);
+	}
+
+	/*
+	 * Request the string from Perl, in UTF-8 encoding; but if we're in a
+	 * SQL_ASCII database, just request the byte soup without trying to make it
+	 * UTF8, because that might fail.
+	 */
+	if (GetDatabaseEncoding() == PG_SQL_ASCII)
+		val = SvPV(sv, len);
+	else
+		val = SvPVutf8(sv, len);
+
+	/*
+	 * Now convert to database encoding.  We use perl's length in the event we
+	 * had an embedded null byte to ensure we error out properly.
+	 */
+	res = utf_u2e(val, len);
+
+	/* safe now to garbage collect the new SV */
+	SvREFCNT_dec(sv);
+
+	return res;
 }
 
 /*
  * Create a new SV from a string assumed to be in the current database's
  * encoding.
  */
-
 static inline SV *
 cstr2sv(const char *str)
 {
 	SV		   *sv;
-	char	   *utf8_str = utf_e2u(str);
+	char	   *utf8_str;
+
+	/* no conversion when SQL_ASCII */
+	if (GetDatabaseEncoding() == PG_SQL_ASCII)
+		return newSVpv(str, 0);
+
+	utf8_str = utf_e2u(str);
 
 	sv = newSVpv(utf8_str, 0);
 	SvUTF8_on(sv);
-
 	pfree(utf8_str);
 
 	return sv;
+}
+
+/*
+ * croak() with specified message, which is given in the database encoding.
+ *
+ * Ideally we'd just write croak("%s", str), but plain croak() does not play
+ * nice with non-ASCII data.  In modern Perl versions we can call cstr2sv()
+ * and pass the result to croak_sv(); in versions that don't have croak_sv(),
+ * we have to work harder.
+ */
+static inline void
+croak_cstr(const char *str)
+{
+#ifdef croak_sv
+	/* Use sv_2mortal() to be sure the transient SV gets freed */
+	croak_sv(sv_2mortal(cstr2sv(str)));
+#else
+
+	/*
+	 * The older way to do this is to assign a UTF8-marked value to ERRSV and
+	 * then call croak(NULL).  But if we leave it to croak() to append the
+	 * error location, it does so too late (only after popping the stack) in
+	 * some Perl versions.  Hence, use mess() to create an SV with the error
+	 * location info already appended.
+	 */
+	SV		   *errsv = get_sv("@", GV_ADD);
+	char	   *utf8_str = utf_e2u(str);
+	SV		   *ssv;
+
+	ssv = mess("%s", utf8_str);
+	SvUTF8_on(ssv);
+
+	pfree(utf8_str);
+
+	sv_setsv(errsv, ssv);
+
+	croak(NULL);
+#endif   /* croak_sv */
 }
 
 #endif   /* PL_PERL_HELPERS_H */

--- a/src/pl/plperl/plperlu--1.0.sql
+++ b/src/pl/plperl/plperlu--1.0.sql
@@ -7,3 +7,5 @@
  */
 
 CREATE PROCEDURAL LANGUAGE plperlu;
+
+COMMENT ON PROCEDURAL LANGUAGE plperlu IS 'PL/PerlU untrusted procedural language';

--- a/src/pl/plperl/ppport.h
+++ b/src/pl/plperl/ppport.h
@@ -2589,7 +2589,7 @@ else {
   eval {
     require File::Find;
     File::Find::find(sub {
-      $File$srcext)$/i
+      $File::Find::name =~ /($srcext)$/i
           and push @files, $File::Find::name;
     }, '.');
   };
@@ -7061,4 +7061,3 @@ DPPP_(my_pv_display)(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRL
 #endif /* _P_P_PORTABILITY_H_ */
 
 /* End of File ppport.h */
-

--- a/src/pl/plperl/sql/plperl_array.sql
+++ b/src/pl/plperl/sql/plperl_array.sql
@@ -63,6 +63,21 @@ select plperl_concat('{"NULL","NULL","NULL''"}');
 select plperl_concat('{{NULL,NULL,NULL}}');
 select plperl_concat('{"hello"," ","world!"}');
 
+-- array of rows --
+CREATE TYPE foo AS (bar INTEGER, baz TEXT);
+CREATE OR REPLACE FUNCTION plperl_array_of_rows(foo[]) RETURNS TEXT AS $$
+	my $array_arg = shift;
+	my $result = "";
+	
+	for my $row_ref (@$array_arg) {
+		die "not a hash reference" unless (ref $row_ref eq "HASH");
+			$result .= $row_ref->{bar}." items of ".$row_ref->{baz}.";";
+	}
+	return $result .' '. $array_arg;
+$$ LANGUAGE plperl;
+
+select plperl_array_of_rows(ARRAY[ ROW(2, 'coffee'), ROW(0, 'sugar')]::foo[]);
+
 -- composite type containing arrays
 CREATE TYPE rowfoo AS (bar INTEGER, baz INTEGER[]);
 
@@ -87,6 +102,42 @@ $$ LANGUAGE plperl;
 
 select plperl_sum_row_elements(ROW(1, ARRAY[2,3,4,5,6,7,8,9,10])::rowfoo);
 
+-- composite type containing array of another composite type, which, in order,
+-- contains an array of integers.
+CREATE TYPE rowbar AS (foo rowfoo[]);
+
+CREATE OR REPLACE FUNCTION plperl_sum_array_of_rows(rowbar) RETURNS TEXT AS $$
+	my $rowfoo_ref = shift;
+	my $result = 0;
+	
+	if (ref $rowfoo_ref eq 'HASH') {
+		my $row_array_ref = $rowfoo_ref->{foo};
+		if (is_array_ref($row_array_ref)) {
+			foreach my $row_ref (@{$row_array_ref}) {
+				if (ref $row_ref eq 'HASH') {
+					$result += $row_ref->{bar};
+					die "not an array reference".ref ($row_ref->{baz}) 
+					unless (is_array_ref($row_ref->{baz}));
+					foreach my $elem (@{$row_ref->{baz}}) {
+						$result += $elem unless ref $elem;
+					}
+				}
+				else {
+					die "element baz is not a reference to a rowfoo";
+				}
+			}
+		} else {
+			die "not a reference to an array of rowfoo elements"
+		}
+	} else {
+		die "not a reference to type rowbar";
+	}
+	return $result;
+$$ LANGUAGE plperl;
+
+select plperl_sum_array_of_rows(ROW(ARRAY[ROW(1, ARRAY[2,3,4,5,6,7,8,9,10])::rowfoo, 
+ROW(11, ARRAY[12,13,14,15,16,17,18,19,20])::rowfoo])::rowbar);
+
 -- check arrays as out parameters
 CREATE OR REPLACE FUNCTION plperl_arrays_out(OUT INTEGER[]) AS $$
 	return [[1,2,3],[4,5,6]];
@@ -100,6 +151,13 @@ CREATE OR REPLACE FUNCTION plperl_arrays_inout(INTEGER[]) returns INTEGER[] AS $
 $$ LANGUAGE plperl;
 
 select plperl_arrays_inout('{{1}, {2}, {3}}');
+
+-- check that we can return an array literal
+CREATE OR REPLACE FUNCTION plperl_arrays_inout_l(INTEGER[]) returns INTEGER[] AS $$
+	return shift.''; # stringify it
+$$ LANGUAGE plperl;
+
+select plperl_arrays_inout_l('{{1}, {2}, {3}}');
 
 -- make sure setof works
 create or replace function perl_setof_array(integer[]) returns setof integer[] language plperl as $$

--- a/src/pl/plperl/sql/plperl_init.sql
+++ b/src/pl/plperl/sql/plperl_init.sql
@@ -3,7 +3,8 @@
 -- Avoid need for custom_variable_classes = 'plperl'
 LOAD 'plperl';
 
-SET SESSION plperl.on_plperl_init = ' system("/nonesuch") ';
+SET SESSION plperl.on_plperl_init = ' system("/nonesuch"); ';
 
 SHOW plperl.on_plperl_init;
 
+DO $$ warn 42 $$ language plperl;

--- a/src/pl/plperl/sql/plperl_lc.sql
+++ b/src/pl/plperl/sql/plperl_lc.sql
@@ -1,0 +1,8 @@
+--
+-- Make sure strings are validated
+-- Should fail for all encodings, as nul bytes are never permitted.
+--
+CREATE OR REPLACE FUNCTION perl_zerob() RETURNS TEXT AS $$
+  return "abcd\0efg";
+$$ LANGUAGE plperl;
+SELECT perl_zerob();

--- a/src/pl/plperl/sql/plperl_util.sql
+++ b/src/pl/plperl/sql/plperl_util.sql
@@ -44,6 +44,17 @@ $$;
 
 select perl_decode_bytea();
 
+-- test encode_bytea
+
+create or replace function perl_encode_bytea() returns setof text language plperl as $$
+	return_next encode_bytea(undef); # generates undef warning if warnings enabled
+	return_next encode_bytea($_)
+		for q{@}, qq{@\x01@}, qq{@\x00@}, q{};
+	return undef;
+$$;
+
+select perl_encode_bytea();
+
 -- test encode_array_literal
 
 create or replace function perl_encode_array_literal() returns setof text language plperl as $$

--- a/src/pl/plperl/sql/plperlu.sql
+++ b/src/pl/plperl/sql/plperlu.sql
@@ -6,6 +6,7 @@ LOAD 'plperl';
 
 -- Test plperl.on_plperlu_init gets run
 SET plperl.on_plperlu_init = '$_SHARED{init} = 42';
+DO $$ warn $_SHARED{init} $$ language plperlu;
 
 --
 -- Test compilation of unicode regex - regardless of locale.

--- a/src/test/regress/expected/gp_toolkit.out
+++ b/src/test/regress/expected/gp_toolkit.out
@@ -614,6 +614,8 @@ select n_queries_exec from pg_stat_resqueues where queuename = 'q';
 (1 row)
 
 reset role;
+drop role resqueuetest;
+drop resource queue q;
 -- GP Readable Data Table
 -- Check that the tables created above are present in gp_toolkit.__gp_user_data_tables_readable
 -- view.

--- a/src/test/regress/expected/rangefuncs_cdb.out
+++ b/src/test/regress/expected/rangefuncs_cdb.out
@@ -162,8 +162,7 @@ $$ language plperlu NO SQL;
 -- function in select clause
 --   Fails: plperl does not support SFRM_Materialize
 select foor(1);
-ERROR:  Unsupported Perl function "foor"
-DETAIL:  function returning record called in context that cannot accept type record
+ERROR:  set-valued function called in context that cannot accept a set
 CONTEXT:  PL/Perl function "foor"
 -- expanding columns in the select list
 --    Fails: record type not registered
@@ -186,8 +185,7 @@ select * from foor(1) as (fooid int, f2 int);
 -- function over function (executed on master) 
 --    Fails: plperl does not support SFRM_Materialize
 select foor(fooid), * from foor(3) as (fooid int, f2 int);
-ERROR:  Unsupported Perl function "foor"
-DETAIL:  function returning record called in context that cannot accept type record
+ERROR:  set-valued function called in context that cannot accept a set
 CONTEXT:  PL/Perl function "foor"
 -- Joining with a table
 select * from foo2, foor(3) z(fooid int, f2 int) where foo2.f2 = z.f2;

--- a/src/test/regress/expected/rangefuncs_cdb_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_cdb_optimizer.out
@@ -162,8 +162,7 @@ $$ language plperlu NO SQL;
 -- function in select clause
 --   Fails: plperl does not support SFRM_Materialize
 select foor(1);
-ERROR:  Unsupported Perl function "foor"
-DETAIL:  function returning record called in context that cannot accept type record
+ERROR:  set-valued function called in context that cannot accept a set
 CONTEXT:  PL/Perl function "foor"
 -- expanding columns in the select list
 --    Fails: record type not registered
@@ -186,8 +185,7 @@ select * from foor(1) as (fooid int, f2 int);
 -- function over function (executed on master) 
 --    Fails: plperl does not support SFRM_Materialize
 select foor(fooid), * from foor(3) as (fooid int, f2 int);
-ERROR:  Unsupported Perl function "foor"
-DETAIL:  function returning record called in context that cannot accept type record
+ERROR:  set-valued function called in context that cannot accept a set
 CONTEXT:  PL/Perl function "foor"
 -- Joining with a table
 select * from foo2, foor(3) z(fooid int, f2 int) where foo2.f2 = z.f2;

--- a/src/test/regress/output/mapred.source
+++ b/src/test/regress/output/mapred.source
@@ -499,24 +499,26 @@ row 3,data 3
 SELECT mapreduce('@abs_srcdir@/yml/perlerror.yml') ORDER BY 1;
 mapreduce
 ---------------------
-STDERR> ERROR:  creation of Perl function failed
-STDERR> DETAIL:  syntax error at line 18, near "[]"
+STDERR> ERROR:  syntax error at line 18, near "[]"
+STDERR> DETAIL:  
 STDERR> syntax error at line 20, near ";
 STDERR>  }"
+STDERR> CONTEXT:  compilation of PL/Perl function "mapreduce_1977_grep_map"
 STDERR> Error: Object creation Failure
-STDERR> ERROR:  creation of Perl function failed
-STDERR> DETAIL:  syntax error at line 28, near "[]"
+STDERR> ERROR:  syntax error at line 28, near "[]"
+STDERR> DETAIL:  
 STDERR> syntax error at line 29, near ";
 STDERR>  }"
+STDERR> CONTEXT:  compilation of PL/Perl function "mapreduce_1992_grep_map"
 STDERR> Error: Object creation Failure
-STDERR> ERROR:  creation of Perl function failed
-STDERR> DETAIL:  syntax error at line 37, near "[]"
+STDERR> ERROR:  syntax error at line 37, near "[]"
+STDERR> CONTEXT:  compilation of PL/Perl function "mapreduce_2000_grep_map"
 STDERR> Error: Object creation Failure
-STDERR> ERROR:  creation of Perl function failed
-STDERR> DETAIL:  syntax error at line 45, near "[]"
+STDERR> ERROR:  syntax error at line 45, near "[]"
+STDERR> CONTEXT:  compilation of PL/Perl function "mapreduce_2011_grep_map"
 STDERR> Error: Object creation Failure
-STDERR> ERROR:  creation of Perl function failed
-STDERR> DETAIL:  syntax error at line 53, near "[]"
+STDERR> ERROR:  syntax error at line 53, near "[]"
+STDERR> CONTEXT:  compilation of PL/Perl function "mapreduce_2020_grep_map"
 STDERR> Error: Object creation Failure
 STDERR>
 STDOUT>

--- a/src/test/regress/sql/gp_toolkit.sql
+++ b/src/test/regress/sql/gp_toolkit.sql
@@ -349,6 +349,8 @@ set role resqueuetest;
 select 1;
 select n_queries_exec from pg_stat_resqueues where queuename = 'q';
 reset role;
+drop role resqueuetest;
+drop resource queue q;
 
 -- GP Readable Data Table
 


### PR DESCRIPTION
The main part of this PR is the second patch, to add installcheck-world target to the top-level makefile. Per commit message:

    Add "installcheck-world" makefile target.
    
    The master plan is that we will have straightforward "world" makefile
    targets, like newer versions of PostgreSQL has, that build, install,
    and test everything in the source tree. For example, "make world" builds
    everything and the kitchen sink, and "make installcheck-world" runs
    every test suite against an existing installation.
    
    This patch is the first step in that direction. It creates a top-level
    "installcheck-world" target, that runs some of the test suites we have.
    It does not run everything, because the tests for some components are
    either broken, or require additional setup to run. The point of this
    first step is to establish the precedence, and clean up and add
    everything else that we care about to this new target. For example, this
    does not run the gphdfs tests, gpmapreduce tests, or orafce tests yet.
    
    Also, this only adds the "installcheck-world" target, not "world",
    "install-world" nor "check-world". Those are TODOs.
    
    Adjust the concourse pipeline scripts to run the new "installcheck-world"
    target, replacing the separate "installcheck-good" and
    "installcheck-bugbuster" tasks. In the future, whenever a new test suite
    is added, it can be added to the installcheck-world target, and the
    pipeline will pick it up immediately, without having to modify the yaml
    files.
    
    An immediate benefit of this is that we now run the isolationtester test
    suite, and the PL tests, as part of the pipeline.

To make the PL regression tests pass, this also fixes plperl, by syncing it with the upstream 9.1 version of the source tree and tests. (We had backported it from 9.1 earlier, but the backport was incomplete, and the regression tests were neglected)