### PR TITLE
Reporting workfile spilling in explain analyze for non-mk sort

### DIFF
--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -1293,6 +1293,12 @@ puttuple_common(Tuplesortstate *state, SortTuple *tuple)
 			 * Dump tuples until we are back under the limit.
 			 */
 			dumptuples(state, false);
+
+			if (state->instrument)
+			{
+				state->instrument->workfileCreated = true;
+			}
+
 			break;
 
 		case TSS_BOUNDED:

--- a/src/test/regress/expected/runtime_stats.out
+++ b/src/test/regress/expected/runtime_stats.out
@@ -3,7 +3,6 @@
 --
 -- Examines if run-time statistics are correct.
 --
-create language plpythonu;
 -- Returns 1 if workfiles are spilled during query execution; 0 otherwise.
 create or replace function isSpilling(explain_query text) returns int as
 $$

--- a/src/test/regress/expected/runtime_stats.out
+++ b/src/test/regress/expected/runtime_stats.out
@@ -1,0 +1,38 @@
+--
+-- Test runtime_stats 
+--
+-- Examines if run-time statistics are correct.
+--
+create language plpythonu;
+-- Returns 1 if workfiles are spilled during query execution; 0 otherwise.
+create or replace function isSpilling(explain_query text) returns int as
+$$
+rv = plpy.execute(explain_query)
+search_text = 'Workfile: ('
+result = 0
+for i in range(len(rv)):
+   cur_line = rv[i]['QUERY PLAN']
+   if search_text.lower() in cur_line.lower():
+      str_trim = cur_line.split('Workfile: (')
+      str_trim = str_trim[1].split(' spilling')
+      if int(str_trim[0]) > 0:
+         result = 1
+return result
+$$
+language plpythonu;
+-- Force Sort operator to spill workfiles and examine if stats are correct
+drop table if exists testsort; 
+NOTICE:  table "testsort" does not exist, skipping
+create table testsort (i1 int, i2 int, i3 int, i4 int); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into testsort select i, i % 1000, i % 100000, i % 75 from generate_series(0,199999) i; 
+set statement_mem="5MB";
+set gp_resqueue_print_operator_memory_limits=on;
+set gp_enable_mk_sort=off; 
+select isSpilling('explain analyze select i1,i2 from testsort order by i2'); 
+ isspilling 
+------------
+          1
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -80,7 +80,7 @@ test: resource_queue
 # vacuum from removing dead tuples.
 test: gp_toolkit
 
-test: filespace trig auth_constraint role rle portals_updatable plpgsql_cache timeseries resource_queue_function pg_stat_last_operation gp_numeric_agg partindex_test direct_dispatch partition_pruning_with_fn dsp
+test: filespace trig auth_constraint role rle portals_updatable plpgsql_cache timeseries resource_queue_function pg_stat_last_operation gp_numeric_agg partindex_test direct_dispatch partition_pruning_with_fn dsp runtime_stats
 
 # direct dispatch tests
 test: bfv_dd bfv_dd_multicolumn bfv_dd_types

--- a/src/test/regress/sql/runtime_stats.sql
+++ b/src/test/regress/sql/runtime_stats.sql
@@ -1,0 +1,35 @@
+--
+-- Test runtime_stats 
+--
+-- Examines if run-time statistics are correct.
+--
+
+create language plpythonu;
+-- Returns 1 if workfiles are spilled during query execution; 0 otherwise.
+create or replace function isSpilling(explain_query text) returns int as
+$$
+rv = plpy.execute(explain_query)
+search_text = 'Workfile: ('
+result = 0
+for i in range(len(rv)):
+   cur_line = rv[i]['QUERY PLAN']
+   if search_text.lower() in cur_line.lower():
+      str_trim = cur_line.split('Workfile: (')
+      str_trim = str_trim[1].split(' spilling')
+      if int(str_trim[0]) > 0:
+         result = 1
+return result
+$$
+language plpythonu;
+
+
+-- Force Sort operator to spill workfiles and examine if stats are correct
+drop table if exists testsort; 
+create table testsort (i1 int, i2 int, i3 int, i4 int); 
+insert into testsort select i, i % 1000, i % 100000, i % 75 from generate_series(0,199999) i; 
+
+set statement_mem="5MB";
+set gp_resqueue_print_operator_memory_limits=on;
+set gp_enable_mk_sort=off; 
+
+select isSpilling('explain analyze select i1,i2 from testsort order by i2'); 

--- a/src/test/regress/sql/runtime_stats.sql
+++ b/src/test/regress/sql/runtime_stats.sql
@@ -4,7 +4,6 @@
 -- Examines if run-time statistics are correct.
 --
 
-create language plpythonu;
 -- Returns 1 if workfiles are spilled during query execution; 0 otherwise.
 create or replace function isSpilling(explain_query text) returns int as
 $$


### PR DESCRIPTION
Reproduce it:

```
drop table if exists testsort; 
create table testsort (i1 int, i2 int, i3 int, i4 int); 
insert into testsort select i, i % 1000, i % 100000, i % 75 from generate_series(0,199999) i; 

SET gp_workfile_caching=true; 
SET gp_workfile_caching_loglevel="INFO"; 
set statement_mem="5MB";
set gp_resqueue_print_operator_memory_limits=on;
set gp_enable_mk_sort=off; 

explain analyze select i1,i2 from testsort order by i2;
```

The output should look like this: 
```
                                                                    QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=19840.80..20339.88 rows=199631 width=8) (operatorMem=100KB)
   Merge Key: i2
   Rows out:  200000 rows at destination with 186 ms to first row, 293 ms to end, start offset by 0.350 ms.
   ->  Sort  (cost=19840.80..20339.88 rows=66544 width=8) (operatorMem=5020KB)
         Sort Key: i2
         Rows out:  Avg 66666.7 rows x 3 workers.  Max 66712 rows (seg1) with 186 ms to first row, 212 ms to end, start offset by 0.539 ms.
         Executor memory:  5849K bytes avg, 5849K bytes max (seg0).
         Work_mem used:  5849K bytes avg, 5849K bytes max (seg0). Workfile: (3 spilling)
         Work_mem wanted: 7761K bytes avg, 7764K bytes max (seg1) to lessen workfile I/O affecting 3 workers.
         ->  Seq Scan on testsort  (cost=0.00..2266.31 rows=66544 width=8) (operatorMem=100KB)
               Rows out:  Avg 66666.7 rows x 3 workers.  Max 66712 rows (seg1) with 0.022 ms to first row, 12 ms to end, start offset by 0.549 ms.
 Slice statistics:
   (slice0)    Executor memory: 395K bytes.
   (slice1)  * Executor memory: 6023K bytes avg x 3 workers, 6023K bytes max (seg0).  Work_mem: 5849K bytes max, 7764K bytes wanted.
 Statement statistics:
   Memory used: 5120K bytes
   Memory wanted: 7963K bytes
 Settings:  gp_enable_mk_sort=off
 Total runtime: 305.891 ms
(19 rows)
```
Signed-off-by: Nikos Armenatzoglou <nikos.armenatzoglou@gmail.com>