### PR TITLE
Add checkpoint flag to convey RESYNC_TO_SYNC transition.

### DIFF
--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -208,6 +208,12 @@ extern bool XLOG_DEBUG;
 /* These indicate the cause of a checkpoint request */
 #define CHECKPOINT_CAUSE_XLOG	0x0010	/* XLOG consumption */
 #define CHECKPOINT_CAUSE_TIME	0x0020	/* Elapsed time */
+/*
+ * This falls in two categories, affects behavior of CreateCheckPoint and also
+ * indicates request is coming from ResyncManager process to switch primary
+ * segment from resync mode to sync mode.
+ */
+#define CHECKPOINT_RESYNC_TO_INSYNC_TRANSITION 0x0040
 
 /* Checkpoint statistics */
 typedef struct CheckpointStatsData

--- a/src/include/cdb/cdbfilerepresyncmanager.h
+++ b/src/include/cdb/cdbfilerepresyncmanager.h
@@ -85,8 +85,6 @@ extern int FileRepResync_DecAppendOnlyCommitCount(int	count);
 
 extern int FileRepResync_GetAppendOnlyCommitCount(void);
 
-extern bool FileRepResync_IsTransitionFromResyncToInSync(void);
-
 extern bool FileRepResync_IsReMirrorAllowed(void);
 
 extern void FileRepResync_SetReMirrorAllowed(void);

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_a/post_sql/expected/insert_heap_unique_index_template_a0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_a/post_sql/expected/insert_heap_unique_index_template_a0.ans
@@ -17,7 +17,7 @@
  date_column         | date                        | 
 Indexes:
     "pg2_heap_unq_idx1_a0" UNIQUE, btree (text_col)
-Distributed by: (numeric_col)
+Distributed by: (text_col)
 
 insert into pg2_heap_table_unique_index_a0 values ('0_a0', 0, '0_a0', 0, 0, 0, '{0}', 0, 0, 0, '2004-10-19 10:23:54', '2004-10-19 10:23:54+02', '1-1-2000');
 INSERT 0 1

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_b/post_sql/expected/insert_heap_unique_index_template_b0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_b/post_sql/expected/insert_heap_unique_index_template_b0.ans
@@ -17,7 +17,7 @@
  date_column         | date                        | 
 Indexes:
     "pg2_heap_unq_idx1_b0" UNIQUE, btree (text_col)
-Distributed by: (numeric_col)
+Distributed by: (text_col)
 
 insert into pg2_heap_table_unique_index_b0 values ('0_b0', 0, '0_b0', 0, 0, 0, '{0}', 0, 0, 0, '2004-10-19 10:23:54', '2004-10-19 10:23:54+02', '1-1-2000');
 INSERT 0 1

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_c/post_sql/expected/insert_heap_unique_index_template_c0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_c/post_sql/expected/insert_heap_unique_index_template_c0.ans
@@ -17,7 +17,7 @@
  date_column         | date                        | 
 Indexes:
     "pg2_heap_unq_idx1_c0" UNIQUE, btree (text_col)
-Distributed by: (numeric_col)
+Distributed by: (text_col)
 
 insert into pg2_heap_table_unique_index_c0 values ('0_c0', 0, '0_c0', 0, 0, 0, '{0}', 0, 0, 0, '2004-10-19 10:23:54', '2004-10-19 10:23:54+02', '1-1-2000');
 INSERT 0 1

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_serial/post_sql/expected/insert_heap_unique_index_template.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/switch_ckpt_serial/post_sql/expected/insert_heap_unique_index_template.ans
@@ -17,7 +17,7 @@
  date_column         | date                        | 
 Indexes:
     "pg2_heap_unq_idx1_template" UNIQUE, btree (text_col)
-Distributed by: (numeric_col)
+Distributed by: (text_col)
 
 insert into pg2_heap_table_unique_index_template values ('0_template', 0, '0_template', 0, 0, 0, '{0}', 0, 0, 0, '2004-10-19 10:23:54', '2004-10-19 10:23:54+02', '1-1-2000');
 INSERT 0 1


### PR DESCRIPTION
With commit 324653d, we stopped performing checkpoint within filerep backend
process like Resyncmanager process. Instead started using RequestCheckpoint
mechanism to get the job done by checkpoint process. Since CreateCheckpoint code
is also handling the resync_to_sync transition processing due to locking
constraints, need to modify the mechanism to convey the same to checkpoint
process. Hence adding flag so that ResyncManager process can convey to
checkpoint process to perform the transition actions. Without the change primary
segment would encounter fault and transition back to changetracking from resync
instead of moving to sync state.