### PR TITLE
Create dtx context if it's destroyed in the loop of exec_simple_query

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1700,6 +1700,13 @@ exec_simple_query(const char *query_string, const char *seqServerHost, int seqSe
 					 errmsg("current transaction is aborted, "
 						"commands ignored until end of transaction block")));
 
+		/*
+		 * If the last statement in the parsetree is 'COMMIT', the dtx context
+		 * is already destroyed, and the transaction context is set to 'DTX_CONTEXT_LOCAL_ONLY'
+		 */
+		if (Gp_role == GP_ROLE_DISPATCH)
+			setupRegularDtxContext();
+
 		/* Make sure we are in a transaction command */
 		start_xact_command();
 

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -346,3 +346,8 @@ close c1;
 end;
 drop table if exists dtmcurse_foo;
 drop table if exists dtmcurse_bar;
+-- Test distribute transaction if 'COMMIT/END' is included in a multi-queries command.
+\! psql postgres -c "begin;end; create table dtx_test1(c1 int); drop table dtx_test1;"
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+DROP TABLE

--- a/src/test/regress/sql/distributed_transactions.sql
+++ b/src/test/regress/sql/distributed_transactions.sql
@@ -279,3 +279,6 @@ end;
 
 drop table if exists dtmcurse_foo;
 drop table if exists dtmcurse_bar;
+
+-- Test distribute transaction if 'COMMIT/END' is included in a multi-queries command.
+\! psql postgres -c "begin;end; create table dtx_test1(c1 int); drop table dtx_test1;"


### PR DESCRIPTION
When parse tree contains multiple queries and there's a 'COMMIT' in the
middle, the dtx context will be destroyed, and the subsequent queries that
require distributed transaction will fail.

Signed-off-by: Pengzhou Tang <ptang@pivotal.io>