### PR TITLE
Fix diff in LegacyRETTestCase.test_query03 test case.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/read/sql/query03.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/read/sql/query03.ans
@@ -656,12 +656,14 @@ location ('file://@hostname@@abs_srcdir@/data/no/such/place/badt1.tbl' )
 format 'text' (delimiter '|');
 CREATE EXTERNAL TABLE
 select * from badt1;
+NOTICE:  gfile stat @abs_srcdir@/data/no/such/place/badt1.tbl failure: No such file or directory  (seg0 slice1 @hostname@:25432 pid=9328)
+NOTICE:  fstream unable to open file @abs_srcdir@/data/no/such/place/badt1.tbl  (seg0 slice1 @hostname@:25432 pid=9328)
 ERROR:  could not open "file://@hostname@@abs_srcdir@/data/no/such/place/badt1.tbl" for reading: 404 file not found  (seg0 slice1 @hostname@:21000 pid=11611)
 drop external table badt1;
 DROP EXTERNAL TABLE
 -- start_ignore
 drop external table if exists badt2;
-NOTICE:  external table "badt2" does not exist, skipping
+NOTICE:  table "badt2" does not exist, skipping
 DROP EXTERNAL TABLE
 -- end_ignore
 create external table badt2 (x text) 
@@ -673,7 +675,7 @@ location ('gpfdist://@hostname@:99/missing.csv')
 format 'csv';
 CREATE EXTERNAL TABLE
 select count(*) from ext_missing;
-ERROR:  connection failed while gpfdist://@hostname@:@gp_port@/whois.csv (url.i:175)  (seg1 slice1 @hostname@:12003 pid=56223)
+ ERROR:  connection with gpfdist failed for gpfdist://@hostname@:99/missing.csv. effective url: http://127.0.0.1:99/missing.csv. error code = 61 (Connection refused)  (seg0 slice1 @hostname@:25432 pid=18974)
 drop external table ext_missing;
 DROP EXTERNAL TABLE
 -- start_ignore


### PR DESCRIPTION
This commit resolves the dif in LegacyRETTestCase.test_query03 test called from
storage/basic/exttab/read/test_read.py.

The dif is due to NOTICE text changes in 5.0. Therefore, I am udpating the
answer file with the 5.0 output.