### PR TITLE
Fix copy of compresstype in appendonly_beginrangescan_internal().

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1724,7 +1724,7 @@ appendonly_beginrangescan_internal(Relation relation,
 	else
 	{
 		attr->compress = true;
-		attr->compressType = NameStr(relation->rd_appendonly->compresstype);
+		attr->compressType = pstrdup(NameStr(relation->rd_appendonly->compresstype));
 	}
 	attr->compressLevel     = relation->rd_appendonly->compresslevel;
 	attr->checksum			= relation->rd_appendonly->checksum;


### PR DESCRIPTION
When building a scan descriptor for appendonly tables, the compression type for
a table is copied from the pg_appendonly row from relcache. When the
pg_appendonly row for the AO table gets updated, as part of relcache
invalidation, the old relation object will be destroyed. However the new
relation object would still point to the original compresstype object. So
appendonly_beginrange scan_internal() should use pstrdup to copy the
compression type instead of copying the pointer directly.