### PR TITLE
Fix ALTER OPERATOR FAMILY to dispatch Oid

### DIFF
--- a/src/backend/commands/opclasscmds.c
+++ b/src/backend/commands/opclasscmds.c
@@ -929,7 +929,7 @@ AlterOpFamily(AlterOpFamilyStmt *stmt)
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,
-									NIL, /* FIXME */
+									GetAssignedOidsForDispatch(),
 									NULL);
 }
 

--- a/src/test/regress/expected/opclass_ddl.out
+++ b/src/test/regress/expected/opclass_ddl.out
@@ -50,3 +50,37 @@ ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user2;  -- faile
 ERROR:  must be member of role "regtest_alter_user2"
 ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user3;  -- OK
 RESET SESSION AUTHORIZATION;
+-- Test adding operators to an existing opfamily as that requires oid
+-- dispatching to the segments
+-- Should fail. duplicate operator number / function number in ALTER OPERATOR FAMILY ... ADD FUNCTION
+CREATE OPERATOR FAMILY alt_opf17 USING btree;
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD OPERATOR 1 < (int4, int4), OPERATOR 1 < (int4, int4); -- operator # appears twice in same statement
+ERROR:  operator number 1 for (integer,integer) appears more than once
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD OPERATOR 1 < (int4, int4); -- operator 1 requested first-time
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD OPERATOR 1 < (int4, int4); -- operator 1 requested again in separate statement
+ERROR:  operator 1(integer,integer) already exists in operator family "alt_opf17"
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
+  OPERATOR 1 < (int4, int2) ,
+  OPERATOR 2 <= (int4, int2) ,
+  OPERATOR 3 = (int4, int2) ,
+  OPERATOR 4 >= (int4, int2) ,
+  OPERATOR 5 > (int4, int2) ,
+  FUNCTION 1 btint42cmp(int4, int2) ,
+  FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 appears twice in same statement
+ERROR:  procedure number 1 for (integer,smallint) appears more than once
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
+  OPERATOR 1 < (int4, int2) ,
+  OPERATOR 2 <= (int4, int2) ,
+  OPERATOR 3 = (int4, int2) ,
+  OPERATOR 4 >= (int4, int2) ,
+  OPERATOR 5 > (int4, int2) ,
+  FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 appears first time
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
+  OPERATOR 1 < (int4, int2) ,
+  OPERATOR 2 <= (int4, int2) ,
+  OPERATOR 3 = (int4, int2) ,
+  OPERATOR 4 >= (int4, int2) ,
+  OPERATOR 5 > (int4, int2) ,
+  FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 requested again in separate statement
+ERROR:  operator 1(integer,smallint) already exists in operator family "alt_opf17"
+DROP OPERATOR FAMILY alt_opf17 USING btree;

--- a/src/test/regress/sql/opclass_ddl.sql
+++ b/src/test/regress/sql/opclass_ddl.sql
@@ -60,3 +60,35 @@ ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user2;  -- faile
 ALTER OPERATOR CLASS alt_opc2 USING hash OWNER TO regtest_alter_user3;  -- OK
 
 RESET SESSION AUTHORIZATION;
+
+-- Test adding operators to an existing opfamily as that requires oid
+-- dispatching to the segments
+
+-- Should fail. duplicate operator number / function number in ALTER OPERATOR FAMILY ... ADD FUNCTION
+CREATE OPERATOR FAMILY alt_opf17 USING btree;
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD OPERATOR 1 < (int4, int4), OPERATOR 1 < (int4, int4); -- operator # appears twice in same statement
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD OPERATOR 1 < (int4, int4); -- operator 1 requested first-time
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD OPERATOR 1 < (int4, int4); -- operator 1 requested again in separate statement
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
+  OPERATOR 1 < (int4, int2) ,
+  OPERATOR 2 <= (int4, int2) ,
+  OPERATOR 3 = (int4, int2) ,
+  OPERATOR 4 >= (int4, int2) ,
+  OPERATOR 5 > (int4, int2) ,
+  FUNCTION 1 btint42cmp(int4, int2) ,
+  FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 appears twice in same statement
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
+  OPERATOR 1 < (int4, int2) ,
+  OPERATOR 2 <= (int4, int2) ,
+  OPERATOR 3 = (int4, int2) ,
+  OPERATOR 4 >= (int4, int2) ,
+  OPERATOR 5 > (int4, int2) ,
+  FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 appears first time
+ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
+  OPERATOR 1 < (int4, int2) ,
+  OPERATOR 2 <= (int4, int2) ,
+  OPERATOR 3 = (int4, int2) ,
+  OPERATOR 4 >= (int4, int2) ,
+  OPERATOR 5 > (int4, int2) ,
+  FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 requested again in separate statement
+DROP OPERATOR FAMILY alt_opf17 USING btree;


### PR DESCRIPTION
When adding operators to an existing operator family, ensure to dispatch the Oids of the created objects to the segments. The issue was a leftover from the Oid dispatching patch where we left a fair amount of Alter commands as FIXMEs to address later (as most, not all, of them aren't creating new Oids and thus don't need dispatching). This also adds a test in opclass_ddl suite.

Reported by Dhanashree Kashid in #1538.