### PR TITLE
Migrate kerberos and gppkg tinc tests

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/abstime.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/abstime.ans.orca
@@ -58,7 +58,6 @@ INSERT INTO ABSTIME_TBL (f1) VALUES ('bad date format');
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/abstime_orca.sql:42: ERROR:  invalid input syntax for type abstime: "bad date format"
 INSERT INTO ABSTIME_TBL (f1) VALUES ('Jun 10, 1843');
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/abstime_orca.sql:43: ERROR:  cannot convert abstime "invalid" to timestamp
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 -- test abstime operators
 SELECT '' AS eight, * FROM ABSTIME_TBL ORDER BY 2;
  eight |           f1           

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/gpctas.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/gpctas.ans.orca
@@ -20,17 +20,17 @@ INSERT 0 1
 -- MPP-2859
 create table ctas_dst as 
 SELECT attr, class, (select count(distinct class) from ctas_src) as dclass FROM ctas_src GROUP BY attr, class distributed by (attr);
-SELECT
+SELECT 2
 drop table ctas_dst;
 DROP TABLE
 create table ctas_dst as 
 SELECT attr, class, (select max(class) from ctas_src) as maxclass FROM ctas_src GROUP BY attr, class distributed by (attr);
-SELECT
+SELECT 2
 drop table ctas_dst;
 DROP TABLE
 create table ctas_dst as 
 SELECT attr, class, (select count(distinct class) from ctas_src) as dclass, (select max(class) from ctas_src) as maxclass, (select min(class) from ctas_src) as minclass FROM ctas_src GROUP BY attr, class distributed by (attr);
-SELECT
+SELECT 2
 -- MPP-4298: "unknown" datatypes.
 drop table if exists ctas_foo;
 DROP TABLE
@@ -39,13 +39,13 @@ DROP TABLE
 drop table if exists ctas_baz;
 DROP TABLE
 create table ctas_foo as select * from generate_series(1, 100);
-psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:35: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:35: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
 SELECT 100
 create table ctas_bar as select a.generate_series as a, b.generate_series as b from ctas_foo a, ctas_foo b;
-psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:36: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:36: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
 SELECT 10000
 create table ctas_baz as select 'delete me' as action, * from ctas_bar;
-psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:38: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:38: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/gpctas_orca.sql:38: WARNING:  column "action" has type "unknown"
 DETAIL:  Proceeding with relation creation anyway.
 SELECT 10000

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/privileges.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/privileges.ans
@@ -357,7 +357,6 @@ SELECT testfunc1(5); -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_planner.sql:202: ERROR:  permission denied for function testfunc1
 SELECT col1 FROM atest2 WHERE col2 = true; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_planner.sql:203: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 SELECT testfunc4(true); -- ok
  testfunc4 
 -----------

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/privileges.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/privileges.ans.orca
@@ -135,14 +135,12 @@ INSERT INTO atest1 VALUES (2, 'two'); -- ok
 INSERT 0 1
 INSERT INTO atest2 VALUES ('foo', true); -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:81: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 INSERT INTO atest1 SELECT 1, b FROM atest1; -- ok
 INSERT 0 1
 UPDATE atest1 SET b = 'twotwo' WHERE a = 2; -- ok
 UPDATE 1
 UPDATE atest2 SET col2 = NOT col2; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:84: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 SELECT * FROM atest1 FOR UPDATE; -- ok
  a |   b    
 ---+--------
@@ -152,10 +150,8 @@ SELECT * FROM atest1 FOR UPDATE; -- ok
 
 SELECT * FROM atest2 FOR UPDATE; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:86: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 DELETE FROM atest2; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:87: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 LOCK atest2 IN ACCESS EXCLUSIVE MODE; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:88: ERROR:  permission denied for relation atest2
 COPY atest2 FROM stdin; -- fail
@@ -191,35 +187,26 @@ SELECT * FROM atest1 order by 1; -- ok
 
 SELECT * FROM atest2; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:101: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 INSERT INTO atest1 VALUES (2, 'two'); -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:102: ERROR:  permission denied for relation atest1
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 INSERT INTO atest2 VALUES ('foo', true); -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:103: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 INSERT INTO atest1 SELECT 1, b FROM atest1; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:104: ERROR:  permission denied for relation atest1
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 UPDATE atest1 SET b = 'twotwo' WHERE a = 2; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:105: ERROR:  permission denied for relation atest1
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 UPDATE atest2 SET col2 = NULL; -- ok
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:106: ERROR:  permission denied for relation atest2
 UPDATE atest2 SET col2 = NOT col2; -- fails; requires SELECT on atest2
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:107: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 UPDATE atest2 SET col2 = true FROM atest1 WHERE atest1.a = 5; -- ok
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:108: ERROR:  permission denied for relation atest2
 SELECT * FROM atest1 FOR UPDATE; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:109: ERROR:  permission denied for relation atest1
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 SELECT * FROM atest2 FOR UPDATE; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:110: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 DELETE FROM atest2; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:111: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 LOCK atest2 IN ACCESS EXCLUSIVE MODE; -- ok
 LOCK TABLE
 COPY atest2 FROM stdin; -- fail
@@ -227,10 +214,8 @@ psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_
 -- checks in subquery, both fail
 SELECT * FROM atest1 WHERE ( b IN ( SELECT col1 FROM atest2 ) );
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:116: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 SELECT * FROM atest2 WHERE ( col1 IN ( SELECT b FROM atest1 ) );
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:117: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 SET SESSION AUTHORIZATION regressuser4;
 SET
 COPY atest2 FROM stdin; -- ok
@@ -254,7 +239,6 @@ SET SESSION AUTHORIZATION regressuser1;
 SET
 SELECT * FROM atest3; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:134: ERROR:  permission denied for relation atest3
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 DELETE FROM atest3; -- ok
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:135: ERROR:  permission denied for relation atest3
 -- views
@@ -276,7 +260,6 @@ SELECT * FROM atestv1; -- ok
 
 SELECT * FROM atestv2; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:148: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 GRANT SELECT ON atestv1, atestv3 TO regressuser4;
 GRANT
 GRANT SELECT ON atestv2 TO regressuser2;
@@ -292,7 +275,6 @@ SELECT * FROM atestv1; -- ok
 
 SELECT * FROM atestv2; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:155: ERROR:  permission denied for relation atestv2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 SELECT * FROM atestv3; -- ok
  one | two | three 
 -----+-----+-------
@@ -312,7 +294,6 @@ SET
 -- Two complex cases:
 SELECT * FROM atestv3; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:166: ERROR:  permission denied for relation atestv3
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 SELECT * FROM atestv4; -- ok (even though regressuser2 cannot access underlying atestv3)
  one | two | three 
 -----+-----+-------
@@ -326,7 +307,6 @@ SELECT * FROM atest2; -- ok
 
 SELECT * FROM atestv2; -- fail (even though regressuser2 can access underlying atest2)
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:170: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 -- privileges on functions, languages
 -- switch to superuser
 \c -
@@ -379,7 +359,6 @@ SELECT testfunc1(5); -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:203: ERROR:  permission denied for function testfunc1
 SELECT col1 FROM atest2 WHERE col2 = true; -- fail
 psql:/data/gpadmin/pulse2-agent/agents/agent1/work/GPDB-43_STABLE-TINC-kerberos_smoke/rhel6_kerberos_smoke/cdbunit/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/output/privileges_orca.sql:204: ERROR:  permission denied for relation atest2
-ERROR:  GPDB exception. Aborting PQO plan generation. (CGPOptimizer.cpp:73)
 SELECT testfunc4(true); -- ok
  testfunc4 
 -----------

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/strings.ans.orca
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/security/kerberos/expected/strings.ans.orca
@@ -951,7 +951,7 @@ select * from (select 'a' as a, 'b' as b, 'c' as c, 1 as d)d union select 'a' as
 -- Make sure we can convert unknown to other useful types (MPP-4298)
 create table t as select j as a, 'abc' as i from
 generate_series(1, 10) j;
-psql:/path/sql_file:1: NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+psql:/path/sql_file:1: NOTICE:  Table doesn't have 'distributed by' clause. Creating a NULL policy entry.
 psql:/path/sql_file:1: WARNING:  column "i" has type "unknown"
 DETAIL:  Proceeding with relation creation anyway.
 SELECT 10

--- a/src/test/tinc/tincrepo/mpp/lib/gppkg/gppkg.py
+++ b/src/test/tinc/tincrepo/mpp/lib/gppkg/gppkg.py
@@ -124,8 +124,14 @@ class Gppkg:
         if product_version.startswith('4.3'):
             gpdb_version = '4.3'
         orca = ""
-        if product_version >= '4.3.5':
-            orca = 'orca'
+        try:
+            minor_version = float(re.compile('.*\d+\.\d+\.(\d+\.\d+)').match(product_version).group(1))
+            if minor_version >= float(5.0): #minor version grabbed from 4.3.5.0 when orca was introduced
+                orca = 'orca'
+        except Exception as e:
+            logger.error("%s" % str(e))
+            raise Exception('Unable to parse product_version: %s' % product_version)
+
         os_, platform_ = self.get_os_platform()
         compatiable = self.check_os_compatibility(os_, gppkg)
         if not compatiable:


### PR DESCRIPTION
Update answer files for kerberos tinc tests and fix versioning for gppkg tinc tests.

These tests were being used and updated in a separate repo and although versions were in this repo, they were not up to date. We will now be running these tests from this repo.

Authors: Marbin Tan and Chris Hajas