### PR TITLE
Make ICG qp_correlated_query more stable.

### DIFF
--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -5,52 +5,44 @@
 create schema qp_correlated_query;
 set search_path to qp_correlated_query;
 -- end_ignore
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_in.sql (Correlated Subquery: CSQ using IN clause (Heap))
 -- ----------------------------------------------------------------------
 -- start_ignore
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table qp_csq_t1(a int, b int) distributed by (a);
 insert into qp_csq_t1 values (1,2);
 insert into qp_csq_t1 values (3,4);
 insert into qp_csq_t1 values (5,6);
 insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze qp_csq_t1;
+create table qp_csq_t2(x int,y int) distributed by (x);
 insert into qp_csq_t2 values(1,1);
 insert into qp_csq_t2 values(3,9);
 insert into qp_csq_t2 values(5,25);
 insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze qp_csq_t2;
+create table qp_csq_t3(c int, d text) distributed by (c);
 insert into qp_csq_t3 values(1,'one');
 insert into qp_csq_t3 values(3,'three');
 insert into qp_csq_t3 values(5,'five');
 insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze qp_csq_t3;
+create table A(i integer, j integer) distributed by (i);
 insert into A values(1,1);
 insert into A values(19,5);
 insert into A values(99,62);
 insert into A values(1,1);
 insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze A;
+create table B(i integer, j integer) distributed by (i);
 insert into B values(1,43);
 insert into B values(88,1);
 insert into B values(-1,62);
 insert into B values(1,1);
 insert into B values(32,5);
 insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze B;
+create table C(i integer, j integer) distributed by (i);
 insert into C values(1,889);
 insert into C values(288,1);
 insert into C values(-1,625);
@@ -60,6 +52,7 @@ insert into C values(3,-1);
 insert into C values(99,7);
 insert into C values(78,62);
 insert into C values(2,7);
+analyze C;
 -- end_ignore
 -- -- -- --
 -- Basic queries with IN clause
@@ -67,10 +60,10 @@ insert into C values(2,7);
 select a, x from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a in (select x);
  a | x 
 ---+---
+ 1 | 1
  3 | 3
  5 | 5
  7 | 7
- 1 | 1
 (4 rows)
 
 select A.i from A where A.i in (select B.i from B where A.i = B.i) order by A.i;
@@ -80,36 +73,12 @@ select A.i from A where A.i in (select B.i from B where A.i = B.i) order by A.i;
  1
 (2 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 select * from B where exists (select * from C,A where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i != 10)) order by 1, 2;
  i | j  
 ---+----
  1 |  1
  1 | 43
 (2 rows)
-
-select * from B where exists (select * from C,A where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i != 10)) order by 1, 2;
- i | j  
----+----
- 1 |  1
- 1 | 43
-(2 rows)
-
--- Not supported select A.i, B.i, C.j from A, B, C where not exists (select C.j from C where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
-select * from B where not exists (select * from C,A where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i != 10)) order by 1,2;
- i  | j  
-----+----
- -1 | 62
-  2 |  7
- 32 |  5
- 88 |  1
-(4 rows)
-
-select * from A where not exists (select * from C,B where C.j = A.j and B.i in (select C.i from C where C.i = B.i and C.i != 10));
- i  | j 
-----+---
- 19 | 5
-(1 row)
 
 select * from B where not exists (select * from C,A where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i != 10)) order by 1,2;
  i  | j  
@@ -209,7 +178,6 @@ select A.i from A where A.i not in (select B.i from B where A.i = B.i) order by 
  99
 (3 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and B.i not in (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 select * from A where exists (select * from B,C where C.j = A.j and B.i not in (select sum(C.i) from C where C.i = B.i and C.i != 10)) order by 1,2;
  i  | j  
 ----+----
@@ -227,49 +195,6 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i not in (
  78 | -1 | 88 | 1
  99 | 62 | 88 | 1
 (4 rows)
-
-select * from A where exists (select * from B,C where C.j = A.j and B.i not in (select sum(C.i) from C where C.i = B.i and C.i != 10)) order by 1,2;
- i  | j  
-----+----
-  1 |  1
-  1 |  1
- 78 | -1
- 99 | 62
-(4 rows)
-
-select * from A,B where exists (select * from C where C.j = A.j and B.i not in (select C.i from C where C.i != 10)) order by 1,2,3,4;
- i  | j  | i  | j 
-----+----+----+---
-  1 |  1 | 88 | 1
-  1 |  1 | 88 | 1
- 78 | -1 | 88 | 1
- 99 | 62 | 88 | 1
-(4 rows)
-
--- Not supported select A.i, B.i, C.j from A, B, C where not exists (select C.j from C where C.j = A.j and B.i not in (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
-select * from B where not exists (select * from A,C where C.j = A.j and B.i in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
- i  | j  
-----+----
- -1 | 62
-  2 |  7
- 32 |  5
- 88 |  1
-(4 rows)
-
-select * from B where not exists (select * from A,C where C.j = A.j and B.i not in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
- i | j 
----+---
-(0 rows)
-
-select * from A where not exists (select * from B,C where C.j = A.j and B.i not in (select max(C.i) from C where C.i = B.i and C.i != 10)) order by 1, 2;
- i  | j  
-----+----
-  1 |  1
-  1 |  1
- 19 |  5
- 78 | -1
- 99 | 62
-(5 rows)
 
 select * from B where not exists (select * from A,C where C.j = A.j and B.i in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
  i  | j  
@@ -401,68 +326,9 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
  -1
 (10 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_any.sql - Correlated Subquery: CSQ using ANY clause (Heap)
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- --
 -- Basic queries with ANY clause
 -- -- -- --
@@ -534,23 +400,9 @@ select * from A where A.j = any (select C.j from C,B where C.j = A.j and B.i = a
  99 | 62
 (4 rows)
 
-select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = any (select C.i from C where C.i != 10 and C.i = A.i)) order by 1,2,3,4; -- Not supported, should fail
+-- Planner should fail due to skip-level correlation not supported. ORCA should pass
+select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = any (select C.i from C where C.i != 10 and C.i = A.i)) order by 1,2,3,4;
 ERROR:  correlated subquery with skip-level correlations is not supported
-select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
- i  | i  |  j  
-----+----+-----
- 99 | -1 |  -1
- 99 | -1 |   1
- 99 | -1 |   7
- 99 | -1 |   7
- 99 | -1 |  62
- 99 | -1 |  62
- 99 | -1 |  65
- 99 | -1 | 625
- 99 | -1 | 889
- 99 |  1 |  -1
-(10 rows)
-
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i  | i  |  j  
 ----+----+-----
@@ -586,68 +438,9 @@ select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j =
 ---+---+---
 (0 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using ALL clause (Heap)
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- --
 -- Basic queries with ALL clause
 -- -- -- --
@@ -692,10 +485,9 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
  99 | 62 | 1 | 43
 (8 rows)
 
-select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4; -- Should fail. Skip-level correlations are not supported
+-- Planner should fail due to skip-level correlation not supported. ORCA should pass
+select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
 ERROR:  correlated subquery with skip-level correlations is not supported
-select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10; -- Should fail (Sub-query returns more than one row)
-ERROR:  more than one row returned by a subquery used as an expression  (seg2 slice5 vraghavan.local:25434 pid=51919)
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
 ---+----+----
@@ -731,68 +523,9 @@ select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j =
  1 | -1 | 62
 (10 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using EXISTS clause (Heap)
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- -- 
 -- Basic queries with EXISTS clause
 -- -- -- --
@@ -822,7 +555,6 @@ with t as (select * from qp_csq_t2) select b from qp_csq_t1 where exists(select 
  2
 (1 row)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and exists (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 20;
 select * from A where exists (select * from C where C.j = A.j) order by 1,2;
  i  | j  
 ----+----
@@ -843,7 +575,6 @@ select * from A where exists (select * from C,B where C.j = A.j and exists (sele
 
 select * from A,B where exists (select * from C where C.j = A.j and exists (select * from C where C.i = B.i));
 ERROR:  correlated subquery with skip-level correlations is not supported
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and exists (select sum(C.i) from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 20;
 select * from A where exists (select * from B, C where C.j = A.j and exists (select sum(C.i) from C where C.i != 10 and C.i = B.i)) order by 1, 2;
  i  | j  
 ----+----
@@ -853,7 +584,8 @@ select * from A where exists (select * from B, C where C.j = A.j and exists (sel
  99 | 62
 (4 rows)
 
-select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2; -- Should fail, not supported
+-- Planner should fail due to skip-level correlation not supported. ORCA should pass
+select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2;
 ERROR:  correlated subquery with skip-level correlations is not supported
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 20;
  i  | i  |  j  
@@ -905,13 +637,11 @@ select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.
  1 |  1 |  -1
 (20 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists(select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where A.i = B.i and A.i !=10)) order by A.i, B.i, C.j limit 20;
 select * from A where exists (select * from C where C.j = A.j and not exists (select sum(B.i) from B where B.i = C.i));
  i | j 
 ---+---
 (0 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists(select * from C where C.i = A.i and exists (select C.j where C.j = B.j and A.j < 10)) order by A.i, B.i, C.j limit 20;
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and B.j < 10)) order by 1,2;
  i  | j  
 ----+----
@@ -953,7 +683,6 @@ select A.i from A where not exists(select B.i from B where A.i = B.i) order by A
  99
 (3 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and not exists (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 select * from A where not exists (select * from C,B where C.j = A.j and exists (select * from C where C.i = B.i and C.j < B.j)) order by 1,2;
  i  | j  
 ----+----
@@ -1030,60 +759,32 @@ select C.j from C where not exists (select rank() over (order by B.i) from B  wh
  62
 (4 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
 -- ----------------------------------------------------------------------
 -- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-create table qp_csq_t1(a int, b int) distributed by (b);
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table A(i integer, j integer) distributed by (j);
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
+drop table if exists qp_csq_t4;
+NOTICE:  table "qp_csq_t4" does not exist, skipping
+create table qp_csq_t4(a int, b int) distributed by (b);
+insert into qp_csq_t4 values (1,2);
+insert into qp_csq_t4 values (3,4);
+insert into qp_csq_t4 values (5,6);
+insert into qp_csq_t4 values (7,8);
+analyze qp_csq_t4;
+drop table if exists D;
+NOTICE:  table "d" does not exist, skipping
+create table D(i integer, j integer) distributed by (j);
+insert into D values(1,1);
+insert into D values(19,5);
+insert into D values(99,62);
+insert into D values(1,1);
+insert into D values(78,-1);
+analyze D;
 -- end_ignore
 -- -- -- --
 -- Basic CSQ with UPDATE statements
 -- -- -- --
-select * from qp_csq_t1 order by a;
+select * from qp_csq_t4 order by a;
  a | b 
 ---+---
  1 | 2
@@ -1092,8 +793,8 @@ select * from qp_csq_t1 order by a;
  7 | 8
 (4 rows)
 
-update qp_csq_t1 set a = (select y from qp_csq_t2 where x=a) where b < 8;
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = (select y from qp_csq_t2 where x=a) where b < 8;
+select * from qp_csq_t4 order by a;
  a  | b 
 ----+---
   1 | 2
@@ -1102,8 +803,8 @@ select * from qp_csq_t1 order by a;
  25 | 6
 (4 rows)
 
-update qp_csq_t1 set a = 9999 where qp_csq_t1.a = (select max(x) from qp_csq_t2);
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = 9999 where qp_csq_t4.a = (select max(x) from qp_csq_t2);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     1 | 2
@@ -1112,8 +813,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-update qp_csq_t1 set a = (select max(y) from qp_csq_t2 where x=a) where qp_csq_t1.a = (select min(x) from qp_csq_t2);
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = (select max(y) from qp_csq_t2 where x=a) where qp_csq_t4.a = (select min(x) from qp_csq_t2);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     1 | 2
@@ -1122,8 +823,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-update qp_csq_t1 set a = 8888 where (select (y*2)>b from qp_csq_t2 where a=x);
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = 8888 where (select (y*2)>b from qp_csq_t2 where a=x);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     1 | 2
@@ -1132,8 +833,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-update qp_csq_t1 set a = 3333 where qp_csq_t1.a in (select x from qp_csq_t2);
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = 3333 where qp_csq_t4.a in (select x from qp_csq_t2);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1142,32 +843,32 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-update A set i = 11111 from C where C.i = A.i and exists (select C.j from C,B where C.j = B.j and A.j < 10);
-select * from A;
+update D set i = 11111 from C where C.i = D.i and exists (select C.j from C,B where C.j = B.j and D.j < 10);
+select * from D;
    i   | j  
 -------+----
-    19 |  5
     99 | 62
  11111 |  1
- 11111 | -1
  11111 |  1
+ 11111 | -1
+    19 |  5
 (5 rows)
 
-update A set i = 22222 from C where C.i = A.i and not exists (select C.j from C,B where C.j = B.j and A.j < 10);
-select * from A;
+update D set i = 22222 from C where C.i = D.i and not exists (select C.j from C,B where C.j = B.j and D.j < 10);
+select * from D;
    i   | j  
 -------+----
-    19 |  5
+ 11111 |  1
  11111 |  1
  11111 | -1
- 11111 |  1
+    19 |  5
  22222 | 62
 (5 rows)
 
 -- -- -- --
 -- Basic CSQ with DELETE statements
 -- -- -- --
-select * from qp_csq_t1 order by a;
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1176,8 +877,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from qp_csq_t1 where a <= (select min(y) from qp_csq_t2 where x=a);
-select * from qp_csq_t1 order by a;
+delete from qp_csq_t4 where a <= (select min(y) from qp_csq_t2 where x=a);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1186,9 +887,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from qp_csq_t1 where qp_csq_t1.a = (select x from qp_csq_t2);
-ERROR:  more than one row returned by a subquery used as an expression
-select * from qp_csq_t1 order by a;
+delete from qp_csq_t4 where qp_csq_t4.a = (select min(x) from qp_csq_t2);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1197,8 +897,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from qp_csq_t1 where exists (select (y*2)>b from qp_csq_t2 where a=x);
-select * from qp_csq_t1 order by a;
+delete from qp_csq_t4 where exists (select (y*2)>b from qp_csq_t2 where a=x);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1207,8 +907,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from qp_csq_t1  where qp_csq_t1.a = (select x from qp_csq_t2 where a=x);
-select * from qp_csq_t1 order by a;
+delete from qp_csq_t4  where qp_csq_t4.a = (select x from qp_csq_t2 where a=x);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1217,81 +917,22 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from  A TableA where exists (select C.j from C, B where C.j = B.j and TableA.j < 10);
-select * from A order by A.i;
+delete from  D TableD where exists (select C.j from C, B where C.j = B.j and TableD.j < 10);
+select * from D order by D.i;
    i   | j  
 -------+----
  22222 | 62
 (1 row)
 
-delete from A TableA where not exists (select C.j from C,B where C.j = B.j and TableA.j < 10);
-select * from A order by A.i;
+delete from D TableD where not exists (select C.j from C,B where C.j = B.j and TableD.j < 10);
+select * from D order by D.i;
  i | j 
 ---+---
 (0 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using WHERE clause (Heap)
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- --
 -- Basic queries with WHERE clause
 -- -- -- --
@@ -1329,76 +970,407 @@ SELECT a, (SELECT d FROM qp_csq_t3 WHERE a=c) FROM qp_csq_t1 GROUP BY a order by
  7 | seven
 (4 rows)
 
-RESET ALL;
+-- ----------------------------------------------------------------------
+-- Test: Correlated Subquery: CSQ in select list (Heap) 
+-- ----------------------------------------------------------------------
+-- -- -- --
+-- Basic queries in SELECT list
+-- -- -- --
+select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
+ i  | c_j 
+----+-----
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+(10 rows)
+
+select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x)) as avg_x from qp_csq_t1 order by 1;
+ avg_x 
+-------
+     4
+     4
+     4
+     4
+(4 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: Correlated Subquery: CSQ with multiple columns (Heap)
+-- ----------------------------------------------------------------------
+select A.i, B.i from A, B where (A.i,A.j) = (select min(B.i),min(B.j) from B where B.i = A.i) order by A.i, B.i;
+ i | i  
+---+----
+ 1 | -1
+ 1 | -1
+ 1 |  1
+ 1 |  1
+ 1 |  1
+ 1 |  1
+ 1 |  2
+ 1 |  2
+ 1 | 32
+ 1 | 32
+ 1 | 88
+ 1 | 88
+(12 rows)
+
+select A.i, B.i from A, B where (A.i,A.j) = all(select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
+ i  | i  
+----+----
+ 19 | -1
+ 19 |  1
+ 19 |  1
+ 19 |  2
+ 19 | 32
+ 19 | 88
+ 78 | -1
+ 78 |  1
+ 78 |  1
+ 78 |  2
+ 78 | 32
+ 78 | 88
+ 99 | -1
+ 99 |  1
+ 99 |  1
+ 99 |  2
+ 99 | 32
+ 99 | 88
+(18 rows)
+
+select A.i, B.i from A, B where not exists (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
+ i  | i  
+----+----
+ 19 | -1
+ 19 |  1
+ 19 |  1
+ 19 |  2
+ 19 | 32
+ 19 | 88
+ 78 | -1
+ 78 |  1
+ 78 |  1
+ 78 |  2
+ 78 | 32
+ 78 | 88
+ 99 | -1
+ 99 |  1
+ 99 |  1
+ 99 |  2
+ 99 | 32
+ 99 | 88
+(18 rows)
+
+select A.i, B.i from A, B where (A.i,A.j) in (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
+ i | i  
+---+----
+ 1 | -1
+ 1 | -1
+ 1 |  1
+ 1 |  1
+ 1 |  1
+ 1 |  1
+ 1 |  2
+ 1 |  2
+ 1 | 32
+ 1 | 32
+ 1 | 88
+ 1 | 88
+(12 rows)
+
+select A.i, B.i,C.i from A, B, C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
+ i | i | i 
+---+---+---
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+(4 rows)
+
+select A.i, B.i,C.i from A, B, C where not exists (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
+ i  | i  |  i  
+----+----+-----
+  1 | -1 |  -1
+  1 | -1 |  -1
+  1 | -1 |   2
+  1 | -1 |   2
+  1 | -1 |   3
+  1 | -1 |   3
+  1 | -1 |  32
+  1 | -1 |  32
+  1 | -1 |  32
+  1 | -1 |  32
+  1 | -1 |  78
+  1 | -1 |  78
+  1 | -1 |  99
+  1 | -1 |  99
+  1 | -1 | 288
+  1 | -1 | 288
+  1 |  1 |  -1
+  1 |  1 |  -1
+  1 |  1 |  -1
+  1 |  1 |  -1
+  1 |  1 |   2
+  1 |  1 |   2
+  1 |  1 |   2
+  1 |  1 |   2
+  1 |  1 |   3
+  1 |  1 |   3
+  1 |  1 |   3
+  1 |  1 |   3
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  78
+  1 |  1 |  78
+  1 |  1 |  78
+  1 |  1 |  78
+  1 |  1 |  99
+  1 |  1 |  99
+  1 |  1 |  99
+  1 |  1 |  99
+  1 |  1 | 288
+  1 |  1 | 288
+  1 |  1 | 288
+  1 |  1 | 288
+  1 |  2 |  -1
+  1 |  2 |  -1
+  1 |  2 |   2
+  1 |  2 |   2
+  1 |  2 |   3
+  1 |  2 |   3
+  1 |  2 |  32
+  1 |  2 |  32
+  1 |  2 |  32
+  1 |  2 |  32
+  1 |  2 |  78
+  1 |  2 |  78
+  1 |  2 |  99
+  1 |  2 |  99
+  1 |  2 | 288
+  1 |  2 | 288
+  1 | 32 |  -1
+  1 | 32 |  -1
+  1 | 32 |   2
+  1 | 32 |   2
+  1 | 32 |   3
+  1 | 32 |   3
+  1 | 32 |  32
+  1 | 32 |  32
+  1 | 32 |  32
+  1 | 32 |  32
+  1 | 32 |  78
+  1 | 32 |  78
+  1 | 32 |  99
+  1 | 32 |  99
+  1 | 32 | 288
+  1 | 32 | 288
+  1 | 88 |  -1
+  1 | 88 |  -1
+  1 | 88 |   2
+  1 | 88 |   2
+  1 | 88 |   3
+  1 | 88 |   3
+  1 | 88 |  32
+  1 | 88 |  32
+  1 | 88 |  32
+  1 | 88 |  32
+  1 | 88 |  78
+  1 | 88 |  78
+  1 | 88 |  99
+  1 | 88 |  99
+  1 | 88 | 288
+  1 | 88 | 288
+ 19 | -1 |  -1
+ 19 | -1 |   2
+ 19 | -1 |   3
+ 19 | -1 |  32
+ 19 | -1 |  32
+ 19 | -1 |  78
+ 19 | -1 |  99
+ 19 | -1 | 288
+ 19 |  1 |  -1
+ 19 |  1 |  -1
+ 19 |  1 |   2
+ 19 |  1 |   2
+ 19 |  1 |   3
+ 19 |  1 |   3
+ 19 |  1 |  32
+ 19 |  1 |  32
+ 19 |  1 |  32
+ 19 |  1 |  32
+ 19 |  1 |  78
+ 19 |  1 |  78
+ 19 |  1 |  99
+ 19 |  1 |  99
+ 19 |  1 | 288
+ 19 |  1 | 288
+ 19 |  2 |  -1
+ 19 |  2 |   2
+ 19 |  2 |   3
+ 19 |  2 |  32
+ 19 |  2 |  32
+ 19 |  2 |  78
+ 19 |  2 |  99
+ 19 |  2 | 288
+ 19 | 32 |  -1
+ 19 | 32 |   2
+ 19 | 32 |   3
+ 19 | 32 |  32
+ 19 | 32 |  32
+ 19 | 32 |  78
+ 19 | 32 |  99
+ 19 | 32 | 288
+ 19 | 88 |  -1
+ 19 | 88 |   2
+ 19 | 88 |   3
+ 19 | 88 |  32
+ 19 | 88 |  32
+ 19 | 88 |  78
+ 19 | 88 |  99
+ 19 | 88 | 288
+ 78 | -1 |  -1
+ 78 | -1 |   2
+ 78 | -1 |   3
+ 78 | -1 |  32
+ 78 | -1 |  32
+ 78 | -1 |  78
+ 78 | -1 |  99
+ 78 | -1 | 288
+ 78 |  1 |  -1
+ 78 |  1 |  -1
+ 78 |  1 |   2
+ 78 |  1 |   2
+ 78 |  1 |   3
+ 78 |  1 |   3
+ 78 |  1 |  32
+ 78 |  1 |  32
+ 78 |  1 |  32
+ 78 |  1 |  32
+ 78 |  1 |  78
+ 78 |  1 |  78
+ 78 |  1 |  99
+ 78 |  1 |  99
+ 78 |  1 | 288
+ 78 |  1 | 288
+ 78 |  2 |  -1
+ 78 |  2 |   2
+ 78 |  2 |   3
+ 78 |  2 |  32
+ 78 |  2 |  32
+ 78 |  2 |  78
+ 78 |  2 |  99
+ 78 |  2 | 288
+ 78 | 32 |  -1
+ 78 | 32 |   2
+ 78 | 32 |   3
+ 78 | 32 |  32
+ 78 | 32 |  32
+ 78 | 32 |  78
+ 78 | 32 |  99
+ 78 | 32 | 288
+ 78 | 88 |  -1
+ 78 | 88 |   2
+ 78 | 88 |   3
+ 78 | 88 |  32
+ 78 | 88 |  32
+ 78 | 88 |  78
+ 78 | 88 |  99
+ 78 | 88 | 288
+ 99 | -1 |  -1
+ 99 | -1 |   2
+ 99 | -1 |   3
+ 99 | -1 |  32
+ 99 | -1 |  32
+ 99 | -1 |  78
+ 99 | -1 |  99
+ 99 | -1 | 288
+ 99 |  1 |  -1
+ 99 |  1 |  -1
+ 99 |  1 |   2
+ 99 |  1 |   2
+ 99 |  1 |   3
+ 99 |  1 |   3
+ 99 |  1 |  32
+ 99 |  1 |  32
+ 99 |  1 |  32
+ 99 |  1 |  32
+ 99 |  1 |  78
+ 99 |  1 |  78
+ 99 |  1 |  99
+ 99 |  1 |  99
+ 99 |  1 | 288
+ 99 |  1 | 288
+ 99 |  2 |  -1
+ 99 |  2 |   2
+ 99 |  2 |   3
+ 99 |  2 |  32
+ 99 |  2 |  32
+ 99 |  2 |  78
+ 99 |  2 |  99
+ 99 |  2 | 288
+ 99 | 32 |  -1
+ 99 | 32 |   2
+ 99 | 32 |   3
+ 99 | 32 |  32
+ 99 | 32 |  32
+ 99 | 32 |  78
+ 99 | 32 |  99
+ 99 | 32 | 288
+ 99 | 88 |  -1
+ 99 | 88 |   2
+ 99 | 88 |   3
+ 99 | 88 |  32
+ 99 | 88 |  32
+ 99 | 88 |  78
+ 99 | 88 |  99
+ 99 | 88 | 288
+(240 rows)
+
+select A.i, B.i,C.i from A, B, C where (A.i,B.i) in (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
+ i | i | i 
+---+---+---
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+(4 rows)
+
+select * from A,B,C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < C.i and B.i = C.i and C.i not in (select A.i from A where A.j = 1 and A.j = B.j)) order by 1,2,3,4,5,6;
+ i  | j | i  | j | i  | j  
+----+---+----+---+----+----
+  1 | 1 |  2 | 7 |  2 |  7
+  1 | 1 |  2 | 7 |  2 |  7
+  1 | 1 | 32 | 5 | 32 | 62
+  1 | 1 | 32 | 5 | 32 | 62
+  1 | 1 | 32 | 5 | 32 | 65
+  1 | 1 | 32 | 5 | 32 | 65
+ 19 | 5 | 32 | 5 | 32 | 62
+ 19 | 5 | 32 | 5 | 32 | 65
+(8 rows)
+
+select A.i as A_i, B.i as B_i,C.i as C_i from A, B, C where (A.i,B.i) = (select min(A.i), min(B.i) from A,B where A.i = C.i and B.i = C.i) order by A_i, B_i, C_i;
+ a_i | b_i | c_i 
+-----+-----+-----
+   1 |   1 |   1
+   1 |   1 |   1
+   1 |   1 |   1
+   1 |   1 |   1
+(4 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using HAVING clause (Heap) 
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-drop table if exists csq_emp;
-NOTICE:  table "csq_emp" does not exist, skipping
-create table csq_emp(name text, department text, salary numeric);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into csq_emp values('a','adept',11200.00);
-insert into csq_emp values('b','adept',22222.00);
-insert into csq_emp values('c','bdept',99222.00);
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- --
 -- Basic queries with HAVING clause
 -- -- -- -- 
@@ -1440,6 +1412,17 @@ select A.i, B.i, C.j from A, B, C where exists (select C.j from C group by C.j h
  1 | -1 | 62
 (10 rows)
 
+-- start_ignore
+drop table if exists csq_emp;
+NOTICE:  table "csq_emp" does not exist, skipping
+create table csq_emp(name text, department text, salary numeric);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into csq_emp values('a','adept',11200.00);
+insert into csq_emp values('b','adept',22222.00);
+insert into csq_emp values('c','bdept',99222.00);
+analyze csq_emp;
+-- end_ignore
 SELECT name, department, salary FROM csq_emp ea group by name, department,salary
   HAVING avg(salary) >
     (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department);
@@ -1447,11 +1430,10 @@ SELECT name, department, salary FROM csq_emp ea group by name, department,salary
 ------+------------+--------
 (0 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multi-row subqueries (Heap)
 -- ----------------------------------------------------------------------
---start_ignore
+-- start_ignore
 drop table if exists Employee;
 NOTICE:  table "employee" does not exist, skipping
 drop table if exists product;
@@ -1460,7 +1442,6 @@ drop table if exists product_order;
 NOTICE:  table "product_order" does not exist, skipping
 drop table if exists job;
 NOTICE:  table "job" does not exist, skipping
---end_ignore
 -- Multi-row queries (See http://www.java2s.com/Tutorial/Oracle/0040__Query-Select/0680__Multiple-Row-Subquery.htm)
 -- Using IN clause with multi-row subqueries
 create table Employee(
@@ -1489,6 +1470,8 @@ insert into Employee(ID, First_Name, Last_Name, Start_Date, End_Date, Salary, Ci
     values('07','David',    'Larry',   to_date('19901231','YYYYMMDD'), to_date('19980212','YYYYMMDD'), 7897.78,'New York',  'Manager');
 insert into Employee(ID, First_Name, Last_Name, Start_Date, End_Date, Salary, City, Description)
     values('08','James',    'Cat',     to_date('19960917','YYYYMMDD'), to_date('20020415','YYYYMMDD'), 1232.78,'Vancouver', 'Tester');
+analyze Employee;
+-- end_ignore
 select count(*) from Employee;
  count 
 -------
@@ -1505,15 +1488,10 @@ SELECT id, first_name FROM employee WHERE id IN
  08 | James
 (4 rows)
 
-drop table Employee;
 -- Using UPDATE  (Update products that aren't selling)
-CREATE TABLE product (
-         product_name     VARCHAR(25) PRIMARY KEY,
-         product_price    decimal(4,2),
-         quantity_on_hand decimal(5,0),
-         last_stock_date  DATE
-    ) distributed by (product_name);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "product_pkey" for table "product"
+-- start_ignore
+drop table if exists product_order;
+NOTICE:  table "product_order" does not exist, skipping
 CREATE TABLE product_order (
          product_name  VARCHAR(25),
          salesperson   VARCHAR(3),
@@ -1529,12 +1507,24 @@ INSERT INTO product_order VALUES ('Product 4', 'GA', '15-JUL-03', 8);
 INSERT INTO product_order VALUES ('Product 4', 'GA', '15-JUL-03', 8);
 INSERT INTO product_order VALUES ('Product 6', 'CA', '16-JUL-03', 5);
 INSERT INTO product_order VALUES ('Product 7', 'CA', '17-JUL-03', 1);
+analyze product_order;
+drop table if exists product;
+NOTICE:  table "product" does not exist, skipping
+CREATE TABLE product (
+         product_name     VARCHAR(25) PRIMARY KEY,
+         product_price    decimal(4,2),
+         quantity_on_hand decimal(5,0),
+         last_stock_date  DATE
+    ) distributed by (product_name);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "product_pkey" for table "product"
 INSERT INTO product VALUES ('Product 1', 99,  1,    '15-JAN-03');
 INSERT INTO product VALUES ('Product 2', 75,  1000, '15-JAN-02');
 INSERT INTO product VALUES ('Product 3', 50,  100,  '15-JAN-03');
 INSERT INTO product VALUES ('Product 4', 25,  10000, null);
 INSERT INTO product VALUES ('Product 5', 9.95,1234, '15-JAN-04');
 INSERT INTO product VALUES ('Product 6', 45,  1,    TO_DATE('December 31, 2008, 11:30 P.M.','Month dd, YYYY, HH:MI P.M.'));
+analyze product;
+-- end_ignore
 select count(*) from product;
  count 
 -------
@@ -1554,9 +1544,9 @@ SELECT * FROM  product order by product_name;
  Product 6    |         45.00 |                1 | 12-31-2008
 (6 rows)
 
-drop table product;
-drop table product_order;
 -- Show products that aren't selling
+-- start_ignore
+drop table if exists product;
 CREATE TABLE product (
          product_name     VARCHAR(25) PRIMARY KEY,
          product_price    decimal(4,2),
@@ -1564,6 +1554,14 @@ CREATE TABLE product (
          last_stock_date  DATE
     ) distributed by (product_name);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "product_pkey" for table "product"
+INSERT INTO product VALUES ('Product 1', 99,  1,    '15-JAN-03');
+INSERT INTO product VALUES ('Product 2', 75,  1000, '15-JAN-02');
+INSERT INTO product VALUES ('Product 3', 50,  100,  '15-JAN-03');
+INSERT INTO product VALUES ('Product 4', 25,  10000, null);
+INSERT INTO product VALUES ('Product 5', 9.95,1234, '15-JAN-04');
+INSERT INTO product VALUES ('Product 6', 45,  1,    TO_DATE('December 31, 2008, 11:30 P.M.','Month dd, YYYY, HH:MI P.M.'));
+analyze product;
+drop table if exists product_order;
 CREATE TABLE product_order (
          product_name  VARCHAR(25),
          salesperson   VARCHAR(3),
@@ -1576,15 +1574,11 @@ INSERT INTO product_order VALUES ('Product 1', 'CA', '14-JUL-03', 1);
 INSERT INTO product_order VALUES ('Product 2', 'BB', '14-JUL-03', 75);
 INSERT INTO product_order VALUES ('Product 3', 'GA', '14-JUL-03', 2);
 INSERT INTO product_order VALUES ('Product 4', 'GA', '15-JUL-03', 8);
- INSERT INTO product_order VALUES ('Product 5', 'LB', '15-JUL-03', 20);
+INSERT INTO product_order VALUES ('Product 5', 'LB', '15-JUL-03', 20);
 INSERT INTO product_order VALUES ('Product 6', 'CA', '16-JUL-03', 5);
 INSERT INTO product_order VALUES ('Product 7', 'CA', '17-JUL-03', 1);
-INSERT INTO product VALUES ('Product 1', 99,  1,    '15-JAN-03');
-INSERT INTO product VALUES ('Product 2', 75,  1000, '15-JAN-02');
-INSERT INTO product VALUES ('Product 3', 50,  100,  '15-JAN-03');
-INSERT INTO product VALUES ('Product 4', 25,  10000, null);
-INSERT INTO product VALUES ('Product 5', 9.95,1234, '15-JAN-04');
-INSERT INTO product VALUES ('Product 6', 45,  1,    TO_DATE('December 31, 2008, 11:30 P.M.','Month dd, YYYY, HH:MI P.M.'));
+analyze product_order;
+-- end_ignore
 SELECT * FROM product_order ORDER BY product_name;
  product_name | salesperson | order_date | quantity 
 --------------+-------------+------------+----------
@@ -1604,20 +1598,10 @@ SELECT * FROM product
 --------------+---------------+------------------+-----------------
 (0 rows)
 
-drop table product;
-drop table product_order;
 -- Uses NOT IN to check if an id is not in the list of id values in the employee table
-create table Employee(
-      EMPNO         INTEGER,
-      ENAME         VARCHAR(15),
-      HIREDATE      DATE,
-      ORIG_SALARY   INTEGER,
-      CURR_SALARY   INTEGER,
-      REGION        VARCHAR(1),
-      MANAGER_ID    INTEGER
-    );
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'empno' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- start_ignore
+drop table if exists job;
+NOTICE:  table "job" does not exist, skipping
 create table job (
       EMPNO         INTEGER,
       jobtitle      VARCHAR(20)
@@ -1633,6 +1617,19 @@ insert into job (EMPNO, Jobtitle) values (6,'Mediator');
 insert into job (EMPNO, Jobtitle) values (7,'Proffessor');
 insert into job (EMPNO, Jobtitle) values (8,'Programmer');
 insert into job (EMPNO, Jobtitle) values (9,'Developer');
+analyze job;
+drop table if exists Employee;
+create table Employee(
+      EMPNO         INTEGER,
+      ENAME         VARCHAR(15),
+      HIREDATE      DATE,
+      ORIG_SALARY   INTEGER,
+      CURR_SALARY   INTEGER,
+      REGION        VARCHAR(1),
+      MANAGER_ID    INTEGER
+    );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'empno' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into Employee(EMPNO, EName, HIREDATE, ORIG_SALARY, CURR_SALARY, REGION, MANAGER_ID)
     values (1, 'Jason', to_date('19960725','YYYYMMDD'), 1234, 8767, 'E', 2);
 insert into Employee(EMPNO, EName, HIREDATE, ORIG_SALARY, CURR_SALARY, REGION, MANAGER_ID)
@@ -1651,6 +1648,8 @@ insert into Employee(EMPNO, EName, HIREDATE, ORIG_SALARY, CURR_SALARY, REGION)
     values (8, 'Joke', to_date('20020101','YYYYMMDD'), 8765, 4543, 'W');
 insert into Employee(EMPNO, EName, HIREDATE, ORIG_SALARY, CURR_SALARY, REGION)
     values (9, 'Jack',  to_date('20010829','YYYYMMDD'), 7896, 1232, 'E');
+analyze Employee;
+-- end_ignore
 SELECT empno, ename
   FROM employee
   WHERE empno NOT IN (SELECT empno FROM job);
@@ -1658,9 +1657,9 @@ SELECT empno, ename
 -------+-------
 (0 rows)
 
-drop table employee;
-drop table job;
 -- Multiple Column Subqueries
+-- start_ignore
+drop table if exists Employee;
 create table Employee(
       ID                 VARCHAR(4) NOT NULL,
       First_Name         VARCHAR(10),
@@ -1670,9 +1669,7 @@ create table Employee(
       Salary             DECIMAL(8,2),
       City               VARCHAR(10),
       Description        VARCHAR(15)
-   );
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+   ) distributed by (ID);
 insert into Employee(ID,  First_Name, Last_Name, Start_Date, End_Date, Salary,  City, Description)
      values ('01','Jason',    'Martin',  to_date('19960725','YYYYMMDD'), to_date('20060725','YYYYMMDD'), 1234.56, 'Toronto',  'Programmer');
 insert into Employee(ID,  First_Name, Last_Name, Start_Date, End_Date, Salary,  City, Description)
@@ -1689,6 +1686,8 @@ insert into Employee(ID,  First_Name, Last_Name, Start_Date, End_Date, Salary, C
      values('07','David',    'Larry',   to_date('19901231','YYYYMMDD'), to_date('19980212','YYYYMMDD'), 7897.78,'New York',  'Manager');
 insert into Employee(ID,  First_Name, Last_Name, Start_Date, End_Date, Salary, City, Description)
      values('08','James', 'Cat', to_date('19960917','YYYYMMDD'), to_date('20020415','YYYYMMDD'), 1232.78,'Vancouver', 'Tester');
+analyze Employee;
+-- end_ignore
 SELECT id, first_name, salary from employee
     where (id, salary) IN
         (SELECT id, MIN(salary) FROM employee GROUP BY id) order by id;
@@ -1704,205 +1703,6 @@ SELECT id, first_name, salary from employee
  08 | James      | 1232.78
 (8 rows)
 
-drop table Employee;
-RESET ALL;
--- ----------------------------------------------------------------------
--- Test: Correlated Subquery: CSQ in select list (Heap) 
--- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
--- -- -- --
--- Basic queries in SELECT list
--- -- -- --
-select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
- i  | c_j 
-----+-----
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
-(10 rows)
-
-select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x)) as avg_x from qp_csq_t1 order by 1;
- avg_x 
--------
-     4
-     4
-     4
-     4
-(4 rows)
-
-RESET ALL;
--- ----------------------------------------------------------------------
--- Test: Correlated Subquery: CSQ with multiple columns (Heap)
--- ----------------------------------------------------------------------
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(2,1);
-insert into A values(24,98);
-insert into A values(1,98);
-insert into B values(1,1);
-insert into B values(3,6);
-insert into C values(1,18);
-insert into C values(3,27);
-insert into C values(3,98);
-select A.i, B.i from A, B where (A.i,A.j) = (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
- i | i 
----+---
- 1 | 1
- 1 | 3
-(2 rows)
-
-select A.i, B.i from A, B where (A.i,A.j) = all(select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
- i  | i 
-----+---
-  1 | 1
-  1 | 3
-  2 | 1
-  2 | 3
- 24 | 1
- 24 | 3
-(6 rows)
-
-select A.i, B.i from A, B where not exists (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
- i  | i 
-----+---
-  2 | 1
-  2 | 3
- 24 | 1
- 24 | 3
-(4 rows)
-
-select A.i, B.i from A, B where (A.i,A.j) in (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
- i | i 
----+---
- 1 | 1
- 1 | 3
-(2 rows)
-
-select A.i, B.i,C.i from A, B, C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
- i | i | i 
----+---+---
- 1 | 1 | 1
- 1 | 1 | 1
-(2 rows)
-
-select A.i, B.i,C.i from A, B, C where not exists (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
- i  | i | i 
-----+---+---
-  1 | 1 | 3
-  1 | 1 | 3
-  1 | 1 | 3
-  1 | 1 | 3
-  1 | 3 | 3
-  1 | 3 | 3
-  1 | 3 | 3
-  1 | 3 | 3
-  2 | 1 | 3
-  2 | 1 | 3
-  2 | 3 | 3
-  2 | 3 | 3
- 24 | 1 | 3
- 24 | 1 | 3
- 24 | 3 | 3
- 24 | 3 | 3
-(16 rows)
-
-select A.i, B.i,C.i from A, B, C where (A.i,B.i) in (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
- i | i | i 
----+---+---
- 1 | 1 | 1
- 1 | 1 | 1
-(2 rows)
-
--- Not supported select A.i, B.i,C.i from A, B, C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < C.i and B.i = C.i and (A.i,B.i) in (select A.i, B.i from A,B where A.j = C.j)) order by A.i, B.i, C.i;
-select * from A,B,C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < C.i and B.i = C.i and C.i not in (select A.i from A where A.j = 1 and A.j = B.j)) order by 1,2,3,4,5,6;
- i | j  | i | j | i | j  
----+----+---+---+---+----
- 1 |  1 | 3 | 6 | 3 | 27
- 1 |  1 | 3 | 6 | 3 | 98
- 1 | 98 | 3 | 6 | 3 | 27
- 1 | 98 | 3 | 6 | 3 | 98
- 2 |  1 | 3 | 6 | 3 | 27
- 2 |  1 | 3 | 6 | 3 | 98
-(6 rows)
-
-select A.i as A_i, B.i as B_i,C.i as C_i from A, B, C where (A.i,B.i) = (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A_i, B_i, C_i; -- Should fail
-ERROR:  more than one row returned by a subquery used as an expression  (seg2 slice5 vraghavan.local:25434 pid=51919)
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Misc Queries
 -- ----------------------------------------------------------------------
@@ -1913,6 +1713,7 @@ create table with_test1 (i int, t text, value int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
+analyze with_test1;
 drop table if exists with_test2 cascade;
 NOTICE:  table "with_test2" does not exist, skipping
 create table with_test2 (i int, t text, value int);
@@ -1922,6 +1723,7 @@ insert into with_test2 select i%100, 'text' || i%200, i%300 from generate_series
 insert into with_test2
 select i, i || '', total
 from (select i, sum(value) as total from with_test1 group by i) as tmp;
+analyze with_test2;
 -- end_ignore
 select with_test2.* from with_test2
 where value < any (select sum(value) from with_test1 group by i having i = with_test2.i) order by i, t, value;
@@ -1993,142 +1795,6 @@ where value < any (select sum(value) from with_test1 group by i having i = with_
  9 | text9   |   109
 (64 rows)
 
--- start_ignore
-drop table if exists csq_emp;
-    create table csq_emp(name text, department text, salary numeric);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-    insert into csq_emp values('a','adept',11200.00);
-    insert into csq_emp values('b','adept',22222.00);
-    insert into csq_emp values('c','bdept',99222.00);
-    insert into csq_emp values('d','adept',23211.00);
-    insert into csq_emp values('e','adept',45222.00);
-    insert into csq_emp values('f','adept',992222.00);
-    insert into csq_emp values('g','adept',90343.00);
-    insert into csq_emp values('h','adept',11200.00);
-    insert into csq_emp values('i','bdept',11200.00);
-    insert into csq_emp values('j','adept',11200.00);
--- end_ignore
-SELECT name, department, salary FROM csq_emp ea
-  WHERE salary IN
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea
-  WHERE  salary = ANY
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea
-  WHERE salary = 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary > 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department | salary 
-------+------------+--------
-(0 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary < 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary  
-------+------------+----------
- a    | adept      | 11200.00
- b    | adept      | 22222.00
- d    | adept      | 23211.00
- e    | adept      | 45222.00
- g    | adept      | 90343.00
- h    | adept      | 11200.00
- i    | bdept      | 11200.00
- j    | adept      | 11200.00
-(8 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary IN 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary NOT IN 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary  
-------+------------+----------
- a    | adept      | 11200.00
- b    | adept      | 22222.00
- d    | adept      | 23211.00
- e    | adept      | 45222.00
- g    | adept      | 90343.00
- h    | adept      | 11200.00
- i    | bdept      | 11200.00
- j    | adept      | 11200.00
-(8 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE  salary = ANY 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary = ALL 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea group by name, department,salary
-  HAVING avg(salary) >
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department | salary 
-------+------------+--------
-(0 rows)
-
-SELECT name, department, salary FROM csq_emp ea group by name, department,salary
-  HAVING avg(salary) > ALL
-    (SELECT salary FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department | salary 
-------+------------+--------
-(0 rows)
-
--- start_ignore
-drop table if exists with_test1 cascade;
-create table with_test1 (i int, t text, value int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
-drop table if exists with_test2 cascade;
-create table with_test2 (i int, t text, value int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into with_test2 select i%100, 'text' || i%200, i%300 from generate_series(0, 999) i;
-insert into with_test2
-select i, i || '', total
-from (select i, sum(value) as total from with_test1 group by i) as tmp;
--- end_ignore
 select with_test2.* from with_test2
 where value < all (select sum(value) from with_test1 group by i having i = with_test2.i) order by i, t, value;
  i  |    t    | value 
@@ -3099,15 +2765,133 @@ where value < all (select sum(value) from with_test1 group by i having i = with_
  99 | text99  |   299
 (964 rows)
 
-RESET ALL;
---start_ignore
+-- start_ignore
+drop table if exists csq_emp;
+create table csq_emp(name text, department text, salary numeric) distributed by (name);
+insert into csq_emp values('a','adept',11200.00);
+insert into csq_emp values('b','adept',22222.00);
+insert into csq_emp values('c','bdept',99222.00);
+insert into csq_emp values('d','adept',23211.00);
+insert into csq_emp values('e','adept',45222.00);
+insert into csq_emp values('f','adept',992222.00);
+insert into csq_emp values('g','adept',90343.00);
+insert into csq_emp values('h','adept',11200.00);
+insert into csq_emp values('i','bdept',11200.00);
+insert into csq_emp values('j','adept',11200.00);
+analyze csq_emp;
+-- end_ignore
+SELECT name, department, salary FROM csq_emp ea
+  WHERE salary IN
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea
+  WHERE  salary = ANY
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea
+  WHERE salary = 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary > 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department | salary 
+------+------------+--------
+(0 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary < 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary  
+------+------------+----------
+ a    | adept      | 11200.00
+ b    | adept      | 22222.00
+ d    | adept      | 23211.00
+ e    | adept      | 45222.00
+ g    | adept      | 90343.00
+ h    | adept      | 11200.00
+ i    | bdept      | 11200.00
+ j    | adept      | 11200.00
+(8 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary IN 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary NOT IN 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary  
+------+------------+----------
+ a    | adept      | 11200.00
+ b    | adept      | 22222.00
+ d    | adept      | 23211.00
+ e    | adept      | 45222.00
+ g    | adept      | 90343.00
+ h    | adept      | 11200.00
+ i    | bdept      | 11200.00
+ j    | adept      | 11200.00
+(8 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE  salary = ANY 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary = ALL 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea group by name, department,salary
+  HAVING avg(salary) >
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department | salary 
+------+------------+--------
+(0 rows)
+
+SELECT name, department, salary FROM csq_emp ea group by name, department,salary
+  HAVING avg(salary) > ALL
+    (SELECT salary FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department | salary 
+------+------------+--------
+(0 rows)
+
+-- start_ignore
 drop table if exists t1;
 NOTICE:  table "t1" does not exist, skipping
 CREATE OR REPLACE FUNCTION f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL;
-CREATE TABLE t1(a int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t1(a int) distributed by (a);
 INSERT INTO t1 VALUES (1);
+analyze t1;
 -- end_ignore
 SELECT * FROM t1 WHERE a IN (SELECT * FROM f(t1.a));
  a 
@@ -3126,8 +2910,17 @@ SELECT * FROM t1 where a not in (SELECT f FROM f(t1.a));
 ---
 (0 rows)
 
-RESET ALL;
 -- start_ignore
+DROP TABLE IF EXISTS tversion;
+NOTICE:  table "tversion" does not exist, skipping
+DROP TABLE IF EXISTS qp_tjoin1;
+NOTICE:  table "qp_tjoin1" does not exist, skipping
+DROP TABLE IF EXISTS qp_tjoin2;
+NOTICE:  table "qp_tjoin2" does not exist, skipping
+DROP TABLE IF EXISTS qp_tjoin3;
+NOTICE:  table "qp_tjoin3" does not exist, skipping
+DROP TABLE IF EXISTS qp_tjoin4;
+NOTICE:  table "qp_tjoin4" does not exist, skipping
 CREATE TABLE tversion (
     rnum integer NOT NULL,
     c1 integer,
@@ -3160,6 +2953,11 @@ COPY qp_tjoin1 (rnum, c1, c2) FROM stdin;
 COPY qp_tjoin2 (rnum, c1, c2) FROM stdin;
 COPY qp_tjoin3 (rnum, c1, c2) FROM stdin;
 COPY qp_tjoin4 (rnum, c1, c2) FROM stdin;
+analyze tversion;
+analyze qp_tjoin1;
+analyze qp_tjoin2;
+analyze qp_tjoin3;
+analyze qp_tjoin4;
 -- end_ignore
 select qp_tjoin1.rnum, qp_tjoin1.c1, case when 10 in ( select 1 from tversion ) then 'yes' else 'no' end from qp_tjoin1 order by rnum;
  rnum | c1 | case 
@@ -3206,5 +3004,26 @@ select rnum, c1, c2 from qp_tjoin2 where 20 > all ( select c1 from qp_tjoin1) or
 -- ----------------------------------------------------------------------
 -- start_ignore
 drop schema qp_correlated_query cascade;
+NOTICE:  drop cascades to table qp_tjoin4
+NOTICE:  drop cascades to table qp_tjoin3
+NOTICE:  drop cascades to table qp_tjoin2
+NOTICE:  drop cascades to table qp_tjoin1
+NOTICE:  drop cascades to table tversion
+NOTICE:  drop cascades to table t1
+NOTICE:  drop cascades to function f(integer)
+NOTICE:  drop cascades to table csq_emp
+NOTICE:  drop cascades to table with_test2
+NOTICE:  drop cascades to table with_test1
+NOTICE:  drop cascades to table employee
+NOTICE:  drop cascades to table job
+NOTICE:  drop cascades to table product_order
+NOTICE:  drop cascades to table product
+NOTICE:  drop cascades to table d
+NOTICE:  drop cascades to table qp_csq_t4
+NOTICE:  drop cascades to table c
+NOTICE:  drop cascades to table b
+NOTICE:  drop cascades to table a
+NOTICE:  drop cascades to table qp_csq_t3
+NOTICE:  drop cascades to table qp_csq_t2
+NOTICE:  drop cascades to table qp_csq_t1
 -- end_ignore
-RESET ALL;

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -5,52 +5,44 @@
 create schema qp_correlated_query;
 set search_path to qp_correlated_query;
 -- end_ignore
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_in.sql (Correlated Subquery: CSQ using IN clause (Heap))
 -- ----------------------------------------------------------------------
 -- start_ignore
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table qp_csq_t1(a int, b int) distributed by (a);
 insert into qp_csq_t1 values (1,2);
 insert into qp_csq_t1 values (3,4);
 insert into qp_csq_t1 values (5,6);
 insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze qp_csq_t1;
+create table qp_csq_t2(x int,y int) distributed by (x);
 insert into qp_csq_t2 values(1,1);
 insert into qp_csq_t2 values(3,9);
 insert into qp_csq_t2 values(5,25);
 insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze qp_csq_t2;
+create table qp_csq_t3(c int, d text) distributed by (c);
 insert into qp_csq_t3 values(1,'one');
 insert into qp_csq_t3 values(3,'three');
 insert into qp_csq_t3 values(5,'five');
 insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze qp_csq_t3;
+create table A(i integer, j integer) distributed by (i);
 insert into A values(1,1);
 insert into A values(19,5);
 insert into A values(99,62);
 insert into A values(1,1);
 insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze A;
+create table B(i integer, j integer) distributed by (i);
 insert into B values(1,43);
 insert into B values(88,1);
 insert into B values(-1,62);
 insert into B values(1,1);
 insert into B values(32,5);
 insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+analyze B;
+create table C(i integer, j integer) distributed by (i);
 insert into C values(1,889);
 insert into C values(288,1);
 insert into C values(-1,625);
@@ -60,6 +52,7 @@ insert into C values(3,-1);
 insert into C values(99,7);
 insert into C values(78,62);
 insert into C values(2,7);
+analyze C;
 -- end_ignore
 -- -- -- --
 -- Basic queries with IN clause
@@ -80,36 +73,12 @@ select A.i from A where A.i in (select B.i from B where A.i = B.i) order by A.i;
  1
 (2 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 select * from B where exists (select * from C,A where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i != 10)) order by 1, 2;
  i | j  
 ---+----
  1 |  1
  1 | 43
 (2 rows)
-
-select * from B where exists (select * from C,A where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i != 10)) order by 1, 2;
- i | j  
----+----
- 1 |  1
- 1 | 43
-(2 rows)
-
--- Not supported select A.i, B.i, C.j from A, B, C where not exists (select C.j from C where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
-select * from B where not exists (select * from C,A where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i != 10)) order by 1,2;
- i  | j  
-----+----
- -1 | 62
-  2 |  7
- 32 |  5
- 88 |  1
-(4 rows)
-
-select * from A where not exists (select * from C,B where C.j = A.j and B.i in (select C.i from C where C.i = B.i and C.i != 10));
- i  | j 
-----+---
- 19 | 5
-(1 row)
 
 select * from B where not exists (select * from C,A where C.j = A.j and B.i in (select C.i from C where C.i = A.i and C.i != 10)) order by 1,2;
  i  | j  
@@ -209,7 +178,6 @@ select A.i from A where A.i not in (select B.i from B where A.i = B.i) order by 
  99
 (3 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and B.i not in (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 select * from A where exists (select * from B,C where C.j = A.j and B.i not in (select sum(C.i) from C where C.i = B.i and C.i != 10)) order by 1,2;
  i  | j  
 ----+----
@@ -220,56 +188,33 @@ select * from A where exists (select * from B,C where C.j = A.j and B.i not in (
 (4 rows)
 
 select * from A,B where exists (select * from C where C.j = A.j and B.i not in (select C.i from C where C.i != 10)) order by 1,2,3,4;
- i  | j  | i  | j 
-----+----+----+---
-  1 |  1 | 88 | 1
-  1 |  1 | 88 | 1
- 78 | -1 | 88 | 1
- 99 | 62 | 88 | 1
-(4 rows)
-
-select * from A where exists (select * from B,C where C.j = A.j and B.i not in (select sum(C.i) from C where C.i = B.i and C.i != 10)) order by 1,2;
- i  | j  
-----+----
-  1 |  1
-  1 |  1
- 78 | -1
- 99 | 62
-(4 rows)
-
-select * from A,B where exists (select * from C where C.j = A.j and B.i not in (select C.i from C where C.i != 10)) order by 1,2,3,4;
- i  | j  | i  | j 
-----+----+----+---
-  1 |  1 | 88 | 1
-  1 |  1 | 88 | 1
- 78 | -1 | 88 | 1
- 99 | 62 | 88 | 1
-(4 rows)
-
--- Not supported select A.i, B.i, C.j from A, B, C where not exists (select C.j from C where C.j = A.j and B.i not in (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
-select * from B where not exists (select * from A,C where C.j = A.j and B.i in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
- i  | j  
-----+----
- -1 | 62
-  2 |  7
- 32 |  5
- 88 |  1
-(4 rows)
-
-select * from B where not exists (select * from A,C where C.j = A.j and B.i not in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
- i | j 
----+---
-(0 rows)
-
-select * from A where not exists (select * from B,C where C.j = A.j and B.i not in (select max(C.i) from C where C.i = B.i and C.i != 10)) order by 1, 2;
- i  | j  
-----+----
-  1 |  1
-  1 |  1
- 19 |  5
- 78 | -1
- 99 | 62
-(5 rows)
+ i  | j  | i  | j  
+----+----+----+----
+  1 |  1 | -1 | 62
+  1 |  1 | -1 | 62
+  1 |  1 |  1 |  1
+  1 |  1 |  1 |  1
+  1 |  1 |  1 | 43
+  1 |  1 |  1 | 43
+  1 |  1 |  2 |  7
+  1 |  1 |  2 |  7
+  1 |  1 | 32 |  5
+  1 |  1 | 32 |  5
+  1 |  1 | 88 |  1
+  1 |  1 | 88 |  1
+ 78 | -1 | -1 | 62
+ 78 | -1 |  1 |  1
+ 78 | -1 |  1 | 43
+ 78 | -1 |  2 |  7
+ 78 | -1 | 32 |  5
+ 78 | -1 | 88 |  1
+ 99 | 62 | -1 | 62
+ 99 | 62 |  1 |  1
+ 99 | 62 |  1 | 43
+ 99 | 62 |  2 |  7
+ 99 | 62 | 32 |  5
+ 99 | 62 | 88 |  1
+(24 rows)
 
 select * from B where not exists (select * from A,C where C.j = A.j and B.i in (select max(C.i) from C where C.i = A.i and C.i != 10)) order by 1, 2;
  i  | j  
@@ -401,68 +346,9 @@ select A.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i n
  -1
 (10 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_any.sql - Correlated Subquery: CSQ using ANY clause (Heap)
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- --
 -- Basic queries with ANY clause
 -- -- -- --
@@ -534,7 +420,8 @@ select * from A where A.j = any (select C.j from C,B where C.j = A.j and B.i = a
  99 | 62
 (4 rows)
 
-select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = any (select C.i from C where C.i != 10 and C.i = A.i)) order by 1,2,3,4; -- Not supported, should fail
+-- Planner should fail due to skip-level correlation not supported. ORCA should pass
+select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = any (select C.i from C where C.i != 10 and C.i = A.i)) order by 1,2,3,4;
  i | j | i | j  
 ---+---+---+----
  1 | 1 | 1 |  1
@@ -542,21 +429,6 @@ select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = a
  1 | 1 | 1 | 43
  1 | 1 | 1 | 43
 (4 rows)
-
-select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
- i  | i  |  j  
-----+----+-----
- 99 | -1 |  -1
- 99 | -1 |   1
- 99 | -1 |   7
- 99 | -1 |   7
- 99 | -1 |  62
- 99 | -1 |  62
- 99 | -1 |  65
- 99 | -1 | 625
- 99 | -1 | 889
- 99 |  1 |  -1
-(10 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i  | i  |  j  
@@ -593,68 +465,9 @@ select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j =
 ---+---+---
 (0 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using ALL clause (Heap)
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- --
 -- Basic queries with ALL clause
 -- -- -- --
@@ -699,17 +512,12 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
  99 | 62 | 1 | 43
 (8 rows)
 
-select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4; -- Should fail. Skip-level correlations are not supported
- i  | j  | i | j 
-----+----+---+---
-  1 |  1 | 1 | 1
-  1 |  1 | 1 | 1
- 78 | -1 | 1 | 1
- 99 | 62 | 1 | 1
-(4 rows)
+-- Planner should fail due to skip-level correlation not supported. ORCA should pass
+select * from A,B where exists (select * from C where C.j = A.j and B.i = all (select min(C.j) from C where C.j = B.j)) order by 1,2,3,4;
+ i | j | i | j 
+---+---+---+---
+(0 rows)
 
-select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10; -- Should fail (Sub-query returns more than one row)
-ERROR:  more than one row returned by a subquery used as an expression  (seg2 slice3 vraghavan.local:25434 pid=52340)
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
 ---+----+----
@@ -745,68 +553,9 @@ select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j =
  1 | -1 | 62
 (10 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using EXISTS clause (Heap)
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- -- 
 -- Basic queries with EXISTS clause
 -- -- -- --
@@ -836,7 +585,6 @@ with t as (select * from qp_csq_t2) select b from qp_csq_t1 where exists(select 
  2
 (1 row)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and exists (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 20;
 select * from A where exists (select * from C where C.j = A.j) order by 1,2;
  i  | j  
 ----+----
@@ -858,10 +606,14 @@ select * from A where exists (select * from C,B where C.j = A.j and exists (sele
 select * from A,B where exists (select * from C where C.j = A.j and exists (select * from C where C.i = B.i));
  i  | j  | i  | j  
 ----+----+----+----
- 99 | 62 | 32 |  5
- 78 | -1 | 32 |  5
-  1 |  1 | 32 |  5
-  1 |  1 | 32 |  5
+  1 |  1 |  1 | 43
+  1 |  1 | -1 | 62
+  1 |  1 |  1 |  1
+  1 |  1 |  2 |  7
+  1 |  1 |  1 | 43
+  1 |  1 | -1 | 62
+  1 |  1 |  1 |  1
+  1 |  1 |  2 |  7
  99 | 62 |  1 | 43
  99 | 62 | -1 | 62
  99 | 62 |  1 |  1
@@ -870,17 +622,12 @@ select * from A,B where exists (select * from C where C.j = A.j and exists (sele
  78 | -1 | -1 | 62
  78 | -1 |  1 |  1
  78 | -1 |  2 |  7
-  1 |  1 |  1 | 43
-  1 |  1 | -1 | 62
-  1 |  1 |  1 |  1
-  1 |  1 |  2 |  7
-  1 |  1 |  1 | 43
-  1 |  1 | -1 | 62
-  1 |  1 |  1 |  1
-  1 |  1 |  2 |  7
+  1 |  1 | 32 |  5
+  1 |  1 | 32 |  5
+ 99 | 62 | 32 |  5
+ 78 | -1 | 32 |  5
 (20 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and exists (select sum(C.i) from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 20;
 select * from A where exists (select * from B, C where C.j = A.j and exists (select sum(C.i) from C where C.i != 10 and C.i = B.i)) order by 1, 2;
  i  | j  
 ----+----
@@ -890,7 +637,8 @@ select * from A where exists (select * from B, C where C.j = A.j and exists (sel
  99 | 62
 (4 rows)
 
-select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2; -- Should fail, not supported
+-- Planner should fail due to skip-level correlation not supported. ORCA should pass
+select * from A where exists (select * from C where C.j = A.j and exists (select sum(C.i) from C where C.i !=10 and C.i = A.i)) order by 1, 2;
  i  | j  
 ----+----
   1 |  1
@@ -949,13 +697,11 @@ select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.
  1 |  1 |  -1
 (20 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists(select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where A.i = B.i and A.i !=10)) order by A.i, B.i, C.j limit 20;
 select * from A where exists (select * from C where C.j = A.j and not exists (select sum(B.i) from B where B.i = C.i));
  i | j 
 ---+---
 (0 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists(select * from C where C.i = A.i and exists (select C.j where C.j = B.j and A.j < 10)) order by A.i, B.i, C.j limit 20;
 select * from A where exists (select * from C where C.i = A.i and exists (select * from B where C.j = B.j and B.j < 10)) order by 1,2;
  i  | j  
 ----+----
@@ -1001,7 +747,6 @@ select A.i from A where not exists(select B.i from B where A.i = B.i) order by A
  99
 (3 rows)
 
--- Not supported select A.i, B.i, C.j from A, B, C where exists (select C.j from C where C.j = A.j and not exists (select C.i from C where C.i = A.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 select * from A where not exists (select * from C,B where C.j = A.j and exists (select * from C where C.i = B.i and C.j < B.j)) order by 1,2;
  i  | j  
 ----+----
@@ -1078,60 +823,32 @@ select C.j from C where not exists (select rank() over (order by B.i) from B  wh
  62
 (4 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test:  Correlated Subquery: CSQ using DML (Heap) 
 -- ----------------------------------------------------------------------
 -- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-create table qp_csq_t1(a int, b int) distributed by (b);
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table A(i integer, j integer) distributed by (j);
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
+drop table if exists qp_csq_t4;
+NOTICE:  table "qp_csq_t4" does not exist, skipping
+create table qp_csq_t4(a int, b int) distributed by (b);
+insert into qp_csq_t4 values (1,2);
+insert into qp_csq_t4 values (3,4);
+insert into qp_csq_t4 values (5,6);
+insert into qp_csq_t4 values (7,8);
+analyze qp_csq_t4;
+drop table if exists D;
+NOTICE:  table "d" does not exist, skipping
+create table D(i integer, j integer) distributed by (j);
+insert into D values(1,1);
+insert into D values(19,5);
+insert into D values(99,62);
+insert into D values(1,1);
+insert into D values(78,-1);
+analyze D;
 -- end_ignore
 -- -- -- --
 -- Basic CSQ with UPDATE statements
 -- -- -- --
-select * from qp_csq_t1 order by a;
+select * from qp_csq_t4 order by a;
  a | b 
 ---+---
  1 | 2
@@ -1140,8 +857,8 @@ select * from qp_csq_t1 order by a;
  7 | 8
 (4 rows)
 
-update qp_csq_t1 set a = (select y from qp_csq_t2 where x=a) where b < 8;
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = (select y from qp_csq_t2 where x=a) where b < 8;
+select * from qp_csq_t4 order by a;
  a  | b 
 ----+---
   1 | 2
@@ -1150,8 +867,8 @@ select * from qp_csq_t1 order by a;
  25 | 6
 (4 rows)
 
-update qp_csq_t1 set a = 9999 where qp_csq_t1.a = (select max(x) from qp_csq_t2);
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = 9999 where qp_csq_t4.a = (select max(x) from qp_csq_t2);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     1 | 2
@@ -1160,8 +877,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-update qp_csq_t1 set a = (select max(y) from qp_csq_t2 where x=a) where qp_csq_t1.a = (select min(x) from qp_csq_t2);
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = (select max(y) from qp_csq_t2 where x=a) where qp_csq_t4.a = (select min(x) from qp_csq_t2);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     1 | 2
@@ -1170,8 +887,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-update qp_csq_t1 set a = 8888 where (select (y*2)>b from qp_csq_t2 where a=x);
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = 8888 where (select (y*2)>b from qp_csq_t2 where a=x);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     1 | 2
@@ -1180,8 +897,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-update qp_csq_t1 set a = 3333 where qp_csq_t1.a in (select x from qp_csq_t2);
-select * from qp_csq_t1 order by a;
+update qp_csq_t4 set a = 3333 where qp_csq_t4.a in (select x from qp_csq_t2);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1190,32 +907,32 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-update A set i = 11111 from C where C.i = A.i and exists (select C.j from C,B where C.j = B.j and A.j < 10);
-select * from A;
+update D set i = 11111 from C where C.i = D.i and exists (select C.j from C,B where C.j = B.j and D.j < 10);
+select * from D;
    i   | j  
 -------+----
+ 11111 |  1
+ 11111 |  1
+ 11111 | -1
     19 |  5
     99 | 62
- 11111 |  1
- 11111 |  1
- 11111 | -1
 (5 rows)
 
-update A set i = 22222 from C where C.i = A.i and not exists (select C.j from C,B where C.j = B.j and A.j < 10);
-select * from A;
+update D set i = 22222 from C where C.i = D.i and not exists (select C.j from C,B where C.j = B.j and D.j < 10);
+select * from D;
    i   | j  
 -------+----
-    19 |  5
  11111 |  1
  11111 |  1
  11111 | -1
+    19 |  5
  22222 | 62
 (5 rows)
 
 -- -- -- --
 -- Basic CSQ with DELETE statements
 -- -- -- --
-select * from qp_csq_t1 order by a;
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1224,8 +941,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from qp_csq_t1 where a <= (select min(y) from qp_csq_t2 where x=a);
-select * from qp_csq_t1 order by a;
+delete from qp_csq_t4 where a <= (select min(y) from qp_csq_t2 where x=a);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1234,10 +951,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from qp_csq_t1 where qp_csq_t1.a = (select x from qp_csq_t2);
-ERROR:  One or more assertions failed  (seg1 vraghavan.local:25433 pid=52336)
-DETAIL:  Expected no more than one row to be returned by expression
-select * from qp_csq_t1 order by a;
+delete from qp_csq_t4 where qp_csq_t4.a = (select min(x) from qp_csq_t2);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1246,8 +961,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from qp_csq_t1 where exists (select (y*2)>b from qp_csq_t2 where a=x);
-select * from qp_csq_t1 order by a;
+delete from qp_csq_t4 where exists (select (y*2)>b from qp_csq_t2 where a=x);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1256,8 +971,8 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from qp_csq_t1  where qp_csq_t1.a = (select x from qp_csq_t2 where a=x);
-select * from qp_csq_t1 order by a;
+delete from qp_csq_t4  where qp_csq_t4.a = (select x from qp_csq_t2 where a=x);
+select * from qp_csq_t4 order by a;
   a   | b 
 ------+---
     9 | 4
@@ -1266,81 +981,22 @@ select * from qp_csq_t1 order by a;
  9999 | 8
 (4 rows)
 
-delete from  A TableA where exists (select C.j from C, B where C.j = B.j and TableA.j < 10);
-select * from A order by A.i;
+delete from  D TableD where exists (select C.j from C, B where C.j = B.j and TableD.j < 10);
+select * from D order by D.i;
    i   | j  
 -------+----
  22222 | 62
 (1 row)
 
-delete from A TableA where not exists (select C.j from C,B where C.j = B.j and TableA.j < 10);
-select * from A order by A.i;
+delete from D TableD where not exists (select C.j from C,B where C.j = B.j and TableD.j < 10);
+select * from D order by D.i;
  i | j 
 ---+---
 (0 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using WHERE clause (Heap)
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- --
 -- Basic queries with WHERE clause
 -- -- -- --
@@ -1378,76 +1034,407 @@ SELECT a, (SELECT d FROM qp_csq_t3 WHERE a=c) FROM qp_csq_t1 GROUP BY a order by
  7 | seven
 (4 rows)
 
-RESET ALL;
+-- ----------------------------------------------------------------------
+-- Test: Correlated Subquery: CSQ in select list (Heap) 
+-- ----------------------------------------------------------------------
+-- -- -- --
+-- Basic queries in SELECT list
+-- -- -- --
+select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
+ i  | c_j 
+----+-----
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+ 99 |   1
+(10 rows)
+
+select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x)) as avg_x from qp_csq_t1 order by 1;
+ avg_x 
+-------
+     4
+     4
+     4
+     4
+(4 rows)
+
+-- ----------------------------------------------------------------------
+-- Test: Correlated Subquery: CSQ with multiple columns (Heap)
+-- ----------------------------------------------------------------------
+select A.i, B.i from A, B where (A.i,A.j) = (select min(B.i),min(B.j) from B where B.i = A.i) order by A.i, B.i;
+ i | i  
+---+----
+ 1 | -1
+ 1 | -1
+ 1 |  1
+ 1 |  1
+ 1 |  1
+ 1 |  1
+ 1 |  2
+ 1 |  2
+ 1 | 32
+ 1 | 32
+ 1 | 88
+ 1 | 88
+(12 rows)
+
+select A.i, B.i from A, B where (A.i,A.j) = all(select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
+ i  | i  
+----+----
+ 19 | -1
+ 19 |  1
+ 19 |  1
+ 19 |  2
+ 19 | 32
+ 19 | 88
+ 78 | -1
+ 78 |  1
+ 78 |  1
+ 78 |  2
+ 78 | 32
+ 78 | 88
+ 99 | -1
+ 99 |  1
+ 99 |  1
+ 99 |  2
+ 99 | 32
+ 99 | 88
+(18 rows)
+
+select A.i, B.i from A, B where not exists (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
+ i  | i  
+----+----
+ 19 | -1
+ 19 |  1
+ 19 |  1
+ 19 |  2
+ 19 | 32
+ 19 | 88
+ 78 | -1
+ 78 |  1
+ 78 |  1
+ 78 |  2
+ 78 | 32
+ 78 | 88
+ 99 | -1
+ 99 |  1
+ 99 |  1
+ 99 |  2
+ 99 | 32
+ 99 | 88
+(18 rows)
+
+select A.i, B.i from A, B where (A.i,A.j) in (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
+ i | i  
+---+----
+ 1 | -1
+ 1 | -1
+ 1 |  1
+ 1 |  1
+ 1 |  1
+ 1 |  1
+ 1 |  2
+ 1 |  2
+ 1 | 32
+ 1 | 32
+ 1 | 88
+ 1 | 88
+(12 rows)
+
+select A.i, B.i,C.i from A, B, C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
+ i | i | i 
+---+---+---
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+(4 rows)
+
+select A.i, B.i,C.i from A, B, C where not exists (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
+ i  | i  |  i  
+----+----+-----
+  1 | -1 |  -1
+  1 | -1 |  -1
+  1 | -1 |   2
+  1 | -1 |   2
+  1 | -1 |   3
+  1 | -1 |   3
+  1 | -1 |  32
+  1 | -1 |  32
+  1 | -1 |  32
+  1 | -1 |  32
+  1 | -1 |  78
+  1 | -1 |  78
+  1 | -1 |  99
+  1 | -1 |  99
+  1 | -1 | 288
+  1 | -1 | 288
+  1 |  1 |  -1
+  1 |  1 |  -1
+  1 |  1 |  -1
+  1 |  1 |  -1
+  1 |  1 |   2
+  1 |  1 |   2
+  1 |  1 |   2
+  1 |  1 |   2
+  1 |  1 |   3
+  1 |  1 |   3
+  1 |  1 |   3
+  1 |  1 |   3
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  32
+  1 |  1 |  78
+  1 |  1 |  78
+  1 |  1 |  78
+  1 |  1 |  78
+  1 |  1 |  99
+  1 |  1 |  99
+  1 |  1 |  99
+  1 |  1 |  99
+  1 |  1 | 288
+  1 |  1 | 288
+  1 |  1 | 288
+  1 |  1 | 288
+  1 |  2 |  -1
+  1 |  2 |  -1
+  1 |  2 |   2
+  1 |  2 |   2
+  1 |  2 |   3
+  1 |  2 |   3
+  1 |  2 |  32
+  1 |  2 |  32
+  1 |  2 |  32
+  1 |  2 |  32
+  1 |  2 |  78
+  1 |  2 |  78
+  1 |  2 |  99
+  1 |  2 |  99
+  1 |  2 | 288
+  1 |  2 | 288
+  1 | 32 |  -1
+  1 | 32 |  -1
+  1 | 32 |   2
+  1 | 32 |   2
+  1 | 32 |   3
+  1 | 32 |   3
+  1 | 32 |  32
+  1 | 32 |  32
+  1 | 32 |  32
+  1 | 32 |  32
+  1 | 32 |  78
+  1 | 32 |  78
+  1 | 32 |  99
+  1 | 32 |  99
+  1 | 32 | 288
+  1 | 32 | 288
+  1 | 88 |  -1
+  1 | 88 |  -1
+  1 | 88 |   2
+  1 | 88 |   2
+  1 | 88 |   3
+  1 | 88 |   3
+  1 | 88 |  32
+  1 | 88 |  32
+  1 | 88 |  32
+  1 | 88 |  32
+  1 | 88 |  78
+  1 | 88 |  78
+  1 | 88 |  99
+  1 | 88 |  99
+  1 | 88 | 288
+  1 | 88 | 288
+ 19 | -1 |  -1
+ 19 | -1 |   2
+ 19 | -1 |   3
+ 19 | -1 |  32
+ 19 | -1 |  32
+ 19 | -1 |  78
+ 19 | -1 |  99
+ 19 | -1 | 288
+ 19 |  1 |  -1
+ 19 |  1 |  -1
+ 19 |  1 |   2
+ 19 |  1 |   2
+ 19 |  1 |   3
+ 19 |  1 |   3
+ 19 |  1 |  32
+ 19 |  1 |  32
+ 19 |  1 |  32
+ 19 |  1 |  32
+ 19 |  1 |  78
+ 19 |  1 |  78
+ 19 |  1 |  99
+ 19 |  1 |  99
+ 19 |  1 | 288
+ 19 |  1 | 288
+ 19 |  2 |  -1
+ 19 |  2 |   2
+ 19 |  2 |   3
+ 19 |  2 |  32
+ 19 |  2 |  32
+ 19 |  2 |  78
+ 19 |  2 |  99
+ 19 |  2 | 288
+ 19 | 32 |  -1
+ 19 | 32 |   2
+ 19 | 32 |   3
+ 19 | 32 |  32
+ 19 | 32 |  32
+ 19 | 32 |  78
+ 19 | 32 |  99
+ 19 | 32 | 288
+ 19 | 88 |  -1
+ 19 | 88 |   2
+ 19 | 88 |   3
+ 19 | 88 |  32
+ 19 | 88 |  32
+ 19 | 88 |  78
+ 19 | 88 |  99
+ 19 | 88 | 288
+ 78 | -1 |  -1
+ 78 | -1 |   2
+ 78 | -1 |   3
+ 78 | -1 |  32
+ 78 | -1 |  32
+ 78 | -1 |  78
+ 78 | -1 |  99
+ 78 | -1 | 288
+ 78 |  1 |  -1
+ 78 |  1 |  -1
+ 78 |  1 |   2
+ 78 |  1 |   2
+ 78 |  1 |   3
+ 78 |  1 |   3
+ 78 |  1 |  32
+ 78 |  1 |  32
+ 78 |  1 |  32
+ 78 |  1 |  32
+ 78 |  1 |  78
+ 78 |  1 |  78
+ 78 |  1 |  99
+ 78 |  1 |  99
+ 78 |  1 | 288
+ 78 |  1 | 288
+ 78 |  2 |  -1
+ 78 |  2 |   2
+ 78 |  2 |   3
+ 78 |  2 |  32
+ 78 |  2 |  32
+ 78 |  2 |  78
+ 78 |  2 |  99
+ 78 |  2 | 288
+ 78 | 32 |  -1
+ 78 | 32 |   2
+ 78 | 32 |   3
+ 78 | 32 |  32
+ 78 | 32 |  32
+ 78 | 32 |  78
+ 78 | 32 |  99
+ 78 | 32 | 288
+ 78 | 88 |  -1
+ 78 | 88 |   2
+ 78 | 88 |   3
+ 78 | 88 |  32
+ 78 | 88 |  32
+ 78 | 88 |  78
+ 78 | 88 |  99
+ 78 | 88 | 288
+ 99 | -1 |  -1
+ 99 | -1 |   2
+ 99 | -1 |   3
+ 99 | -1 |  32
+ 99 | -1 |  32
+ 99 | -1 |  78
+ 99 | -1 |  99
+ 99 | -1 | 288
+ 99 |  1 |  -1
+ 99 |  1 |  -1
+ 99 |  1 |   2
+ 99 |  1 |   2
+ 99 |  1 |   3
+ 99 |  1 |   3
+ 99 |  1 |  32
+ 99 |  1 |  32
+ 99 |  1 |  32
+ 99 |  1 |  32
+ 99 |  1 |  78
+ 99 |  1 |  78
+ 99 |  1 |  99
+ 99 |  1 |  99
+ 99 |  1 | 288
+ 99 |  1 | 288
+ 99 |  2 |  -1
+ 99 |  2 |   2
+ 99 |  2 |   3
+ 99 |  2 |  32
+ 99 |  2 |  32
+ 99 |  2 |  78
+ 99 |  2 |  99
+ 99 |  2 | 288
+ 99 | 32 |  -1
+ 99 | 32 |   2
+ 99 | 32 |   3
+ 99 | 32 |  32
+ 99 | 32 |  32
+ 99 | 32 |  78
+ 99 | 32 |  99
+ 99 | 32 | 288
+ 99 | 88 |  -1
+ 99 | 88 |   2
+ 99 | 88 |   3
+ 99 | 88 |  32
+ 99 | 88 |  32
+ 99 | 88 |  78
+ 99 | 88 |  99
+ 99 | 88 | 288
+(240 rows)
+
+select A.i, B.i,C.i from A, B, C where (A.i,B.i) in (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
+ i | i | i 
+---+---+---
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+(4 rows)
+
+select * from A,B,C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < C.i and B.i = C.i and C.i not in (select A.i from A where A.j = 1 and A.j = B.j)) order by 1,2,3,4,5,6;
+ i  | j | i  | j | i  | j  
+----+---+----+---+----+----
+  1 | 1 |  2 | 7 |  2 |  7
+  1 | 1 |  2 | 7 |  2 |  7
+  1 | 1 | 32 | 5 | 32 | 62
+  1 | 1 | 32 | 5 | 32 | 62
+  1 | 1 | 32 | 5 | 32 | 65
+  1 | 1 | 32 | 5 | 32 | 65
+ 19 | 5 | 32 | 5 | 32 | 62
+ 19 | 5 | 32 | 5 | 32 | 65
+(8 rows)
+
+select A.i as A_i, B.i as B_i,C.i as C_i from A, B, C where (A.i,B.i) = (select min(A.i), min(B.i) from A,B where A.i = C.i and B.i = C.i) order by A_i, B_i, C_i;
+ a_i | b_i | c_i 
+-----+-----+-----
+   1 |   1 |   1
+   1 |   1 |   1
+   1 |   1 |   1
+   1 |   1 |   1
+(4 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using HAVING clause (Heap) 
 -- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-drop table if exists csq_emp;
-NOTICE:  table "csq_emp" does not exist, skipping
-create table csq_emp(name text, department text, salary numeric);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into csq_emp values('a','adept',11200.00);
-insert into csq_emp values('b','adept',22222.00);
-insert into csq_emp values('c','bdept',99222.00);
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
 -- -- -- --
 -- Basic queries with HAVING clause
 -- -- -- -- 
@@ -1489,6 +1476,17 @@ select A.i, B.i, C.j from A, B, C where exists (select C.j from C group by C.j h
  1 | -1 | 62
 (10 rows)
 
+-- start_ignore
+drop table if exists csq_emp;
+NOTICE:  table "csq_emp" does not exist, skipping
+create table csq_emp(name text, department text, salary numeric);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into csq_emp values('a','adept',11200.00);
+insert into csq_emp values('b','adept',22222.00);
+insert into csq_emp values('c','bdept',99222.00);
+analyze csq_emp;
+-- end_ignore
 SELECT name, department, salary FROM csq_emp ea group by name, department,salary
   HAVING avg(salary) >
     (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department);
@@ -1496,11 +1494,10 @@ SELECT name, department, salary FROM csq_emp ea group by name, department,salary
 ------+------------+--------
 (0 rows)
 
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multi-row subqueries (Heap)
 -- ----------------------------------------------------------------------
---start_ignore
+-- start_ignore
 drop table if exists Employee;
 NOTICE:  table "employee" does not exist, skipping
 drop table if exists product;
@@ -1509,7 +1506,6 @@ drop table if exists product_order;
 NOTICE:  table "product_order" does not exist, skipping
 drop table if exists job;
 NOTICE:  table "job" does not exist, skipping
---end_ignore
 -- Multi-row queries (See http://www.java2s.com/Tutorial/Oracle/0040__Query-Select/0680__Multiple-Row-Subquery.htm)
 -- Using IN clause with multi-row subqueries
 create table Employee(
@@ -1538,6 +1534,8 @@ insert into Employee(ID, First_Name, Last_Name, Start_Date, End_Date, Salary, Ci
     values('07','David',    'Larry',   to_date('19901231','YYYYMMDD'), to_date('19980212','YYYYMMDD'), 7897.78,'New York',  'Manager');
 insert into Employee(ID, First_Name, Last_Name, Start_Date, End_Date, Salary, City, Description)
     values('08','James',    'Cat',     to_date('19960917','YYYYMMDD'), to_date('20020415','YYYYMMDD'), 1232.78,'Vancouver', 'Tester');
+analyze Employee;
+-- end_ignore
 select count(*) from Employee;
  count 
 -------
@@ -1554,15 +1552,10 @@ SELECT id, first_name FROM employee WHERE id IN
  08 | James
 (4 rows)
 
-drop table Employee;
 -- Using UPDATE  (Update products that aren't selling)
-CREATE TABLE product (
-         product_name     VARCHAR(25) PRIMARY KEY,
-         product_price    decimal(4,2),
-         quantity_on_hand decimal(5,0),
-         last_stock_date  DATE
-    ) distributed by (product_name);
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "product_pkey" for table "product"
+-- start_ignore
+drop table if exists product_order;
+NOTICE:  table "product_order" does not exist, skipping
 CREATE TABLE product_order (
          product_name  VARCHAR(25),
          salesperson   VARCHAR(3),
@@ -1578,12 +1571,24 @@ INSERT INTO product_order VALUES ('Product 4', 'GA', '15-JUL-03', 8);
 INSERT INTO product_order VALUES ('Product 4', 'GA', '15-JUL-03', 8);
 INSERT INTO product_order VALUES ('Product 6', 'CA', '16-JUL-03', 5);
 INSERT INTO product_order VALUES ('Product 7', 'CA', '17-JUL-03', 1);
+analyze product_order;
+drop table if exists product;
+NOTICE:  table "product" does not exist, skipping
+CREATE TABLE product (
+         product_name     VARCHAR(25) PRIMARY KEY,
+         product_price    decimal(4,2),
+         quantity_on_hand decimal(5,0),
+         last_stock_date  DATE
+    ) distributed by (product_name);
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "product_pkey" for table "product"
 INSERT INTO product VALUES ('Product 1', 99,  1,    '15-JAN-03');
 INSERT INTO product VALUES ('Product 2', 75,  1000, '15-JAN-02');
 INSERT INTO product VALUES ('Product 3', 50,  100,  '15-JAN-03');
 INSERT INTO product VALUES ('Product 4', 25,  10000, null);
 INSERT INTO product VALUES ('Product 5', 9.95,1234, '15-JAN-04');
 INSERT INTO product VALUES ('Product 6', 45,  1,    TO_DATE('December 31, 2008, 11:30 P.M.','Month dd, YYYY, HH:MI P.M.'));
+analyze product;
+-- end_ignore
 select count(*) from product;
  count 
 -------
@@ -1603,9 +1608,9 @@ SELECT * FROM  product order by product_name;
  Product 6    |         45.00 |                1 | 12-31-2008
 (6 rows)
 
-drop table product;
-drop table product_order;
 -- Show products that aren't selling
+-- start_ignore
+drop table if exists product;
 CREATE TABLE product (
          product_name     VARCHAR(25) PRIMARY KEY,
          product_price    decimal(4,2),
@@ -1613,6 +1618,14 @@ CREATE TABLE product (
          last_stock_date  DATE
     ) distributed by (product_name);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "product_pkey" for table "product"
+INSERT INTO product VALUES ('Product 1', 99,  1,    '15-JAN-03');
+INSERT INTO product VALUES ('Product 2', 75,  1000, '15-JAN-02');
+INSERT INTO product VALUES ('Product 3', 50,  100,  '15-JAN-03');
+INSERT INTO product VALUES ('Product 4', 25,  10000, null);
+INSERT INTO product VALUES ('Product 5', 9.95,1234, '15-JAN-04');
+INSERT INTO product VALUES ('Product 6', 45,  1,    TO_DATE('December 31, 2008, 11:30 P.M.','Month dd, YYYY, HH:MI P.M.'));
+analyze product;
+drop table if exists product_order;
 CREATE TABLE product_order (
          product_name  VARCHAR(25),
          salesperson   VARCHAR(3),
@@ -1625,15 +1638,11 @@ INSERT INTO product_order VALUES ('Product 1', 'CA', '14-JUL-03', 1);
 INSERT INTO product_order VALUES ('Product 2', 'BB', '14-JUL-03', 75);
 INSERT INTO product_order VALUES ('Product 3', 'GA', '14-JUL-03', 2);
 INSERT INTO product_order VALUES ('Product 4', 'GA', '15-JUL-03', 8);
- INSERT INTO product_order VALUES ('Product 5', 'LB', '15-JUL-03', 20);
+INSERT INTO product_order VALUES ('Product 5', 'LB', '15-JUL-03', 20);
 INSERT INTO product_order VALUES ('Product 6', 'CA', '16-JUL-03', 5);
 INSERT INTO product_order VALUES ('Product 7', 'CA', '17-JUL-03', 1);
-INSERT INTO product VALUES ('Product 1', 99,  1,    '15-JAN-03');
-INSERT INTO product VALUES ('Product 2', 75,  1000, '15-JAN-02');
-INSERT INTO product VALUES ('Product 3', 50,  100,  '15-JAN-03');
-INSERT INTO product VALUES ('Product 4', 25,  10000, null);
-INSERT INTO product VALUES ('Product 5', 9.95,1234, '15-JAN-04');
-INSERT INTO product VALUES ('Product 6', 45,  1,    TO_DATE('December 31, 2008, 11:30 P.M.','Month dd, YYYY, HH:MI P.M.'));
+analyze product_order;
+-- end_ignore
 SELECT * FROM product_order ORDER BY product_name;
  product_name | salesperson | order_date | quantity 
 --------------+-------------+------------+----------
@@ -1653,20 +1662,10 @@ SELECT * FROM product
 --------------+---------------+------------------+-----------------
 (0 rows)
 
-drop table product;
-drop table product_order;
 -- Uses NOT IN to check if an id is not in the list of id values in the employee table
-create table Employee(
-      EMPNO         INTEGER,
-      ENAME         VARCHAR(15),
-      HIREDATE      DATE,
-      ORIG_SALARY   INTEGER,
-      CURR_SALARY   INTEGER,
-      REGION        VARCHAR(1),
-      MANAGER_ID    INTEGER
-    );
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'empno' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- start_ignore
+drop table if exists job;
+NOTICE:  table "job" does not exist, skipping
 create table job (
       EMPNO         INTEGER,
       jobtitle      VARCHAR(20)
@@ -1682,6 +1681,19 @@ insert into job (EMPNO, Jobtitle) values (6,'Mediator');
 insert into job (EMPNO, Jobtitle) values (7,'Proffessor');
 insert into job (EMPNO, Jobtitle) values (8,'Programmer');
 insert into job (EMPNO, Jobtitle) values (9,'Developer');
+analyze job;
+drop table if exists Employee;
+create table Employee(
+      EMPNO         INTEGER,
+      ENAME         VARCHAR(15),
+      HIREDATE      DATE,
+      ORIG_SALARY   INTEGER,
+      CURR_SALARY   INTEGER,
+      REGION        VARCHAR(1),
+      MANAGER_ID    INTEGER
+    );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'empno' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into Employee(EMPNO, EName, HIREDATE, ORIG_SALARY, CURR_SALARY, REGION, MANAGER_ID)
     values (1, 'Jason', to_date('19960725','YYYYMMDD'), 1234, 8767, 'E', 2);
 insert into Employee(EMPNO, EName, HIREDATE, ORIG_SALARY, CURR_SALARY, REGION, MANAGER_ID)
@@ -1700,6 +1712,8 @@ insert into Employee(EMPNO, EName, HIREDATE, ORIG_SALARY, CURR_SALARY, REGION)
     values (8, 'Joke', to_date('20020101','YYYYMMDD'), 8765, 4543, 'W');
 insert into Employee(EMPNO, EName, HIREDATE, ORIG_SALARY, CURR_SALARY, REGION)
     values (9, 'Jack',  to_date('20010829','YYYYMMDD'), 7896, 1232, 'E');
+analyze Employee;
+-- end_ignore
 SELECT empno, ename
   FROM employee
   WHERE empno NOT IN (SELECT empno FROM job);
@@ -1707,9 +1721,9 @@ SELECT empno, ename
 -------+-------
 (0 rows)
 
-drop table employee;
-drop table job;
 -- Multiple Column Subqueries
+-- start_ignore
+drop table if exists Employee;
 create table Employee(
       ID                 VARCHAR(4) NOT NULL,
       First_Name         VARCHAR(10),
@@ -1719,9 +1733,7 @@ create table Employee(
       Salary             DECIMAL(8,2),
       City               VARCHAR(10),
       Description        VARCHAR(15)
-   );
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+   ) distributed by (ID);
 insert into Employee(ID,  First_Name, Last_Name, Start_Date, End_Date, Salary,  City, Description)
      values ('01','Jason',    'Martin',  to_date('19960725','YYYYMMDD'), to_date('20060725','YYYYMMDD'), 1234.56, 'Toronto',  'Programmer');
 insert into Employee(ID,  First_Name, Last_Name, Start_Date, End_Date, Salary,  City, Description)
@@ -1738,6 +1750,8 @@ insert into Employee(ID,  First_Name, Last_Name, Start_Date, End_Date, Salary, C
      values('07','David',    'Larry',   to_date('19901231','YYYYMMDD'), to_date('19980212','YYYYMMDD'), 7897.78,'New York',  'Manager');
 insert into Employee(ID,  First_Name, Last_Name, Start_Date, End_Date, Salary, City, Description)
      values('08','James', 'Cat', to_date('19960917','YYYYMMDD'), to_date('20020415','YYYYMMDD'), 1232.78,'Vancouver', 'Tester');
+analyze Employee;
+-- end_ignore
 SELECT id, first_name, salary from employee
     where (id, salary) IN
         (SELECT id, MIN(salary) FROM employee GROUP BY id) order by id;
@@ -1753,205 +1767,6 @@ SELECT id, first_name, salary from employee
  08 | James      | 1232.78
 (8 rows)
 
-drop table Employee;
-RESET ALL;
--- ----------------------------------------------------------------------
--- Test: Correlated Subquery: CSQ in select list (Heap) 
--- ----------------------------------------------------------------------
--- start_ignore
-drop table if exists qp_csq_t1;
-drop table if exists qp_csq_t2;
-drop table if exists qp_csq_t3;
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table qp_csq_t1(a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t1 values (1,2);
-insert into qp_csq_t1 values (3,4);
-insert into qp_csq_t1 values (5,6);
-insert into qp_csq_t1 values (7,8);
-create table qp_csq_t2(x int,y int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t2 values(1,1);
-insert into qp_csq_t2 values(3,9);
-insert into qp_csq_t2 values(5,25);
-insert into qp_csq_t2 values(7,49);
-create table qp_csq_t3(c int, d text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into qp_csq_t3 values(1,'one');
-insert into qp_csq_t3 values(3,'three');
-insert into qp_csq_t3 values(5,'five');
-insert into qp_csq_t3 values(7,'seven');
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(19,5);
-insert into A values(99,62);
-insert into A values(1,1);
-insert into A values(78,-1);
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into B values(1,43);
-insert into B values(88,1);
-insert into B values(-1,62);
-insert into B values(1,1);
-insert into B values(32,5);
-insert into B values(2,7);
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into C values(1,889);
-insert into C values(288,1);
-insert into C values(-1,625);
-insert into C values(32,65);
-insert into C values(32,62);
-insert into C values(3,-1);
-insert into C values(99,7);
-insert into C values(78,62);
-insert into C values(2,7);
--- end_ignore
--- -- -- --
--- Basic queries in SELECT list
--- -- -- --
-select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
- i  | c_j 
-----+-----
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
- 99 |   1
-(10 rows)
-
-select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x)) as avg_x from qp_csq_t1 order by 1;
- avg_x 
--------
-     4
-     4
-     4
-     4
-(4 rows)
-
-RESET ALL;
--- ----------------------------------------------------------------------
--- Test: Correlated Subquery: CSQ with multiple columns (Heap)
--- ----------------------------------------------------------------------
-drop table if exists A;
-drop table if exists B;
-drop table if exists C;
-create table A(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table B(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table C(i integer, j integer);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into A values(1,1);
-insert into A values(2,1);
-insert into A values(24,98);
-insert into A values(1,98);
-insert into B values(1,1);
-insert into B values(3,6);
-insert into C values(1,18);
-insert into C values(3,27);
-insert into C values(3,98);
-select A.i, B.i from A, B where (A.i,A.j) = (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
- i | i 
----+---
- 1 | 1
- 1 | 3
-(2 rows)
-
-select A.i, B.i from A, B where (A.i,A.j) = all(select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
- i  | i 
-----+---
-  1 | 1
-  1 | 3
-  2 | 1
-  2 | 3
- 24 | 1
- 24 | 3
-(6 rows)
-
-select A.i, B.i from A, B where not exists (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
- i  | i 
-----+---
-  2 | 1
-  2 | 3
- 24 | 1
- 24 | 3
-(4 rows)
-
-select A.i, B.i from A, B where (A.i,A.j) in (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
- i | i 
----+---
- 1 | 1
- 1 | 3
-(2 rows)
-
-select A.i, B.i,C.i from A, B, C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
- i | i | i 
----+---+---
- 1 | 1 | 1
- 1 | 1 | 1
-(2 rows)
-
-select A.i, B.i,C.i from A, B, C where not exists (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
- i  | i | i 
-----+---+---
-  1 | 1 | 3
-  1 | 1 | 3
-  1 | 1 | 3
-  1 | 1 | 3
-  1 | 3 | 3
-  1 | 3 | 3
-  1 | 3 | 3
-  1 | 3 | 3
-  2 | 1 | 3
-  2 | 1 | 3
-  2 | 3 | 3
-  2 | 3 | 3
- 24 | 1 | 3
- 24 | 1 | 3
- 24 | 3 | 3
- 24 | 3 | 3
-(16 rows)
-
-select A.i, B.i,C.i from A, B, C where (A.i,B.i) in (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
- i | i | i 
----+---+---
- 1 | 1 | 1
- 1 | 1 | 1
-(2 rows)
-
--- Not supported select A.i, B.i,C.i from A, B, C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < C.i and B.i = C.i and (A.i,B.i) in (select A.i, B.i from A,B where A.j = C.j)) order by A.i, B.i, C.i;
-select * from A,B,C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < C.i and B.i = C.i and C.i not in (select A.i from A where A.j = 1 and A.j = B.j)) order by 1,2,3,4,5,6;
- i | j  | i | j | i | j  
----+----+---+---+---+----
- 1 |  1 | 3 | 6 | 3 | 27
- 1 |  1 | 3 | 6 | 3 | 98
- 1 | 98 | 3 | 6 | 3 | 27
- 1 | 98 | 3 | 6 | 3 | 98
- 2 |  1 | 3 | 6 | 3 | 27
- 2 |  1 | 3 | 6 | 3 | 98
-(6 rows)
-
-select A.i as A_i, B.i as B_i,C.i as C_i from A, B, C where (A.i,B.i) = (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A_i, B_i, C_i; -- Should fail
-ERROR:  more than one row returned by a subquery used as an expression  (seg2 slice5 vraghavan.local:25434 pid=52337)
-RESET ALL;
 -- ----------------------------------------------------------------------
 -- Test: Misc Queries
 -- ----------------------------------------------------------------------
@@ -1962,6 +1777,7 @@ create table with_test1 (i int, t text, value int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
+analyze with_test1;
 drop table if exists with_test2 cascade;
 NOTICE:  table "with_test2" does not exist, skipping
 create table with_test2 (i int, t text, value int);
@@ -1971,6 +1787,7 @@ insert into with_test2 select i%100, 'text' || i%200, i%300 from generate_series
 insert into with_test2
 select i, i || '', total
 from (select i, sum(value) as total from with_test1 group by i) as tmp;
+analyze with_test2;
 -- end_ignore
 select with_test2.* from with_test2
 where value < any (select sum(value) from with_test1 group by i having i = with_test2.i) order by i, t, value;
@@ -2042,142 +1859,6 @@ where value < any (select sum(value) from with_test1 group by i having i = with_
  9 | text9   |   109
 (64 rows)
 
--- start_ignore
-drop table if exists csq_emp;
-    create table csq_emp(name text, department text, salary numeric);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-    insert into csq_emp values('a','adept',11200.00);
-    insert into csq_emp values('b','adept',22222.00);
-    insert into csq_emp values('c','bdept',99222.00);
-    insert into csq_emp values('d','adept',23211.00);
-    insert into csq_emp values('e','adept',45222.00);
-    insert into csq_emp values('f','adept',992222.00);
-    insert into csq_emp values('g','adept',90343.00);
-    insert into csq_emp values('h','adept',11200.00);
-    insert into csq_emp values('i','bdept',11200.00);
-    insert into csq_emp values('j','adept',11200.00);
--- end_ignore
-SELECT name, department, salary FROM csq_emp ea
-  WHERE salary IN
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea
-  WHERE  salary = ANY
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea
-  WHERE salary = 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary > 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department | salary 
-------+------------+--------
-(0 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary < 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary  
-------+------------+----------
- a    | adept      | 11200.00
- b    | adept      | 22222.00
- d    | adept      | 23211.00
- e    | adept      | 45222.00
- g    | adept      | 90343.00
- h    | adept      | 11200.00
- i    | bdept      | 11200.00
- j    | adept      | 11200.00
-(8 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary IN 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary NOT IN 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary  
-------+------------+----------
- a    | adept      | 11200.00
- b    | adept      | 22222.00
- d    | adept      | 23211.00
- e    | adept      | 45222.00
- g    | adept      | 90343.00
- h    | adept      | 11200.00
- i    | bdept      | 11200.00
- j    | adept      | 11200.00
-(8 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE  salary = ANY 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea 
-  WHERE salary = ALL 
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department |  salary   
-------+------------+-----------
- c    | bdept      |  99222.00
- f    | adept      | 992222.00
-(2 rows)
-
-SELECT name, department, salary FROM csq_emp ea group by name, department,salary
-  HAVING avg(salary) >
-    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department | salary 
-------+------------+--------
-(0 rows)
-
-SELECT name, department, salary FROM csq_emp ea group by name, department,salary
-  HAVING avg(salary) > ALL
-    (SELECT salary FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
- name | department | salary 
-------+------------+--------
-(0 rows)
-
--- start_ignore
-drop table if exists with_test1 cascade;
-create table with_test1 (i int, t text, value int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
-drop table if exists with_test2 cascade;
-create table with_test2 (i int, t text, value int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into with_test2 select i%100, 'text' || i%200, i%300 from generate_series(0, 999) i;
-insert into with_test2
-select i, i || '', total
-from (select i, sum(value) as total from with_test1 group by i) as tmp;
--- end_ignore
 select with_test2.* from with_test2
 where value < all (select sum(value) from with_test1 group by i having i = with_test2.i) order by i, t, value;
  i  |    t    | value 
@@ -3148,15 +2829,133 @@ where value < all (select sum(value) from with_test1 group by i having i = with_
  99 | text99  |   299
 (964 rows)
 
-RESET ALL;
---start_ignore
+-- start_ignore
+drop table if exists csq_emp;
+create table csq_emp(name text, department text, salary numeric) distributed by (name);
+insert into csq_emp values('a','adept',11200.00);
+insert into csq_emp values('b','adept',22222.00);
+insert into csq_emp values('c','bdept',99222.00);
+insert into csq_emp values('d','adept',23211.00);
+insert into csq_emp values('e','adept',45222.00);
+insert into csq_emp values('f','adept',992222.00);
+insert into csq_emp values('g','adept',90343.00);
+insert into csq_emp values('h','adept',11200.00);
+insert into csq_emp values('i','bdept',11200.00);
+insert into csq_emp values('j','adept',11200.00);
+analyze csq_emp;
+-- end_ignore
+SELECT name, department, salary FROM csq_emp ea
+  WHERE salary IN
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea
+  WHERE  salary = ANY
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea
+  WHERE salary = 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary > 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department | salary 
+------+------------+--------
+(0 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary < 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary  
+------+------------+----------
+ a    | adept      | 11200.00
+ b    | adept      | 22222.00
+ d    | adept      | 23211.00
+ e    | adept      | 45222.00
+ g    | adept      | 90343.00
+ h    | adept      | 11200.00
+ i    | bdept      | 11200.00
+ j    | adept      | 11200.00
+(8 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary IN 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary NOT IN 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary  
+------+------------+----------
+ a    | adept      | 11200.00
+ b    | adept      | 22222.00
+ d    | adept      | 23211.00
+ e    | adept      | 45222.00
+ g    | adept      | 90343.00
+ h    | adept      | 11200.00
+ i    | bdept      | 11200.00
+ j    | adept      | 11200.00
+(8 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE  salary = ANY 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea 
+  WHERE salary = ALL 
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department |  salary   
+------+------------+-----------
+ c    | bdept      |  99222.00
+ f    | adept      | 992222.00
+(2 rows)
+
+SELECT name, department, salary FROM csq_emp ea group by name, department,salary
+  HAVING avg(salary) >
+    (SELECT MAX(salary) FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department | salary 
+------+------------+--------
+(0 rows)
+
+SELECT name, department, salary FROM csq_emp ea group by name, department,salary
+  HAVING avg(salary) > ALL
+    (SELECT salary FROM csq_emp eb WHERE eb.department = ea.department) order by name, department, salary;
+ name | department | salary 
+------+------------+--------
+(0 rows)
+
+-- start_ignore
 drop table if exists t1;
 NOTICE:  table "t1" does not exist, skipping
 CREATE OR REPLACE FUNCTION f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL;
-CREATE TABLE t1(a int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t1(a int) distributed by (a);
 INSERT INTO t1 VALUES (1);
+analyze t1;
 -- end_ignore
 SELECT * FROM t1 WHERE a IN (SELECT * FROM f(t1.a));
  a 
@@ -3175,8 +2974,17 @@ SELECT * FROM t1 where a not in (SELECT f FROM f(t1.a));
 ---
 (0 rows)
 
-RESET ALL;
 -- start_ignore
+DROP TABLE IF EXISTS tversion;
+NOTICE:  table "tversion" does not exist, skipping
+DROP TABLE IF EXISTS qp_tjoin1;
+NOTICE:  table "qp_tjoin1" does not exist, skipping
+DROP TABLE IF EXISTS qp_tjoin2;
+NOTICE:  table "qp_tjoin2" does not exist, skipping
+DROP TABLE IF EXISTS qp_tjoin3;
+NOTICE:  table "qp_tjoin3" does not exist, skipping
+DROP TABLE IF EXISTS qp_tjoin4;
+NOTICE:  table "qp_tjoin4" does not exist, skipping
 CREATE TABLE tversion (
     rnum integer NOT NULL,
     c1 integer,
@@ -3209,6 +3017,11 @@ COPY qp_tjoin1 (rnum, c1, c2) FROM stdin;
 COPY qp_tjoin2 (rnum, c1, c2) FROM stdin;
 COPY qp_tjoin3 (rnum, c1, c2) FROM stdin;
 COPY qp_tjoin4 (rnum, c1, c2) FROM stdin;
+analyze tversion;
+analyze qp_tjoin1;
+analyze qp_tjoin2;
+analyze qp_tjoin3;
+analyze qp_tjoin4;
 -- end_ignore
 select qp_tjoin1.rnum, qp_tjoin1.c1, case when 10 in ( select 1 from tversion ) then 'yes' else 'no' end from qp_tjoin1 order by rnum;
  rnum | c1 | case 
@@ -3255,5 +3068,26 @@ select rnum, c1, c2 from qp_tjoin2 where 20 > all ( select c1 from qp_tjoin1) or
 -- ----------------------------------------------------------------------
 -- start_ignore
 drop schema qp_correlated_query cascade;
+NOTICE:  drop cascades to table qp_tjoin4
+NOTICE:  drop cascades to table qp_tjoin3
+NOTICE:  drop cascades to table qp_tjoin2
+NOTICE:  drop cascades to table qp_tjoin1
+NOTICE:  drop cascades to table tversion
+NOTICE:  drop cascades to table t1
+NOTICE:  drop cascades to function f(integer)
+NOTICE:  drop cascades to table csq_emp
+NOTICE:  drop cascades to table with_test2
+NOTICE:  drop cascades to table with_test1
+NOTICE:  drop cascades to table employee
+NOTICE:  drop cascades to table job
+NOTICE:  drop cascades to table product_order
+NOTICE:  drop cascades to table product
+NOTICE:  drop cascades to table d
+NOTICE:  drop cascades to table qp_csq_t4
+NOTICE:  drop cascades to table c
+NOTICE:  drop cascades to table b
+NOTICE:  drop cascades to table a
+NOTICE:  drop cascades to table qp_csq_t3
+NOTICE:  drop cascades to table qp_csq_t2
+NOTICE:  drop cascades to table qp_csq_t1
 -- end_ignore
-RESET ALL;


### PR DESCRIPTION
Occationally qp_correlated_query failed with missing statistic information.

- Remove RESET ALL so that it can actually test with optimizer=on
- Remove duplicated population of table A, B, C
- Rename tables touched by DML to avoid duplicated setup
- Fix subquery to verify the correct result other than verify error message

Now, with GPORCA, all SQL statements passed without ERROR. Planner still got few
failures due to multi-level correlated subqueries, which is expected.

[#135989003]

Signed-off-by: Omer Arap <oarap@pivotal.io>