### PR TITLE
Add dependency for external table only for custom protocols

### DIFF
--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -162,7 +162,12 @@ InsertExtTableEntry(Oid 	tbloid,
 			referenced.objectId = LookupExtProtocolOid(protocol, true);
 			referenced.objectSubId = 0;
 
-			recordDependencyOn(&myself, &referenced, DEPENDENCY_NORMAL);
+			/*
+			 * Only tables with custom protocol should create dependency, for
+			 * internal protocols will get referenced.objectId as 0.
+			 */
+			if (referenced.objectId)
+				recordDependencyOn(&myself, &referenced, DEPENDENCY_NORMAL);
 		}
 
 	}

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -42,6 +42,10 @@ CREATE EXTERNAL TABLE EXT_REGION  (LIKE REG_REGION)
 location ('file://@hostname@@abs_srcdir@/data/region.tbl' )
 FORMAT 'text' (delimiter '|');
 
+-- Only tables with custom protocol should create dependency, due to a bug there
+-- used to be entries created for non custom protocol tables with refobjid=0.
+SELECT * FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and refobjid = 0;
+
 -- drop tables
 
 DROP EXTERNAL TABLE EXT_NATION;
@@ -157,7 +161,13 @@ GRANT INSERT ON PROTOCOL demoprot TO extprotu;
 SET SESSION AUTHORIZATION extprotu;
 
 CREATE WRITABLE EXTERNAL TABLE ext_w(a int) location('demoprot://demoprotfile.txt') format 'text'; -- should succeed
+-- For tables using custom protocol should have dependency
+SELECT count(*) FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and objid = 'ext_w'::regclass;
+
 CREATE READABLE EXTERNAL TABLE ext_r(a int) location('demoprot://demoprotfile.txt') format 'text'; -- should succeed
+-- For tables using custom protocol should have dependency
+SELECT count(*) FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and objid = 'ext_r'::regclass;
+
 DROP EXTERNAL TABLE IF EXISTS ext_w;
 DROP EXTERNAL TABLE IF EXISTS ext_r;
 

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -39,6 +39,13 @@ FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL TABLE EXT_REGION  (LIKE REG_REGION)
 location ('file://@hostname@@abs_srcdir@/data/region.tbl' )
 FORMAT 'text' (delimiter '|');
+-- Only tables with custom protocol should create dependency, due to a bug there
+-- used to be entries created for non custom protocol tables with refobjid=0.
+SELECT * FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and refobjid = 0;
+ classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype 
+---------+-------+----------+------------+----------+-------------+---------
+(0 rows)
+
 -- drop tables
 DROP EXTERNAL TABLE EXT_NATION;
 DROP EXTERNAL TABLE EXT_REGION;
@@ -244,7 +251,21 @@ GRANT SELECT ON PROTOCOL demoprot TO extprotu;
 GRANT INSERT ON PROTOCOL demoprot TO extprotu;
 SET SESSION AUTHORIZATION extprotu;
 CREATE WRITABLE EXTERNAL TABLE ext_w(a int) location('demoprot://demoprotfile.txt') format 'text'; -- should succeed
+-- For tables using custom protocol should have dependency
+SELECT count(*) FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and objid = 'ext_w'::regclass;
+ count 
+-------
+     1
+(1 row)
+
 CREATE READABLE EXTERNAL TABLE ext_r(a int) location('demoprot://demoprotfile.txt') format 'text'; -- should succeed
+-- For tables using custom protocol should have dependency
+SELECT count(*) FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and objid = 'ext_r'::regclass;
+ count 
+-------
+     1
+(1 row)
+
 DROP EXTERNAL TABLE IF EXISTS ext_w;
 DROP EXTERNAL TABLE IF EXISTS ext_r;
 RESET SESSION AUTHORIZATION;


### PR DESCRIPTION
Only for custom protocols entry exists in pg_extprotocol. So, only for external
tables with custom protocols add dependency in pg_depend.

Fixes #1547.