### PR TITLE
A few small external tables tweaks to aid user friendliness

### DIFF
--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -470,28 +470,6 @@ transformLocationUris(List *locs, bool isweb, bool iswritable)
 	astate = NULL;
 
 	/*
-	 * first, check for duplicate URI entries
-	 */
-	foreach(cell, locs)
-	{
-		Value	   *v1 = lfirst(cell);
-		const char *uri1 = v1->val.str;
-		ListCell   *rest;
-
-		for_each_cell(rest, lnext(cell))
-		{
-			Value	   *v2 = lfirst(rest);
-			const char *uri2 = v2->val.str;
-
-			if (strcmp(uri1, uri2) == 0)
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
-						 errmsg("location uri \"%s\" appears more than once",
-								uri1)));
-		}
-	}
-
-	/*
 	 * iterate through the user supplied URI list from LOCATION clause.
 	 */
 	foreach(cell, locs)

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -8949,7 +8949,15 @@ DeallocateStmt: DEALLOCATE name
 
 cdb_string_list:
 			cdb_string							{ $$ = list_make1($1); }  
-			| cdb_string_list ',' cdb_string	{ $$ = lappend($1, $3); }
+			| cdb_string_list ',' cdb_string
+				{
+					if (list_member($1, $3))
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+								 errmsg("duplicate location uri"),
+								 scanner_errposition(@3)));
+					$$ = lappend($1, $3);
+				}
 		;
 
 

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -443,7 +443,6 @@ create readable external table ret_region(like wet_region) location('gpfdist://@
 
 -- negative
 create writable external table wet_neg1(a text, b text) location('file://@hostname@@abs_srcdir@/badt1.tbl') format 'text';
-create writable external table wet_neg1(a text, b text) location('gpfdist://@hostname@:7070/wet.out', 'gpfdist://@hostname@:7070/wet.out') format 'text';
 create writable external web table wet_pos5(a text, b text) execute 'some command' on segment 0 format 'text';
 
 --

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -705,8 +705,6 @@ create readable external table ret_region(like wet_region) location('gpfdist://@
 create writable external table wet_neg1(a text, b text) location('file://@hostname@@abs_srcdir@/badt1.tbl') format 'text';
 ERROR:  unsupported URI protocol 'file' for writable external table
 HINT:  Writable external tables may use 'gpfdist', 'gpfdists' or 'gphdfs' URIs only.
-create writable external table wet_neg1(a text, b text) location('gpfdist://@hostname@:7070/wet.out', 'gpfdist://@hostname@:7070/wet.out') format 'text';
-ERROR:  location uri "gpfdist://@hostname@:7070/wet.out" appears more than once
 create writable external web table wet_pos5(a text, b text) execute 'some command' on segment 0 format 'text';
 ERROR:  ON clause may not be used with a writable external table
 --

--- a/src/bin/gpfdist/regress/output/exttab1_optimizer.source
+++ b/src/bin/gpfdist/regress/output/exttab1_optimizer.source
@@ -705,8 +705,6 @@ create readable external table ret_region(like wet_region) location('gpfdist://@
 create writable external table wet_neg1(a text, b text) location('file://@hostname@@abs_srcdir@/badt1.tbl') format 'text';
 ERROR:  unsupported URI protocol 'file' for writable external table
 HINT:  Writable external tables may use 'gpfdist', 'gpfdists' or 'gphdfs' URIs only.
-create writable external table wet_neg1(a text, b text) location('gpfdist://@hostname@:7070/wet.out', 'gpfdist://@hostname@:7070/wet.out') format 'text';
-ERROR:  location uri "gpfdist://@hostname@:7070/wet.out" appears more than once
 create writable external web table wet_pos5(a text, b text) execute 'some command' on segment 0 format 'text';
 ERROR:  ON clause may not be used with a writable external table
 --

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -184,7 +184,7 @@ create writable external web table wet_pos4(a text, b text) execute 'some comman
 
 -- negative
 create writable external table wet_neg1(a text, b text) location('file://@hostname@@abs_srcdir@/badt1.tbl') format 'text';
-create writable external table wet_neg1(a text, b text) location('gpfdist://@hostname@:7070/wet.out', 'gpfdist://@hostname@:7070/wet.out') format 'text';
+create writable external table wet_neg1(a text, b text) location('gpfdist://foo:7070/wet.out', 'gpfdist://foo:7070/wet.out') format 'text';
 create writable external web table wet_pos5(a text, b text) execute 'some command' on segment 0 format 'text';
 --
 -- test CREATE EXTERNAL TABLE privileges

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -269,8 +269,10 @@ create writable external web table wet_pos4(a text, b text) execute 'some comman
 create writable external table wet_neg1(a text, b text) location('file://@hostname@@abs_srcdir@/badt1.tbl') format 'text';
 ERROR:  unsupported URI protocol 'file' for writable external table
 HINT:  Writable external tables may use 'gpfdist', 'gpfdists' or 'gphdfs' URIs only.
-create writable external table wet_neg1(a text, b text) location('gpfdist://@hostname@:7070/wet.out', 'gpfdist://@hostname@:7070/wet.out') format 'text';
-ERROR:  location uri "gpfdist://@hostname@:7070/wet.out" appears more than once
+create writable external table wet_neg1(a text, b text) location('gpfdist://foo:7070/wet.out', 'gpfdist://foo:7070/wet.out') format 'text';
+ERROR:  duplicate location uri
+LINE 1: ...t, b text) location('gpfdist://foo:7070/wet.out', 'gpfdist:/...
+                                                             ^
 create writable external web table wet_pos5(a text, b text) execute 'some command' on segment 0 format 'text';
 ERROR:  ON clause may not be used with a writable external table
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional_multiple_gpfdist.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/functional_multiple_gpfdist.ans
@@ -3,8 +3,10 @@ CREATE TABLE
 insert into test values (generate_series(1,5),'test_1');
 INSERT 0 5
 -- Negative Test of using 2 identical gpfdist URLS. Should Fail
-CREATE WRITABLE EXTERNAL TABLE tbl_wet_2gpfdist_identical ( a int, b text) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_2gpfdist.tbl', 'gpfdist://@hostname@:@gp_port@/output/wet_2gpfdist.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null'  ) ;
-psql:/path/sql_file:1: ERROR:  location uri "gpfdist://@hostname@:@gp_port@/output/wet_2gpfdist.tbl" appears more than once
+CREATE WRITABLE EXTERNAL TABLE tbl_wet_2gpfdist_identical ( a int, b text) LOCATION ('gpfdist://hostname:123/output/wet_2gpfdist.tbl', 'gpfdist://hostname:123/output/wet_2gpfdist.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
+psql:/path/sql_file:1: ERROR:  duplicate location uri
+LINE 1: ... ('gpfdist://hostname:123/output/wet_2gpfdist.tbl', 'gpfdist...
+                                                               ^
 -- Negative Test of using more gpfdist URLS than valid primary segments. Should Fail
 CREATE WRITABLE EXTERNAL TABLE tbl_wet_multiple_gpfdist ( a int, b text) LOCATION ('gpfdist://@hostname@:@gp_port@/output/wet_2gpfdist1.tbl', 'gpfdist://@hostname@:@gp_port@/output/wet_2gpfdist2.tbl','gpfdist://@hostname@:@gp_port@/output/wet_2gpfdist3.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null'  ) ;
 CREATE EXTERNAL TABLE


### PR DESCRIPTION
A few small patches I had lying around after reading the external tables code. There are no changes to functionality, just trying to help the user a bit.

**Move duplicate handling of LOCATION to the parsing stage:** Creating an external table with duplicate location URIs is a syntax error so move the duplicate check to the parsing step. Simplifies the external table command code as well as provides an error message with context marker to the user.

**Issue a WARNING for external tables with too many URIs:** External tables with protocols file or http which specify more URIs than segments won't be allowed to query until the cluster has been extended. Rather than silently allow creation, issue a warning and
hint to the user to assist troubleshooting. Writable tables error out for the same problem but avoiding to change behavior this late in the release cycle seems like a good idea.