### PR TITLE
Add support for binary COPY

### DIFF
--- a/doc/src/sgml/ref/copy.sgml
+++ b/doc/src/sgml/ref/copy.sgml
@@ -23,6 +23,7 @@ PostgreSQL documentation
 <synopsis>
 COPY table [(column [, ...])] FROM {'file' | STDIN}
      [ [WITH] 
+       [BINARY]
        [OIDS]
        [HEADER]
        [DELIMITER [ AS ] 'delimiter']
@@ -37,6 +38,7 @@ COPY table [(column [, ...])] FROM {'file' | STDIN}
 
 COPY {table [(column [, ...])] | (query)} TO {'file' | STDOUT}
       [ [WITH] 
+        [BINARY]
         [OIDS]
         [HEADER]
         [DELIMITER [ AS ] 'delimiter']

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -187,6 +187,19 @@ cdbCopyStart(CdbCopy *c, char *copyCmd)
 }
 
 /*
+ * sends data to a copy command on all segments.
+ */
+void
+cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes)
+{
+	Gang *gp = c->primary_writer;
+	for (int i = 0; i < gp->size; ++i) {
+		int seg = gp->db_descriptors[i].segindex;
+		cdbCopySendData(c, seg, buffer, nbytes);
+	}
+}
+
+/*
  * sends data to a copy command on a specific segment (usually
  * the hash result of the data value).
  */

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -61,6 +61,7 @@ typedef struct CdbCopy
 CdbCopy    *makeCdbCopy(bool copy_in);
 int			cdbCopyGetDbCount(int total_segs, int seg);
 void		cdbCopyStart(CdbCopy *cdbCopy, char *copyCmd);
+void		cdbCopySendDataToAll(CdbCopy *c, const char *buffer, int nbytes);
 void		cdbCopySendData(CdbCopy *c, int target_seg, const char *buffer, int nbytes);
 bool		cdbCopyGetData(CdbCopy *c, bool cancel, uint64 *rows_processed);
 int			cdbCopyEnd(CdbCopy *c);

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -139,6 +139,7 @@ typedef struct CopyStateData
 	char	   *filename;		/* filename, or NULL for STDIN/STDOUT */
 	bool		custom;			/* custom format? */
 	bool		oids;			/* include OIDs? */
+	bool        binary;         /* binary format */
 	bool		csv_mode;		/* Comma Separated Value format? */
 	bool		header_line;	/* CSV header line? */
 	char	   *null_print;		/* NULL marker string (server encoding!) */
@@ -250,6 +251,17 @@ typedef CopyStateData *CopyState;
 
 #define ISOCTAL(c) (((c) >= '0') && ((c) <= '7'))
 #define OCTVALUE(c) ((c) - '0')
+
+/*
+ * Some platforms like macOS (since Yosemite) already define 64 bit versions
+ * of htonl and nhohl so we need to guard against redefinition.
+ */
+#ifndef htonll
+#define htonll(x) ((1==htonl(1)) ? (x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#endif
+#ifndef ntohll
+#define ntohll(x) ((1==ntohl(1)) ? (x) : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
+#endif
 
 extern void ValidateControlChars(bool copy, bool load, bool csv_mode, char *delim,
 								 char *null_print, char *quote, char *escape,

--- a/src/test/regress/input/misc.source
+++ b/src/test/regress/input/misc.source
@@ -69,12 +69,11 @@ COPY onek2 FROM '@abs_builddir@/results/onek.data';
 
 SELECT unique1 FROM onek2 WHERE unique1 < 2 ORDER BY unique1;
 
--- GPDB does not support BINARY-mode COPY.
---COPY BINARY stud_emp TO '@abs_builddir@/results/stud_emp.data';
+COPY BINARY stud_emp TO '@abs_builddir@/results/stud_emp.data';
 
---DELETE FROM stud_emp;
+DELETE FROM stud_emp;
 
---COPY BINARY stud_emp FROM '@abs_builddir@/results/stud_emp.data';
+COPY BINARY stud_emp FROM '@abs_builddir@/results/stud_emp.data';
 
 SELECT * FROM stud_emp;
 

--- a/src/test/regress/output/misc.source
+++ b/src/test/regress/output/misc.source
@@ -65,10 +65,9 @@ SELECT unique1 FROM onek2 WHERE unique1 < 2 ORDER BY unique1;
        1
 (2 rows)
 
--- GPDB does not support BINARY-mode COPY.
---COPY BINARY stud_emp TO '@abs_builddir@/results/stud_emp.data';
---DELETE FROM stud_emp;
---COPY BINARY stud_emp FROM '@abs_builddir@/results/stud_emp.data';
+COPY BINARY stud_emp TO '@abs_builddir@/results/stud_emp.data';
+DELETE FROM stud_emp;
+COPY BINARY stud_emp FROM '@abs_builddir@/results/stud_emp.data';
 SELECT * FROM stud_emp;
  name  | age |  location  | salary | manager | gpa | percent 
 -------+-----+------------+--------+---------+-----+---------


### PR DESCRIPTION
Binary COPY was previously disabled in Greenplum, this commit re-enables the binary mode by incorporating the upstream code from PostgreSQL.

This is a rebased, and slightly hacked up by me (make ICW run locally), version of #1211 by @alldefector. Re-submitted as a new PR to get a full run of the PR pipeline of the new new version of the code.