### PR TITLE
Print CHECK_FOR_INTERRUPTS location during query cancellation

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3480,7 +3480,7 @@ die(SIGNAL_ARGS)
 			DisableCatchupInterrupt();
 			DisableClientWaitTimeoutInterrupt();
 			InterruptHoldoffCount--;
-			ProcessInterrupts();
+			ProcessInterrupts(__FILE__, __LINE__);
 		}
 	}
 
@@ -3538,7 +3538,7 @@ StatementCancelHandler(SIGNAL_ARGS)
 			DisableNotifyInterrupt();
 			DisableCatchupInterrupt();
 			InterruptHoldoffCount--;
-			ProcessInterrupts();
+			ProcessInterrupts(__FILE__, __LINE__);
 		}
 	}
 
@@ -3631,9 +3631,12 @@ SigHupHandler(SIGNAL_ARGS)
  * If an interrupt condition is pending, and it's safe to service it,
  * then clear the flag and accept the interrupt.  Called only when
  * InterruptPending is true.
+ *
+ * Parameters filename and lineno contain the file name and the line number where
+ * ProcessInterrupts was invoked, respectively.
  */
 void
-ProcessInterrupts(void)
+ProcessInterrupts(const char* filename, int lineno)
 {
 
 #ifdef USE_TEST_UTILS
@@ -3690,7 +3693,7 @@ ProcessInterrupts(void)
 
 	if (QueryCancelPending)
 	{
-		elog(LOG,"Process interrupt for 'query cancel pending'.");
+		elog(LOG,"Process interrupt for 'query cancel pending' (%s:%d)", filename, lineno);
 
 		QueryCancelPending = false;
 

--- a/src/backend/tcop/test/postgres_test.c
+++ b/src/backend/tcop/test/postgres_test.c
@@ -111,7 +111,7 @@ test__ProcessInterrupts__ClientConnectionLost(void **state)
 	PG_TRY();
 	{
 		/* Run function under test */
-		ProcessInterrupts();
+		ProcessInterrupts(__FILE__, __LINE__);
 		assert_true(false);
 	}
 	PG_CATCH();
@@ -151,7 +151,7 @@ test__ProcessInterrupts__DoingCommandRead(void **state)
 	expect_any(elog_finish, fmt);
 	will_be_called(elog_finish);
 
-	ProcessInterrupts();
+	ProcessInterrupts(__FILE__, __LINE__);
 
 	assert_false(QueryCancelPending);
 
@@ -179,7 +179,7 @@ test__ProcessInterrupts__DoingCommandRead(void **state)
 	PG_TRY();
 	{
 		/* Run function under test */
-		ProcessInterrupts();
+		ProcessInterrupts(__FILE__, __LINE__);
 		assert_true(false);
 	}
 	PG_CATCH();

--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -514,7 +514,7 @@ VmemTracker_ReserveVmem(int64 newlyRequestedBytes)
 		if (vmem_process_interrupt && InterruptPending)
 		{
 			/* ProcessInterrupts should check for InterruptHoldoffCount and CritSectionCount */
-			ProcessInterrupts();
+			ProcessInterrupts(__FILE__, __LINE__);
 		}
 
 		/*

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -123,10 +123,7 @@ do { \
 		}\
 	}\
 	if (InterruptPending) \
-	{\
-		write_stderr("CHECK_FOR_INTERRUPTS is triggered in %s:%d", __FILE__, __LINE__); \
 		ProcessInterrupts(); \
-	}\
 	if (gp_enable_resqueue_priority)	\
 		BackoffBackendTick(); \
 	ReportOOMConsumption(); \
@@ -136,10 +133,7 @@ do { \
 #define CHECK_FOR_INTERRUPTS() \
 do { \
 	if (InterruptPending) \
-	{\
-		write_stderr("CHECK_FOR_INTERRUPTS is triggered in %s:%d", __FILE__, __LINE__); \
 		ProcessInterrupts(); \
-	}\
 	if (gp_enable_resqueue_priority)	\
 		BackoffBackendTick(); \
 	ReportOOMConsumption(); \
@@ -154,10 +148,7 @@ do { \
 	if (UNBLOCKED_SIGNAL_QUEUE()) \
 		pgwin32_dispatch_queued_signals(); \
 	if (InterruptPending) \
-	{\
-		write_stderr("CHECK_FOR_INTERRUPTS is triggered in %s:%d", __FILE__, __LINE__); \
 		ProcessInterrupts(); \
-	}\
 } while(0)
 #endif   /* WIN32 */
 

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -123,7 +123,10 @@ do { \
 		}\
 	}\
 	if (InterruptPending) \
+	{\
+		write_stderr("CHECK_FOR_INTERRUPTS is triggered in %s:%d", __FILE__, __LINE__); \
 		ProcessInterrupts(); \
+	}\
 	if (gp_enable_resqueue_priority)	\
 		BackoffBackendTick(); \
 	ReportOOMConsumption(); \
@@ -133,7 +136,10 @@ do { \
 #define CHECK_FOR_INTERRUPTS() \
 do { \
 	if (InterruptPending) \
+	{\
+		write_stderr("CHECK_FOR_INTERRUPTS is triggered in %s:%d", __FILE__, __LINE__); \
 		ProcessInterrupts(); \
+	}\
 	if (gp_enable_resqueue_priority)	\
 		BackoffBackendTick(); \
 	ReportOOMConsumption(); \
@@ -148,7 +154,10 @@ do { \
 	if (UNBLOCKED_SIGNAL_QUEUE()) \
 		pgwin32_dispatch_queued_signals(); \
 	if (InterruptPending) \
+	{\
+		write_stderr("CHECK_FOR_INTERRUPTS is triggered in %s:%d", __FILE__, __LINE__); \
 		ProcessInterrupts(); \
+	}\
 } while(0)
 #endif   /* WIN32 */
 

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -88,7 +88,7 @@ extern PGDLLIMPORT volatile int32 InterruptHoldoffCount;
 extern PGDLLIMPORT volatile int32 CritSectionCount;
 
 /* in tcop/postgres.c */
-extern void ProcessInterrupts(void);
+extern void ProcessInterrupts(const char* filename, int lineno);
 extern void BackoffBackendTick(void);
 extern bool gp_enable_resqueue_priority;
 
@@ -123,7 +123,7 @@ do { \
 		}\
 	}\
 	if (InterruptPending) \
-		ProcessInterrupts(); \
+		ProcessInterrupts(__FILE__, __LINE__); \
 	if (gp_enable_resqueue_priority)	\
 		BackoffBackendTick(); \
 	ReportOOMConsumption(); \
@@ -133,7 +133,7 @@ do { \
 #define CHECK_FOR_INTERRUPTS() \
 do { \
 	if (InterruptPending) \
-		ProcessInterrupts(); \
+		ProcessInterrupts(__FILE__, __LINE__); \
 	if (gp_enable_resqueue_priority)	\
 		BackoffBackendTick(); \
 	ReportOOMConsumption(); \
@@ -148,7 +148,7 @@ do { \
 	if (UNBLOCKED_SIGNAL_QUEUE()) \
 		pgwin32_dispatch_queued_signals(); \
 	if (InterruptPending) \
-		ProcessInterrupts(); \
+		ProcessInterrupts(__FILE__, __LINE__); \
 } while(0)
 #endif   /* WIN32 */
 


### PR DESCRIPTION
We don't have any clue when GPDB crashes because of query cancellation. In this PR, we want to print file name and line number of the place where CHECK_FOR_INTERRUPTS got called.

**Repro**
```
DROP TABLE IF EXISTS segspace_test_hj_skew;
CREATE TABLE segspace_test_hj_skew (i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int) DISTRIBUTED BY (i1);

-- many values with i1 = 1
INSERT INTO segspace_test_hj_skew SELECT 1,i,i,i,i,i,i,i FROM 
	(select generate_series(1, nsegments * 50000) as i from 
	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
-- some nicely distributed values
INSERT INTO segspace_test_hj_skew SELECT i,i,i,i,i,i,i,i FROM 
	(select generate_series(1, nsegments * 100000) as i from 
	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;

ANALYZE segspace_test_hj_skew;

-- enable the fault injector
--start_ignore
\! gpfaultinjector -f exec_hashjoin_new_batch -y reset --seg_dbid 2
\! gpfaultinjector -f exec_hashjoin_new_batch -y interrupt --seg_dbid 2
--end_ignore

set gp_workfile_type_hashjoin=buffile;
set statement_mem=2048;
set gp_autostats_mode = none;
set gp_hashjoin_metadata_memory_percent=0;

SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE t1.i1=t2.i2;
```

After executing the above sequence of statements, seg0's log file will contain the message: "CHECK_FOR_INTERRUPTS is triggered in nodeHashjoin.c:927"