### PR TITLE
[#135859893] Guc to disable broadcast for large number of rows

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -781,6 +781,7 @@ COptTasks::PoconfCreate
 	ULONG ulJoinArityForAssociativityCommutativity = (ULONG) optimizer_join_arity_for_associativity_commutativity;
 	ULONG ulArrayExpansionThreshold = (ULONG) optimizer_array_expansion_threshold;
 	ULONG ulJoinOrderThreshold = (ULONG) optimizer_join_order_threshold;
+	ULONG ulBroadcastThreshold = (ULONG) optimizer_penalize_broadcast_threshold;
 
 	return GPOS_NEW(pmp) COptimizerConfig
 						(
@@ -793,7 +794,8 @@ COptTasks::PoconfCreate
 								INT_MAX /* optimizer_parts_to_force_sort_on_insert */,
 								ulJoinArityForAssociativityCommutativity,
 								ulArrayExpansionThreshold,
-								ulJoinOrderThreshold
+								ulJoinOrderThreshold,
+								ulBroadcastThreshold
 								)
 						);
 }

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -546,6 +546,7 @@ double		optimizer_damping_factor_join;
 double		optimizer_damping_factor_groupby;
 int			optimizer_segments;
 int			optimizer_join_arity_for_associativity_commutativity;
+int			optimizer_penalize_broadcast_threshold;
 int         optimizer_array_expansion_threshold;
 int         optimizer_join_order_threshold;
 bool		optimizer_analyze_root_partition;
@@ -4701,6 +4702,16 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"optimizer_penalize_broadcast_threshold", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Maximum number of rows of a relation that can be broadcasted without penalty."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_penalize_broadcast_threshold,
+		10000000, 0, INT_MAX, NULL, NULL
+	},
+
+	{
 		{"optimizer_mdcache_size", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the size of MDCache."),
 			NULL,
@@ -4883,6 +4894,7 @@ struct config_real ConfigureNamesReal_gp[] =
 		&gp_statistics_ndistinct_scaling_ratio_threshold,
 		0.10, 0.001, 1.0, NULL, NULL
 	},
+
 	{
 		{"gp_statistics_sampling_threshold", PGC_USERSET, STATS_ANALYZE,
 			gettext_noop("Only tables larger than this size will be sampled."),
@@ -4892,6 +4904,7 @@ struct config_real ConfigureNamesReal_gp[] =
 		&gp_statistics_sampling_threshold,
 		20000.0, 0.0, DBL_MAX, NULL, NULL
 	},
+
 	{
 		{"gp_resqueue_priority_cpucores_per_segment", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("Number of processing units associated with a segment."),

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -456,6 +456,7 @@ extern double optimizer_damping_factor_join;
 extern double optimizer_damping_factor_groupby;
 extern int optimizer_segments;
 extern int optimizer_join_arity_for_associativity_commutativity;
+extern int optimizer_penalize_broadcast_threshold;
 extern int optimizer_array_expansion_threshold;
 extern int optimizer_join_order_threshold;
 extern bool optimizer_analyze_root_partition;


### PR DESCRIPTION
Added a guc, `optimizer_large_table_broadcast` to set the threshold on
maximum number of rows to broadcast.

Old plan with ORCA :
```
                                             QUERY PLAN
-----------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..869.16 rows=1 width=16)
   ->  Hash Join  (cost=0.00..869.16 rows=1 width=16)
         Hash Cond: bar.d = foo.a
         ->  Table Scan on bar  (cost=0.00..431.69 rows=33190 width=8)
         ->  Hash  (cost=431.02..431.02 rows=100 width=8)
               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.02 rows=100 width=8)
                     ->  Table Scan on foo  (cost=0.00..431.00 rows=34 width=8)
 Settings:  optimizer=on
 Optimizer status: PQO version 1.694
```

If this guc is set to a value lower than the row count such `set optimizer_large_table_broadcast to 10;`,  ORCA will penalize the broadcast motion with huge cost so that plan with large broadcast does not get picked up eventually.

The new plan will look like:
```
                                             QUERY PLAN
----------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..882.24 rows=1 width=16)
   ->  Hash Join  (cost=0.00..882.24 rows=1 width=16)
         Hash Cond: bar.d = foo.a
         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..433.44 rows=33190 width=8)
               Hash Key: bar.d
               ->  Table Scan on bar  (cost=0.00..431.69 rows=33190 width=8)
         ->  Hash  (cost=431.00..431.00 rows=34 width=8)
               ->  Table Scan on foo  (cost=0.00..431.00 rows=34 width=8)
 Settings:  optimizer=on; optimizer_large_table_broadcast=10
```
