### PR TITLE
[#134494265] Update Translator files to refer 'OpFamily'

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2662,12 +2662,12 @@ gpdb::CheckRTPermissions
 	GP_WRAP_END;
 }
 
-// check permissions on range table
+// get index op family properties
 void
 gpdb::IndexOpProperties
 	(
 	Oid opno,
-	Oid opclass,
+	Oid opfamily,
 	int *strategy,
 	Oid *subtype,
 	bool *recheck
@@ -2677,20 +2677,19 @@ gpdb::IndexOpProperties
 	{
 		/* catalog tables: pg_amop */
 
-		// FIXME: We assume the 'opclass' arg is actually an opfamily
-		// Also, only the right type is returned to the caller, the left
+		// Only the right type is returned to the caller, the left
 		// type is simply ignored.
 		Oid	lefttype;
 
-		get_op_opfamily_properties(opno, opclass, strategy, &lefttype, subtype, recheck);
+		get_op_opfamily_properties(opno, opfamily, strategy, &lefttype, subtype, recheck);
 		return;
 	}
 	GP_WRAP_END;
 }
 
-// get oids of opclasses for the index keys
+// get oids of opfamilies for the index keys
 List *
-gpdb::PlIndexOpClasses
+gpdb::PlIndexOpFamilies
 	(
 	Oid oidIndex
 	)
@@ -2699,9 +2698,7 @@ gpdb::PlIndexOpClasses
 	{
 		/* catalog tables: pg_index */
 
-		// FIXME: We actually return the operator *families* of the index keys.
-		// As long as we do the same for operators below, i.e. fetch the
-		// operator families that an operator belons to, this works.
+		// We return the operator families of the index keys.
 		return get_index_opfamilies(oidIndex);
 	}
 	GP_WRAP_END;
@@ -2709,9 +2706,9 @@ gpdb::PlIndexOpClasses
 	return NIL;
 }
 
-// get oids of classes this operator belongs to
+// get oids of families this operator belongs to
 List *
-gpdb::PlScOpOpClasses
+gpdb::PlScOpOpFamilies
 	(
 	Oid opno
 	)
@@ -2720,9 +2717,8 @@ gpdb::PlScOpOpClasses
 	{
 		/* catalog tables: pg_amop */
 
-		// FIXME: We actually return the operator *families* this operator
-		// belongs to. As long as we do the same for index columns above,
-		// this works.
+		// We return the operator families this operator
+		// belongs to.
 		return get_operator_opfamilies(opno);
 	}
 	GP_WRAP_END;

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1527,9 +1527,9 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 		
 		OID oidCmpOperator = CTranslatorUtils::OidCmpOperator(pexprIndexCond);
 		GPOS_ASSERT(InvalidOid != oidCmpOperator);
-		OID oidOpclass = CTranslatorUtils::OidIndexQualOpclass(iAttno, CMDIdGPDB::PmdidConvert(pmdindex->Pmdid())->OidObjectId());
-		GPOS_ASSERT(InvalidOid != oidOpclass);
-		gpdb::IndexOpProperties(oidCmpOperator, oidOpclass, &iSN, &oidIndexSubtype, &fRecheck);
+		OID oidOpFamily = CTranslatorUtils::OidIndexQualOpFamily(iAttno, CMDIdGPDB::PmdidConvert(pmdindex->Pmdid())->OidObjectId());
+		GPOS_ASSERT(InvalidOid != oidOpFamily);
+		gpdb::IndexOpProperties(oidCmpOperator, oidOpFamily, &iSN, &oidIndexSubtype, &fRecheck);
 		GPOS_ASSERT(!fRecheck);
 		
 		// create index qual

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1044,7 +1044,7 @@ CTranslatorRelcacheToDXL::Pmdindex
 	}
 
 	pmdidIndex->AddRef();	
-	DrgPmdid *pdrgpmdidOpClasses = PdrgpmdidIndexOpClasses(pmp, pmdidIndex);
+	DrgPmdid *pdrgpmdidOpFamilies = PdrgpmdidIndexOpFamilies(pmp, pmdidIndex);
 	
 	CMDIndexGPDB *pmdindex = GPOS_NEW(pmp) CMDIndexGPDB
 										(
@@ -1058,7 +1058,7 @@ CTranslatorRelcacheToDXL::Pmdindex
 										false, // fPartial
 										pdrgpulKeyCols,
 										pdrgpulIncludeCols,
-										pdrgpmdidOpClasses,
+										pdrgpmdidOpFamilies,
 										NULL // pmdpartcnstr
 										);
 
@@ -1251,7 +1251,7 @@ CTranslatorRelcacheToDXL::PmdindexPartTable
 		pmdidItemType = GPOS_NEW(pmp) CMDIdGPDB(GPDB_ANY);
 	}
 	
-	DrgPmdid *pdrgpmdidOpClasses = PdrgpmdidIndexOpClasses(pmp, pmdidIndex);
+	DrgPmdid *pdrgpmdidOpFamilies = PdrgpmdidIndexOpFamilies(pmp, pmdidIndex);
 	
 	CMDIndexGPDB *pmdindex = GPOS_NEW(pmp) CMDIndexGPDB
 										(
@@ -1265,7 +1265,7 @@ CTranslatorRelcacheToDXL::PmdindexPartTable
 										fPartial,
 										pdrgpulKeyCols,
 										pdrgpulIncludeCols,
-										pdrgpmdidOpClasses,
+										pdrgpmdidOpFamilies,
 										pmdpartcnstr
 										);
 	
@@ -1624,7 +1624,7 @@ CTranslatorRelcacheToDXL::Pmdscop
 											pmdidOpInverse,
 											ecmpt,
 											fReturnsNullOnNullInput,
-											PdrgpmdidScOpOpClasses(pmp, pmdid)
+											PdrgpmdidScOpOpFamilies(pmp, pmdid)
 											);
 	return pmdscop;
 }
@@ -3423,28 +3423,28 @@ CTranslatorRelcacheToDXL::UlCmpt
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpmdidIndexOpClasses
+//		CTranslatorRelcacheToDXL::PdrgpmdidIndexOpFamilies
 //
 //	@doc:
-//		Retrieve the opclasses for the keys of the given index
+//		Retrieve the opfamilies for the keys of the given index
 //
 //---------------------------------------------------------------------------
 DrgPmdid * 
-CTranslatorRelcacheToDXL::PdrgpmdidIndexOpClasses
+CTranslatorRelcacheToDXL::PdrgpmdidIndexOpFamilies
 	(
 	IMemoryPool *pmp,
 	IMDId *pmdidIndex
 	)
 {
-	List *plOpClasses = gpdb::PlIndexOpClasses(CMDIdGPDB::PmdidConvert(pmdidIndex)->OidObjectId());
+	List *plOpFamilies = gpdb::PlIndexOpFamilies(CMDIdGPDB::PmdidConvert(pmdidIndex)->OidObjectId());
 	DrgPmdid *pdrgpmdid = GPOS_NEW(pmp) DrgPmdid(pmp);
 	
 	ListCell *plc = NULL;
 	
-	ForEach(plc, plOpClasses)
+	ForEach(plc, plOpFamilies)
 	{
-		OID oidOpClass = lfirst_oid(plc);
-		pdrgpmdid->Append(GPOS_NEW(pmp) CMDIdGPDB(oidOpClass));
+		OID oidOpFamily = lfirst_oid(plc);
+		pdrgpmdid->Append(GPOS_NEW(pmp) CMDIdGPDB(oidOpFamily));
 	}
 	
 	return pdrgpmdid;
@@ -3452,28 +3452,28 @@ CTranslatorRelcacheToDXL::PdrgpmdidIndexOpClasses
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorRelcacheToDXL::PdrgpmdidScOpOpClasses
+//		CTranslatorRelcacheToDXL::PdrgpmdidScOpOpFamilies
 //
 //	@doc:
-//		Retrieve the opclasses for the keys of the given scalar operator
+//		Retrieve the families for the keys of the given scalar operator
 //
 //---------------------------------------------------------------------------
 DrgPmdid * 
-CTranslatorRelcacheToDXL::PdrgpmdidScOpOpClasses
+CTranslatorRelcacheToDXL::PdrgpmdidScOpOpFamilies
 	(
 	IMemoryPool *pmp,
 	IMDId *pmdidScOp
 	)
 {
-	List *plOpClasses = gpdb::PlScOpOpClasses(CMDIdGPDB::PmdidConvert(pmdidScOp)->OidObjectId());
+	List *plOpFamilies = gpdb::PlScOpOpFamilies(CMDIdGPDB::PmdidConvert(pmdidScOp)->OidObjectId());
 	DrgPmdid *pdrgpmdid = GPOS_NEW(pmp) DrgPmdid(pmp);
 	
 	ListCell *plc = NULL;
 	
-	ForEach(plc, plOpClasses)
+	ForEach(plc, plOpFamilies)
 	{
-		OID oidOpClass = lfirst_oid(plc);
-		pdrgpmdid->Append(GPOS_NEW(pmp) CMDIdGPDB(oidOpClass));
+		OID oidOpFamily = lfirst_oid(plc);
+		pdrgpmdid->Append(GPOS_NEW(pmp) CMDIdGPDB(oidOpFamily));
 	}
 	
 	return pdrgpmdid;

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -981,18 +981,14 @@ CTranslatorUtils::OidCmpOperator
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorUtils::OidCmpOperator
+//		CTranslatorUtils::OidIndexQualOpFamily
 //
 //	@doc:
-//		Extract comparison operator from an OpExpr, ScalarArrayOpExpr or RowCompareExpr
-//
-//	FIXME: This function comment is completely bogus.
-//	FIXME: This actually returns the operator family, not operator
-//	class!
+//		Extract comparison operator family for the given index column
 //
 //---------------------------------------------------------------------------
 OID
-CTranslatorUtils::OidIndexQualOpclass
+CTranslatorUtils::OidIndexQualOpFamily
 	(
 	INT iAttno,
 	OID oidIndex

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -578,14 +578,14 @@ namespace gpdb {
 	// check permissions on range table 
 	void CheckRTPermissions(List *plRangeTable);
 	
-	// get index operator properties
-	void IndexOpProperties(Oid opno, Oid opclass, int *strategy, Oid *subtype, bool *recheck);
+	// get index operator family properties
+	void IndexOpProperties(Oid opno, Oid opfamily, int *strategy, Oid *subtype, bool *recheck);
 	
-	// get oids of classes this operator belongs to
-	List *PlScOpOpClasses(Oid opno);
+	// get oids of families this operator belongs to
+	List *PlScOpOpFamilies(Oid opno);
 	
 	// get oids of op classes for the index keys
-	List *PlIndexOpClasses(Oid oidIndex);
+	List *PlIndexOpFamilies(Oid oidIndex);
 
 	// returns the result of evaluating 'pexpr' as an Expr. Caller keeps ownership of 'pexpr'
 	// and takes ownership of the result 

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -373,13 +373,13 @@ namespace gpdxl
 			static
 			ULONG UlCmpt(IMDType::ECmpType ecmpt);
 			
-			// retrieve the opclass mdids for the given scalar op
+			// retrieve the opfamilies mdids for the given scalar op
 			static
-			DrgPmdid *PdrgpmdidScOpOpClasses(IMemoryPool *pmp, IMDId *pmdidScOp);
+			DrgPmdid *PdrgpmdidScOpOpFamilies(IMemoryPool *pmp, IMDId *pmdidScOp);
 			
-			// retrieve the opclass mdids for the given index
+			// retrieve the opfamilies mdids for the given index
 			static
-			DrgPmdid *PdrgpmdidIndexOpClasses(IMemoryPool *pmp, IMDId *pmdidIndex);
+			DrgPmdid *PdrgpmdidIndexOpFamilies(IMemoryPool *pmp, IMDId *pmdidIndex);
 
             // for non-leaf partition tables return the number of child partitions
             // else return 1

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -118,9 +118,9 @@ namespace gpdxl
 			static
 			OID OidCmpOperator(Expr* pexpr);
 
-			// get the opclass for index key
+			// get the opfamily for index key
 			static
-			OID OidIndexQualOpclass(INT iAttno, OID oidIndex);
+			OID OidIndexQualOpFamily(INT iAttno, OID oidIndex);
 			
 			// return the type for the system column with the given number
 			static


### PR DESCRIPTION
With PostgreSQL 8.3, there's a new concept called "operator families".
An operator class is now part of an operator family, which can contain
cross-datatype operators that are "compatible" with each other.

ORCA doesn't know anything about that. This commit updates the
Translator files to refer to OpFamily instead of 'OpClasses'.

Signed-off-by: Haisheng Yuan <hyuan@pivotal.io>