### PR TITLE
More Coverity fixes

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9838,8 +9838,8 @@ xlog_desc(StringInfo buf, XLogRecPtr beginLoc, XLogRecord *record)
 										record->xl_len,
 										&beginLoc,
 										/* errlevel */ -1,	// Suppress elog altogether on master mirroring checkpoint length checking.
-										&tablespaceCount,
 										&filespaceCount,
+										&tablespaceCount,
 										&databaseCount))
 
 				{

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -496,6 +496,7 @@ processCopyEndResults(CdbCopy *c,
 			else if (PQresultStatus(res) == PGRES_COPY_OUT)
 			{
 				char	   *buffer = NULL;
+				int			ret;
 
 				elog(LOG, "Segment still in copy out, canceling QE");
 				/*
@@ -509,10 +510,31 @@ processCopyEndResults(CdbCopy *c,
 				 */
 				PQrequestCancel(q->conn);
 
-				/* Need to consume data from QE until he recognizes cancel. */
-				PQgetCopyData(q->conn, &buffer, false);
-				if (buffer)
-					free(buffer);
+				/*
+				 * Need to consume data from the QE until cancellation is
+				 * recognized. PQgetCopyData() returns -1 when the COPY is
+				 * done, a non-zero result indicates data was returned and
+				 * in that case we'll drop it immediately since we aren't
+				 * interested in the contents.
+				 */
+				while ((ret = PQgetCopyData(q->conn, &buffer, false)) != -1)
+				{
+					if (ret > 0)
+					{
+						if (buffer)
+							PQfreemem(buffer);
+						continue;
+					}
+
+					/* An error occurred, log the error and break out */
+					if (ret == -2)
+					{
+						ereport(WARNING,
+								(errmsg("Error during cancellation: \"%s\"",
+								PQerrorMessage(q->conn))));
+						break;
+					}
+				}
 			}
 
 			/* in SREH mode, check if this seg rejected (how many) rows */

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2268,7 +2268,9 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand, int flags,
 
 	for (i = 0; i < resultCount; i++)
 		PQclear(results[i]);
-	free(results);
+
+	if (results)
+		free(results);
 
 	return (numOfFailed == 0);
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -82,7 +82,7 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	CdbDispatcherState ds = {NULL, NULL, NULL};
 
 	CdbDispatchResults* pr = NULL;
-	CdbPgResults cdb_pgresults;
+	CdbPgResults cdb_pgresults = {NULL, 0};
 
 	DispatchCommandDtxProtocolParms dtxProtocolParms;
 	Gang *primaryGang;

--- a/src/backend/gp_libpq_fe/fe-protocol3.c
+++ b/src/backend/gp_libpq_fe/fe-protocol3.c
@@ -243,7 +243,8 @@ pqParseInput3(PGconn *conn)
 						if (!conn->result)
 							return;
 					}
-					strncpy(conn->result->cmdStatus, conn->workBuffer.data, CMDSTATUS_LEN);
+					strlcpy(conn->result->cmdStatus, conn->workBuffer.data,
+							CMDSTATUS_LEN);
 					conn->asyncStatus = PGASYNC_READY;
 
 					break;
@@ -504,9 +505,8 @@ pqParseInput3(PGconn *conn)
 						if (!conn->result)
 							return;
 					}
-					strncpy(conn->result->cmdStatus, conn->workBuffer.data,
+					strlcpy(conn->result->cmdStatus, conn->workBuffer.data,
 							CMDSTATUS_LEN);
-					
 					
 					if (pqGetInt(&conn->result->extraslen, 4, conn))
 						return;

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1001,10 +1001,16 @@ OpenNamedFile(const char   *fileName,
 	char		tempfilepath[MAXPGPATH];
 	File		file;
 	int			fileFlags;
+	size_t		len;
 
 	ResourceOwnerEnlargeFiles(CurrentResourceOwner);
 
-	strncpy(tempfilepath, fileName, sizeof(tempfilepath));
+	len = strlcpy(tempfilepath, fileName, sizeof(tempfilepath));
+	if (len >= sizeof(tempfilepath))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				errmsg("requested filename too long, %lu characters, max is %d",
+				len, MAXPGPATH)));
 
 	/*
 	 * Open the file.  Note: we don't use O_EXCL, in case there is an orphaned

--- a/src/backend/utils/workfile_manager/workfile_mgr_test.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr_test.c
@@ -195,7 +195,7 @@ cacheEltPopulate(const void *resource, const void *param)
 	TestCacheElt *elt = (TestCacheElt *) resource;
 	TestPopParam *eltInfo = (TestPopParam *) param;
 
-	strncpy(elt->key, eltInfo->key, TEST_NAME_LENGTH);
+	strlcpy(elt->key, eltInfo->key, sizeof(elt->key));
 	elt->data = eltInfo->data;
 }
 
@@ -265,7 +265,7 @@ cache_test_acquire(void)
 	elog(LOG, "Running sub-test: CacheAcquireEntry");
 
 	TestPopParam param;
-	strncpy(param.key, "Test Key 1", TEST_NAME_LENGTH);
+	strlcpy(param.key, "Test Key 1", sizeof(param.key));
 	param.data = 4567;
 
 	CacheEntry *entry = Cache_AcquireEntry(cache, &param);
@@ -293,7 +293,7 @@ cache_test_insert()
 	elog(LOG, "Running sub-test: CacheAcquireEntry");
 
 	TestPopParam param;
-	strncpy(param.key, "Test Key 2", TEST_NAME_LENGTH);
+	strlcpy(param.key, "Test Key 2", sizeof(param.key));
 	param.data = 1111;
 
 	CacheEntry *entry = Cache_AcquireEntry(cache, &param);
@@ -308,7 +308,7 @@ cache_test_insert()
 	/* Look-up test */
 	elog(LOG, "Running sub-test: CacheLookup");
 
-	strncpy(param.key, "Test Key 2", TEST_NAME_LENGTH);
+	strlcpy(param.key, "Test Key 2", sizeof(param.key));
 	param.data = 1111;
 	CacheEntry *localEntry = Cache_AcquireEntry(cache, &param);
 
@@ -332,21 +332,21 @@ cache_test_remove(void)
 
 	/* Insert one entry */
 	TestPopParam param;
-	strncpy(param.key, testKey, TEST_NAME_LENGTH);
+	strlcpy(param.key, testKey, sizeof(param.key));
 	param.data = 1111;
 	CacheEntry *entry1 = Cache_AcquireEntry(cache, &param);
 	Cache_Insert(cache, entry1);
 	Cache_Release(cache, entry1);
 
 	/* Insert another entry */
-	strncpy(param.key, testKey, TEST_NAME_LENGTH);
+	strlcpy(param.key, testKey, sizeof(param.key));
 	param.data = 2222;
 	CacheEntry *entry2 = Cache_AcquireEntry(cache, &param);
 	Cache_Insert(cache, entry2);
 	Cache_Release(cache, entry2);
 
 	/* Look-up and remove an entry */
-	strncpy(param.key, testKey, TEST_NAME_LENGTH);
+	strlcpy(param.key, testKey, sizeof(param.key));
 	param.data = 2222;
 	CacheEntry *localEntry = Cache_AcquireEntry(cache, &param);
 
@@ -393,7 +393,7 @@ cache_test_concurrency(void)
 			/* snprintf(key, TEST_NAME_LENGTH, "PID=%d cache key no. %d", MyProcPid, i); */
 			snprintf(key, TEST_NAME_LENGTH, "cache key no. %d", i);
 
-			strncpy(param.key, key, TEST_NAME_LENGTH);
+			strlcpy(param.key, key, sizeof(param.key));
 			param.data = MyProcPid;
 
 			entries[i] = Cache_AcquireEntry(cache, &param);
@@ -419,7 +419,7 @@ cache_test_concurrency(void)
 		{
 			//snprintf(key, TEST_NAME_LENGTH, "PID=%d cache key no. %d", MyProcPid, i);
 			snprintf(key, TEST_NAME_LENGTH, "cache key no. %d", i);
-			strncpy(param.key, key, TEST_NAME_LENGTH);
+			strlcpy(param.key, key, sizeof(param.key));
 			param.data = MyProcPid;
 
 			CacheEntry *localEntry = Cache_AcquireEntry(cache, &param);
@@ -452,7 +452,7 @@ cache_test_concurrency(void)
 		{
 			//snprintf(key, TEST_NAME_LENGTH, "PID=%d cache key no. %d", MyProcPid, i);
 			snprintf(key, TEST_NAME_LENGTH, "cache key no. %d", i);
-			strncpy(param.key, key, TEST_NAME_LENGTH);
+			strlcpy(param.key, key, sizeof(param.key));
 			param.data = MyProcPid;
 
 			CacheEntry *localEntry = Cache_AcquireEntry(cache, &param);

--- a/src/backend/utils/workfile_manager/workfile_segmentspace.c
+++ b/src/backend/utils/workfile_manager/workfile_segmentspace.c
@@ -82,24 +82,13 @@ WorkfileSegspace_Reserve(int64 bytes_to_reserve)
 	{
 		return true;
 	}
-	else
-	{
-		/* We exceeded the logical limit. Revert the reserved space */
-		(void) pg_atomic_sub_fetch_u64(used_segspace, bytes_to_reserve);
 
-		workfileError = WORKFILE_ERROR_LIMIT_PER_SEGMENT;
+	/* We exceeded the logical limit. Revert the reserved space */
+	(void) pg_atomic_sub_fetch_u64(used_segspace, bytes_to_reserve);
 
-		/* Set diskfull to true to stop any further attempts to write more data */
-		WorkfileDiskspace_SetFull(true /* isFull */);
-		return false;
-	}
+	workfileError = WORKFILE_ERROR_LIMIT_PER_SEGMENT;
 
-
-	/*
-	 * We exceeded max_eviction_attempts and did not manage to reserve.
-	 * Set diskfull to true to stop any further attempts to write more data
-	 * and notify the caller.
-	 */
+	/* Set diskfull to true to stop any further attempts to write more data */
 	WorkfileDiskspace_SetFull(true /* isFull */);
 	return false;
 }

--- a/src/bin/pg_dump/cdb/cdb_dump.c
+++ b/src/bin/pg_dump/cdb/cdb_dump.c
@@ -1641,7 +1641,13 @@ reportBackupResults(InputOptions inputopts, ThreadParmArray *pParmAr)
 	SegmentDatabase *pSegDB;
 	ThreadParm *p;
 
-	if (pParmAr == NULL || pParmAr->count == 0)
+	if (pParmAr == NULL)
+	{
+		mpp_err_msg(logError, progname, "Report data missing\n");
+		return 2;
+	}
+
+	if (pParmAr->count == 0)
 	{
 		pParmAr->count = 1;		/* just use master in this case (early error) */
 		pParmAr->pData = (ThreadParm *) calloc(1, sizeof(ThreadParm));

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -8232,12 +8232,14 @@ formGenericFilePathName(char *keyword, char *pszBackupDirectory, char *pszBackup
 	{
 		mpp_err_msg(logWarn, progname, "Backup catalog FileName based on path %s and key %s too long",
 					pszBackupDirectory, pszBackupKey);
+		exit_nicely();
 	}
 
 	pszBackupFileName = (char *) malloc(sizeof(char) * (1 + len));
 	if (pszBackupFileName == NULL)
 	{
 		mpp_err_msg(logError, progname, "out of memory");
+		exit_nicely();
 	}
 
 	strcpy(pszBackupFileName, pszBackupDirectory);


### PR DESCRIPTION
This adds more defensive programming to handle potential errors that aren't terribly likely to begin with, but belts are very stylish when combined with suspenders. The aim is to pass Coverity analysis with only false positives ignored.

The interesting commit is 554be08066ba8aa4be9ab042d59bde79d166bdc8, I haven't been able to reproduce a case where a single `PQgetCopyData()` doesn't drain but it doesn't seem safe to assume it can't happen.