### PR TITLE
Reset mppIsWriter field of PGPROC to false in hook function of GUC gp_session_role  if the new value is GP_ROLE_UTILITY

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -26,6 +26,7 @@
 #include "libpq/libpq-be.h"
 #include "utils/memutils.h"
 #include "storage/bfz.h"
+#include "storage/proc.h"
 #include "cdb/memquota.h"
 
 /*
@@ -524,6 +525,9 @@ assign_gp_session_role(const char *newval, bool doit, GucSource source __attribu
 
 		if (Gp_role == GP_ROLE_DISPATCH)
 			Gp_segment = -1;
+
+		if (Gp_role == GP_ROLE_UTILITY && MyProc != NULL)
+			MyProc->mppIsWriter = false;
 	}
 	return newval;
 }


### PR DESCRIPTION
When someone is connecting to a segment in utility mode, and there exists a connection
from QD to this segment having a same session id coincidently, reader QE on this
segment may possibly treat the utility backend as its corresponding writer QE, this may lead
to confusion on shared snapshot, and reader QE of extended query may report error saying it
cannot find snapshot temp file.

We avoid this by excluding utility backend from writer list.

Signed-off-by Pengzhou Tang <ptang@pivotal.io>