### PR TITLE
Fix analyzedb hang issue and incorrect WorkerPool usage

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -390,12 +390,11 @@ class AnalyzeDb(Operation):
                                     (len(self.success_list), len(ordered_candidates)))
                     wait_count -= 1
 
-                for worker in pool.workers:
-                    worker.join(1)
+                pool.join()
+                pool.haltWork()
             except:
                 pool.haltWork()
-                for worker in pool.workers:
-                    worker.join(1)
+                pool.joinWorkers()
                 raise
 
             finally:
@@ -1134,6 +1133,7 @@ class AnalyzeWorkerPool(WorkerPool):
         self.workers=[]
         self.work_queue=Queue()
         self.completed_queue=Queue()
+        self.should_stop=False
         self.num_assigned=0
         if items is not None:
             for item in items:
@@ -1148,30 +1148,37 @@ class AnalyzeWorkerPool(WorkerPool):
         self.numWorkers = numWorkers
         self.logger = logger
 
-
-class AnalyzeWorker(Thread):
+class AnalyzeWorker(Worker):
     """
     a custom worker thread for Analyze
     """
-    pool=None
-    cmd=None
-    name=None
-    logger=None
-
     def __init__(self,name,pool):
-        self.name=name
-        self.pool=pool
-        self.logger=logger
-        self.stoprequest = threading.Event()
-        Thread.__init__(self)
-
+        Worker.__init__(self, name, pool)
+    
+    
     def run(self):
-        while not self.stoprequest.isSet():
+        while True:
             try:
-                self.cmd = self.pool.getNextWorkItem()
+                try:
+                    self.cmd = self.pool.getNextWorkItem()
+                except TypeError:
+                    # misleading exception raised during interpreter shutdown
+                    return 
 
-                if self.cmd is not None:
-                    # tablename = self.cmd.cmdStr.split()[-1][:-1]
+                # we must have got a command to run here
+                if self.cmd is None:
+                    self.logger.debug("[%s] got a None cmd" % self.name)
+                    self.pool.markTaskDone()
+                elif self.cmd is self.pool.halt_command:
+                    self.logger.debug("[%s] got a halt cmd" % self.name)
+                    self.pool.markTaskDone()
+                    self.cmd=None
+                    return
+                elif self.pool.should_stop:
+                    self.logger.debug("[%s] got cmd and pool is stopped: %s" % (self.name, self.cmd))
+                    self.pool.markTaskDone()
+                    self.cmd=None
+                else:
                     self.logger.info("[%s] started  %s" % (self.name, self.cmd.name))
                     start_time = time.time()
                     self.cmd.run()
@@ -1185,24 +1192,13 @@ class AnalyzeWorker(Thread):
                     self.pool.addFinishedWorkItem(self.cmd)
                     self.cmd=None
 
-            except Empty:
-                return
-
-            except:
+            except Exception,e:
+                self.logger.exception(e)
                 if self.cmd:
                     self.logger.debug("[%s] finished cmd with exception: %s" % (self.name, self.cmd))
                     self.pool.addFinishedWorkItem(self.cmd)
                     self.cmd=None
-                raise
-
-    def haltWork(self):
-        self.stoprequest.set()
-        c = self.cmd
-        if c is not None:
-            c.interrupt()
-            c.cancel()
-
-
+    
 if __name__ == '__main__':
     sys.argv[0] = EXECNAME
     simple_main(create_parser, AnalyzeDb)

--- a/gpMgmt/bin/gpmigrator_mirror
+++ b/gpMgmt/bin/gpmigrator_mirror
@@ -357,6 +357,7 @@ class GPUpgrade(GPUpgradeBase):
         # Wait for the segments to finish
         try:
             self.pool.join()
+            self.pool.haltWork()
         except:
             self.pool.haltWork()
             self.pool.joinWorkers()

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -47,11 +47,11 @@ SSH_MAX_RETRY=10
 # Delay before retrying ssh connection, in seconds
 SSH_RETRY_DELAY=.5
 
-halt_command='halt command'
 
 class WorkerPool(object):
     """TODO:"""
     
+    halt_command='halt command'
     def __init__(self,numWorkers=16,items=None):        
         self.workers=[]
         self.should_stop=False
@@ -160,7 +160,7 @@ class WorkerPool(object):
         self.should_stop=True
         for w in self.workers:
             w.haltWork()    
-            self.work_queue.put(halt_command)
+            self.work_queue.put(self.halt_command)
 
 class OperationWorkerPool(WorkerPool):
     """ TODO: This is a hack! In reality, the WorkerPool should work with Operations, and
@@ -204,7 +204,7 @@ class Worker(Thread):
                 if self.cmd is None:
                     self.logger.debug("[%s] got a None cmd" % self.name)
                     self.pool.markTaskDone()
-                elif self.cmd is halt_command:
+                elif self.cmd is self.pool.halt_command:
                     self.logger.debug("[%s] got a halt cmd" % self.name)
                     self.pool.markTaskDone()
                     self.cmd=None

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -1090,6 +1090,7 @@ class RecoverRemoteDumps(Operation):
                                      dstFile=self.context.generate_filename("global")))
         self.pool.join()
         self.pool.check_results()
+        self.pool.haltWork()
 
 class GetDumpTablesOperation(Operation):
     def __init__(self, context):

--- a/gpMgmt/sbin/gpupgrademirror.py
+++ b/gpMgmt/sbin/gpupgrademirror.py
@@ -206,6 +206,7 @@ def StartupPrimaries(gparray):
          # Wait for the segments to finish
          try:
              pool.join()
+             pool.haltWork()
          except:
              pool.haltWork()
              pool.joinWorkers()
@@ -261,6 +262,7 @@ def ShutdownPrimaries(gparray):
          # Wait for the segments to finish                                                                                                                
          try:
              pool.join()
+             pool.haltWork()
          except:
              pool.haltWork()
              pool.joinWorkers()

--- a/src/test/tinc/tincrepo/mpp/lib/gprecoverseg.py
+++ b/src/test/tinc/tincrepo/mpp/lib/gprecoverseg.py
@@ -43,7 +43,8 @@ class GpRecoverseg():
 
         pool = WorkerPool()
         pool.addCommand(cmd)
-        
+        pool.join()
+        pool.haltWork()
 
     def run(self,option=' ', validate=True, results=True):
         '''


### PR DESCRIPTION
To avoid hang issue, rewrite AnalyzerWorker to follow the same logic as Worker class. Besides, haltWork()
need to be called after join() to shutdown the whole WorkerPool, fix some incorrect usage for this.

@xiong-gang please help to review