### PR TITLE
Write statement in log if an exception was encountered during its execution

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4740,7 +4740,11 @@ PostgresMain(int argc, char *argv[],
 		 * Make sure debug_query_string gets reset before we possibly clobber
 		 * the storage it points at.
 		 */
-		debug_query_string = NULL;
+		if (debug_query_string != NULL)
+		{
+			write_stderr("An exception was encountered during the execution of statement: %s", debug_query_string);
+			debug_query_string = NULL;
+		}
 
 		/* No active snapshot any more either */
 		ActiveSnapshot = NULL;


### PR DESCRIPTION
If an exception is encountered during the evaluation of a statement, then `PostgresMain` function resets `debug_query_string` global variable, which is a pointer to the query string. Consequently, if GPDB crashes in `AbortTransaction`, then the value of `debug_query_string` in the generated core will be NULL.

In this patch, if GPDB encounters an exception, then it first writes `debug_query_string`'s value to master's log file and then resets it. 

This will help us during the debugging process.