### PR TITLE
Remove `haveNonTemp` from RecordTransactionCommit()

### DIFF
--- a/src/backend/access/transam/persistentendxactrec.c
+++ b/src/backend/access/transam/persistentendxactrec.c
@@ -299,8 +299,7 @@ int32 PersistentEndXactRec_FetchObjectsFromSmgr(
 		case PersistentEndXactObjKind_FileSysAction:
 			count = smgrGetPendingFileSysWork(
 									endXactRecKind,
-									(PersistentEndXactFileSysActionInfo**)&data,
-									NULL);
+									(PersistentEndXactFileSysActionInfo**)&data);
 			len = count * sizeof(PersistentEndXactFileSysActionInfo);
 
 			PersistentEndXactRec_VerifyFileSysActionInfos(

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -612,7 +612,7 @@ static struct config_bool ConfigureNamesBool[] =
 		true, NULL, NULL
 	},
 	{
-		{"synchronous_commit", PGC_USERSET, WAL_SETTINGS,
+		{"synchronous_commit", PGC_USERSET, DEFUNCT_OPTIONS,
 			gettext_noop("Sets immediate fsync at commit."),
 			NULL
 		},

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -372,8 +372,7 @@ extern bool smgrgetappendonlyinfo(
 
 	int64							*mirrorDataLossTrackingSessionNum);
 extern int smgrGetPendingFileSysWork(EndXactRecKind endXactRecKind,
-						  PersistentEndXactFileSysActionInfo **ptr,
-						  bool *haveNonTemp);
+						  PersistentEndXactFileSysActionInfo **ptr);
 extern int	smgrGetAppendOnlyMirrorResyncEofs(
 	EndXactRecKind									endXactRecKind,
 


### PR DESCRIPTION
This is addressing the GPDB_83_MERGE_FIXME comment in xact.c:1081.

GPDB doesn't need `haveNonTemp` check, since GPDB doesn't allow data loss,
hence GPDB doesn't support the asynchronous commits from upstream. We disable
the user GUC `synchronous_commit` by converting it to PGC_INTERNAL (instead
of PGC_USERSET), and always set to true.

The original check for temp table in smgrGetPendingFileSysWork() is not valid
in GPDB, since GPDB temp table use shared buffers to support access across slices.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>