### PR TITLE
gpcloud: gpcheckcloud: fix crash with invalid hostname

### DIFF
--- a/gpAux/extensions/gpcloud/include/s3exception.h
+++ b/gpAux/extensions/gpcloud/include/s3exception.h
@@ -44,6 +44,22 @@ class S3ConnectionError : public S3Exception {
     string message;
 };
 
+class S3ResolveError : public S3Exception {
+   public:
+    S3ResolveError(const string& msg) : message(msg) {
+    }
+    virtual ~S3ResolveError() {
+    }
+    virtual string getMessage() {
+        return "Server connection failed: " + message;
+    }
+    virtual string getType() {
+        return "S3ResolveError";
+    }
+
+    string message;
+};
+
 class S3FailedAfterRetry : public S3Exception {
    public:
     S3FailedAfterRetry(const string& url, uint64_t times, string msg)

--- a/gpAux/extensions/gpcloud/src/s3common_writer.cpp
+++ b/gpAux/extensions/gpcloud/src/s3common_writer.cpp
@@ -18,5 +18,7 @@ uint64_t S3CommonWriter::write(const char* buf, uint64_t count) {
 }
 
 void S3CommonWriter::close() {
-    this->upstreamWriter->close();
+    if (this->upstreamWriter != NULL) {
+        this->upstreamWriter->close();
+    }
 }

--- a/gpAux/extensions/gpcloud/src/s3restful_service.cpp
+++ b/gpAux/extensions/gpcloud/src/s3restful_service.cpp
@@ -112,9 +112,12 @@ Response S3RESTfulService::get(const string &url, HTTPHeaders &headers) {
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, RESTfulServiceWriteFuncCallback);
 
     CURLcode res = curl_easy_perform(curl);
-
     if (res != CURLE_OK) {
-        S3_DIE(S3ConnectionError, curl_easy_strerror(res));
+        if (res == CURLE_COULDNT_RESOLVE_HOST) {
+            S3_DIE(S3ResolveError, curl_easy_strerror(res));
+        } else {
+            S3_DIE(S3ConnectionError, curl_easy_strerror(res));
+        }
     } else {
         long responseCode;
         // Get the HTTP response status code from HTTP header
@@ -215,7 +218,11 @@ ResponseCode S3RESTfulService::head(const string &url, HTTPHeaders &headers) {
     CURLcode res = curl_easy_perform(curl);
 
     if (res != CURLE_OK) {
-        S3_DIE(S3ConnectionError, curl_easy_strerror(res));
+        if (res == CURLE_COULDNT_RESOLVE_HOST) {
+            S3_DIE(S3ResolveError, curl_easy_strerror(res));
+        } else {
+            S3_DIE(S3ConnectionError, curl_easy_strerror(res));
+        }
     } else {
         // Get the HTTP response status code from HTTP header
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);


### PR DESCRIPTION
Cause:
   When gpcheckcloud uploads file to S3, it will check if the file
is already existed first. If hostname is invalid, genUniqueKeyName
will fail before commonWriter.open. upstreamReader is not assigned
a value but destructor is called.

Fix:
   Add NULL check in S3CommonWriter::close.

Misc:
   Add S3ResolveError exception type to prevent retry.