### PR TITLE
Skip external tables in file pg_upgrade file mapping

### DIFF
--- a/contrib/pg_upgrade/info.c
+++ b/contrib/pg_upgrade/info.c
@@ -64,6 +64,10 @@ gen_db_file_maps(migratorContext *ctx, DbInfo *old_db, DbInfo *new_db,
 			pg_log(ctx, PG_FATAL, "Mismatch of relation id: database \"%s\", old relid %d, new relid %d\n",
 				   old_db->db_name, old_rel->reloid, new_rel->reloid);
 
+		/* external tables have relfilenodes but no physical files */
+		if (old_rel->relstorage == 'x')
+			continue;
+
 		/* aoseg tables are handled by their AO table */
 		if (strcmp(new_rel->nspname, "pg_aoseg") == 0)
 			continue;


### PR DESCRIPTION
In `gen_db_file_maps()` a mapping between the file in the old and new cluster is generated and this mapping is later uses for transferring the datafiles between the clusters. Since external tables (relstorage x) doesn't have a backing datafile even though there is a relfilenode, skip them when mapping.

This tackles one of the remaining TODO items left on the pg_upgrade code.

Ping @davecramer @hlinnaka 