### PR TITLE
Make UAO catalog tests deterministic.

### DIFF
--- a/src/test/regress/expected/uao_catalog_tables.out
+++ b/src/test/regress/expected/uao_catalog_tables.out
@@ -28,6 +28,19 @@ BEGIN
   return result;
 END;
 $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION gp_aoseg_dist_random(
+  IN relid oid) RETURNS setof record AS $$
+DECLARE
+  result record;
+BEGIN
+  for result in
+      EXECUTE 'select gp_segment_id, * from gp_dist_random(''pg_aoseg.pg_aoseg_' || relid || ''');'
+  loop
+      return next result;
+  end loop;
+  return;
+END;
+$$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION gp_aotable_eof_dist_random(
   IN relation_name text) RETURNS setof record AS $$
 DECLARE
@@ -39,9 +52,10 @@ BEGIN
       EXECUTE 'select a.segno, a.tupcount, a.eofuncompressed, b.mirror_append_only_new_eof
               from gp_dist_random(''pg_aoseg.pg_aoseg_' || relid ||''') a,
               gp_dist_random(''gp_persistent_relation_node'') b
-              where a.segno = b.segment_file_num and b.relfilenode_oid = ' || relid || ' and
+              where a.gp_segment_id = b.gp_segment_id and a.segno = b.segment_file_num
+              and b.relfilenode_oid = ' || relid || ' and
               b.mirror_append_only_new_eof = a.eofuncompressed and
-              a.eofuncompressed != 0;'
+              a.eofuncompressed != 0 and a.state = 1;'
   loop
       return next result;
   end loop;
@@ -239,7 +253,10 @@ select count(*) from uao_table_tupcount_changes_after_delete;
 (1 row)
 
 vacuum full uao_table_tupcount_changes_after_delete;
-select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_delete');
+select sum(tupcount) from gp_aoseg_dist_random('uao_table_tupcount_changes_after_delete'::regclass) as
+ (gp_segment_id int, segno int, eof bigint, tupcount bigint, varblockcount bigint,
+  eofuncompressed bigint, modcount bigint, formatversion smallint, state smallint)
+ where state = 1;
  sum 
 -----
    9
@@ -280,7 +297,10 @@ select count(*) from uao_table_tupcount_changes_after_update;
 (1 row)
 
 vacuum full uao_table_tupcount_changes_after_update;
-select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_update');
+select sum(tupcount) from gp_aoseg_dist_random('uao_table_tupcount_changes_after_update'::regclass) as
+ (gp_segment_id int, segno int, eof bigint, tupcount bigint, varblockcount bigint,
+  eofuncompressed bigint, modcount bigint, formatversion smallint, state smallint)
+ where state = 1;
  sum 
 -----
   10

--- a/src/test/regress/expected/uaocs_catalog_tables.out
+++ b/src/test/regress/expected/uaocs_catalog_tables.out
@@ -1,4 +1,7 @@
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
+CREATE OR REPLACE FUNCTION aocsseg_live_segfiles(oid) RETURNS setof record AS $$
+  SELECT * from gp_toolkit.__gp_aocsseg($1) where state = 1;
+$$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
 DECLARE
@@ -6,7 +9,7 @@ DECLARE
   result record;
 BEGIN
   for record_text in
-      EXECUTE 'select gp_toolkit.__gp_aocsseg(''' || relation_name || '''::regclass)::text from gp_dist_random(''gp_id'');'
+      EXECUTE 'select aocsseg_live_segfiles(''' || relation_name || '''::regclass)::text from gp_dist_random(''gp_id'');'
   loop
       EXECUTE 'select a[3], a[4], a[5], a[6], a[7], a[8] from
               (select regexp_split_to_array(''' || record_text ||''', '','')) as dt(a);' into result;

--- a/src/test/regress/sql/uao_catalog_tables.sql
+++ b/src/test/regress/sql/uao_catalog_tables.sql
@@ -30,6 +30,20 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION gp_aoseg_dist_random(
+  IN relid oid) RETURNS setof record AS $$
+DECLARE
+  result record;
+BEGIN
+  for result in
+      EXECUTE 'select gp_segment_id, * from gp_dist_random(''pg_aoseg.pg_aoseg_' || relid || ''');'
+  loop
+      return next result;
+  end loop;
+  return;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION gp_aotable_eof_dist_random(
   IN relation_name text) RETURNS setof record AS $$
 DECLARE
@@ -41,9 +55,10 @@ BEGIN
       EXECUTE 'select a.segno, a.tupcount, a.eofuncompressed, b.mirror_append_only_new_eof
               from gp_dist_random(''pg_aoseg.pg_aoseg_' || relid ||''') a,
               gp_dist_random(''gp_persistent_relation_node'') b
-              where a.segno = b.segment_file_num and b.relfilenode_oid = ' || relid || ' and
+              where a.gp_segment_id = b.gp_segment_id and a.segno = b.segment_file_num
+              and b.relfilenode_oid = ' || relid || ' and
               b.mirror_append_only_new_eof = a.eofuncompressed and
-              a.eofuncompressed != 0;'
+              a.eofuncompressed != 0 and a.state = 1;'
   loop
       return next result;
   end loop;
@@ -114,7 +129,10 @@ delete from uao_table_tupcount_changes_after_delete where i = 1;
 select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_delete');
 select count(*) from uao_table_tupcount_changes_after_delete;
 vacuum full uao_table_tupcount_changes_after_delete;
-select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_delete');
+select sum(tupcount) from gp_aoseg_dist_random('uao_table_tupcount_changes_after_delete'::regclass) as
+ (gp_segment_id int, segno int, eof bigint, tupcount bigint, varblockcount bigint,
+  eofuncompressed bigint, modcount bigint, formatversion smallint, state smallint)
+ where state = 1;
 select count(*) from uao_table_tupcount_changes_after_delete;
 
 -- Verify the tupcount changes in pg_aoseg when updating uao table
@@ -126,7 +144,10 @@ update uao_table_tupcount_changes_after_update set j=j||'test11' where i = 1;
 select tupcount from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_update');
 select count(*) from uao_table_tupcount_changes_after_update;
 vacuum full uao_table_tupcount_changes_after_update;
-select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_update');
+select sum(tupcount) from gp_aoseg_dist_random('uao_table_tupcount_changes_after_update'::regclass) as
+ (gp_segment_id int, segno int, eof bigint, tupcount bigint, varblockcount bigint,
+  eofuncompressed bigint, modcount bigint, formatversion smallint, state smallint)
+ where state = 1;
 select count(*) from uao_table_tupcount_changes_after_update;
 
 -- Verify the hidden tup_count using UDF gp_aovisimap_hidden_info(oid) for uao relation after delete and vacuum

--- a/src/test/regress/sql/uaocs_catalog_tables.sql
+++ b/src/test/regress/sql/uaocs_catalog_tables.sql
@@ -1,4 +1,8 @@
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
+CREATE OR REPLACE FUNCTION aocsseg_live_segfiles(oid) RETURNS setof record AS $$
+  SELECT * from gp_toolkit.__gp_aocsseg($1) where state = 1;
+$$ LANGUAGE SQL;
+
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
 DECLARE
@@ -6,7 +10,7 @@ DECLARE
   result record;
 BEGIN
   for record_text in
-      EXECUTE 'select gp_toolkit.__gp_aocsseg(''' || relation_name || '''::regclass)::text from gp_dist_random(''gp_id'');'
+      EXECUTE 'select aocsseg_live_segfiles(''' || relation_name || '''::regclass)::text from gp_dist_random(''gp_id'');'
   loop
       EXECUTE 'select a[3], a[4], a[5], a[6], a[7], a[8] from
               (select regexp_split_to_array(''' || record_text ||''', '','')) as dt(a);' into result;


### PR DESCRIPTION
The tests were counting tuples from an AO segfile in AWAITING_DROP state.  This
file should be excluded in counting visble tuples/eof because AWAITING_DROP
segfile is only used by select transactions that run concurrently with VACUUM
transaction on the same AO table.