### PR TITLE
Fix broken Tinc tests due to lacking table distribution

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uao_dml/expected/select_uao_selectinto.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uao_dml/expected/select_uao_selectinto.ans
@@ -1,11 +1,14 @@
 -- @Description select into
--- 
+--
 DROP TABLE IF EXISTS uao_orders_into;
 DROP TABLE
 DROP TABLE IF EXISTS new_uao_orders_into;
 DROP TABLE
-CREATE TABLE uao_orders_into(order_id serial , customer_id integer, 
-      order_datetime timestamp, order_total numeric(10,2)) with (appendonly=true); 
+CREATE TABLE uao_orders_into(order_id serial , customer_id integer,
+      order_datetime timestamp, order_total numeric(10,2)) with (appendonly=true);
+psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create implicit sequence "uao_orders_into_order_id_seq" for serial column "uao_orders_into.order_id"
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'order_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE
 INSERT INTO uao_orders_into(customer_id, order_datetime, order_total)
 VALUES (1,'2009-05-01 10:00 AM', 500),
@@ -16,6 +19,8 @@ VALUES (1,'2009-05-01 10:00 AM', 500),
           (1,'2009-05-20 11:00 AM', 3);
 INSERT 0 6
 select * into new_uao_orders_into from uao_orders_into where order_total > 500 order by order_id;
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'order_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT 1
 select * from new_uao_orders_into;
  order_id | customer_id |   order_datetime    | order_total 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uao_dml/sql/select_uao_selectinto.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uao_dml/sql/select_uao_selectinto.sql
@@ -1,10 +1,10 @@
 -- @Description select into
--- 
+--
 
 DROP TABLE IF EXISTS uao_orders_into;
 DROP TABLE IF EXISTS new_uao_orders_into;
-CREATE TABLE uao_orders_into(order_id serial , customer_id integer, 
-      order_datetime timestamp, order_total numeric(10,2)) with (appendonly=true); 
+CREATE TABLE uao_orders_into(order_id serial , customer_id integer,
+      order_datetime timestamp, order_total numeric(10,2)) with (appendonly=true);
 
 INSERT INTO uao_orders_into(customer_id, order_datetime, order_total)
 VALUES (1,'2009-05-01 10:00 AM', 500),

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/createtable_as_compress.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/expected/createtable_as_compress.ans
@@ -10,6 +10,8 @@ select * from mytab;
     3 | c                   
 (3 rows)
 CREATE TABLE mytab2  WITH (appendonly=true, orientation=column, compresstype = zlib, compresslevel=3) AS SELECT * FROM mytab;
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT 3
 select * from mytab;
  col1 |         name         

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/sql/createtable_as_compress_setup.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_ddl/sql/createtable_as_compress_setup.sql
@@ -3,7 +3,7 @@ SET gp_create_table_random_default_distribution=off;
 -- end_ignore
 DROP TABLE IF EXISTS mytab;
 DROP TABLE IF EXISTS mytab2;
-create table mytab (col1 int, name char(20) ) with (appendonly=true, orientation=column);
+create table mytab (col1 int, name char(20) ) with (appendonly=true, orientation=column) distributed by (col1);
 insert into mytab values (1,'a');
 insert into mytab values (2,'b');
 insert into mytab values (3,'c');

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_dml/expected/select_uao_selectinto.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_dml/expected/select_uao_selectinto.ans
@@ -1,11 +1,14 @@
 -- @Description select into
--- 
+--
 DROP TABLE IF EXISTS uao_orders_into;
 DROP TABLE
 DROP TABLE IF EXISTS new_uao_orders_into;
 DROP TABLE
-CREATE TABLE uao_orders_into(order_id serial , customer_id integer, 
-      order_datetime timestamp, order_total numeric(10,2)) with (appendonly=true, orientation=column); 
+CREATE TABLE uao_orders_into(order_id serial , customer_id integer,
+      order_datetime timestamp, order_total numeric(10,2)) with (appendonly=true, orientation=column);
+psql:/path/sql_file:1: NOTICE:  CREATE TABLE will create implicit sequence "uao_orders_into_order_id_seq" for serial column "uao_orders_into.order_id"
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'order_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE
 INSERT INTO uao_orders_into(customer_id, order_datetime, order_total)
 VALUES (1,'2009-05-01 10:00 AM', 500),
@@ -16,6 +19,8 @@ VALUES (1,'2009-05-01 10:00 AM', 500),
           (1,'2009-05-20 11:00 AM', 3);
 INSERT 0 6
 select * into new_uao_orders_into from uao_orders_into where order_total > 500 order by order_id;
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'order_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT 1
 select * from new_uao_orders_into;
  order_id | customer_id |   order_datetime    | order_total 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_dml/sql/select_uao_selectinto.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/uao/uaocs_dml/sql/select_uao_selectinto.sql
@@ -1,10 +1,10 @@
 -- @Description select into
--- 
+--
 
 DROP TABLE IF EXISTS uao_orders_into;
 DROP TABLE IF EXISTS new_uao_orders_into;
-CREATE TABLE uao_orders_into(order_id serial , customer_id integer, 
-      order_datetime timestamp, order_total numeric(10,2)) with (appendonly=true, orientation=column); 
+CREATE TABLE uao_orders_into(order_id serial , customer_id integer,
+      order_datetime timestamp, order_total numeric(10,2)) with (appendonly=true, orientation=column);
 
 INSERT INTO uao_orders_into(customer_id, order_datetime, order_total)
 VALUES (1,'2009-05-01 10:00 AM', 500),


### PR DESCRIPTION
Commit bbed411 removed the explicit ignoring of 'DISTRIBUTED BY' NOTICEs from atmsort as it made all distrubution notices and hints consistent in its output. This added the requirement that all ans, and other output, files must memorize the NOTICE as it comes from GPDB or add a proper DISTRIBUTED BY (..) clause.

Add table distribution and relevant NOTICEs to the sql and expected files that were missed in bbed411 since that commit focused on the misspelled ones, not the ones where it was missing completely.

Ping @asimrp, you seem to be the resident Tinc expert, does this seem to make sense given the test failure in the cs-uao-regression pipeline step?