### PR TITLE
Call ereport when code generating float operators

### DIFF
--- a/src/backend/codegen/include/codegen/pg_arith_func_generator.h
+++ b/src/backend/codegen/include/codegen/pg_arith_func_generator.h
@@ -22,6 +22,10 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Value.h"
 
+extern "C" {
+#include "utils/elog.h"
+}
+
 namespace gpcodegen {
 
 /** \addtogroup gpcodegen
@@ -96,12 +100,10 @@ class PGArithFuncGenerator {
   static bool MulWithOverflow(gpcodegen::GpCodegenUtils* codegen_utils,
                               const PGFuncGeneratorInfo& pg_func_info,
                                llvm::Value** llvm_out_value) {
-    llvm::Value* llvm_err_msg = codegen_utils->GetConstant(
-        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg());
     return ArithOpWithOverflow(
         codegen_utils,
         &gpcodegen::GpCodegenUtils::CreateMulOverflow<rtype>,
-        llvm_err_msg,
+        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg(),
         pg_func_info,
         llvm_out_value);
   }
@@ -123,12 +125,10 @@ class PGArithFuncGenerator {
   static bool AddWithOverflow(gpcodegen::GpCodegenUtils* codegen_utils,
                               const PGFuncGeneratorInfo& pg_func_info,
                               llvm::Value** llvm_out_value) {
-    llvm::Value* llvm_err_msg = codegen_utils->GetConstant(
-        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg());
     return ArithOpWithOverflow(
         codegen_utils,
         &gpcodegen::GpCodegenUtils::CreateAddOverflow<rtype>,
-        llvm_err_msg,
+        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg(),
         pg_func_info,
         llvm_out_value);
   }
@@ -293,19 +293,17 @@ class PGArithFuncGenerator {
   static bool SubWithOverflow(gpcodegen::GpCodegenUtils* codegen_utils,
                               const PGFuncGeneratorInfo& pg_func_info,
                               llvm::Value** llvm_out_value) {
-    llvm::Value* llvm_err_msg = codegen_utils->GetConstant(
-        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg());
     return ArithOpWithOverflow(
         codegen_utils,
         &gpcodegen::GpCodegenUtils::CreateSubOverflow<rtype>,
-        llvm_err_msg,
+        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg(),
         pg_func_info,
         llvm_out_value);
   }
 
   static bool ArithOpWithOverflow(gpcodegen::GpCodegenUtils* codegen_utils,
                                   CGArithOpFunc codegen_mem_funcptr,
-                                  llvm::Value* llvm_error_msg,
+                                  const char* error_msg,
                                   const PGFuncGeneratorInfo& pg_func_info,
                                   llvm::Value** llvm_out_value);
 };
@@ -341,19 +339,17 @@ class PGArithUnaryFuncGenerator {
   static bool IncWithOverflow(gpcodegen::GpCodegenUtils* codegen_utils,
                               const PGFuncGeneratorInfo& pg_func_info,
                               llvm::Value** llvm_out_value) {
-    llvm::Value* llvm_err_msg = codegen_utils->GetConstant(
-        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg());
     return PGArithUnaryFuncGenerator<rtype, Arg>::ArithOpWithOverflow(
         codegen_utils,
         &gpcodegen::GpCodegenUtils::CreateIncOverflow<rtype>,
-        llvm_err_msg,
+        ArithOpOverFlowErrorMsg<rtype>::OverFlowErrMsg(),
         pg_func_info,
         llvm_out_value);
   }
 
   static bool ArithOpWithOverflow(gpcodegen::GpCodegenUtils* codegen_utils,
                                    CGArithOpFunc codegen_mem_funcptr,
-                                   llvm::Value* llvm_error_msg,
+                                   const char* error_msg,
                                    const PGFuncGeneratorInfo& pg_func_info,
                                    llvm::Value** llvm_out_value);
 };
@@ -366,7 +362,7 @@ class PGArithUnaryFuncGenerator {
  * @param codegen_utils     Utility for easy code generation.
  * @param pg_func_info      Details for pgfunc generation
  * @param llvm_arith_output Result of the arithmetic operation
- * @param llvm_error_msg    Error message to use when overflow occurs
+ * @param error_msg         Error message to use when overflow occurs
  * @param llvm_out_value    Store location for the result
  *
  * @return true if generation was successful otherwise return false
@@ -378,11 +374,11 @@ static bool CreateOverflowCheckLogic(
     gpcodegen::GpCodegenUtils* codegen_utils,
     const PGFuncGeneratorInfo& pg_func_info,
     llvm::Value* llvm_arith_output,
-    llvm::Value* llvm_error_msg,
+    const char* error_msg,
     llvm::Value** llvm_out_value) {
   assert(nullptr != codegen_utils);
   assert(nullptr != llvm_arith_output);
-  assert(nullptr != llvm_error_msg);
+  assert(nullptr != error_msg);
 
   llvm::IRBuilder<>* irb = codegen_utils->ir_builder();
 
@@ -399,9 +395,10 @@ static bool CreateOverflowCheckLogic(
                     llvm_non_overflow_block);
 
   irb->SetInsertPoint(llvm_overflow_block);
-  EXPAND_CREATE_ELOG(codegen_utils,
-      ERROR,
-      "%s", llvm_error_msg);
+  EXPAND_CREATE_EREPORT(codegen_utils,
+                        ERROR,
+                        ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE,
+                        error_msg);
   irb->CreateBr(pg_func_info.llvm_error_block);
 
   irb->SetInsertPoint(llvm_non_overflow_block);
@@ -413,13 +410,13 @@ template <typename rtype, typename Arg>
 bool PGArithUnaryFuncGenerator<rtype, Arg>::ArithOpWithOverflow(
     gpcodegen::GpCodegenUtils* codegen_utils,
     CGArithOpFunc codegen_mem_funcptr,
-    llvm::Value* llvm_error_msg,
+    const char* error_msg,
     const PGFuncGeneratorInfo& pg_func_info,
     llvm::Value** llvm_out_value) {
   assert(nullptr != codegen_utils);
   assert(nullptr != llvm_out_value);
   assert(nullptr != codegen_mem_funcptr);
-  assert(nullptr != llvm_error_msg);
+  assert(nullptr != error_msg);
 
   // Assumed caller checked vector size and nullptr for codegen_utils
   llvm::Value* casted_arg =
@@ -431,7 +428,7 @@ bool PGArithUnaryFuncGenerator<rtype, Arg>::ArithOpWithOverflow(
   return CreateOverflowCheckLogic<rtype>(codegen_utils,
                                          pg_func_info,
                                          llvm_arith_output,
-                                         llvm_error_msg,
+                                         error_msg,
                                          llvm_out_value);
 }
 
@@ -440,13 +437,13 @@ template <typename rtype, typename Arg0, typename Arg1>
 bool PGArithFuncGenerator<rtype, Arg0, Arg1>::ArithOpWithOverflow(
     gpcodegen::GpCodegenUtils* codegen_utils,
     CGArithOpFunc codegen_mem_funcptr,
-    llvm::Value* llvm_error_msg,
+    const char* error_msg,
     const PGFuncGeneratorInfo& pg_func_info,
     llvm::Value** llvm_out_value) {
   assert(nullptr != codegen_utils);
   assert(nullptr != llvm_out_value);
   assert(nullptr != codegen_mem_funcptr);
-  assert(nullptr != llvm_error_msg);
+  assert(nullptr != error_msg);
 
   // Assumed caller checked vector size and nullptr for codegen_utils
   llvm::Value* casted_arg0 =
@@ -460,7 +457,7 @@ bool PGArithFuncGenerator<rtype, Arg0, Arg1>::ArithOpWithOverflow(
   return CreateOverflowCheckLogic<rtype>(codegen_utils,
                                          pg_func_info,
                                          llvm_arith_output,
-                                         llvm_error_msg,
+                                         error_msg,
                                          llvm_out_value);
 }
 

--- a/src/backend/codegen/pg_date_func_generator.cc
+++ b/src/backend/codegen/pg_date_func_generator.cc
@@ -73,8 +73,6 @@ llvm::Value* PGDateFuncGenerator::GenerateDate2Timestamp(
           GetConstant<int64_t>(USECS_PER_DAY);
 
   llvm::Value* llvm_out_value = nullptr;
-  llvm::Value* llvm_err_msg = codegen_utils->GetConstant(
-      "date out of range for timestamp");
   PGFuncGeneratorInfo pg_timestamp_func_info(
       pg_func_info.llvm_main_func,
       pg_func_info.llvm_error_block,
@@ -84,7 +82,7 @@ llvm::Value* PGDateFuncGenerator::GenerateDate2Timestamp(
   PGArithFuncGenerator<int64_t, int32_t, int64_t>::ArithOpWithOverflow(
       codegen_utils,
       &gpcodegen::GpCodegenUtils::CreateMulOverflow<int64_t>,
-      llvm_err_msg,
+      "date out of range for timestamp",
       pg_timestamp_func_info,
       &llvm_out_value);
 


### PR DESCRIPTION
This fixes a failures in ICG that printed line numbers because we used
elog earlier. Part of this commit is a refector that uses const char*
instead of llvm::Value* for passing the correct error message

@foyzur @karthijrk @armenatzoglou Please take a look.