### PR TITLE
Fix printing of 'ok's in initdb.

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -2215,9 +2215,9 @@ setup_cdb_schema(void)
 				 "\"%s\" %s template1 >%s",
 				 backend_exec, backend_options,
 				 backend_output);
-
-		check_ok();
 	}
+
+	check_ok();
 }
 
 /*


### PR DESCRIPTION
We used to printed an "ok" after loading each SQL script from the
cdb_init.d directory. However, we only printed one "creating Greenplum
Database schema ..." line. That leads to funny output:

```
creating information schema ... ok
creating Greenplum Database schema ... ok
ok
ok
vacuuming database template1 ... ok
copying template1 to template0 ... ok
copying template1 to postgres ... ok
```

To fix, only print one "ok", after loading all the scripts from cdb_init.d.