### PR TITLE
Implement bytea HEX encode/decode

### DIFF
--- a/src/backend/catalog/pg_largeobject.c
+++ b/src/backend/catalog/pg_largeobject.c
@@ -18,7 +18,7 @@
 #include "access/heapam.h"
 #include "catalog/indexing.h"
 #include "catalog/pg_largeobject.h"
-#include "utils/builtins.h"
+#include "utils/bytea.h"
 #include "utils/fmgroids.h"
 #include "utils/rel.h"
 #include "utils/tqual.h"

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -36,6 +36,7 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
+#include "utils/bytea.h"
 #include "nodes/makefuncs.h"
 
 static int  GetNextSegid(CdbSreh *cdbsreh);

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -35,6 +35,7 @@
 #include "tcop/utility.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/bytea.h"
 #include "utils/fmgroids.h"
 #include "utils/inval.h"
 #include "utils/lsyscache.h"

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -33,6 +33,7 @@
 #include "optimizer/var.h"
 #include "parser/parsetree.h"
 #include "utils/builtins.h"
+#include "utils/bytea.h"
 #include "utils/lsyscache.h"
 #include "utils/pg_locale.h"
 #include "utils/selfuncs.h"

--- a/src/backend/utils/adt/encode.c
+++ b/src/backend/utils/adt/encode.c
@@ -109,7 +109,7 @@ binary_decode(PG_FUNCTION_ARGS)
  * HEX
  */
 
-static const char *hextbl = "0123456789abcdef";
+static const char hextbl[] = "0123456789abcdef";
 
 static const int8 hexlookup[128] = {
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -122,7 +122,7 @@ static const int8 hexlookup[128] = {
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
-static unsigned
+unsigned
 hex_encode(const char *src, unsigned len, char *dst)
 {
 	const char *end = src + len;
@@ -136,7 +136,7 @@ hex_encode(const char *src, unsigned len, char *dst)
 	return len * 2;
 }
 
-static char
+static inline char
 get_hex(char c)
 {
 	int			res = -1;
@@ -152,7 +152,7 @@ get_hex(char c)
 	return (char) res;
 }
 
-static unsigned
+unsigned
 hex_decode(const char *src, unsigned len, char *dst)
 {
 	const char *s,

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -95,6 +95,7 @@
 #include "parser/parse_expr.h"
 #include "parser/parsetree.h"
 #include "utils/builtins.h"
+#include "utils/bytea.h"
 #include "utils/date.h"
 #include "utils/datum.h"
 #include "utils/fmgroids.h"

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -438,7 +438,7 @@ log_autostats=off	# print additional autostats information
 #statement_timeout = 0			# 0 is disabled
 #idle_session_gang_timeout = 18s 	# in milliseconds, 0 is disabled
 #vacuum_freeze_min_age = 100000000
-
+#bytea_output='escape'
 # - Locale and Formatting -
 
 #datestyle = 'iso, mdy'

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -439,6 +439,7 @@ log_autostats=off	# print additional autostats information
 #idle_session_gang_timeout = 18s 	# in milliseconds, 0 is disabled
 #vacuum_freeze_min_age = 100000000
 #bytea_output='escape'
+
 # - Locale and Formatting -
 
 #datestyle = 'iso, mdy'

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -11483,6 +11483,8 @@ dumpTrigger(Archive *fout, TriggerInfo *tginfo)
 	TableInfo  *tbinfo = tginfo->tgtable;
 	PQExpBuffer query;
 	PQExpBuffer delqry;
+	char	   *tgargs;
+	size_t		lentgargs;
 	const char *p;
 	int			findx;
 
@@ -11568,53 +11570,29 @@ dumpTrigger(Archive *fout, TriggerInfo *tginfo)
 	appendPQExpBuffer(query, "EXECUTE PROCEDURE %s(",
 					  tginfo->tgfname);
 
-	p = tginfo->tgargs;
+	tgargs = (char *) PQunescapeBytea(tginfo->tgargs, &lentgargs);
+	p = tgargs;
 	for (findx = 0; findx < tginfo->tgnargs; findx++)
 	{
-		const char *s = p;
+		/* find the embedded null that terminates this trigger argument */
+		size_t	tlen = strlen(p);
 
-		/* Set 'p' to end of arg string. marked by '\000' */
-		for (;;)
+		if (p + tlen >= tgargs + lentgargs)
 		{
-			p = strchr(p, '\\');
-			if (p == NULL)
-			{
-				write_msg(NULL, "invalid argument string (%s) for trigger \"%s\" on table \"%s\"\n",
-						  tginfo->tgargs,
-						  tginfo->dobj.name,
-						  tbinfo->dobj.name);
-				exit_nicely();
-			}
-			p++;
-			if (*p == '\\')		/* is it '\\'? */
-			{
-				p++;
-				continue;
-			}
-			if (p[0] == '0' && p[1] == '0' && p[2] == '0')		/* is it '\000'? */
-				break;
+			/* hm, not found before end of bytea value... */
+			write_msg(NULL, "invalid argument string (%s) for trigger \"%s\" on table \"%s\"\n",
+					  tginfo->tgargs,
+					  tginfo->dobj.name,
+					  tbinfo->dobj.name);
+			exit_nicely();
 		}
-		p--;
 
-		appendPQExpBufferChar(query, '\'');
-		while (s < p)
-		{
-			if (*s == '\'')
-				appendPQExpBufferChar(query, '\'');
-
-			/*
-			 * bytea unconditionally doubles backslashes, so we suppress the
-			 * doubling for standard_conforming_strings.
-			 */
-			if (fout->std_strings && *s == '\\' && s[1] == '\\')
-				s++;
-			appendPQExpBufferChar(query, *s++);
-		}
-		appendPQExpBufferChar(query, '\'');
-		appendPQExpBuffer(query,
-						  (findx < tginfo->tgnargs - 1) ? ", " : "");
-		p = p + 4;
+		if (findx > 0)
+			appendPQExpBuffer(query, ", ");
+		appendStringLiteralAH(query, p, fout);
+		p += tlen + 1;
 	}
+	free(tgargs);
 	appendPQExpBuffer(query, ");\n");
 
 	if (tginfo->tgenabled != 't' && tginfo->tgenabled != 'O')

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -116,6 +116,12 @@ extern Datum char_text(PG_FUNCTION_ARGS);
 extern Datum domain_in(PG_FUNCTION_ARGS);
 extern Datum domain_recv(PG_FUNCTION_ARGS);
 
+/* encode.c */
+extern Datum binary_encode(PG_FUNCTION_ARGS);
+extern Datum binary_decode(PG_FUNCTION_ARGS);
+extern unsigned hex_encode(const char *src, unsigned len, char *dst);
+extern unsigned hex_decode(const char *src, unsigned len, char *dst);
+
 /* enum.c */
 extern Datum enum_in(PG_FUNCTION_ARGS);
 extern Datum enum_out(PG_FUNCTION_ARGS);
@@ -751,28 +757,6 @@ extern Datum unknownout(PG_FUNCTION_ARGS);
 extern Datum unknownrecv(PG_FUNCTION_ARGS);
 extern Datum unknownsend(PG_FUNCTION_ARGS);
 
-extern Datum byteain(PG_FUNCTION_ARGS);
-extern Datum byteaout(PG_FUNCTION_ARGS);
-extern Datum bytearecv(PG_FUNCTION_ARGS);
-extern Datum byteasend(PG_FUNCTION_ARGS);
-extern Datum byteaoctetlen(PG_FUNCTION_ARGS);
-extern Datum byteaGetByte(PG_FUNCTION_ARGS);
-extern Datum byteaGetBit(PG_FUNCTION_ARGS);
-extern Datum byteaSetByte(PG_FUNCTION_ARGS);
-extern Datum byteaSetBit(PG_FUNCTION_ARGS);
-extern Datum binary_encode(PG_FUNCTION_ARGS);
-extern Datum binary_decode(PG_FUNCTION_ARGS);
-extern Datum byteaeq(PG_FUNCTION_ARGS);
-extern Datum byteane(PG_FUNCTION_ARGS);
-extern Datum bytealt(PG_FUNCTION_ARGS);
-extern Datum byteale(PG_FUNCTION_ARGS);
-extern Datum byteagt(PG_FUNCTION_ARGS);
-extern Datum byteage(PG_FUNCTION_ARGS);
-extern Datum byteacmp(PG_FUNCTION_ARGS);
-extern Datum byteacat(PG_FUNCTION_ARGS);
-extern Datum byteapos(PG_FUNCTION_ARGS);
-extern Datum bytea_substr(PG_FUNCTION_ARGS);
-extern Datum bytea_substr_no_len(PG_FUNCTION_ARGS);
 extern Datum pg_column_size(PG_FUNCTION_ARGS);
 
 extern Datum string_agg_transfn(PG_FUNCTION_ARGS);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -113,18 +113,6 @@ extern bool ParseConfigFile(const char *config_file, const char *calling_file,
 							struct name_value_pair **tail_p);
 extern void free_name_value_list(struct name_value_pair * list);
 
-/*
- * The possible values of an enum variable are specified by an array of
- * name-value pairs.  The "hidden" flag means the value is accepted but
- * won't be displayed when guc.c is asked for a list of acceptable values.
- */
-struct config_enum_entry
-{
-	const char *name;
-	int			val;
-	bool		hidden;
-};
-
 typedef const char *(*GucStringAssignHook) (const char *newval, bool doit, GucSource source);
 typedef bool (*GucBoolAssignHook) (bool newval, bool doit, GucSource source);
 typedef bool (*GucIntAssignHook) (int newval, bool doit, GucSource source);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -113,6 +113,18 @@ extern bool ParseConfigFile(const char *config_file, const char *calling_file,
 							struct name_value_pair **tail_p);
 extern void free_name_value_list(struct name_value_pair * list);
 
+/*
+ * The possible values of an enum variable are specified by an array of
+ * name-value pairs.  The "hidden" flag means the value is accepted but
+ * won't be displayed when guc.c is asked for a list of acceptable values.
+ */
+struct config_enum_entry
+{
+	const char *name;
+	int			val;
+	bool		hidden;
+};
+
 typedef const char *(*GucStringAssignHook) (const char *newval, bool doit, GucSource source);
 typedef bool (*GucBoolAssignHook) (bool newval, bool doit, GucSource source);
 typedef bool (*GucIntAssignHook) (int newval, bool doit, GucSource source);

--- a/src/test/regress/expected/conversion.out
+++ b/src/test/regress/expected/conversion.out
@@ -1,3 +1,5 @@
+-- ensure consistent test output regardless of the default bytea format
+SET bytea_output TO escape;
 --
 -- create user defined conversion
 --

--- a/src/test/regress/expected/strings.out
+++ b/src/test/regress/expected/strings.out
@@ -4,16 +4,22 @@
 --
 -- create required tables
 CREATE TABLE CHAR_STRINGS_TBL(f1 char(4));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO CHAR_STRINGS_TBL (f1) VALUES ('a'),
 ('ab'),
 ('abcd'),
 ('abcd    ');
 CREATE TABLE VARCHAR_STRINGS_TBL(f1 varchar(4));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO VARCHAR_STRINGS_TBL (f1) VALUES ('a'),
 ('ab'),
 ('abcd'),
 ('abcd    ');
 CREATE TABLE TEXT_STRINGS_TBL (f1 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO TEXT_STRINGS_TBL VALUES ('doh!'),
 ('hi de ho neighbor');
 -- SQL92 string continuation syntax
@@ -35,6 +41,99 @@ SELECT 'first line'
 ERROR:  syntax error at or near "' - third line'"
 LINE 3: ' - third line'
         ^
+-- bytea
+SET bytea_output TO hex;
+SELECT E'\\xDeAdBeEf'::bytea;
+   bytea    
+------------
+ \xdeadbeef
+(1 row)
+
+SELECT E'\\x De Ad Be Ef '::bytea;
+   bytea    
+------------
+ \xdeadbeef
+(1 row)
+
+SELECT E'\\xDeAdBeE'::bytea;
+ERROR:  invalid hexadecimal data: odd number of digits
+LINE 1: SELECT E'\\xDeAdBeE'::bytea;
+               ^
+SELECT E'\\xDeAdBeEx'::bytea;
+ERROR:  invalid hexadecimal digit: "x"
+LINE 1: SELECT E'\\xDeAdBeEx'::bytea;
+               ^
+SELECT E'\\xDe00BeEf'::bytea;
+   bytea    
+------------
+ \xde00beef
+(1 row)
+
+SELECT E'DeAdBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465416442654566
+(1 row)
+
+SELECT E'De\\000dBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465006442654566
+(1 row)
+
+SELECT E'De\123dBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465536442654566
+(1 row)
+
+SELECT E'De\\123dBeEf'::bytea;
+       bytea        
+--------------------
+ \x4465536442654566
+(1 row)
+
+SELECT E'De\\678dBeEf'::bytea;
+ERROR:  invalid input syntax for type bytea
+LINE 1: SELECT E'De\\678dBeEf'::bytea;
+               ^
+SET bytea_output TO escape;
+SELECT E'\\xDeAdBeEf'::bytea;
+      bytea       
+------------------
+ \336\255\276\357
+(1 row)
+
+SELECT E'\\x De Ad Be Ef '::bytea;
+      bytea       
+------------------
+ \336\255\276\357
+(1 row)
+
+SELECT E'\\xDe00BeEf'::bytea;
+      bytea       
+------------------
+ \336\000\276\357
+(1 row)
+
+SELECT E'DeAdBeEf'::bytea;
+  bytea   
+----------
+ DeAdBeEf
+(1 row)
+
+SELECT E'De\\000dBeEf'::bytea;
+    bytea    
+-------------
+ De\000dBeEf
+(1 row)
+
+SELECT E'De\\123dBeEf'::bytea;
+  bytea   
+----------
+ DeSdBeEf
+(1 row)
+
 --
 -- test conversions between various string types
 -- E021-10 implicit casting among the character data types
@@ -927,6 +1026,8 @@ select * from ( select 'a' as a) x join (select 'b' as b) y on a=b;
 
 -- Test "unknown" with typmod MPP-2658
 create table unknown_test (v varchar(20), n numeric(20, 2), t timestamp(2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'v' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into unknown_test select '100', '123.23', '2008-01-01 11:11:11';
 select 'foo'::varchar(10) || bar from (select 'bar' as bar) moo;
  ?column? 
@@ -975,6 +1076,8 @@ select * from (select 'a' as a, 'b' as b, 'c' as c, 1 as d)d union select 'a' as
 -- Make sure we can convert unknown to other useful types (MPP-4298)
 create table t as select j as a, 'abc' as i from
 generate_series(1, 10) j;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 WARNING:  column "i" has type "unknown"
 DETAIL:  Proceeding with relation creation anyway.
 select * from t order by a;
@@ -993,7 +1096,7 @@ select * from t order by a;
 (10 rows)
 
 alter table t alter i type int; -- should fail
-ERROR:  invalid input syntax for integer: "abc"
+ERROR:  invalid input syntax for integer: "abc"  (seg2 192.168.0.4:25434 pid=51141)
 alter table t alter i type text; -- should work
 select * from t order by a;
  a  |  i  
@@ -1015,6 +1118,8 @@ drop table t;
 -- test substr with toasted text values
 --
 CREATE TABLE toasttest(f1 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into toasttest values(repeat('1234567890',10000));
 insert into toasttest values(repeat('1234567890',10000));
 --
@@ -1037,7 +1142,7 @@ SELECT substr(f1, -1, 5) from toasttest;
 
 -- If the length is less than zero, an ERROR is thrown.
 SELECT substr(f1, 5, -1) from toasttest;
-ERROR:  negative substring length not allowed
+ERROR:  negative substring length not allowed  (seg1 slice1 192.168.0.4:25433 pid=51140)
 -- If no third argument (length) is provided, the length to the end of the
 -- string is assumed.
 SELECT substr(f1, 99995) from toasttest;
@@ -1065,6 +1170,8 @@ DROP TABLE toasttest;
 -- test substr with toasted bytea values
 --
 CREATE TABLE toasttest(f1 bytea);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into toasttest values("decode"(repeat('1234567890',10000),'escape'));
 insert into toasttest values(pg_catalog.decode(repeat('1234567890',10000),'escape'));
 --
@@ -1087,7 +1194,7 @@ SELECT substr(f1, -1, 5) from toasttest;
 
 -- If the length is less than zero, an ERROR is thrown.
 SELECT substr(f1, 5, -1) from toasttest;
-ERROR:  negative substring length not allowed
+ERROR:  negative substring length not allowed  (seg1 slice1 192.168.0.4:25433 pid=51140)
 -- If no third argument (length) is provided, the length to the end of the
 -- string is assumed.
 SELECT substr(f1, 99995) from toasttest;
@@ -1117,6 +1224,8 @@ DROP TABLE toasttest;
 -- datum must be given a 4-byte header because there are no bits to indicate
 -- compression in a 1-byte header
 CREATE TABLE toasttest (c char(4096));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO toasttest VALUES('x');
 SELECT length(c), c::text FROM toasttest;
  length | c 
@@ -1395,7 +1504,7 @@ select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3, 'abcd\\'   as f4, '
 -- test unicode escape
 --
 select E'A\u0041' as f1, E'\u0127' as f2;
- f1 | f2
+ f1 | f2 
 ----+----
  AA | ħ
 (1 row)

--- a/src/test/regress/input/largeobject.source
+++ b/src/test/regress/input/largeobject.source
@@ -2,6 +2,9 @@
 -- Test large object support
 --
 
+-- ensure consistent test output regardless of the default bytea format
+SET bytea_output TO escape;
+
 -- Load a file
 CREATE TABLE lotest_stash_values (loid oid, fd integer) DISTRIBUTED BY (loid);
 -- lo_creat(mode integer) returns oid

--- a/src/test/regress/output/largeobject.source
+++ b/src/test/regress/output/largeobject.source
@@ -1,6 +1,8 @@
 --
 -- Test large object support
 --
+-- ensure consistent test output regardless of the default bytea format
+SET bytea_output TO escape;
 -- Load a file
 CREATE TABLE lotest_stash_values (loid oid, fd integer);
 -- lo_creat(mode integer) returns oid

--- a/src/test/regress/output/largeobject_1.source
+++ b/src/test/regress/output/largeobject_1.source
@@ -1,6 +1,8 @@
 --
 -- Test large object support
 --
+-- ensure consistent test output regardless of the default bytea format
+SET bytea_output TO escape;
 -- Load a file
 CREATE TABLE lotest_stash_values (loid oid, fd integer);
 -- lo_creat(mode integer) returns oid

--- a/src/test/regress/sql/conversion.sql
+++ b/src/test/regress/sql/conversion.sql
@@ -1,3 +1,6 @@
+-- ensure consistent test output regardless of the default bytea format
+SET bytea_output TO escape;
+
 --
 -- create user defined conversion
 --

--- a/src/test/regress/sql/strings.sql
+++ b/src/test/regress/sql/strings.sql
@@ -33,6 +33,27 @@ SELECT 'first line'
 ' - third line'
 	AS "Illegal comment within continuation";
 
+-- bytea
+SET bytea_output TO hex;
+SELECT E'\\xDeAdBeEf'::bytea;
+SELECT E'\\x De Ad Be Ef '::bytea;
+SELECT E'\\xDeAdBeE'::bytea;
+SELECT E'\\xDeAdBeEx'::bytea;
+SELECT E'\\xDe00BeEf'::bytea;
+SELECT E'DeAdBeEf'::bytea;
+SELECT E'De\\000dBeEf'::bytea;
+SELECT E'De\123dBeEf'::bytea;
+SELECT E'De\\123dBeEf'::bytea;
+SELECT E'De\\678dBeEf'::bytea;
+
+SET bytea_output TO escape;
+SELECT E'\\xDeAdBeEf'::bytea;
+SELECT E'\\x De Ad Be Ef '::bytea;
+SELECT E'\\xDe00BeEf'::bytea;
+SELECT E'DeAdBeEf'::bytea;
+SELECT E'De\\000dBeEf'::bytea;
+SELECT E'De\\123dBeEf'::bytea;
+
 --
 -- test conversions between various string types
 -- E021-10 implicit casting among the character data types


### PR DESCRIPTION
this is from upstream commit a2a8c7a662ec96537b6d1faba0770c516b921911
The primary reason for back patching is to allow pgadmin4 to work
Unfortunately there are a few hacks to make this work without Enum Config GUCs
mostly around setting the GUC as the target is an integer but the guc value is a string