### PR TITLE
Fix a bug that Rollup causes query to crash

### DIFF
--- a/src/test/regress/expected/qp_olap_group_optimizer.out
+++ b/src/test/regress/expected/qp_olap_group_optimizer.out
@@ -1423,7 +1423,7 @@ SELECT DISTINCT sale.vn,sale.vn,GROUPING(sale.vn),GROUP_ID(), TO_CHAR(COALESCE(S
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY CUBE((sale.cn,sale.prc),(sale.vn),(sale.prc),(sale.cn)),CUBE((sale.cn,sale.cn,sale.qty),(sale.pn),(sale.pn,sale.dt,sale.cn)),ROLLUP((sale.pn),(sale.qty,sale.pn));
-ERROR:  division by zero  (seg0 slice12 127.0.0.1:25432 pid=86018)
+ERROR:  division by zero  (seg0 slice12 127.0.0.1:25432 pid=85362)
 -- ###### Queries involving STDDEV_SAMP() function ###### --
 SELECT DISTINCT sale.vn,sale.dt,sale.prc, TO_CHAR(COALESCE(STDDEV_SAMP(floor(sale.pn+sale.vn)),0),'99999999.9999999') 
 FROM sale,vendor
@@ -6016,26 +6016,25 @@ SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + 1 AS f, 1 AS g FRO
  cn_r | f  | g 
 ------+----+---
     1 | 11 | 1
+    2 | 31 |  
+    2 | 51 |  
+    2 | 51 | 1
+    1 | 21 |  
+    3 | 41 |  
     1 | 21 | 1
     2 | 31 | 1
     3 | 41 | 1
-    2 | 51 | 1
-(5 rows)
+    1 | 11 |  
+(10 rows)
 
 PREPARE p AS SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + $1 AS f, $1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (g > 1);
 EXECUTE p(2);
  cn_r | f  | g 
 ------+----+---
-    1 | 12 | 2
     1 | 22 | 2
     2 | 32 | 2
+    1 | 12 | 2
     3 | 42 | 2
     2 | 52 | 2
-    1 | 12 |  
-    1 | 22 |  
-    2 | 32 |  
-    3 | 42 |  
-    2 | 52 |  
-    4 |    |  
-(11 rows)
+(5 rows)
 

--- a/src/test/regress/sql/qp_olap_group.sql
+++ b/src/test/regress/sql/qp_olap_group.sql
@@ -157,4 +157,8 @@ FROM sale,product
 WHERE sale.pn=product.pn
 GROUP BY ROLLUP((sale.prc),(sale.prc,sale.vn),(sale.qty,sale.qty),(sale.vn)),GROUPING SETS((),ROLLUP((sale.prc,sale.cn,sale.prc),(sale.cn,sale.cn),(sale.vn),(sale.vn,sale.cn))),GROUPING SETS(CUBE((sale.cn),(sale.pn,sale.qty,sale.qty)),ROLLUP((sale.prc,sale.cn,sale.prc),(sale.qty)));
 
-
+-- ###### Rollup with DQA and constants in target list expressions and qualifications with same value as that of constant grouping column ###### --
+SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, CASE WHEN (vn = 0) THEN 1 END AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g);
+SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + 1 AS f, 1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (f > 1);
+PREPARE p AS SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + $1 AS f, $1 AS g FROM sale) sale_view GROUP BY ROLLUP(f,g) HAVING (g > 1);
+EXECUTE p(2);


### PR DESCRIPTION
In rollup() processing, when the grouping cols are processed, the target list is
traversed for each grouping col to find a match. Each node in the target list is
mutated in `replace_grouping_columns_mutator()` to find match for grouping cols.

In the failing query:

```
SELECT COUNT(DISTINCT c) AS r
FROM (
    SELECT c
    , CASE WHEN (e = 2) THEN 1 END AS f
    , 1 AS g FROM foo
    ) f_view
GROUP BY ROLLUP(f,g);
```

grouping cols ‘g’ is a constant 1. when target entry for ‘f’ is being mutated,
we mutate all the fields of caseexpr recursively. since the `result` field in
caseexpr is a const with same value as that of ‘g’, it gets considered as a
match and we replace the node by null which later results in crash.

Essentially, since we traverse all the fields of expr, a const
node (appearing anywhere in caseexpr) with same value as that of const grouping
col will be matched.

Hence the following query also fails where one of the arg of equality operator
is a const with same value as that of ‘g’.

```
SELECT COUNT(DISTINCT c) AS r
FROM (
    SELECT c
    , CASE WHEN (e = 1) THEN 2 END AS f
    , 1 AS g FROM foo
    ) f_view
GROUP BY ROLLUP(f,g);
```

Fix:
1. refactored the `replace_grouping_columns_mutator()` to have separate
routines for target list replacement and qual replacement.
2. for target list, just look at top level node. do not recurse.
3. for quals, the top level is always some kind of expression, so we
need to recurse to find the match. Skip replacing constants here.

[#136294589]

Signed-off-by: Xin Zhang <xzhang@pivotal.io>