### PR TITLE
Modified partition attribute check to ignore column ordinality.

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/drop_and_readd_column.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/drop_and_readd_column.sql
@@ -1,3 +1,3 @@
 -- partition table
-ALTER TABLE employee DROP COLUMN gender;
-ALTER TABLE employee ADD COLUMN gender char(1);
+ALTER TABLE sales DROP COLUMN trans_id;
+ALTER TABLE sales ADD COLUMN trans_id int;

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/insert_into_sales_columns_reordered.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/insert_into_sales_columns_reordered.sql
@@ -1,0 +1,1 @@
+insert into sales values('2011-01-01', 10.1, 'asia', 1);

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/one_level_range_prt_1_different_prt_column.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/one_level_range_prt_1_different_prt_column.sql
@@ -1,0 +1,8 @@
+-- range partition type, column key: id
+DROP TABLE IF EXISTS employee;
+CREATE TABLE employee(id int, rank int, gender char(1))
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (rank)
+( START (1) INCLUSIVE
+  END (3) EXCLUSIVE
+  EVERY (1) );

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -360,8 +360,8 @@ class GpTransfer(GpTestCase):
         with open(SOURCE_MAP_FILENAME, "w") as src_map_file:
             src_map_file.write("sdw1,12700\nsdw2,12700")
         INPUT_FILENAME = "/tmp/gptransfer_test"
-        with open(INPUT_FILENAME, "w") as src_map_file:
-            src_map_file.write("my_first_database.public.my_table")
+        with open(INPUT_FILENAME, "w") as input_file:
+            input_file.write("my_first_database.public.my_table")
         self.cursor.side_effect = CursorSideEffect().cursor_side_effect
         self.db_singleton.side_effect = SingletonSideEffect().singleton_side_effect
         options = {}

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -3640,7 +3640,7 @@ class GpTransfer(object):
 
     def _has_same_column_types(self, table_pair):
         """
-        Columns at the same ordinal_position of two partition tables need to be of same type
+        Columns at the same position of two partition tables need to be of same type
         """
         src_tbl_columns = self._get_table_columns(table_pair.source, self._options.source_host, self._options.source_port, self._options.source_user)
         dest_tbl_columns = self._get_table_columns(table_pair.dest, self._options.dest_host, self._options.dest_port, self._options.dest_user)
@@ -3772,6 +3772,21 @@ class GpTransfer(object):
                                                                  self._options.dest_host,
                                                                  self._options.dest_port,
                                                                  self._options.dest_user)
+
+        source_ordinal_positions = self._get_ordinal_positions_list(table_pair.source.database,
+                                                                 table_pair.source.schema,
+                                                                 table_pair.source.table,
+                                                                 self._options.source_host,
+                                                                 self._options.source_port,
+                                                                 self._options.source_user)
+
+        dest_ordinal_positions = self._get_ordinal_positions_list(table_pair.dest.database,
+                                                                 table_pair.dest.schema,
+                                                                 table_pair.dest.table,
+                                                                 self._options.dest_host,
+                                                                 self._options.dest_port,
+                                                                 self._options.dest_user)
+
         for level_key in source_partition_column_info:
             if source_partition_column_info[level_key]['parkind'] != dest_partition_column_info[level_key]['parkind']:
                 logger.error('Partition type is different at level %s between %s' % (level_key, source_dest_info))
@@ -3780,14 +3795,40 @@ class GpTransfer(object):
                 logger.error('Number of partition columns is different at level %s between %s' % (level_key, source_dest_info))
                 return False
 
-            # this handles multi column partition, sort them before compare, in case same partition columns but in random order
-            source_paratts = [att.strip() for att in source_partition_column_info[level_key]['paratts'].split(' ')]
-            dest_paratts = [att.strip() for att in dest_partition_column_info[level_key]['paratts'].split(' ')]
-            if sorted(source_paratts) != sorted(dest_paratts):
+            if not self._has_same_paratts(table_pair,
+                                     source_partition_column_info[level_key]['paratts'],
+                                     dest_partition_column_info[level_key]['paratts'],
+                                     source_ordinal_positions,
+                                     dest_ordinal_positions):
                 logger.error('Partition column attributes are different at level %s between %s' %
                             (level_key, source_dest_info))
                 return False
         return True
+
+    def _has_same_paratts(self, table_pair, source_paratts_str, dest_paratts_str, source_ordinal_positions, dest_ordinal_positions):
+        # this handles multi column partitions by sorting them before comparison, in case same partition columns are in random order
+        # we compare the index of the column within the list of ordinal positions to account for cases where
+        # actual ordinal positions may not match, but the order of the columns is the same (i.e. dropping and re-adding)
+        source_paratts = [int(att.strip()) for att in source_paratts_str.split(' ')]
+        dest_paratts = [int(att.strip()) for att in dest_paratts_str.split(' ')]
+
+        source_and_dest_paratts = zip(sorted(source_paratts), sorted(dest_paratts))
+        for source_paratt, dest_paratt in source_and_dest_paratts:
+            if source_ordinal_positions.index(source_paratt) != dest_ordinal_positions.index(dest_paratt):
+                return False
+        return True
+
+    def _get_ordinal_positions_list(self, db, schema, table, host, port, user):
+        ordinal_positions_list = []
+        ordinal_pos_sql = ''' select ordinal_position from information_schema.columns
+                              where table_schema = '%s' and table_name = '%s'
+                              order by ordinal_position ''' % (pg.escape_string(schema), pg.escape_string(table))
+        with dbconn.connect(dbconn.DbURL(host, port, db, user)) as conn:
+            cursor = execSQL(conn, ordinal_pos_sql)
+            for row in cursor:
+                ordinal_positions_list.append(row[0])
+
+        return ordinal_positions_list
 
     def _get_partition_column_info(self, db, schema, table, host, port, user):
         level_partition_info = defaultdict(dict)


### PR DESCRIPTION
Previously gptransfer compared attribute numbers of the partition columns
to determine if two partition tables had the same structure. However, if a
column located before the partition columns was dropped and re-added on the source
system and then a dump was taken of that table and used to create a table with
the same structure on the destination system, the two tables would have differing
partition column attributes due to the order of column creation on the source
system, and the transfer would fail.

We have modified this check to compare the positions of the partition columns
within the table instead of just looking at the attribute numbers so that
the above scenario can now run successfully.

Authors: Karen Huddleston and Jamie McAtamney