### PR TITLE
Explicitly take snapshot in FTS.

### DIFF
--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -878,6 +878,7 @@ probeUpdateConfig(FtsSegmentStatusChange *changes, int changeCount)
 	 */
 	ResourceOwner save = CurrentResourceOwner;
 	StartTransactionCommand();
+	GetTransactionSnapshot();
 	elog(LOG, "probeUpdateConfig called for %d changes", changeCount);
 
 	histrel = heap_open(GpConfigHistoryRelationId,
@@ -1120,6 +1121,7 @@ FtsMarkSegmentsInSync(CdbComponentDatabaseInfo *primary, CdbComponentDatabaseInf
 	 */
 	ResourceOwner save = CurrentResourceOwner;
 	StartTransactionCommand();
+	GetTransactionSnapshot();
 
 	/* update primary */
 	segStatus = ftsProbeInfo->fts_status[primary->dbid];


### PR DESCRIPTION
FTS processes uses SnapshotNow everywhere to perform catalog lookups, but
certain other interfaces like heap_hot_search_buffer are coded with assumption
that transaction always takes an snapshot. Hence to fulfill the same added to
take snapshot after starting transaction in FTS.