### PR TITLE
Disable multiple validations for master data directory in gpactivatestandby

### DIFF
--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -102,25 +102,20 @@ def parseargs():
         parser.print_version()
         parser.exit(0, None)
 
-    # check that there isn't a conflict between -d option and MASTER_DATA_DIRECTORY env
-    env_master_data_dir = os.getenv('MASTER_DATA_DIRECTORY', None)
-    if not env_master_data_dir:
-        logger.fatal('MASTER_DATA_DIRECTORY environment variable not set.')
-        parser.exit(2, None)
 
-    env_master_data_dir = os.path.normpath(env_master_data_dir)
     if not options.master_data_dir:
+        logger.info('Option -d or --master-data-directory not set. Checking environment variable MASTER_DATA_DIRECTORY')
+        env_master_data_dir = os.getenv('MASTER_DATA_DIRECTORY', None)
+        # check for environment variable MASTER_DATA_DIRECTORY
+        if not env_master_data_dir:
+            logger.fatal('Both -d parameter and MASTER_DATA_DIRECTORY environment variable are not set.')
+            logger.fatal('Required option master data directory is missing.')
+            parser.exit(2, None)
         options.master_data_dir = env_master_data_dir
-    else:
-        # We have to normalize this path for a later comparison
-        normpath = os.path.abspath(options.master_data_dir)
-        options.master_data_dir = normpath
-
-    # Check if they don't conflict
-    if env_master_data_dir != options.master_data_dir:
-        logger.fatal('Current setting of MASTER_DATA_DIRECTORY not same as -d parameter.')
-        parser.exit(2, None)
         
+    # We have to normalize this path for a later comparison
+    options.master_data_dir = os.path.abspath(options.master_data_dir)
+
     # check if PGPORT environment variable is set.
     env_pgport = os.getenv('PGPORT', None)
     if not env_pgport:


### PR DESCRIPTION
Refers to issue #1424  - Enables gpactivatestandby to use environment variable MASTER_DATA_DIRECTORY if command line argument -d is not set. If both -d and environment variable MASTER_DATA_DIRECTORY are set, -d will take precedence over environment variable.