### PR TITLE
Remove fail-fast check for pid file.

### DIFF
--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -642,26 +642,6 @@ test_postmaster_connection(bool do_checkpoint __attribute__((unused)))
 #endif
 			print_msg(".");
 
-
-		/*
-		 * our connection attempt failed.
-		 * after two attempts check if the postmaster is still alive before sleeping.
-		 */
-		if (i > 1)
-		{
-			pgpid_t pid = get_pgpid();
-			if (pid == 0)				/* no pid file */
-			{
-				write_stderr(_("%s: PID file \"%s\" does not exist\n"), progname, pid_file);
-				return PQPING_NO_RESPONSE;
-			}
-			if (!postmaster_is_alive((pid_t) pid))
-			{
-				write_stderr(_("%s: postmaster pid %ld not running\n"), progname, pid);
-				return PQPING_NO_RESPONSE;
-			}
-		}
-
 		pg_usleep(1000000); /* 1 sec */
 	}
 


### PR DESCRIPTION
-- previously, within a 60-second loop to test if a pqPing was
successful, there was a 2-second fail-fast test to make sure that
the postmaster.pid file was written to disk.

-- However, in extreme loading conditions, the underlying OS may be too
busy to accomplish that within 2 seconds. Removing the fail-fast means
that in that extreme loading case, pg_ctl will still be able to start,
assuming that the OS can write a file within 60 seconds.

-- This does mean that in cases where the pidfile cannot be written at
all (for instance, if the disk is full) the failure will take the full
60 seconds to be reported.