### PR TITLE
gpcheckcat should not check for AO segidxid

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2137,7 +2137,6 @@ def checkOwners():
     from gp_dist_random('pg_class') r
       join pg_class c on (c.oid = r.oid)
       left join pg_appendonly ao on (c.oid = ao.segrelid or
-                                     c.oid = ao.segidxid or
                                      c.oid = ao.blkdirrelid or
                                      c.oid = ao.blkdiridxid)
       left join pg_class t on (t.reltoastidxid = c.oid)


### PR DESCRIPTION
The segidxid column is no longer available.  It was removed in
https://github.com/greenplum-db/gpdb/commit/6580341ab62242f72738bfa865a690fcda4b5dee.

All unit tests in gpMgmt/bin/gppylib/test/unit pass.