### PR TITLE
Change the package name to Greenplum Database

### DIFF
--- a/configure
+++ b/configure
@@ -580,11 +580,11 @@ MFLAGS=
 MAKEFLAGS=
 
 # Identity of this package.
-PACKAGE_NAME='PostgreSQL'
-PACKAGE_TARNAME='postgresql'
+PACKAGE_NAME='Greenplum Database'
+PACKAGE_TARNAME='greenplum-database'
 PACKAGE_VERSION='8.3.23'
-PACKAGE_STRING='PostgreSQL 8.3.23'
-PACKAGE_BUGREPORT='pgsql-bugs@postgresql.org'
+PACKAGE_STRING='Greenplum Database 8.3.23'
+PACKAGE_BUGREPORT='support@greenplum.org'
 PACKAGE_URL=''
 
 ac_unique_file="src/backend/access/common/heaptuple.c"


### PR DESCRIPTION
This is required by other programs to identify ourselves as
Greenplum. Notably madlib uses it in their build