### PR TITLE
Add default value for master port in gppkg.

### DIFF
--- a/gpMgmt/bin/gppylib/programs/gppkg.py
+++ b/gpMgmt/bin/gppylib/programs/gppkg.py
@@ -166,7 +166,7 @@ class GpPkgProgram:
        
         logger.debug('_get_master_port')
         pgconf_dict = pgconf.readfile(os.path.join(datadir, 'postgresql.conf'))
-        return pgconf_dict.int('port')
+        return pgconf_dict.int('port') or os.getenv('PGPORT', 5432)
 
     def run(self):
         if self.build:


### PR DESCRIPTION
I had a long debugging session trying to figure out why I couldn't install any packages using gppkg. I found that I had commented out the port option in my postgresql.conf-file, meaning that nothing was returned from the configuration file parser. This fixes the issue.