### PR TITLE
Extend the length of signed S3 urls that are used to trigger Pulse

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -1,4 +1,14 @@
 ## ======================================================================
+## resource types
+## ======================================================================
+
+resource_types:
+- name: s3-week-long-urls
+  type: docker-image
+  source:
+    repository: pivotaldata/s3-resource
+
+## ======================================================================
 ## resources
 ## ======================================================================
 
@@ -50,7 +60,7 @@ resources:
     versioned_file: {{sync_tools_gpdb_centos_versioned_file}}
 
 - name: installer_rhel6_gpdb_rc
-  type: s3
+  type: s3-week-long-urls
   source:
     access_key_id: {{bucket-access-key-id}}
     bucket: {{bucket-name}}
@@ -86,7 +96,7 @@ resources:
     versioned_file: deliverables/greenplum-db-appliance-4.3.99.0-build-1-rhel6-x86_64.zip.md5
 
 - name: qautils_rhel6_tarball
-  type: s3
+  type: s3-week-long-urls
   source:
     access_key_id: {{bucket-access-key-id}}
     bucket: {{bucket-name}}
@@ -95,7 +105,7 @@ resources:
     versioned_file: deliverables/QAUtils-rhel6-x86_64.tar.gz
 
 - name: gpdb_src_tinc_tarball
-  type: s3
+  type: s3-week-long-urls
   source:
     access_key_id: {{bucket-access-key-id}}
     bucket: {{bucket-name}}


### PR DESCRIPTION
We are providing a fork / extension of the Concourse built-in S3 resource, which extends the duration of the signed URLs, which the [pulse triggering steps at the end of the master pipeline](https://gpdb.ci.pivotalci.info/teams/gpdb/pipelines/gpdb_master/jobs/cs-uao-regression/builds/3) use.

Code for our fork: https://github.com/Pivotal-DataFabric/s3-resource/tree/s3-week-long-urls
Dockerhub for the publicly available image: https://hub.docker.com/r/pivotaldata/s3-resource/

The diff you would see if you ran `fly set-pipeline` with this change:

![image](https://cloud.githubusercontent.com/assets/10500670/20909812/bb88a682-bb12-11e6-8e94-720e370f9d81.png)

Signed-off-by: C.J. Jameson <cjameson@pivotal.io>