### PR TITLE
Mark gp_external_grant_privileges as deprecated

### DIFF
--- a/gpAux/extensions/gphdfs/expected/privileges.out
+++ b/gpAux/extensions/gphdfs/expected/privileges.out
@@ -1,12 +1,6 @@
 --
 -- test CREATE EXTERNAL TABLE privileges
 --
-show gp_external_grant_privileges; -- MUST BE OFF for the following tests to work.
- gp_external_grant_privileges 
-------------------------------
- off
-(1 row)
-
 CREATE ROLE exttab1_su SUPERUSER; -- SU with no privs in pg_auth
 CREATE ROLE exttab1_u4 CREATEEXTTABLE(protocol='gphdfs', type='readable'); 
 WARNING:  GRANT/REVOKE on gphdfs is deprecated

--- a/gpAux/extensions/gphdfs/sql/privileges.sql
+++ b/gpAux/extensions/gphdfs/sql/privileges.sql
@@ -1,8 +1,6 @@
 --
 -- test CREATE EXTERNAL TABLE privileges
 --
-show gp_external_grant_privileges; -- MUST BE OFF for the following tests to work.
-
 CREATE ROLE exttab1_su SUPERUSER; -- SU with no privs in pg_auth
 CREATE ROLE exttab1_u4 CREATEEXTTABLE(protocol='gphdfs', type='readable'); 
 CREATE ROLE exttab1_u5 CREATEEXTTABLE(protocol='gphdfs', type='writable'); 

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -89,7 +89,6 @@ class GpStart:
         self.lc_monetary=None
         self.lc_numeric=None
         self.max_connections = None
-        self.gp_external_grant_privileges=None
         logger.debug("Setting level of parallelism to: %d" % self.parallel)
 
     ######
@@ -222,8 +221,6 @@ class GpStart:
         logger.debug("Read from postgresql.conf port=%s" % self.port)
         self.max_connections = pgconf_dict.int('max_connections')
         logger.debug("Read from postgresql.conf max_connections=%s" % self.max_connections)
-        self.gp_external_grant_privileges = pgconf_dict.str('gp_external_grant_privileges');
-        logger.debug("gp_external_grant_privileges is %s" % self.gp_external_grant_privileges);
 
     ######
     def _check_version(self):
@@ -370,11 +367,6 @@ class GpStart:
                 line.append("Primary" if db.isSegmentPrimary(True) else "Mirror")
             tabLog.info(line)
         tabLog.outputTable()
-# show a warn if gp_external_grant_privileges is on
-        if self.gp_external_grant_privileges and "on" in self.gp_external_grant_privileges:
-        	logger.warning("--------------------------------------")
-        	logger.warning("Using gp_external_grant_privileges is not recommended and will soon be deprecated.")
-        	logger.warning("--------------------------------------") 
 
     ######
     def _get_format_string(self):

--- a/gpMgmt/doc/gpload_help
+++ b/gpMgmt/doc/gpload_help
@@ -251,11 +251,6 @@ USER - Optional. Specifies which database role to use to connect.
        You can also specify the database role on the command line using 
        the -U option. 
 
-       If the user running gpload is not a Greenplum superuser, then the 
-       server configuration parameter gp_external_grant_privileges must 
-       be set to on in order for the load to be processed. See the
-       "Greenplum Database Reference Guide" for more information.
-
 HOST - Optional. Specifies Greenplum master host name. If not specified, 
        defaults to localhost or $PGHOST if set. You can also specify the 
        master host name on the command line using the -h option.

--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -1120,9 +1120,6 @@
                 <codeph>gp_external_enable_exec</codeph>
               </p>
               <p>
-                <codeph>gp_external_grant_privileges</codeph>
-              </p>
-              <p>
                 <codeph>gp_external_max_segs</codeph>
               </p>
             </stentry>

--- a/gpdb-doc/dita/admin_guide/topics/g-external-table-parameters.xml
+++ b/gpdb-doc/dita/admin_guide/topics/g-external-table-parameters.xml
@@ -14,9 +14,6 @@
                   <codeph>gp_external_enable_exec</codeph>
                </p>
                <p>
-                  <codeph>gp_external_grant_privileges</codeph>
-               </p>
-               <p>
                   <codeph>gp_external_max_segs</codeph>
                </p>
             </stentry>

--- a/gpdb-doc/dita/client_tool_guides/load/windows/gploadpy.xml
+++ b/gpdb-doc/dita/client_tool_guides/load/windows/gploadpy.xml
@@ -223,9 +223,8 @@
             to the current user or <codeph>$PGUSER</codeph> if set. You can also specify the
             database role on the command line using the <codeph>-U</codeph> option. </pd>
           <pd>If the user running <codeph>gpload.py</codeph> is not a Greenplum Database superuser,
-            then the server configuration parameter <codeph>gp_external_grant_privileges</codeph>
-            must be set to <codeph>on</codeph> in order for the load to be processed. See the
-              <i>Greenplum Database Reference Guide</i> for more information.</pd>
+            the appropriate rights must be granted to the user for the load to be processed. See the
+            <i>Greenplum Database Reference Guide</i> for more information.</pd>
         </plentry>
         <plentry>
           <pt id="cfhost">HOST</pt>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1121,10 +1121,6 @@
               <xref href="guc-list.xml#gp_external_enable_exec" type="section">gp_external_enable_exec</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#gp_external_grant_privileges" type="section"
-                >gp_external_grant_privileges</xref>
-            </p>
-            <p>
               <xref href="guc-list.xml#gp_external_max_segs" type="section">gp_external_max_segs</xref>
             </p>
           </stentry>

--- a/gpdb-doc/dita/relnotes/GPDB_500_README.xml
+++ b/gpdb-doc/dita/relnotes/GPDB_500_README.xml
@@ -78,6 +78,11 @@
       <p>Greenplum Database 5.0.0 has removed these features:</p>
       <ul id="ul_psh_g4m_5y">
         <li>&lt;features here></li>
+        <li>
+          <p>The previously deprecated <codeph>gp_external_grant_privileges</codeph> GUC has
+            been removed. Rights management for creating external gphdfs and http tables is
+            performed using GRANT/REVOKE.</p>
+        </li>
       </ul>
       <p>Greenplum Database 5.0.0 has deprecated these features:</p>
       <ul id="ul_n35_m4m_5y">

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpload.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpload.xml
@@ -240,9 +240,8 @@
                         also specify the database role on the command line using the
                             <codeph>-U</codeph> option. </pd>
                     <pd>If the user running <codeph>gpload</codeph> is not a Greenplum Database
-                        superuser, then the server configuration parameter
-                            <codeph>gp_external_grant_privileges</codeph> must be set to
-                            <codeph>on</codeph> in order for the load to be processed. See the
+                        superuser, then the appropriate rights must be granted to the user for the
+                        load to be processed. See the
                             <i>Greenplum Database Reference Guide</i> for more information.</pd>
                 </plentry>
                 <plentry>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpmapreduce.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpmapreduce.xml
@@ -33,9 +33,8 @@
         <li id="kx141310">You must be a Greenplum Database superuser to run MapReduce jobs with
             <codeph>EXEC</codeph> and <codeph>FILE</codeph> inputs.</li>
         <li id="kx141334">You must be a Greenplum Database superuser to run MapReduce jobs with
-            <codeph>GPFDIST</codeph> input unless the server configuration parameter
-            <codeph>gp_external_grant_privileges</codeph> is set to <codeph>on</codeph>. See the
-            <i>Greenplum Database Reference Guide</i> for more information.</li>
+            <codeph>GPFDIST</codeph> input unless the the user has the appropriate rigths granted.
+            See the <i>Greenplum Database Reference Guide</i> for more information.</li>
       </ul>
     </section>
     <section id="section4">

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -74,10 +74,6 @@ int			gp_backup_directIO_read_chunk_mb = 20;		/* size of readChunk
 bool		gp_external_enable_exec = true;		/* allow ext tables with
 												 * EXECUTE */
 
-bool		gp_external_grant_privileges = false;		/* allow creating
-														 * http/gpfdist/gpfdists
-														 * for non-su */
-
 int			gp_external_max_segs;		/* max segdbs per gpfdist/gpfdists URI */
 
 int			gp_safefswritesize; /* set for safe AO writes in non-mature fs */

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -128,9 +128,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	 * - Always allow if superuser.
 	 * - Never allow EXECUTE or 'file' exttables if not superuser.
 	 * - Allow http, gpfdist or gpfdists tables if pg_auth has the right
-	 *	 permissions for this role and for this type of table, or if
-	 *	 gp_external_grant_privileges is on (gp_external_grant_privileges
-	 *	 should be deprecated at some point).
+	 *	 permissions for this role and for this type of table
 	 *----------
 	 */
 	if (!superuser() && Gp_role == GP_ROLE_DISPATCH)
@@ -156,7 +154,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 						 errmsg("must be superuser to create an external table with a file protocol")));
 			}
-			else if (!gp_external_grant_privileges)
+			else
 			{
 				/*
 				 * Check if this role has the proper 'gpfdist', 'gpfdists' or

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1321,15 +1321,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_external_grant_privileges", PGC_POSTMASTER, EXTERNAL_TABLES,
-			gettext_noop("Enable non superusers to create http or gpfdist external tables."),
-			NULL
-		},
-		&gp_external_grant_privileges,
-		false, NULL, NULL
-	},
-
-	{
 		{"resource_scheduler", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("Enable resource scheduling."),
 			NULL,

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -500,7 +500,6 @@ gp_resqueue_memory_policy = 'eager_free'	# memory request based queueing.
 # EXTERNAL TABLES
 #---------------------------------------------------------------------------
 #gp_external_enable_exec = on   # enable external tables with EXECUTE.
-#gp_external_grant_privileges = off #enable create http/gpfdist for non su's
 
 #---------------------------------------------------------------------------
 # APPEND ONLY TABLES

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -486,7 +486,6 @@ select count(*) from ext_whois;
 --
 -- test CREATE EXTERNAL TABLE privileges
 --
-show gp_external_grant_privileges; -- MUST BE OFF for the following tests to work.
 CREATE ROLE exttab1_su SUPERUSER; -- SU with no privs in pg_auth
 CREATE ROLE exttab1_u1 CREATEEXTTABLE(protocol='gpfdist', type='readable'); 
 CREATE ROLE exttab1_u2 CREATEEXTTABLE(protocol='gpfdist', type='writable'); 

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -765,12 +765,6 @@ ERROR:  connection with gpfdist failed for gpfdist://@hostname@:7070/whois.csv. 
 --
 -- test CREATE EXTERNAL TABLE privileges
 --
-show gp_external_grant_privileges; -- MUST BE OFF for the following tests to work.
- gp_external_grant_privileges 
-------------------------------
- off
-(1 row)
-
 CREATE ROLE exttab1_su SUPERUSER; -- SU with no privs in pg_auth
 CREATE ROLE exttab1_u1 CREATEEXTTABLE(protocol='gpfdist', type='readable'); 
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/src/bin/gpfdist/regress/output/exttab1_optimizer.source
+++ b/src/bin/gpfdist/regress/output/exttab1_optimizer.source
@@ -764,12 +764,6 @@ ERROR:  connection with gpfdist failed for gpfdist://@hostname@:7070/whois.csv. 
 --
 -- test CREATE EXTERNAL TABLE privileges
 --
-show gp_external_grant_privileges; -- MUST BE OFF for the following tests to work.
- gp_external_grant_privileges 
-------------------------------
- off
-(1 row)
-
 CREATE ROLE exttab1_su SUPERUSER; -- SU with no privs in pg_auth
 CREATE ROLE exttab1_u1 CREATEEXTTABLE(protocol='gpfdist', type='readable'); 
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -263,15 +263,6 @@ extern int gp_backup_directIO_read_chunk_mb;
  */
 extern bool gp_external_enable_exec;
 
-/*
- * gp_external_grant_privileges
- *
- * when set to 'false' only superusers can create external tables.
- * when set to 'true' http, gpfdist and gpfdists external tables are also allowed to be
- * created by non superusers. Default is 'false'
- */
-extern bool gp_external_grant_privileges;
-
 /* gp_external_max_segs
  *
  * The maximum number of segment databases that will get assigned to

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -199,7 +199,6 @@ create writable external web table wet_pos5(a text, b text) execute 'some comman
 --
 -- test CREATE EXTERNAL TABLE privileges
 --
-show gp_external_grant_privileges; -- MUST BE OFF for the following tests to work.
 CREATE ROLE exttab1_su SUPERUSER; -- SU with no privs in pg_auth
 CREATE ROLE exttab1_u1 CREATEEXTTABLE(protocol='gpfdist', type='readable'); 
 CREATE ROLE exttab1_u2 CREATEEXTTABLE(protocol='gpfdist', type='writable'); 

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -299,12 +299,6 @@ ERROR:  ON clause may not be used with a writable external table
 --
 -- test CREATE EXTERNAL TABLE privileges
 --
-show gp_external_grant_privileges; -- MUST BE OFF for the following tests to work.
- gp_external_grant_privileges 
-------------------------------
- off
-(1 row)
-
 CREATE ROLE exttab1_su SUPERUSER; -- SU with no privs in pg_auth
 CREATE ROLE exttab1_u1 CREATEEXTTABLE(protocol='gpfdist', type='readable'); 
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/privileges.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/privileges.ans
@@ -1,9 +1,3 @@
-show gp_external_grant_privileges; -- MUST BE OFF for the following tests to work.
- gp_external_grant_privileges 
-------------------------------
- off
-(1 row)
-
 --
 -- Super User priv
 --

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/privileges.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/basic/exttab/write/sql/privileges.sql
@@ -1,8 +1,6 @@
 --
 -- test CREATE EXTERNAL TABLE privileges
 --
-show gp_external_grant_privileges; -- MUST BE OFF for the following tests to work.
-
 --
 -- Super User priv
 --


### PR DESCRIPTION
The `gp_external_grant_privileges` GUC was needed before 4.0 to let non superusers create external tables for gphdfs and http protocols. This is now handled via the normal GRANT mechanism but the GUC has not yet been removed. This is not something we should carry forward, especially if we want to change inner plumbings of external tables over to FDW with future upstream merges. Mark as deprecated now for 5.0 so that we can remove it in 6.0. If approved it requires a corresponding doc patch (and perhaps an updated entry in the base config file where it's listed as default off).

@ivannovick @Eulerizeit 