### PR TITLE
Support 'OPTION' keyword in GPDB external table

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3291,6 +3291,7 @@ _copyCreateExternalStmt(CreateExternalStmt *from)
 	COPY_SCALAR_FIELD(isweb);
 	COPY_SCALAR_FIELD(iswritable);
 	COPY_NODE_FIELD(sreh);
+	COPY_NODE_FIELD(extOptions);
 	COPY_NODE_FIELD(encoding);
 	COPY_NODE_FIELD(distributedBy);	
 	if (from->policy)

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1224,6 +1224,7 @@ _equalCreateExternalStmt(CreateExternalStmt *a, CreateExternalStmt *b)
 	COMPARE_SCALAR_FIELD(isweb);
 	COMPARE_SCALAR_FIELD(iswritable);
 	COMPARE_NODE_FIELD(sreh);
+	COMPARE_NODE_FIELD(extOptions);
 	COMPARE_NODE_FIELD(encoding);
 	COMPARE_NODE_FIELD(distributedBy);
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2322,6 +2322,7 @@ _outCreateExternalStmt(StringInfo str, CreateExternalStmt *node)
 	WRITE_BOOL_FIELD(isweb);
 	WRITE_BOOL_FIELD(iswritable);
 	WRITE_NODE_FIELD(sreh);
+	WRITE_NODE_FIELD(extOptions);
 	WRITE_NODE_FIELD(encoding);
 	WRITE_NODE_FIELD(distributedBy);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1304,6 +1304,7 @@ _readCreateExternalStmt(void)
 	READ_BOOL_FIELD(isweb);
 	READ_BOOL_FIELD(iswritable);
 	READ_NODE_FIELD(sreh);
+	READ_NODE_FIELD(extOptions);
 	READ_NODE_FIELD(encoding);
 	READ_NODE_FIELD(distributedBy);
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2244,6 +2244,7 @@ _readCreateExternalStmt(void)
 	READ_BOOL_FIELD(isweb);
 	READ_BOOL_FIELD(iswritable);
 	READ_NODE_FIELD(sreh);
+	READ_NODE_FIELD(extOptions);
 	READ_NODE_FIELD(encoding);
 	READ_NODE_FIELD(distributedBy);
 	local_node->policy = NULL;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1545,6 +1545,7 @@ typedef struct CreateExternalStmt
 	bool		isweb;
 	bool		iswritable;
 	Node	   *sreh;			/* Single row error handling info */
+	List       *extOptions;        /* generic options to external table */
 	List	   *encoding;		/* List (size 1 max) of DefElem nodes for
 								   data encoding */
 	List       *distributedBy;   /* what columns we distribute the data by */


### PR DESCRIPTION
In case user wanna specify parameters with OPTION rather than
config file, it provides flexible and friendly grammar.

Usage:
```sql
    CREATE EXTERNAL TABLE tests3_orig (col1 int)
		LOCATION ('s3://path/to/key config=/path/to/config') FORMAT 'csv';
    CREATE EXTERNAL TABLE tests3_option_empty (col1 int)
		LOCATION ('s3://path/to/key config=/path/to/config') FORMAT 'csv'
		OPTION ();
    CREATE EXTERNAL TABLE tests3_option_two_str (col1 int)
		LOCATION ('s3://path/to/key config=/path/to/config') FORMAT 'csv'
		OPTION ('hello' 'world');
    CREATE EXTERNAL TABLE tests3_option_hello (col1 int)
		LOCATION ('s3://path/to/key config=/path/to/config') FORMAT 'csv'
		OPTION (hello 'world');
    CREATE EXTERNAL TABLE tests3_option_hello_again (col1 int)
		LOCATION ('s3://path/to/key config=/path/to/config') FORMAT 'csv'
		OPTION (hello 'world', hello 'world again', hello 'world again and again');
```