### PR TITLE
Fix split partition as superuser for tables created by non-superuser.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -586,7 +586,8 @@ DefineRelation(CreateStmt *stmt, char relkind, char relstorage, bool dispatch)
 	}
 	else
 	{
-		stmt->ownerid = GetUserId();
+		if (!OidIsValid(stmt->ownerid))
+			stmt->ownerid = GetUserId();
 	}
 
 	/* MPP-8405: disallow OIDS on partitioned tables */


### PR DESCRIPTION
When a superuser tries to split a partition table which was created by a non
superuser, the split should complete successfully and the resulting partitions
should have the owner set to the owner of the parent table.