### PR TITLE
Fix dispatch of pre-assigned OIDs in queries with initplans.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -646,6 +646,8 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 			build_tuple_node_list(&queryDesc->ddesc->transientTypeRecords);
 
+			queryDesc->ddesc->oidAssignments = GetAssignedOidsForDispatch();
+
 			/*
 			 * First, see whether we need to pre-execute any initPlan subplans.
 			 */
@@ -661,8 +663,6 @@ ExecutorStart(QueryDesc *queryDesc, int eflags)
 																   queryDesc->params,
 																   queryDesc->estate->es_param_exec_vals);
 			}
-
-			queryDesc->ddesc->oidAssignments = GetAssignedOidsForDispatch();
 
 			/*
 			 * This call returns after launching the threads that send the

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -110,3 +110,21 @@ select action::text, b from ctas_baz order by 1,2 limit 5;
  delete me | 1
 (5 rows)
 
+-- Test CTAS with a function that executes another query that's dispatched.
+-- Once upon a time, we had a bug in dispatching the table's OID in this
+-- scenario.
+create table ctas_input(x int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into ctas_input select * from generate_series(1, 10);
+CREATE FUNCTION ctas_inputArray() RETURNS INT[] AS $$
+DECLARE theArray INT[];
+BEGIN
+   SELECT array(SELECT * FROM ctas_input ORDER BY x) INTO theArray;
+   RETURN theArray;
+--EXCEPTION WHEN OTHERS THEN RAISE NOTICE 'Catching the exception ...%', SQLERRM;
+END;
+$$ LANGUAGE plpgsql;
+create table ctas_output as select ctas_inputArray()::int[] as x;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.


### PR DESCRIPTION
If a CTAS query uses a query with an InitPlan, and the InitPlan contains
a call to a function that dispatches another query to the segments, the
list of Oids is dispatched to the segments prematurely, in the inner query.
As a result, when the CTAS query is dispatched, the OID of the new table
is not included, and you get a "no pre-assigned OID for relation" error.

To fix, attach the OID of the new table to the query descriptor before
executing the InitPlans.

Fixes github issue #1543, reported with test case by Abhijit Subramanya.