### PR TITLE
Make zlib's workfile_hashjoin_failure fault injection test to fail if faultinjection is failed to inject.

### DIFF
--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -69,17 +69,21 @@ create table t (i int, j text);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into t select i, i from generate_series(1,1000000) as i;
+create table t1(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 set gp_workfile_compress_algorithm ='zlib';
 set statement_mem='10MB';
 create or replace function FuncA()
 returns void as
 $body$
 begin
+ 	insert into t values(2387283, 'a');
+ 	insert into t1 values(1, 2);
     CREATE TEMP table TMP_Q_QR_INSTM_ANL_01 WITH(APPENDONLY=true,COMPRESSLEVEL=5,ORIENTATION=row,COMPRESSTYPE=zlib) on commit drop as
     SELECT t1.i from t as t1 join t as t2 on t1.i = t2.i;
 EXCEPTION WHEN others THEN
  -- do nothing
- insert into t values(2387283, 'a');
 end
 $body$ language plpgsql;
 -- Inject fault before we close workfile in ExecHashJoinNewBatch
@@ -103,11 +107,16 @@ select FuncA();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CONTEXT:  SQL statement "CREATE TEMP table TMP_Q_QR_INSTM_ANL_01 WITH(APPENDONLY=true,COMPRESSLEVEL=5,ORIENTATION=row,COMPRESSTYPE=zlib) on commit drop as SELECT t1.i from t as t1 join t as t2 on t1.i = t2.i"
-PL/pgSQL function "funca" line 2 at SQL statement
+PL/pgSQL function "funca" line 4 at SQL statement
  funca 
 -------
  
 (1 row)
+
+select * from t1;
+ i | j 
+---+---
+(0 rows)
 
 drop function FuncA();
 drop table t;

--- a/src/test/regress/sql/zlib.sql
+++ b/src/test/regress/sql/zlib.sql
@@ -40,6 +40,7 @@ SELECT MAX(i1) FROM test_zlib_hagg GROUP BY i2;
 
 create table t (i int, j text);
 insert into t select i, i from generate_series(1,1000000) as i;
+create table t1(i int, j int);
 
 set gp_workfile_compress_algorithm ='zlib';
 set statement_mem='10MB';
@@ -48,11 +49,12 @@ create or replace function FuncA()
 returns void as
 $body$
 begin
+ 	insert into t values(2387283, 'a');
+ 	insert into t1 values(1, 2);
     CREATE TEMP table TMP_Q_QR_INSTM_ANL_01 WITH(APPENDONLY=true,COMPRESSLEVEL=5,ORIENTATION=row,COMPRESSTYPE=zlib) on commit drop as
     SELECT t1.i from t as t1 join t as t2 on t1.i = t2.i;
 EXCEPTION WHEN others THEN
  -- do nothing
- insert into t values(2387283, 'a');
 end
 $body$ language plpgsql;
 
@@ -63,6 +65,7 @@ $body$ language plpgsql;
 --end_ignore
 
 select FuncA();
+select * from t1;
 
 drop function FuncA();
 drop table t;


### PR DESCRIPTION
If faultinjection failed to inject the fault for some reason, the test was passing. Now with this change we would get the failure. The regression diff will look like

```
  1*** ./expected/zlib.out 2016-12-16 04:01:40.000000000 -0800
  2 --- ./results/zlib.out  2016-12-16 04:01:40.000000000 -0800
  3 ***************
  4 *** 107,113 ****
  5   select * from t1;
  6    i | j
  7   ---+---
  8 ! (0 rows)
  9
 10   drop function FuncA();
 11   drop table t;
 12 --- 101,108 ----
 13   select * from t1;
 14    i | j
 15   ---+---
 16 !  1 | 2
 17 ! (1 row)
```