### PR TITLE
Fix ERROR if you try to turn an AO table into a view with CREATE RULE.

### DIFF
--- a/src/backend/rewrite/rewriteDefine.c
+++ b/src/backend/rewrite/rewriteDefine.c
@@ -383,6 +383,13 @@ DefineQueryRewrite(char *rulename,
 		{
 			HeapScanDesc scanDesc;
 
+			/* In GPDB, also forbid turning AO tables or external tables into views. */
+			if (!RelationIsHeap(event_relation))
+				ereport(ERROR,
+						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						 errmsg("cannot convert non-heap table \"%s\" to a view",
+								RelationGetRelationName(event_relation))));
+
 			scanDesc = heap_beginscan(event_relation, SnapshotNow, 0, NULL);
 			if (heap_getnext(scanDesc, ForwardScanDirection) != NULL)
 				ereport(ERROR,

--- a/src/test/regress/expected/gp_rules.out
+++ b/src/test/regress/expected/gp_rules.out
@@ -1,0 +1,22 @@
+-- Some additional checks for RULEs
+-- Test turning a table into a view.
+CREATE table table_to_view_test1 (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE table table_to_view_test2 (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE rule "_RETURN" as on select to table_to_view_test1
+        do instead select * from table_to_view_test2;
+-- Same for an Append-Only table. It is currently not supported.
+CREATE table aotable_to_view_test1 (a int) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE table aotable_to_view_test2 (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE rule "_RETURN" as on select to aotable_to_view_test1
+        do instead select * from aotable_to_view_test2;
+ERROR:  cannot convert non-heap table "aotable_to_view_test1" to a view
+drop table aotable_to_view_test1;
+drop table aotable_to_view_test2;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -25,7 +25,7 @@ test: leastsquares
 test: opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy gp_create_table
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var
 test: bitmap_index gp_dump_query_oids
-test: indexjoin as_alias regex_gp gpparams with_clause transient_types
+test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules
 # dispatch should always run seperately from other cases.
 test: dispatch
 

--- a/src/test/regress/sql/gp_rules.sql
+++ b/src/test/regress/sql/gp_rules.sql
@@ -1,0 +1,18 @@
+-- Some additional checks for RULEs
+
+-- Test turning a table into a view.
+
+CREATE table table_to_view_test1 (a int);
+CREATE table table_to_view_test2 (a int);
+CREATE rule "_RETURN" as on select to table_to_view_test1
+        do instead select * from table_to_view_test2;
+
+-- Same for an Append-Only table. It is currently not supported.
+
+CREATE table aotable_to_view_test1 (a int) with (appendonly=true);
+CREATE table aotable_to_view_test2 (a int);
+CREATE rule "_RETURN" as on select to aotable_to_view_test1
+        do instead select * from aotable_to_view_test2;
+
+drop table aotable_to_view_test1;
+drop table aotable_to_view_test2;


### PR DESCRIPTION
The code in rewriteDefine.c didn't know about AO tables, and tried to use
heap_beginscan() on an AO table. It resulted in an ERROR, because even for
an empty table, RelationGetNumberOfBlocks() returned 1, but we tried to
scan it like a heap table, heap_getnext() couldn't find the block. To fix,
add an explicit check that you can only turn heap tables into views this
way. This also forbids turning an external table into a view. (We could
possible relax that limitation, but it's a pointless feature anyway we only
support for backwards-compatibility reasons in PostgreSQL.)

Also add test case for this.