### PR TITLE
Remove errno check in append_stacktrace

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3072,7 +3072,9 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 				function = "<symbol not found>";
 			}
 
-			/* check if lineInfo was retrieved */
+			// check if lineInfo was retrieved
+			// if lineinfo does not contains symbol ':' then the output of cmd contains the input address
+			// if lineinfo contains symbol '?' then the filename and line number cannot be determined (the output is ??:0)
 			if (strchr(lineInfo, ':') == NULL ||
 			    strchr(lineInfo, '?') != NULL)
 			{

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3073,7 +3073,7 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 			}
 
 			// check if lineInfo was retrieved
-			// if lineinfo does not contains symbol ':' then the output of cmd contains the input address
+			// if lineinfo does not contain symbol ':' then the output of cmd contains the input address
 			// if lineinfo contains symbol '?' then the filename and line number cannot be determined (the output is ??:0)
 			if (strchr(lineInfo, ':') == NULL ||
 			    strchr(lineInfo, '?') != NULL)

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3004,12 +3004,12 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 
 		cmdresult[0][0] = '\0';
 		fd = popen(cmd,"r");
-		if (fd != NULL && errno == 0)
+		if (fd != NULL)
 			fd_ok = true;
 
 		if (fd_ok)
 		{
-			for (stack_no = 0; stack_no < stacksize && stack_no < STACK_DEPTH_MAX && errno == 0; stack_no++)
+			for (stack_no = 0; stack_no < stacksize && stack_no < STACK_DEPTH_MAX; stack_no++)
 			{
 				/* initialize the string */
 				cmdresult[stack_no][0] = '\0';
@@ -3073,7 +3073,8 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 			}
 
 			/* check if lineInfo was retrieved */
-			if (strchr(lineInfo, ':') == NULL)
+			if (strchr(lineInfo, ':') == NULL ||
+			    strchr(lineInfo, '?') != NULL)
 			{
 				/* no line info, print offset in function */
 				symbol_len = snprintf(symbol,


### PR DESCRIPTION
For some backtrace put under LOGs, we don't have line numbers, but we need them to help us debug customer issues.

Here I describe a common scenario. 
If GPDB crashes, then a logger process will be triggered and it will execute the `append_stacktrace` function that writes the stacktrace to a log file. To retrieve line information for every frame, `append_stacktrace` makes an `addr2line` system call and processes the result. However, if `errno != 0` (see sys/errno.h for more details), then it does not process the output of `addr2line`, and it prints the offset instead of the line number.

In this PR, we remove the `errno == 0` check such that `append_stacktrace` always processes the output of `addr2line`, since this is not harmful.  