### PR TITLE
gpload local_hostname var should be list instead of string

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1635,9 +1635,9 @@ class gpload:
                 # resolve the fqdn rather than just grabbing the hostname.
                 fqdn = self.getconfig('gpload:input:fully_qualified_domain_name', bool, False)
                 if fqdn:
-                    local_hostname = socket.getfqdn()
+                    local_hostname = [socket.getfqdn()]
                 else:
-                    local_hostname = socket.gethostname()
+                    local_hostname = [socket.gethostname()]
 
             # build gpfdist parameters
             popenList = ['gpfdist']


### PR DESCRIPTION
This was fixed in GPDB 4.3 immediately after it was brought up but was
never ported to 5.0. Issue was introduced in
https://github.com/greenplum-db/gpdb/commit/232eb64ad9f93dce8941f7b124a98f0c21c3350b
which has the initial discussion.