### PR TITLE
Refactor planner code's handling of sort ordering in Motion nodes

### DIFF
--- a/src/backend/cdb/cdbpathtoplan.c
+++ b/src/backend/cdb/cdbpathtoplan.c
@@ -72,25 +72,6 @@ cdbpathtoplan_create_flow(PlannerInfo  *root,
         flow = makeFlow(FLOW_PARTITIONED);
     else
         Insist(0);
-	
-    /*
-     * Describe the ordering of the result rows.  The ordering info will be
-     * truncated upon encountering an expr which is not already present in the
-     * plan's targetlist.  Duplicate cols and constant cols will be omitted.
-     */
-    if (pathkeys)
-    {
-        Sort   *sort = make_sort_from_pathkeys(root, plan, pathkeys, -1.0, false);
-
-        if (sort)
-        {
-            flow->numSortCols = sort->numCols;
-            flow->sortColIdx = sort->sortColIdx;
-            flow->sortOperators = sort->sortOperators;
-			flow->nullsFirst = sort->nullsFirst;
-			Assert(flow->nullsFirst);
-        }
-    }
 
     flow->req_move = MOVEMENT_NONE;
 	flow->locustype = locus.locustype;
@@ -135,12 +116,10 @@ cdbpathtoplan_create_motion_plan(PlannerInfo   *root,
             {
                 /* Result node might have been added below the Sort */
                 subplan = sort->plan.lefttree; 
-                motion = make_sorted_union_motion(subplan,
+                motion = make_sorted_union_motion(root,
+												  subplan,
                                                   destSegIndex,
-                                                  sort->numCols,
-                                                  sort->sortColIdx,
-                                                  sort->sortOperators,
-												  sort->nullsFirst,
+												  path->path.pathkeys,
                                                   false /* useExecutorVarFormat */
                                                   );
             }

--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -708,9 +708,6 @@ plan_tree_mutator(Node *node,
 
 				FLATCOPY(newflow, flow, Flow);
 				MUTATE(newflow->hashExpr, flow->hashExpr, List *);
-				COPYARRAY(newflow, flow, numSortCols, sortColIdx);
-				COPYARRAY(newflow, flow, numSortCols, sortOperators);
-				COPYARRAY(newflow, flow, numSortCols, nullsFirst);
 				return (Node *) newflow;
 			}
 			break;

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2070,11 +2070,6 @@ _copyFlow(Flow *from)
 	COPY_SCALAR_FIELD(req_move);
 	COPY_SCALAR_FIELD(locustype);
 	COPY_SCALAR_FIELD(segindex);
-	COPY_SCALAR_FIELD(numSortCols);
-	COPY_POINTER_FIELD(sortColIdx, from->numSortCols*sizeof(AttrNumber));
-	COPY_POINTER_FIELD(sortOperators, from->numSortCols*sizeof(Oid));
-	COPY_POINTER_FIELD(nullsFirst, from->numSortCols*sizeof(bool));
-	COPY_SCALAR_FIELD(numOrderbyCols);
 	COPY_NODE_FIELD(hashExpr);
 	COPY_NODE_FIELD(flow_before_req_move);
 
@@ -2842,6 +2837,7 @@ _copyQuery(Query *from)
 	COPY_NODE_FIELD(distinctClause);
 	COPY_NODE_FIELD(sortClause);
 	COPY_NODE_FIELD(scatterClause);
+	COPY_SCALAR_FIELD(isTableValueSelect);
 	COPY_NODE_FIELD(cteList);
 	COPY_SCALAR_FIELD(hasRecursive);
 	COPY_NODE_FIELD(limitOffset);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -734,9 +734,6 @@ _equalFlow(Flow *a, Flow *b)
 	COMPARE_SCALAR_FIELD(req_move);
 	COMPARE_SCALAR_FIELD(locustype);
 	COMPARE_SCALAR_FIELD(segindex);
-	COMPARE_SCALAR_FIELD(numSortCols);
-	COMPARE_POINTER_FIELD(sortColIdx, a->numSortCols*sizeof(AttrNumber));
-	COMPARE_POINTER_FIELD(sortOperators, a->numSortCols*sizeof(Oid));
 	COMPARE_NODE_FIELD(hashExpr);
 
 	return true;
@@ -857,6 +854,7 @@ _equalQuery(Query *a, Query *b)
 	COMPARE_NODE_FIELD(distinctClause);
 	COMPARE_NODE_FIELD(sortClause);
 	COMPARE_NODE_FIELD(scatterClause);
+	COMPARE_SCALAR_FIELD(isTableValueSelect);
 	COMPARE_NODE_FIELD(cteList);
 	COMPARE_SCALAR_FIELD(hasRecursive);
 	COMPARE_NODE_FIELD(limitOffset);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -643,31 +643,6 @@ _outJoinExpr(StringInfo str, JoinExpr *node)
 	WRITE_INT_FIELD(rtindex);
 }
 
-static void
-_outFlow(StringInfo str, Flow *node)
-{
-
-	WRITE_NODE_TYPE("FLOW");
-
-	WRITE_ENUM_FIELD(flotype, FlowType);
-	WRITE_ENUM_FIELD(req_move, Movement);
-	WRITE_ENUM_FIELD(locustype, CdbLocusType);
-	WRITE_INT_FIELD(segindex);
-
-	/* This array format as in Group and Sort nodes. */
-	WRITE_INT_FIELD(numSortCols);
-
-	WRITE_INT_ARRAY(sortColIdx, node->numSortCols, AttrNumber);
-	WRITE_OID_ARRAY(sortOperators, node->numSortCols);
-	WRITE_BOOL_ARRAY(nullsFirst, node->numSortCols);
-
-	WRITE_INT_FIELD(numOrderbyCols);
-
-	WRITE_NODE_FIELD(hashExpr);
-
-	WRITE_NODE_FIELD(flow_before_req_move);
-}
-
 /*****************************************************************************
  *
  *	Stuff from relation.h.
@@ -913,6 +888,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(distinctClause);
 	WRITE_NODE_FIELD(sortClause);
 	WRITE_NODE_FIELD(scatterClause);
+	WRITE_BOOL_FIELD(isTableValueSelect);
 	WRITE_NODE_FIELD(cteList);
 	WRITE_BOOL_FIELD(hasRecursive);
 	WRITE_NODE_FIELD(limitOffset);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1691,12 +1691,9 @@ _outFromExpr(StringInfo str, FromExpr *node)
 	WRITE_NODE_FIELD(quals);
 }
 
-#ifndef COMPILING_BINARY_FUNCS
 static void
 _outFlow(StringInfo str, Flow *node)
 {
-	int i;
-
 	WRITE_NODE_TYPE("FLOW");
 
 	WRITE_ENUM_FIELD(flotype, FlowType);
@@ -1704,33 +1701,10 @@ _outFlow(StringInfo str, Flow *node)
 	WRITE_ENUM_FIELD(locustype, CdbLocusType);
 	WRITE_INT_FIELD(segindex);
 
-	/* This array format as in Group and Sort nodes. */
-	WRITE_INT_FIELD(numSortCols);
-	if(node->numSortCols > 0)
-	{
-		appendStringInfoLiteral(str, " :sortColIdx");
-		if(node->sortColIdx == NULL)
-			appendStringInfoString(str, " <>");
-		else {
-			for ( i = 0; i < node->numSortCols; i++ )
-				appendStringInfo(str, " %d", node->sortColIdx[i]);
-		}
-
-		appendStringInfoLiteral(str, " :sortOperators");
-		if(node->sortOperators == NULL)
-			appendStringInfoString(str, " <>");
-		else {
-			for ( i = 0; i < node->numSortCols; i++ )
-				appendStringInfo(str, " %u", node->sortOperators[i]);
-		}
-	}
-	WRITE_INT_FIELD(numOrderbyCols);
-
 	WRITE_NODE_FIELD(hashExpr);
 
 	WRITE_NODE_FIELD(flow_before_req_move);
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
 /*****************************************************************************
  *
@@ -3506,6 +3480,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(distinctClause);
 	WRITE_NODE_FIELD(sortClause);
 	WRITE_NODE_FIELD(scatterClause);
+	WRITE_BOOL_FIELD(isTableValueSelect);
 	WRITE_NODE_FIELD(cteList);
 	WRITE_BOOL_FIELD(hasRecursive);
 	WRITE_NODE_FIELD(limitOffset);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -242,6 +242,7 @@ _readQuery(void)
 	READ_NODE_FIELD(distinctClause);
 	READ_NODE_FIELD(sortClause);
 	READ_NODE_FIELD(scatterClause);
+	READ_BOOL_FIELD(isTableValueSelect);
 	READ_NODE_FIELD(cteList);
 	READ_BOOL_FIELD(hasRecursive);
 	READ_NODE_FIELD(limitOffset);
@@ -2157,13 +2158,6 @@ _readFlow(void)
 	READ_ENUM_FIELD(req_move, Movement);
 	READ_ENUM_FIELD(locustype, CdbLocusType);
 	READ_INT_FIELD(segindex);
-
-	READ_INT_FIELD(numSortCols);
-	READ_INT_ARRAY(sortColIdx, local_node->numSortCols, AttrNumber);
-	READ_OID_ARRAY(sortOperators, local_node->numSortCols);
-	READ_BOOL_ARRAY(nullsFirst, local_node->numSortCols);
-
-	READ_INT_FIELD(numOrderbyCols);
 
 	READ_NODE_FIELD(hashExpr);
 	READ_NODE_FIELD(flow_before_req_move);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -336,6 +336,7 @@ _readQuery(void)
 	READ_NODE_FIELD(distinctClause);
 	READ_NODE_FIELD(sortClause);
 	READ_NODE_FIELD(scatterClause);
+	READ_BOOL_FIELD(isTableValueSelect);
 	READ_NODE_FIELD(cteList);
 	READ_BOOL_FIELD(hasRecursive);
 	READ_NODE_FIELD(limitOffset);

--- a/src/backend/optimizer/plan/planagg.c
+++ b/src/backend/optimizer/plan/planagg.c
@@ -560,7 +560,7 @@ make_agg_subplan(PlannerInfo *root, MinMaxAggInfo *info)
 							   0, 1);
 
     /* Decorate the Limit node with a Flow node. */
-    plan->flow = pull_up_Flow(plan, plan->lefttree, false);
+    plan->flow = pull_up_Flow(plan, plan->lefttree);
 
 	/*
 	 * Convert the plan into an InitPlan, and make a Param for its result.

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -212,6 +212,46 @@ static TargetEntry *tlist_member_by_ressortgroupref(List *targetList, int ressor
 	return NULL;
 }
 
+
+/*
+ * Reorder a path key, using given column mappings.
+ */
+static List *
+reorder_pathkeys(PlannerInfo *root,
+				 List *pathkeys,
+				 AttrNumber *orig_grpColIdx,
+				 AttrNumber *new_grpColIdx)
+{
+	List	   *result = NIL;
+	int			grpno;
+	int			numgrpkeys = list_length(pathkeys);
+
+	for (grpno = 0; grpno < numgrpkeys; grpno++)
+	{
+		PathKey	   *pk;
+		int			pos;
+
+		/*
+		 * Find the index position in orig_grpColIdx, in which the element is
+		 * equal to new_grpColIdx[grpno]. This index position points to the
+		 * place that the corresponding PathKey in pathkeys.
+		 */
+		for (pos = 0; pos < numgrpkeys; pos++)
+		{
+			if (orig_grpColIdx[pos] == new_grpColIdx[grpno])
+				break;
+		}
+
+		Assert(pos < numgrpkeys);
+
+		pk = (PathKey *) list_nth(pathkeys, pos);
+
+		result = lappend(result, pk);
+	}
+
+	return result;
+}
+
 /**
  * Grouping extension planner does not correctly support a scenario where multiple grouping sets contain
  * references to expressions where one of which subsumes another in the select targetlist.
@@ -508,6 +548,7 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 	/* The query has a non-empty set group clause */
 	bool has_groups = (root->parse->groupClause != NIL);
 	bool need_repeat_node = false;
+	List	   *group_pathkeys;
 
 	TargetEntry *tle;
 	uint64    input_grouping = 0;
@@ -626,19 +667,16 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 			/* Add sort node if needed, and set AggStrategy */
 			if (root->parse->groupClause)
 			{
-				if (!pathkeys_contained_in(root->group_pathkeys,
+				group_pathkeys =  reorder_pathkeys(root, root->group_pathkeys,
+												   orig_grpColIdx,
+												   groupColIdx);
+				if (!pathkeys_contained_in(group_pathkeys,
 										   context->current_pathkeys))
 				{
 					current_lefttree = (Plan *)
-						make_sort_from_reordered_groupcols(root,
-														   root->parse->groupClause,
-														   orig_grpColIdx,
-														   groupColIdx,
-														   NULL,
-														   NULL,
-														   context->current_rollup->numcols - group_no,
-														   current_lefttree);
-					context->current_pathkeys = root->group_pathkeys;
+						make_sort_from_pathkeys(root, current_lefttree, group_pathkeys,
+												-1, false);
+					context->current_pathkeys = group_pathkeys;
 					mark_sort_locus(current_lefttree);
 
 					if (!context->is_agg)
@@ -865,6 +903,10 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 			for (attno=0; attno<context->numGroupCols -1; attno++)
 				orig_prelimGroupColIdx[attno] = attno+1;
 
+			group_pathkeys =  reorder_pathkeys(root, root->group_pathkeys,
+											   orig_prelimGroupColIdx,
+											   prelimGroupColIdx);
+
 			grouping_entry =
 				get_tle_by_resno(agg_node->targetlist,
 								 prelimGroupColIdx[context->numGroupCols - 2]);
@@ -872,14 +914,8 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 				get_tle_by_resno(agg_node->targetlist,
 								 prelimGroupColIdx[context->numGroupCols - 1]);
 			agg_node = (Plan *)
-				make_sort_from_reordered_groupcols(root,
-												   root->parse->groupClause,
-												   orig_prelimGroupColIdx,
-												   prelimGroupColIdx,
-												   grouping_entry,
-												   groupid_entry,
-												   context->numGroupCols - 2,
-												   agg_node);
+				make_sort_from_pathkeys_and_groupingcol(root, agg_node, group_pathkeys,
+														grouping_entry, groupid_entry);
 			pfree(orig_prelimGroupColIdx);
 			mark_sort_locus(agg_node);
 		}
@@ -933,8 +969,7 @@ make_list_aggs_for_rollup(PlannerInfo *root,
  * added and the first subplan is returned.
  */
 static Plan *
-add_append_node(List *subplans,
-				GroupExtContext *context)
+add_append_node(PlannerInfo *root, List *subplans, GroupExtContext *context)
 {
 	Plan *result_plan;
 	GpSetOpType optype = PSETOP_NONE;
@@ -945,7 +980,7 @@ add_append_node(List *subplans,
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
 			optype = choose_setop_type(subplans);
-			adjust_setop_arguments(subplans, optype);
+			adjust_setop_arguments(root, subplans, optype);
 		}
 		
 		/* Append all agg_plans together */
@@ -1193,7 +1228,7 @@ generate_dqa_plan(PlannerInfo *root,
 		root->parse = orig_query;
 		root->parse->groupClause = new_groupClause;
 		root->parse->havingQual = (Node *)new_qual;
-		
+
 		/* Add an explicit sort if we couldn't make the path
 		 * come out the way the Agg/Group node needs it.
 		 */
@@ -1201,11 +1236,8 @@ generate_dqa_plan(PlannerInfo *root,
 								   pathkeys_copy))
 		{
 			subplan = (Plan *)
-				make_sort_from_groupcols(root,
-										 root->parse->groupClause,
-										 context->grpColIdx,
-										 false,
-										 subplan);
+				make_sort_from_pathkeys(root, subplan, root->group_pathkeys,
+										-1, false);
 			pathkeys_copy = root->group_pathkeys;
 			mark_sort_locus(subplan);
 			
@@ -1338,30 +1370,30 @@ plan_append_aggs_with_gather(PlannerInfo *root,
 	AttrNumber *orig_grpColIdx;
 	Oid		   *orig_grpOperators;
 	double      motion_cost_per_row;
+	List	   *group_pathkeys;
 
 	orig_grpColIdx = context->grpColIdx;
 	orig_grpOperators = context->grpOperators;
 	context->grpColIdx = context->current_rollup->colIdx;
 	context->grpOperators = context->current_rollup->operators;
-	
+
+	group_pathkeys = reorder_pathkeys(root,
+									  root->group_pathkeys,
+									  orig_grpColIdx,
+									  context->grpColIdx);
+
 	/* Add an explicit sort if we couldn't make the path
 	 * come out the way the Agg/Group node needs it.
 	 */
-	if (!pathkeys_contained_in(root->group_pathkeys,
+	if (!pathkeys_contained_in(group_pathkeys,
 							   context->current_pathkeys))
 	{
 		lefttree = (Plan *)
-			make_sort_from_reordered_groupcols(root,
-											   root->parse->groupClause,
-											   orig_grpColIdx,
-											   context->grpColIdx,
-											   NULL,
-											   NULL,
-											   context->numGroupCols,
-											   lefttree);
-		context->current_pathkeys = root->group_pathkeys;
+			make_sort_from_pathkeys(root, lefttree, group_pathkeys,
+									-1, false);
+		context->current_pathkeys = group_pathkeys;
 		mark_sort_locus(lefttree);
-		
+
 		/* If this is a Group node, pass DISTINCT to sort */
 		if (!context->is_agg &&
 			IsA(lefttree, Sort) &&
@@ -1391,7 +1423,7 @@ plan_append_aggs_with_gather(PlannerInfo *root,
 	if (lefttree->flow->flotype != FLOW_SINGLETON)
 	{
 		gather_subplan =
-			(Plan *)make_motion_gather_to_QE(lefttree, (context->current_pathkeys != NIL));
+			(Plan *)make_motion_gather_to_QE(root, lefttree, context->current_pathkeys);
 		gather_subplan->total_cost +=
 			motion_cost_per_row * gather_subplan->plan_rows;
 	}
@@ -1437,15 +1469,12 @@ plan_append_aggs_with_gather(PlannerInfo *root,
 			/* Add an explicit sort if we couldn't make the path
 			 * come out the way the Agg/Group node needs it.
 			 */
-			if (!pathkeys_contained_in(root->group_pathkeys,
+			if (!pathkeys_contained_in(group_pathkeys,
 									   pathkeys))
 			{
 				subplan = (Plan *)
-					make_sort_from_groupcols(root,
-											 root->parse->groupClause,
-											 context->grpColIdx,
-											 false,
-											 subplan);
+					make_sort_from_pathkeys(root, subplan, group_pathkeys,
+											-1, false);
 				mark_sort_locus(subplan);
 
 				/* If this is a Group node, pass DISTINCT to sort */
@@ -1492,7 +1521,7 @@ plan_append_aggs_with_gather(PlannerInfo *root,
 		}
 	}
 
-	result_plan = add_append_node(agg_plans, context);
+	result_plan = add_append_node(root, agg_plans, context);
 
 	return result_plan;
 }
@@ -1658,7 +1687,7 @@ plan_append_aggs_with_rewrite(PlannerInfo *root,
 	root->simple_rel_array_size = orig_rel_array_size;
 	memcpy(root->parse, final_query, sizeof(Query));
 
-	result_plan = add_append_node(agg_plans, context);
+	result_plan = add_append_node(root, agg_plans, context);
 	
 	return result_plan;
 }
@@ -1732,9 +1761,7 @@ add_first_agg(PlannerInfo *root,
 			current_lefttree);
 
 	/* Pull up the Flow from the subplan */
-	agg_node->flow =
-		pull_up_Flow(agg_node, agg_node->lefttree,
-					 context->aggstrategy == AGG_SORTED);
+	agg_node->flow = pull_up_Flow(agg_node, agg_node->lefttree);
 
 	/* Simply pulling up the Flow from the subplan is not enough.
 	 * We set hash->hashExpr to NULL since we can not be sure that
@@ -2134,7 +2161,7 @@ plan_list_rollup_plans(PlannerInfo *root,
 		{
 			Plan *plan = (Plan *) make_result(root, lefttree->targetlist, NULL, lefttree);
 			if (lefttree->flow)
-				plan->flow = pull_up_Flow(plan, lefttree, true);
+				plan->flow = pull_up_Flow(plan, lefttree);
 			lefttree = plan;
 		}
 	
@@ -2289,7 +2316,7 @@ plan_list_rollup_plans(PlannerInfo *root,
 		if ( Gp_role == GP_ROLE_DISPATCH )
 		{
 			optype = choose_setop_type(rollup_plans);
-			adjust_setop_arguments(rollup_plans, optype);
+			adjust_setop_arguments(root, rollup_plans, optype);
 		}
 
 		/* Append all rollup_plans together */

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -548,6 +548,8 @@ PlannerConfig *DefaultPlannerConfig(void)
 
 	c1->gp_cte_sharing = gp_cte_sharing;
 
+	c1->honor_order_by = true;
+
 	return c1;
 }
 

--- a/src/backend/optimizer/plan/planshare.c
+++ b/src/backend/optimizer/plan/planshare.c
@@ -27,7 +27,6 @@
 #include "cdb/cdbgroup.h"					/* cdbpathlocus_collocates() */
 #include "cdb/cdbpath.h"
 #include "cdb/cdbsetop.h"					/* make_motion... routines */
-#include "cdb/cdbmutate.h" 					/* add_slice_to_motion */
 #include "cdb/cdbvars.h"
 
 int get_plan_share_id(Plan *p)

--- a/src/backend/optimizer/plan/planwindow.c
+++ b/src/backend/optimizer/plan/planwindow.c
@@ -1658,6 +1658,10 @@ Plan *assure_collocation_and_order(
 			if(!pathkeys_contained_in(sort_pathkeys, *pathkeys_ptr))
 			{
 				result_plan = (Plan *) make_sort_from_sortclauses(root, sortclause, result_plan);
+
+				/* re-phrase the pathkeys in terms of the sort node's target list. */
+				sort_pathkeys = make_pathkeys_for_sortclauses(root, sortclause, result_plan->targetlist, true);
+
 				*pathkeys_ptr = sort_pathkeys;
 				mark_sort_locus(result_plan);
 			}
@@ -1666,7 +1670,7 @@ Plan *assure_collocation_and_order(
 		/* bring to single locus */
 		if( CdbPathLocus_IsPartitioned(input_locus))
 		{
-			result_plan = (Plan *) make_motion_gather_to_QE(result_plan, (*pathkeys_ptr != NULL));
+			result_plan = (Plan *) make_motion_gather_to_QE(root, result_plan, *pathkeys_ptr);
 			result_plan->total_cost += motion_cost_per_row * result_plan->plan_rows;
 		}
 
@@ -1717,9 +1721,13 @@ Plan *assure_collocation_and_order(
 
 		if(sortclause != NIL)
 		{
-			if(! pathkeys_contained_in(sort_pathkeys, *pathkeys_ptr))
+			if(!pathkeys_contained_in(sort_pathkeys, *pathkeys_ptr))
 			{
 				result_plan = (Plan *) make_sort_from_sortclauses(root, sortclause, result_plan);
+
+				/* re-phrase the pathkeys in terms of the sort node's target list. */
+				sort_pathkeys = make_pathkeys_for_sortclauses(root, sortclause, result_plan->targetlist, true);
+
 				*pathkeys_ptr = sort_pathkeys;
 				mark_sort_locus(result_plan);
 			}
@@ -1821,9 +1829,7 @@ static Plan *plan_trivial_window_query(PlannerInfo *root, WindowContext *context
 	 * must have a Flow node.
 	 */
 	if (!result_plan->flow)
-		result_plan->flow = pull_up_Flow(result_plan, 
-										 result_plan->lefttree, 
-										 (pathkeys != NIL));
+		result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 
 	/* TODO Check our API.
 	 *
@@ -2236,7 +2242,7 @@ static Plan *plan_sequential_stage(PlannerInfo *root,
 					agg_plan /* now just the shared input */
 					);
 
-		agg_plan->flow = pull_up_Flow(agg_plan, agg_plan->lefttree, true);
+		agg_plan->flow = pull_up_Flow(agg_plan, agg_plan->lefttree);
 		
 		/* Later we'll package this Agg plan as the second sub-query RTE
 		 * in a fake Query representing a two-way join of Window sub-query 
@@ -2303,7 +2309,7 @@ static Plan *plan_sequential_stage(PlannerInfo *root,
 							(List*) translate_upper_vars_sequential((Node*)winfo->key_list, context), /* XXX mutate windowKeys to translate any Var nodes in frame vals. */
 							window_plan);
 							
-			window_plan->flow = pull_up_Flow(window_plan, window_plan->lefttree, true);
+			window_plan->flow = pull_up_Flow(window_plan, window_plan->lefttree);
 		}
 
 		
@@ -2529,7 +2535,7 @@ static Plan *plan_sequential_stage(PlannerInfo *root,
 		join_plan->total_cost = agg_plan->total_cost + window_plan->total_cost;
 		join_plan->total_cost += cpu_tuple_cost * join_plan->plan_rows;
 		
-		join_plan->flow = pull_up_Flow(join_plan, join_plan->righttree, true);
+		join_plan->flow = pull_up_Flow(join_plan, join_plan->righttree);
 		window_plan = join_plan;
 	}	
 
@@ -2598,9 +2604,7 @@ static Plan *plan_parallel_window_query(PlannerInfo *root, WindowContext *contex
 									  NIL, /* No ordering */
 									  subplan);
 		if (!subplan->flow)
-			subplan->flow = pull_up_Flow(subplan, 
-											 subplan->lefttree, 
-											 (pathkeys != NIL));
+			subplan->flow = pull_up_Flow(subplan, subplan->lefttree);
 	}
 	else
 	{
@@ -3125,9 +3129,7 @@ static RangeTblEntry *rte_for_coplan(
 	}
 
 	if (!new_plan->flow)
-		new_plan->flow = pull_up_Flow(new_plan, 
-				new_plan->lefttree, 
-				(subplan_pathkeys != NIL));
+		new_plan->flow = pull_up_Flow(new_plan, new_plan->lefttree);
 
 	/* Need to specify eref for messages. */
 	new_eref = makeNode(Alias);

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -492,6 +492,7 @@ pull_up_simple_subquery(PlannerInfo *root, Node *jtnode, RangeTblEntry *rte,
     AssertImply(subquery->jointree->fromlist, list_length(subquery->jointree->fromlist) == 1);
     
     subroot->config = CopyPlannerConfig(root->config);
+	subroot->config->honor_order_by = false;
 	/* CDB: Clear fallback */
 	subroot->config->mpp_trying_fallback_plan = false;
 

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -38,6 +38,7 @@
 #include "commands/tablecmds.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/clauses.h"
+#include "optimizer/paths.h"
 #include "optimizer/plancat.h"
 #include "optimizer/planmain.h"
 #include "optimizer/planner.h"
@@ -195,6 +196,7 @@ recurse_set_operations(Node *setOp, PlannerInfo *root,
 		 * Generate plan for primitive subquery
 		 */
 		PlannerConfig *config = CopyPlannerConfig(root->config);
+		config->honor_order_by = false;
 		subplan = subquery_planner(root->glob, subquery,
 								   root,
 								   false,
@@ -266,7 +268,7 @@ recurse_set_operations(Node *setOp, PlannerInfo *root,
 												 refnames_tlist),
 							NULL,
 							plan);
-            plan->flow = pull_up_Flow(plan, plan->lefttree, false);
+            plan->flow = pull_up_Flow(plan, plan->lefttree);
 		}
 		return plan;
 	}
@@ -376,7 +378,7 @@ generate_union_plan(SetOperationStmt *op, PlannerInfo *root,
 	if ( Gp_role == GP_ROLE_DISPATCH )
 	{
 		optype = choose_setop_type(planlist);
-		adjust_setop_arguments(planlist, optype);
+		adjust_setop_arguments(root, planlist, optype);
 	}
 	else if (Gp_role == GP_ROLE_UTILITY ||
 			 Gp_role == GP_ROLE_EXECUTE) /* MPP-2928 */
@@ -419,7 +421,7 @@ generate_union_plan(SetOperationStmt *op, PlannerInfo *root,
 			plan = (Plan *) make_sort_from_sortclauses(root, sortList, plan);
 			mark_sort_locus(plan); /* CDB */
 			plan = (Plan *) make_unique(plan, sortList);
-            plan->flow = pull_up_Flow(plan, plan->lefttree, true);
+            plan->flow = pull_up_Flow(plan, plan->lefttree);
 		}
 		*sortClauses = sortList;
 	}
@@ -464,7 +466,7 @@ generate_nonunion_plan(SetOperationStmt *op, PlannerInfo *root,
 	if ( Gp_role == GP_ROLE_DISPATCH )
 	{
 		optype = choose_setop_type(planlist);
-		adjust_setop_arguments(planlist, optype);
+		adjust_setop_arguments(root, planlist, optype);
 	}
 	else if ( Gp_role == GP_ROLE_UTILITY 
 			|| Gp_role == GP_ROLE_EXECUTE ) /* MPP-2928 */
@@ -526,7 +528,7 @@ generate_nonunion_plan(SetOperationStmt *op, PlannerInfo *root,
 			break;
 	}
 	plan = (Plan *) make_setop(cmd, plan, sortList, list_length(op->colTypes) + 1);
-    plan->flow = pull_up_Flow(plan, plan->lefttree, true);
+    plan->flow = pull_up_Flow(plan, plan->lefttree);
 
 	*sortClauses = sortList;
 

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1673,6 +1673,8 @@ transformTableValueExpr(ParseState *pstate, TableValueExpr *t)
 	/* Analyze and transform the subquery */
 	query = parse_sub_analyze(t->subquery, pstate);
 
+	query->isTableValueSelect = true;
+
 	/* 
 	 * Check that we got something reasonable.  Most of these conditions
 	 * are probably impossible given restrictions in the grammar.

--- a/src/include/cdb/cdbllize.h
+++ b/src/include/cdb/cdbllize.h
@@ -32,7 +32,7 @@ extern bool is_plan_node(Node *node);
 
 extern Flow *makeFlow(FlowType flotype);
 
-extern Flow *pull_up_Flow(Plan *plan, Plan *subplan, bool withSort);
+extern Flow *pull_up_Flow(Plan *plan, Plan *subplan);
 
 extern bool focusPlan(Plan *plan, bool stable, bool rescannable);
 extern bool repartitionPlan(Plan *plan, bool stable, bool rescannable, List *hashExpr);

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -25,9 +25,8 @@ extern Plan *apply_motion(struct PlannerInfo *root, Plan *plan, Query *query);
 
 extern Motion *make_union_motion(Plan *lefttree,
 		                                int destSegIndex, bool useExecutorVarFormat);
-extern Motion *make_sorted_union_motion(Plan *lefttree, int destSegIndex,
-						 int numSortCols, AttrNumber *sortColIdx,
-						 Oid *sortOperators, bool *nullsFirst,
+extern Motion *make_sorted_union_motion(PlannerInfo *root, Plan *lefttree, int destSegIndex,
+										List *sortPathKeys,
 						 bool useExecutorVarFormat);
 extern Motion *make_hashed_motion(Plan *lefttree,
 				    List *hashExpr, bool useExecutorVarFormat);
@@ -38,11 +37,6 @@ extern Motion *make_explicit_motion(Plan *lefttree, AttrNumber segidColIdx, bool
 
 void 
 cdbmutate_warn_ctid_without_segid(struct PlannerInfo *root, struct RelOptInfo *rel);
-
-extern void add_slice_to_motion(Motion *m,
-		MotionType motionType, List *hashExpr, 
-		int numOutputSegs, int *outputSegIdx 
-		);
 
 extern Plan *zap_trivial_result(PlannerInfo *root, Plan *plan); 
 extern Plan *apply_shareinput_dag_to_tree(PlannerGlobal *glob, Plan *plan, List *rtable);

--- a/src/include/cdb/cdbsetop.h
+++ b/src/include/cdb/cdbsetop.h
@@ -62,7 +62,7 @@ extern
 GpSetOpType choose_setop_type(List *planlist); 
 
 extern
-void adjust_setop_arguments(List *planlist, GpSetOpType setop_type);
+void adjust_setop_arguments(PlannerInfo *root, List *planlist, GpSetOpType setop_type);
 
 
 extern
@@ -72,13 +72,13 @@ extern
 Motion* make_motion_hash(PlannerInfo *root, Plan *subplan, List *hashexprs);
 
 extern
-Motion* make_motion_gather_to_QD(Plan *subplan, bool keep_ordering);
+Motion* make_motion_gather_to_QD(PlannerInfo *root, Plan *subplan, List *sortPathKeys);
 
 extern
-Motion* make_motion_gather_to_QE(Plan *subplan, bool keep_ordering);
+Motion* make_motion_gather_to_QE(PlannerInfo *root, Plan *subplan, List *sortPathKeys);
 
 extern
-Motion* make_motion_gather(Plan *subplan, int segindex, bool keep_ordering);
+Motion* make_motion_gather(PlannerInfo *root, Plan *subplan, int segindex, List *sortPathKeys);
 
 extern
 void mark_append_locus(Plan *plan, GpSetOpType optype);

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -157,6 +157,7 @@ typedef struct Query
 	List	   *sortClause;		/* a list of SortGroupClause's */
 
 	List	   *scatterClause;	/* a list of tle's */
+	bool		isTableValueSelect; /* GPDB: Is this a TABLE (...) subquery argument? */
 
 	List	   *cteList;		/* a list of CommonTableExprs in WITH clause */
 	bool		hasRecursive;	/* Whether this query has a recursive WITH

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -52,6 +52,8 @@ typedef struct PlannerConfig
 
 	bool		gp_cte_sharing; /* Indicate whether sharing is to be disabled on any CTEs */
 
+	bool		honor_order_by;
+
 	/* These ones are tricky */
 	//GpRoleValue	Gp_role; // TODO: this one is tricky
 	//int			gp_singleton_segindex; // TODO: change this.

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1350,15 +1350,7 @@ typedef struct Flow
 	 * the desired segment for the resulting singleton flow.
 	 */
 	int			segindex;		/* Segment index of singleton flow. */
-	
-	/* Sort specifications. */
-	int			numSortCols;		/* number of sort key columns */
-	AttrNumber	*sortColIdx;		/* their indexes in target list */
-	Oid			*sortOperators;		/* OID of operators to sort them by */
-	bool		*nullsFirst;
 
-	int			numOrderbyCols;		/* number of explicit order-by columns */
-	
 	/* If req_move is MOVEMENT_REPARTITION, these express the desired 
      * partitioning for a hash motion.  Else if flotype is FLOW_PARTITIONED,
      * this is the partitioning key.  Otherwise NIL. 

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -141,16 +141,15 @@ extern Sort *make_sort_from_sortclauses(PlannerInfo *root, List *sortcls,
 extern Sort *make_sort_from_groupcols(PlannerInfo *root, List *groupcls,
 									  AttrNumber *grpColIdx, bool appendGrouping,
 									  Plan *lefttree);
-extern Sort *make_sort_from_reordered_groupcols(PlannerInfo *root,
-												List *groupcls,
-												AttrNumber *orig_grpColIdx,
-												AttrNumber *new_grpColIdx,
-												TargetEntry *grouping,
-												TargetEntry *groupid,
-												int req_ngrpkeys,
-												Plan *lefttree);
+extern Sort *make_sort_from_pathkeys_and_groupingcol(PlannerInfo *root,
+										Plan *lefttree,
+										List *pathkeys,
+										TargetEntry *grouping,
+										TargetEntry *groupid);
 extern List *reconstruct_group_clause(List *orig_groupClause, List *tlist,
 						 AttrNumber *grpColIdx, int numcols);
+
+extern Motion *make_motion(PlannerInfo *root, Plan *lefttree, List *sortPathKeys, bool useExecutorVarFormat);
 
 extern Agg *make_agg(PlannerInfo *root, List *tlist, List *qual,
 					 AggStrategy aggstrategy, bool streaming,

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -299,9 +299,31 @@ NOTICE:  stabletestfunc executed
   1
 (1 row)
 
+-- Test agg on top of join subquery on partition table with ORDER-BY clause
+CREATE TABLE bfv_planner_t1 (a int, b int, c int) distributed by (c);
+CREATE TABLE bfv_planner_t2 (f int,g int) DISTRIBUTED BY (f) PARTITION BY RANGE(g)
+(
+PARTITION "201612" START (1) END (10)
+);
+NOTICE:  CREATE TABLE will create partition "bfv_planner_t2_1_prt_201612" for table "bfv_planner_t2"
+insert into bfv_planner_t1 values(1,2,3), (2,3,4), (3,4,5);
+insert into bfv_planner_t2 values(3,1), (4,2), (5,2);
+select count(*) from
+(select a,b,c from bfv_planner_t1 order by c) T1
+join
+(select f,g from bfv_planner_t2) T2
+on
+T1.a=T2.g and T1.c=T2.f;
+ count 
+-------
+     2
+(1 row)
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;
 drop table if exists bfv_planner_foo;
 drop table if exists testmedian;
+drop table if exists bfv_planner_t1;
+drop table if exists bfv_planner_t2;
 -- end_ignore

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -196,9 +196,28 @@ execute myprep;
 execute myprep;
 
 
+-- Test agg on top of join subquery on partition table with ORDER-BY clause
+CREATE TABLE bfv_planner_t1 (a int, b int, c int) distributed by (c);
+CREATE TABLE bfv_planner_t2 (f int,g int) DISTRIBUTED BY (f) PARTITION BY RANGE(g)
+(
+PARTITION "201612" START (1) END (10)
+);
+insert into bfv_planner_t1 values(1,2,3), (2,3,4), (3,4,5);
+insert into bfv_planner_t2 values(3,1), (4,2), (5,2);
+
+select count(*) from
+(select a,b,c from bfv_planner_t1 order by c) T1
+join
+(select f,g from bfv_planner_t2) T2
+on
+T1.a=T2.g and T1.c=T2.f;
+
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;
 drop table if exists bfv_planner_foo;
 drop table if exists testmedian;
+drop table if exists bfv_planner_t1;
+drop table if exists bfv_planner_t2;
 -- end_ignore


### PR DESCRIPTION
@hsyuan asked me to have a quick look at PR #1450. I'm not entirely sure why it didn't work as intended, but it got me thinking, why we need to track sort ordering in Flow nodes in the first place. It seems error-prone, having to keep the column index information up-to-date throughout the later stages of the planner, given that PostgreSQL doesn't need to do that. Digging into that rabbit hole, I ended up with this patch.
