### PR TITLE
[#136294589] Fix a bug that Rollup causes query to crash

### DIFF
--- a/src/test/regress/expected/qp_olap_group.out
+++ b/src/test/regress/expected/qp_olap_group.out
@@ -1423,7 +1423,7 @@ SELECT DISTINCT sale.vn,sale.vn,GROUPING(sale.vn),GROUP_ID(), TO_CHAR(COALESCE(S
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY CUBE((sale.cn,sale.prc),(sale.vn),(sale.prc),(sale.cn)),CUBE((sale.cn,sale.cn,sale.qty),(sale.pn),(sale.pn,sale.dt,sale.cn)),ROLLUP((sale.pn),(sale.qty,sale.pn));
-ERROR:  division by zero  (seg0 slice12 office-4-59.pa.pivotal.io:25432 pid=94574)
+ERROR:  division by zero  (seg0 slice12 127.0.0.1:25432 pid=24508)
 -- ###### Queries involving STDDEV_SAMP() function ###### --
 SELECT DISTINCT sale.vn,sale.dt,sale.prc, TO_CHAR(COALESCE(STDDEV_SAMP(floor(sale.pn+sale.vn)),0),'99999999.9999999') 
 FROM sale,vendor
@@ -6002,4 +6002,40 @@ GROUP BY ROLLUP((sale.prc),(sale.prc,sale.vn),(sale.qty,sale.qty),(sale.vn)),GRO
     |          .0000000
     |        60.0000000
 (8 rows)
+
+-- ###### Rollup with DQA and constants in target list expressions and qualifications with same value as that of constant grouping column ###### --
+SELECT COUNT(DISTINCT cn) as cn_r FROM (SELECT cn, CASE WHEN (vn = 0) THEN 1 END AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g);
+ cn_r 
+------
+    4
+    4
+    4
+(3 rows)
+
+SELECT COUNT(DISTINCT cn) as cn_r FROM (SELECT cn, vn + 1 AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (f > 1);
+ cn_r 
+------
+    1
+    1
+    2
+    3
+    2
+(5 rows)
+
+PREPARE p AS SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + $1 AS f, $1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (g > 1);
+EXECUTE p(2);
+ cn_r | f  | g 
+------+----+---
+    1 | 12 | 2
+    1 | 22 | 2
+    2 | 32 | 2
+    3 | 42 | 2
+    2 | 52 | 2
+    1 | 12 |  
+    1 | 22 |  
+    2 | 32 |  
+    3 | 42 |  
+    2 | 52 |  
+    4 |    |  
+(11 rows)
 

--- a/src/test/regress/sql/qp_olap_group.sql
+++ b/src/test/regress/sql/qp_olap_group.sql
@@ -157,4 +157,8 @@ FROM sale,product
 WHERE sale.pn=product.pn
 GROUP BY ROLLUP((sale.prc),(sale.prc,sale.vn),(sale.qty,sale.qty),(sale.vn)),GROUPING SETS((),ROLLUP((sale.prc,sale.cn,sale.prc),(sale.cn,sale.cn),(sale.vn),(sale.vn,sale.cn))),GROUPING SETS(CUBE((sale.cn),(sale.pn,sale.qty,sale.qty)),ROLLUP((sale.prc,sale.cn,sale.prc),(sale.qty)));
 
-
+-- ###### Rollup with DQA and constants in target list expressions and qualifications with same value as that of constant grouping column ###### --
+SELECT COUNT(DISTINCT cn) as cn_r FROM (SELECT cn, CASE WHEN (vn = 0) THEN 1 END AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g);
+SELECT COUNT(DISTINCT cn) as cn_r FROM (SELECT cn, vn + 1 AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (f > 1);
+PREPARE p AS SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + $1 AS f, $1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (g > 1);
+EXECUTE p(2);


### PR DESCRIPTION
In rollup() processing, when the grouping cols are processed, the target list is
traversed for each grouping col to find a match. Each node in the target list is
mutated in `replace_grouping_columns_mutator()` to find match for grouping cols.

In the failing query:
select  count(distinct c) as r from ( select c
, case when (e = 1) then 1 end as f  , 1 as g from foo) f_view group by
rollup(f,g);

grouping cols ‘g’ is a constant 1. When target entry for ‘f’ is being mutated,
we mutate all the fields of CaseExpr recursively. Since the `result` field in
CaseExpr is a Const with same value as that of ‘g’, it gets considered as a
match and we replace the node by NULL which later results in crash.

Essentially, since we traverse all the fields of CaseExpr, a Const
node(appearing anywhere in CaseExpr) with same value as that of Const grouping
col will be matched.

Hence the following query also fails where one of the arg of equality operator
is a Const with same value as that of ‘g’.

select  count(distinct c) as r
from ( select c  , case when (e = 1) then 2 end as f  , 1 as g from foo) f_view
group by rollup(f,g);

Fix:
If a grouping column is a Constant then `replace_grouping_columns_mutator()` confuses it with other constants appearing in target list expressions and qual_lists. In the fix, if the grouping col is a Constant then don't bother replacing it by NULL. 

Signed-off-by: Haisheng Yuan <hyuan@pivotal.io>