### PR TITLE
Fix bugs of pg_dump of dumping s3 external table

### DIFF
--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -130,10 +130,10 @@ InsertExtTableEntry(Oid 	tbloid,
     heap_close(pg_exttable_rel, NoLock);
 
 	/*
-	 * Add the dependency of s3 external table
+	 * Add the dependency of custom external table
 	 */
 
-	if (locationUris != 0)
+	if (locationUris != (Datum) 0)
 	{
 		Datum	   *elems;
 		int			nelems;
@@ -150,10 +150,6 @@ InsertExtTableEntry(Oid 	tbloid,
 			char	   *protocol;
 			Size		position;
 
-			/*
-			* s3 external table only reads the first location and does not support
-			* multiple locations
-			*/
 			location = DatumGetCString(DirectFunctionCall1(textout, elems[i]));
 			position = strchr(location, ':') - location;
 			protocol = pnstrdup(location, position);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -10274,16 +10274,21 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 
 			/* the URI of custom protocol will contains \"\" and need to be removed */
 
-			if (locations[0] == '\"')
-			{
-				locations++;
-				locations[strlen(locations) - 1] = '\0';
-			}
-
 			location = nextToken(&locations, ",");
+
+			if (location[0] == '\"')
+			{
+				location++;
+				location[strlen(location) - 1] = '\0';
+			}
 			appendPQExpBuffer(q, " LOCATION (\n    '%s'", location);
 			for (; (location = nextToken(&locations, ",")) != NULL;)
 			{
+				if (location[0] == '\"')
+				{
+					location++;
+					location[strlen(location) - 1] = '\0';
+				}
 				appendPQExpBuffer(q, ",\n    '%s'", location);
 			}
 			appendPQExpBuffer(q, "\n) ");

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -10268,16 +10268,13 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 		else
 		{
 			/* add LOCATION clause, remove '{"' and '"}' */
-			char	*usingProtocol;
-			Size	position;
 
 			locations[strlen(locations) - 1] = '\0';
 			locations++;
 
-			position = strchr(locations, ':') - locations;
-			usingProtocol = strndup(locations + 1, position - 1);
+			/* the URI of custom protocol will contains \"\" and need to be removed */
 
-			if (strcmp("s3", usingProtocol) == 0)
+			if (locations[0] == '\"')
 			{
 				locations++;
 				locations[strlen(locations) - 1] = '\0';


### PR DESCRIPTION
1. Add s3 external table dependency with protocol to keep the dumped
   SQL ordered correctly. (create protocol must execute before creating s3
   extrenal table)

2. Remove \" from dumped location URI.

Signed-off-by: Peifeng Qiu <pqiu@pivotal.io>
Signed-off-by: Yuan Zhao <yuzhao@pivotal.io>