### PR TITLE
Speed up qp_misc_jiras test case.

### DIFF
--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -2130,8 +2130,6 @@ insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_tabl
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
-insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
-insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 set gp_enable_agg_distinct_pruning  = off;
 select count(distinct i), count(distinct j) from qp_misc_jiras.tbl6535_table;
  count | count 
@@ -2158,10 +2156,11 @@ ERROR:  canceling statement due to statement timeout
 drop table statement_timeout_test;
 reset statement_timeout;
 set gp_autostats_mode=none;
+-- Test for an old bug with ANALYZE (analyze code has been rewritten since).
 create table qp_misc_jiras.tbl_6934(x inet);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_misc_jiras.tbl_6934 select (i%200 || '.' || i%11 || '.' || i%11 || '.' || i%100)::inet from generate_series(1,4000000) i;
+insert into qp_misc_jiras.tbl_6934 select (i%200 || '.' || i%11 || '.' || i%11 || '.' || i%100)::inet from generate_series(1,40000) i;
 analyze qp_misc_jiras.tbl_6934; 
 drop table qp_misc_jiras.tbl_6934;
 create table qp_misc_jiras.tbl7286_test (i int, d date);
@@ -3855,38 +3854,31 @@ select  * from qp_misc_jiras.test_co where ctid='(33554432,32769)' and gp_segmen
  0 | 0
 (1 row)
 
--- start_ignore
--- This is to verify MPP-10856: test gp_enable_explain_allstat 
--- end_ignore
+-- This is to verify MPP-10856: test gp_enable_explain_allstat
 set gp_enable_explain_allstat=on;
-create table qp_misc_jiras.test_tbl10856 (i int, j int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_misc_jiras.test_tbl10856 select i, i from generate_series(0, 999999) i;
-explain analyze select count(*) from qp_misc_jiras.test_tbl10856;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=4316.91..4316.92 rows=1 width=8)
-   Rows out:  1 rows with 70 ms to end, start offset by 0.190 ms.
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=4316.84..4316.89 rows=1 width=8)
-         Rows out:  3 rows at destination with 69 ms to first row, 70 ms to end, start offset by 0.190 ms.
-         ->  Aggregate  (cost=4316.84..4316.85 rows=1 width=8)
-               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 70 ms to end, start offset by 0.432 ms.
-               allstat: seg_firststart_total_ntuples/seg0_0.432 ms_70 ms_1/seg1_0.431 ms_68 ms_1/seg2_0.431 ms_68 ms_1//end
-               ->  Seq Scan on test_tbl10856  (cost=0.00..3526.87 rows=105329 width=0)
-                     Rows out:  Avg 333333.3 rows x 3 workers.  Max 333384 rows (seg2) with 0.027 ms to first row, 36 ms to end, start offset by 0.431 ms.
-                     allstat: seg_firststart_total_ntuples/seg0_0.432 ms_34 ms_333357/seg1_0.431 ms_33 ms_333259/seg2_0.431 ms_36 ms_333384//end
+insert into qp_misc_jiras.test_heap select i, i from generate_series(0, 99999) i;
+explain analyze select count(*) from qp_misc_jiras.test_heap;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=1176.32..1176.33 rows=1 width=8)
+   Rows out:  1 rows with 16 ms to end, start offset by 0.333 ms.
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1176.25..1176.30 rows=1 width=8)
+         Rows out:  3 rows at destination with 16 ms to end, start offset by 0.334 ms.
+         ->  Aggregate  (cost=1176.25..1176.26 rows=1 width=8)
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 15 ms to end, start offset by 0.621 ms.
+               allstat: seg_firststart_total_ntuples/seg0_0.621 ms_15 ms_1/seg1_0.621 ms_15 ms_1/seg2_0.634 ms_15 ms_1//end
+               ->  Seq Scan on test_heap  (cost=0.00..961.00 rows=28700 width=0)
+                     Rows out:  Avg 33333.7 rows x 3 workers.  Max 33350 rows (seg0) with 0.035 ms to first row, 7.878 ms to end, start offset by 0.622 ms.
+                     allstat: seg_firststart_total_ntuples/seg0_0.622 ms_7.878 ms_33350/seg1_0.622 ms_7.850 ms_33336/seg2_0.634 ms_7.866 ms_33315//end
  Slice statistics:
-   (slice0)    Executor memory: 159K bytes.
+   (slice0)    Executor memory: 382K bytes.
    (slice1)    Executor memory: 163K bytes avg x 3 workers, 163K bytes max (seg0).
  Statement statistics:
    Memory used: 128000K bytes
- Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=off; optimizer_segments=3
- Optimizer status: legacy query optimizer
- Total runtime: 70.739 ms
-(18 rows)
+ Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer_segments=3
+ Total runtime: 15.974 ms
+(17 rows)
 
-drop table if exists qp_misc_jiras.test_tbl10856;
 -- start_ignore
 -- This is to verify MPP-8946
 -- ramans2 : Modifying queries to add filter on schema name to remove diffs in multi-node cdbfast runs

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -2124,8 +2124,6 @@ insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_tabl
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
-insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
-insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 set gp_enable_agg_distinct_pruning  = off;
 select count(distinct i), count(distinct j) from qp_misc_jiras.tbl6535_table;
  count | count 
@@ -2152,10 +2150,11 @@ ERROR:  canceling statement due to statement timeout
 drop table statement_timeout_test;
 reset statement_timeout;
 set gp_autostats_mode=none;
+-- Test for an old bug with ANALYZE (analyze code has been rewritten since).
 create table qp_misc_jiras.tbl_6934(x inet);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_misc_jiras.tbl_6934 select (i%200 || '.' || i%11 || '.' || i%11 || '.' || i%100)::inet from generate_series(1,4000000) i;
+insert into qp_misc_jiras.tbl_6934 select (i%200 || '.' || i%11 || '.' || i%11 || '.' || i%100)::inet from generate_series(1,40000) i;
 analyze qp_misc_jiras.tbl_6934; 
 drop table qp_misc_jiras.tbl_6934;
 create table qp_misc_jiras.tbl7286_test (i int, d date);
@@ -3883,38 +3882,32 @@ select  * from qp_misc_jiras.test_co where ctid='(33554432,32769)' and gp_segmen
  0 | 0
 (1 row)
 
--- start_ignore
--- This is to verify MPP-10856: test gp_enable_explain_allstat 
--- end_ignore
+-- This is to verify MPP-10856: test gp_enable_explain_allstat
 set gp_enable_explain_allstat=on;
-create table qp_misc_jiras.test_tbl10856 (i int, j int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_misc_jiras.test_tbl10856 select i, i from generate_series(0, 999999) i;
-explain analyze select count(*) from qp_misc_jiras.test_tbl10856;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
+insert into qp_misc_jiras.test_heap select i, i from generate_series(0, 99999) i;
+explain analyze select count(*) from qp_misc_jiras.test_heap;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   Rows out:  1 rows with 52 ms to end, start offset by 0.192 ms.
+   Rows out:  1 rows with 10 ms to end, start offset by 0.342 ms.
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-         Rows out:  3 rows at destination with 50 ms to first row, 52 ms to end, start offset by 0.193 ms.
+         Rows out:  3 rows at destination with 10 ms to end, start offset by 0.343 ms.
          ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 51 ms to end, start offset by 0.470 ms.
-               allstat: seg_firststart_total_ntuples/seg0_0.470 ms_51 ms_1/seg1_0.461 ms_50 ms_1/seg2_0.461 ms_51 ms_1//end
-               ->  Table Scan on test_tbl10856  (cost=0.00..431.00 rows=1 width=1)
-                     Rows out:  Avg 333333.3 rows x 3 workers.  Max 333384 rows (seg2) with 0.029 ms to first row, 25 ms to end, start offset by 0.462 ms.
-                     allstat: seg_firststart_total_ntuples/seg0_0.470 ms_26 ms_333357/seg1_0.462 ms_25 ms_333259/seg2_0.462 ms_25 ms_333384//end
+               Rows out:  Avg 1.0 rows x 3 workers.  Max 1 rows (seg0) with 10 ms to end, start offset by 0.638 ms.
+               allstat: seg_firststart_total_ntuples/seg0_0.638 ms_10 ms_1/seg1_0.636 ms_10 ms_1/seg2_0.637 ms_10 ms_1//end
+               ->  Table Scan on test_heap  (cost=0.00..431.00 rows=1 width=1)
+                     Rows out:  Avg 33333.7 rows x 3 workers.  Max 33350 rows (seg0) with 0.039 ms to first row, 5.346 ms to end, start offset by 0.638 ms.
+                     allstat: seg_firststart_total_ntuples/seg0_0.638 ms_5.346 ms_33350/seg1_0.636 ms_5.368 ms_33336/seg2_0.637 ms_5.264 ms_33315//end
  Slice statistics:
-   (slice0)    Executor memory: 159K bytes.
+   (slice0)    Executor memory: 382K bytes.
    (slice1)    Executor memory: 163K bytes avg x 3 workers, 163K bytes max (seg0).
  Statement statistics:
    Memory used: 128000K bytes
  Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
- Optimizer status: PQO version 1.624
- Total runtime: 51.892 ms
+ Optimizer status: PQO version 1.684
+ Total runtime: 10.892 ms
 (18 rows)
 
-drop table if exists qp_misc_jiras.test_tbl10856;
 -- start_ignore
 -- This is to verify MPP-8946
 -- ramans2 : Modifying queries to add filter on schema name to remove diffs in multi-node cdbfast runs

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -1281,9 +1281,8 @@ select count(*) from qp_misc_jiras.tbl7161_co;
 insert into qp_misc_jiras.tbl7161_co (a, b) select i, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' || i from generate_series(0, 4) i;
 select count(*) from qp_misc_jiras.tbl7161_co;
 drop table qp_misc_jiras.tbl7161_co;
+
 select i, j into qp_misc_jiras.tbl6535_table from generate_series(1, 200) i, generate_series(1, 201) j;
-insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
-insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
 insert into qp_misc_jiras.tbl6535_table select * from qp_misc_jiras.tbl6535_table ;
@@ -1294,6 +1293,7 @@ select count(distinct i), count(distinct j) from qp_misc_jiras.tbl6535_table;
 set gp_enable_agg_distinct = off;
 select count(distinct i), count(distinct j) from qp_misc_jiras.tbl6535_table;
 drop table qp_misc_jiras.tbl6535_table;
+
 create table statement_timeout_test(a int, b int);
 insert into statement_timeout_test select i,i+1 from generate_series(1,10000)i;
 prepare prestmt as select * from statement_timeout_test s1, statement_timeout_test s2, statement_timeout_test s3, statement_timeout_test s4, statement_timeout_test s5;
@@ -1302,10 +1302,13 @@ execute prestmt; -- should get cancelled automatically
 drop table statement_timeout_test;
 reset statement_timeout;
 set gp_autostats_mode=none;
+
+-- Test for an old bug with ANALYZE (analyze code has been rewritten since).
 create table qp_misc_jiras.tbl_6934(x inet);
-insert into qp_misc_jiras.tbl_6934 select (i%200 || '.' || i%11 || '.' || i%11 || '.' || i%100)::inet from generate_series(1,4000000) i;
+insert into qp_misc_jiras.tbl_6934 select (i%200 || '.' || i%11 || '.' || i%11 || '.' || i%100)::inet from generate_series(1,40000) i;
 analyze qp_misc_jiras.tbl_6934; 
 drop table qp_misc_jiras.tbl_6934;
+
 create table qp_misc_jiras.tbl7286_test (i int, d date);
 insert into qp_misc_jiras.tbl7286_test select i%10, '2009/01/01'::date + (i || ' days')::interval from generate_series(0, 99999) i;
 
@@ -2379,15 +2382,11 @@ create table qp_misc_jiras.test_co (i int, j int) with (appendonly=true, orienta
 insert into qp_misc_jiras.test_co values (0, 0);
 explain select  * from qp_misc_jiras.test_co where ctid='(33554432,32769)' and gp_segment_id >= 0;
 select  * from qp_misc_jiras.test_co where ctid='(33554432,32769)' and gp_segment_id >= 0;
--- start_ignore
--- This is to verify MPP-10856: test gp_enable_explain_allstat 
--- end_ignore
 
+-- This is to verify MPP-10856: test gp_enable_explain_allstat
 set gp_enable_explain_allstat=on;
-create table qp_misc_jiras.test_tbl10856 (i int, j int);
-insert into qp_misc_jiras.test_tbl10856 select i, i from generate_series(0, 999999) i;
-explain analyze select count(*) from qp_misc_jiras.test_tbl10856;
-drop table if exists qp_misc_jiras.test_tbl10856;
+insert into qp_misc_jiras.test_heap select i, i from generate_series(0, 99999) i;
+explain analyze select count(*) from qp_misc_jiras.test_heap;
 
 -- start_ignore
 -- This is to verify MPP-8946


### PR DESCRIPTION
Use smaller test tables for tests that are not sensitive to the size of
the table.