### PR TITLE
More generic with respect to sync_tools OS

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -180,7 +180,7 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb_centos
+    - get: sync_tools_gpdb
       resource: sync_tools_gpdb_centos
       passed: [compile_gpdb_centos6]
     - get: bin_gpdb
@@ -202,7 +202,7 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb_centos
+    - get: sync_tools_gpdb
       resource: sync_tools_gpdb_centos
       passed: [compile_gpdb_centos6]
     - get: bin_gpdb
@@ -224,7 +224,7 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb_centos
+    - get: sync_tools_gpdb
       resource: sync_tools_gpdb_centos
       passed: [compile_gpdb_centos6]
     - get: bin_gpdb
@@ -246,7 +246,7 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb_centos
+    - get: sync_tools_gpdb
       resource: sync_tools_gpdb_centos
       passed: [compile_gpdb_centos6]
     - get: bin_gpdb
@@ -267,7 +267,7 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb_centos
+    - get: sync_tools_gpdb
       resource: sync_tools_gpdb_centos
       passed: [compile_gpdb_centos6]
     - get: bin_gpdb

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -138,7 +138,7 @@ jobs:
     - aggregate:
       - get: gpdb_pr
         passed: [compile_gpdb_centos6]
-      - get: sync_tools_gpdb_centos
+      - get: sync_tools_gpdb
         resource: sync_tools_gpdb_centos
         passed: [compile_gpdb_centos6]
       - get: bin_gpdb

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -19,7 +19,7 @@ function install_gpdb() {
 }
 
 function install_sync_tools() {
-    tar -xzf sync_tools_gpdb_centos/sync_tools_gpdb.tar.gz -C gpdb_src/gpAux
+    tar -xzf sync_tools_gpdb/sync_tools_gpdb.tar.gz -C gpdb_src/gpAux
 }
 
 function configure() {

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -19,7 +19,9 @@ function install_gpdb() {
 }
 
 function install_sync_tools() {
-    tar -xzf sync_tools_gpdb/sync_tools_gpdb.tar.gz -C gpdb_src/gpAux
+    [ -s sync_tools_gpdb/sync_tools_gpdb.tar.gz ] && \
+    tar -xzf sync_tools_gpdb/sync_tools_gpdb.tar.gz -C gpdb_src/gpAux || \
+    tar -xzf sync_tools_gpdb_centos/sync_tools_gpdb.tar.gz -C gpdb_src/gpAux
 }
 
 function configure() {

--- a/concourse/tasks/gpMgmt_check_gpdb.yml
+++ b/concourse/tasks/gpMgmt_check_gpdb.yml
@@ -4,7 +4,7 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
-  - name: sync_tools_gpdb_centos
+  - name: sync_tools_gpdb
 outputs:
 params:
   TEST_OS: ""

--- a/concourse/tasks/ic_gpdb.yml
+++ b/concourse/tasks/ic_gpdb.yml
@@ -4,7 +4,7 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
-  - name: sync_tools_gpdb_centos
+  - name: sync_tools_gpdb
 outputs:
 params:
   MAKE_TEST_COMMAND: ""


### PR DESCRIPTION
common.bash doesn't respect sync_tools OS, which was exposed by PR #1521. This fixes it but requires resetting pipelines.