### PR TITLE
Fix to print port/replication port number, when there is a conflict while adding mirrors

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -463,8 +463,8 @@ class GpMirrorListToBuild:
                 port = segment.getSegmentPort()
                 dbid = segment.getSegmentDbId()
                 if port in usedPorts:
-                    raise Exception("On host %s, a port for segment with dbid %s conflicts with a port for segment dbid %s" \
-                            % (hostName, dbid, usedPorts.get(port)))
+                    raise Exception("On host %s, port %s for segment with dbid %s conflicts with port for segment dbid %s" \
+                            % (hostName, port, dbid, usedPorts.get(port)))
 
                 if segment.isSegmentQE():
                     if replicationPort is None:
@@ -472,8 +472,8 @@ class GpMirrorListToBuild:
                                 % (hostName, dbid))
 
                     if replicationPort in usedPorts:
-                        raise Exception("On host %s, a port for segment with dbid %s conflicts with a port for segment dbid %s" \
-                                % (hostName, dbid, usedPorts.get(replicationPort)))
+                        raise Exception("On host %s, replication port %s for segment with dbid %s conflicts with a port for segment dbid %s" \
+                                % (hostName, dbid, replicationPort, usedPorts.get(replicationPort)))
 
                     if port == replicationPort:
                         raise Exception("On host %s, segment with dbid %s has equal port and replication port" \


### PR DESCRIPTION
While adding mirrors through gpaddmirrors utility, if there is a port conflict gpdb prints messages in the following format:

'On host gpdb8.dev.com, a port for segment with dbid xx conflicts with a port for segment dbid xx'

The current message is same for both normal and replication ports. It doesn't print which port number conflicts. Although port number can be derived by the mapping back dbid to content id but it will be easier for end user to directly trace back to type and number of port.

This pull request addresses this problem.