### PR TITLE
Wrong assumption in IsCorrelatedOpExpr()

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -281,7 +281,14 @@ IsCorrelatedOpExpr(OpExpr *opexp, Expr **innerExpr)
 
 	/**
 	 * One of the vars must be outer, and other must be inner.
+	 *
+	 * If both sides of the condition referring to outer variable,
+	 * then fail to extract the innerExpr.
 	 */
+	if (contain_vars_of_level((Node *) e1, 1) && contain_vars_of_level((Node *) e2, 1))
+	{
+		return false;
+	}
 
 	Expr	   *tOuterExpr = NULL;
 	Expr	   *tInnerExpr = NULL;

--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -308,7 +308,7 @@ IsCorrelatedOpExpr(OpExpr *opexp, Expr **innerExpr)
 	 * It is correlated only if we found an outer var and inner expr
 	 */
 
-	if (tOuterExpr)
+	if (tOuterExpr && contain_vars_of_level((Node *) tInnerExpr, 0))
 	{
 		*innerExpr = tInnerExpr;
 		return true;

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1304,3 +1304,54 @@ select * from nested_in_tbl t1  where tc1 in
 (0 rows)
 
 drop table nested_in_tbl;
+--
+-- In some cases of a NOT EXISTS subquery, planner mistook one side of the
+-- predicate as a (derived or direct) attribute on the inner relation, and
+-- incorrectly decorrelated the subquery into a JOIN
+-- start_ignore
+drop table if exists foo;
+NOTICE:  table "foo" does not exist, skipping
+drop table if exists bar;
+NOTICE:  table "bar" does not exist, skipping
+create table foo(a, b) as (values (1, 'a'), (2, 'b'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar(c, d) as (values (1, 'a'), (2, 'b'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- end_ignore
+select * from foo where not exists (select * from bar where foo.a + bar.c = 1);
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+select * from foo where not exists (select * from bar where foo.b || bar.d = 'hola');
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+select * from foo where not exists (select * from bar where foo.a = foo.a + 1);
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+select * from foo where not exists (select * from bar where foo.b = foo.b || 'a');
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+select * from foo where foo.a = (select min(bar.c) from bar where foo.b || bar.d = 'bb');
+ a | b 
+---+---
+ 2 | b
+(1 row)
+
+drop table foo, bar;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1288,3 +1288,54 @@ select * from nested_in_tbl t1  where tc1 in
 (0 rows)
 
 drop table nested_in_tbl;
+--
+-- In some cases of a NOT EXISTS subquery, planner mistook one side of the
+-- predicate as a (derived or direct) attribute on the inner relation, and
+-- incorrectly decorrelated the subquery into a JOIN
+-- start_ignore
+drop table if exists foo;
+NOTICE:  table "foo" does not exist, skipping
+drop table if exists bar;
+NOTICE:  table "bar" does not exist, skipping
+create table foo(a, b) as (values (1, 'a'), (2, 'b'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table bar(c, d) as (values (1, 'a'), (2, 'b'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- end_ignore
+select * from foo where not exists (select * from bar where foo.a + bar.c = 1);
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+select * from foo where not exists (select * from bar where foo.b || bar.d = 'hola');
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+select * from foo where not exists (select * from bar where foo.a = foo.a + 1);
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+select * from foo where not exists (select * from bar where foo.b = foo.b || 'a');
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+select * from foo where foo.a = (select min(bar.c) from bar where foo.b || bar.d = 'bb');
+ a | b 
+---+---
+ 2 | b
+(1 row)
+
+drop table foo, bar;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -587,3 +587,25 @@ select * from nested_in_tbl t1  where tc1 in
   (select 1 from nested_in_tbl t2 where tc1 in
     (select 1 from nested_in_tbl t3 where t3.tc2 = t2.tc2));
 drop table nested_in_tbl;
+
+--
+-- In some cases of a NOT EXISTS subquery, planner mistook one side of the
+-- predicate as a (derived or direct) attribute on the inner relation, and
+-- incorrectly decorrelated the subquery into a JOIN
+
+-- start_ignore
+drop table if exists foo;
+drop table if exists bar;
+create table foo(a, b) as (values (1, 'a'), (2, 'b'));
+create table bar(c, d) as (values (1, 'a'), (2, 'b'));
+-- end_ignore
+
+select * from foo where not exists (select * from bar where foo.a + bar.c = 1);
+select * from foo where not exists (select * from bar where foo.b || bar.d = 'hola');
+
+select * from foo where not exists (select * from bar where foo.a = foo.a + 1);
+select * from foo where not exists (select * from bar where foo.b = foo.b || 'a');
+
+select * from foo where foo.a = (select min(bar.c) from bar where foo.b || bar.d = 'bb');
+
+drop table foo, bar;


### PR DESCRIPTION
# Repro

Considering following repro with correlated subquery:

```
-- foo.c is a text
select * from foo where not exists (select * from bar where foo.c = foo.c || 'a');
```

This query will crash because referring param across slices. Here is the plan:

```
xzhang=#  explain select * from foo where not exists (select * from bar where foo.c = foo.c || 'a');
                                             QUERY PLAN
-----------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice3; segments: 3)  (cost=1.06..2.13 rows=4 width=3)
   ->  Hash Left Anti Semi Join  (cost=1.06..2.13 rows=2 width=3)
         Hash Cond: foo.c::text = "Expr_SUBQUERY".csq_c0
         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=3)
               Hash Key: foo.c::text
               ->  Seq Scan on foo  (cost=0.00..1.01 rows=1 width=3)
         ->  Hash  (cost=1.05..1.05 rows=1 width=32)
               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.01..1.05 rows=1 width=32)
                     Hash Key: "Expr_SUBQUERY".csq_c0
                     ->  Result  (cost=0.01..1.02 rows=1 width=0)
                           One-Time Filter: ($0::text || 'a'::text) IS NOT NULL
                           ->  Seq Scan on bar  (cost=0.01..1.01 rows=1 width=0)
 Optimizer status: legacy query optimizer
(13 rows)
```

# Root Cause

IsCorrelatedOpExpr() is checking an opexpr in format of:

```
foo(outer.var) OP bar(inner.var)
```

Then, extract the bar(inner.var) as innerExpr.

It assumes one side of the operator must be an inner
variable, and one side of the operator must be an outer variable.

However, there are cases where both of `opexp->args` are referring
to outer variables. Then, it mistakenly pick one side as inner variable.

# Fix

Add a check to fail to extract `innerExpr` if both sides of opexr are outer variables
and return false.

Then, the subquery cannot be decorrelated, and hence remain as subplan. The correct query
plan is:

```
gpadmin=# explain select * from foo where not exists (select * from bar where foo.c = foo.c || 'a');
                                                      QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1474.89 rows=26400 width=32)
   ->  Seq Scan on foo  (cost=0.00..1474.89 rows=8800 width=32)
         Filter: NOT ((subplan))
         SubPlan 1
           ->  Result  (cost=0.01..1062.01 rows=32067 width=4)
                 One-Time Filter: $0 = ($0 || 'a'::text)
                 ->  Result  (cost=1158.21..2120.20 rows=32067 width=4)
                       ->  Materialize  (cost=1158.21..2120.20 rows=32067 width=4)
                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.01..1062.01 rows=32067 width=4)
                                   ->  Seq Scan on bar  (cost=0.01..1062.01 rows=32067 width=4)
 Optimizer status: legacy query optimizer
(11 rows)
```

[#135636211]

Signed-off-by: HaiSheng Yuan <hyuan@pivotal.io>