### PR TITLE
Fix bug with missing Flow on a Result node that replaces an empty App…

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1274,11 +1274,16 @@ inheritance_planner(PlannerInfo *root)
 		root->resultRelations = list_make1_int(parentRTindex);
 		/* although dummy, it must have a valid tlist for executor */
 		tlist = preprocess_targetlist(root, parse->targetList);
-		return (Plan *) make_result(root,
+		plan = (Plan *) make_result(root,
 									tlist,
 									(Node *) list_make1(makeBoolConst(false,
 																	  false)),
 									NULL);
+
+		if (Gp_role == GP_ROLE_DISPATCH)
+			mark_plan_general(plan);
+
+		return plan;
 	}
 
 	/* Suppress Append if there's only one surviving child rel */

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -62,5 +62,10 @@ select * from target;
  5 | 100 | 3
 (7 rows)
 
+-- Also test an update with a qual that doesn't match any partition. The
+-- Append degenerates into a dummy Result with false One-Time Filter.
+alter table target drop default partition;
+NOTICE:  dropped partition "extra" for relation "target"
+update target set b = 10 where c = 10;
 drop table todelete;
 drop table target;

--- a/src/test/regress/sql/update_gp.sql
+++ b/src/test/regress/sql/update_gp.sql
@@ -45,6 +45,10 @@ update target set b=target.b+100 where c = 3 and a in (select b from todelete);
 
 select * from target;
 
+-- Also test an update with a qual that doesn't match any partition. The
+-- Append degenerates into a dummy Result with false One-Time Filter.
+alter table target drop default partition;
+update target set b = 10 where c = 10;
+
 drop table todelete;
 drop table target;
-


### PR DESCRIPTION
…end.

If you perform an DELETE or UPDATE on an inherited table, but the
qual rules out all inheritance children, the planner generates a dummy
Result node with a false One-Filter, instead of an Append node. That
dummy Result node did not have a Flow attached to it, which resulted
in an assertion failure later. To fix, attach a Flow to the Result node,
like we do to an Append node in the non-degenerate case.

I wasn't exactly sure what kind of a Flow is appropriate for a dummy node
like this, but mark_plan_general(), i.e. FLOW_SINGLETON, seems to work.
That's what we also use for the similar Result node that we generate for
the case of a HAVING without aggregates or GROUP BY, in grouping_planner().

Fixes github issue #1433.