### PR TITLE
137043181 analyze on partition tables

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -2896,7 +2896,7 @@ rel_get_leaf_relids_from_rule(Oid ruleOid)
 	ScanKeyData	scankey;
 	Relation	part_rule_rel;
 	SysScanDesc sscan;
-	bool		hasChildren;
+	bool		hasChildren = false;
 	List	   *lChildrenOid = NIL;
 	HeapTuple	tuple;
 

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -95,7 +95,7 @@ static VacAttrStats *examine_attribute(Relation onerel, int attnum);
 static int acquire_sample_rows(Relation onerel, HeapTuple *rows,
 					int targrows, double *totalrows, double *totaldeadrows);
 static int acquire_sample_rows_by_query(Relation onerel, int nattrs, VacAttrStats **attrstats, HeapTuple **rows,
-										int targrows, double *totalrows, double *totaldeadrows, BlockNumber *totalpages);
+										int targrows, double *totalrows, double *totaldeadrows, BlockNumber *totalpages, bool rootonly);
 static double random_fract(void);
 static double init_selection_state(int n);
 static double get_next_S(double t, int n, double *stateptr);
@@ -390,7 +390,7 @@ analyze_rel(Oid relid, VacuumStmt *vacstmt,
 	 * Acquire the sample rows
 	 */
 	numrows = acquire_sample_rows_by_query(onerel, attr_cnt, vacattrstats, &rows, targrows,
-										   &totalrows, &totaldeadrows, &totalpages);
+										   &totalrows, &totaldeadrows, &totalpages, vacstmt->rootonly);
 
 	/*
 	 * Compute the statistics.	Temporary results during the calculations for
@@ -1307,7 +1307,7 @@ compare_rows(const void *a, const void *b)
 static int
 acquire_sample_rows_by_query(Relation onerel, int nattrs, VacAttrStats **attrstats,
 							 HeapTuple **rows, int targrows,
-							 double *totalrows, double *totaldeadrows, BlockNumber *totalblocks)
+							 double *totalrows, double *totaldeadrows, BlockNumber *totalblocks, bool rootonly)
 {
 	StringInfoData str;
 	StringInfoData columnStr;
@@ -1327,7 +1327,7 @@ acquire_sample_rows_by_query(Relation onerel, int nattrs, VacAttrStats **attrsta
 	Assert(targrows > 0.0);
 
 	analyzeEstimateReltuplesRelpages(RelationGetRelid(onerel), &relTuples, &relPages,
-									 false);
+									 rootonly);
 	*totalrows = relTuples;
 	*totaldeadrows = 0;
 	*totalblocks = relPages;

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -1,0 +1,836 @@
+DROP DATABASE IF EXISTS testanalyze;
+CREATE DATABASE testanalyze;
+\c testanalyze
+set client_min_messages='WARNING';
+-- Case 1: Analyzing root table with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set off should only populate stats for leaf tables
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         0 |        1
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(5 rows)
+
+-- Case 2: Analyzing a midlevel partition directly should give a WARNING message and should not update any stats for the table.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales_1_prt_2;
+WARNING:  skipping "p3_sales_1_prt_2" --- cannot analyze a mid-level partition. Please run ANALYZE on the root partition table.
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         0 |        0
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+(0 rows)
+
+-- Case 3: Analyzing leaf table directly should update the stats only for itself
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales_1_prt_2_2_prt_2_3_prt_usa;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         0 |        0
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(5 rows)
+
+-- Case 4: Analyzing the database with the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should update stats for all table except root tables
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         0 |        1
+ p3_sales_1_prt_2                                                |         2 |        1
+ p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2                   | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(15 rows)
+
+-- Case 5: Vacuum analyzing the database should vacuum all the tables for p3_sales and should update the stats for all partitions for p3_sales except root partition
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+vacuum analyze;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         0 |        1
+ p3_sales_1_prt_2                                                |         0 |        1
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2                   | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(15 rows)
+
+select count(*) from pg_stat_last_operation pgl, pg_class pgc where pgl.objid=pgc.oid and pgc.relname like 'p3_sales%';
+ count 
+-------
+    59
+(1 row)
+
+-- Case 6: Analyzing root table with ROOTPARTITION keyword should only update the stats of the root table when the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition are set off
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(5 rows)
+
+-- Case 7: Analyzing a midlevel partition should give a warning if using ROOTPARTITION keyword and should not update any stats.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales_1_prt_2;
+WARNING:  skipping "p3_sales_1_prt_2" --- cannot analyze a non-root partition using ANALYZE ROOTPARTITION
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         0 |        0
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+(0 rows)
+
+-- Case 8: Analyzing a leaf partition should give a warning if using ROOTPARTITION keyword and should not update any stats.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales_1_prt_2_2_prt_2_3_prt_usa;
+WARNING:  skipping "p3_sales_1_prt_2_2_prt_2_3_prt_usa" --- cannot analyze a non-root partition using ANALYZE ROOTPARTITION
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         0 |        0
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+(0 rows)
+
+-- Case 9: Analyzing root table with GUC optimizer_analyze_root_partition set to ON and GUC optimizer_analyze_midlevel_partition set to off should update the leaf table and the root table stats.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales                           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales                           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales                           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(10 rows)
+
+-- Case 10: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to ON and GUC optimizer_analyze_midlevel_partition set to off should update the root table stats only.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(5 rows)
+
+-- Case 11: Analyzing root table with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should update the stats for root, midlevel and leaf partitions.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=on;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         2 |        1
+ p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales                           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales                           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales                           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(20 rows)
+
+-- Case 12: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should update the stats for root and midlevel partitions only.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=on;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         2 |        1
+ p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname |        tablename         | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+--------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales                 | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales                 | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                 | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                 | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales                 | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(15 rows)
+
+-- Case 13: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should update the stats for root partition only.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(5 rows)
+
+-- Case 14: Analyzing root table with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to On should update the stats for midlevel and leaf partition only.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=on;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         0 |        1
+ p3_sales_1_prt_2                                                |         2 |        1
+ p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2                   | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(15 rows)
+
+-- Case 15: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to On should update the stats for root, midlevel and leaf partition only.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=on;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+                             relname                             | reltuples | relpages 
+-----------------------------------------------------------------+-----------+----------
+ p3_sales                                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         2 |        1
+ p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+(15 rows)
+
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+ schemaname |        tablename         | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+--------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales                 | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales                 | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                 | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                 | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales                 | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2         | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2 | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(15 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS p3_sales;
+-- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -24,7 +24,7 @@ test: zlib
 test: leastsquares
 test: opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile naivebayes join_gp union_gp gpcopy gp_create_table
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var
-test: bitmap_index gp_dump_query_oids
+test: bitmap_index gp_dump_query_oids analyze
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules
 # dispatch should always run seperately from other cases.
 test: dispatch

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -1,0 +1,369 @@
+DROP DATABASE IF EXISTS testanalyze;
+CREATE DATABASE testanalyze;
+\c testanalyze
+set client_min_messages='WARNING';
+-- Case 1: Analyzing root table with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set off should only populate stats for leaf tables
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+
+-- Case 2: Analyzing a midlevel partition directly should give a WARNING message and should not update any stats for the table.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales_1_prt_2;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 3: Analyzing leaf table directly should update the stats only for itself
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales_1_prt_2_2_prt_2_3_prt_usa;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 4: Analyzing the database with the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should update stats for all table except root tables
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 5: Vacuum analyzing the database should vacuum all the tables for p3_sales and should update the stats for all partitions for p3_sales except root partition
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+vacuum analyze;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+select count(*) from pg_stat_last_operation pgl, pg_class pgc where pgl.objid=pgc.oid and pgc.relname like 'p3_sales%';
+
+-- Case 6: Analyzing root table with ROOTPARTITION keyword should only update the stats of the root table when the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition are set off
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 7: Analyzing a midlevel partition should give a warning if using ROOTPARTITION keyword and should not update any stats.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales_1_prt_2;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 8: Analyzing a leaf partition should give a warning if using ROOTPARTITION keyword and should not update any stats.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales_1_prt_2_2_prt_2_3_prt_usa;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 9: Analyzing root table with GUC optimizer_analyze_root_partition set to ON and GUC optimizer_analyze_midlevel_partition set to off should update the leaf table and the root table stats.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 10: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to ON and GUC optimizer_analyze_midlevel_partition set to off should update the root table stats only.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 11: Analyzing root table with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should update the stats for root, midlevel and leaf partitions.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=on;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 12: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should update the stats for root and midlevel partitions only.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=on;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 13: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should update the stats for root partition only.
+set optimizer_analyze_root_partition=on;
+set optimizer_analyze_midlevel_partition=off;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 14: Analyzing root table with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to On should update the stats for midlevel and leaf partition only.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=on;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- Case 15: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to On should update the stats for root, midlevel and leaf partition only.
+set optimizer_analyze_root_partition=off;
+set optimizer_analyze_midlevel_partition=on;
+DROP TABLE if exists p3_sales;
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+analyze rootpartition p3_sales;
+select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
+select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
+
+-- start_ignore
+DROP TABLE IF EXISTS p3_sales;
+-- end_ignore


### PR DESCRIPTION
This pull request address missing functionality of `analyze` as well as making the `analyze` and `vacuum` to produce the same results for partition tables as 4.3_STABLE.

On Master, if we run `analyze rootpartition tablename` with the value of GUC `optimizer_analyze_root_partition` set to off, the stats are not collected on the root table. Only when the value of `optimizer_analyze_root_partition` is set to on the stats are collected.
However, the expected behavior should be that irrespective of the value of `optimizer_analyze_root_partition`, if specifically `ANALYZE ROOTPARTITION tablename` command is run the stats should be collected.
Expectation:
Case 1:
```
set optimizer_analyze_root_partition=off;
analyze tablename;
-- Stats should only be collected for the leaf tables
analyze rootpartition tablename;
-- Stats should be only collected for the root table
```
Case 2:
```
set optimizer_analyze_root_partition=on;
analyze tablename;
-- Stats should be collected for the root and the leaf table;
analyze rootpartition tablename;
-- Stats should be only collected for the root table
```

Additionally, the vacuum and analyze for different test cases produces different results compared to the 4.3.X. This pull request addresses the incompatibilities for different cases which are provided in the `analyze.sql`. 