### PR TITLE
Fix pg_locks test to not not use the transaction column.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/transaction_management/mpp20964/test_mpp20964.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/transaction_management/mpp20964/test_mpp20964.py
@@ -25,9 +25,10 @@ class test_mpp20964(MPPTestCase):
 
     def check_lock_corruption(self):
         """
-        Check if pg_locks has records with transaction = 0, which is corrupted.
+        Check if pg_locks has records with NULL pid or mppsessionid = 0.
+        These must be corrupted lock entries.
         """
-        sql = "SELECT count(*) FROM pg_locks WHERE transaction = 0"
+        sql = "SELECT count(*) FROM pg_locks WHERE pid IS NULL OR mppsessionid = 0"
         # Use -A and -t, suppress -a, to get only the number.
         psql = PSQL(sql_cmd=sql, flags='-A -t')
         psql.run()
@@ -37,7 +38,7 @@ class test_mpp20964(MPPTestCase):
 
     def test_mpp20964(self):
         """
-        
+
         @description Test MPP-20964, uncleaned lock table by pg_terminate_backend
         @created 2013-08-21 00:00:00
         @modified 2013-08-21 00:00:00
@@ -75,11 +76,11 @@ class test_mpp20964(MPPTestCase):
             FROM gp_dist_random('gp_id')
             WHERE gp_segment_id = 0
           )s
-          WHERE sess_id <> current_setting('gp_session_id')
+          WHERE sess_id <> current_setting('gp_session_id')::int
           UNION
           SELECT pg_terminate_backend(procpid)
           FROM pg_stat_activity
-          WHERE sess_id <> current_setting('gp_session_id')
+          WHERE sess_id <> current_setting('gp_session_id')::int
         """
         PSQL.run_sql_command(sql)
 


### PR DESCRIPTION
In going from PG 8.2 to 8.3, the pg_locks table does not have a `transaction`
column anymore.  Instead, it has a `virtualtransaction` column which is a
composite of the backend number plus some sequential number.

Since the test is trying to find orphan locks, a better test is to look for
locks with NULL owner `pid`s or 0 `mppsessionid`.

The type of `current_setting('gp_session_id')` is also changed from integer to
text.  Therefore, this is also casted to int.