### PR TITLE
Make error logging consistent and human readable

### DIFF
--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -149,10 +149,9 @@ static void BufferedAppendWrite(
 		currentWritePosition = FileNonVirtualCurSeek(bufferedAppend->file);
 		if (currentWritePosition < 0)
 			ereport(ERROR, (errcode_for_file_access(),
-							errmsg("unable to get current position in table \"%s\" for file \"%s\" (errcode %d)",
+							errmsg("unable to get current position in table \"%s\" for file \"%s\": %m",
 								   bufferedAppend->relationName,
-							       bufferedAppend->filePathName,
-								   errno)));
+							       bufferedAppend->filePathName)));
 
 		if (currentWritePosition != bufferedAppend->largeWritePosition)
 			ereport(ERROR, (errcode_for_file_access(),
@@ -178,12 +177,12 @@ static void BufferedAppendWrite(
 		if (primaryError != 0)
 			ereport(ERROR,
 					(errcode_for_file_access(),
-					 errmsg("Could not write in table \"%s\" to segment file '%s': %m", 
+					 errmsg("Could not write in table \"%s\" to segment file \"%s\": %m",
 					 		bufferedAppend->relationName,
 							bufferedAppend->filePathName)));
 	   
 		elogif(Debug_appendonly_print_append_block, LOG,
-				"Append-Only storage write: table '%s', segment file '%s', write position " INT64_FORMAT ", "
+				"Append-Only storage write: table \"%s\", segment file \"%s\", write position " INT64_FORMAT ", "
 				"writeLen %d (equals large write length %d is %s)",
 				bufferedAppend->relationName,
 				bufferedAppend->filePathName,

--- a/src/backend/cdb/cdbbufferedread.c
+++ b/src/backend/cdb/cdbbufferedread.c
@@ -168,10 +168,9 @@ static void BufferedReadIo(
 		currentReadPosition = FileNonVirtualCurSeek(bufferedRead->file);
 		if (currentReadPosition < 0)
 			ereport(ERROR, (errcode_for_file_access(),
-							errmsg("unable to get current position for table \"%s\" in file \"%s\" (errcode %d)",
+							errmsg("unable to get current position for table \"%s\" in file \"%s\": %m",
 								   bufferedRead->relationName,
-							       bufferedRead->filePathName,
-								   errno)));
+							       bufferedRead->filePathName)));
 			
 		if (currentReadPosition != bufferedRead->largeReadPosition)
 		{
@@ -195,8 +194,8 @@ static void BufferedReadIo(
 
 		if (actualLen == 0) 
 			ereport(ERROR, (errcode_for_file_access(),
-							errmsg("read beyond eof in table \"%s\" in file \"%s\","
-								"read postition " INT64_FORMAT " (small offset %d),"
+							errmsg("read beyond eof in table \"%s\" file \"%s\", "
+								"read position " INT64_FORMAT " (small offset %d), "
 								"actual read length %d (large read length %d)",
 								bufferedRead->relationName,
 								bufferedRead->filePathName,
@@ -206,19 +205,18 @@ static void BufferedReadIo(
 								bufferedRead->largeReadLen)));
 		else if (actualLen < 0)
 			ereport(ERROR, (errcode_for_file_access(),
-							errmsg("unable to read table \"%s\" file \"%s\" (errcode %d)"
-								"read postition " INT64_FORMAT " (small offset %d),"
-								"actual read length %d (large read length %d)",
+							errmsg("unable to read table \"%s\" file \"%s\", "
+								"read position " INT64_FORMAT " (small offset %d), "
+								"actual read length %d (large read length %d): %m",
 								bufferedRead->relationName,
 								bufferedRead->filePathName,
-								errno,
 								bufferedRead->largeReadPosition,
 								offset,
 								actualLen,
 								bufferedRead->largeReadLen)));
 		
 		elogif(Debug_appendonly_print_read_block, LOG,
-				 "Append-Only storage read: table '%s', segment file '%s', read postition " INT64_FORMAT " (small offset %d), "
+				 "Append-Only storage read: table \"%s\", segment file \"%s\", read position " INT64_FORMAT " (small offset %d), "
 				 "actual read length %d (equals large read length %d is %s)",
 				 bufferedRead->relationName,
 				 bufferedRead->filePathName,
@@ -419,10 +417,9 @@ void BufferedReadSetTemporaryRange(
 		int64 seekPos = FileSeek(bufferedRead->file, seekOffset, SEEK_CUR);
 		if (seekPos != beginFileOffset)
 			ereport(ERROR, (errcode_for_file_access(),
-							errmsg("unable to seek to position for table \"%s\" in file \"%s\" (errcode %d):%m",
+							errmsg("unable to seek to position for table \"%s\" in file \"%s\": %m",
 								   bufferedRead->relationName,
-								   bufferedRead->filePathName,
-								   errno)));
+								   bufferedRead->filePathName)));
 
 		bufferedRead->bufferOffset = 0;
 

--- a/src/backend/cdb/cdbbufferedread.c
+++ b/src/backend/cdb/cdbbufferedread.c
@@ -408,10 +408,10 @@ void BufferedReadSetTemporaryRange(
 
 		/* 
 		 * Seek to the requested beginning position. 
-		 * MPP-17061: allow seeking backward(negative offset) in file,
-		 * this could happen during index scan, if we do look up for a
+		 * MPP-17061: allow seeking backward (negative offset) in file,
+		 * this could happen during index scan, if we do lookup for a
 		 * block directory entry at the end of the segment file, followed
-		 * by a look up for a block directory entry at the beginning of file.
+		 * by a lookup for a block directory entry at the beginning of file.
 		 */
 		int64 seekOffset = beginFileOffset - largeReadAfterPos;
 		int64 seekPos = FileSeek(bufferedRead->file, seekOffset, SEEK_CUR);
@@ -663,9 +663,8 @@ int64 BufferedReadCurrentPosition(
 }
 
 /*
- * Flushes the current file for append.  Caller is resposible for closing
+ * Flushes the current file for append.  Caller is responsible for closing
  * the file afterwards.
- *
  */
 void BufferedReadCompleteFile(
     BufferedRead       *bufferedRead)

--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -3548,7 +3548,7 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 						 ((IsA(pBSpec, PartitionValuesSpec)) ?
 						  parser_errposition(pstate,
 								((PartitionValuesSpec *) pBSpec)->location) :
-				/* else use invalid parsestate/postition */
+				/* else use invalid parsestate/position */
 						  parser_errposition(NULL, 0)
 						  )
 						 ));


### PR DESCRIPTION
Instead of logging errno, include the `%m` format specifier which pulls in the human readable errno translation. Also fix typos and make the error logging a bit more consistent with regards to style, string quoting and spelling.

Inspired by a request from @hlinnaka in issue #1507. There is likely more cleaning that can be had on these but for making them properly readable seems like a good start.

Also fix the observed typo from the error message in parse_partition.c as well as some other ones in the path of hackery.

 