### PR TITLE
Set statement_mem to 125MB as part of the analyze statement

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -46,8 +46,8 @@ STATEFILE_DIR = 'db_analyze'
 logger = gplog.get_default_logger()
 CURR_TIME = None
 
-ANALYZE_SQL = """analyze %s"""
-ANALYZE_ROOT_SQL = """analyze rootpartition %s"""
+ANALYZE_SQL = """set statement_mem=125000; analyze %s"""
+ANALYZE_ROOT_SQL = """set statement_mem=125000; analyze rootpartition %s"""
 
 PG_PARTITIONS_SURROGATE = """
 SELECT n.nspname AS schemaname, cl.relname AS tablename, n2.nspname AS partitionschemaname, cl2.relname AS partitiontablename, cl3.relname AS parentpartitiontablename
@@ -563,7 +563,7 @@ class AnalyzeDb(Operation):
             ret.append(tup)
         return ret
 
-    
+
 
     def _write_back(self, curr_ao_state, curr_last_op, prev_ao_state, prev_last_op, heap_partitions,
                    input_col_dict, prev_col_dict, root_partition_col_dict, is_full, dirty_partitions, target_list):


### PR DESCRIPTION
* We are specifically setting the statement_mem to 125MB during the
connection that does the analysis (and just that connection).

Experimentally, this amount yields faster analysis than using a larger
statement_mem. It is not clear why this occurs within the GPDB analyze
tool. But for clients that have statement_mem set higher as a
default configuration, it is important to restrict it only for analyze.

Authors: Marbin Tan & Larry Hamel