### PR TITLE
Enable partition transfer to non-partitioned tables.

### DIFF
--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -143,7 +143,7 @@ class ProgramArgumentValidationException(Exception):
     """
     def __init__(self, msg, shouldPrintHelp=False):
         "init"
-        Exception.__init__(self)
+        Exception.__init__(self, msg)
         self.__shouldPrintHelp = shouldPrintHelp
         self.__msg = msg
 

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gptransfer.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gptransfer.feature
@@ -1740,7 +1740,7 @@ Feature: gptransfer tests
         And there is a file "input_file" with tables "gptest.public.sales_1_prt_2_2_prt_2, gptest.public.sales_1_prt_p1_2_prt_1"
         When the user runs "gptransfer -f input_file --partition-transfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
         Then gptransfer should return a return code of 2
-        And gptransfer should print Table gptest.public.sales_1_prt_p1_2_prt_1 does not exist in destination database to transfer partition tables to stdout
+        And gptransfer should print Table gptest.public.sales_1_prt_p1_2_prt_1 does not exist in destination database when transferring from partition tables to stdout
 
     @partition_transfer
     @prt_transfer_8
@@ -1752,7 +1752,7 @@ Feature: gptransfer tests
         And there is a file "input_file" with tables "gptest.public.sales_1_prt_2_2_prt_2, gptest.nonexist_schema.sales_1_prt_p1_2_prt_1"
         When the user runs "gptransfer -f input_file --partition-transfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
         Then gptransfer should return a return code of 2
-        And gptransfer should print Table gptest.nonexist_schema.sales_1_prt_p1_2_prt_1 does not exist in destination database to transfer partition tables to stdout
+        And gptransfer should print Table gptest.nonexist_schema.sales_1_prt_p1_2_prt_1 does not exist in destination database when transferring from partition tables to stdout
 
     @partition_transfer
     @prt_transfer_9
@@ -1764,7 +1764,7 @@ Feature: gptransfer tests
         And there is a file "input_file" with tables "gptest.public.sales_1_prt_2_2_prt_2, gptest.public.nonexist_table"
         When the user runs "gptransfer -f input_file --partition-transfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
         Then gptransfer should return a return code of 2
-        And gptransfer should print Table gptest.public.nonexist_table does not exist in destination database to transfer partition tables to stdout
+        And gptransfer should print Table gptest.public.nonexist_table does not exist in destination database when transferring from partition tables to stdout
 
     @partition_transfer
     @prt_transfer_10
@@ -2226,7 +2226,7 @@ Feature: gptransfer tests
         And there is a file "input_file" with tables "gptest.public.employee_1_prt_1, gptest.public.employee_1_prt_1"
         When the user runs "gptransfer -f input_file --partition-transfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
         Then gptransfer should return a return code of 2
-        And gptransfer should print Source partition table gptest.public.employee_1_prt_1 has different column layout or types from destination partition table gptest.public.employee_1_prt_1 to stdout
+        And gptransfer should print Source partition table gptest.public.employee_1_prt_1 has different column layout or types from destination table gptest.public.employee_1_prt_1 to stdout
         Then the user runs "psql -p $GPTRANSFER_DEST_PORT -h $GPTRANSFER_DEST_HOST -U $GPTRANSFER_DEST_USER -f gppylib/test/behave/mgmt_utils/steps/data/gptransfer/one_level_range_prt_1_different_prt_column.sql -d gptest"
         And the user runs "gptransfer -f input_file --partition-transfer --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE"
         Then gptransfer should return a return code of 2
@@ -2258,7 +2258,8 @@ Feature: gptransfer tests
         And the user waits for "gptransfer" to finish running
 
     @partition-transfer-non-partition-target
-    @prt_transfer_47
+    @partition_transfer
+    @prt_transfer_49
     Scenario: transfer multiple partition leaves to same non-partition table
         Given the database is running
         And database "gptest" exists

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gptransfer.feature
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/gptransfer.feature
@@ -626,6 +626,8 @@ Feature: gptransfer tests
         Then gptransfer should return a return code of 2
         And gptransfer should print Invalid fully qualified table name to stdout
 
+    # this test creates an incomplete map file by *removing* the first line from the source map file.
+    # If you have only 1 segment, you will be left with an empty hosts map, and this test will fail
     @T339837
     Scenario: gptransfer incomplete map file
         Given the database is running

--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/create_heap_table.sql
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/data/gptransfer/create_heap_table.sql
@@ -1,1 +1,1 @@
-CREATE TABLE heap_employee(id int, rank int, gender char(1));
+DROP TABLE IF EXISTS heap_employee; CREATE TABLE heap_employee(id int, rank int, gender char(1));

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -1,14 +1,33 @@
 import imp
 import os
+import re
+import tempfile
+
+import shutil
 from mock import *
 from gp_unittest import *
 from gparray import GpDB, GpArray
 from gppylib.db.dbconn import UnexpectedRowsError
 from pygresql import pgdb
 
+cursor_keys = dict(
+    normal_tables=re.compile(".*n\.nspname, c\.relname, c\.relstorage.*c\.oid NOT IN \( SELECT parchildrelid.*"),
+    partition_tables=re.compile(".*n\.nspname, c\.relname, c\.relstorage(?!.*SELECT parchildrelid).*"),
+    relations=re.compile(".*select relname from pg_class r.*"),
+    table_info=re.compile(".*select is_nullable, data_type, character_maximum_length,.*"),
+    partition_info=re.compile(".*select parkind, parlevel, parnatts, paratts.*"),
+    schema_name=re.compile(".*SELECT fsname FROM pg_catalog.pg_filespace.*"),
+    create_schema=re.compile(".*CREATE SCHEMA.*")
+)
 
 class GpTransfer(GpTestCase):
+    TEMP_DIR =  "/tmp/test_unit_gptransfer"
+
+
     def setUp(self):
+        if not os.path.exists(self.TEMP_DIR):
+            os.makedirs(self.TEMP_DIR)
+
         # because gptransfer does not have a .py extension,
         # we have to use imp to import it
         # if we had a gptransfer.py, this is equivalent to:
@@ -19,22 +38,30 @@ class GpTransfer(GpTestCase):
         self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning'])
         self.gparray = self.createGpArrayWith2Primary2Mirrors()
 
-        self.db_connection = MagicMock(spec=["__exit__", "close", "__enter__"])
+        self.db_connection = MagicMock()
+        # TODO: We should be using a spec here, but I haven't been able to narrow down exactly which call is causing an attribute error when using the spec.
+        # The error is occuring because we don't mock out every possible SQL command, and some get swallowed (which is fine so far), but to fully support specs
+        # we need to go through and mock all the SQL calls
+        # self.db_connection = MagicMock(spec=["__exit__", "close", "__enter__", "commit", "rollback"])
         self.cursor = MagicMock(spec=pgdb.pgdbCursor)
+
         self.db_singleton = Mock()
+        self.workerpool = MagicMock()
+        self.workerpool.work_queue.qsize.return_value = 0
 
         self.apply_patches([
-            patch('os.environ', new={}),
+            patch('os.environ', new={"GPHOME": "my_gp_home"}),
             patch('gppylib.operations.dump.GpArray.initFromCatalog', return_value=self.gparray),
             patch('gptransfer.connect', return_value=self.db_connection),
-            patch('gptransfer.getUserDatabaseList', return_value=[["my_first_database"],["my_second_database"]]),
+            patch('gptransfer.getUserDatabaseList', return_value=[["my_first_database"], ["my_second_database"]]),
             patch('gppylib.db.dbconn.connect', return_value=self.db_connection),
-            patch('gptransfer.WorkerPool', return_value=Mock()),
-            patch('gptransfer.doesSchemaExist', return_value=True),
+            patch('gptransfer.WorkerPool', return_value=self.workerpool),
+            patch('gptransfer.doesSchemaExist', return_value=False),
             patch('gptransfer.dropSchemaIfExist'),
             patch('gptransfer.execSQL', new=self.cursor),
             patch('gptransfer.execSQLForSingletonRow', new=self.db_singleton),
-            patch("gppylib.commands.unix.FileDirExists.remote", return_value=True)
+            patch("gppylib.commands.unix.FileDirExists.remote", return_value=True),
+            patch("gptransfer.wait_for_pool", return_value=([], []))
         ])
 
         # We have a GIGANTIC class that uses 31 arguments, so pre-setting this
@@ -91,13 +118,14 @@ class GpTransfer(GpTestCase):
             format='CSV',
             full=False,
             input_file=None,
-            interactive=True,
+            interactive=False,
             last_port=-1,
             logfileDirectory=None,
             max_gpfdist_instances=1,
             max_line_length=10485760,
             no_final_count_validation=False,
             partition_transfer=False,
+            pt_non_pt_target=False,
             quiet=None,
             quote='\x01',
             schema_only=False,
@@ -115,6 +143,10 @@ class GpTransfer(GpTestCase):
             wait_time=3,
             work_base_dir='/home/gpadmin/',
         )
+
+    def tearDown(self):
+        pass
+        # shutil.rmtree(self.TEMP_DIR)
 
     @patch('gptransfer.TableValidatorFactory', return_value=Mock())
     @patch('gptransfer.execSQLForSingletonRow', side_effect=[['MYDATE'],
@@ -145,8 +177,7 @@ class GpTransfer(GpTestCase):
 
     @patch('gptransfer.TableValidatorFactory', return_value=Mock())
     @patch('gptransfer.execSQLForSingletonRow',
-           side_effect=[UnexpectedRowsError(1, 0, "sql foo"),
-                        ""])
+           side_effect=[UnexpectedRowsError(1, 0, "sql foo"), ""])
     def test__get_distributed_randomly(self, mock1, mock2):
         gptransfer = self.subject
         cmd_args = self.GpTransferCommand_args
@@ -168,47 +199,279 @@ class GpTransfer(GpTestCase):
         self.assertEqual(1, len(self.subject.logger.method_calls))
         self.assertEqual(expected_distribution, result_distribution)
 
-    def test__validates_good_partition(self):
-        options = self.setup_partition_validation()
-        self.cursor.side_effect = CursorSideEffect().cursor_side_effect
+    def test__normal_transfer_no_tables_does_nothing_but_log(self):
+        options = self.setup_normal_to_normal_validation()
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write("my_first_database.public.nonexistent_table")
+        with self.assertRaises(SystemExit):
+            self.subject.GpTransfer(Mock(**options), [])
+        log_messages = self.get_info_messages()
+        self.assertIn("Found no tables to transfer.", log_messages[-1])
+
+    def test__normal_transfer_with_tables_validates(self):
+        options = self.setup_normal_to_normal_validation()
 
         self.subject.GpTransfer(Mock(**options), [])
 
-    def test__validate_bad_partition_not_leaf(self):
-        options = self.setup_partition_validation()
+        log_messages = self.get_info_messages()
+        self.assertIn("Validating transfer table set...", log_messages)
 
+    def test__normal_transfer_when_destination_table_already_exists_fails(self):
+        options = self.setup_normal_to_normal_validation()
         additional = {
-            "select relname from pg_class r": ["many", "relations"],
+            cursor_keys["normal_tables"]: [["public", "my_normal_table", ""]],
         }
-        self.cursor.side_effect = CursorSideEffect(additional).cursor_side_effect
-
-        with self.assertRaisesRegexp(Exception, "Destination table "):
+        self.cursor.side_effect = CursorSideEffect(additional=additional).cursor_side_effect
+        with self.assertRaisesRegexp(Exception, "Table my_first_database.public.my_normal_table exists in database my_first_database"):
             self.subject.GpTransfer(Mock(**options), [])
 
-    def test__validate_bad_partition_different_number_columns(self):
+    def test__normal_transfer_when_input_file_bad_format_comma_fails(self):
+        options = self.setup_normal_to_normal_validation()
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write("my_first_database.public.my_table, my_second_database.public.my_table")
+        self.cursor.side_effect = CursorSideEffect().cursor_side_effect
+
+        with self.assertRaisesRegexp(Exception, "Destination tables \(comma separated\) are only allowed for partition tables"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    @patch('gptransfer.CountTableValidator.accumulate', side_effect=Exception('BOOM'))
+    def test__final_count_validation_when_throws_should_raises_exception(self, mock1):
+        options = self.setup_normal_to_normal_validation()
+        with self.assertRaisesRegexp(Exception, "Final count validation failed"):
+            self.subject.GpTransfer(Mock(**options), []).run()
+
+    def test__final_count_invalid_one_src_one_dest_table_logs_error(self):
+        options = self.setup_normal_to_normal_validation()
+        additional = {
+            "SELECT count(*) FROM": [3]
+        }
+        self.db_singleton.side_effect = SingletonSideEffect(additional).singleton_side_effect
+
+        self.subject.GpTransfer(Mock(**options), []).run()
+
+        self.assertIn("Validation failed for %s", self.get_error_logging())
+
+    def test__partition_to_partition_final_count_invalid_one_src_one_dest_table_logs_warning(self):
+        options = self.setup_partition_validation()
+        additional = {
+            "SELECT count(*) FROM": [3]
+        }
+        self.db_singleton.side_effect = SingletonSideEffect(additional).singleton_side_effect
+
+        self.subject.GpTransfer(Mock(**options), []).run()
+
+        self.assertIn("Validation failed for %s", self.get_warnings())
+
+    def test__partition_to_partition_when_invalid_final_counts_should_warn(self):
+        options = self.setup_partition_validation()
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write(
+                "my_first_database.public.my_table_partition1, my_first_database.public.my_table_partition1\n"
+                "my_first_database.public.my_table_partition2")
+
+        additional = {
+            cursor_keys["partition_tables"]: [["public", "my_table_partition1", ""],
+                                              ["public", "my_table_partition2", ""]],
+        }
+        cursor_side_effect = CursorSideEffect(additional=additional)
+        self.cursor.side_effect = cursor_side_effect.cursor_side_effect
+
+        multi = {
+            "SELECT count(*) FROM": [[12], [10]]
+        }
+        self.db_singleton.side_effect = SingletonSideEffect(multi_list=multi).singleton_side_effect
+
+        self.subject.GpTransfer(Mock(**options), []).run()
+
+        self.assertIn("Validation failed for %s", self.get_warnings())
+
+    def test__partition_to_partition_when_valid_final_counts_mult_src_same_dest_table_succeeds(self):
+        options = self.setup_partition_validation()
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write(
+                "my_first_database.public.my_table_partition1, my_first_database.public.my_table_partition1\n"
+                "my_first_database.public.my_table_partition2")
+
+        additional = {
+            cursor_keys["partition_tables"]: [["public", "my_table_partition1", ""],
+                                              ["public", "my_table_partition2", ""]],
+        }
+        cursor_side_effect = CursorSideEffect(additional=additional)
+        self.cursor.side_effect = cursor_side_effect.cursor_side_effect
+
+        self.subject.GpTransfer(Mock(**options), []).run()
+
+        self.assertIn("Validation of %s successful", self.get_info_messages())
+
+    def test__partition_to_normal_table_succeeds(self):
+        options = self.setup_partition_to_normal_validation()
+
+        # simulate that dest normal table has 0 rows to begin with and 20 when finished
+        multi = {
+            "SELECT count(*) FROM": [[20], [0]]
+        }
+        self.db_singleton.side_effect = SingletonSideEffect(multi_list=multi).singleton_side_effect
+
+        self.subject.GpTransfer(Mock(**options), []).run()
+
+        self.assertNotIn("Validation failed for %s", self.get_warnings())
+        self.assertIn("Validation of %s successful", self.get_info_messages())
+
+    def test__final_count_validation_same_counts_src_dest_passes(self):
+        options = self.setup_normal_to_normal_validation()
+
+        self.subject.GpTransfer(Mock(**options), []).run()
+
+        self.assertIn("Validation of %s successful", self.get_info_messages())
+
+    def test__validates_good_partition(self):
+        options = self.setup_partition_validation()
+
+        self.subject.GpTransfer(Mock(**options), [])
+
+        self.assertIn("Validating partition table transfer set...", self.get_info_messages())
+
+    def test__partition_to_nonexistent_partition_fails(self):
+        options = self.setup_partition_validation()
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write(
+                "my_first_database.public.my_table_partition1, my_first_database.public.my_table_partition2")
+        self.cursor.side_effect = CursorSideEffect().cursor_side_effect
+
+        with self.assertRaisesRegexp(Exception, "does not exist in destination database"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__partition_to_nonexistent_normal_table_fails(self):
+        options = self.setup_partition_to_normal_validation()
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write("my_first_database.public.my_table_partition1, my_first_database.public.does_not_exist")
+        self.cursor.side_effect = CursorSideEffect().cursor_side_effect
+
+        with self.assertRaisesRegexp(Exception, "does not exist in destination database"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__partition_to_multiple_same_partition_tables_fails(self):
+        options = self.setup_partition_validation()
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write(
+                "my_first_database.public.my_table_partition1\nmy_first_database.public.my_table_partition3, my_first_database.public.my_table_partition1")
+
+        cursor_side_effect = CursorSideEffect()
+        cursor_side_effect.first_values[cursor_keys["partition_tables"]] = [["public", "my_table_partition1", ""],
+                                                                            ["public", "my_table_partition3", ""]]
+        self.cursor.side_effect = cursor_side_effect.cursor_side_effect
+        with self.assertRaisesRegexp(Exception, "Multiple tables map to"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__partition_to_nonpartition_table_with_different_columns_fails(self):
+        options = self.setup_partition_to_normal_validation()
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write("my_first_database.public.my_table_partition1, my_first_database.public.my_normal_table")
+
+        additional = {
+            cursor_keys["normal_tables"]: [["public", "my_normal_table", ""]],
+            cursor_keys['table_info']: [
+                [1, "t", "my_new_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
+        }
+        cursor_side_effect = CursorSideEffect(additional=additional)
+        cursor_side_effect.first_values[cursor_keys["partition_tables"]] = [["public", "my_table_partition1", ""]]
+        self.cursor.side_effect = cursor_side_effect.cursor_side_effect
+        with self.assertRaisesRegexp(Exception, "has different column layout or types"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__multiple_partitions_to_same_normal_table_succeeds(self):
+        options = self.setup_partition_to_normal_validation()
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write(
+                "my_first_database.public.my_table_partition1, my_first_database.public.my_normal_table\nmy_first_database.public.my_table_partition2, my_first_database.public.my_normal_table")
+
+        additional = {
+            cursor_keys["normal_tables"]: [["public", "my_normal_table", ""]],
+        }
+        cursor_side_effect = CursorSideEffect(additional=additional)
+        cursor_side_effect.first_values[cursor_keys["partition_tables"]] = [["public", "my_table_partition1", ""],
+                                                                            ["public", "my_table_partition2", ""]]
+        self.cursor.side_effect = cursor_side_effect.cursor_side_effect
+
+        class SingletonSideEffectWithIterativeReturns(SingletonSideEffect):
+            def __init__(self):
+                SingletonSideEffect.__init__(self)
+                self.values["SELECT count(*) FROM public.my_normal_table"] = [[[30, 15, 15]]]
+                self.counters["SELECT count(*) FROM public.my_normal_table"] = 0
+
+            def singleton_side_effect(self, *args):
+                for key in self.values.keys():
+                    for arg in args:
+                        if key in arg:
+                            value_list = self.values[key]
+                            result = value_list[self.counters[key] % len(value_list)]
+                            if any(isinstance(i, list) for i in value_list):
+                                result = result[self.counters[key] % len(value_list)]
+                            self.counters[key] += 1
+                            return result
+                return None
+        self.db_singleton.side_effect = SingletonSideEffectWithIterativeReturns().singleton_side_effect
+
+        self.subject.GpTransfer(Mock(**options), []).run()
+
+        self.assertNotIn("Validation failed for %s", self.get_warnings())
+        self.assertIn("Validation of %s successful", self.get_info_messages())
+
+    def test__partition_to_multiple_same_nonpartition_tables_with_truncate_fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options.update(truncate=True)
+        with open(options["input_file"], "w") as src_map_file:
+            src_map_file.write(
+                "my_first_database.public.my_table_partition1, my_first_database.public.my_normal_table\n"
+                "my_first_database.public.my_table_partition2, my_first_database.public.my_normal_table")
+
+        additional = {
+            cursor_keys["normal_tables"]: [["public", "my_normal_table", ""]],
+        }
+        cursor_side_effect = CursorSideEffect(additional=additional)
+        cursor_side_effect.first_values[cursor_keys["partition_tables"]] = [["public", "my_table_partition1", ""],
+                                                                            ["public", "my_table_partition2", ""]]
+        self.cursor.side_effect = cursor_side_effect.cursor_side_effect
+
+        with self.assertRaisesRegexp(Exception, "--truncate is not allowed with option --partition-transfer-non-partition-target"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_bad_partition_source_not_leaf_fails(self):
+        options = self.setup_partition_validation()
+
+        cursor_side_effect = CursorSideEffect()
+        cursor_side_effect.first_values[cursor_keys['relations']] = ["my_relname1", "my_relname2"]
+        self.cursor.side_effect = cursor_side_effect.cursor_side_effect
+
+        with self.assertRaisesRegexp(Exception, "Source table "):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_bad_partition_different_number_columns_fails(self):
         options = self.setup_partition_validation()
 
         additional = {
-            "select is_nullable, data_type, character_maximum_length,": [["t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"],
-                                                                                           [2, "t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
+            cursor_keys['table_info']: [
+                ["t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"],
+                ["t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
         }
         self.cursor.side_effect = CursorSideEffect(additional).cursor_side_effect
 
         with self.assertRaisesRegexp(Exception, "has different column layout or types"):
             self.subject.GpTransfer(Mock(**options), [])
 
-    def test__validate_bad_partition_different_column_type(self):
+    def test__validate_bad_partition_different_column_type_fails(self):
         options = self.setup_partition_validation()
 
         additional = {
-            "select is_nullable, data_type, character_maximum_length,": [["t", "my_new_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
+            cursor_keys['table_info']: [
+                ["t", "my_new_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
         }
         self.cursor.side_effect = CursorSideEffect(additional).cursor_side_effect
 
         with self.assertRaisesRegexp(Exception, "has different column layout or types"):
             self.subject.GpTransfer(Mock(**options), [])
 
-    def test__validate_bad_partition_different_max_levels(self):
+    def test__validate_bad_partition_different_max_levels_fails(self):
         options = self.setup_partition_validation()
 
         additional = {
@@ -219,59 +482,59 @@ class GpTransfer(GpTestCase):
         with self.assertRaisesRegexp(Exception, "has different partition criteria from destination table"):
             self.subject.GpTransfer(Mock(**options), [])
 
-        log_messages = [args[0][0] for args in self.subject.logger.error.call_args_list]
+        log_messages = self.get_error_logging()
         self.assertIn("Max level of partition is not same between", log_messages[0])
 
-    def test__validate_bad_partition_different_values_of_attributes(self):
+    def test__validate_bad_partition_different_values_of_attributes_fails(self):
         options = self.setup_partition_validation()
 
         additional = {
-            "select parkind, parlevel, parnatts, paratts": [["my_parkind", 1, 1, "3 4"]],
+            cursor_keys['partition_info']: [["my_parkind", 1, "my_parnatts", "3 4"]],
         }
         self.cursor.side_effect = CursorSideEffect(additional).cursor_side_effect
 
         with self.assertRaisesRegexp(Exception, "has different partition criteria from destination table"):
             self.subject.GpTransfer(Mock(**options), [])
 
-        log_messages = [args[0][0] for args in self.subject.logger.error.call_args_list]
+        log_messages = self.get_error_logging()
         self.assertIn("Partition type or key is different between", log_messages[1])
         self.assertIn("Partition column attributes are different at level", log_messages[0])
 
-    def test__validate_bad_partition_different_parent_kind(self):
+    def test__validate_bad_partition_different_parent_kind_fails(self):
         options = self.setup_partition_validation()
 
         additional = {
-            "select parkind, parlevel, parnatts, paratts": [["different_parkind", 1, 1, "1"]],
+            cursor_keys['partition_info']: [["different_parkind", 1, "my_parnatts", "my_paratts"]],
         }
         self.cursor.side_effect = CursorSideEffect(additional).cursor_side_effect
 
         with self.assertRaisesRegexp(Exception, "has different partition criteria from destination table"):
             self.subject.GpTransfer(Mock(**options), [])
 
-        log_messages = [args[0][0] for args in self.subject.logger.error.call_args_list]
+        log_messages = self.get_error_logging()
         self.assertIn("Partition type or key is different between", log_messages[1])
         self.assertIn("Partition type is different at level", log_messages[0])
 
-    def test__validate_bad_partition_different_number_of_attributes(self):
+    def test__validate_bad_partition_different_number_of_attributes_fails(self):
         options = self.setup_partition_validation()
 
         additional = {
-            "select parkind, parlevel, parnatts, paratts": [["my_parkind", 1, 2, "1"]],
+            cursor_keys['partition_info']: [["my_parkind", 1, 2, "my_paratts"]],
         }
         self.cursor.side_effect = CursorSideEffect(additional).cursor_side_effect
 
         with self.assertRaisesRegexp(Exception, "has different partition criteria from destination table"):
             self.subject.GpTransfer(Mock(**options), [])
 
-        log_messages = [args[0][0] for args in self.subject.logger.error.call_args_list]
+        log_messages = self.get_error_logging()
         self.assertIn("Partition type or key is different between", log_messages[1])
         self.assertIn("Number of partition columns is different at level ", log_messages[0])
 
-    def test__validate_bad_partition_different_partition_values(self):
+    def test__validate_bad_partition_different_partition_values_fails(self):
         options = self.setup_partition_validation()
 
         additional = {
-            "select n.nspname, c.relname": [["not_public", "not_my_table", ""],["public", "my_table", ""]],
+            "select n.nspname, c.relname": [["not_public", "not_my_table", ""], ["public", "my_table_partition1", ""]],
             "select parisdefault, parruleord, parrangestartincl,": ["t", "1", "t", "t", 100, 10, "", ""],
         }
         self.db_singleton.side_effect = SingletonSideEffect(additional).singleton_side_effect
@@ -279,11 +542,11 @@ class GpTransfer(GpTestCase):
         with self.assertRaisesRegexp(Exception, "has different partition criteria from destination table"):
             self.subject.GpTransfer(Mock(**options), [])
 
-        log_messages = [args[0][0] for args in self.subject.logger.error.call_args_list]
+        log_messages = self.get_error_logging()
         self.assertIn("One of the subpartition table is a default partition", log_messages[0])
         self.assertIn("Partition value is different in the partition hierarchy between", log_messages[1])
 
-    def test__validate_bad_partition_unknown_type(self):
+    def test__validate_bad_partition_unknown_type_fails(self):
         options = self.setup_partition_validation()
         my_singleton = SingletonSideEffect()
         my_singleton.values["select partitiontype"] = ["unknown"]
@@ -292,7 +555,7 @@ class GpTransfer(GpTestCase):
         with self.assertRaisesRegexp(Exception, "Unknown partitioning type "):
             self.subject.GpTransfer(Mock(**options), [])
 
-    def test__validate_bad_partition_different_list_values(self):
+    def test__validate_bad_partition_different_list_values_fails(self):
         options = self.setup_partition_validation()
 
         additional = {
@@ -306,21 +569,27 @@ class GpTransfer(GpTestCase):
         with self.assertRaisesRegexp(Exception, "has different partition criteria from destination table"):
             self.subject.GpTransfer(Mock(**options), [])
 
-        log_messages = [args[0][0] for args in self.subject.logger.error.call_args_list]
+        log_messages = self.get_error_logging()
         self.assertIn("List partition value is different between", log_messages[0])
         self.assertIn("Partition value is different in the partition hierarchy between", log_messages[1])
 
-    def test__validate_bad_partition_different_range_values(self):
-        self.run_range_partition_value({"select parisdefault, parruleord, parrangestartincl,": ["f", "1", "f", "t", 100, 10, "", "different"]})
-        self.run_range_partition_value({"select parisdefault, parruleord, parrangestartincl,": ["f", "1", "t", "f", 999, 10, "", "different"]})
-        self.run_range_partition_value({"select parisdefault, parruleord, parrangestartincl,": ["f", "1", "t", "t", 100, 999, "", "different"]})
-        self.run_range_partition_value({"select parisdefault, parruleord, parrangestartincl,": ["f", "1", "t", "t", 100, 10, 999, "different"]})
+    def test__validate_bad_partition_different_range_values_fails(self):
+        self.run_range_partition_value(
+            {"select parisdefault, parruleord, parrangestartincl,": ["f", "1", "f", "t", 100, 10, "", "different"]})
+        self.run_range_partition_value(
+            {"select parisdefault, parruleord, parrangestartincl,": ["f", "1", "t", "f", 999, 10, "", "different"]})
+        self.run_range_partition_value(
+            {"select parisdefault, parruleord, parrangestartincl,": ["f", "1", "t", "t", 100, 999, "", "different"]})
+        self.run_range_partition_value(
+            {"select parisdefault, parruleord, parrangestartincl,": ["f", "1", "t", "t", 100, 10, 999, "different"]})
 
-    def test__validate_bad_partition_different_parent_partition(self):
+    def test__validate_bad_partition_different_parent_partition_fails(self):
         options = self.setup_partition_validation()
 
         multi = {
-            "select parisdefault, parruleord, parrangestartincl,": [["f", "1", "t", "t", 100, 10, "", ""], ["f", "1", "t", "t", 100, 10, "", ""], ["f", "1", "t", "t", 999, 10, "", ""]],
+            "select parisdefault, parruleord, parrangestartincl,": [["f", "1", "t", "t", 100, 10, "", ""],
+                                                                    ["f", "1", "t", "t", 100, 10, "", ""],
+                                                                    ["f", "1", "t", "t", 999, 10, "", ""]],
         }
         singleton_side_effect = SingletonSideEffect(multi_list=multi)
         self.db_singleton.side_effect = singleton_side_effect.singleton_side_effect
@@ -328,48 +597,135 @@ class GpTransfer(GpTestCase):
         with self.assertRaisesRegexp(Exception, "has different partition criteria from destination table"):
             self.subject.GpTransfer(Mock(**options), [])
 
-        log_messages = [args[0][0] for args in self.subject.logger.error.call_args_list]
-        self.assertIn("Range partition value is different between source partition table", log_messages[0])
-        self.assertIn("Partitions have different parents at level", log_messages[1])
+        error_messages = self.get_error_logging()
+        self.assertIn("Range partition value is different between source partition table", error_messages[0])
+        self.assertIn("Partitions have different parents at level", error_messages[1])
 
+    def test__validate_pt_non_pt_target_with_validator__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['validator'] = "MD5"
 
-####################################################################################################################
-        # End of tests, start of private methods/objects
-####################################################################################################################
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option cannot be used with --validate option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_with_partition_transfer__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['partition_transfer'] = True
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer option cannot be used with --partition-transfer-non-partition-target option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_without_input_file__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['input_file'] = None
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option must be used with -f option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_with_databases__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['databases'] = ['db1']
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option cannot be used with -d option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_with_dest_databases__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['dest_database'] = ['db1']
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option cannot be used with --dest-database option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_with_drop__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['drop'] = True
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option cannot be used with --drop option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_with_tables__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['tables'] = ['public.table1']
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option cannot be used with -t option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_with_schema_only__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['schema_only'] = True
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option cannot be used with --schema-only option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_with_full__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['full'] = True
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option cannot be used with --full option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_with_exclude_input_file__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['exclude_input_file'] = tempfile.NamedTemporaryFile(dir=self.TEMP_DIR, delete=False)
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option cannot be used with any exclude table option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_pt_non_pt_target_with_exclude_tables__fails(self):
+        options = self.setup_partition_to_normal_validation()
+        options['exclude_tables'] = ['public.table1']
+
+        with self.assertRaisesRegexp(Exception, "--partition-transfer-non-partition-target option cannot be used with any exclude table option"):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    ####################################################################################################################
+    # End of tests, start of private methods/objects
+    ####################################################################################################################
+
+    def get_error_logging(self):
+        return [args[0][0] for args in self.subject.logger.error.call_args_list]
+
+    def get_info_messages(self):
+        return [args[0][0] for args in self.subject.logger.info.call_args_list]
+
+    def get_warnings(self):
+        return [args[0][0] for args in self.subject.logger.warning.call_args_list]
 
     def run_range_partition_value(self, additional):
         options = self.setup_partition_validation()
         self.db_singleton.side_effect = SingletonSideEffect(additional).singleton_side_effect
         with self.assertRaisesRegexp(Exception, "has different partition criteria from destination table"):
             self.subject.GpTransfer(Mock(**options), [])
-        log_messages = [args[0][0] for args in self.subject.logger.error.call_args_list]
+        log_messages = self.get_error_logging()
         self.assertIn("Range partition value is different between", log_messages[0])
         self.assertIn("Partition value is different in the partition hierarchy between", log_messages[1])
 
     def createGpArrayWith2Primary2Mirrors(self):
-        master = GpDB.initFromString("1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        primary0 = GpDB.initFromString("2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString("3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        mirror0 = GpDB.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        mirror1 = GpDB.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
         return GpArray([master, primary0, primary1, mirror0, mirror1])
 
     def setup_partition_validation(self):
-        os.environ["GPHOME"] = "my_gp_home"
-        SOURCE_MAP_FILENAME = "/tmp/gptransfer_test_source_map"
-        with open(SOURCE_MAP_FILENAME, "w") as src_map_file:
-            src_map_file.write("sdw1,12700\nsdw2,12700")
-        INPUT_FILENAME = "/tmp/gptransfer_test"
-        with open(INPUT_FILENAME, "w") as input_file:
-            input_file.write("my_first_database.public.my_table")
+        source_map_filename = tempfile.NamedTemporaryFile(dir=self.TEMP_DIR, delete=False)
+        source_map_filename.write("sdw1,12700\nsdw2,12700")
+        input_filename = tempfile.NamedTemporaryFile(dir=self.TEMP_DIR, delete=False)
+        input_filename.write("my_first_database.public.my_table_partition1")
         self.cursor.side_effect = CursorSideEffect().cursor_side_effect
         self.db_singleton.side_effect = SingletonSideEffect().singleton_side_effect
         options = {}
         options.update(self.GpTransfer_options_defaults)
         options.update(
             partition_transfer=True,
-            input_file=INPUT_FILENAME,
-            source_map_file=SOURCE_MAP_FILENAME,
+            input_file=input_filename.name,
+            source_map_file=source_map_filename.name,
             base_port=15432,
             max_line_length=32768,
             work_base_dir="/tmp",
@@ -378,15 +734,73 @@ class GpTransfer(GpTestCase):
         )
         return options
 
+    def setup_partition_to_normal_validation(self):
+        source_map_filename = tempfile.NamedTemporaryFile(dir=self.TEMP_DIR, delete=False)
+        source_map_filename.write("sdw1,12700\nsdw2,12700")
+        input_filename = tempfile.NamedTemporaryFile(dir=self.TEMP_DIR, delete=False)
+        input_filename.write("my_first_database.public.my_table_partition1, "
+                             "my_second_database.public.my_normal_table")
+
+        additional = {
+            cursor_keys['relations']: ["my_relname", "another_rel"],
+        }
+        self.cursor.side_effect = CursorSideEffect(additional=additional).cursor_side_effect
+
+        self.db_singleton.side_effect = SingletonSideEffect().singleton_side_effect
+        options = {}
+        options.update(self.GpTransfer_options_defaults)
+        options.update(
+            pt_non_pt_target=True,
+            input_file=input_filename.name,
+            source_map_file=source_map_filename.name,
+            base_port=15432,
+            max_line_length=32768,
+            work_base_dir="/tmp",
+            source_port=45432,
+            dest_port=15432,
+        )
+        return options
+
+    def setup_normal_to_normal_validation(self):
+        source_map_filename = tempfile.NamedTemporaryFile(dir=self.TEMP_DIR, delete=False)
+        source_map_filename.write("sdw1,12700\nsdw2,12700")
+        source_map_filename.flush()
+        input_filename = tempfile.NamedTemporaryFile(dir=self.TEMP_DIR, delete=False)
+        input_filename.write("my_first_database.public.my_normal_table")
+        input_filename.flush()
+        additional = {
+            cursor_keys["normal_tables"]: [["public", "my_normal1_table", ""]],
+        }
+        cursor_side_effect = CursorSideEffect(additional=additional)
+        cursor_side_effect.second_values["normal_tables"] = [[]]
+        self.cursor.side_effect = cursor_side_effect.cursor_side_effect
+
+        self.db_singleton.side_effect = SingletonSideEffect().singleton_side_effect
+        options = {}
+        options.update(self.GpTransfer_options_defaults)
+        options.update(
+            input_file=input_filename.name,
+            source_map_file=source_map_filename.name,
+            base_port=15432,
+            max_line_length=32768,
+            work_base_dir="/tmp",
+            source_port=45432,
+            dest_port=15432,
+        )
+        return options
+
+
 class CursorSideEffect:
     def __init__(self, additional=None):
         self.first_values = {
-            "n.nspname, c.relname, c.relstorage": [["public", "my_table", ""]],
-            "select relname from pg_class r": ["my_relname"],
-            "select is_nullable, data_type, character_maximum_length,": [["t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
-            "select parkind, parlevel, parnatts, paratts": [["my_parkind", 1, 1, "1"]],
-            "SELECT fsname FROM pg_catalog.pg_filespace": ["public"],
-            "select ordinal_position from": [[1]],
+            cursor_keys["normal_tables"]: [["public", "my_normal_table", ""]],
+            cursor_keys["partition_tables"]: [["public", "my_table_partition1", ""]],
+            cursor_keys['relations']: ["my_relname"],
+            cursor_keys['table_info']: [
+                ["t", "my_data_type", 255, 16, 1024, 1024, 1, 1024, "my_interval_type", "my_udt_name"]],
+            cursor_keys['partition_info']: [["my_parkind", 1, "my_parnatts", "my_paratts"]],
+            cursor_keys['schema_name']: ["public"],
+            cursor_keys['create_schema']: ["my_schema"],
         }
         self.counters = dict((key, 0) for key in self.first_values.keys())
         self.second_values = self.first_values.copy()
@@ -396,7 +810,8 @@ class CursorSideEffect:
     def cursor_side_effect(self, *args):
         for key in self.first_values.keys():
             for arg in args[1:]:
-                if key in arg:
+                arg_oneline = " ".join(arg.split("\n"))
+                if key.search(arg_oneline):
                     if self.has_called(key):
                         return FakeCursor(self.second_values[key])
                     return FakeCursor(self.first_values[key])
@@ -423,15 +838,17 @@ class FakeCursor:
     def fetchall(self):
         return self.list
 
+# Represents partition info
 class SingletonSideEffect:
     def __init__(self, additional=None, multi_list=None):
         self.values = {
-                "select partitiontype": ["range"],
-                "select max(p1.partitionlevel)": [1],
-                "select schemaname, tablename from pg_catalog.pg_partitions": ["public", "my_table"],
-                "select c.oid": ["oid1", "oid1"],
-                "select parisdefault, parruleord, parrangestartincl,": ["f", "1", "t", "t", 100, 10, "", ""],
-                "select n.nspname, c.relname": ["public", "my_table"]
+            "select partitiontype": ["range"],
+            "select max(p1.partitionlevel)": [1],
+            "select schemaname, tablename from pg_catalog.pg_partitions": ["public", "my_table_partition1"],
+            "select c.oid": ["oid1", "oid1"],
+            "select parisdefault, parruleord, parrangestartincl,": ["f", "1", "t", "t", 100, 10, "", ""],
+            "select n.nspname, c.relname": ["public", "my_table_partition1"],
+            "SELECT count(*) FROM": [20]
         }
 
         self.counters = dict((key, 0) for key in self.values.keys())

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -729,6 +729,19 @@ class GpTransfer(GpTestCase):
                                                 "must share the same parent"):
             self.subject.GpTransfer(Mock(**options), []).run()
 
+    def test__validating_transfer_with_empty_source_map_file_raises_proper_exception(self):
+        options = self.setup_partition_to_normal_validation()
+
+        source_map_filename = tempfile.NamedTemporaryFile(dir=self.TEMP_DIR, delete=False)
+        source_map_filename.write("")
+        source_map_filename.flush()
+        options.update(
+            source_map_file=source_map_filename.name
+        )
+
+        with self.assertRaisesRegexp(Exception, "No hosts in map"):
+            self.subject.GpTransfer(Mock(**options), [])
+
     ####################################################################################################################
     # End of tests, start of private methods/objects
     ####################################################################################################################

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -2461,6 +2461,8 @@ class GpTransfer(object):
         else:
             self._validator_class = None
 
+        self._validate_host_map()
+
         # Get number of gpfdists per source host
         source_host_count = len(self._host_map.keys())
         self._gpfdist_instance_count = \
@@ -2469,8 +2471,6 @@ class GpTransfer(object):
 
         # validate options
         self._post_validate_options()
-
-        self._validate_host_map()
 
         self._validate_table_transfer_set()
         if self._options.partition_transfer or self._options.partition_transfer_non_pt_target:

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -45,7 +45,8 @@ try:
     from gppylib.db import dbconn
     from gppylib.db.dbconn import connect, DbURL, execSQL, \
         execSQLForSingletonRow, UnexpectedRowsError
-    from gppylib.db.catalog import getUserDatabaseList, doesSchemaExist, dropSchemaIfExist
+    from gppylib.db.catalog import getUserDatabaseList, doesSchemaExist, \
+        dropSchemaIfExist
     from gppylib.gparray import GpArray
     from gppylib.userinput import ask_yesno
     from gppylib.operations.backup_utils import escapeDoubleQuoteInSQLString
@@ -61,7 +62,6 @@ except ImportError, import_exception:
 __author__ = 'Chris Pedrotti <cpedrotti@gopivotal.com>'
 __date__ = '1 February 2014'
 __version__ = '0.0.1'
-
 
 # --------------------------------------------------------------------------
 # Description, help and usage constants
@@ -79,7 +79,7 @@ __help__ = []
 EXECNAME = os.path.split(__file__)[-1]
 GPTRANSFER_PID_FILE = 'gptransfer.pid'
 
-DEFAULT_BASE_WORKDIR=os.path.expanduser('~/')
+DEFAULT_BASE_WORKDIR = os.path.expanduser('~/')
 GPTRANSFER_TMP_DIR = 'gptransfer_%d' % os.getpid()
 
 now = datetime.datetime.now()
@@ -93,12 +93,12 @@ MAX_BATCH_SIZE = 10
 DEFAULT_SUB_BATCH_SIZE = 25
 MAX_SUB_BATCH_SIZE = 50
 
-SCHEMA_DELIMITER='.'
+SCHEMA_DELIMITER = '.'
 
 DEFAULT_PORT = 5432
 DEFAULT_USER = 'gpadmin'
 
-DEFAULT_WAIT_TIME=3
+DEFAULT_WAIT_TIME = 3
 
 DEFAULT_MAX_GPFDIST_INSTANCES = 1
 DEFAULT_GPFDIST_MAX_LINE_LENGTH = 1024 * 1024 * 10  # (10MB)
@@ -111,13 +111,11 @@ MIN_GPFDIST_TIMEOUT = 2
 MAX_GPFDIST_TIMEOUT = 600
 GPFDIST_PORT_REGEX = r"Serving HTTP on port (\d+)"
 
-
 # --------------------------------------------------------------------------
 # Logging
 # --------------------------------------------------------------------------
 
 logger = get_default_logger()
-
 
 # --------------------------------------------------------------------------
 # Global cancel flag and SIG method
@@ -126,11 +124,13 @@ logger = get_default_logger()
 canceled = False
 running_gpfdists = False
 
+
 def wait_until_set_or_cancel(evt):
     while True:
         evt.wait(1)
         if evt.isSet() or canceled:
             return
+
 
 def cancel_handler(_sig, _frame):  # pylint: disable=W0613
     """
@@ -193,8 +193,7 @@ def create_parser():
                        version='%prog version $Revision: #1 $',
                        description=__description__)
 
-    addStandardLoggingAndHelpOptions(parser,
-                                     includeNonInteractiveOption=True)
+    addStandardLoggingAndHelpOptions(parser, includeNonInteractiveOption=True)
 
     # General Options ####
     general_option_group = OptionGroup(parser, 'General Options')
@@ -239,8 +238,17 @@ def create_parser():
         dest='partition_transfer',
         default=False,
         action='store_true',
-        help='Transfer partition tables if enabled, disabled by default, this is '
-             'used in combination with -f option'
+        help='Transfer partition tables if enabled, disabled by default, '
+             'this is used in combination with -f option'
+    )
+
+    general_option_group.add_option(
+        '--partition-transfer-non-partition-target',
+        dest='pt_non_pt_target',
+        default=False,
+        action='store_true',
+        help='Transfer partition tables to non-partition table if enabled, disabled by default, '
+             'this is used in combination with -f option'
     )
 
     general_option_group.add_option(
@@ -263,12 +271,12 @@ def create_parser():
         action='store',
         metavar='<timeout>',
         help='gpfdist timeout in seconds [default: %d, minimum: %d, maximum: %d]'
-            % (DEFAULT_GPFDIST_TIMEOUT, MIN_GPFDIST_TIMEOUT, MAX_GPFDIST_TIMEOUT)
+             % (DEFAULT_GPFDIST_TIMEOUT, MIN_GPFDIST_TIMEOUT, MAX_GPFDIST_TIMEOUT)
     )
     general_option_group.add_option(
         '--delimiter',
         type='string',
-        default= ',',
+        default=',',
         action='store',
         metavar='<delim>',
         help='Delimiter to use for external tables'
@@ -294,7 +302,7 @@ def create_parser():
         dest='format',
         default='CSV',
         action='store',
-        choices=['CSV', 'csv', 'TEXT','text'],
+        choices=['CSV', 'csv', 'TEXT', 'text'],
         help='Transfer data in CSV(default) or TEXT format'
     )
     general_option_group.add_option(
@@ -399,7 +407,6 @@ def create_parser():
         help='Table to exclude from transfer.  Can be specified multiple times to exclude '
              'multiple tables'
     )
-
 
     # database
     source_option_group.add_option(
@@ -585,6 +592,7 @@ def create_parser():
 
     return parser
 
+
 def wait_for_pool(pool, max_queued, wait_until_empty):
     """
     Waits for pool to empty below the number of workers.  This helps prevent
@@ -615,11 +623,12 @@ def wait_for_pool(pool, max_queued, wait_until_empty):
             else:
                 successful_commands.append(cmd)
         if (has_completed_cmds and not (wait_until_empty and pool.work_queue.qsize() == 0)) or \
-            ((canceled or wait_until_empty) and pool.work_queue.qsize() == 0):
+                ((canceled or wait_until_empty) and pool.work_queue.qsize() == 0):
             break
         time.sleep(1)
 
-    return (successful_commands, failed_commands)
+    return successful_commands, failed_commands
+
 
 # --------------------------------------------------------------------------
 
@@ -630,7 +639,7 @@ def split_fqn(fqn):
     """
 
     index = 0
-    partitions = ['','','']
+    partitions = ['', '', '']
     regexp_parsing = False
 
     for c in fqn:
@@ -649,13 +658,13 @@ def split_fqn(fqn):
                 index += 1
             else:
                 partitions[index] = partitions[index] + c
-
     if index != 2:
         raise Exception('Invalid fully qualified table name %s' % fqn)
 
     (database, schema, table) = partitions
 
-    return (database, schema, table)
+    return database, schema, table
+
 
 def _process_regexp(regexp=None):
     """
@@ -712,15 +721,16 @@ def get_databases_by_regexp(host, port, user, databases, warning=False):
         db_matched = False
         for db in all_dbs:
             try:
-                if re.match(r'%s' % database, db, re.L|re.U) and db not in dbs:
+                if re.match(r'%s' % database, db, re.L | re.U) and db not in dbs:
                     dbs.append(db)
                     db_matched = True
             except Exception, e:
-                raise Exception("Error matching regular expression %s with %s\n%s" %(database, db, e))
+                raise Exception("Error matching regular expression %s with %s\n%s" % (database, db, e))
         if not db_matched and warning:
-            logger.warning('Find no user databases matching "%s" in source system' % database[1 : len(database) - 1])
+            logger.warning('Find no user databases matching "%s" in source system' % database[1: len(database) - 1])
 
     return dbs
+
 
 def get_user_tables(host, port, user, databases=None, full=False, partition_transfer=False):
     """
@@ -739,11 +749,13 @@ SELECT
     n.nspname, c.relname, c.relstorage
 FROM
     pg_class c JOIN pg_namespace n ON (c.relnamespace=n.oid)
-    JOIN pg_catalog.gp_distribution_policy p on (c.oid = p.localoid)
+    JOIN pg_catalog.gp_distribution_policy p ON (c.oid = p.localoid)
 WHERE """
-    table_sql_parttion_transfer = """c.oid NOT IN ( SELECT parchildrelid as oid FROM pg_partition_rule ) AND """
+    table_sql_non_partition_transfer = """c.oid NOT IN ( SELECT parchildrelid as oid FROM pg_partition_rule ) AND """
     table_sql_part2 = """ n.nspname NOT IN ('gpexpand', 'pg_bitmapindex', 'information_schema', 'gp_toolkit');"""
-    all_tables_sql = table_sql_part1 + (table_sql_parttion_transfer if not partition_transfer else '') + table_sql_part2
+    all_tables_sql = table_sql_part1 + \
+                     (table_sql_non_partition_transfer if not partition_transfer else '') + \
+                     table_sql_part2
 
     all_tables = set()
 
@@ -808,8 +820,9 @@ def schema_exists_on_system(host, port, user, schema, databases=None):
         if schema_exists:
             return True
 
+
 def drop_existing_schema_on_system(host, port, user, schema, databases=None):
-    """  
+    """
     host: hostname or ip address of Greenplum DB
     port: port of Greenplum DB
     user: user to connect as
@@ -826,17 +839,14 @@ def drop_existing_schema_on_system(host, port, user, schema, databases=None):
     for database in databases:
         url = DbURL(host, port, database, user)
         conn = connect(url)
-        schema_exists = dropSchemaIfExist(conn, schema)
+        dropSchemaIfExist(conn, schema)
         conn.close()
-        if schema_exists: # todo this smells like an error since it can exit early. Please investigate
-            return True
 
 # --------------------------------------------------------------------------
 # Validation classes
 # --------------------------------------------------------------------------
 
 class TableValidator(object):
-
     """
     Base class for table validators.
     """
@@ -972,12 +982,11 @@ class TableValidator(object):
 # --------------------------------------------------------------------------
 
 class CountTableValidator(TableValidator):
-
     """
     Simple COUNT(*) "validation".
     """
 
-    def __init__(self, work_dir, table_pair, src_conn, dest_conn):
+    def __init__(self, work_dir, table_pair, src_conn=None, dest_conn=None):
         """
         table_pair: table pair to validate
         src_conn: Database connection to the source system
@@ -993,6 +1002,20 @@ class CountTableValidator(TableValidator):
                                 sql % (src_schema, src_table),
                                 sql % (dest_schema, dest_table))
 
+    def init_dest_dict(self, dest_tables_dict=None, table_pair=None):
+        try:
+            dest_res = execSQLForSingletonRow(self._dest_conn, self._dest_sql)[0]
+            dest_tables_dict[str(table_pair.dest)] = dest_res
+        except:
+            self._dest_failed = True
+
+    def accumulate(self, dest_tables_dict=None, table_pair=None):
+        try:
+            src_res = execSQLForSingletonRow(self._src_conn, self._src_sql)[0]
+            dest_tables_dict[str(table_pair.dest)] -= src_res
+        except:
+            self._dest_failed = True
+
     @staticmethod
     def get_name():
         """
@@ -1000,11 +1023,11 @@ class CountTableValidator(TableValidator):
         """
         return 'count'
 
+
 # --------------------------------------------------------------------------
 
 
 class MD5MergeTableValidator(TableValidator):
-
     """
     Validation that compares the MD5 hashes of all the rows in a table.
     """
@@ -1112,7 +1135,7 @@ class MD5MergeTableValidator(TableValidator):
             self._pool.check_results()
             if not self._dest_failed and not self._src_failed:
                 res = ((self._src_md5_cmd.get_results()).stdout.strip()
-                        == (self._dest_md5_cmd.get_results()).stdout.strip())
+                       == (self._dest_md5_cmd.get_results()).stdout.strip())
         finally:
             pass
         return res
@@ -1124,11 +1147,11 @@ class MD5MergeTableValidator(TableValidator):
         """
         return 'md5'
 
+
 # --------------------------------------------------------------------------
 
 
 class TableValidatorFactory(object):
-
     """
     Class reponsible for managing the various validation classes.
     """
@@ -1142,8 +1165,8 @@ class TableValidatorFactory(object):
         """
         classes = inspect.getmembers(sys.modules[__name__],
                                      lambda m: inspect.isclass(m) and
-                                     m.__module__ == __name__ and
-                                     issubclass(m, TableValidator))
+                                               m.__module__ == __name__ and
+                                               issubclass(m, TableValidator))
         for (_, c) in classes:
             name = c.get_name()
             if name:
@@ -1168,10 +1191,12 @@ class TableValidatorFactory(object):
         except:
             raise Exception('Unknown validator %s' % name)
 
+
 # --------------------------------------------------------------------------
 # Validator factory
 # --------------------------------------------------------------------------
 validator_factory = TableValidatorFactory()
+
 
 # --------------------------------------------------------------------------
 # Command classes for data transfer
@@ -1179,7 +1204,6 @@ validator_factory = TableValidatorFactory()
 
 
 class PsqlFile(Command):
-
     """
     psql command for executing file
     """
@@ -1194,14 +1218,13 @@ class PsqlFile(Command):
         filename: SQL file to execute
         """
         cmdStr = 'psql -U %s -h %s -p %d -f %s %s' \
-            % (user, host, port, filename, database)
+                 % (user, host, port, filename, database)
         Command.__init__(self, name, cmdStr, LOCAL, None)
 
 
 # --------------------------------------------------------------------------
 
 class CreateDB(Command):
-
     """
     Create database command
     """
@@ -1215,14 +1238,13 @@ class CreateDB(Command):
         database: GPDB database
         """
         cmdStr = 'createdb -U %s -h %s -p %d %s' \
-            % (user, host, port, database)
+                 % (user, host, port, database)
         Command.__init__(self, name, cmdStr, LOCAL, None)
 
 
 # --------------------------------------------------------------------------
 
 class GpCreateNamedPipe(Command):
-
     """
     Command for creating a named pipe on *nix systems.
     """
@@ -1239,7 +1261,6 @@ class GpCreateNamedPipe(Command):
 
 # --------------------------------------------------------------------------
 class GpCloseNamedPipe(Command):
-
     """
     Opens and closes named pipe to make sure process at other end received
     EOF
@@ -1253,11 +1274,11 @@ class GpCloseNamedPipe(Command):
         cmdStr = """python -c 'f = open("%s", "w+"); f.close()'""" % fifo_name
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
+
 # --------------------------------------------------------------------------
 
 
 class GpCreateGpfdist(Command):
-
     """
     Command for starting a gpfdist instance.
     """
@@ -1288,7 +1309,7 @@ class GpCreateGpfdist(Command):
         if res and res.wasSuccessful():
             host = self.remoteHost
             m = re.search(GPFDIST_PORT_REGEX, res.stdout)
-            if m: 
+            if m:
                 port = m.group(1)
                 url = "gpfdist://%s:%s/%s" % (host, port, self._data_file)
 
@@ -1296,10 +1317,10 @@ class GpCreateGpfdist(Command):
             raise Exception("Failed to find port in gpfdist log file")
         return url
 
+
 # --------------------------------------------------------------------------
 
 class GpCleanupGpfdist(Command):
-
     """
     Command for terminating a running gpfdist instance and removing its pid file
     """
@@ -1371,7 +1392,6 @@ os.unlink(sys.argv[1])' %s %s""" % (pid_file, log_file)
 # --------------------------------------------------------------------------
 
 class GpSchemaDump(Command):
-
     """
     Command for dumping the schema of a GPDB table.  Currently it only dumps
     the table schema and does not include ownership or dependent database
@@ -1399,10 +1419,10 @@ class GpSchemaDump(Command):
 
         if full:
             cmdStr = 'pg_dumpall -s --gp-syntax -h %s -p %d -U %s' \
-                % (host, port, user)
+                     % (host, port, user)
         else:
             cmdStr = 'pg_dump -s -x -O --gp-syntax -h %s -p %d -U %s -t ' \
-                '\'\"%s\".\"%s\"\' %s' % (host, port, user, schema, table, database)
+                     '\'\"%s\".\"%s\"\' %s' % (host, port, user, schema, table, database)
 
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
 
@@ -1440,20 +1460,18 @@ class GpSchemaDump(Command):
 
 # --------------------------------------------------------------------------
 class GpTransferCommand(Command):
-
     """
     Command to transfer data in a table from one GPDB system to another.
 
-    TODO: too many params
     """
 
     def __init__(
-        self, name, src_host, src_port, src_user, dest_host, dest_port,
-        dest_user, table_pair, dest_exists, truncate, analyze, drop,
-        fast_mode, exclusive_lock, schema_only, work_dir,
-        host_map, source_config, batch_size, gpfdist_port, gpfdist_last_port, 
-        gpfdist_instance_count, max_line_length, timeout, wait_time, 
-        delimiter, validator, format, quote, table_transfer_set_total):
+            self, name, src_host, src_port, src_user, dest_host, dest_port,
+            dest_user, table_pair, dest_exists, truncate, analyze, drop,
+            fast_mode, exclusive_lock, schema_only, work_dir,
+            host_map, source_config, batch_size, gpfdist_port, gpfdist_last_port,
+            gpfdist_instance_count, max_line_length, timeout, wait_time,
+            delimiter, validator, format, quote, table_transfer_set_total):
         """
         name: name of the command
         src_host: source GPDB host
@@ -1564,6 +1582,7 @@ class GpTransferCommand(Command):
                             self._table_pair.source,
                             self._table_pair.dest)
 
+                # NOTE: These connections are used for table validation
                 url = DbURL(self._src_host, self._src_port,
                             self._table_pair.source.database, self._src_user)
                 self._src_conn = connect(url)
@@ -1589,6 +1608,7 @@ class GpTransferCommand(Command):
                     self._start_read_gpfdist()
                     self._create_source_wext()
                     self._create_dest_ext()
+
                     self._transfer_data()
                     if self._validator_class:
                         self._validate()
@@ -1639,10 +1659,11 @@ class GpTransferCommand(Command):
 
             if not canceled:
                 if self._success:
-            	    with tableCountLock:
-                    	remaining_tables = remaining_tables - 1
+                    with tableCountLock:
+                        remaining_tables = remaining_tables - 1
                     logger.info(
-                               "Finished transferring table %s, remaining %s of %s tables", str(self._table_pair.source), remaining_tables, self._table_transfer_set_total)
+                        "Finished transferring table %s, remaining %s of %s tables", str(self._table_pair.source),
+                        remaining_tables, self._table_transfer_set_total)
                 else:
                     logger.error(
                         "Failed to transfer table %s", str(self._table_pair.source))
@@ -1651,7 +1672,6 @@ class GpTransferCommand(Command):
                     if self._dest_exception:
                         logger.error(self._dest_exception)
                     logger.info('Remaining %s of %s tables', remaining_tables, self._table_transfer_set_total)
-
 
     def _get_distributed_by(self):
         sql = '''SELECT STRING_AGG(attname, ', ' ORDER BY colorder)
@@ -1754,7 +1774,7 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
                 for i in xrange(0, self._gpfdist_instance_count):
                     pipe = "%s.%d" % (self._pipe, i)
                     named_pipes.append((address, pipe))
-        return named_pipes        
+        return named_pipes
 
     def _create_named_pipe(self):
         """
@@ -1764,7 +1784,7 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
 
         self._pool.empty_completed_items()
         logger.debug('Creating FIFO pipes for source table %s...',
-                    self._table_pair.source)
+                     self._table_pair.source)
 
         for host in self._host_map.keys():
             address = iter(self._host_map[host]).next()
@@ -1785,10 +1805,9 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
         self._pool.join()
         self._pool.check_results()
 
-
         for (address, pipe) in self._get_named_pipes():
             cmd = GpCreateNamedPipe('Create pipe for table %s on %s'
-                                    % (self._table_pair.source, address), 
+                                    % (self._table_pair.source, address),
                                     pipe, REMOTE, address)
 
             self._pool.addCommand(cmd)
@@ -1801,7 +1820,7 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
         """
 
         logger.debug('Creating source writable external table for source '
-                    'table %s...', self._table_pair.source)
+                     'table %s...', self._table_pair.source)
 
         urls = ','.join(["'%s'" % url for url in self._wext_gpfdist_urls])
 
@@ -1810,7 +1829,7 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
             wext_sql = \
                 '''CREATE WRITABLE EXTERNAL WEB TABLE gptransfer.%s (LIKE \"%s\".\"%s\")
                    EXECUTE 'cat > %s.$GP_SEGMENT_ID'
-                   FORMAT '%s' 
+                   FORMAT '%s'
                 ''' % (self._wext_name,
                        self._table_pair.source.schema,
                        self._table_pair.source.table,
@@ -1845,12 +1864,12 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
         """
 
         logger.debug('Creating external table for destination table %s...',
-                    self._table_pair.dest)
+                     self._table_pair.dest)
         urls = ','.join(["'%s'" % url for url in self._ext_gpfdist_urls])
         ext_sql = \
             """CREATE EXTERNAL TABLE gptransfer.%s (LIKE \"%s\".\"%s\")
                LOCATION(%s)
-               FORMAT '%s' """\
+               FORMAT '%s' """ \
             % (self._ext_name,
                self._table_pair.dest.schema,
                self._table_pair.dest.table,
@@ -1870,7 +1889,7 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
 
         logger.info('Analyzing destination table %s...', self._table_pair.dest)
         sql = 'ANALYZE \"%s\".\"%s\"' % (self._table_pair.dest.schema,
-                                 self._table_pair.dest.table)
+                                         self._table_pair.dest.table)
         cur = execSQL(self._dest_conn, sql)
         cur.close()
 
@@ -1910,7 +1929,7 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
             self._pool.join()
             for cmd in self._pool.getCompletedItems():
                 if not cmd.get_results().wasSuccessful():
-                    raise  ExecutionError("Error Executing Command: ", cmd)           
+                    raise ExecutionError("Error Executing Command: ", cmd)
                 url = cmd.get_url()
                 self._wext_gpfdist_urls.append(url)
 
@@ -1973,12 +1992,11 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
 
         for cmd in self._pool.getCompletedItems():
             if not cmd.get_results().wasSuccessful():
-                raise  ExecutionError("Error Executing Command: ", cmd)           
+                raise ExecutionError("Error Executing Command: ", cmd)
             url = cmd.get_url()
             self._ext_gpfdist_urls.append(url)
 
         self._pool.empty_completed_items()
-
 
     def _transfer_data(self):
         """
@@ -2056,12 +2074,12 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
         cur = None
         try:
             query = """INSERT INTO gptransfer.%s SELECT * FROM \"%s\".\"%s\"""" \
-                % (self._wext_name,
-                   self._table_pair.source.schema,
-                   self._table_pair.source.table)
+                    % (self._wext_name,
+                       self._table_pair.source.schema,
+                       self._table_pair.source.table)
             if self._exclusive_lock:
                 lock_query = "LOCK TABLE \"%s\".\"%s\" IN EXCLUSIVE MODE;" % \
-                    (self._table_pair.source.schema, self._table_pair.source.table)
+                             (self._table_pair.source.schema, self._table_pair.source.table)
                 execSQL(self._src_conn, lock_query)
 
             self._src_ready.set()
@@ -2085,12 +2103,12 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
         cur = None
         try:
             query = """INSERT INTO \"%s\".\"%s\" SELECT * FROM gptransfer.%s""" \
-                % (self._table_pair.dest.schema,
-                   self._table_pair.dest.table,
-                   self._ext_name)
+                    % (self._table_pair.dest.schema,
+                       self._table_pair.dest.table,
+                       self._ext_name)
             if self._exclusive_lock:
                 lock_query = "LOCK TABLE \"%s\".\"%s\" IN EXCLUSIVE MODE" % \
-                    (self._table_pair.dest.schema, self._table_pair.dest.table)
+                             (self._table_pair.dest.schema, self._table_pair.dest.table)
                 execSQL(self._dest_conn, lock_query)
 
             self._dest_ready.set()
@@ -2098,8 +2116,6 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
             if canceled:
                 return
 
-            # TODO: The source query should to start executing before the destination
-            #       query but there is no way to coordinate the two here.
             time.sleep(1)
             cur = execSQL(self._dest_conn, query)
             cur.close()
@@ -2121,7 +2137,7 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
                 'Dropping writable external table for source table %s...',
                 self._table_pair.source)
             drop_wext_sql = """DROP EXTERNAL WEB TABLE gptransfer.%s""" \
-                % (self._wext_name)
+                            % (self._wext_name)
             cur = execSQL(self._src_conn, drop_wext_sql)
             cur.close()
         except:
@@ -2135,9 +2151,9 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
 
         try:
             logger.debug('Dropping external table for destination table %s...',
-                        self._table_pair.dest)
+                         self._table_pair.dest)
             drop_ext_sql = """DROP EXTERNAL TABLE gptransfer.%s""" \
-                % (self._ext_name)
+                           % (self._ext_name)
             cur = execSQL(self._dest_conn, drop_ext_sql)
             cur.close()
         except:
@@ -2152,7 +2168,7 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
 
         self._pool.empty_completed_items()
         logger.debug('Stopping gpfdist for source table %s...',
-                    self._table_pair.source)
+                     self._table_pair.source)
         if self._fast_mode:
             for seg in self._source_config.getSegDbList():
                 if seg.isSegmentMirror(True) or seg.isSegmentQD():
@@ -2172,17 +2188,17 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
                 for i in xrange(0, self._gpfdist_instance_count):
                     cmd = GpCleanupGpfdist('stopping gpfdist on %s' % address,
                                            os.path.join(self._work_dir,
-                                           'gpfdist_read_%s_%d.pid' % (str(self._table_pair.source), i)),
+                                                        'gpfdist_read_%s_%d.pid' % (str(self._table_pair.source), i)),
                                            os.path.join(self._work_dir,
-                                           'gpfdist_read_%s_%d.log' % (str(self._table_pair.source), i)),
+                                                        'gpfdist_read_%s_%d.log' % (str(self._table_pair.source), i)),
                                            REMOTE, address)
                     self._pool.addCommand(cmd)
                     cmd = GpCleanupGpfdist(
                         'stopping gpfdist on %s' % address,
                         os.path.join(self._work_dir,
-                        'gpfdist_write_%s_%d.pid' % (str(self._table_pair.source), i)),
+                                     'gpfdist_write_%s_%d.pid' % (str(self._table_pair.source), i)),
                         os.path.join(self._work_dir,
-                        'gpfdist_write_%s_%d.log' % (str(self._table_pair.source), i)),
+                                     'gpfdist_write_%s_%d.log' % (str(self._table_pair.source), i)),
                         REMOTE, address)
                     self._pool.addCommand(cmd)
 
@@ -2197,7 +2213,7 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
 
         self._pool.empty_completed_items()
         logger.debug('Removing FIFO pipes for source table %s...',
-                    self._table_pair.source)
+                     self._table_pair.source)
 
         for host in self._host_map.keys():
             address = iter(self._host_map[host]).next()
@@ -2220,7 +2236,6 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
 
         self._pool.join()
         self._pool.check_results()
-
 
     def _validate(self):
         """
@@ -2252,7 +2267,6 @@ GROUP BY nspname, relname;''' % (self._table_pair.source.schema,
 # --------------------------------------------------------------------------
 
 class GpTransferTable(object):
-
     """
     Class for describing one side of the data transfer.
     """
@@ -2292,9 +2306,32 @@ class GpTransferTable(object):
 
         return hash(str(self))
 
+    def is_identifier_supported(self):
+        return (self._is_identifier_supported(self.database) and
+                self._is_identifier_supported(self.schema) and
+                self._is_identifier_supported(self.table))
+
+    def _is_identifier_supported(self, identifier):
+        """
+        Verify that the characters of identifier starts with a-z, or A-Z or underscore,
+        followed by lower or upper case (a-z, A-Z), or digits(0-9), or underscore (_)
+        """
+
+        if not ((identifier[0:1] >= 'a' and identifier[0:1] <= 'z') or
+                    (identifier[0:1] >= 'A' and identifier[0:1] <= 'Z') or
+                        identifier[0:1] == '_'):
+            return False
+
+        for c in identifier:
+            if not ((c >= 'a' and c <= 'z') or
+                        (c >= 'A' and c <= 'Z') or
+                        (c >= '0' and c <= '9') or
+                        (c == '_')):
+                return False
+        return True
+
 
 class GpTransferTablePair(object):
-
     """
     Wrapper the describes the source and destination table transfer.
     """
@@ -2339,7 +2376,6 @@ class GpTransferTablePair(object):
 # --------------------------------------------------------------------------
 
 class GpTransfer(object):
-
     """
     Main application class for data transfer.
     """
@@ -2373,12 +2409,13 @@ class GpTransfer(object):
         self._src_dest_partition_table_mapping = None
 
         self._all_src_databases = get_user_databases(self._options.source_host,
-                                             self._options.source_port,
-                                             self._options.source_user)
+                                                     self._options.source_port,
+                                                     self._options.source_user)
         self._all_dest_databases = get_user_databases(self._options.dest_host,
-                                             self._options.dest_port,
-                                             self._options.dest_user)
+                                                      self._options.dest_port,
+                                                      self._options.dest_user)
 
+        self.multiple_same_target_set = set()
         self._src_tables = self._get_source_tables()
 
         self._validate_schema_not_exists()
@@ -2392,17 +2429,25 @@ class GpTransfer(object):
                             [db for db in self._dest_databases if db in self._all_dest_databases],
                             False,
                             self._options.partition_transfer)
+        self._dest_non_partition_tables = set()
+        if self._options.partition_transfer:
+            self._dest_non_partition_tables = \
+                get_user_tables(self._options.dest_host,
+                                self._options.dest_port,
+                                self._options.dest_user,
+                                [db for db in self._dest_databases if db in self._all_dest_databases],
+                                False,
+                                partition_transfer=False)
         # segment address list
         self._host_map = self._get_host_map()
-
         # build up table pairs to transfer and validate them
-        self._table_transfer_set = self._build_table_transfer_set()
+        self._table_transfer_set = self._build_table_transfer_list()
         self._table_transfer_set_total = len(self._table_transfer_set)
 
         self._fast_mode = \
             True if (self._dest_config.numPrimarySegments >= self._src_config.numPrimarySegments and
                      not options.force_standard_mode) \
-            else False
+                else False
         if self._fast_mode:
             logger.info('gptransfer will use "fast" mode for transfer.')
         else:
@@ -2428,7 +2473,7 @@ class GpTransfer(object):
         self._validate_host_map()
 
         self._validate_table_transfer_set()
-        if self._options.partition_transfer:
+        if self._options.partition_transfer or self._options.pt_non_pt_target:
             self._validate_partition_table_transfer_set()
 
         self._validate_filespace(self._options.source_host, self._options.source_port, self._options.source_user,
@@ -2470,13 +2515,14 @@ class GpTransfer(object):
             failed_tables = list()
             max_queued = self._options.batch_size + 1
             cmds_queued = 0
+
+            self.before_dest_tables_dict = {}
+            if self._options.pt_non_pt_target:
+                self.before_dest_tables_dict = self.get_dest_row_count_before_transfer()
+
             for table_pair in self._table_transfer_set:
-                truncate = (True if self._options.truncate
-                            and table_pair.dest
-                            in self._dest_tables else False)
-                drop = (True if self._options.drop
-                        and table_pair.dest
-                        in self._dest_tables else False)
+                truncate = (True if self._options.truncate and table_pair.dest in self._dest_tables else False)
+                drop = (True if self._options.drop and table_pair.dest in self._dest_tables else False)
 
                 cmd = GpTransferCommand(
                     'transfer of %s' % table_pair.source,
@@ -2514,7 +2560,7 @@ class GpTransfer(object):
                 self._pool.addCommand(cmd)
                 cmds_queued += 1
 
-                (successful_commands, failed_commands) = wait_for_pool(self._pool, 
+                (successful_commands, failed_commands) = wait_for_pool(self._pool,
                                                                        max_queued,
                                                                        cmds_queued == len(self._table_transfer_set))
                 for failed_cmd in failed_commands:
@@ -2535,7 +2581,7 @@ class GpTransfer(object):
                 return 1
             else:
                 if self._validator_class:
-                   self._final_count_validation()
+                    self._final_count_validation()
         else:
             # dry run
             self._dry_run()
@@ -2710,7 +2756,6 @@ class GpTransfer(object):
 
             self._pool.join()
 
-
             if self._options.validator:
                 logger.info('Cleaning up validator...')
                 validator = validator_factory.get_validator(
@@ -2812,7 +2857,6 @@ class GpTransfer(object):
                             str(pair.dest),
                             action_msg)
 
-
     def _pre_validate_options(self):
         """
         Validates the options passed in to the application.
@@ -2820,26 +2864,31 @@ class GpTransfer(object):
 
         logger.info('Validating options...')
         if self._options.batch_size > MAX_BATCH_SIZE \
-	    or self._options.batch_size < 1:
+                or self._options.batch_size < 1:
             raise ProgramArgumentValidationException('Invalid value for --batch-size.  '
-                                   '--batch-size must be greater than 0 and '
-                                   'less than %s' % MAX_BATCH_SIZE)
+                                                     '--batch-size must be greater than 0 and '
+                                                     'less than %s' % MAX_BATCH_SIZE)
 
         if self._options.sub_batch_size > MAX_SUB_BATCH_SIZE \
-            or self._options.sub_batch_size < 1:
+                or self._options.sub_batch_size < 1:
             raise ProgramArgumentValidationException('Invalid value for --sub-batch-size.  '
-                                   'Must be greater than 0 and less than %s'
-                                   % MAX_SUB_BATCH_SIZE)
+                                                     'Must be greater than 0 and less than %s'
+                                                     % MAX_SUB_BATCH_SIZE)
 
         if self._options.full and len(self._options.exclude_tables) != 0:
             raise ProgramArgumentValidationException('Cannot specify -T and --full options '
-                                   'together')
+                                                     'together')
 
         if self._options.full and self._options.exclude_input_file:
             raise ProgramArgumentValidationException('Cannot specify -F and --full options '
-                                   'together')
+                                                     'together')
 
+        if self._options.input_file and not os.path.isfile(self._options.input_file):
+            raise ProgramArgumentValidationException('Input file %s is not a valid file' % self._options.input_file)
 
+        if (self._options.partition_transfer and self._options.pt_non_pt_target):
+            raise ProgramArgumentValidationException('--partition-transfer option cannot be '
+                                                     'used with --partition-transfer-non-partition-target option')
 
         if (self._options.partition_transfer and not self._options.input_file):
             raise ProgramArgumentValidationException('--partition-transfer option must be '
@@ -2870,50 +2919,83 @@ class GpTransfer(object):
             raise ProgramArgumentValidationException('--partition-transfer option cannot be used '
                                                      'with any exclude table option')
 
-        if self._options.input_file and not os.path.isfile(self._options.input_file):
-            raise ProgramArgumentValidationException('Input file %s is not a valid file' % self._options.input_file)
-
         if (self._options.partition_transfer and self._options.full):
-            raise ProgramArgumentValidationException('--partition-transfer option cannot be ' 
+            raise ProgramArgumentValidationException('--partition-transfer option cannot be '
                                                      'used with --full option')
 
+        if (self._options.pt_non_pt_target and not self._options.input_file):
+            raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option must be '
+                                                     'used with -f option')
+
+        if (self._options.pt_non_pt_target and self._options.databases):
+            raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be '
+                                                     'used with -d option')
+
+        if (self._options.pt_non_pt_target and self._options.dest_database):
+            raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be '
+                                                     'used with --dest-database option')
+
+        if (self._options.pt_non_pt_target and self._options.drop):
+            raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be used '
+                                                     'with --drop option')
+
+        if (self._options.pt_non_pt_target and self._options.tables):
+            raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be used '
+                                                     'with -t option')
+
+        if (self._options.pt_non_pt_target and self._options.schema_only):
+            raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be used '
+                                                     'with --schema-only option')
+
+        if (self._options.pt_non_pt_target and (self._options.exclude_tables or self._options.exclude_input_file)):
+            raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be used '
+                                                     'with any exclude table option')
+
+        if (self._options.pt_non_pt_target and self._options.full):
+            raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be '
+                                                     'used with --full option')
+
+        if (self._options.pt_non_pt_target and self._options.validator):
+            raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be '
+                                                     'used with --validate option')
+
         if self._options.full and (self._options.truncate or self._options.drop or
-                                   self._options.skip_existing):
+                                       self._options.skip_existing):
             raise ProgramArgumentValidationException('Cannot specify --drop, --truncate or '
-                                   '--skip-existing with --full option')
+                                                     '--skip-existing with --full option')
 
         if self._options.truncate and self._options.skip_existing:
             raise ProgramArgumentValidationException('Cannot specify --truncate and '
-                                   '--skip-existing together')
+                                                     '--skip-existing together')
 
         if self._options.truncate and self._options.drop:
             raise ProgramArgumentValidationException('Cannot specify --truncate and '
-                                   '--drop together')
+                                                     '--drop together')
 
         if self._options.skip_existing and self._options.drop:
             raise ProgramArgumentValidationException('Cannot specify --drop and '
-                                   '--skip-existing together')
+                                                     '--skip-existing together')
 
         if self._options.schema_only and self._options.truncate:
             raise ProgramArgumentValidationException('Cannot specify --schema-only and '
-                                   '--truncate together')
+                                                     '--truncate together')
 
         if not self._options.source_map_file and \
-                self._options.source_host != self._options.dest_host and \
-                self._options.source_port != self._options.dest_port:
+                        self._options.source_host != self._options.dest_host and \
+                        self._options.source_port != self._options.dest_port:
             raise ProgramArgumentValidationException(
                 '--source-addresses-file option is required')
 
         if self._options.source_map_file and not os.path.isfile(self._options.source_map_file):
             raise ProgramArgumentValidationException('File %s does not exist'
-                                   % self._options.source_map_file)
+                                                     % self._options.source_map_file)
 
         if not self._options.source_host:
             raise ProgramArgumentValidationException('--source-host option is required.')
 
         if not self._options.full and len(self._options.tables) == 0 \
-            and len(self._options.databases) == 0 \
-            and not self._options.input_file:
+                and len(self._options.databases) == 0 \
+                and not self._options.input_file:
             raise ProgramArgumentValidationException('One of --full, -f, -t, or -d must be specified')
 
         if sum(bool(option) for option in (self._options.full,
@@ -2936,18 +3018,19 @@ class GpTransfer(object):
             self._options.last_port = self._options.base_port + 1000
             if self._options.last_port > 65535:
                 raise ProgramArgumentValidationException('--base-port value causes last port to be invalid.')
-            logger.warn('--last-port value is less than --base-port.  Setting last port to %d' % (self._options.last_port))
+            logger.warn(
+                '--last-port value is less than --base-port.  Setting last port to %d' % (self._options.last_port))
 
         if self._options.max_line_length < MIN_GPFDIST_MAX_LINE_LENGTH or \
-            self._options.max_line_length > MAX_GPFDIST_MAX_LINE_LENGTH:
+                        self._options.max_line_length > MAX_GPFDIST_MAX_LINE_LENGTH:
             raise ProgramArgumentValidationException('Invalid --max-line-length option.  Value must be '
-                                   'between %d and %d' % (MIN_GPFDIST_MAX_LINE_LENGTH,
-                                                          MAX_GPFDIST_MAX_LINE_LENGTH))
+                                                     'between %d and %d' % (MIN_GPFDIST_MAX_LINE_LENGTH,
+                                                                            MAX_GPFDIST_MAX_LINE_LENGTH))
 
         if self._options.timeout < MIN_GPFDIST_TIMEOUT or \
-            self._options.timeout > MAX_GPFDIST_TIMEOUT:
+                        self._options.timeout > MAX_GPFDIST_TIMEOUT:
             raise ProgramArgumentValidationException('Invalid --timeout option.  Value must be between '
-                                   '%d and %d' % (MIN_GPFDIST_TIMEOUT, MAX_GPFDIST_TIMEOUT))
+                                                     '%d and %d' % (MIN_GPFDIST_TIMEOUT, MAX_GPFDIST_TIMEOUT))
 
         if self._options.wait_time < 0:
             raise ProgramArgumentValidationException('--wait-time must be greater than 0')
@@ -2956,7 +3039,7 @@ class GpTransfer(object):
         if not FileDirExists.remote('remote gphome check',
                                     self._options.source_host, self._gphome):
             raise ProgramArgumentValidationException('GPHOME directory does not exist on %s'
-                                   % self._options.source_host)
+                                                     % self._options.source_host)
 
         if self._options.validator and self._options.validator not in \
                 validator_factory.get_available_validators():
@@ -2964,19 +3047,19 @@ class GpTransfer(object):
                 'Unknown validator %s' % self._options.validator)
 
         if self._options.source_host == self._options.dest_host and \
-                self._options.source_port == self._options.dest_port and \
+                        self._options.source_port == self._options.dest_port and \
                 not self._options.dest_database and \
                 not self._options.partition_transfer:
             raise ProgramArgumentValidationException('Source and destination systems cannot be '
-                                   'the same unless --dest-database or --partition-transfer option is '
-                                   'set')
+                                                     'the same unless --dest-database or --partition-transfer option is '
+                                                     'set')
 
         if self._options.full and self._options.dest_database:
             raise ProgramArgumentValidationException('--dest-database option cannot be used with'
-                                   ' the --full option')
+                                                     ' the --full option')
 
         if (self._options.delimiter[0] == "\\" and len(self._options.delimiter) != 4) and \
-           (len(self._options.delimiter) != 1):
+                (len(self._options.delimiter) != 1):
             raise ProgramArgumentValidationException(
                 'Invalid --delimiter.  Must be single character')
 
@@ -2995,7 +3078,7 @@ class GpTransfer(object):
 
         if self._options.full and self._dest_databases != None and len(self._dest_databases) != 0:
             raise ProgramArgumentValidationException('--full option specified but databases exist '
-                                   'in destination system')
+                                                     'in destination system')
 
         if self._gpfdist_instance_count == 0:
             raise Exception('Destination system is too small')
@@ -3006,20 +3089,32 @@ class GpTransfer(object):
 
     def _final_count_validation(self):
         logger.info('Running final table row count validation on destination tables...')
+
+        # build a hash of dest tables
+        # add the count of tables into the hash
+        # remove # of tables from source to the hash of dest table
+        #
+        dest_table_dict = {}
         for table_pair in self._table_transfer_set:
+            dest_conn = None
+            src_conn = None
             try:
-                url = DbURL(self._options.source_host, self._options.source_port, table_pair.source.database, self._options.source_user)
+                if not str(table_pair.dest) in dest_table_dict:
+                    dest_table_dict[str(table_pair.dest)] = 0
+                    url = DbURL(self._options.dest_host, self._options.dest_port, table_pair.dest.database,
+                                self._options.dest_user)
+                    dest_conn = connect(url)
+
+                url = DbURL(self._options.source_host, self._options.source_port, table_pair.source.database,
+                            self._options.source_user)
                 src_conn = connect(url)
-                url = DbURL(self._options.dest_host, self._options.dest_port, table_pair.dest.database, self._options.dest_user)
-                dest_conn = connect(url)
                 validator = self._validator_class(self._work_dir,
                                                   table_pair,
                                                   src_conn,
                                                   dest_conn)
-                if not validator.validate():
-                   logger.error('Validation failed for %s', table_pair.dest)
-                else:
-                   logger.info('Validation of %s successful', table_pair.dest)
+                if dest_conn:
+                    validator.init_dest_dict(dest_table_dict, table_pair)
+                validator.accumulate(dest_table_dict, table_pair)
             except Exception, e:
                 raise Exception("Final count validation failed for %s" % e)
             finally:
@@ -3027,6 +3122,37 @@ class GpTransfer(object):
                     src_conn.close()
                 if dest_conn:
                     dest_conn.close()
+
+        for dest_table, validation_count in dest_table_dict.items():
+            before_transfer_row_count = self.before_dest_tables_dict[dest_table] \
+                if self.before_dest_tables_dict else 0
+            if (validation_count - before_transfer_row_count) != 0:
+                if self._options.partition_transfer or self._options.pt_non_pt_target:
+                    logger.warning('Validation failed for %s', dest_table)
+                else:
+                    logger.error('Validation failed for %s', dest_table)
+            else:
+                logger.info('Validation of %s successful', dest_table)
+
+    def get_dest_row_count_before_transfer(self):
+        before_dest_tables_dict = {}
+        for table_pair in self._table_transfer_set:
+            dest_conn = None
+            try:
+                url = DbURL(self._options.dest_host, self._options.dest_port, table_pair.dest.database,
+                            self._options.dest_user)
+                dest_conn = connect(url)
+                schemaname = pg.escape_string(table_pair.dest.schema)
+                tablename = pg.escape_string(table_pair.dest.table)
+                dest_sql = "SELECT count(*) FROM %s.%s" % (schemaname, tablename)
+                dest_res = execSQLForSingletonRow(dest_conn, dest_sql)[0]
+                before_dest_tables_dict[str(table_pair.dest)] = dest_res
+            except Exception, e:
+                raise Exception("Failed to get table row count before transfer: %s" % e)
+            finally:
+                if dest_conn:
+                    dest_conn.close()
+        return before_dest_tables_dict
 
     # Validate if destination system is missing required filespaces
     def _validate_filespace(self, source_host, source_port, source_user, dest_host, dest_port, dest_user, full):
@@ -3043,12 +3169,13 @@ class GpTransfer(object):
             template_source_fs_sql = """SELECT fsname FROM pg_catalog.pg_filespace WHERE oid IN
                                         (SELECT spcfsoid FROM pg_catalog.pg_tablespace
                                         WHERE oid IN (SELECT dattablespace FROM pg_catalog.pg_database WHERE datname = '%s')
-                                        OR oid IN (SELECT reltablespace FROM pg_catalog.pg_class where relname = '%s'));"""
+                                        OR oid IN (SELECT reltablespace FROM pg_catalog.pg_class WHERE relname = '%s'));"""
             for table_pair in self._table_transfer_set:
                 dbname = pg.escape_string(table_pair.source.database)
                 tablename = pg.escape_string(table_pair.source.table)
                 source_fs_sql = template_source_fs_sql % (dbname, tablename)
-                self._check_filespace(source_host, source_port, table_pair.source.database, source_user, list_dest_fs, source_fs_sql)
+                self._check_filespace(source_host, source_port, table_pair.source.database, source_user, list_dest_fs,
+                                      source_fs_sql)
 
     def _get_destination_filespaces(self, dest_host, dest_port, database, dest_user):
         list_dest_fs = []
@@ -3067,7 +3194,8 @@ class GpTransfer(object):
                 fs = row[0]
                 if fs not in list_dest_fs:
                     source_cur.close()
-                    raise Exception("Filespace '%s' does not exist on destination. Please create the filespace to run gptransfer" % fs)
+                    raise Exception(
+                        "Filespace '%s' does not exist on destination. Please create the filespace to run gptransfer" % fs)
             source_cur.close()
 
     def _get_configurations(self):
@@ -3085,7 +3213,6 @@ class GpTransfer(object):
         url = DbURL(self._options.dest_host, self._options.dest_port,
                     'template1', self._options.dest_user)
         self._dest_config = GpArray.initFromCatalog(url)
-
 
     def _validate_schema_not_exists(self):
         """
@@ -3157,12 +3284,11 @@ class GpTransfer(object):
                                                'gptransfer',
                                                [db for db in self._dest_databases if db in self._all_dest_databases])
 
-
     def _get_source_tables(self):
         source_tables = list()
         # --partition-transfer will have the exact database name for each destination table,
         # not support the regexp
-        if self._options.partition_transfer:
+        if (self._options.partition_transfer or self._options.pt_non_pt_target):
 
             self._src_dest_partition_table_mapping = dict()
 
@@ -3172,7 +3298,7 @@ class GpTransfer(object):
                                           self._options.source_user,
                                           self._src_databases,
                                           False,
-                                          self._options.partition_transfer)
+                                          (self._options.partition_transfer or self._options.pt_non_pt_target))
 
             # filter out non-exist source tables from source databases.
             # key in dict: self._src_dest_partition_table_mapping maps to index of list: source_tables
@@ -3195,8 +3321,8 @@ class GpTransfer(object):
             for src_table in get_user_tables(self._options.source_host,
                                              self._options.source_port,
                                              self._options.source_user,
-                                             full = True,
-                                             partition_transfer = False):
+                                             full=True,
+                                             partition_transfer=False):
                 if src_table.database != 'gpperfmon':
                     source_tables.append(src_table)
 
@@ -3217,10 +3343,10 @@ class GpTransfer(object):
             for database in self._options.databases:
                 databases.append(_process_regexp(database))
             databases_full_transfer = get_databases_by_regexp(
-                                               self._options.source_host,
-                                               self._options.source_port,
-                                               self._options.source_user,
-                                               databases, True)
+                self._options.source_host,
+                self._options.source_port,
+                self._options.source_user,
+                databases, True)
 
             # add all tables of source databases
             for table in get_user_tables(self._options.source_host,
@@ -3228,7 +3354,7 @@ class GpTransfer(object):
                                          self._options.source_user,
                                          databases_full_transfer,
                                          False,
-                                         self._options.partition_transfer):
+                                         (self._options.partition_transfer or self._options.pt_non_pt_target)):
                 source_tables.append(table)
 
             del databases[:]
@@ -3243,14 +3369,13 @@ class GpTransfer(object):
                 self._get_tables_from_input_file(databases, tables)
 
             databases_table_transfer = get_databases_by_regexp(
-                                           self._options.source_host,
-                                           self._options.source_port,
-                                           self._options.source_user,
-                                           databases, True)
+                self._options.source_host,
+                self._options.source_port,
+                self._options.source_user,
+                databases, True)
 
             # get all source databases to transfer tables from
             self._src_databases = databases_full_transfer + databases_table_transfer
-
 
             # get all destination databases
             if self._options.dest_database:
@@ -3265,7 +3390,7 @@ class GpTransfer(object):
                                           self._options.source_user,
                                           databases_table_transfer,
                                           False,
-                                          self._options.partition_transfer)
+                                          (self._options.partition_transfer or self._options.pt_non_pt_target))
 
             # Filter down to only the tables needed to added
             seen = set()
@@ -3274,12 +3399,12 @@ class GpTransfer(object):
                     database, schema, table = user_table.database, user_table.schema, user_table.table
 
                     try:
-                        if (re.match(r'%s' % db_, database, re.L|re.U) and
-                            re.match(r'%s' % schema_, schema, re.L|re.U) and
-                            re.match(r'%s' % table_, table, re.L|re.U)):
-                                if user_table not in seen:
-                                    seen.add(user_table)
-                                    source_tables.append(user_table)
+                        if (re.match(r'%s' % db_, database, re.L | re.U) and
+                                re.match(r'%s' % schema_, schema, re.L | re.U) and
+                                re.match(r'%s' % table_, table, re.L | re.U)):
+                            if user_table not in seen:
+                                seen.add(user_table)
+                                source_tables.append(user_table)
 
                     except Exception, e:
                         raise Exception('Error matching regular expression, %s with database name %s'
@@ -3299,11 +3424,14 @@ class GpTransfer(object):
         """
         if users provide an input file, add all tables specified.
         """
-        with open (self._options.input_file) as input_file:
+        with open(self._options.input_file) as input_file:
             for line in input_file:
                 line = line.strip()
                 if line.startswith('#'):
                     continue
+                if ',' in line:
+                    raise Exception("Destination tables (comma separated) are only allowed for partition tables. "
+                                    "line: %s" % line)
                 self._process_tables_details(line, databases, tables)
 
     def _get_tables_from_partition_input_file(self):
@@ -3317,7 +3445,7 @@ class GpTransfer(object):
         self._src_databases = []
         fqn_format = '<db_name>.<schema_name>.<table_name>'
         logger.info('Reading partition table transfer pairs from input file %s', self._options.input_file)
-        with open (self._options.input_file) as input_file:
+        with open(self._options.input_file) as input_file:
             for line in input_file:
                 line = line.strip()
                 if line.startswith('#') or line == '':
@@ -3326,7 +3454,7 @@ class GpTransfer(object):
                 if ',' in line:
                     if line.count(',') > 1:
                         raise Exception('Wrong format found for table transfer pair "%s", use single comma '
-                                         'to separate source and destination table' % line)
+                                        'to separate source and destination table' % line)
                     src_table, dest_table = line.split(',')
                 else:
                     src_table = dest_table = line
@@ -3347,21 +3475,23 @@ class GpTransfer(object):
 
                 if dest_table.count(SCHEMA_DELIMITER) != 2:
                     raise Exception('Destination table name "%s" isn\'t fully qualified format: %s' %
-                                     (dest_table, fqn_format))
+                                    (dest_table, fqn_format))
 
                 if (src_table == dest_table and self._options.source_host == self._options.dest_host and
-                   self._options.source_port == self._options.dest_port):
+                            self._options.source_port == self._options.dest_port):
                     raise Exception('Cannot transfer between same partition table %s' % src_table)
 
                 if src_table in self._src_prt_tables:
                     indexes = [i for i, tbl in enumerate(self._src_prt_tables) if tbl == src_table]
                     for i in indexes:
                         if self._dest_prt_tables[i] == dest_table:
-                            logger.warning('Duplicate entries found, source partition table %s, destination partition table %s ' %
-                                          (src_table, dest_table))
+                            logger.warning(
+                                'Duplicate entries found, source partition table %s, destination partition table %s ' %
+                                (src_table, dest_table))
                     continue
 
-                logger.debug('Getting source partition table "%s", destination partition table "%s"' % (src_table, dest_table))
+                logger.debug(
+                    'Getting source partition table "%s", destination partition table "%s"' % (src_table, dest_table))
                 self._src_prt_tables.append(src_table)
                 self._dest_prt_tables.append(dest_table)
 
@@ -3390,7 +3520,7 @@ class GpTransfer(object):
         schema = _process_regexp(schema)
         table = _process_regexp(table)
 
-        return (database, schema, table)
+        return database, schema, table
 
     def _get_exclude_tables(self):
         """
@@ -3422,29 +3552,26 @@ class GpTransfer(object):
 
                     exclude_tables.add((database, schema, table))
 
-        return exclude_tables 
-
+        return exclude_tables
 
     def filter_tables(self, source_tables, exclude_tables):
         """
         filter out the source tables from transferring
         """
         if (source_tables is None or len(source_tables) == 0 or
-            exclude_tables is None or len(exclude_tables) == 0):
-
+                    exclude_tables is None or len(exclude_tables) == 0):
             return source_tables
 
         tables_to_transfer = list()
-        for src_table in  source_tables:
+        for src_table in source_tables:
             database, schema, table = src_table.database, src_table.schema, src_table.table
 
             is_exclude_table_match = False
             for (db_, schema_, table_) in exclude_tables:
                 try:
-                    if (re.match(r'%s' % db_, database, re.L|re.U) and
-                        re.match(r'%s' % schema_, schema, re.L|re.U) and
-                        re.match(r'%s' % table_, table, re.L|re.U)):
-
+                    if (re.match(r'%s' % db_, database, re.L | re.U) and
+                            re.match(r'%s' % schema_, schema, re.L | re.U) and
+                            re.match(r'%s' % table_, table, re.L | re.U)):
                         is_exclude_table_match = True
                         break
                 except Exception, e:
@@ -3463,7 +3590,7 @@ class GpTransfer(object):
 
         return tables_to_transfer
 
-    def _build_table_transfer_set(self):
+    def _build_table_transfer_list(self):
         """
         Builds up the list of tables to transfer.
         """
@@ -3476,14 +3603,14 @@ class GpTransfer(object):
 
             src_table = self._src_tables[i]
 
-            if self._options.partition_transfer:
-                dest_prt_table = self._src_dest_partition_table_mapping[i]
-                dest_db, dest_schema, dest_tbl = split_fqn(dest_prt_table)
+            if self._options.partition_transfer or self._options.pt_non_pt_target:
+                dest_table = self._src_dest_partition_table_mapping[i]
+                dest_db, dest_schema, dest_tbl = split_fqn(dest_table)
                 table_pair = GpTransferTablePair(src_table,
-                                             GpTransferTable(dest_db,
-                                                             dest_schema,
-                                                             dest_tbl,
-                                                             src_table.external))
+                                                 GpTransferTable(dest_db,
+                                                                 dest_schema,
+                                                                 dest_tbl,
+                                                                 src_table.external))
 
             else:
                 dest_database = src_table.database
@@ -3506,27 +3633,6 @@ class GpTransfer(object):
 
         return table_pairs
 
-
-    def _is_identifier_supported(self, identifier):
-        """
-        Verify that the characters of identifier starts with a-z, or A-Z or underscore,
-        followed by lower or upper case (a-z, A-Z), or digits(0-9), or underscore (_)
-        """
-
-        if not ((identifier[0:1] >= 'a' and identifier[0:1] <= 'z') or
-                (identifier[0:1] >= 'A' and identifier[0:1] <= 'Z') or
-                identifier[0:1] == '_'):
-
-           return False
-
-        for c in identifier:
-            if not ((c >= 'a' and c <= 'z') or
-                    (c >= 'A' and c <= 'Z') or
-                    (c >= '0' and c <= '9') or
-                    (c == '_')):
-                return False
-        return True
-
     def _validate_table_transfer_set(self):
         """
         Validates the table transfers, checking if tables exist, etc.
@@ -3542,63 +3648,58 @@ class GpTransfer(object):
         drop_list = list()
 
         for table_pair in self._table_transfer_set:
+            if table_pair.dest.external:
+                continue
 
-            if not (self._is_identifier_supported(table_pair.source.database) and
-                    self._is_identifier_supported(table_pair.source.schema) and
-                    self._is_identifier_supported(table_pair.source.table)):
+            if table_pair.dest in self._dest_tables and self._options.skip_existing:
+                remove_list.append(table_pair)
+                continue
 
-                non_supported_table_name_list.append(table_pair)
+            if not table_pair.source.is_identifier_supported():
+                non_supported_table_name_list.append(table_pair.source)
+
+            if not table_pair.dest.is_identifier_supported():
+                non_supported_table_name_list.append(table_pair.dest)
+
+            if self._options.truncate and self._options.pt_non_pt_target:
+                raise Exception('--truncate is not allowed with option --partition-transfer-non-partition-target')
 
             if table_pair.dest in target_tables:
-                raise Exception('Multiple tables map to %s.  Remove one of '
-                                'the tables ' % table_pair.dest
-                                + 'from the list or do not use the '
-                                '--dest-database option.')
+                if self._options.pt_non_pt_target:
+                    self.multiple_same_target_set.add(table_pair.dest)
+                else:
+                    raise Exception('Multiple tables map to %s.  Remove one of '
+                                    'the tables ' % table_pair.dest
+                                    + 'from the list or do not use the '
+                                      '--dest-database option.')
             target_tables.add(table_pair.dest)
 
-            if table_pair.dest in self._dest_tables:
-                if self._options.skip_existing:
-                    remove_list.append(table_pair)
+            self._create_special_case_lists(table_pair, truncate_list, drop_list)
 
-                    #remove tables with non supported name if not to transfer
-                    if table_pair in non_supported_table_name_list:
-                        non_supported_table_name_list.remove(table_pair)
-                elif table_pair.dest.external:
-                    continue
-                elif not self._options.truncate and not self._options.drop and not self._options.partition_transfer:
-                    raise Exception('Table %s exists in database %s.'
-                                    % (table_pair.dest,
-                                    table_pair.dest.database))
-                else:
-                    if self._options.truncate:
-                        truncate_list.append(table_pair.dest)
-                    elif not self._options.partition_transfer:
-                        drop_list.append(table_pair.dest)
+        self._report_non_supported_names(non_supported_table_name_list)
 
-            if self._options.partition_transfer:
-                if table_pair.dest not in self._dest_tables:
-                    raise Exception('Table %s does not exist in destination database ' 
-                                     'to transfer partition tables' % str(table_pair.dest))
+        [self._table_transfer_set.remove(table) for table in remove_list]
 
+        if len(self._table_transfer_set) == 0 and not self._options.dry_run:
+            logger.info('Found no tables to transfer.')
+            sys.exit(0)
+
+        self._prompt_interactive_mode(drop_list, truncate_list)
+
+    def _report_non_supported_names(self, non_supported_table_name_list):
         if len(non_supported_table_name_list) > 0:
             with open(GPTRANSFER_FAILED_TABLES_FILE, 'w') as failed_file:
-                for table_pair in non_supported_table_name_list:
+                for table_obj in non_supported_table_name_list:
                     failed_file.write("%s%s%s%s%s\n" %
-                                     (table_pair.source.database, SCHEMA_DELIMITER,
-                                      table_pair.source.schema, SCHEMA_DELIMITER, table_pair.source.table))
+                                      (table_obj.database, SCHEMA_DELIMITER,
+                                       table_obj.schema, SCHEMA_DELIMITER, table_obj.table))
             logger.error('Found unsupported identifiers')
             logger.error('Valid identifiers must start with a-z, or A-Z or underscore followed by a-z, '
                          'or A-Z, or 0-9, or underscore')
             logger.error('A list of these tables has been written to the file %s', GPTRANSFER_FAILED_TABLES_FILE)
             sys.exit(1)
 
-        for remove in remove_list:
-            self._table_transfer_set.remove(remove)
-
-        if len(self._table_transfer_set) == 0 and not self._options.dry_run:
-            logger.info('Found no tables to transfer.')
-            sys.exit(0)
-
+    def _prompt_interactive_mode(self, drop_list, truncate_list):
         if self._options.interactive and not self._options.dry_run:
             ask = False
             if self._options.truncate and len(truncate_list) > 0:
@@ -3620,6 +3721,19 @@ class GpTransfer(object):
                 if not cont:
                     raise Exception('Canceled')
 
+    def _create_special_case_lists(self, table_pair, truncate_list, drop_list):
+        if table_pair.dest in self._dest_tables:
+            if not self._options.truncate and not self._options.drop and not \
+                    self._options.partition_transfer and not self._options.pt_non_pt_target:
+                raise Exception('Table %s exists in database %s.'
+                                % (table_pair.dest,
+                                   table_pair.dest.database))
+            else:
+                if self._options.truncate:
+                    truncate_list.append(table_pair.dest)
+                elif not self._options.partition_transfer:
+                    drop_list.append(table_pair.dest)
+
     def _validate_partition_table_transfer_set(self):
         """
         validate that the table pair to transfer are actually leaf partition tables.
@@ -3629,14 +3743,21 @@ class GpTransfer(object):
         logger.info('Validating partition table transfer set...')
 
         for table_pair in self._table_transfer_set:
+
             self._check_leaf_partition_set(table_pair)
+
+            if table_pair.dest not in self._dest_tables:
+                raise Exception('Table %s does not exist in destination database '
+                                'to transfer partition tables' % str(table_pair.dest))
 
             if not self._has_same_column_types(table_pair):
                 raise Exception('Source partition table %s has different column layout or types from '
-                                'destination partition table %s' % (str(table_pair.source), str(table_pair.dest)))        
-            if not self._has_same_partition_criteria(table_pair):
-                raise Exception('Source partition table %s has different partition criteria from '
                                 'destination table %s' % (str(table_pair.source), str(table_pair.dest)))
+
+            if self._options.partition_transfer:
+                if not self._has_same_partition_criteria(table_pair):
+                    raise Exception('Source partition table %s has different partition criteria from '
+                                    'destination table %s' % (str(table_pair.source), str(table_pair.dest)))
 
     def _has_same_column_types(self, table_pair):
         """
@@ -3655,32 +3776,31 @@ class GpTransfer(object):
             cursor = execSQL(conn, get_columns_sql)
         return list(cursor.fetchall())
 
-
     def _has_same_partition_levels(self, table_pair):
         logger.debug('Verifying that partition table transfer pair has same level of partition.')
         src_prt_levels = self._get_partition_levels(table_pair.source, self._options.source_host,
-                                                           self._options.source_port, self._options.source_user)
+                                                    self._options.source_port, self._options.source_user)
         dest_prt_levels = self._get_partition_levels(table_pair.dest, self._options.dest_host,
-                                                            self._options.dest_port, self._options.dest_user)
+                                                     self._options.dest_port, self._options.dest_user)
         if src_prt_levels != dest_prt_levels:
             return False
         return True
 
-
     def _get_partition_levels(self, tbl, host, port, user):
-        get_max_partition_sql = ''' select max(p1.partitionlevel) from pg_partitions p1, pg_partitions p2 
+        get_max_partition_sql = ''' select max(p1.partitionlevel) from pg_partitions p1, pg_partitions p2
                                     where p1.schemaname = p2.schemaname and p1.tablename = p2.tablename and
-                                    p2.partitionschemaname = '%s' and p2.partitiontablename = '%s';''' % (pg.escape_string(tbl.schema),
-                                                                                                          pg.escape_string(tbl.table))
+                                    p2.partitionschemaname = '%s' and p2.partitiontablename = '%s';''' % (
+        pg.escape_string(tbl.schema),
+        pg.escape_string(tbl.table))
         with dbconn.connect(dbconn.DbURL(host, port, tbl.database, user)) as conn:
             res = execSQLForSingletonRow(conn, get_max_partition_sql)
             return res[0]
 
-
     def _has_same_partition_criteria(self, table_pair):
-        #verify the current subpartition pair:
+        # verify the current subpartition pair:
         logger.debug('Verifying that partition table transfer pair has same partition criteria')
-        source_dest_info = 'source partition table %s and destination partition table %s' % (str(table_pair.source), str(table_pair.dest))
+        source_dest_info = 'source partition table %s and destination partition table %s' % (
+        str(table_pair.source), str(table_pair.dest))
         if not self._has_same_partition_levels(table_pair):
             logger.error('Max level of partition is not same between %s' % source_dest_info)
             return False
@@ -3688,17 +3808,17 @@ class GpTransfer(object):
             logger.error('Partition type or key is different between %s' % source_dest_info)
             return False
         if not self._has_same_parent_partition_value(
-                                                      self._get_partition_levels(
-                                                          table_pair.source,
-                                                          self._options.source_host,
-                                                          self._options.source_port,
-                                                          self._options.source_user),
-                                                      table_pair.source.database,
-                                                      table_pair.source.schema,
-                                                      table_pair.source.table,
-                                                      table_pair.dest.database,
-                                                      table_pair.dest.schema,
-                                                      table_pair.dest.table):
+                self._get_partition_levels(
+                    table_pair.source,
+                    self._options.source_host,
+                    self._options.source_port,
+                    self._options.source_user),
+                table_pair.source.database,
+                table_pair.source.schema,
+                table_pair.source.table,
+                table_pair.dest.database,
+                table_pair.dest.schema,
+                table_pair.dest.table):
             logger.error('Partition value is different in the partition hierarchy between %s' % source_dest_info)
             return False
         return True
@@ -3708,9 +3828,12 @@ class GpTransfer(object):
             return False
         if level == 0:
             return True
-        src_schema, src_table = self._get_parentpartable(src_db, src_schema, src_table, self._options.source_host, self._options.source_port, self._options.source_user)
-        dest_schema, dest_table = self._get_parentpartable(dest_db, dest_schema, dest_table, self._options.dest_host, self._options.dest_port, self._options.dest_user)
-        result = self._has_same_parent_partition_value(level - 1, src_db, src_schema, src_table, dest_db, dest_schema, dest_table)
+        src_schema, src_table = self._get_parentpartable(src_db, src_schema, src_table, self._options.source_host,
+                                                         self._options.source_port, self._options.source_user)
+        dest_schema, dest_table = self._get_parentpartable(dest_db, dest_schema, dest_table, self._options.dest_host,
+                                                           self._options.dest_port, self._options.dest_user)
+        result = self._has_same_parent_partition_value(level - 1, src_db, src_schema, src_table, dest_db, dest_schema,
+                                                       dest_table)
         if not result:
             logger.error("Partitions have different parents at level: %d" % (level - 1))
         return result
@@ -3741,11 +3864,11 @@ class GpTransfer(object):
         """
         table_info = 'table %s.%s.%s, host %s' % (db, schema, table, host)
         logger.debug('Getting top level parent table information for %s' % (table_info))
-        get_top_level_table_sql = ''' select schemaname, tablename from pg_catalog.pg_partitions 
+        get_top_level_table_sql = ''' select schemaname, tablename from pg_catalog.pg_partitions
                                       where partitionschemaname = '%s'
                                             and partitiontablename = '%s' ''' % (
-                                            pg.escape_string(schema),
-                                            pg.escape_string(table))
+            pg.escape_string(schema),
+            pg.escape_string(table))
         with dbconn.connect(dbconn.DbURL(host, port, db, user)) as conn:
             row = execSQLForSingletonRow(conn, get_top_level_table_sql)
             if not row:
@@ -3792,7 +3915,8 @@ class GpTransfer(object):
                 logger.error('Partition type is different at level %s between %s' % (level_key, source_dest_info))
                 return False
             if source_partition_column_info[level_key]['parnatts'] != dest_partition_column_info[level_key]['parnatts']:
-                logger.error('Number of partition columns is different at level %s between %s' % (level_key, source_dest_info))
+                logger.error(
+                    'Number of partition columns is different at level %s between %s' % (level_key, source_dest_info))
                 return False
 
             if not self._has_same_paratts(table_pair,
@@ -3801,7 +3925,7 @@ class GpTransfer(object):
                                      source_ordinal_positions,
                                      dest_ordinal_positions):
                 logger.error('Partition column attributes are different at level %s between %s' %
-                            (level_key, source_dest_info))
+                             (level_key, source_dest_info))
                 return False
         return True
 
@@ -3834,7 +3958,7 @@ class GpTransfer(object):
         level_partition_info = defaultdict(dict)
         top_level_table_oid = self._get_top_level_parent_table_oid(db, schema, table, host, port, user)
         get_partition_colum = ''' select parkind, parlevel, parnatts, paratts from pg_partition
-                                  where paristemplate = 'f' 
+                                  where paristemplate = 'f'
                                   and parrelid = %s ''' % top_level_table_oid
         with dbconn.connect(dbconn.DbURL(host, port, db, user)) as conn:
             cursor = execSQL(conn, get_partition_colum)
@@ -3854,9 +3978,9 @@ class GpTransfer(object):
         dest_partition_info = self._get_partition_info(dest_db, dest_schema, dest_table, self._options.dest_host,
                                                        self._options.dest_port, self._options.dest_user)
 
-        part_transfer_pair_msg = '''source partition table %s.%s.%s and 
-                                    destination partition table %s.%s.%s.''' % (src_db, src_schema, 
-                                                                                src_table, dest_db, 
+        part_transfer_pair_msg = '''source partition table %s.%s.%s and
+                                    destination partition table %s.%s.%s.''' % (src_db, src_schema,
+                                                                                src_table, dest_db,
                                                                                 dest_schema, dest_table)
         part_type = source_partition_info['partitiontype']
         if source_partition_info['parisdefault'] != dest_partition_info['parisdefault']:
@@ -3864,20 +3988,21 @@ class GpTransfer(object):
             return False
 
         if part_type == 'list':
-            return self._has_same_list_partition_value(source_partition_info, dest_partition_info, part_transfer_pair_msg)
+            return self._has_same_list_partition_value(source_partition_info, dest_partition_info,
+                                                       part_transfer_pair_msg)
         elif part_type == 'range':
-            return self._has_same_range_partition_value(source_partition_info, dest_partition_info, part_transfer_pair_msg)
+            return self._has_same_range_partition_value(source_partition_info, dest_partition_info,
+                                                        part_transfer_pair_msg)
         else:
             raise Exception('Unknown partitioning type %s found, %s' % (part_type, part_transfer_pair_msg))
 
     def _has_same_range_partition_value(self, source_partition_info, dest_partition_info, part_transfer_pair_msg):
         if (source_partition_info['parrangestartincl'] != dest_partition_info['parrangestartincl'] or
-            source_partition_info['parrangestart'] != dest_partition_info['parrangestart'] or
-            source_partition_info['parrangeend'] != dest_partition_info['parrangeend'] or
-            source_partition_info['parrangeevery'] != dest_partition_info['parrangeevery']):
-
-             logger.error('Range partition value is different between %s' % part_transfer_pair_msg)
-             return False
+                    source_partition_info['parrangestart'] != dest_partition_info['parrangestart'] or
+                    source_partition_info['parrangeend'] != dest_partition_info['parrangeend'] or
+                    source_partition_info['parrangeevery'] != dest_partition_info['parrangeevery']):
+            logger.error('Range partition value is different between %s' % part_transfer_pair_msg)
+            return False
         return True
 
     def _has_same_list_partition_value(self, source_partition_info, dest_partition_info, part_transfer_pair_msg):
@@ -3895,14 +4020,14 @@ class GpTransfer(object):
         In the scenario of multiple partition colums, the partition values will
         be in the format: (({constraint1} {constraint2})) in pg_catalog.pg_partition_rule
         """
-        partition_values = partition_info[2 : len(partition_info) - 2].split('} {')
+        partition_values = partition_info[2: len(partition_info) - 2].split('} {')
         partition_values = [val.strip('{') if '{' in val else val.strip('}') for val in partition_values]
         return partition_values
 
     def _get_oid(self, db, schema, table, host, port, user):
         get_oid_sql = ''' select c.oid
                      from pg_catalog.pg_class c, pg_catalog.pg_namespace n
-                     where c.relname = '%s' 
+                     where c.relname = '%s'
                            and n.oid = c.relnamespace
                            and n.nspname = '%s'
                            ''' % (pg.escape_string(table), pg.escape_string(schema))
@@ -3912,63 +4037,61 @@ class GpTransfer(object):
                 raise Exception('Failed to retrieve the oid of table %s.%s.%s on host %s' % (db, schema, table, host))
             return res[0]
 
-
     def _get_partition_info(self, db, schema, table, host, port, user):
-        part_type = None
         partition_info = dict()
         oid = self._get_oid(db, schema, table, host, port, user)
 
         get_partition_type = ''' select partitiontype
                                  from pg_catalog.pg_partitions
                                  where partitionschemaname = '%s'
-                                       and partitiontablename = '%s';''' % (pg.escape_string(schema), pg.escape_string(table))
+                                       and partitiontablename = '%s';''' % (
+        pg.escape_string(schema), pg.escape_string(table))
         with dbconn.connect(dbconn.DbURL(host, port, db, user)) as conn:
             part_type = execSQLForSingletonRow(conn, get_partition_type)
             partition_info['partitiontype'] = part_type[0]
 
         get_partition_info_sql = '''select parisdefault, parruleord, parrangestartincl, parrangeendincl, parrangestart,
                                            parrangeend, parrangeevery, parlistvalues
-                                    from pg_catalog.pg_partition_rule 
+                                    from pg_catalog.pg_partition_rule
                                     where parchildrelid = %s;''' % oid
 
         with dbconn.connect(dbconn.DbURL(host, port, db, user)) as conn:
             row = execSQLForSingletonRow(conn, get_partition_info_sql)
-            partition_info['parisdefault'] = row[0] 
-            partition_info['parruleord'] = row[1] 
-            partition_info['parrangestartincl'] = row[2] 
-            partition_info['parrangeendincl'] = row[3] 
-            partition_info['parrangestart'] = row[4] 
-            partition_info['parrangeend'] = row[5] 
-            partition_info['parrangeevery'] = row[6] 
-            partition_info['parlistvalues'] = row[7] 
+            partition_info['parisdefault'] = row[0]
+            partition_info['parruleord'] = row[1]
+            partition_info['parrangestartincl'] = row[2]
+            partition_info['parrangeendincl'] = row[3]
+            partition_info['parrangestart'] = row[4]
+            partition_info['parrangeend'] = row[5]
+            partition_info['parrangeevery'] = row[6]
+            partition_info['parlistvalues'] = row[7]
         return partition_info
-
 
     def _check_leaf_partition_set(self, table_pair):
         # check if the source and destination table are all leaf partition tables
 
         logger.debug('Verifying partition table is leaf partition table.')
         if not self._is_leaf_partition(table_pair.source, self._options.source_host,
-                                      self._options.source_port, self._options.source_user):
+                                       self._options.source_port, self._options.source_user):
             raise Exception('Source table %s is not a leaf partition table.' % str(table_pair.source))
 
-        if not self._is_leaf_partition(table_pair.dest, self._options.dest_host,
-                                      self._options.dest_port, self._options.dest_user):
+        if self._options.partition_transfer and not self._is_leaf_partition(table_pair.dest, self._options.dest_host,
+                                                                            self._options.dest_port,
+                                                                            self._options.dest_user):
             raise Exception('Destination table %s is not a leaf partition table.' % str(table_pair.dest))
-       
+
     def _is_leaf_partition(self, tbl, host, port, user):
-        check_leaf_partition_sql = '''select relname from pg_class r 
-                             where not relhassubclass and exists 
-                             (select oid from pg_partition_rule p where r.oid = p.parchildrelid) and not exists 
-                             (select oid from pg_partition p where r.oid = p.parrelid) and  
-                             relnamespace = (select oid from pg_namespace where nspname = '%s') and 
+        check_leaf_partition_sql = '''select relname from pg_class r
+                             where not relhassubclass and exists
+                             (select oid from pg_partition_rule p where r.oid = p.parchildrelid) and not exists
+                             (select oid from pg_partition p where r.oid = p.parrelid) and
+                             relnamespace = (select oid from pg_namespace where nspname = '%s') and
                              relname = '%s' ;''' % (pg.escape_string(tbl.schema), pg.escape_string(tbl.table))
         with dbconn.connect(dbconn.DbURL(host, port, tbl.database, user)) as conn:
             cursor = execSQL(conn, check_leaf_partition_sql)
             if cursor.rowcount != 1:
                 return False
         return True
-
 
     def _get_host_map(self):
         """
@@ -3996,9 +4119,9 @@ class GpTransfer(object):
                     if hostname not in host_map:
                         host_map[hostname] = set()
                     map(host_map[hostname].add, [address.strip()
-                        for address in addresses])
+                                                 for address in addresses])
         elif self._options.source_host == self._options.dest_host and \
-                self._options.source_port == self._options.dest_port and \
+                        self._options.source_port == self._options.dest_port and \
                 self._options.dest_database and not self._options.full:
             # src and dest are same so we don't need map file, we can build it
             host_map = dict()
@@ -4050,4 +4173,4 @@ if __name__ == '__main__':
     sys.argv[0] = EXECNAME
     simple_main(create_parser, GpTransfer,
                 {'pidfilename': GPTRANSFER_PID_FILE,
-                'programNameOverride': EXECNAME})
+                 'programNameOverride': EXECNAME})

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -244,7 +244,7 @@ def create_parser():
 
     general_option_group.add_option(
         '--partition-transfer-non-partition-target',
-        dest='pt_non_pt_target',
+        dest='partition_transfer_non_pt_target',
         default=False,
         action='store_true',
         help='Transfer partition tables to non-partition table if enabled, disabled by default, '
@@ -751,10 +751,10 @@ FROM
     pg_class c JOIN pg_namespace n ON (c.relnamespace=n.oid)
     JOIN pg_catalog.gp_distribution_policy p ON (c.oid = p.localoid)
 WHERE """
-    table_sql_non_partition_transfer = """c.oid NOT IN ( SELECT parchildrelid as oid FROM pg_partition_rule ) AND """
+    table_sql_filter_out_child_partitions = """c.oid NOT IN ( SELECT parchildrelid as oid FROM pg_partition_rule ) AND """
     table_sql_part2 = """ n.nspname NOT IN ('gpexpand', 'pg_bitmapindex', 'information_schema', 'gp_toolkit');"""
     all_tables_sql = table_sql_part1 + \
-                     (table_sql_non_partition_transfer if not partition_transfer else '') + \
+                     ('' if partition_transfer else table_sql_filter_out_child_partitions) + \
                      table_sql_part2
 
     all_tables = set()
@@ -2428,7 +2428,7 @@ class GpTransfer(object):
                             self._options.dest_user,
                             [db for db in self._dest_databases if db in self._all_dest_databases],
                             False,
-                            self._options.partition_transfer)
+                                self._options.partition_transfer)
         self._dest_non_partition_tables = set()
         if self._options.partition_transfer:
             self._dest_non_partition_tables = \
@@ -2473,7 +2473,7 @@ class GpTransfer(object):
         self._validate_host_map()
 
         self._validate_table_transfer_set()
-        if self._options.partition_transfer or self._options.pt_non_pt_target:
+        if self._options.partition_transfer or self._options.partition_transfer_non_pt_target:
             self._validate_partition_table_transfer_set()
 
         self._validate_filespace(self._options.source_host, self._options.source_port, self._options.source_user,
@@ -2517,7 +2517,7 @@ class GpTransfer(object):
             cmds_queued = 0
 
             self.before_dest_tables_dict = {}
-            if self._options.pt_non_pt_target:
+            if self._options.partition_transfer_non_pt_target:
                 self.before_dest_tables_dict = self.get_dest_row_count_before_transfer()
 
             for table_pair in self._table_transfer_set:
@@ -2886,7 +2886,7 @@ class GpTransfer(object):
         if self._options.input_file and not os.path.isfile(self._options.input_file):
             raise ProgramArgumentValidationException('Input file %s is not a valid file' % self._options.input_file)
 
-        if (self._options.partition_transfer and self._options.pt_non_pt_target):
+        if (self._options.partition_transfer and self._options.partition_transfer_non_pt_target):
             raise ProgramArgumentValidationException('--partition-transfer option cannot be '
                                                      'used with --partition-transfer-non-partition-target option')
 
@@ -2923,41 +2923,44 @@ class GpTransfer(object):
             raise ProgramArgumentValidationException('--partition-transfer option cannot be '
                                                      'used with --full option')
 
-        if (self._options.pt_non_pt_target and not self._options.input_file):
+        if (self._options.partition_transfer_non_pt_target and not self._options.input_file):
             raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option must be '
                                                      'used with -f option')
 
-        if (self._options.pt_non_pt_target and self._options.databases):
+        if (self._options.partition_transfer_non_pt_target and self._options.databases):
             raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be '
                                                      'used with -d option')
 
-        if (self._options.pt_non_pt_target and self._options.dest_database):
+        if (self._options.partition_transfer_non_pt_target and self._options.dest_database):
             raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be '
                                                      'used with --dest-database option')
 
-        if (self._options.pt_non_pt_target and self._options.drop):
+        if (self._options.partition_transfer_non_pt_target and self._options.drop):
             raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be used '
                                                      'with --drop option')
 
-        if (self._options.pt_non_pt_target and self._options.tables):
+        if (self._options.partition_transfer_non_pt_target and self._options.tables):
             raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be used '
                                                      'with -t option')
 
-        if (self._options.pt_non_pt_target and self._options.schema_only):
+        if (self._options.partition_transfer_non_pt_target and self._options.schema_only):
             raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be used '
                                                      'with --schema-only option')
 
-        if (self._options.pt_non_pt_target and (self._options.exclude_tables or self._options.exclude_input_file)):
+        if (self._options.partition_transfer_non_pt_target and (self._options.exclude_tables or self._options.exclude_input_file)):
             raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be used '
                                                      'with any exclude table option')
 
-        if (self._options.pt_non_pt_target and self._options.full):
+        if (self._options.partition_transfer_non_pt_target and self._options.full):
             raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be '
                                                      'used with --full option')
 
-        if (self._options.pt_non_pt_target and self._options.validator):
+        if (self._options.partition_transfer_non_pt_target and self._options.validator):
             raise ProgramArgumentValidationException('--partition-transfer-non-partition-target option cannot be '
                                                      'used with --validate option')
+
+        if self._options.truncate and self._options.partition_transfer_non_pt_target:
+            raise Exception('--truncate is not allowed with option --partition-transfer-non-partition-target')
 
         if self._options.full and (self._options.truncate or self._options.drop or
                                        self._options.skip_existing):
@@ -3127,7 +3130,7 @@ class GpTransfer(object):
             before_transfer_row_count = self.before_dest_tables_dict[dest_table] \
                 if self.before_dest_tables_dict else 0
             if (validation_count - before_transfer_row_count) != 0:
-                if self._options.partition_transfer or self._options.pt_non_pt_target:
+                if self._options.partition_transfer or self._options.partition_transfer_non_pt_target:
                     logger.warning('Validation failed for %s', dest_table)
                 else:
                     logger.error('Validation failed for %s', dest_table)
@@ -3288,7 +3291,7 @@ class GpTransfer(object):
         source_tables = list()
         # --partition-transfer will have the exact database name for each destination table,
         # not support the regexp
-        if (self._options.partition_transfer or self._options.pt_non_pt_target):
+        if (self._options.partition_transfer or self._options.partition_transfer_non_pt_target):
 
             self._src_dest_partition_table_mapping = dict()
 
@@ -3298,7 +3301,7 @@ class GpTransfer(object):
                                           self._options.source_user,
                                           self._src_databases,
                                           False,
-                                          (self._options.partition_transfer or self._options.pt_non_pt_target))
+                                          (self._options.partition_transfer or self._options.partition_transfer_non_pt_target))
 
             # filter out non-exist source tables from source databases.
             # key in dict: self._src_dest_partition_table_mapping maps to index of list: source_tables
@@ -3354,7 +3357,7 @@ class GpTransfer(object):
                                          self._options.source_user,
                                          databases_full_transfer,
                                          False,
-                                         (self._options.partition_transfer or self._options.pt_non_pt_target)):
+                                         (self._options.partition_transfer or self._options.partition_transfer_non_pt_target)):
                 source_tables.append(table)
 
             del databases[:]
@@ -3390,7 +3393,7 @@ class GpTransfer(object):
                                           self._options.source_user,
                                           databases_table_transfer,
                                           False,
-                                          (self._options.partition_transfer or self._options.pt_non_pt_target))
+                                          (self._options.partition_transfer or self._options.partition_transfer_non_pt_target))
 
             # Filter down to only the tables needed to added
             seen = set()
@@ -3603,7 +3606,7 @@ class GpTransfer(object):
 
             src_table = self._src_tables[i]
 
-            if self._options.partition_transfer or self._options.pt_non_pt_target:
+            if self._options.partition_transfer or self._options.partition_transfer_non_pt_target:
                 dest_table = self._src_dest_partition_table_mapping[i]
                 dest_db, dest_schema, dest_tbl = split_fqn(dest_table)
                 table_pair = GpTransferTablePair(src_table,
@@ -3661,11 +3664,8 @@ class GpTransfer(object):
             if not table_pair.dest.is_identifier_supported():
                 non_supported_table_name_list.append(table_pair.dest)
 
-            if self._options.truncate and self._options.pt_non_pt_target:
-                raise Exception('--truncate is not allowed with option --partition-transfer-non-partition-target')
-
             if table_pair.dest in target_tables:
-                if self._options.pt_non_pt_target:
+                if self._options.partition_transfer_non_pt_target:
                     self.multiple_same_target_set.add(table_pair.dest)
                 else:
                     raise Exception('Multiple tables map to %s.  Remove one of '
@@ -3724,7 +3724,7 @@ class GpTransfer(object):
     def _create_special_case_lists(self, table_pair, truncate_list, drop_list):
         if table_pair.dest in self._dest_tables:
             if not self._options.truncate and not self._options.drop and not \
-                    self._options.partition_transfer and not self._options.pt_non_pt_target:
+                    self._options.partition_transfer and not self._options.partition_transfer_non_pt_target:
                 raise Exception('Table %s exists in database %s.'
                                 % (table_pair.dest,
                                    table_pair.dest.database))
@@ -3738,17 +3738,25 @@ class GpTransfer(object):
         """
         validate that the table pair to transfer are actually leaf partition tables.
         validate that the pair have same layout and partition criteria.
+        validate that the destination tables are non partition table for --partition-transfer-non-partition-target
         """
 
         logger.info('Validating partition table transfer set...')
 
+        if self._options.partition_transfer_non_pt_target:
+            self._validate_partition_sources_to_a_common_dest_must_have_same_parent()
+
         for table_pair in self._table_transfer_set:
+            if table_pair.dest not in self._dest_tables:
+                current_option = "--partition-transfer" if self._options.partition_transfer else "--partition-transfer-non-partition-target"
+                looking_for = "leaf partitions" if self._options.partition_transfer else "non-partition tables"
+                error_message = 'Table %s does not exist in destination database ' \
+                                'when transferring from partition tables ' \
+                                '(filtering for destination %s because of option "%s")' % \
+                                (str(table_pair.dest), looking_for, current_option)
+                raise Exception(error_message)
 
             self._check_leaf_partition_set(table_pair)
-
-            if table_pair.dest not in self._dest_tables:
-                raise Exception('Table %s does not exist in destination database '
-                                'to transfer partition tables' % str(table_pair.dest))
 
             if not self._has_same_column_types(table_pair):
                 raise Exception('Source partition table %s has different column layout or types from '
@@ -3758,6 +3766,49 @@ class GpTransfer(object):
                 if not self._has_same_partition_criteria(table_pair):
                     raise Exception('Source partition table %s has different partition criteria from '
                                     'destination table %s' % (str(table_pair.source), str(table_pair.dest)))
+
+    def _validate_partition_sources_to_a_common_dest_must_have_same_parent(self):
+        diff_parented_sources_for_common_dest = self._get_table_pair_with_different_parent_for_common_destinations()
+        if len(diff_parented_sources_for_common_dest) > 0:
+            sources = diff_parented_sources_for_common_dest[0]["sources"]
+            dest = diff_parented_sources_for_common_dest[0]["dest"]
+            raise Exception("partition sources: %s when transferred to the "
+                            "same destination: table %s , must share the same parent" % (sources, dest))
+
+    def _get_table_pair_with_different_parent_for_common_destinations(self):
+        mismatch = list()
+        # assemble all common destinations and validate
+        all_destinations = dict()
+        for table_pair in self._table_transfer_set:
+            all_destinations.setdefault(table_pair.dest, list()).append(table_pair.source)
+
+        # when a common destination has multiple sources, validate that all come from same parent partition
+        for dest, source_list in all_destinations.iteritems():
+            if len(source_list) > 1:
+                parent_schema_previous = None
+                parent_table_previous = None
+                for source in source_list:
+                    parent_schema, parent_table = self._get_parentpartable(source.database,
+                                                                           source.schema,
+                                                                           source.table,
+                                                                           self._options.source_host,
+                                                                           self._options.source_port,
+                                                                           self._options.source_user)
+
+                    if parent_schema_previous and parent_schema_previous != parent_schema:
+                        sources = ""
+                        for source in source_list:
+                            sources += source.schema + "." + source.table + ", "
+                        mismatch.append(dict(sources=sources, dest=dest.schema + "." + dest.table))
+                    if parent_table_previous and parent_table_previous != parent_table:
+                        sources = ""
+                        for source in source_list:
+                            sources += source.schema + "." + source.table + ", "
+                        mismatch.append(dict(sources=sources, dest=dest.schema + "." + dest.table))
+                    parent_table_previous = parent_table
+                    parent_schema_previous = parent_schema
+
+        return mismatch
 
     def _has_same_column_types(self, table_pair):
         """
@@ -3919,7 +3970,7 @@ class GpTransfer(object):
                     'Number of partition columns is different at level %s between %s' % (level_key, source_dest_info))
                 return False
 
-            if not self._has_same_paratts(table_pair,
+            if not self._has_same_paratts(
                                      source_partition_column_info[level_key]['paratts'],
                                      dest_partition_column_info[level_key]['paratts'],
                                      source_ordinal_positions,
@@ -3929,8 +3980,8 @@ class GpTransfer(object):
                 return False
         return True
 
-    def _has_same_paratts(self, table_pair, source_paratts_str, dest_paratts_str, source_ordinal_positions, dest_ordinal_positions):
-        # this handles multi column partitions by sorting them before comparison, in case same partition columns are in random order
+    def _has_same_paratts(self, source_paratts_str, dest_paratts_str, source_ordinal_positions, dest_ordinal_positions):
+        # this handles multi column partitions by sorting them before comparison.
         # we compare the index of the column within the list of ordinal positions to account for cases where
         # actual ordinal positions may not match, but the order of the columns is the same (i.e. dropping and re-adding)
         source_paratts = [int(att.strip()) for att in source_paratts_str.split(' ')]

--- a/gpMgmt/doc/gptransfer_help
+++ b/gpMgmt/doc/gptransfer_help
@@ -12,13 +12,12 @@ gptransfer
    { --full |
    { [-d <database1> [ -d <database2> ... ]] | 
    [-t <db.schema.table> [ -t <db1.schema1.table1> ... ]] |
-   [-f <table-file> ]
+   [-f <table-file> [--partition-transfer | --partition-transfer-non-partition-target]]
    [-T <db.schema.table> [ -T <db1.schema1.table1> ... ]]
    [-F <table-file> ] } }
    [--skip-existing | --truncate | --drop] 
    [--analyze] [--validate=<type> ] [-x] [--dry-run] 
    [--schema-only ]
-   [--partition-transfer ]
    [--no-final-count]
 
    [--source-host=<source_host> [--source-port=<source_port>] 
@@ -72,11 +71,13 @@ following types of operations:
   When you specify a destination database, the source database tables are 
   copied into the specified destination database. 
 
-  For partitioned tables, you can specify the --partition-transfer and -f
-  options to copy specific leaf child partitions of partitioned tables from
-  a source database to a destination database. The leaf child partitions are
-  the lowest level partitions of a partitioned database. If the child
-  partition is not a leaf child partition, the utility returns an error.
+  For partitioned tables, you can specify the --partition-transfer or the
+  --partitiontransfer-non-partition-target option with -f option to copy
+  specific leaf child partitions of partitioned tables from a source database.
+  The leaf child partitions are the lowest level partitions of a partitioned
+  database. For the --partition-transfer option, the destination tables are
+  leaf child partitions. For the --partition-transfer-non-partition-target
+  option, the destination tables are non-partitioned tables.
 
 If an invalid set of gptransfer options are specified, or if a specified 
 source table or database does not exist, gptransfer returns an error and 
@@ -418,6 +419,43 @@ OPTIONS
      can specify the --truncate option to truncate the table for the transfer
      operation.
 
+ --partition-transfer-non-partition-target (non-partitioned destination table)
+
+     Specify this option with the -f option to copy data from leaf child
+     partition tables of partitioned tables in a source database to non-
+     partitioned tables in a destination database. The text file specified by
+     the -f option contains a list of fully qualified leaf child partition
+     table names in the source database and non-partitioned tables names in
+     the destination database with this syntax.
+
+         src_db.src_schema.src_part_tbl, dest_db.dest_schema.dest_tbl
+
+     Wildcard characters are not supported in the fully qualified table names.
+     The destination tables must exist, and both source and destination table
+     names are required in the file. If a source table is not a leaf child 
+     partition table or a destination table is not a nonpartitioned table, the
+     utility returns an error and no data are transferred. If the source and
+     destination Greenplum Database systems are the same, you must specify a
+     destination table where at least one of the following must be different
+     between the source and destination table: db_name, schema, or table. For
+     the partitioned table in the source database and the table in the
+     destination database, the number of table columns and the order of the
+     column data types must be the same (the source and destination table 
+     column names can be different). The same destination table can be
+     specified in the file for multiple source leaf child partition tables that
+     belong to a single partitioned table. Transferring data from source leaf
+     child partition tables that belong to different partitioned tables to a
+     single nonpartitioned table is not supported.
+
+      This option is not valid with these options: -d, --dest-database, --drop,
+     -F, --full, --schema-only, -T, -t, --truncate, --validate.
+
+     Note: If the data in the source or destination table changes during a
+     transfer operation (rows are inserted or deleted), the table row count
+     validation fails due to row count mismatch.
+
+     You can specify the -x option to acquire exclusive locks on the tables
+     during a transfer operation.
 
 -F <table-file> 
 
@@ -472,8 +510,8 @@ OPTIONS
  --source-map-file option, the --dest-host option, and if necessary, the 
  other destination system options. 
 
- The --full option cannot be specified with the -t, -d, -f, or
- --partition-transfer options.
+ The --full option cannot be specified with the -t, -d, -f, 
+ --partition-transfer, or --partition-transfer-non-partition-target options.
 
  A full migration copies all database objects including, tables, indexes, 
  views, users, roles, functions, and resource queues for all user defined 


### PR DESCRIPTION
Adds a new flag --partition-transfer-non-partition-target to gptransfer.  This allows the user to move data from a partitioned table to a non-partitioned one.

Additionally:
- Updates the help file
- Enables testing of exception messages
- Makes gptransfer tests less environment-dependent

Authors: Chumki Roy, Karen Huddleston, Larry Hamel, Stephen Wu