### PR TITLE
Return timeline as integer from the fetch_tli() function.

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -262,7 +262,7 @@ class GpStart:
             controldata = PgControlData("Latest checkpoint's TimeLineID", data_dir_path, REMOTE, remoteHost)
 
         controldata.run(validateAfter=True)
-        return controldata.get_value("Latest checkpoint's TimeLineID")
+        return int(controldata.get_value("Latest checkpoint's TimeLineID"))
 
     def _check_standby_activated(self):
         logger.debug("Checking if standby has been activated...")
@@ -273,8 +273,8 @@ class GpStart:
             primary_tli = self.fetch_tli(self.master_datadir)
             standby_tli = self.fetch_tli(self.gparray.standbyMaster.getSegmentDataDirectory(), self.gparray.standbyMaster.getSegmentHostName())
 
-            logger.debug("Primary TLI = " + primary_tli)
-            logger.debug("Standby TLI = " + standby_tli)
+            logger.debug("Primary TLI = %d" % primary_tli)
+            logger.debug("Standby TLI = %d" % standby_tli)
 
             if primary_tli < standby_tli:
                 # stop the master we've started up.


### PR DESCRIPTION
The fetch_tli() function was returning timeline ID as string. In
_check_activate_standby(), the timeline IDs of the master and standby were
compared. Once the timeline IDs reached '9' and '10', then the string comparison
is no longer a correct test.  Hence, the return value from fetch_tli() is now
returned as an int.

The walreplication tinc test `GpstartTestCase.test_gpstart_original_master_after_promote` failed due to this bug. We ran the test manually with our fix to test it.

Authors: Shoaib Lari and Abhijit Subramanya