### PR TITLE
Enable startup logging in pg_ctl

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -192,7 +192,7 @@ class PgCtlBackendOptions(CmdArgs):
             "-p", str(port),
             "--gp_dbid="+ str(dbid),
             "--gp_num_contents_in_cluster="+ str(numcids),
-            "--silent-mode=true"
+            "--silent-mode=false"
         ])
 
     #


### PR DESCRIPTION
Set the silent flag to false to enable more debug logging to startup.log when starting the cluster.

Authors: Chris Hajas and Chumki Roy