### PR TITLE
Fix planner bug that sortColIdx of plan flow node may refer to wrong resno

### DIFF
--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -192,9 +192,31 @@ order by b,c;
      25 |     1
 (1 row)
 
+-- Test agg on top of join subquery on partition table with ORDER-BY clause
+CREATE TABLE bfv_planner_t1 (a int, b int, c int) distributed by (c);
+CREATE TABLE bfv_planner_t2 (f int,g int) DISTRIBUTED BY (f) PARTITION BY RANGE(g)
+(
+PARTITION "201612" START (1) END (10)
+);
+NOTICE:  CREATE TABLE will create partition "bfv_planner_t2_1_prt_201612" for table "bfv_planner_t2"
+insert into bfv_planner_t1 values(1,2,3), (2,3,4), (3,4,5);
+insert into bfv_planner_t2 values(3,1), (4,2), (5,2);
+select count(*) from
+(select a,b,c from bfv_planner_t1 order by c) T1
+join
+(select f,g from bfv_planner_t2) T2
+on
+T1.a=T2.g and T1.c=T2.f;
+ count 
+-------
+     2
+(1 row)
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;
 drop table if exists bfv_planner_foo;
 drop table if exists testmedian;
+drop table if exists bfv_planner_t1;
+drop table if exists bfv_planner_t2;
 -- end_ignore

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -131,9 +131,27 @@ where c ='25'
 group by b, c, value2
 order by b,c;
 
+-- Test agg on top of join subquery on partition table with ORDER-BY clause
+CREATE TABLE bfv_planner_t1 (a int, b int, c int) distributed by (c);
+CREATE TABLE bfv_planner_t2 (f int,g int) DISTRIBUTED BY (f) PARTITION BY RANGE(g)
+(
+PARTITION "201612" START (1) END (10)
+);
+insert into bfv_planner_t1 values(1,2,3), (2,3,4), (3,4,5);
+insert into bfv_planner_t2 values(3,1), (4,2), (5,2);
+
+select count(*) from
+(select a,b,c from bfv_planner_t1 order by c) T1
+join
+(select f,g from bfv_planner_t2) T2
+on
+T1.a=T2.g and T1.c=T2.f;
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;
 drop table if exists bfv_planner_foo;
 drop table if exists testmedian;
+drop table if exists bfv_planner_t1;
+drop table if exists bfv_planner_t2;
 -- end_ignore


### PR DESCRIPTION
In the following case, planner generated plan flow node that has sortColIdx
refering to old resno of TargetEntry, which has already been updated with new
resno when unused columns are pruned during join plan creation.

```sql
CREATE TABLE foo (a int, b int, c int) DISTRIBUTED BY (c);
CREATE TABLE bar (f int,g int) DISTRIBUTED BY (f) PARTITION BY RANGE(g)
(
PARTITION "201612" START (1) END (10)
);

explain select count(*) from
(select a,b,c from foo order by c) T1
join
(select f,g from bar) T2
on
T1.a=T2.f and T1.c=T2.g;
```

The above issue has been fixed in this patch.