### PR TITLE
Removing redundant partitions during a join partition elimination

### DIFF
--- a/src/backend/utils/adt/gp_partition_functions.c
+++ b/src/backend/utils/adt/gp_partition_functions.c
@@ -140,6 +140,46 @@ InsertPidIntoDynamicTableScanInfo(int32 index, Oid partOid, int32 selectorId)
 }
 
 /*
+ * RemovePartSelectorForPartOid
+ * 		Un-endorse a partition oid for a given partition selector.
+ *
+ * 		Each partition selector endorses a partition oid that
+ * 		becomes chosen only if all available partition selectors
+ * 		vouch for that part oid for a given dynamic scan operator.
+ * 		This method removes the endorsement of one partition selector
+ * 		for a given partOid for a target partIndex.
+ */
+void
+RemovePartSelectorForPartOid(int32 index, Oid partOid, int32 selectorId)
+{
+	Assert(dynamicTableScanInfo != NULL &&
+		   dynamicTableScanInfo->memoryContext != NULL);
+
+	/* We should have inserted previously */
+	Assert(index <= dynamicTableScanInfo->numScans);
+	Assert(dynamicTableScanInfo->pidIndexes[index - 1] != NULL);
+
+	Assert(partOid != InvalidOid);
+	bool found = false;
+	PartOidEntry *hashEntry =
+		hash_search(dynamicTableScanInfo->pidIndexes[index - 1],
+					&partOid, HASH_FIND, &found);
+
+	Assert(found);
+	Assert(hashEntry->partOid == partOid);
+	Assert(NULL != hashEntry->selectorList);
+	hashEntry->selectorList = list_delete_int(hashEntry->selectorList, selectorId);
+
+	if (hashEntry->selectorList == NULL)
+	{
+		found = false;
+		hash_search(dynamicTableScanInfo->pidIndexes[index - 1],
+					&partOid, HASH_REMOVE, &found);
+		Assert(found);
+	}
+}
+
+/*
  * dumpDynamicTableScanPidIndex
  *   Write out pids for a given dynamic table scan.
  */

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -222,6 +222,7 @@ extern Oid getPhysicalIndexRelid(Relation partRel, LogicalIndexInfo *iInfo);
 extern LogicalIndexInfo *logicalIndexInfoForIndexOid(Oid rootOid, Oid indexOid);
 
 extern void InsertPidIntoDynamicTableScanInfo(int32 index, Oid partOid, int32 selectorId);
+extern void RemovePartSelectorForPartOid(int32 index, Oid partOid, int32 selectorId);
 
 extern char *
 DebugPartitionOid(Datum *elements, int n);

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2656,7 +2656,7 @@ struct PartitionSelectorState
 	List *levelExprStates;                              /* ExprState for general expressions for all levels */
 	ExprState *residualPredicateExprState;              /* ExprState for evaluating residual predicate */
 	ExprState *propagationExprState;                    /* ExprState for evaluating propagation expression */
-
+	struct SelectedParts *prevSelParts;						/* Selected parts during the last run */
 };
 
 extern void initGpmonPktForResult(Plan *planNode, gpmon_packet_t *gpmon_pkt, EState *estate);

--- a/src/test/regress/expected/qp_dpe.out
+++ b/src/test/regress/expected/qp_dpe.out
@@ -342,6 +342,67 @@ select * from (select count(*) over (order by a rows between 1 preceding and 1 f
 
 RESET ALL;
 -- ----------------------------------------------------------------------
+-- Test: DPE: Failure to remove unnecessary partitions
+-- ----------------------------------------------------------------------
+-- start_ignore
+create language plpythonu;
+ERROR:  language "plpythonu" already exists
+create or replace function part_count(explain_query text) returns float as
+$$
+import re
+rv = plpy.execute(explain_query)
+search_text = 'Partitions scanned'
+result = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    if search_text.lower() in cur_line.lower():
+        p = re.compile('.+ ([\d\.]+) \(out of (\d+)\)')
+        m = p.match(cur_line)
+        return m.group(1)
+return result
+$$
+language plpythonu;
+drop table if exists part;
+NOTICE:  table "part" does not exist, skipping
+create table part(a int, b int)
+  with (appendonly=true, orientation=row)
+  distributed by (b)
+  partition by range (a)
+  (
+      PARTITION pfirst  END(1) INCLUSIVE,
+      PARTITION pinter  START(1) EXCLUSIVE END (2) INCLUSIVE,
+      PARTITION plast   START (2) EXCLUSIVE
+  );
+NOTICE:  CREATE TABLE will create partition "part_1_prt_pfirst" for table "part"
+NOTICE:  CREATE TABLE will create partition "part_1_prt_pinter" for table "part"
+NOTICE:  CREATE TABLE will create partition "part_1_prt_plast" for table "part"
+--First partition
+insert into part values(1, 1);
+--Second partition
+insert into part values(2, 1);
+--Third partition
+insert into part values(3, 1);
+drop table if exists whole;
+NOTICE:  table "whole" does not exist, skipping
+-- Unpartitioned
+create table whole(a int, b int)
+  with (appendonly=true, orientation=row)
+  distributed by (b);
+insert into whole values(1, 1);
+insert into whole values(2, 1);
+insert into whole values(3, 1);
+set optimizer=on;
+set optimizer_enable_broadcast_nestloop_outer_child = on;
+set optimizer_enumerate_plans=true;
+set optimizer_plan_id=2;
+-- end_ignore
+select part_count('explain analyze select part.a, whole.a from part join whole on part.a >= whole.a;');
+ part_count 
+------------
+        1.5
+(1 row)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore


### PR DESCRIPTION
Prior to this PR PartitionSelector only appended list of partitions to scan in the existing list of partitions, without ever removing parts. For a join partition elimination (where partitions vary depending on the outer tuple's value) we kept scanning redundant partitions based on prior values of outer tuples. E.g., in a repro like this:

```
drop table if exists part;
create table part(a int, b int)
  with (appendonly=true, orientation=row)
  distributed by (b)
  partition by range (a)
  (
      PARTITION pfirst  END(1) INCLUSIVE,
      PARTITION pinter  START(1) EXCLUSIVE END (2) INCLUSIVE,
      PARTITION plast   START (2) EXCLUSIVE
  );

--First partition
insert into part values(1, 1);

--Second partition
insert into part values(2, 1);

--Third partition
insert into part values(3, 1);

drop table if exists whole;
-- Unpartitioned
create table whole(a int, b int)
  with (appendonly=true, orientation=row)
  distributed by (b);

insert into whole values(1, 1);
insert into whole values(2, 1);
insert into whole values(3, 1);


set optimizer=on;
set optimizer_enable_broadcast_nestloop_outer_child = on;
set optimizer_enumerate_plans=true;
set client_min_messages='log';
set optimizer_plan_id=2;
set optimizer_partition_selection_log=on;

select part.a, whole.a from part join whole on part.a >= whole.a;
```

The first outer tuple would be a="1" and therefore, the partition selector will scan all the partitions on the "part" table (everything on part table is greater or equal to 1 for column a). Successively, when a = 2 comes from the outer side, the partition selector would produce only two parts on the inner side. But, because it never removed any parts, the list of selected parts will still remain all three parts. For the final iteration of a=3 from outer side, only 1 part of the inner will qualify. Even for that the prior implementation will keep scanning all three parts.

The above repro produces a plan like:

```
frahman=# explain select part.a, whole.a from part join whole on part.a >= whole.a;
LOG:  statement: explain select part.a, whole.a from part join whole on part.a >= whole.a;
LOG:  2016-12-19 16:59:25:845975 PST,THD000,TRACE,"[OPT]: Number of plan alternatives: 7
",
2016-12-19 16:59:25:846292 PST,THD000,TRACE,"[OPT]: Successfully generated plan: 2
",
                                             QUERY PLAN
----------------------------------------------------------------------------------------------------
 Gather Motion 2:1  (slice2; segments: 2)  (cost=0.00..1324032.36 rows=1 width=8)
   ->  Nested Loop  (cost=0.00..1324032.36 rows=1 width=8)
         Join Filter: part.a >= whole.a
         ->  Partition Selector for part (dynamic scan id: 1)  (cost=10.00..100.00 rows=50 width=4)
               Filter: part.a >= part.a
               ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=4)
                     ->  Table Scan on whole  (cost=0.00..431.00 rows=1 width=4)
         ->  Dynamic Table Scan on part (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
 Settings:  optimizer=on
 Optimizer status: PQO version 1.695
(10 rows)
```

The resulting output from above repro looks like:

```
frahman=# select part.a, whole.a from part join whole on part.a >= whole.a;
LOG:  statement: select part.a, whole.a from part join whole on part.a >= whole.a;
LOG:  2016-12-19 15:17:03:500030 PST,THD000,TRACE,"[OPT]: Number of plan alternatives: 7
",
2016-12-19 15:17:03:500512 PST,THD000,TRACE,"[OPT]: Successfully generated plan: 2
",
LOG:  DPE matched partitions: {}  (seg0 slice2 127.0.0.1:25432 pid=24868)
LOG:  DPE matched partitions: {part_1_prt_plast, part_1_prt_pfirst, part_1_prt_pinter, }  (seg0 slice2 127.0.0.1:25432 pid=24868)
LOG:  DPE matched partitions: {part_1_prt_plast, part_1_prt_pfirst, part_1_prt_pinter, }  (seg0 slice2 127.0.0.1:25432 pid=24868)
LOG:  DPE matched partitions: {part_1_prt_plast, part_1_prt_pfirst, part_1_prt_pinter, }  (seg0 slice2 127.0.0.1:25432 pid=24868)
 a | a
---+---
 3 | 1
 1 | 1
 2 | 1
 3 | 2
 2 | 2
 3 | 3
(6 rows)
```

With the fix of this PR the output looks like:

```
frahman=# select part.a, whole.a from part join whole on part.a >= whole.a;
LOG:  statement: select part.a, whole.a from part join whole on part.a >= whole.a;
LOG:  2016-12-19 16:58:15:259185 PST,THD000,TRACE,"[OPT]: Number of plan alternatives: 7
",
2016-12-19 16:58:15:259521 PST,THD000,TRACE,"[OPT]: Successfully generated plan: 2
",
LOG:  DPE matched partitions: {}  (seg0 slice2 127.0.0.1:25432 pid=72939)
LOG:  DPE matched partitions: {part_1_prt_plast, part_1_prt_pfirst, part_1_prt_pinter, }  (seg0 slice2 127.0.0.1:25432 pid=72939)
LOG:  DPE matched partitions: {part_1_prt_plast, part_1_prt_pinter, }  (seg0 slice2 127.0.0.1:25432 pid=72939)
LOG:  DPE matched partitions: {part_1_prt_plast, }  (seg0 slice2 127.0.0.1:25432 pid=72939)
```

This PR undoes previous part selection by saving the previous run's selected parts. A simple context reset doesn't work as other partition selectors might be sharing the selection process. The PartitionSelector is designed to be a "voting" based mechanism where multiple partition selectors can feed into one scan operator's set of chosen parts using "votes". The DTS will eventually figure out if all partition selectors voted yes, and then it considers such parts as selected. The selected partitions are saved as PartOidEntry in a hash table which has selectorList that contains all the "voters" PartitionSelector. Therefore, just because one PartitionSelector decides not to chose, doesn't mean we can throw such an entry using simple memory context. Because of this complexity, this PR undoes the previous selector for each PartitionSelector.