### PR TITLE
Fix get_ao_compression_ratio related issues

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -2036,8 +2036,17 @@ aorow_compression_ratio_internal(Relation parentrel)
 			 * tables upgraded from GPDB 3.3 the eofuncompressed column could
 			 * contain NULL, this is fixed in more recent upgrades.
 			 */
-			if (scanint8(SPI_getvalue(tuple, tupdesc, 1), true, &eof) &&
-				scanint8(SPI_getvalue(tuple, tupdesc, 2), true, &eof_uncomp))
+			char *attr1 = SPI_getvalue(tuple, tupdesc, 1);
+			char *attr2 = SPI_getvalue(tuple, tupdesc, 2);
+
+			if (NULL == attr1 || NULL == attr2)
+			{
+				SPI_finish();
+				PG_RETURN_FLOAT8(1);
+			}
+
+			if (scanint8(attr1, true, &eof) &&
+				scanint8(attr2, true, &eof_uncomp))
 			{
 				/* guard against division by zero */
 				if (eof > 0)

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301612161
+#define CATALOG_VERSION_NO	301612211
 
 #endif

--- a/src/include/catalog/pg_proc_gp.h
+++ b/src/include/catalog/pg_proc_gp.h
@@ -2454,11 +2454,11 @@ DATA(insert OID = 7170 ( get_ao_distribution  PGNSP PGUID 12 1 1000 0 f f f t v 
 DESCR("show append only table tuple distribution across segment databases");
 
 /* get_ao_compression_ratio(oid) => float8 */ 
-DATA(insert OID = 7171 ( get_ao_compression_ratio  PGNSP PGUID 12 1 0 0 f f f f v 1 0 701 f "26" _null_ _null_ _null_ _null_ get_ao_compression_ratio_oid _null_ _null_ _null_ r ));
+DATA(insert OID = 7171 ( get_ao_compression_ratio  PGNSP PGUID 12 1 0 0 f f t f v 1 0 701 f "26" _null_ _null_ _null_ _null_ get_ao_compression_ratio_oid _null_ _null_ _null_ r ));
 DESCR("show append only table compression ratio");
 
 /* get_ao_compression_ratio(text) => float8 */ 
-DATA(insert OID = 7172 ( get_ao_compression_ratio  PGNSP PGUID 12 1 0 0 f f f f v 1 0 701 f "25" _null_ _null_ _null_ _null_ get_ao_compression_ratio_name _null_ _null_ _null_ r ));
+DATA(insert OID = 7172 ( get_ao_compression_ratio  PGNSP PGUID 12 1 0 0 f f t f v 1 0 701 f "25" _null_ _null_ _null_ _null_ get_ao_compression_ratio_name _null_ _null_ _null_ r ));
 DESCR("show append only table compression ratio");
 
 /* gp_update_ao_master_stats(oid) => int8 */ 


### PR DESCRIPTION
As I mentioned in issue https://github.com/greenplum-db/gpdb/issues/1467, GPDB crashes if we execute:
* `Select get_ao_compression_ratio_name(null)`, or
* `Select get_ao_compression_ratio_name(foo)`, where table `foo` contains no tuples.

This PR fixes the above issues. 