### PR TITLE
Fix dispatch and interconnect defects when postmaster is not alive

### DIFF
--- a/src/backend/cdb/cdbfilerepprimary.c
+++ b/src/backend/cdb/cdbfilerepprimary.c
@@ -153,8 +153,8 @@ FileRepPrimary_GetAppendOnlyCommitWorkCount(void)
  * If (dataState == Change Logging) then mirroring is not required.
  * If (dataState == InSync or InResync) then mirroring is required
  * except when segmentState is in Fault.
- * In that case the request is on hold. It is waiting on third coordinator 
- * to decide about the next action (failover, stop, ...). 
+ * In that case the request is on hold. It is waiting on third coordinator
+ * to decide about the next action (failover, stop, ...).
  */
 static bool
 FileRepPrimary_IsMirroringRequired(

--- a/src/backend/cdb/cdbfilerepprimary.c
+++ b/src/backend/cdb/cdbfilerepprimary.c
@@ -268,6 +268,12 @@ FileRepPrimary_IsMirroringRequired(
 						/* database transitions to suspended state, IO activity on the segment is suspended */
 						primaryMirrorSetIOSuspended(TRUE);
 					}
+
+					if (!PostmasterIsAlive(true))
+					{
+						LWLockReleaseAll();
+						proc_exit(0);
+					}
 					pg_usleep(500000L); /* 500 ms */
 					continue;
 				}

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -72,6 +72,7 @@ typedef struct CdbDispatchCmdAsync
 
 }   CdbDispatchCmdAsync;
 
+static int	timeoutCounter = 0;
 
 static void *
 cdbdisp_makeDispatchParams_async(int maxSlices, char *queryText, int len);
@@ -118,6 +119,9 @@ signalQEs(CdbDispatchCmdAsync* pParms);
 
 static void
 checkSegmentAlive(CdbDispatchCmdAsync * pParms);
+
+static void
+handlePollError(CdbDispatchCmdAsync* pParms);
 
 static void
 handlePollSuccess(CdbDispatchCmdAsync* pParms, struct pollfd *fds);
@@ -344,7 +348,6 @@ checkDispatchResult(CdbDispatcherState *ds,
 	CdbDispatchResult *dispatchResult;
 	int	i;
 	int db_count = 0;
-	int	timeoutCounter = 0;
 	int timeout = 0;
 	bool sentSignal = false;
 	struct pollfd *fds;
@@ -436,30 +439,35 @@ checkDispatchResult(CdbDispatcherState *ds,
 
 			elog(LOG, "handlePollError poll() failed; errno=%d", sock_errno);
 
-			if (pParms->waitMode != DISPATCH_WAIT_NONE)
-			{
-				signalQEs(pParms);
-				sentSignal = true;
-			}
-			else
-				checkSegmentAlive(pParms);
-		}
-		/* If the time limit expires, poll() returns 0 */
-		else if (n == 0)
-		{
-			if (!wait)
-				break;
+			handlePollError(pParms);	
+			checkSegmentAlive(pParms);
 
 			if (pParms->waitMode != DISPATCH_WAIT_NONE)
 			{
 				signalQEs(pParms);
 				sentSignal = true;
+			}
+
+			if (!wait)
+				break;
+		}
+		/* If the time limit expires, poll() returns 0 */
+		else if (n == 0)
+		{
+			if (pParms->waitMode != DISPATCH_WAIT_NONE)
+			{
+				signalQEs(pParms);
+				sentSignal = true;
 			} 
-			else if (timeoutCounter++ > 30)
+
+			if (timeoutCounter++ > (wait ? 30 : 300))
 			{
 				checkSegmentAlive(pParms);
 				timeoutCounter = 0;
 			}
+
+			if (!wait)
+				break;
 		}
 		/* We have data waiting on one or more of the connections. */
 		else
@@ -514,6 +522,50 @@ dispatchCommand(CdbDispatchResult * dispatchResult,
 	dispatchResult->hasDispatched = true;
 
 	ELOG_DISPATCHER_DEBUG("Command dispatched to QE (%s)", dispatchResult->segdbDesc->whoami);
+}
+
+/* 
+ * Helper function to checkDispatchResult that handles errors that occur
+ * during the poll() call.
+ *
+ * NOTE: The cleanup of the connections will be performed by handlePollTimeout().
+ */
+static void
+handlePollError(CdbDispatchCmdAsync* pParms)
+{
+	int i;
+
+	for (i = 0; i < pParms->dispatchCount; i++)
+	{
+		CdbDispatchResult *dispatchResult = pParms->dispatchResultPtrArray[i];
+		SegmentDatabaseDescriptor *segdbDesc = dispatchResult->segdbDesc;
+
+		/* Skip if already finished or didn't dispatch. */
+		if (!dispatchResult->stillRunning)
+			continue;
+
+		/* We're done with this QE, sadly. */
+		if (PQstatus(segdbDesc->conn) == CONNECTION_BAD)
+		{
+			char *msg = PQerrorMessage(segdbDesc->conn);
+			if (msg)
+				elog(LOG, "Dispatcher encountered connection error on %s: %s", segdbDesc->whoami, msg);
+
+			elog(LOG, "Dispatcher noticed bad connection in handlePollError()");
+
+			/* Save error info for later. */
+			cdbdisp_appendMessageNonThread(dispatchResult, LOG,
+								  "Error after dispatch from %s: %s",
+								  segdbDesc->whoami,
+								  msg ? msg : "unknown error");
+
+			PQfinish(segdbDesc->conn);
+			segdbDesc->conn = NULL;
+			dispatchResult->stillRunning = false;
+		}
+	}
+
+	return;
 }
 
 /*
@@ -678,6 +730,12 @@ checkSegmentAlive(CdbDispatchCmdAsync * pParms)
 								  "FTS detected connection lost during dispatch to %s: %s",
 								  dispatchResult->segdbDesc->whoami, msg ? msg : "unknown error");
 
+			/*
+			 * Not a good idea to store into the PGconn object.
+			 * Instead, just close it. 
+			 */
+			PQfinish(segdbDesc->conn);
+			segdbDesc->conn = NULL;	
 		}
 
 		forceScan = false;

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -180,9 +180,6 @@ AllocateReaderGang(GangType type, char *portal_name)
 	/* let the gang know which portal it is being assigned to */
 	gp->portal_name = (portal_name ? pstrdup(portal_name) : (char *) NULL);
 
-	/* sanity check the gang */
-	insist_log(GangOK(gp), "could not connect to segment: initialization of segworker group failed");
-
 	addGangToAllocated(gp);
 
 	MemoryContextSwitchTo(oldContext);
@@ -219,7 +216,24 @@ AllocateWriterGang()
 	 * if it exists, we return it.
 	 * Else, we create a new gang
 	 */
-	if (primaryWriterGang == NULL)
+	if (primaryWriterGang != NULL)
+	{
+		if (!GangOK(primaryWriterGang))
+		{
+			elog(LOG, "WARN: existing primary writer gang is invalid, will create a new gang");
+			DisconnectAndDestroyAllGangs(true);
+			CheckForResetSession();
+			primaryWriterGang = NULL;
+			writerGang = NULL;
+		}
+		else
+		{
+			ELOG_DISPATCHER_DEBUG("Reusing an existing primary writer gang");
+			writerGang = primaryWriterGang;
+		}
+	}
+
+	if (writerGang == NULL)
 	{
 		int nsegdb = getgpsegmentCount();
 
@@ -250,16 +264,7 @@ AllocateWriterGang()
 
 		MemoryContextSwitchTo(oldContext);
 	}
-	else
-	{
-		ELOG_DISPATCHER_DEBUG("Reusing an existing primary writer gang");
-		writerGang = primaryWriterGang;
-	}
-
-	/* sanity check the gang */
-	if (!GangOK(writerGang))
-		elog(ERROR, "could not connect to segment: initialization of segworker group failed");
-
+	
 	ELOG_DISPATCHER_DEBUG("AllocateWriterGang end.");
 
 	primaryWriterGang = writerGang;
@@ -849,6 +854,14 @@ static Gang *getAvailableGang(GangType type, int size, int content)
 		Assert(false);
 	}
 
+	/* sanity check */
+	if (retGang && !GangOK(retGang))
+	{
+		/* connection is bad or segment is down */
+		DisconnectAndDestroyGang(retGang);	
+		retGang = NULL;
+	}
+		
 	return retGang;
 }
 
@@ -1193,6 +1206,10 @@ static bool cleanupGang(Gang *gp)
 		Assert(segdbDesc != NULL);
 
 		if (cdbconn_isBadConnection(segdbDesc))
+			return false;
+
+		/* if segment is down, the gang can not be reused */
+		if (!FtsTestConnection(segdbDesc->segment_database_info, false))
 			return false;
 
 		/* Note, we cancel all "still running" queries */
@@ -1678,6 +1695,8 @@ bool GangOK(Gang *gp)
 		SegmentDatabaseDescriptor *segdbDesc = &(gp->db_descriptors[i]);
 
 		if (cdbconn_isBadConnection(segdbDesc))
+			return false;
+		if (!FtsTestConnection(segdbDesc->segment_database_info, false))
 			return false;
 	}
 

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -259,13 +259,6 @@ create_gang_retry:
 		{
 			Assert(successful_connections + in_recovery_mode_count == size);
 
-			/* FTS shows some segment DBs are down */
-			if (isFTSEnabled() &&
-				FtsTestSegmentDBIsDown(newGangDefinition->db_descriptors, size))
-				ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-								errmsg("failed to acquire resources on one or more segments"),
-								errdetail("FTS detected one or more segments are down")));
-
 			if ( gp_gang_creation_retry_count <= 0 ||
 				create_gang_retry_counter++ >= gp_gang_creation_retry_count ||
 				type != GANGTYPE_PRIMARY_WRITER)
@@ -283,6 +276,22 @@ create_gang_retry:
 	PG_CATCH();
 	{
 		MemoryContextSwitchTo(GangContext);
+
+		/* FTS shows some segment DBs are down */
+		if (isFTSEnabled() &&
+			FtsTestSegmentDBIsDown(newGangDefinition->db_descriptors, size))
+		{
+
+			DisconnectAndDestroyGang(newGangDefinition);
+			newGangDefinition = NULL;
+			DisconnectAndDestroyAllGangs(true);
+			CheckForResetSession();
+			ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+							errmsg("failed to acquire resources on one or more segments"),
+							errdetail("FTS detected one or more segments are down")));
+
+		}
+
 		DisconnectAndDestroyGang(newGangDefinition);
 		newGangDefinition = NULL;
 

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -112,9 +112,6 @@ void mockLibpq(PGconn *pgConn, int motionListener, int qePid)
 	expect_value_count(PQstatus, conn, pgConn, -1);
 	will_return_count(PQstatus, CONNECTION_OK, -1);
 
-	expect_value_count(PQsocket, conn, pgConn, -1);
-	will_return_count(PQsocket, 100, -1);
-
 	expect_value_count(PQsetNoticeReceiver, conn, pgConn, -1);
 	expect_any_count(PQsetNoticeReceiver, proc, -1);
 	expect_any_count(PQsetNoticeReceiver, arg, -1);


### PR DESCRIPTION
Although postmaster of one segment is killed, QEs of it are still available and for some defects, query may get hung. Improvements in this commit include:
1. Interconnect motion receiver and sender check segments status if no data available for long time
to avoid query hang issue.
2. Add segments status checking into gang sanity test.
3. Do not reuse Gangs whose postmaster is not alive, just destroy it.
4. Check segments status when creating gang failed.

repo step:
1. create table demo (c1 int);
2. create table demo1 (c1 int);
3. insert into demo select * from generate_series(1, 10000000);
4. insert into demo1 select c1+1 from demo;
5. kill -9  postmaster of one segment // query will get hung
