### PR TITLE
Re-enable leastsquares test.

### DIFF
--- a/src/test/regress/expected/leastsquares.out
+++ b/src/test/regress/expected/leastsquares.out
@@ -18,7 +18,7 @@
 -- s|Failed on request of size \d+ bytes|Failed on request of size BIGALLOC bytes|
 --
 -- m/(ERROR|WARNING|CONTEXT|NOTICE):.*\(float\.c\:\d+\)/
--- s/user\.c\:\d+/float.c:DUMMY/
+-- s/\(float\.c:\d+\)//
 --
 -- end_matchsubs
 CREATE TABLE weibull
@@ -586,29 +586,29 @@ select float8_mregr_combine('{0}'::float8[], '{0}'::float8[]);
 (1 row)
 
 select float8_regr_accum('{}'::float8[], 1, 2);
-ERROR:  float8_regr_accum: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_accum: expected 6-element float8 array
 select float8_regr_amalg('{}'::float8[], array[0,0,0,0,0,0]);
-ERROR:  float8_regr_amalg: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_amalg: expected 6-element float8 array
 select float8_regr_amalg(array[0,0,0,0,0,0], '{}'::float8[]);
-ERROR:  float8_regr_amalg: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_amalg: expected 6-element float8 array
 select float8_regr_amalg(array[null,0,0,0,0,0], '{}'::float8[]);
-ERROR:  float8_regr_amalg: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_amalg: expected 6-element float8 array
 select float8_regr_sxx('{}'::float8[]);
-ERROR:  float8_regr_sxx: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_sxx: expected 6-element float8 array
 select float8_regr_syy('{}'::float8[]);
-ERROR:  float8_regr_syy: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_syy: expected 6-element float8 array
 select float8_regr_sxy('{}'::float8[]);
-ERROR:  float8_regr_sxy: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_sxy: expected 6-element float8 array
 select float8_regr_avgx('{}'::float8[]);
-ERROR:  float8_regr_avgx: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_avgx: expected 6-element float8 array
 select float8_regr_avgy('{}'::float8[]);
-ERROR:  float8_regr_avgy: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_avgy: expected 6-element float8 array
 select float8_regr_slope('{}'::float8[]);
-ERROR:  float8_regr_slope: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_slope: expected 6-element float8 array
 select float8_regr_r2('{}'::float8[]);
-ERROR:  float8_regr_r2: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_r2: expected 6-element float8 array
 select float8_regr_intercept('{}'::float8[]);
-ERROR:  float8_regr_intercept: expected 6-element float8 array (float.c:1892)
+ERROR:  float8_regr_intercept: expected 6-element float8 array
 select float8_mregr_accum('{}'::float8[], 1, array[1,null]);
 ERROR:  transition function "float8_mregr_accum(double precision[],double precision,double precision[])" called with invalid parameters
 select float8_mregr_accum('{}'::float8[], 1, array[1,2]);

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -21,7 +21,7 @@ test: variadic_parameters default_parameters
 # 'zlib' utilizes fault injectors so it needs to be in a group by itself
 test: zlib
 
-ignore: leastsquares
+test: leastsquares
 test: opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy gp_create_table
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var
 test: bitmap_index gp_dump_query_oids

--- a/src/test/regress/sql/leastsquares.sql
+++ b/src/test/regress/sql/leastsquares.sql
@@ -17,6 +17,10 @@
 -- start_matchsubs
 -- m|Failed on request of size \d+ bytes|
 -- s|Failed on request of size \d+ bytes|Failed on request of size BIGALLOC bytes|
+--
+-- m/(ERROR|WARNING|CONTEXT|NOTICE):.*\(float\.c\:\d+\)/
+-- s/\(float\.c:\d+\)//
+--
 -- end_matchsubs
 
 CREATE TABLE weibull


### PR DESCRIPTION
It was disabled back in 2011, with a commit that merely said:

> Temporarily disable leastsquares -- it's causing grief on 64 bit platforms.

I have no idea what the grief was, but presumably it's been fixed since.
And if it hasn't, we want to find out.