### PR TITLE
gpcheckcat query for gp_relation_node to include tablespace.

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2535,23 +2535,35 @@ def checkPersistentTables():
 
     qname = "gp_persistent_relation_node   <=> gp_relation_node"
     qry = """
-    SELECT  coalesce(p.relfilenode_oid, r.relfilenode_oid) as relfilenode,
-        p.ctid, r.persistent_tid
-    FROM  (
-      SELECT p.ctid, p.* FROM gp_persistent_relation_node p
-      WHERE persistent_state = 2 AND p.database_oid in (
-        SELECT oid FROM pg_database WHERE datname = current_database()
-        UNION ALL
-        SELECT 0
-        )
-      ) p
-      FULL OUTER JOIN gp_relation_node r
-        ON (p.relfilenode_oid = r.relfilenode_oid and
-            p.segment_file_num = r.segment_file_num)
-    WHERE  (p.relfilenode_oid is NULL OR
-            r.relfilenode_oid is NULL OR
-            p.ctid != r.persistent_tid)
-    """
+    SELECT COALESCE(p.relfilenode_oid, r.relfilenode_oid) AS relfilenode,
+           p.ctid,
+           r.persistent_tid
+    FROM   (SELECT p.ctid,
+                   CASE
+                     WHEN p.tablespace_oid IN (SELECT dattablespace
+                                               FROM   pg_database
+                                               WHERE  datname = Current_database())
+                   THEN 0
+                     ELSE p.tablespace_oid
+                   END,
+                   p.database_oid,
+                   p.relfilenode_oid,
+                   p.segment_file_num,
+                   p.persistent_state
+            FROM   gp_persistent_relation_node p
+            WHERE  persistent_state = 2
+                   AND p.database_oid IN (SELECT oid
+                                          FROM   pg_database
+                                          WHERE  datname = Current_database()
+                                          UNION ALL
+                                          SELECT 0)) p
+           FULL OUTER JOIN gp_relation_node r
+                        ON ( p.relfilenode_oid = r.relfilenode_oid
+                             AND p.segment_file_num = r.segment_file_num
+                             AND p.tablespace_oid = r.tablespace_oid )
+    WHERE  ( p.relfilenode_oid IS NULL
+              OR r.relfilenode_oid IS NULL
+              OR p.ctid != r.persistent_tid ) """
     queries.append([qname, qry])
 
     qname = "gp_persistent_relation_node   <=> pg_class"


### PR DESCRIPTION
Commit 8fe321aff600d0b52d4d77fafc23d3292109d3ec added tablespace OID to
gp_relation_node to correctly reflect unique relfilenode. As a result need to
modify the gpcheckcat query by adding tablespace OID validating
gp_relation_node's correctness with gp_persistent_relation_node.

Looking for suggestions to optimize out the query to perform `SELECT dattablespace FROM   pg_database WHERE  datname = Current_database()` only once.