### PR TITLE
add gpadmin to tty group to permit python ssh session test

### DIFF
--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -44,6 +44,7 @@ setup_gpadmin_user() {
   echo -e "password\npassword" | passwd gpadmin
   groupadd supergroup
   usermod -a -G supergroup gpadmin
+  usermod -a -G tty gpadmin
   setup_ssh_for_user gpadmin
   transfer_ownership
 }


### PR DESCRIPTION
On master, the existing unit tests for management utilities (MU) fail because of an error like

```OSError: out of pty devices```

This occurs for gpadmin, but not root. In linux docs, we see that the "tty" group gives permission to a user, so we add gpadmin to this group in this pull request.

Our theory is that the underlying centos 6 system gives fewer privileges than the centos 5 system used by 4.3_STABLE.