### PR TITLE
Grab bag of fixes to Coverity defects

### DIFF
--- a/gpAux/extensions/gphdfs/gphdfsformatter.c
+++ b/gpAux/extensions/gphdfs/gphdfsformatter.c
@@ -548,7 +548,7 @@ gphdfsformatter_import(PG_FUNCTION_ARGS)
 	 * forward and then raise the error. But then, the framework will still
 	 * call the formatter the function again. Now, the formatter function will
 	 * be provided with a zero length data buffer. In this case, we should not
-	 * raise an error again, but simply retruns "NEED MORE DATA". This is how
+	 * raise an error again, but simply returns "NEED MORE DATA". This is how
 	 * the formatter framework works.
 	 */
 	if (remaining == 0 && FORMATTER_GET_SAW_EOF(fcinfo))

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -1846,7 +1846,13 @@ url_fclose(URL_FILE *file, bool failOnError, const char *relname)
 			break;
     }
 
-    free(file);
+	/*
+	 * If failOnError is true then we won't reach here due to previous calls to
+	 * ereport(), but static analysers might not pick that up so make the
+	 * intention explicit to avoid warnings for double free().
+	 */
+	if (!failOnError && file)
+		free(file);
 
     return ret;
 }

--- a/src/backend/cdb/cdbfilerep.c
+++ b/src/backend/cdb/cdbfilerep.c
@@ -4319,10 +4319,14 @@ FileRepStats_GpmonCreateSock(void)
 		elog(DEBUG1, "FileRepStats_GpmonCreateSock destAddress localhost, port %d\n",
 				 gpperfmon_port);
 
+		pg_freeaddrinfo_all(hint.ai_family, addrs);
 		return;
 	}
-	elog(WARNING, "gpmon: cannot create socket (%m)");
 
+	if (addrs)
+		pg_freeaddrinfo_all(hint.ai_family, addrs);
+
+	elog(WARNING, "gpmon: cannot create socket (%m)");
 }
 
 /*

--- a/src/backend/cdb/cdbfilerepconnserver.c
+++ b/src/backend/cdb/cdbfilerepconnserver.c
@@ -105,7 +105,11 @@ FileRepConnServer_CreateConnection()
 		struct timeval tv;
 		tv.tv_sec = file_rep_socket_timeout;
 		tv.tv_usec = 0;	/* Not initializing this can cause strange errors */
-		setsockopt(port->sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv,sizeof(struct timeval));
+
+		if (setsockopt(port->sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(struct timeval)) == -1)
+			ereport(WARNING,
+					(errcode_for_socket_access(),
+					errmsg("could not set receive timeout on socket")));
 
 		/* set TCP keep-alive parameters for FileRep connection */
 		(void) pq_setkeepalivesidle(gp_filerep_tcp_keepalives_idle, port);

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -4344,6 +4344,9 @@ selectHashPartition(PartitionNode *partnode, Datum *values, bool *isnull,
 	PartitionRule *rule;
 	MemoryContext oldcxt = NULL;
 
+	if (partnode->rules == NIL)
+		return NULL;
+
 	if (accessMethods && accessMethods->part_cxt)
 		oldcxt = MemoryContextSwitchTo(accessMethods->part_cxt);
 

--- a/src/backend/cdb/cdbresynchronizechangetracking.c
+++ b/src/backend/cdb/cdbresynchronizechangetracking.c
@@ -1851,7 +1851,9 @@ File ChangeTracking_OpenFile(CTFType ftype)
 									 S_IRUSR | S_IWUSR);
 
 			if (file == -1)
-				elog(ERROR, "failed to open meta \"%s\" in ChangeTracking_OpenFile", path);
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						errmsg("could not open file \"%s\": %m", path)));
 
 			/* 
 			 * seek to beginning of file. The meta file only has a single
@@ -1873,7 +1875,9 @@ File ChangeTracking_OpenFile(CTFType ftype)
 									 S_IRUSR | S_IWUSR);
 				
 			if (file == -1)
-				elog(ERROR, "failed to open log \"%s\" in ChangeTracking_OpenFile", path);
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						errmsg("could not open file \"%s\": %m", path)));
 
 			FileSeek(file, 0, SEEK_END); 
 			break;

--- a/src/backend/cdb/cdbresynchronizechangetracking.c
+++ b/src/backend/cdb/cdbresynchronizechangetracking.c
@@ -1850,6 +1850,9 @@ File ChangeTracking_OpenFile(CTFType ftype)
 									 O_RDWR | O_CREAT | PG_BINARY, 
 									 S_IRUSR | S_IWUSR);
 
+			if (file == -1)
+				elog(ERROR, "failed to open meta \"%s\" in ChangeTracking_OpenFile", path);
+
 			/* 
 			 * seek to beginning of file. The meta file only has a single
 			 * block. we will overwrite it each time with new meta data.
@@ -1869,6 +1872,9 @@ File ChangeTracking_OpenFile(CTFType ftype)
 									 O_RDWR | O_CREAT | PG_BINARY, 
 									 S_IRUSR | S_IWUSR);
 				
+			if (file == -1)
+				elog(ERROR, "failed to open log \"%s\" in ChangeTracking_OpenFile", path);
+
 			FileSeek(file, 0, SEEK_END); 
 			break;
 

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -53,7 +53,6 @@ GpSetOpType choose_setop_type(List *planlist)
 	bool ok_general = TRUE;
 	bool ok_partitioned = TRUE;
 	bool ok_replicated = TRUE;
-	bool ok_single_qd = TRUE;
 	bool ok_single_qe = TRUE;
 	bool has_partitioned = FALSE;
 	
@@ -100,10 +99,8 @@ GpSetOpType choose_setop_type(List *planlist)
 		return PSETOP_PARALLEL_PARTITIONED;
 	else if ( ok_single_qe )
 		return PSETOP_SEQUENTIAL_QE;
-	else if ( ok_single_qd )
-		return PSETOP_SEQUENTIAL_QD;
-	
-	return PSETOP_NONE;
+
+	return PSETOP_SEQUENTIAL_QD;
 }
 
 

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -570,7 +570,7 @@ ErrorLogWrite(CdbSreh *cdbsreh)
 	LWLockAcquire(ErrorLogLock, LW_EXCLUSIVE);
 	fp = AllocateFile(filename, "a");
 
-	if (!fp && (errno == EMFILE || errno == ENFILE))
+	if (!fp && (errno == EMFILE || errno == ENFILE))
 		ereport(ERROR, (errmsg("could not open \"%s\", too many open files: %m", filename)));
 
 	if (!fp && errno == ENOENT)

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -237,7 +237,7 @@ create_gang_retry:
 			goto create_gang_retry;
 		}
 
-		appendPQExpBuffer(&create_gang_error, "segments are in recovery mode\n");
+		appendPQExpBuffer(&create_gang_error, "segment(s) are in recovery mode\n");
 	}
 	
 exit:

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -65,7 +65,7 @@ CreateGangFunc pCreateGangFuncThreaded = createGang_thread;
 static Gang *
 createGang_thread(GangType type, int gang_id, int size, int content)
 {
-	Gang *newGangDefinition;
+	Gang *newGangDefinition = NULL;
 	SegmentDatabaseDescriptor *segdbDesc = NULL;
 	DoConnectParms *doConnectParmsAr = NULL;
 	DoConnectParms *pParms = NULL;
@@ -100,9 +100,12 @@ createGang_thread(GangType type, int gang_id, int size, int content)
 	initPQExpBuffer(&create_gang_error);
 
 create_gang_retry:
-	/* If we're in a retry, we may need to reset our initial state, a bit */
-	newGangDefinition = NULL;
-	doConnectParmsAr = NULL;
+	/*
+	 * If we're in a retry, we may need to reset our initial state a bit. We
+	 * also want to ensure that all resources have been released.
+	 */
+	Assert(newGangDefinition == NULL);
+	Assert(doConnectParmsAr == NULL);
 	successful_connections = 0;
 	in_recovery_mode_count = 0;
 	threadCount = 0;

--- a/src/backend/cdb/dispatcher/cdbgang_thread.c
+++ b/src/backend/cdb/dispatcher/cdbgang_thread.c
@@ -223,7 +223,7 @@ create_gang_retry:
 		{
 			/*
 			 * Retry for non-writer gangs is meaningless because
-			 * writer gang must has gone when QE is in recovery mode
+			 * writer gang must be gone when QE is in recovery mode
 			 */
 			DisconnectAndDestroyGang(newGangDefinition);
 			newGangDefinition = NULL;
@@ -237,7 +237,7 @@ create_gang_retry:
 			goto create_gang_retry;
 		}
 
-		appendPQExpBuffer(&create_gang_error, "segments is in recovery mode\n");
+		appendPQExpBuffer(&create_gang_error, "segments are in recovery mode\n");
 	}
 	
 exit:

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -919,7 +919,10 @@ SendDummyPacket(void)
 		if (!pg_set_noblock(sockfd))
 		{
 			if (sockfd >= 0)
+			{
 				closesocket(sockfd);
+				sockfd = -1;
+			}
 			continue;
 		}
 		break;
@@ -961,7 +964,7 @@ SendDummyPacket(void)
 	}
 
 	pg_freeaddrinfo_all(hint.ai_family, addrs);
-	close(sockfd);
+	closesocket(sockfd);
 	return;
 
 send_error:
@@ -972,7 +975,7 @@ send_error:
 	}
 	if (sockfd != -1)
 	{
-		close(sockfd);
+		closesocket(sockfd);
 	}
 	return;
 }

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -935,14 +935,14 @@ SendDummyPacket(void)
 	}
 
 	/*
-	* Send a dummy package to the interconnect listener, try 10 times
-	*/
+	 * Send a dummy package to the interconnect listener, try 10 times
+	 */
 	int counter = 0;
 	while (counter < 10)
 	{
 		counter++;
 		ret = sendto(sockfd, dummy_pkt, strlen(dummy_pkt), 0, rp->ai_addr, rp->ai_addrlen);
-		if(ret < 0)
+		if (ret < 0)
 		{
 			if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
 			{

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -880,14 +880,15 @@ SendDummyPacket(void)
 	struct addrinfo* addrs = NULL;
 	struct addrinfo* rp = NULL;
 	struct addrinfo hint;
-	uint16 udp_listenner;
+	uint16 udp_listener;
 	char	port_str[32] = {0};
 	char* dummy_pkt = "stop it";
+
 	/*
-	* Get address info from interconnect udp listenner port
-	*/
-	udp_listenner = Gp_listener_port;
-	snprintf(port_str, sizeof(port_str), "%d", udp_listenner);
+	 * Get address info from interconnect udp listener port
+	 */
+	udp_listener = Gp_listener_port;
+	snprintf(port_str, sizeof(port_str), "%d", udp_listener);
 
 	MemSet(&hint, 0, sizeof(hint));
 	hint.ai_socktype = SOCK_DGRAM;

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1888,7 +1888,7 @@ sendStatusQueryMessage(MotionConn *conn, int fd, uint32 seq)
  * putRxBufferAndSendAck
  * 		Return a buffer and send an acknowledgment.
  *
- *  SHOULD BE CALLED WITH rx_control_info.lock *LOCKED*
+ *  SHOULD BE CALLED WITH ic_control_info.lock *LOCKED*
  */
 static void
 putRxBufferAndSendAck(MotionConn *conn, AckSendParam *param)
@@ -1977,7 +1977,7 @@ MlPutRxBufferIFC(ChunkTransportState *transportStates, int motNodeID, int route)
  * getRxBuffer
  * 		Get a receive buffer.
  *
- * SHOULD BE CALLED WITH rx_control_info.lock *LOCKED*
+ * SHOULD BE CALLED WITH ic_control_info.lock *LOCKED*
  *
  * NOTE: This function MUST NOT contain elog or ereport statements.
  * elog is NOT thread-safe.  Developers should instead use something like:
@@ -2036,7 +2036,7 @@ getRxBuffer(RxBufferPool *p)
  * putRxBufferToFreeList
  * 		Return a receive buffer to free list
  *
- *  SHOULD BE CALLED WITH rx_control_info.lock *LOCKED*
+ *  SHOULD BE CALLED WITH ic_control_info.lock *LOCKED*
  */
 static inline void
 putRxBufferToFreeList(RxBufferPool *p, icpkthdr *buf)
@@ -2050,7 +2050,7 @@ putRxBufferToFreeList(RxBufferPool *p, icpkthdr *buf)
  * getRxBufferFromFreeList
  * 		Get a receive buffer from free list
  *
- * SHOULD BE CALLED WITH rx_control_info.lock *LOCKED*
+ * SHOULD BE CALLED WITH ic_control_info.lock *LOCKED*
  *
  * NOTE: This function MUST NOT contain elog or ereport statements.
  * elog is NOT thread-safe.  Developers should instead use something like:
@@ -3612,7 +3612,7 @@ TeardownUDPIFCInterconnect(ChunkTransportState *transportStates,
  * prepareRxConnForRead
  * 		Prepare the receive connection for reading.
  *
- * MUST BE CALLED WITH rx_control_info.lock LOCKED.
+ * MUST BE CALLED WITH ic_control_info.lock LOCKED.
  */
 static void
 prepareRxConnForRead(MotionConn *conn)
@@ -3631,7 +3631,7 @@ prepareRxConnForRead(MotionConn *conn)
  * receiveChunksUDPIFC
  * 		Receive chunks from the senders
  *
- * MUST BE CALLED WITH rx_control_info.lock LOCKED.
+ * MUST BE CALLED WITH ic_control_info.lock LOCKED.
  */
 static TupleChunkListItem
 receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEntry *pEntry,
@@ -3803,7 +3803,7 @@ RecvTupleChunkFromAnyUDPIFC_Internal(MotionLayerState *mlStates,
 		return NULL;
 	}
 
-	/* receiveChunksUDPIFC() releases rx_control_info.lock as a side-effect */
+	/* receiveChunksUDPIFC() releases ic_control_info.lock as a side-effect */
 	tcItem = receiveChunksUDPIFC(transportStates, pEntry, motNodeID, srcRoute, NULL, transportStates->teardownActive);
 
 	pEntry->scanStart = *srcRoute + 1;

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -6146,7 +6146,7 @@ rxThreadFunc(void *arg)
 		/* pthread_yield(); */
 	}
 
-	/* Before retrun, we release the packet. */
+	/* Before return, we release the packet. */
 	if (pkt)
 	{
 		pthread_mutex_lock(&ic_control_info.lock);

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1245,7 +1245,10 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 		if (!pg_set_noblock(fd))
 		{
 			if (fd >= 0)
+			{
 				closesocket(fd);
+				fd = -1;
+			}
 			continue;
 		}
 
@@ -1258,7 +1261,10 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 		}
 
 		if (fd >= 0)
+		{
 			closesocket(fd);
+			fd = -1;
+		}
 	}
 
 	if (rp == NULL)

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -173,10 +173,6 @@ ExecInitSubqueryScan(SubqueryScan *node, EState *estate, int eflags)
 	 */
 	subquerystate->subplan = ExecInitNode(node->subplan, estate, eflags);
 
-	/* return borrowed share node list */
-	estate->es_sharenode = estate->es_sharenode;
-	/*subquerystate->ss.ps.ps_TupFromTlist = false;*/
-
 	/*
 	 * Initialize scan tuple type (needed by ExecAssignScanProjectionInfo)
 	 */

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -1808,9 +1808,8 @@ ident_inet(const SockAddr remote_addr,
 		   const SockAddr local_addr,
 		   char *ident_user)
 {
-	pgsocket	sock_fd,		/* File descriptor for socket on which we talk
-								 * to Ident */
-				rc;				/* Return code from a locally called function */
+	pgsocket	sock_fd = PGINVALID_SOCKET;		/* for talking to Ident server */
+	int			rc;				/* Return code from a locally called function */
 	bool		ident_return;
 	char		remote_addr_s[NI_MAXHOST];
 	char		remote_port[NI_MAXSERV];

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -318,7 +318,8 @@ WalReceiverMain(void)
 				 errmsg("could not open file \"%s\" for reading: %m",
 						"wal_rcv.pid")));
 	}
-	FileClose(pid_file);
+	else
+		FileClose(pid_file);
 
 	walrcv_connect(conninfo, startpoint);
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3551,6 +3551,7 @@ SelectConfigFiles(const char *userDoption, const char *progname)
 	{
 		write_stderr("%s cannot access the server configuration file \"%s\": %s\n",
 					 progname, ConfigFileName, strerror(errno));
+		free(configdir);
 		return false;
 	}
 

--- a/src/backend/utils/workfile_manager/workfile_mgr_test.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr_test.c
@@ -1531,7 +1531,7 @@ buffile_large_file_test(void)
 	}
 	elog(LOG, "Running sub-test: Reading record %s", filename->data);
 
-	char *buffer= buffer = palloc(nchars * sizeof(char));
+	char *buffer = palloc(nchars * sizeof(char));
 
 	BufFileSeek(bfile,  (int64) ((int64)test_entry * (int64) nchars), SEEK_SET);
 
@@ -1624,7 +1624,7 @@ logicaltape_test(void)
 
 	/* Set target LogicalTape */
 	work_tape = LogicalTapeSetGetTape(tape_set, test_tape);
-	char *buffer= buffer = palloc(nchars * sizeof(char));
+	char *buffer = palloc(nchars * sizeof(char));
 
 	elog(LOG, "Running sub-test: Freeze LogicalTape");
 	LogicalTapeFreeze(tape_set, work_tape);

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -400,13 +400,14 @@ readfile(const char *path)
 void
 free_readfile(char **optlines)
 {
-	int i = 0;
+	char   *curr_line = NULL;
+	int		i = 0;
 
 	if (!optlines)
 		return;
 
-	while (optlines[i++])
-		free(optlines[i]);
+	while ((curr_line = optlines[i++]))
+		free(curr_line);
 
 	free(optlines);
 
@@ -1162,6 +1163,7 @@ do_status(void)
 			if (postmaster_is_alive((pid_t) pid))
 			{
 				char	  **optlines;
+				char	  **curr_line;
 
 				printf(_("%s: server is running (PID: %ld)\n"),
 					   progname, pid);
@@ -1169,8 +1171,8 @@ do_status(void)
 				optlines = readfile(postopts_file);
 				if (optlines != NULL)
 				{
-					for (; *optlines != NULL; optlines++)
-						fputs(*optlines, stdout);
+					for (curr_line = optlines; *curr_line != NULL; curr_line++)
+						fputs(*curr_line, stdout);
 
 					/* Free the results of readfile */
 					free_readfile(optlines);

--- a/src/bin/pg_dump/cdb/cdb_dump.c
+++ b/src/bin/pg_dump/cdb/cdb_dump.c
@@ -1516,14 +1516,15 @@ exit_nicely(void)
 
 	pszErrorMsg = MakeString("*** aborted because of error: %s\n", lastMsg);
 
-	mpp_err_msg(logError, progname, pszErrorMsg);
+	if (pszErrorMsg)
+	{
+		mpp_err_msg(logError, progname, pszErrorMsg);
+		free(pszErrorMsg);
+	}
 
 	/* Clean-up synchronization variables */
 	pthread_mutex_destroy(&MyMutex);
 	pthread_cond_destroy(&MyCondVar);
-
-	if (pszErrorMsg)
-		free(pszErrorMsg);
 
 	PQfinish(g_conn);
 	g_conn = NULL;

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -740,7 +740,13 @@ main(int argc, char **argv)
 					exit(1);
 				}
 				include_everything = false;
-                		strcpy(tableFileName, optarg);
+				if (strlcpy(tableFileName, optarg, sizeof(tableFileName)) >= sizeof(tableFileName))
+				{
+					fprintf(stderr,
+							_("%s: invalid --table-file option, filename too long\n"),
+							progname);
+					exit(1);
+				}
 				break;
 			case 4: 			/*	--exclude-table-file */
 				if (!open_file_and_append_to_list(optarg, &table_exclude_patterns, "exclude tables list"))
@@ -828,7 +834,13 @@ main(int argc, char **argv)
 			exit(1);
 		}
 		include_everything = false;
-		strncpy(tableFileName, incrementalFilter, sizeof(tableFileName));
+		if (strlcpy(tableFileName, incrementalFilter, sizeof(tableFileName)) >= sizeof(tableFileName))
+		{
+			fprintf(stderr,
+					_("%s: invalid --incremental-filter option -- filename too long\n"),
+					progname);
+			exit(1);
+		}
 	}
 
 	if (optind < (argc - 1))

--- a/src/bin/pg_dump/cdb/cdb_dump_util.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.c
@@ -305,6 +305,7 @@ GetMasterConnection(const char *progName,
 	{
 		mpp_err_msg_cache("ERROR", progName, "connection to database \"%s\" failed : %s",
 						  PQdb(pConn), PQerrorMessage(pConn));
+		PQfinish(pConn);
 		return (NULL);
 	}
 

--- a/src/bin/psql/print.c
+++ b/src/bin/psql/print.c
@@ -2456,16 +2456,24 @@ setDecimalLocale(void)
 
 	extlconv = localeconv();
 
+	/* Don't accept an empty decimal_point string */
 	if (*extlconv->decimal_point)
 		decimal_point = pg_strdup(extlconv->decimal_point);
 	else
 		decimal_point = ".";	/* SQL output standard */
 
-	if (*extlconv->grouping && atoi(extlconv->grouping) > 0)
-		groupdigits = atoi(extlconv->grouping);
-	else
+	/*
+	 * Although the Open Group standard allows locales to supply more than one
+	 * group width, we consider only the first one, and we ignore any attempt
+	 * to suppress grouping by specifying CHAR_MAX.  As in the backend's
+	 * cash.c, we must apply a range check to avoid being fooled by variant
+	 * CHAR_MAX values.
+	 */
+	groupdigits = *extlconv->grouping;
+	if (groupdigits <= 0 || groupdigits > 6)
 		groupdigits = 3;		/* most common */
 
+	/* Don't accept an empty thousands_sep string, either */
 	/* similar code exists in formatting.c */
 	if (*extlconv->thousands_sep)
 		thousands_sep = pg_strdup(extlconv->thousands_sep);

--- a/src/bin/psql/print.c
+++ b/src/bin/psql/print.c
@@ -40,8 +40,9 @@
  */
 volatile bool cancel_pressed = false;
 
+/* info for locale-aware numeric formatting; set up by setDecimalLocale() */
 static char *decimal_point;
-static char *grouping;
+static int	groupdigits;
 static char *thousands_sep;
 
 /* Line style control structures */
@@ -154,42 +155,33 @@ pg_local_calloc(int count, size_t size)
 	return tmp;
 }
 
+/* Count number of digits in integral part of number */
 static int
 integer_digits(const char *my_str)
 {
-	int			frac_len;
-
-	if (my_str[0] == '-')
+	/* ignoring any sign ... */
+	if (my_str[0] == '-' || my_str[0] == '+')
 		my_str++;
-
-	frac_len = strchr(my_str, '.') ? strlen(strchr(my_str, '.')) : 0;
-
-	return strlen(my_str) - frac_len;
+	/* ... count initial integral digits */
+	return strspn(my_str, "0123456789");
 }
 
-/* Return additional length required for locale-aware numeric output */
+/* Compute additional length required for locale-aware numeric output */
 static int
 additional_numeric_locale_len(const char *my_str)
 {
 	int			int_len = integer_digits(my_str),
 				len = 0;
-	int			groupdigits = atoi(grouping);
 
-	if (int_len > 0)
-		/* Don't count a leading separator */
-		len = (int_len / groupdigits - (int_len % groupdigits == 0)) *
-			strlen(thousands_sep);
+	/* Account for added thousands_sep instances */
+	if (int_len > groupdigits)
+		len += ((int_len - 1) / groupdigits) * strlen(thousands_sep);
 
+	/* Account for possible additional length of decimal_point */
 	if (strchr(my_str, '.') != NULL)
-		len += strlen(decimal_point) - strlen(".");
+		len += strlen(decimal_point) - 1;
 
 	return len;
-}
-
-static int
-strlen_with_numeric_locale(const char *my_str)
-{
-	return strlen(my_str) + additional_numeric_locale_len(my_str);
 }
 
 /*
@@ -199,54 +191,48 @@ strlen_with_numeric_locale(const char *my_str)
 static char *
 format_numeric_locale(const char *my_str)
 {
+	int			new_len = strlen(my_str) + additional_numeric_locale_len(my_str);
+	char	   *new_str = pg_local_malloc(new_len + 1);
+	int			int_len = integer_digits(my_str);
 	int			i,
-				j,
-				int_len = integer_digits(my_str),
 				leading_digits;
-	int			groupdigits = atoi(grouping);
-	int			new_str_start = 0;
-	char	   *new_str = new_str = pg_local_malloc(
-									 strlen_with_numeric_locale(my_str) + 1);
+	int			new_str_pos = 0;
 
-	leading_digits = (int_len % groupdigits != 0) ?
-		int_len % groupdigits : groupdigits;
+	/* number of digits in first thousands group */
+	leading_digits = int_len % groupdigits;
+	if (leading_digits == 0)
+		leading_digits = groupdigits;
 
-	if (my_str[0] == '-')		/* skip over sign, affects grouping
-								 * calculations */
+	/* process sign */
+	if (my_str[0] == '-' || my_str[0] == '+')
 	{
-		new_str[0] = my_str[0];
+		new_str[new_str_pos++] = my_str[0];
 		my_str++;
-		new_str_start = 1;
 	}
 
-	for (i = 0, j = new_str_start;; i++, j++)
+	/* process integer part of number */
+	for (i = 0; i < int_len; i++)
 	{
-		/* Hit decimal point? */
-		if (my_str[i] == '.')
+		/* Time to insert separator? */
+		if (i > 0 && --leading_digits == 0)
 		{
-			strcpy(&new_str[j], decimal_point);
-			j += strlen(decimal_point);
-			/* add fractional part */
-			strcpy(&new_str[j], &my_str[i] + 1);
-			break;
+			strcpy(&new_str[new_str_pos], thousands_sep);
+			new_str_pos += strlen(thousands_sep);
+			leading_digits = groupdigits;
 		}
-
-		/* End of string? */
-		if (my_str[i] == '\0')
-		{
-			new_str[j] = '\0';
-			break;
-		}
-
-		/* Add separator? */
-		if (i != 0 && (i - leading_digits) % groupdigits == 0)
-		{
-			strcpy(&new_str[j], thousands_sep);
-			j += strlen(thousands_sep);
-		}
-
-		new_str[j] = my_str[i];
+		new_str[new_str_pos++] = my_str[i];
 	}
+
+	/* handle decimal point if any */
+	if (my_str[i] == '.')
+	{
+		strcpy(&new_str[new_str_pos], decimal_point);
+		new_str_pos += strlen(decimal_point);
+		i++;
+	}
+
+	/* copy the rest (fractional digits and/or exponent, and \0 terminator) */
+	strcpy(&new_str[new_str_pos], &my_str[i]);
 
 	return new_str;
 }
@@ -2474,10 +2460,11 @@ setDecimalLocale(void)
 		decimal_point = pg_strdup(extlconv->decimal_point);
 	else
 		decimal_point = ".";	/* SQL output standard */
+
 	if (*extlconv->grouping && atoi(extlconv->grouping) > 0)
-		grouping = pg_strdup(extlconv->grouping);
+		groupdigits = atoi(extlconv->grouping);
 	else
-		grouping = "3";			/* most common */
+		groupdigits = 3;		/* most common */
 
 	/* similar code exists in formatting.c */
 	if (*extlconv->thousands_sep)


### PR DESCRIPTION
This is a bit of grab-bag of misc patches to fix various defects highlighted by Coverity scans. Most of these are quite benign and uninteresting but there are some which potentially could've caused a crash or two. The most interesting one to me the potential buffer overflow on user input in a55ac6490eeaf325fe7d375d46c619fac112e289.

Whenever the issue is in upstream code, the resolving commit has either been cherry-picked or been manually merged with the original commit message referenced.