### PR TITLE
Fix the vagrant files so they work

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -65,7 +65,11 @@ pygresql:
 	fi
 
 	mkdir -p $(PYLIB_DIR)/pygresql
-	cp -r $(PYLIB_SRC)/$(PYGRESQL_DIR)/build/lib.*/* $(PYLIB_DIR)/pygresql
+	if [ `uname -s` = 'Darwin' ]; then \
+	  cp -r $(PYLIB_SRC)/$(PYGRESQL_DIR)/build/lib.macosx*/* $(PYLIB_DIR)/pygresql; \
+	else \
+	  cp -r $(PYLIB_SRC)/$(PYGRESQL_DIR)/build/lib.linux*/* $(PYLIB_DIR)/pygresql; \
+	fi
 	touch $(PYLIB_DIR)/__init__.py
 
 #

--- a/src/tools/vagrant/centos/Vagrantfile
+++ b/src/tools/vagrant/centos/Vagrantfile
@@ -15,6 +15,7 @@ Vagrant.configure(2) do |config|
     vb.memory = 8192
     vb.cpus = 4
     vb.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on"]
+    vb.customize ['modifyvm', :id, '--cableconnected1', 'on']
   end
 
   if File.file?('vagrant-local.yml')

--- a/src/tools/vagrant/debian/Vagrantfile
+++ b/src/tools/vagrant/debian/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure("2") do |config|
 
     # Assign additional cores to the guest OS.
     v.customize ["modifyvm", :id, "--cpus", cpu_count]
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
     v.customize ["modifyvm", :id, "--ioapic", "on"]
 
     # This setting makes it so that network access from inside the vagrant guest

--- a/src/tools/vagrant/debian/vagrant-build.sh
+++ b/src/tools/vagrant/debian/vagrant-build.sh
@@ -1,9 +1,12 @@
 cd /gpdb
+
+sudo mkdir /usr/local/gpdb
+sudo chown vagrant:vagrant /usr/local/gpdb
 ./configure --enable-debug --with-python --with-perl --enable-mapreduce --with-libxml --prefix=/usr/local/gpdb
 
 make clean
 make -j 4
-sudo make install
+make install
 
 cd /gpdb/gpAux
 cp -rp gpdemo /home/vagrant/


### PR DESCRIPTION
The gpMgmt Makefile was copying over the libraries without regard to the OS,
 if you had versions built using vagrant that were not
compatible with your OS this would fail

Throttle the vagrants to 50%

Build gpdb on debian as the vagrant user. The root user will fail
to change the uid/gid on the nfs mount