### PR TITLE
Speedup test case for an ancient bitmap index bug.

### DIFF
--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -3329,13 +3329,20 @@ group by 1, 2;
 drop table qp_misc_jiras.foo_6325;
 drop table qp_misc_jiras.bar_6325;
 -- end_ignore
-create table qp_misc_jiras.abc_tbl8621 (a int, b int) with (appendonly=true, orientation=column) distributed by (a);
-create index abc_idx on qp_misc_jiras.abc_tbl8621 using bitmap(b);
-insert into qp_misc_jiras.abc_tbl8621 select 1, i from generate_series(1,100000)i;
-insert into qp_misc_jiras.abc_tbl8621 select 1, i from generate_series(1,100000)i;
--- start_ignore
-DROP TABLE qp_misc_jiras.abc_tbl8621;
--- end_ignore
+-- Test for an old bug in extending a heap relation beyond RELSEG_SIZE (1 GB).
+-- The insert failed with an error:
+--   could not open segment 1 of relation ...: No such file or directory
+create table qp_misc_jiras.heap_tbl8621 (a int) with (fillfactor=10) distributed by (a);
+insert into qp_misc_jiras.heap_tbl8621 select 1 from generate_series(1, 3100000);
+-- Verify that the table really was larger than 1 GB. Otherwise we wouldn't
+-- test the segment boundary.
+select pg_relation_size('qp_misc_jiras.heap_tbl8621') > 1100000000 as over_1gb;
+ over_1gb 
+----------
+ t
+(1 row)
+
+DROP TABLE qp_misc_jiras.heap_tbl8621;
 CREATE TABLE qp_misc_jiras.tbl8860_1 (
      id INTEGER NOT NULL,
      key TEXT NOT NULL

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -3352,13 +3352,20 @@ group by 1, 2;
 drop table qp_misc_jiras.foo_6325;
 drop table qp_misc_jiras.bar_6325;
 -- end_ignore
-create table qp_misc_jiras.abc_tbl8621 (a int, b int) with (appendonly=true, orientation=column) distributed by (a);
-create index abc_idx on qp_misc_jiras.abc_tbl8621 using bitmap(b);
-insert into qp_misc_jiras.abc_tbl8621 select 1, i from generate_series(1,100000)i;
-insert into qp_misc_jiras.abc_tbl8621 select 1, i from generate_series(1,100000)i;
--- start_ignore
-DROP TABLE qp_misc_jiras.abc_tbl8621;
--- end_ignore
+-- Test for an old bug in extending a heap relation beyond RELSEG_SIZE (1 GB).
+-- The insert failed with an error:
+--   could not open segment 1 of relation ...: No such file or directory
+create table qp_misc_jiras.heap_tbl8621 (a int) with (fillfactor=10) distributed by (a);
+insert into qp_misc_jiras.heap_tbl8621 select 1 from generate_series(1, 3100000);
+-- Verify that the table really was larger than 1 GB. Otherwise we wouldn't
+-- test the segment boundary.
+select pg_relation_size('qp_misc_jiras.heap_tbl8621') > 1100000000 as over_1gb;
+ over_1gb 
+----------
+ t
+(1 row)
+
+DROP TABLE qp_misc_jiras.heap_tbl8621;
 CREATE TABLE qp_misc_jiras.tbl8860_1 (
      id INTEGER NOT NULL,
      key TEXT NOT NULL


### PR DESCRIPTION
Although I wasn't able to easily reproduce the original issue, I belive we
don't need to insert that many rows to test this. I added some DEBUG lines
to the code that this runs, and I don't think we do anything differently
as the table grows larger and larger, it's just more of the same.

Before this change, the test index is bloated to over 3 GB in size. With this,
"only" about 700 MB. That greatly reduces the load during testing.