### PR TITLE
Fix crash with CREATE TABLE AS in utility mode.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4714,8 +4714,21 @@ OpenIntoRel(QueryDesc *queryDesc)
 	/*
 	 * Select tablespace to use.  If not specified, use default tablespace
 	 * (which may in turn default to database's default).
+	 *
+	 * In PostgreSQL, we resolve default tablespace here. In GPDB, that's
+	 * done earlier, because we need to dispatch the final tablespace name,
+	 * after resolving any defaults, to the segments. So usually, we already
+	 * have the fully-resolved tablespace name stashed in queryDesc->ddesc->
+	 * intoTableSpaceName. In the dispatcher, we filled it in earlier, and
+	 * in executor nodes, we received it from the dispatcher along with the
+	 * query. In utility mode, however, queryDesc->ddesc is not set at all,
+	 * and we follow the PostgreSQL codepath, resolving the defaults here.
 	 */
-	intoTableSpaceName = queryDesc->ddesc->intoTableSpaceName;
+	if (queryDesc->ddesc)
+		intoTableSpaceName = queryDesc->ddesc->intoTableSpaceName;
+	else
+		intoTableSpaceName = into->tableSpaceName;
+
 	if (intoTableSpaceName)
 	{
 		tablespaceId = get_tablespace_oid(intoTableSpaceName, false);
@@ -4723,13 +4736,7 @@ OpenIntoRel(QueryDesc *queryDesc)
 	else
 	{
 		tablespaceId = GetDefaultTablespace(into->rel->istemp);
-
-		/* Need the real tablespace id for dispatch */
-		if (!OidIsValid(tablespaceId)) 
-			tablespaceId = MyDatabaseTableSpace;
-
-		/* MPP-10329 - must dispatch tablespace */
-		into->tableSpaceName = get_tablespace_name(tablespaceId);
+		/* note InvalidOid is OK in this case */
 	}
 
 	/* Check permissions except when using the database's default space */

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4717,7 +4717,10 @@ OpenIntoRel(QueryDesc *queryDesc)
 	 *
 	 * In PostgreSQL, we resolve default tablespace here. In GPDB, that's
 	 * done earlier, because we need to dispatch the final tablespace name,
-	 * after resolving any defaults, to the segments. So usually, we already
+	 * after resolving any defaults, to the segments. (Otherwise, we would
+	 * rely on the assumption that default_tablespace GUC is kept in sync
+	 * in all segment connections. That actually seems to be the case, as of
+	 * this writing, but better to not rely on it.) So usually, we already
 	 * have the fully-resolved tablespace name stashed in queryDesc->ddesc->
 	 * intoTableSpaceName. In the dispatcher, we filled it in earlier, and
 	 * in executor nodes, we received it from the dispatcher along with the

--- a/src/test/regress/input/filespace.source
+++ b/src/test/regress/input/filespace.source
@@ -1186,6 +1186,23 @@ SELECT count(*) FROM fsts_busted_heap1;
 SELECT count(*) FROM fsts_busted_heap2;
 
 --
+-- Test that default_tablespace correctly affects both the master and
+-- segments, in CREATE TABLE AS. (Used to have a bug where the master
+-- and segments chose different tablespace.)
+--
+
+set default_tablespace = 'regression_ts_b1';
+create table default_tblspc_test as select g from generate_series(1, 10) g;
+
+-- Check that the table was created in the same namespace on every node
+-- (should return 1)
+select count(*) from (
+  select relnamespace from pg_class where relname='default_tblspc_test'
+  union
+  select relnamespace from gp_dist_random('pg_class') where relname='default_tblspc_test'
+) t;
+
+--
 -- Filespace/Tablespace Transaction tests
 --
 BEGIN;

--- a/src/test/regress/output/filespace.source
+++ b/src/test/regress/output/filespace.source
@@ -2469,6 +2469,27 @@ SELECT count(*) FROM fsts_busted_heap2;
 (1 row)
 
 --
+-- Test that default_tablespace correctly affects both the master and
+-- segments, in CREATE TABLE AS. (Used to have a bug where the master
+-- and segments chose different tablespace.)
+--
+set default_tablespace = 'regression_ts_b1';
+create table default_tblspc_test as select g from generate_series(1, 10) g;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Check that the table was created in the same namespace on every node
+-- (should return 1)
+select count(*) from (
+  select relnamespace from pg_class where relname='default_tblspc_test'
+  union
+  select relnamespace from gp_dist_random('pg_class') where relname='default_tblspc_test'
+) t;
+ count 
+-------
+     1
+(1 row)
+
+--
 -- Filespace/Tablespace Transaction tests
 --
 BEGIN;


### PR DESCRIPTION
Connect to a segment in utility mode and run the following query

No test case included, because the bug was only in utility mode, and
that is difficult to automate. But this query triggered the bug:

```
PGOPTIONS="-c gp_session_role=utility" psql -p 25432 gptest
psql (8.3.23)
Type "help" for help.
gptest=# create table t1(a int);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE
gptest=# insert into t1 values (1), (2), (3), (4);
INSERT 0 4
gptest=# create table t2 as select * from t1;
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```

Fixes github issue #1511, reported with test case by Abhijit Subramanya.