### PR TITLE
Remove unnecessary dependencies from gphdfs build.

### DIFF
--- a/gpAux/extensions/gphdfs/ivy.xml
+++ b/gpAux/extensions/gphdfs/ivy.xml
@@ -20,7 +20,6 @@
     <dependencies>
       <dependency org="${org}"     name="${name}"    rev="${revision}"           conf="compile->master"/>
 
-      <dependency org="apache" name="hadoop-annotations" rev="${hadoop-common.revision}" conf="hadoop2->master"/>
       <dependency org="apache" name="hadoop-core"        rev="${revision}"               conf="hadoop2->master"/>
       <dependency org="apache" name="hadoop-mapreduce-client-core"
                   rev="${hadoop-common.revision}" conf="hadoop2->master"/>
@@ -50,13 +49,10 @@
           <artifact name="hadoop-hdfs" type="test-jar" ext="jar" e:classifier="tests" />
       </dependency>
       <dependency org="log4j"                 name="log4j"                 rev="1.2.17" conf="ut->*"/>
-      <dependency org="commons-lang"          name="commons-lang"          rev="2.6"    conf="ut->*"/>
-      <dependency org="commons-configuration" name="commons-configuration" rev="1.9"    conf="ut->*" />
 	  <dependency org="junit"                 name="junit"                 rev="4.10"   conf="ut->*"/>
 
       <dependency org="apache" name="avro" rev="1.7.7" conf="ut->*"/>
       <dependency org="apache" name="avro-mapred" rev="1.7.7" conf="ut->*"/>
-      <dependency org="codehaus" name="jackson-core-asl" rev="1.9.3" conf="ut->*"/>
 
       <dependency org="apache" name="parquet-column"        rev="1.7.0"               conf="ut->*"/>
       <dependency org="apache" name="parquet-common"        rev="1.7.0"               conf="ut->*"/>


### PR DESCRIPTION
By trial & error, these seem to not be required.