### PR TITLE
Add support of array coerce expr in Orca translator

### DIFF
--- a/gpAux/gpdemo/Makefile
+++ b/gpAux/gpdemo/Makefile
@@ -36,5 +36,5 @@ clean:
 	@ echo "======================================================================"
 	@ echo "Deleting cluster.... "
 	@ echo "======================================================================"
-	@ DEMO_PORT_BASE=$(PORT_BASE) ./demo_cluster.sh -d
+	@ MASTER_DEMO_PORT=$(MASTER_PORT) DEMO_PORT_BASE=$(PORT_BASE) NUM_PRIMARY_MIRROR_PAIRS=$(NUM_PRIMARY_MIRROR_PAIRS) ./demo_cluster.sh -d
 	@ echo ""

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -124,7 +124,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" resolve);
 	@echo "Resolve finished";
 
-	wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.2/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.3.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 
 clean_tools: opt_write_test
 	@cd releng/make/dependencies; \

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -160,6 +160,12 @@ namespace gpdxl
 				CMappingColIdVar *pmapcidvar
 				);
 
+			Expr *PcoerceFromDXLNodeScArrayCoerceExpr
+				(
+				const CDXLNode *pdxlnScArrayCoerceExpr,
+				CMappingColIdVar *pmapcidvar
+				);
+
 			Expr *PnulltestFromDXLNodeScNullTest
 				(
 				const CDXLNode *pdxlnScNullTest,

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -256,6 +256,13 @@ namespace gpdxl
 				const Expr *pexpr,
 				const CMappingVarColId* pmapvarcolid
 				);
+		
+			// create a DXL scalar array coerce expression node from a GPDB expression
+			CDXLNode *PdxlnScArrayCoerceExprFromExpr
+				(
+				const Expr *pexpr,
+				const CMappingVarColId* pmapvarcolid
+				);
 
 			// create a DXL scalar funcexpr node from a GPDB expression
 			CDXLNode *PdxlnScFuncExprFromFuncExpr

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -10161,6 +10161,23 @@ LOG:  statement: reset client_min_messages;
 -- start_ignore
 drop table foo;
 -- end_ignore
+-- Test GPDB Expr (T_ArrayCoerceExpr) conversion to Scalar Array Coerce Expr
+-- start_ignore
+create table foo (a int, b character varying(10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- end_ignore
+-- Query should not fallback to planner
+explain select * from foo where b in ('1', '2');
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+   ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=12)
+         Filter: b::text = ANY ('{1,2}'::character varying[]::text[])
+ Settings:  optimizer=on; optimizer_metadata_caching=on
+ Optimizer status: PQO version 2.1
+(5 rows)
+
 -- clean up
 drop schema orca cascade;
 NOTICE:  drop cascades to table orca.index_test

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -1379,6 +1379,13 @@ reset client_min_messages;
 drop table foo;
 -- end_ignore
 
+-- Test GPDB Expr (T_ArrayCoerceExpr) conversion to Scalar Array Coerce Expr
+-- start_ignore
+create table foo (a int, b character varying(10));
+-- end_ignore
+-- Query should not fallback to planner
+explain select * from foo where b in ('1', '2');
+
 -- clean up
 drop schema orca cascade;
 reset optimizer_segments;


### PR DESCRIPTION
`ARRAYCOERCEEXPR` is a new added operator when merging with pg8.3. This patch modify the orca translator to handle the new expression type in GPDB 5.