### PR TITLE
Fix a Coverity error in binary_upgrade and apply some polish

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -2672,6 +2672,14 @@ dumpDumpableObject(Archive *fout, DumpableObject *dobj)
 						 NULL, 0,
 						 dumpBlobComments, NULL);
 			break;
+		/*
+		 * The TYPE_CACHE object is only used for the pg_type cache during
+		 * binary_upgrade operation and should not be dumped. To keep the
+		 * compilers and static analyzers happy we still need to handle
+		 * the case though.
+		 */
+		case DO_TYPE_CACHE:
+			break;
 	}
 }
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6217,6 +6217,12 @@ dumpDumpableObject(Archive *fout, DumpableObject *dobj)
 						 NULL, 0,
 						 dumpBlobComments, NULL);
 			break;
+		/*
+		 * The TYPE_CACHE object is only used for the pg_type cache during
+		 * binary_upgrade operation and should not be dumped. To keep the
+		 * compilers and static analyzers happy we still need to handle
+		 * the case though.
+		 */
 		case DO_TYPE_CACHE:
 			break;
 	}


### PR DESCRIPTION
Coverity complained that the aoseg_namespace variable potentially was uninitialized at usage, and while technically correct it would require the pg_aoseg namespace to be missing in the source cluster, which seems far fatched. Fix by forcing initialization to invalid and ensuring that the Oid has been changed to a valid Oid before using.

While looking at the code I also realized I had been blindly cargoculting it to the same design pattern as the remaining queries, which here was pointless. Simplify the logic and avoid allocating an extra PQExpBuffer.

Also fix a compiler warning for the type cache identifier.