### PR TITLE
Fix gpfdist regression tests

### DIFF
--- a/src/bin/gpfdist/regress/input/custom_format.source
+++ b/src/bin/gpfdist/regress/input/custom_format.source
@@ -7,7 +7,7 @@
 -- --------------------------------------
 set optimizer_disable_missing_stats_collection = on;
 CREATE EXTERNAL WEB TABLE gpfdist_status (x text)
-execute E'( python @bindir@/gppinggpfdist.py @hostname@:7575 2>&1 || echo) '
+execute E'( python @bindir@/lib/gppinggpfdist.py @hostname@:7575 2>&1 || echo) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -76,7 +76,7 @@ select * from check_env;
 -- --------------------------------------
 
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_status (x text)
-execute E'( python @bindir@/gppinggpfdist.py @hostname@:7070 2>&1 || echo) '
+execute E'( python @bindir@/lib/gppinggpfdist.py @hostname@:7070 2>&1 || echo) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/bin/gpfdist/regress/output/custom_format.source
+++ b/src/bin/gpfdist/regress/output/custom_format.source
@@ -6,7 +6,7 @@
 -- --------------------------------------
 set optimizer_disable_missing_stats_collection = on;
 CREATE EXTERNAL WEB TABLE gpfdist_status (x text)
-execute E'( python @bindir@/gppinggpfdist.py @hostname@:7575 2>&1 || echo) '
+execute E'( python @bindir@/lib/gppinggpfdist.py @hostname@:7575 2>&1 || echo) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_start (x text)

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -127,7 +127,7 @@ select * from check_env;
 -- 'gpfdist' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_status (x text)
-execute E'( python @bindir@/gppinggpfdist.py @hostname@:7070 2>&1 || echo) '
+execute E'( python @bindir@/lib/gppinggpfdist.py @hostname@:7070 2>&1 || echo) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_start (x text)

--- a/src/bin/gpfdist/regress/output/exttab1_optimizer.source
+++ b/src/bin/gpfdist/regress/output/exttab1_optimizer.source
@@ -127,7 +127,7 @@ select * from check_env;
 -- 'gpfdist' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_status (x text)
-execute E'( python @bindir@/gppinggpfdist.py @hostname@:7070 2>&1 || echo) '
+execute E'( python @bindir@/lib/gppinggpfdist.py @hostname@:7070 2>&1 || echo) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_start (x text)


### PR DESCRIPTION
The gppinggpfdist.py file is located in $GPHOME/bin/lib. This was
unnoticed because the status check is under ignore blocks.