### PR TITLE
Fix the aoco alter table and catalog tests.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/basic/security_definer/pre_script.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/basic/security_definer/pre_script.ans
@@ -18,7 +18,7 @@ select sec_definer_create_test() ;
 psql:/path/sql_file:1: NOTICE:  Creating table
 psql:/path/sql_file:1: NOTICE:  Table created
  sec_definer_create_test 
--------------
+-------------------------
  
 (1 row)
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/mpp25256/mpp25256.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/mpp25256/mpp25256.ans
@@ -17,12 +17,6 @@ CREATE INDEX
 create index co_i1 on co_t1(a);
 CREATE INDEX
 --Verify that the indexes have unique and primary key constraints on them
-select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aoseg_' || (select relfilenode from pg_class where relname = 'ao_t1') || '_index');
- indisunique | indisprimary 
--------------+--------------
- t           | t
-(1 row)
-
 select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aovisimap_' || (select relfilenode from pg_class where relname = 'ao_t1') || '_index');
  indisunique | indisprimary 
 -------------+--------------
@@ -30,12 +24,6 @@ select indisunique, indisprimary from pg_index where indexrelid = (select oid fr
 (1 row)
 
 select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aoblkdir_' || (select relfilenode from pg_class where relname = 'ao_t1') || '_index');
- indisunique | indisprimary 
--------------+--------------
- t           | t
-(1 row)
-
-select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aocsseg_' || (select relfilenode from pg_class where relname = 'co_t1') || '_index');
  indisunique | indisprimary 
 -------------+--------------
  t           | t

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/mpp25256/mpp25256.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/mpp25256/mpp25256.sql
@@ -8,9 +8,7 @@ create index ao_i1 on ao_t1(a);
 create index co_i1 on co_t1(a);
 
 --Verify that the indexes have unique and primary key constraints on them
-select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aoseg_' || (select relfilenode from pg_class where relname = 'ao_t1') || '_index');
 select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aovisimap_' || (select relfilenode from pg_class where relname = 'ao_t1') || '_index');
 select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aoblkdir_' || (select relfilenode from pg_class where relname = 'ao_t1') || '_index');
-select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aocsseg_' || (select relfilenode from pg_class where relname = 'co_t1') || '_index');
 select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aovisimap_' || (select relfilenode from pg_class where relname = 'co_t1') || '_index');
 select indisunique, indisprimary from pg_index where indexrelid = (select oid from pg_class where relname = 'pg_aoblkdir_' || (select relfilenode from pg_class where relname = 'co_t1') || '_index');

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_mppexec_failbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_mppexec_failbeg_lvl0.ans
@@ -1,4 +1,4 @@
 -- @Description: Setting up the tables for Exception Handling test for SQL (Exception happening while update is done on table)
 -- 
 update worker set salary = salary + 10;
-psql:/path/sql_file:1: ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = MPPEXEC UPDATE (postgres.c:1316)  (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=1043) (cdbdisp.c:1520)
+psql:/path/sql_file:1: ERROR:  Raise ERROR for debug_dtm_action = 2, commandTag = MPPEXEC UPDATE (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=1043)

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_mppexec_failend_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_mppexec_failend_lvl0.ans
@@ -1,4 +1,4 @@
 -- @Description: Setting up the tables for Exception Handling test for SQL (Exception happening while update is done on table)
 -- 
 update worker set salary = salary + 10;
-psql:/path/sql_file:1: ERROR:  Raise ERROR for debug_dtm_action = 3, commandTag = MPPEXEC UPDATE (postgres.c:1316)  (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=1043) (cdbdisp.c:1520)
+psql:/path/sql_file:1: ERROR:  Raise ERROR for debug_dtm_action = 3, commandTag = MPPEXEC UPDATE (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=1043) 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtbeg_failbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtbeg_failbeg_lvl0.ans
@@ -22,7 +22,7 @@ PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "shops_pkey" for table "shops"
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
-psql:/path/sql_file:1: ERROR:  DTM error (gathered 2 results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2178)
+psql:/path/sql_file:1: ERROR:  DTM error (gathered results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2178)
 DETAIL:  Raise ERROR for debug_dtm_action = 2, debug_dtm_action_protocol =  Begin Internal Subtransaction (postgres.c:1420)  (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=17453)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 26 during statement block entry
 select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtbeg_failend_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtbeg_failend_lvl0.ans
@@ -22,7 +22,7 @@ PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "shops_pkey" for table "shops"
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
-psql:/path/sql_file:1: ERROR:  DTM error (gathered 2 results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2178)
+psql:/path/sql_file:1: ERROR:  DTM error (gathered results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2178)
 DETAIL:  Raise error for debug_dtm_action = 3, debug_dtm_action_protocol =  Begin Internal Subtransaction (postgres.c:1440)  (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=7518)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 26 during statement block entry
 select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtbeg_panicbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtbeg_panicbeg_lvl0.ans
@@ -23,10 +23,10 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  DTM error (gathered 2 results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2178)
+psql:/path/sql_file:1: ERROR:  DTM error (gathered results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2178)
 DETAIL:  PANIC for debug_dtm_action = 4, debug_dtm_action_protocol =  Begin Internal Subtransaction (postgres.c:1426)  (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=29325)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 26 during statement block entry
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtbeg_panicbeg_lvl3.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtbeg_panicbeg_lvl3.ans
@@ -21,9 +21,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 36 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrelse_failbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrelse_failbeg_lvl0.ans
@@ -21,7 +21,7 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  catching the exception ...2
-psql:/path/sql_file:1: ERROR:  DTM error (gathered 2 results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2178)
+psql:/path/sql_file:1: ERROR:  DTM error (gathered results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2178)
 DETAIL:  transaction 1398808910-0000000574 at level 1 already processed (current level 1) (cdbtm.c:4391)  (seg1 rh55-qa02.sanmateo.greenplum.com:50000 pid=31635)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 26 during exception cleanup
 select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrelse_failend_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrelse_failend_lvl0.ans
@@ -21,9 +21,8 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  catching the exception ...2
-psql:/path/sql_file:1: ERROR:  DTM error (gathered 2 results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2178)
+psql:/path/sql_file:1: ERROR:  DTM error (gathered results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2178)
 DETAIL:  transaction 1398808910-0000000661 at level 1 already processed (current level 1) (cdbtm.c:4391)  (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=9104)
-transaction 1398808910-0000000661 at level 1 already processed (current level 1) (cdbtm.c:4391)  (seg1 rh55-qa02.sanmateo.greenplum.com:50000 pid=18995)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 26 during exception cleanup
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrelse_panicbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrelse_panicbeg_lvl0.ans
@@ -21,9 +21,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 39 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrelse_panicbeg_lvl4.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrelse_panicbeg_lvl4.ans
@@ -21,9 +21,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 39 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrolbk_failbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrolbk_failbeg_lvl0.ans
@@ -20,7 +20,7 @@ PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "shops_pkey" for table "shops"
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
-psql:/path/sql_file:1: ERROR:  DTM error (gathered 2 results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2178)
+psql:/path/sql_file:1: ERROR:  DTM error (gathered results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2178)
 DETAIL:  Raise ERROR for debug_dtm_action = 2, debug_dtm_action_protocol = Rollback Current Subtransaction (postgres.c:1420)  (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=30888)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 36 during exception cleanup
 select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrolbk_failend_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrolbk_failend_lvl0.ans
@@ -20,7 +20,7 @@ PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "shops_pkey" for table "shops"
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
-psql:/path/sql_file:1: ERROR:  DTM error (gathered 2 results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2178)
+psql:/path/sql_file:1: ERROR:  DTM error (gathered results from cmd 'Rollback Current Subtransaction') (cdbtm.c:2178)
 DETAIL:  Raise error for debug_dtm_action = 3, debug_dtm_action_protocol = Rollback Current Subtransaction (postgres.c:1440)  (seg0 rh55-qa01.sanmateo.greenplum.com:50000 pid=24422)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 36 during exception cleanup
 select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrolbk_panicbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrolbk_panicbeg_lvl0.ans
@@ -21,9 +21,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 36 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrolbk_panicbeg_lvl3.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg0_subtxtrolbk_panicbeg_lvl3.ans
@@ -23,9 +23,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 36 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtbeg_panicbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtbeg_panicbeg_lvl0.ans
@@ -21,10 +21,10 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  DTM error (gathered 2 results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2178)
+psql:/path/sql_file:1: ERROR:  DTM error (gathered results from cmd ' Begin Internal Subtransaction') (cdbtm.c:2178)
 DETAIL:  PANIC for debug_dtm_action = 4, debug_dtm_action_protocol =  Begin Internal Subtransaction (postgres.c:1426)  (seg1 rh55-qa02.sanmateo.greenplum.com:50000 pid=4985)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 26 during statement block entry
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtbeg_panicbeg_lvl3.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtbeg_panicbeg_lvl3.ans
@@ -23,9 +23,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 36 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtrelse_panicbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtrelse_panicbeg_lvl0.ans
@@ -23,9 +23,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 39 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtrelse_panicbeg_lvl4.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtrelse_panicbeg_lvl4.ans
@@ -21,9 +21,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 39 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtrolbk_panicbeg_lvl0.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtrolbk_panicbeg_lvl0.ans
@@ -21,9 +21,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 36 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtrolbk_panicbeg_lvl3.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/catalog/udf_exception_handling/expected/protocol_seg1_subtxtrolbk_panicbeg_lvl3.ans
@@ -23,9 +23,9 @@ psql:/path/sql_file:1: NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit 
 CONTEXT:  SQL statement "CREATE TABLE shops ( id serial PRIMARY KEY, shop varchar(32) )"
 PL/pgSQL function "test_protocol_allseg" line 18 at SQL statement
 psql:/path/sql_file:1: NOTICE:  Releasing segworker groups to finish aborting the transaction.
-psql:/path/sql_file:1: ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+psql:/path/sql_file:1: ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 36 during exception cleanup
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:1629)
+ERROR:  could not connect to segment: initialization of segworker group failed (cdbgang.c:1629)
 select * from employees;
 psql:/path/sql_file:1: ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_alter/aoco_alter_scenario_test/expected/alter_aoco_tab_utilitymode.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_alter/aoco_alter_scenario_test/expected/alter_aoco_tab_utilitymode.ans
@@ -19,7 +19,7 @@ Checksum: t
 
 
 alter table alter_aoco_tab_utilitymode add column add_col1 character varying(35) default 'abc' ;
-psql:/path/sql_file:1: ERROR:  internal alter table cannot allocate new relfilenodes (tablecmds.c:5593)
+psql:/path/sql_file:1: ERROR:  cannot add column in utility mode, relation alter_aoco_tab_utilitymode, segno 1 (aocssegfiles.c:869)
 select count(*) as add_col1  from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_aoco_tab_utilitymode' and attname='add_col1';
  add_col1 
 ----------

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_alter/aoco_alter_sql_test/expected/aoco_allalter.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_alter/aoco_alter_sql_test/expected/aoco_allalter.ans
@@ -155,8 +155,8 @@ INSERT 0 880
  a32    | date                        | default '1988-02-21'::date                                                   | plain    | quicklz          | 1                 | 8192       | 
  a33    | real                        | default 41114                                                                | plain    | quicklz          | 1                 | 8192       | 
  a34    | money                       | default '$7,222.00'::money                                                   | plain    | quicklz          | 1                 | 8192       | 
- a35    | cidr                        | default '192.167.2.0/24'::cidr                                               | plain    | quicklz          | 1                 | 8192       | 
- a36    | inet                        | default '126.2.3.4'::inet                                                    | plain    | quicklz          | 1                 | 8192       | 
+ a35    | cidr                        | default '192.167.2.0/24'::cidr                                               | main     | quicklz          | 1                 | 8192       | 
+ a36    | inet                        | default '126.2.3.4'::inet                                                    | main     | quicklz          | 1                 | 8192       | 
  a37    | time without time zone      | default '10:31:45'::time without time zone                                   | plain    | quicklz          | 1                 | 8192       | 
  a38    | text                        | default 'sdhjfsfksfkjskjfksjfkjsdfkjdshkjfhdsjkfkjsd'::text                  | extended | quicklz          | 1                 | 8192       | 
  a39    | bit(1)                      | default B'0'::"bit"                                                          | extended | quicklz          | 1                 | 8192       | 


### PR DESCRIPTION
- Update answer file for
  tincrepo/mpp/gpdb/tests/catalog/basic/security_definer/pre_script.ans
- Index on pg_aoseg was removed. Update
  tincrepo/mpp/gpdb/tests/catalog/mpp25256/mpp25256.sql and its answer file to
  reflect that.
- UDF exception handling test cases:
  - Some of the answer files had to be updated for the (file: line no) diff
  - The error messages during gang creation has changed. A few answer files had
    to be changed to account for the diff
- AOCO alter table
  - Fix the diff in the \d+ output for aoco table with cidr and inet columns