### PR TITLE
Fix off-by-one bug in quote_literal_internal.

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -6266,7 +6266,7 @@ quote_literal_internal(const char *literal)
 
 	len = strlen(literal);
 	/* We make a worst-case result area; wasting a little space is OK */
-	result = (char *) palloc(len * 2 + 3);
+	result = (char *) palloc(len * 2 + 3 + 1);
 
 	cp1 = literal;
 	cp2 = result;


### PR DESCRIPTION
It turns out that PostgreSQL had effectively the same bug, so reported
and fixed (commit 4f5182e1) there too. See:

https://www.postgresql.org/message-id/20161216105001.13334.42819%40wrigleys.postgresql.org

This needs to be refactored, by latest when we merge with PostgreSQL 9.1,
as there is a function called quote_literal_internal there with different
arguments, and the equivalend of GPDB's quote_literal_internal() is called
quote_literal_cstr() there. But for now, just fix the bug.

Fixes github issue #1301, reported by Tang Pengzhou.