### PR TITLE
Don't report drop errors during postdata restore.

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/backup.feature
@@ -414,6 +414,8 @@ Feature: Validate command line arguments
         And there is a "heap" table "public.heap_table" in "bkdb" with data
         And there is a "ao" partition table "public.ao_part_table" in "bkdb" with data
         And there is a backupfile of tables "public.heap_table, public.ao_part_table" in "bkdb" exists for validation
+        And the user runs "psql -f gppylib/test/behave/mgmt_utils/steps/data/add_rules_indexes_constraints_triggers.sql bkdb"
+        Then psql should return a return code of 0
         When the user runs "gpcrondump -a -x bkdb"
         Then gpcrondump should return a return code of 0
         And the timestamp from gpcrondump is stored
@@ -442,6 +444,15 @@ Feature: Validate command line arguments
         And gpdbrestore should return a return code of 0
         And verify that there is a "heap" table "public.heap_table" in "bkdb" with data
         And verify that there is a "ao" table "public.ao_part_table" in "bkdb" with data
+        And verify that the "report" file in " " dir does not contain "ERROR"
+        And verify that the "status" file in " " dir does not contain "ERROR"
+        And verify that there is a constraint "check_constraint_no_domain" in "bkdb"
+        And verify that there is a constraint "check_constraint_with_domain" in "bkdb"
+        And verify that there is a constraint "unique_constraint" in "bkdb"
+        And verify that there is a constraint "foreign_key" in "bkdb"
+        And verify that there is a rule "myrule" in "bkdb"
+        And verify that there is a trigger "mytrigger" in "bkdb"
+        And verify that there is an index "my_unique_index" in "bkdb"
 
     Scenario: Metadata-only restore
         Given the test is initialized

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/add_rules_indexes_constraints_triggers.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/add_rules_indexes_constraints_triggers.sql
@@ -1,0 +1,51 @@
+-- create various rules, constraints, indexes, domains
+
+drop table if exists mytable;
+drop table if exists mytable2;
+drop table if exists mytable3;
+drop table if exists mytable4;
+drop table if exists us_snail_addy;
+drop domain if exists us_postal_code;
+create table mytable (i int, s varchar);
+create table mytable2 (i int);
+create table mytable3 (i int PRIMARY KEY);
+create table mytable4 (i int UNIQUE);
+
+
+CREATE DOMAIN us_postal_code AS TEXT
+CHECK(
+   VALUE ~ '^\\d{5}$'
+);
+
+CREATE TABLE us_snail_addy (
+  s varchar,
+  address_id SERIAL,
+  postal us_postal_code NOT NULL
+);
+
+
+CREATE OR REPLACE RULE myrule AS
+  ON UPDATE TO mytable             -- another similar rule for DELETE
+  DO INSTEAD NOTHING;
+
+create or replace function do_nothing () returns trigger as
+$$
+begin
+return new;
+end;
+$$ language plpgsql;
+
+
+
+CREATE TRIGGER mytrigger
+    BEFORE UPDATE ON mytable
+    EXECUTE PROCEDURE do_nothing();
+
+CREATE UNIQUE INDEX my_unique_index ON mytable (i);
+
+-- Constraints
+ALTER TABLE mytable ADD CONSTRAINT check_constraint_no_domain CHECK (char_length(s) < 30);
+ALTER TABLE us_snail_addy ADD CONSTRAINT check_constraint_with_domain CHECK (char_length(s) < 30);
+ALTER TABLE us_snail_addy ADD PRIMARY KEY (address_id);
+ALTER TABLE mytable2 add CONSTRAINT unique_constraint UNIQUE (i);
+ALTER TABLE mytable3 ADD CONSTRAINT foreign_key FOREIGN KEY (i) REFERENCES mytable4 (i) MATCH FULL;

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -866,6 +866,21 @@ def impl(context, conname, dbname):
     if not check_constraint_exists(context, dbname=dbname, conname=conname):
         raise Exception("Constraint '%s' does not exist when it should" % conname)
 
+@then('verify that there is a rule "{rulename}" in "{dbname}"')
+def impl(context, rulename, dbname):
+    if not check_rule_exists(context, dbname=dbname, rulename=rulename):
+        raise Exception("Rule '%s' does not exist when it should" % rulename)
+
+@then('verify that there is a trigger "{triggername}" in "{dbname}"')
+def impl(context, triggername, dbname):
+    if not check_trigger_exists(context, dbname=dbname, triggername=triggername):
+        raise Exception("Trigger '%s' does not exist when it should" % triggername)
+
+@then('verify that there is an index "{indexname}" in "{dbname}"')
+def impl(context, indexname, dbname):
+    if not check_index_exists(context, dbname=dbname, indexname=indexname):
+        raise Exception("Index '%s' does not exist when it should" % indexname)
+
 @then('verify that there is a "{table_type}" table "{tablename}" in "{dbname}"')
 def impl(context, table_type, tablename, dbname):
     if not check_table_exists(context, dbname=dbname, table_name=tablename,table_type=table_type):

--- a/gpMgmt/bin/gppylib/test/behave_utils/utils.py
+++ b/gpMgmt/bin/gppylib/test/behave_utils/utils.py
@@ -395,10 +395,23 @@ def check_pl_exists(context, dbname, lan_name):
 
 def check_constraint_exists(context, dbname, conname):
     SQL = """select count(*) from pg_constraint where conname='%s';""" % conname
-    con_count = getRows(dbname, SQL)[0][0]
-    if con_count == 0:
-        return False
-    return True
+    constraint_count = getRows(dbname, SQL)[0][0]
+    return constraint_count != 0
+
+def check_rule_exists(context, dbname, rulename):
+    SQL = """select count(*) from pg_rules where rulename='%s';""" % rulename
+    rule_count = getRows(dbname, SQL)[0][0]
+    return rule_count != 0
+
+def check_trigger_exists(context, dbname, triggername):
+    SQL = """select count(*) from pg_trigger where tgname='%s';""" % triggername
+    trigger_count = getRows(dbname, SQL)[0][0]
+    return trigger_count != 0
+
+def check_index_exists(context, dbname, indexname):
+    SQL = """select count(*) from pg_class where relkind='i' and relname='%s';""" % indexname
+    index_count = getRows(dbname, SQL)[0][0]
+    return index_count != 0
 
 def drop_external_table_if_exists(context, table_name, dbname):
     if check_table_exists(context, table_name=table_name, dbname=dbname, table_type='external'):

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -3381,7 +3381,7 @@ dumpProcLang(Archive *fout, ProcLangInfo *plang)
 	{
 		appendPQExpBuffer(defqry, " HANDLER %s",
 						  fmtId(funcInfo->dobj.name));
-	
+
 		if (OidIsValid(plang->laninline))
 		{
 			appendPQExpBuffer(defqry, " INLINE ");
@@ -6960,7 +6960,7 @@ dumpIndex(Archive *fout, IndxInfo *indxinfo)
 		 * DROP must be fully qualified in case same name appears in
 		 * pg_catalog
 		 */
-		appendPQExpBuffer(delq, "DROP INDEX %s.",
+		appendPQExpBuffer(delq, "DROP INDEX IF EXISTS %s.",
 						  fmtId(tbinfo->dobj.namespace->dobj.name));
 		appendPQExpBuffer(delq, "%s;\n",
 						  fmtId(indxinfo->dobj.name));
@@ -7061,11 +7061,11 @@ dumpConstraint(Archive *fout, ConstraintInfo *coninfo)
 		 * DROP must be fully qualified in case same name appears in
 		 * pg_catalog
 		 */
-		appendPQExpBuffer(delq, "ALTER TABLE ONLY %s.",
+		appendPQExpBuffer(delq, "select pg_temp.drop_table_constraint_only_if_exists('%s',",
 						  fmtId(tbinfo->dobj.namespace->dobj.name));
-		appendPQExpBuffer(delq, "%s ",
+		appendPQExpBuffer(delq, " '%s',",
 						  fmtId(tbinfo->dobj.name));
-		appendPQExpBuffer(delq, "DROP CONSTRAINT %s;\n",
+		appendPQExpBuffer(delq, " '%s');\n",
 						  fmtId(coninfo->dobj.name));
 
 		ArchiveEntry(fout, coninfo->dobj.catId, coninfo->dobj.dumpId,
@@ -7093,11 +7093,11 @@ dumpConstraint(Archive *fout, ConstraintInfo *coninfo)
 		 * DROP must be fully qualified in case same name appears in
 		 * pg_catalog
 		 */
-		appendPQExpBuffer(delq, "ALTER TABLE ONLY %s.",
+		appendPQExpBuffer(delq, "select pg_temp.drop_table_constraint_only_if_exists('%s',",
 						  fmtId(tbinfo->dobj.namespace->dobj.name));
-		appendPQExpBuffer(delq, "%s ",
+		appendPQExpBuffer(delq, " '%s',",
 						  fmtId(tbinfo->dobj.name));
-		appendPQExpBuffer(delq, "DROP CONSTRAINT %s;\n",
+		appendPQExpBuffer(delq, " '%s');\n",
 						  fmtId(coninfo->dobj.name));
 
 		ArchiveEntry(fout, coninfo->dobj.catId, coninfo->dobj.dumpId,
@@ -7430,7 +7430,7 @@ dumpTrigger(Archive *fout, TriggerInfo *tginfo)
 	/*
 	 * DROP must be fully qualified in case same name appears in pg_catalog
 	 */
-	appendPQExpBuffer(delqry, "DROP TRIGGER %s ",
+	appendPQExpBuffer(delqry, "DROP TRIGGER IF EXISTS %s ",
 					  fmtId(tginfo->dobj.name));
 	appendPQExpBuffer(delqry, "ON %s.",
 					  fmtId(tbinfo->dobj.namespace->dobj.name));
@@ -7635,7 +7635,7 @@ dumpRule(Archive *fout, RuleInfo *rinfo)
 	/*
 	 * DROP must be fully qualified in case same name appears in pg_catalog
 	 */
-	appendPQExpBuffer(delcmd, "DROP RULE %s ",
+	appendPQExpBuffer(delcmd, "DROP RULE IF EXISTS %s ",
 					  fmtId(rinfo->dobj.name));
 	appendPQExpBuffer(delcmd, "ON %s.",
 					  fmtId(tbinfo->dobj.namespace->dobj.name));


### PR DESCRIPTION
When performing a dump, the postdata file contains DROP statements that will report an error if the relation already exists. This is misleading since the restore will say that errors have occurred during restore, even though the DB is still in the expected state. For most cases we simply could use the `DROP IF EXISTS` syntax; however, the `DROP CONSTRAINT IF EXISTS` syntax isn't available until postgres 9.0 so we create a temporary procedure to perform this action.

- Replaces DROP statements with DROP IF EXISTS for supported postdata reltypes
- Temporarily adds and uses a function that mimics the behavior of DROP CONSTRAINT IF EXISTS, since this feature is not available in Postgres 8.2

Authors: Chris Hajas, Larry Hamel, Stephen Wu