### PR TITLE
Make sure CallXactCallbacksOnce are executed during preparetransaction     as well.

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsInjectFault.py
+++ b/gpMgmt/bin/gppylib/programs/clsInjectFault.py
@@ -383,6 +383,7 @@ class GpInjectFaultProgram:
 			      "transaction_abort_failure (inject fault to simulate transaction abort failure), " \
 			      "workfile_creation_failure (inject fault to simulate workfile creation failure), " \
 			      "workfile_write_failure (inject fault to simulate workfile write failure), " \
+                  "workfile_hashjoin_failure (inject fault before we close workfile in ExecHashJoinNewBatch), "\
 			      "update_committed_eof_in_persistent_table (inject fault before committed EOF is updated in gp_persistent_relation_node for Append Only segment files), " \
 			      "exec_simple_query_end_command (inject fault before EndCommand in exec_simple_query), " \
 			      "multi_exec_hash_large_vmem (allocate large vmem using palloc inside MultiExecHash to attempt to exceed vmem limit), " \

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3373,16 +3373,6 @@ CommitTransaction(void)
 	AtEOXact_UpdateFlatFiles(true);
 
 	/*
-	 * Free external resources
-	 */
-	AtEOXact_ExtTables(true);
-
-	/* Reset g_dataSourceCtx
-	 * g_dataSourceCtx is allocated in TopTransactionContext, so it's going away.
-	 */
-	AtEOXact_ResetDataSourceCtx();
-
-	/*
 	 * Prepare all QE.
 	 */
 	prepareDtxTransaction();
@@ -3572,6 +3562,16 @@ CommitTransaction(void)
 	s->curTransactionOwner = NULL;
 	CurTransactionResourceOwner = NULL;
 	TopTransactionResourceOwner = NULL;
+
+	/*
+	 * Free external resources
+	 */
+	AtEOXact_ExtTables(true);
+
+	/* Reset g_dataSourceCtx
+	 * g_dataSourceCtx is allocated in TopTransactionContext, so it's going away.
+	 */
+	AtEOXact_ResetDataSourceCtx();
 
 	AtCommit_Memory();
 
@@ -3967,12 +3967,6 @@ AbortTransaction(void)
 	 */
 	AfterTriggerEndXact(false);
 	AtAbort_Portals();
-	AtEOXact_ExtTables(false);
-
-	/* reset g_dataSourceCtx
-	 * g_dataSourceCtx is allocated in TopTransactionContext, so it's going away.
-	 */
-	AtEOXact_ResetDataSourceCtx();
 
 	AtEOXact_SharedSnapshot();
 
@@ -4081,6 +4075,14 @@ AbortTransaction(void)
 		AtEOXact_PgStat(false);
 		pgstat_report_xact_timestamp(0);
 	}
+
+	/* Free external resources */
+	AtEOXact_ExtTables(false);
+
+	/* reset g_dataSourceCtx
+	 * g_dataSourceCtx is allocated in TopTransactionContext, so it's going away.
+	 */
+	AtEOXact_ResetDataSourceCtx();
 
 	/*
 	 * Do abort to all QE. NOTE: we don't process
@@ -4895,10 +4897,6 @@ UnregisterXactCallbackOnce(XactCallback callback, void *arg)
 static void
 CallXactCallbacksOnce(XactEvent event)
 {
-	/* currently callback once should ignore prepare. */
-	if (event == XACT_EVENT_PREPARE)
-		return;
-
 	while(Xact_callbacks_once)
 	{
 		XactCallbackItem *next = Xact_callbacks_once->next;

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -954,6 +954,13 @@ start_over:
 			hashtable->stats->batchstats[curbatch].innerfilesize =
 				ExecWorkFile_Tell64(hashtable->batches[curbatch]->innerside.workfile);
 		}
+#ifdef FAULT_INJECTOR
+		FaultInjector_InjectFaultIfSet(
+				WorkfileHashJoinFailure,
+				DDLNotSpecified,
+				"",  // databaseName
+				""); // tableName
+#endif
 		workfile_mgr_close_file(hashtable->work_set, batch->innerside.workfile);
 		batch->innerside.workfile = NULL;
 	}

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -255,6 +255,8 @@ FaultInjectorIdentifierEnumToString[] = {
 	  /* inject fault to simulate workfile creation failure  */
 	_("workfile_write_failure"),
 	  /* inject fault to simulate workfile write failure  */
+	_("workfile_hashjoin_failure"),
+	 /* inject fault before we close workfile in ExecHashJoinNewBatch */
 	_("update_committed_eof_in_persistent_table"),
 		/* inject fault before committed EOF is updated in gp_persistent_relation_node for Append Only segment files */
 	_("exec_simple_query_end_command"),
@@ -1166,6 +1168,7 @@ FaultInjector_NewHashEntry(
 		case AbortTransactionFail:
 		case WorkfileCreationFail:
 		case WorkfileWriteFail:
+		case WorkfileHashJoinFailure:
 		case UpdateCommittedEofInPersistentTable:
 		case ExecSortBeforeSorting:
 		case FaultDuringExecDynamicTableScan:

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -164,6 +164,7 @@ typedef enum FaultInjectorIdentifier_e {
 	AbortTransactionFail,
 	WorkfileCreationFail,
 	WorkfileWriteFail,
+	WorkfileHashJoinFailure,
 
 	UpdateCommittedEofInPersistentTable,
 

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -65,3 +65,58 @@ ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'erro
 20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
 20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 --end_ignore
+create table t (i int, j text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t select i, i from generate_series(1,1000000) as i;
+set gp_workfile_compress_algorithm ='zlib';
+set statement_mem='10MB';
+create or replace function FuncA()
+returns void as
+$body$
+begin
+    CREATE TEMP table TMP_Q_QR_INSTM_ANL_01 WITH(APPENDONLY=true,COMPRESSLEVEL=5,ORIENTATION=row,COMPRESSTYPE=zlib) on commit drop as
+    SELECT t1.i from t as t1 join t as t2 on t1.i = t2.i;
+EXCEPTION WHEN others THEN
+ -- do nothing
+ insert into t values(2387283, 'a');
+end
+$body$ language plpgsql;
+-- Inject fault before we close workfile in ExecHashJoinNewBatch
+--start_ignore
+\! gpfaultinjector -f workfile_hashjoin_failure -y reset --seg_dbid 2
+20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y reset --seg_dbid 2
+20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
+20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
+20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
+20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
+20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
+\! gpfaultinjector -f workfile_hashjoin_failure -y error --seg_dbid 2
+20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y error --seg_dbid 2
+20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
+20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
+20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
+20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
+20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
+--end_ignore
+select FuncA();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CONTEXT:  SQL statement "CREATE TEMP table TMP_Q_QR_INSTM_ANL_01 WITH(APPENDONLY=true,COMPRESSLEVEL=5,ORIENTATION=row,COMPRESSTYPE=zlib) on commit drop as SELECT t1.i from t as t1 join t as t2 on t1.i = t2.i"
+PL/pgSQL function "funca" line 2 at SQL statement
+ funca 
+-------
+ 
+(1 row)
+
+drop function FuncA();
+drop table t;
+--start_ignore
+\! gpfaultinjector -f workfile_hashjoin_failure -y reset --seg_dbid 2
+20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y reset --seg_dbid 2
+20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
+20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
+20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
+20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
+20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
+--end_ignore


### PR DESCRIPTION
`BFZ` data structure uses `DataSource` context for its memory. `DataSource` Context is allocated on `TopTransactionMemoryContext`. If there are any unfreed `BFZ` data structure exist at the end of the transaction, we will clean up those using `CallXactCallbacksOnce` in `Commit / Abort` transaction.

**Problem** 
During PrepareTransaction we delete the `TopTransactionMemoryContext` and thereby `DataSourceContext`. This happens before we do the clean up for `BFZ` data structure. Later when we do the clean up in `CommitTransaction` for instance, we crash because we try to free `BFZ` data structure but `DataSourceContext` is freed already.

**Proposal in this PR**
We change `CallXactCallbacksOnce` to do the clean up in `PrepareTransaction` itself. This way we made sure that we delete the `BFZ` data structure before `TopTransactionMemoryContext / DataSource` context get deleted.

All of the registered callbacks are just for cleaning up temp files / data structures including `BFZ`. So it is ok to delete those files during `PrepareTransaction`. 

`CallXactCallbacksOnce`  can potentially call following callbacks as of now.
```
1. bfz_close_callback -- Clean up BFZ files
2. XCallBack_NTS -> ntuplestore_cleanup -- Clean up tuplestore data structure and workfiles.
3. XCallBack_ShareInput_FIFO -> shareinput_clean_lk_ctxt -- Clean up temporary fifo files.
```

@foyzur @armenatzoglou @hardikar @asimrp @hlinnaka Could you please take a look at this PR.
