### PR TITLE
Decrease running time for gpcrondump --dump-stats

### DIFF
--- a/gpMgmt/bin/gppylib/operations/backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/backup_utils.py
@@ -14,7 +14,6 @@ from gppylib.mainUtils import gp
 from gppylib import pgconf
 from optparse import Values
 from pygresql import pg
-from gppylib.operations.utils import DEFAULT_NUM_WORKERS
 import gzip
 
 logger = gplog.get_default_logger()
@@ -478,6 +477,9 @@ def execute_sql(query, master_port, dbname):
     conn = dbconn.connect(dburl)
     cursor = execSQL(conn, query)
     return cursor.fetchall()
+
+def execute_sql_with_connection(query, conn):
+    return execSQL(conn, query).fetchall()
 
 def generate_master_status_prefix(dump_prefix):
     return '%sgp_dump_status_1_1_' % (dump_prefix)

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_backup_utils.py
@@ -3,16 +3,15 @@
 # Copyright (c) Greenplum Inc 2016. All Rights Reserved.
 #
 
-import os
-import shutil
-import unittest2 as unittest
 from gppylib.commands.base import CommandResult
 from gppylib.operations.backup_utils import *
+from gppylib.operations import backup_utils
 
-from mock import patch, MagicMock, Mock
-from optparse import Values
+from mock import patch, Mock
 
-class BackupUtilsTestCase(unittest.TestCase):
+from test.unit.gp_unittest import GpTestCase
+
+class BackupUtilsTestCase(GpTestCase):
 
     def setUp(self):
         self.context = Context()
@@ -1150,3 +1149,13 @@ class BackupUtilsTestCase(unittest.TestCase):
                 context = Context()
         finally:
             os.environ['MASTER_DATA_DIRECTORY'] = old_mdd
+
+    def test_execute_sql_with_conn(self):
+        cursor = Mock()
+        cursor.fetchall.return_value = 'queryResults'
+        backup_utils.execSQL = Mock(return_value=cursor)
+
+        query = "fake query"
+        conn = Mock()
+        self.assertEquals('queryResults', execute_sql_with_connection(query, conn))
+        backup_utils.execSQL.assert_called_with(conn, query)


### PR DESCRIPTION
Use only one cached DB connection to perform the statistics dump

We were opening 2 DB connections for each table when dumping stats (one
for tuples and one for stats), causing gpcrondump to take a significant
amount of time.

Authors: Stephen Wu, Natalie Bennett