### PR TITLE
VACUUM FULL should not abstain from drop in appendonly drop phase.

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -5304,9 +5304,13 @@ open_relation_and_check_permission(VacuumStmt *vacstmt,
 	 * My marking the drop transaction as busy before checking, the worst
 	 * thing that can happen is that both transaction see each other and
 	 * both cancel the drop.
+	 *
+	 * The upgreade deadlock is not applicable to vacuum full because
+	 * it begins with an AccessExclusive lock and doesn't need to
+	 * upgrade it.
 	 */
 
-	if (isDropTransaction)
+	if (isDropTransaction && !vacstmt->full)
 	{
 		MyProc->inDropTransaction = true;
 		if (HasDropTransaction(false))

--- a/src/test/regress/expected/uao_catalog_tables.out
+++ b/src/test/regress/expected/uao_catalog_tables.out
@@ -28,19 +28,6 @@ BEGIN
   return result;
 END;
 $$ LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION gp_aoseg_dist_random(
-  IN relid oid) RETURNS setof record AS $$
-DECLARE
-  result record;
-BEGIN
-  for result in
-      EXECUTE 'select gp_segment_id, * from gp_dist_random(''pg_aoseg.pg_aoseg_' || relid || ''');'
-  loop
-      return next result;
-  end loop;
-  return;
-END;
-$$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION gp_aotable_eof_dist_random(
   IN relation_name text) RETURNS setof record AS $$
 DECLARE
@@ -52,10 +39,9 @@ BEGIN
       EXECUTE 'select a.segno, a.tupcount, a.eofuncompressed, b.mirror_append_only_new_eof
               from gp_dist_random(''pg_aoseg.pg_aoseg_' || relid ||''') a,
               gp_dist_random(''gp_persistent_relation_node'') b
-              where a.gp_segment_id = b.gp_segment_id and a.segno = b.segment_file_num
-              and b.relfilenode_oid = ' || relid || ' and
+              where a.segno = b.segment_file_num and b.relfilenode_oid = ' || relid || ' and
               b.mirror_append_only_new_eof = a.eofuncompressed and
-              a.eofuncompressed != 0 and a.state = 1;'
+              a.eofuncompressed != 0;'
   loop
       return next result;
   end loop;
@@ -253,10 +239,7 @@ select count(*) from uao_table_tupcount_changes_after_delete;
 (1 row)
 
 vacuum full uao_table_tupcount_changes_after_delete;
-select sum(tupcount) from gp_aoseg_dist_random('uao_table_tupcount_changes_after_delete'::regclass) as
- (gp_segment_id int, segno int, eof bigint, tupcount bigint, varblockcount bigint,
-  eofuncompressed bigint, modcount bigint, formatversion smallint, state smallint)
- where state = 1;
+select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_delete');
  sum 
 -----
    9
@@ -297,10 +280,7 @@ select count(*) from uao_table_tupcount_changes_after_update;
 (1 row)
 
 vacuum full uao_table_tupcount_changes_after_update;
-select sum(tupcount) from gp_aoseg_dist_random('uao_table_tupcount_changes_after_update'::regclass) as
- (gp_segment_id int, segno int, eof bigint, tupcount bigint, varblockcount bigint,
-  eofuncompressed bigint, modcount bigint, formatversion smallint, state smallint)
- where state = 1;
+select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_update');
  sum 
 -----
   10

--- a/src/test/regress/expected/uaocs_catalog_tables.out
+++ b/src/test/regress/expected/uaocs_catalog_tables.out
@@ -1,7 +1,4 @@
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
-CREATE OR REPLACE FUNCTION aocsseg_live_segfiles(oid) RETURNS setof record AS $$
-  SELECT * from gp_toolkit.__gp_aocsseg($1) where state = 1;
-$$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
 DECLARE
@@ -9,7 +6,7 @@ DECLARE
   result record;
 BEGIN
   for record_text in
-      EXECUTE 'select aocsseg_live_segfiles(''' || relation_name || '''::regclass)::text from gp_dist_random(''gp_id'');'
+      EXECUTE 'select gp_toolkit.__gp_aocsseg(''' || relation_name || '''::regclass)::text from gp_dist_random(''gp_id'');'
   loop
       EXECUTE 'select a[3], a[4], a[5], a[6], a[7], a[8] from
               (select regexp_split_to_array(''' || record_text ||''', '','')) as dt(a);' into result;

--- a/src/test/regress/sql/uao_catalog_tables.sql
+++ b/src/test/regress/sql/uao_catalog_tables.sql
@@ -30,20 +30,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION gp_aoseg_dist_random(
-  IN relid oid) RETURNS setof record AS $$
-DECLARE
-  result record;
-BEGIN
-  for result in
-      EXECUTE 'select gp_segment_id, * from gp_dist_random(''pg_aoseg.pg_aoseg_' || relid || ''');'
-  loop
-      return next result;
-  end loop;
-  return;
-END;
-$$ LANGUAGE plpgsql;
-
 CREATE OR REPLACE FUNCTION gp_aotable_eof_dist_random(
   IN relation_name text) RETURNS setof record AS $$
 DECLARE
@@ -55,10 +41,9 @@ BEGIN
       EXECUTE 'select a.segno, a.tupcount, a.eofuncompressed, b.mirror_append_only_new_eof
               from gp_dist_random(''pg_aoseg.pg_aoseg_' || relid ||''') a,
               gp_dist_random(''gp_persistent_relation_node'') b
-              where a.gp_segment_id = b.gp_segment_id and a.segno = b.segment_file_num
-              and b.relfilenode_oid = ' || relid || ' and
+              where a.segno = b.segment_file_num and b.relfilenode_oid = ' || relid || ' and
               b.mirror_append_only_new_eof = a.eofuncompressed and
-              a.eofuncompressed != 0 and a.state = 1;'
+              a.eofuncompressed != 0;'
   loop
       return next result;
   end loop;
@@ -129,10 +114,7 @@ delete from uao_table_tupcount_changes_after_delete where i = 1;
 select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_delete');
 select count(*) from uao_table_tupcount_changes_after_delete;
 vacuum full uao_table_tupcount_changes_after_delete;
-select sum(tupcount) from gp_aoseg_dist_random('uao_table_tupcount_changes_after_delete'::regclass) as
- (gp_segment_id int, segno int, eof bigint, tupcount bigint, varblockcount bigint,
-  eofuncompressed bigint, modcount bigint, formatversion smallint, state smallint)
- where state = 1;
+select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_delete');
 select count(*) from uao_table_tupcount_changes_after_delete;
 
 -- Verify the tupcount changes in pg_aoseg when updating uao table
@@ -144,10 +126,7 @@ update uao_table_tupcount_changes_after_update set j=j||'test11' where i = 1;
 select tupcount from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_update');
 select count(*) from uao_table_tupcount_changes_after_update;
 vacuum full uao_table_tupcount_changes_after_update;
-select sum(tupcount) from gp_aoseg_dist_random('uao_table_tupcount_changes_after_update'::regclass) as
- (gp_segment_id int, segno int, eof bigint, tupcount bigint, varblockcount bigint,
-  eofuncompressed bigint, modcount bigint, formatversion smallint, state smallint)
- where state = 1;
+select sum(tupcount) from gp_toolkit.__gp_aoseg_name('uao_table_tupcount_changes_after_update');
 select count(*) from uao_table_tupcount_changes_after_update;
 
 -- Verify the hidden tup_count using UDF gp_aovisimap_hidden_info(oid) for uao relation after delete and vacuum

--- a/src/test/regress/sql/uaocs_catalog_tables.sql
+++ b/src/test/regress/sql/uaocs_catalog_tables.sql
@@ -1,8 +1,4 @@
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
-CREATE OR REPLACE FUNCTION aocsseg_live_segfiles(oid) RETURNS setof record AS $$
-  SELECT * from gp_toolkit.__gp_aocsseg($1) where state = 1;
-$$ LANGUAGE SQL;
-
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
 DECLARE
@@ -10,7 +6,7 @@ DECLARE
   result record;
 BEGIN
   for record_text in
-      EXECUTE 'select aocsseg_live_segfiles(''' || relation_name || '''::regclass)::text from gp_dist_random(''gp_id'');'
+      EXECUTE 'select gp_toolkit.__gp_aocsseg(''' || relation_name || '''::regclass)::text from gp_dist_random(''gp_id'');'
   loop
       EXECUTE 'select a[3], a[4], a[5], a[6], a[7], a[8] from
               (select regexp_split_to_array(''' || record_text ||''', '','')) as dt(a);' into result;


### PR DESCRIPTION
VACUUM FULL acquires AccessExclusive lock upfront, so there is no possibility
of deadlock due to a concurrent lazy vacuum that is also performing drop phase.
Upon migration to ICG, UAO catalog tests started running concurrently and this
bug was uncovered.  Now that the issue is fixed, the tests should not worry
about filtering out AWAITING_DROP segfiles.  Hence also revert
506032ac4a411c4b3da6a16abb1f63ff15e04de8.