### PR TITLE
Dump database configuration settings

### DIFF
--- a/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/backup_mgmt_utils.py
+++ b/gpMgmt/bin/gppylib/test/behave/mgmt_utils/steps/backup_mgmt_utils.py
@@ -467,3 +467,11 @@ def impl(context, obj, objname, schemaname, dbname):
         exists = dbconn.execSQLForSingletonRow(conn, cmd_sql)
         if exists[0] is not True:
             raise Exception("The %s '%s' does not exists in schema '%s' and database '%s' " % (obj, objname, schemaname, dbname) )
+
+@then('verify that "{configString}" appears in the datconfig for database "{dbname}"')
+def impl(context, configString, dbname):
+    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+        query = "select datconfig from pg_database where datname in ('%s');" % dbname
+        datconfig = dbconn.execSQLForSingleton(conn, query)
+    if not datconfig or configString not in datconfig:
+        raise Exception("%s is not in the datconfig for database '%s':\n %s" % (configString, dbname, datconfig))


### PR DESCRIPTION
* Backs up search path, optimizer settings, and gp_default_storage_options
* These settings will only be restored during database restores (`-e` option)

The C code was adapted from pg_dumpall.

Authors: Chris Hajas, Stephen Wu, Karan Huddleston