### PR TITLE
Initialize loop control to handle relfilenode Oid collision in GetNewRelFileNode()

### DIFF
--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -909,7 +909,7 @@ GetNewRelFileNode(Oid reltablespace, bool relisshared, Relation pg_class)
 	RelFileNode rnode;
 	char	   *rpath;
 	int			fd;
-	bool		collides;
+	bool		collides = true;
 
 	/* This should match RelationInitPhysicalAddr */
 	rnode.spcNode = reltablespace ? reltablespace : MyDatabaseTableSpace;


### PR DESCRIPTION
In 88f0623 a cache of recently used relfilenode Oids was added, and the cache is interrogated in the GetNewRelFileNode() logic. If the first Oid in the loop is encountered in the cache however, the loop will only retry if the compiler has initialized the loop control variable to true. Explicitly initialize to true to handle this case for compilers that initialize to false such as clang.

Does this make sense @hlinnaka ?