### PR TITLE
Refactor, and revamp, binary-upgrade support in pg_dump

### DIFF
--- a/contrib/pg_upgrade/function.c
+++ b/contrib/pg_upgrade/function.c
@@ -147,6 +147,12 @@ install_system_functions_internal(migratorContext *ctx, char *dbname)
 							  "RETURNS VOID "
 							  "AS '$libdir/pg_upgrade_support' "
 							  "LANGUAGE C STRICT;"));
+	PQclear(executeQueryOrDie(ctx, conn,
+							  "CREATE OR REPLACE FUNCTION "
+							  "binary_upgrade.preassign_operator_oid(OID, OID, TEXT) "
+							  "RETURNS VOID "
+							  "AS '$libdir/pg_upgrade_support' "
+							  "LANGUAGE C STRICT;"));
 	PQfinish(conn);
 }
 

--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -25,6 +25,7 @@
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_opclass.h"
+#include "catalog/pg_operator.h"
 #include "catalog/pg_opfamily.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_resqueue.h"
@@ -60,6 +61,7 @@ Datum		preassign_namespace_oid(PG_FUNCTION_ARGS);
 Datum		preassign_attrdef_oid(PG_FUNCTION_ARGS);
 Datum		preassign_constraint_oid(PG_FUNCTION_ARGS);
 Datum		preassign_rule_oid(PG_FUNCTION_ARGS);
+Datum		preassign_operator_oid(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(preassign_type_oid);
 PG_FUNCTION_INFO_V1(preassign_arraytype_oid);
@@ -81,6 +83,7 @@ PG_FUNCTION_INFO_V1(preassign_namespace_oid);
 PG_FUNCTION_INFO_V1(preassign_attrdef_oid);
 PG_FUNCTION_INFO_V1(preassign_constraint_oid);
 PG_FUNCTION_INFO_V1(preassign_rule_oid);
+PG_FUNCTION_INFO_V1(preassign_operator_oid);
 
 Datum
 preassign_type_oid(PG_FUNCTION_ARGS)
@@ -394,6 +397,22 @@ preassign_rule_oid(PG_FUNCTION_ARGS)
 	{
 		AddPreassignedOidFromBinaryUpgrade(ruleoid, RewriteRelationId, rulename,
 										   InvalidOid, tableoid, InvalidOid);
+	}
+
+	PG_RETURN_VOID();
+}
+
+Datum
+preassign_operator_oid(PG_FUNCTION_ARGS)
+{
+	Oid			opoid = PG_GETARG_OID(0);
+	Oid			nsoid = PG_GETARG_OID(1);
+	char	   *opname = GET_STR(PG_GETARG_TEXT_P(2));
+
+	if (Gp_role == GP_ROLE_UTILITY)
+	{
+		AddPreassignedOidFromBinaryUpgrade(opoid, OperatorRelationId, opname,
+										   nsoid, InvalidOid, InvalidOid);
 	}
 
 	PG_RETURN_VOID();

--- a/src/bin/pg_dump/Makefile
+++ b/src/bin/pg_dump/Makefile
@@ -35,14 +35,14 @@ kwlookup.c: % : $(top_srcdir)/src/backend/parser/%
 all: submake-libpq submake-libpgport pg_dump pg_restore pg_dumpall \
     submake-cdb
 
-pg_dump: pg_dump.o common.o pg_dump_sort.o $(OBJS) $(KEYWRDOBJS) $(libpq_builddir)/libpq.a 
-	$(CC) $(CFLAGS) pg_dump.o common.o pg_dump_sort.o $(KEYWRDOBJS) $(OBJS) $(libpq_pgport) $(LDFLAGS) $(LIBS) -o $@$(X)
+pg_dump: pg_dump.o common.o pg_dump_sort.o binary_upgrade.o $(OBJS) $(KEYWRDOBJS) $(libpq_builddir)/libpq.a 
+	$(CC) $(CFLAGS) pg_dump.o common.o pg_dump_sort.o binary_upgrade.o $(KEYWRDOBJS) $(OBJS) $(libpq_pgport) $(LDFLAGS) $(LIBS) -o $@$(X)
 
 pg_restore: pg_restore.o $(OBJS) $(KEYWRDOBJS) $(libpq_builddir)/libpq.a
 	$(CC) $(CFLAGS) pg_restore.o $(KEYWRDOBJS) $(OBJS) $(libpq_pgport) $(LDFLAGS) $(LIBS) -o $@$(X)
 
-pg_dumpall: pg_dumpall.o dumputils.o $(KEYWRDOBJS) $(libpq_builddir)/libpq.a
-	$(CC) $(CFLAGS) pg_dumpall.o dumputils.o $(KEYWRDOBJS) $(WIN32RES) $(libpq_pgport) $(LDFLAGS) $(LIBS) -o $@$(X)
+pg_dumpall: pg_dumpall.o dumputils.o binary_upgradeall.o $(KEYWRDOBJS) $(libpq_builddir)/libpq.a
+	$(CC) $(CFLAGS) pg_dumpall.o dumputils.o binary_upgradeall.o $(KEYWRDOBJS) $(WIN32RES) $(libpq_pgport) $(LDFLAGS) $(LIBS) -o $@$(X)
 
 submake-cdb: $(KEYWORDOBJS) $(OBJS)
 	$(MAKE) -C cdb all

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -1,0 +1,1049 @@
+/*-------------------------------------------------------------------------
+ *
+ * binary_upgrade.c
+ *		Functions to create ArchiveEntries for Oid preassignment in dumps
+ *
+ * Portions Copyright 2017 Pivotal Software, Inc.
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  src/bin/pg_dump/binary_upgrade.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "binary_upgrade.h"
+#include "pg_dump.h"
+#include "pqexpbuffer.h"
+#include "catalog/pg_class.h"
+#include "catalog/pg_type.h"
+
+static char query_buffer[QUERY_ALLOC];
+
+static const CatalogId nilCatalogId = {0, 0};
+
+/* Cache for array types during binary_upgrade dumping */
+static TypeCache  	   *typecache;
+static DumpableObject **typecacheindex;
+static int				numtypecache;
+
+/* Internal helper methods for preassigning the various object types */
+static void preassign_type_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_type_oid, char *objname);
+static void preassign_constraint_oid(Archive *AH, Oid constroid, Oid nsoid, char *objname, Oid contable, Oid condomain);
+static void preassign_attrdefs_oid(Archive *AH, Oid attrdefoid, Oid attreloid, int adnum);
+static void preassign_pg_class_oids(PGconn *conn, Archive *AH, Oid pg_class_oid);
+static void preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_rel_oid, char *objname);
+
+
+void
+dumpNamespaceOid(Archive *AH, NamespaceInfo *info)
+{
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_namespace_oid("
+			 "'%u'::pg_catalog.oid, '%s'::text);\n",
+			 info->dobj.catId.oid, info->dobj.name);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 info->dobj.name,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, NULL, NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+void
+dumpProcedureOid(Archive *AH, FuncInfo *info)
+{
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_procedure_oid("
+			 "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid);\n",
+			 info->dobj.catId.oid, info->dobj.name, info->dobj.namespace->dobj.catId.oid);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 info->dobj.name,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+/*
+ *	dumpProcLangOid
+ *
+ * Writes out the Oid for custom procedural languages
+ */
+void
+dumpProcLangOid(Archive *AH, ProcLangInfo *info)
+{
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_language_oid("
+			 "'%u'::pg_catalog.oid, '%s'::text);\n",
+			 info->dobj.catId.oid, info->dobj.name);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 info->dobj.name,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+/*
+ *	dumpCastOid()
+ *
+ * Write out preassigned Oid for user defined casts
+ */
+void
+dumpCastOid(Archive *AH, CastInfo *info)
+{
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_cast_oid("
+			 "'%u'::pg_catalog.oid, '%u'::pg_catalog.oid, '%u'::pg_catalog.oid);\n",
+			 info->dobj.catId.oid, info->castsource, info->casttarget);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 "preassign_cast",
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+/*
+ * CREATE CONVERSION ..
+ */
+void
+dumpConversionOid(PGconn *conn, Archive *AH, ConvInfo *info)
+{
+	PQExpBuffer	upgrade_query = createPQExpBuffer();
+	int			ntups;
+	PGresult   *upgrade_res;
+	Oid			connamespace;
+
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	appendPQExpBuffer(upgrade_query,
+					  "SELECT connamespace "
+					  "FROM pg_catalog.pg_conversion "
+					  "WHERE oid = '%u'::pg_catalog.oid",
+					  info->dobj.catId.oid);
+
+	upgrade_res = PQexec(conn, upgrade_query->data);
+	check_sql_result(upgrade_res, conn, upgrade_query->data, PGRES_TUPLES_OK);
+
+	ntups = PQntuples(upgrade_res);
+	if (ntups != 1)
+	{
+		write_msg(NULL, "ERROR: conversion %s not found in catalog", info->dobj.name);
+		exit_nicely();
+	}
+
+	connamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "connamespace")));
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_conversion_oid('%u'::pg_catalog.oid, "
+			 "'%s'::text, '%u'::pg_catalog.oid);\n",
+			 info->dobj.catId.oid, info->dobj.name, connamespace);
+
+	PQclear(upgrade_res);
+	destroyPQExpBuffer(upgrade_query);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 info->dobj.name,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+/*
+ *	dumpRuleOid
+ *
+ * Writes out preassignment operations for user defined rules.
+ */
+void
+dumpRuleOid(Archive *AH, RuleInfo *info)
+{
+	TableInfo *tbinfo = (TableInfo *) info->ruletable;
+
+	if (!info->dobj.dump || !info->separate)
+		return;
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_rule_oid("
+			 "'%u'::pg_catalog.oid, '%u'::pg_catalog.oid, '%s'::text);\n",
+			 info->dobj.catId.oid, tbinfo->dobj.catId.oid, info->dobj.name);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 info->dobj.name,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+/*
+ * dumpOpFamilyOid
+ *
+ * Preassign Oid for CREATE OPERATOR FAMILY .. operations
+ */
+void
+dumpOpFamilyOid(PGconn *conn, Archive *AH, OpfamilyInfo *info)
+{
+	PQExpBuffer	upgrade_query = createPQExpBuffer();
+	int			ntups;
+	PGresult   *upgrade_res;
+	Oid			opfnamespace;
+
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	appendPQExpBuffer(upgrade_query,
+					  "SELECT opfnamespace "
+					  "FROM pg_catalog.pg_opfamily "
+					  "WHERE oid = '%u'::pg_catalog.oid",
+					  info->dobj.catId.oid);
+	
+	upgrade_res = PQexec(conn, upgrade_query->data);
+	check_sql_result(upgrade_res, conn, upgrade_query->data, PGRES_TUPLES_OK);
+
+	ntups = PQntuples(upgrade_res);
+	if (ntups != 1)
+	{
+		write_msg(NULL, "ERROR: opfam %s not found in catalog", info->dobj.name);
+		exit_nicely();
+	}
+
+	opfnamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "opfnamespace")));
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_opfam_oid('%u'::pg_catalog.oid, "
+			 "'%s'::text, '%u'::pg_catalog.oid);",
+			 info->dobj.catId.oid, info->dobj.name, opfnamespace);
+
+	PQclear(upgrade_res);
+	destroyPQExpBuffer(upgrade_query);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 info->dobj.name,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+/*
+ *	dumpOpClassOid
+ *
+ * Preassign Oid for CREATE OPERATOR CLASS .. operations
+ */
+void
+dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info)
+{
+	PQExpBuffer	upgrade_query = createPQExpBuffer();
+	int			ntups;
+	PGresult   *upgrade_res;
+	Oid			pg_opclass_oid;
+	Oid			opcnamespace;
+
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	appendPQExpBuffer(upgrade_query,
+					  "SELECT oid, opcnamespace "
+					  "FROM pg_catalog.pg_opclass "
+					  "WHERE opcname = '%s'::text",
+					  info->dobj.name);
+
+	upgrade_res = PQexec(conn, upgrade_query->data);
+	check_sql_result(upgrade_res, conn, upgrade_query->data, PGRES_TUPLES_OK);
+
+	ntups = PQntuples(upgrade_res);
+	if (ntups != 1)
+	{
+		write_msg(NULL, "ERROR: opclass %s not found in catalog", info->dobj.name);
+		exit_nicely();
+	}
+	pg_opclass_oid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "oid")));
+	opcnamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "opcnamespace")));
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_opclass_oid('%u'::pg_opclass.oid, "
+			 "'%s'::text, '%u'::pg_opclass.opcnamespace);",
+			 info->dobj.catId.oid, info->dobj.name, opcnamespace);
+
+	PQclear(upgrade_res);
+	destroyPQExpBuffer(upgrade_query);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 info->dobj.name,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+
+void
+dumpShellTypeOid(PGconn *conn, Archive *fout, Archive *AH, ShellTypeInfo *info)
+{
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	preassign_type_oid(conn, fout, AH, info->dobj.catId.oid, info->dobj.name);
+}
+
+void
+dumpTypeOid(PGconn *conn, Archive *fout, Archive *AH, TypeInfo *info)
+{
+	int		i;
+
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	/*
+	 * GPDB_84_MERGE_FIXME: dispatching oids for ENUM types is currently
+	 * not implemented as ENUM was first introduced in Greenplum 5.0. When
+	 * merging PostgreSQL 8.4, implement this oid dispatch to cover the
+	 * 5.0 -> 6.0 upgrade cycle.
+	 */
+	if (info->typtype == TYPTYPE_ENUM)
+		return;
+
+	if (info->typtype == TYPTYPE_BASE)
+	{
+		/* We might already have a shell type, but setting pg_type_oid is harmless */
+		preassign_type_oid(conn, fout, AH, info->dobj.catId.oid, info->dobj.name);
+	}
+	else if (info->typtype == TYPTYPE_DOMAIN)
+	{
+		preassign_type_oid(conn, fout, AH, info->dobj.catId.oid, info->dobj.name);
+		for (i = 0; i < info->nDomChecks; i++)
+		{
+			ConstraintInfo *c = &(info->domChecks[i]);
+
+			preassign_constraint_oid(fout, c->dobj.catId.oid,
+									 c->dobj.namespace->dobj.catId.oid,
+									 c->dobj.name,
+								 	 c->contable ? c->contable->dobj.catId.oid : InvalidOid,
+								 	 c->condomain ? c->condomain->dobj.catId.oid : InvalidOid);
+		}
+	}
+	else if (info->typtype == TYPTYPE_COMPOSITE)
+	{
+		preassign_type_oid(conn, fout, AH, info->dobj.catId.oid, info->dobj.name);
+		preassign_pg_class_oids(conn, AH, info->typrelid);
+	}
+}
+
+/*
+ * preassign_type_oid
+ *
+ * Preassign Oids for all pg_type operations, such as CREATE TYPE .. as well
+ * as creating base/array types via CREATE TABLE .. etc. On the first call a
+ * cache will be populated by interrogating pg_type, this cache will then be
+ * used for all lookups to reduce the amount of required SQL calls.
+ */
+static void
+preassign_type_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_type_oid, char *objname)
+{
+	PQExpBuffer upgrade_query;
+	int			ntups;
+	PGresult   *upgrade_res;
+	int			i;
+	int			i_arr_oid;
+	int			i_arr_name;
+	int			i_arr_nsp;
+	int			i_oid;
+	int			i_name;
+	int			i_nsp;
+	TypeCache  *type;
+
+	if (typecache == NULL)
+	{
+		upgrade_query = createPQExpBuffer();
+
+		if (fout->remoteVersion >= 80300)
+		{
+			appendPQExpBuffer(upgrade_query,
+							  "SELECT typ.oid as typoid, typ.typname, typ.typnamespace, "
+							  "       typ.typarray as arr_typoid, arr.typname as arr_typname, arr.typnamespace as arr_typnamespace "
+							  "FROM pg_catalog.pg_type typ "
+							  "  LEFT OUTER JOIN pg_catalog.pg_type arr ON typ.typarray = arr.oid "
+							  "WHERE typ.oid NOT IN (SELECT typarray FROM pg_type)");
+		}
+		else
+		{
+			/*
+			 * Query to get the array type of a base type in GPDB 4.3, should we
+			 * need to support older versions then this would have to be extended.
+			 */
+			appendPQExpBuffer(upgrade_query,
+							  "SELECT typ.oid as typoid, typ.typname, typ.typnamespace, "
+							  "       arr.oid as arr_typoid, arr.typname as arr_typname, arr.typnamespace as arr_typnamespace "
+							  "FROM pg_catalog.pg_type typ "
+							  "  LEFT OUTER JOIN pg_catalog.pg_type arr ON arr.typname = '_' || typ.typname "
+							  "WHERE typ.oid NOT IN (SELECT oid FROM pg_type WHERE substring(typname, 1, 1) = '_')");
+		}
+
+		upgrade_res = PQexec(conn, upgrade_query->data);
+		check_sql_result(upgrade_res, conn, upgrade_query->data, PGRES_TUPLES_OK);
+
+		ntups = PQntuples(upgrade_res);
+
+		if (ntups > 0)
+		{
+			i_oid = PQfnumber(upgrade_res, "typoid");
+			i_name = PQfnumber(upgrade_res, "typname");
+			i_nsp = PQfnumber(upgrade_res, "typnamespace");
+			i_arr_oid = PQfnumber(upgrade_res, "arr_typoid");
+			i_arr_name = PQfnumber(upgrade_res, "arr_typname");
+			i_arr_nsp = PQfnumber(upgrade_res, "arr_typnamespace");
+
+			typecache = calloc(ntups, sizeof(TypeCache));
+			numtypecache = ntups;
+
+			for (i = 0; i < ntups; i++)
+			{
+				typecache[i].dobj.objType = DO_TYPE_CACHE;
+				typecache[i].dobj.catId.oid = atooid(PQgetvalue(upgrade_res, i, i_oid));
+				typecache[i].dobj.name = strdup(PQgetvalue(upgrade_res, i, i_name));
+
+				typecache[i].typnsp = atooid(PQgetvalue(upgrade_res, i, i_nsp));
+
+				/*
+				 * Before PostgreSQL 8.3 arrays for composite types weren't supported
+				 * and base relation types didn't automatically have an array type
+				 * counterpart. If an array type isn't found we need to force a new
+				 * Oid to be allocated even in binary_upgrade mode which otherwise
+				 * work by preassigning Oids. Inject InvalidOid in the preassign call
+				 * to ensure we get a new Oid.
+				 */
+				if (PQgetisnull(upgrade_res, i, i_arr_name))
+				{
+					char array_name[NAMEDATALEN];
+
+					typecache[i].arraytypoid = InvalidOid,
+					typecache[i].arraytypnsp = atooid(PQgetvalue(upgrade_res, i, i_nsp));
+
+					snprintf(array_name, NAMEDATALEN, "_%s", PQgetvalue(upgrade_res, i, i_name));
+					typecache[i].arraytypname = strdup(array_name);
+				}
+				else
+				{
+					typecache[i].arraytypoid = atooid(PQgetvalue(upgrade_res, i, i_arr_oid));
+					typecache[i].arraytypname = strdup(PQgetvalue(upgrade_res, i, i_arr_name));
+					typecache[i].arraytypnsp = atooid(PQgetvalue(upgrade_res, i, i_arr_nsp));
+				}
+			}
+
+			typecacheindex = buildIndexArray(typecache, ntups, sizeof(TypeCache));
+		}
+
+		PQclear(upgrade_res);
+		destroyPQExpBuffer(upgrade_query);
+	}
+
+	/* Query the cached type information */
+	type = (TypeCache *) findObjectByOid(pg_type_oid, typecacheindex, numtypecache);
+
+	/* This shouldn't happen.. */
+	if (!type)
+	{
+		write_msg(NULL, "ERROR: didn't find type information in cache\n");
+		exit_nicely();
+	}
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
+			 "'%s'::text, '%u'::pg_catalog.oid);\n"
+			 "SELECT binary_upgrade.preassign_arraytype_oid('%u'::pg_catalog.oid, "
+			 "'%s'::text, '%u'::pg_catalog.oid);\n",
+			 pg_type_oid, type->dobj.name, type->typnsp,
+			 type->arraytypoid, type->arraytypname, type->arraytypnsp);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 objname,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+/*
+ * dumpConstraintOid
+ *
+ * Writes out preassigned Oids for user defined constraints. Error handling
+ * for non-existing Indexes is performed in dumpConstraint() so defer there
+ * for consistency with upstream even though we are being executed first.
+ */
+void
+dumpConstraintOid(PGconn *conn, Archive *AH, ConstraintInfo *info)
+{
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	/* Index related constraint */
+	if (info->contype == 'p' || info->contype == 'u')
+	{
+		IndxInfo *indxinfo = (IndxInfo *) findObjectByDumpId(info->conindex);
+		/* Error handling for this is performed in dumpConstraints */
+		if (indxinfo == NULL)
+			return;
+
+		preassign_pg_class_oids(conn, AH, indxinfo->dobj.catId.oid);
+		preassign_constraint_oid(AH, info->dobj.catId.oid,
+								 info->dobj.namespace->dobj.catId.oid,
+								 info->dobj.name,
+								 info->contable ? info->contable->dobj.catId.oid : InvalidOid,
+								 info->condomain ? info->condomain->dobj.catId.oid : InvalidOid);
+	}
+	/* CHECK constraint on a table or domain */
+	else if (info->contype == 'c')
+	{
+		TableInfo *tbinfo = (TableInfo *) info->contable;
+
+		if (!info->separate)	
+			return;
+
+		if (tbinfo)
+			preassign_pg_class_oids(conn, AH, tbinfo->dobj.catId.oid);
+
+		preassign_constraint_oid(AH, info->dobj.catId.oid,
+								 info->dobj.namespace->dobj.catId.oid,
+								 info->dobj.name,
+								 info->contable ? info->contable->dobj.catId.oid : InvalidOid,
+								 info->condomain ? info->condomain->dobj.catId.oid : InvalidOid);
+	}
+	/*
+	 * FOREIGN KEY constraint. While FK constraints aren't enforced in
+	 * GPDB they are still created so preserve any Oids.
+	 */
+	else if (info->contype == 'f')
+	{
+		preassign_constraint_oid(AH, info->dobj.catId.oid,
+								 info->dobj.namespace->dobj.catId.oid,
+								 info->dobj.name,
+								 info->contable ? info->contable->dobj.catId.oid : InvalidOid,
+								 info->condomain ? info->condomain->dobj.catId.oid : InvalidOid);
+	}
+}
+
+/*
+ * preassign_constraint_oid
+ *
+ * Preassign Oids for CREATE CONSTRAINT .. calls.
+ */
+static void
+preassign_constraint_oid(Archive *AH, Oid constroid, Oid nsoid, char *objname, Oid contable, Oid condomain)
+{
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_constraint_oid('%u'::pg_catalog.oid, "
+			 "'%u'::pg_catalog.oid, '%s'::text, '%u'::pg_catalog.oid, '%u'::pg_catalog.oid);\n",
+			 constroid, nsoid, objname, contable, condomain);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 objname,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+/*
+ *	dumpExternalProtocolOid
+ *
+ * Preassign Oids for CREATE EXTERNAL PROTOCOL ..
+ */
+void
+dumpExternalProtocolOid(Archive *AH, ExtProtInfo *info)
+{
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_extprotocol_oid("
+			 "'%u'::pg_catalog.oid, '%s'::text);\n",
+			 info->dobj.catId.oid, info->dobj.name);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 info->dobj.name,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+void
+dumpAttrDefsOid(Archive *AH, AttrDefInfo *info)
+{
+	TableInfo   *tbinfo = (TableInfo *) info->adtable;
+
+	if (!info->dobj.dump || !info->separate)
+		return;
+
+	preassign_attrdefs_oid(AH, info->dobj.catId.oid, tbinfo->dobj.catId.oid, info->adnum);
+}
+
+/*
+ * preassign_attrdefs_oid
+ *
+ * Preassign Oids for default attribute values
+ */
+static void
+preassign_attrdefs_oid(Archive *AH, Oid attrdefoid, Oid attreloid, int adnum)
+{
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_attrdef_oid('%u'::pg_catalog.oid, "
+			 "'%u'::pg_catalog.oid, '%u'::pg_catalog.oid);\n",
+			 attrdefoid, attreloid, adnum);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 "preassign_attrdef",
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
+
+void
+dumpIndexOid(PGconn *conn, Archive *AH, IndxInfo *info)
+{
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	preassign_pg_class_oids(conn, AH, info->dobj.catId.oid);
+}
+
+void
+dumpTableOid(PGconn *conn, Archive *fout, Archive *AH, TableInfo *info)
+{
+	int		j;
+
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	preassign_pg_class_oids(conn, AH, info->dobj.catId.oid);
+	preassign_type_oids_by_rel_oid(conn, fout, AH, info->dobj.catId.oid,
+								   info->dobj.name);
+		
+	if (info->relkind == RELKIND_RELATION && info->relstorage != RELSTORAGE_EXTERNAL)
+	{
+		/* Dump Oids for attribute defaults */
+		for (j = 0; j < info->numatts; j++)
+		{
+			if (info->attrdefs[j] != NULL)
+				preassign_attrdefs_oid(AH, info->attrdefs[j]->dobj.catId.oid,
+									   info->dobj.catId.oid,
+									   info->attrdefs[j]->adnum);
+		}
+
+		/* Dump Oids for constraints */
+		for (j = 0; j < info->ncheck; j++)
+		{
+			ConstraintInfo *c = &(info->checkexprs[j]);
+			preassign_constraint_oid(AH, c->dobj.catId.oid,
+									 c->dobj.namespace->dobj.catId.oid,
+									 c->dobj.name,
+									 c->contable ? c->contable->dobj.catId.oid : InvalidOid,
+									 c->condomain ? c->condomain->dobj.catId.oid : InvalidOid);
+		}
+	}
+}
+
+static void
+preassign_pg_class_oids(PGconn *conn, Archive *AH, Oid pg_class_oid)
+{
+	PQExpBuffer upgrade_query = createPQExpBuffer();
+	PQExpBuffer upgrade_buffer = createPQExpBuffer();
+	int			ntups;
+	PGresult   *upgrade_res;
+	Oid			pg_class_reltoastnamespace;
+	Oid			pg_class_reltoastrelid;
+	Oid			pg_class_reltoastidxid;
+	Oid			pg_class_relnamespace;
+	char	   *pg_class_relname;
+	Oid			pg_appendonly_segrelid;
+	Oid			pg_appendonly_blkdirrelid;
+	Oid			pg_appendonly_blkdiridxid;
+	Oid			pg_appendonly_visimaprelid;
+	Oid			pg_appendonly_visimapidxid;
+	PQExpBuffer aoseg_query;
+	PGresult   *aoseg_res;
+	Oid			aoseg_namespace;
+	bool		columnstore;
+
+	appendPQExpBuffer(upgrade_query,
+					  "SELECT c.reltoastrelid, t.reltoastidxid, "
+					  "       t.relnamespace as toastnamespace, "
+					  "       ao.segrelid, c.relnamespace, "
+					  "       ao.blkdirrelid, ao.blkdiridxid, "
+					  "       ao.visimaprelid, ao.visimapidxid, "
+					  "       c.relname, ao.columnstore "
+					  "FROM pg_catalog.pg_class c LEFT JOIN "
+					  "pg_catalog.pg_class t ON (c.reltoastrelid = t.oid) "
+					  "LEFT JOIN pg_catalog.pg_appendonly ao ON (ao.relid = c.oid) "
+					  "WHERE c.oid = '%u'::pg_catalog.oid;",
+					  pg_class_oid);
+
+	upgrade_res = PQexec(conn, upgrade_query->data);
+	check_sql_result(upgrade_res, conn, upgrade_query->data, PGRES_TUPLES_OK);
+
+	/* Expecting a single result only */
+	ntups = PQntuples(upgrade_res);
+	if (ntups != 1)
+	{
+		write_msg(NULL, ngettext("query returned %d row instead of one: %s\n",
+								 "query returned %d rows instead of one: %s\n",
+								 ntups),
+				  ntups, upgrade_query->data);
+		exit_nicely();
+	}
+
+	pg_class_reltoastnamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "toastnamespace")));
+	pg_class_reltoastrelid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "reltoastrelid")));
+	pg_class_reltoastidxid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "reltoastidxid")));
+	pg_class_relnamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "relnamespace")));
+	pg_class_relname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "relname"));
+	pg_appendonly_segrelid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "segrelid")));
+	pg_appendonly_blkdirrelid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "blkdirrelid")));
+	pg_appendonly_blkdiridxid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "blkdiridxid")));
+	pg_appendonly_visimaprelid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "visimaprelid")));
+	pg_appendonly_visimapidxid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "visimapidxid")));
+	columnstore = (strcmp(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "columnstore")), "t") == 0) ? true : false;
+
+	appendPQExpBuffer(upgrade_buffer,
+					  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
+					  											   "'%s'::text, "
+																   "'%u'::pg_catalog.oid);\n",
+					  pg_class_oid, pg_class_relname, pg_class_relnamespace);
+
+	/*
+	 * If we have an AO relation we will need the aoseg namespace so
+	 * extract and save
+	 */
+	if (OidIsValid(pg_appendonly_segrelid))
+	{
+		aoseg_query = createPQExpBuffer();
+
+		appendPQExpBuffer(aoseg_query, "SELECT oid from pg_namespace WHERE nspname = 'pg_aoseg';");
+		aoseg_res = PQexec(conn, aoseg_query->data);
+		aoseg_namespace = atooid(PQgetvalue(aoseg_res, 0, PQfnumber(aoseg_res, "oid")));
+
+		PQclear(aoseg_res);
+		destroyPQExpBuffer(aoseg_query);
+	}
+
+	/* only tables have toast tables, not indexes */
+	if (OidIsValid(pg_class_reltoastrelid))
+	{
+		/*
+		 * One complexity is that the table definition might not require
+		 * the creation of a TOAST table, and the TOAST table might have
+		 * been created long after table creation, when the table was
+		 * loaded with wide data.  By setting the TOAST oid we force
+		 * creation of the TOAST heap and TOAST index by the backend so we
+		 * can cleanly copy the files during binary upgrade.
+		 */
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
+																	   "'pg_toast_%u'::text, "
+																	   "'%u'::pg_catalog.oid);\n",
+						  pg_class_reltoastrelid, pg_class_oid, pg_class_reltoastnamespace);
+
+
+		/* every toast table has an index */
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
+																	   "'pg_toast_%u_index'::text, "
+																	   "'%u'::pg_catalog.oid);\n",
+						  pg_class_reltoastidxid, pg_class_oid, pg_class_reltoastnamespace);
+	}
+	if (OidIsValid(pg_appendonly_segrelid))
+	{
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
+																	   "'pg_ao%sseg_%u'::text, "
+																	   "'%u'::pg_catalog.oid);\n",
+						  pg_appendonly_segrelid, (columnstore ? "cs" : ""), pg_class_oid, aoseg_namespace);
+	}
+	if (OidIsValid(pg_appendonly_blkdirrelid))
+	{
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
+																	   "'pg_aoblkdir_%u'::text, "
+																	   "'%u'::pg_catalog.oid);\n",
+						  pg_appendonly_blkdirrelid, pg_class_oid, aoseg_namespace);
+
+		/* every aoblkdir table has an index */
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
+																	   "'pg_aoblkdir_%u_index'::text, "
+																	   "'%u'::pg_catalog.oid);\n",
+						  pg_appendonly_blkdiridxid, pg_class_oid, aoseg_namespace);
+	}
+	if (OidIsValid(pg_appendonly_visimaprelid))
+	{
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
+						  											   "'pg_aovisimap_%u'::text, "
+																	   "'%u'::pg_catalog.oid);\n",
+						  pg_appendonly_visimaprelid, pg_class_oid, aoseg_namespace);
+
+		/* every aovisimap table has an index */
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
+						  											   "'pg_aovisimap_%u_index'::text, "
+																	   "'%u'::pg_catalog.oid);\n",
+						  pg_appendonly_visimapidxid, pg_class_oid, aoseg_namespace);
+	}
+
+	appendPQExpBuffer(upgrade_buffer, "\n");
+
+	PQclear(upgrade_res);
+	destroyPQExpBuffer(upgrade_query);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 "preassign_pg_class",
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", upgrade_buffer->data, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+
+	destroyPQExpBuffer(upgrade_buffer);
+}
+
+void
+preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_rel_oid, char *objname)
+{
+	PQExpBuffer upgrade_query;
+	PQExpBuffer upgrade_buffer;
+	int			ntups;
+	PGresult   *upgrade_res;
+	Oid			pg_type_oid;
+	bool		columnstore;
+
+	/* we only support old >= 8.3 for binary upgrades */
+	if (fout->remoteVersion >= 80300)
+		return;
+
+	upgrade_query = createPQExpBuffer();
+	upgrade_buffer = createPQExpBuffer();
+
+	appendPQExpBuffer(upgrade_query,
+					  "SELECT c.reltype AS crel, t.reltype AS trel, "
+					  "       t.relnamespace AS trelnamespace, "
+					  "       aoseg.reltype AS aosegrel, "
+					  "       aoseg.relnamespace AS aonamespace, "
+					  "       aoblkdir.reltype AS aoblkdirrel, "
+					  "       aoblkdir.relnamespace AS aoblkdirnamespace, "
+					  "       aovisimap.reltype AS aovisimaprel, "
+					  "       aovisimap.relnamespace AS aovisimapnamespace, "
+					  "       ao.columnstore, "
+					  "       CASE WHEN c.relhassubclass THEN True "
+					  "       ELSE NULL END AS par_parent "
+					  "FROM pg_catalog.pg_class c "
+					  "LEFT JOIN pg_catalog.pg_class t ON "
+					  "  (c.reltoastrelid = t.oid) "
+					  "LEFT JOIN pg_catalog.pg_appendonly ao ON "
+					  "  (c.oid = ao.relid) "
+					  "LEFT JOIN pg_catalog.pg_class aoseg ON "
+					  "  (ao.segrelid = aoseg.oid) "
+					  "LEFT JOIN pg_catalog.pg_class aoblkdir ON "
+					  "  (ao.blkdirrelid = aoblkdir.oid) "
+					  "LEFT JOIN pg_catalog.pg_class aovisimap ON "
+					  "  (ao.visimaprelid = aovisimap.oid) "
+					  "WHERE c.oid = '%u'::pg_catalog.oid;",
+					  pg_rel_oid);
+
+	upgrade_res = PQexec(conn, upgrade_query->data);
+	check_sql_result(upgrade_res, conn, upgrade_query->data, PGRES_TUPLES_OK);
+
+	/* Expecting a single result only */
+	ntups = PQntuples(upgrade_res);
+	if (ntups != 1)
+	{
+		write_msg(NULL, ngettext("query returned %d row instead of one: %s\n",
+							   "query returned %d rows instead of one: %s\n",
+								 ntups),
+				  ntups, upgrade_query->data);
+		exit_nicely();
+	}
+
+	pg_type_oid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "crel")));
+	columnstore = (strcmp(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "columnstore")), "t") == 0) ? true : false;
+
+	preassign_type_oid(conn, fout, AH, pg_type_oid, objname);
+
+	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "trel")))
+	{
+		/* Toast tables do not have pg_type array rows */
+		Oid			pg_type_toast_oid = atooid(PQgetvalue(upgrade_res, 0,
+											PQfnumber(upgrade_res, "trel")));
+		Oid			pg_type_toast_namespace_oid = atooid(PQgetvalue(upgrade_res, 0,
+											PQfnumber(upgrade_res, "trelnamespace")));
+
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
+																	   "'pg_toast_%u'::text, "
+																	   "'%u'::pg_catalog.oid);\n",
+						  pg_type_toast_oid, pg_rel_oid, pg_type_toast_namespace_oid);
+	}
+
+	/*
+	 * If the table is partitioned and is the parent, we need to dump the Oids
+	 * of the child tables as well
+	 */
+	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "par_parent")))
+	{
+		PQExpBuffer parquery = createPQExpBuffer();
+		PGresult   *par_res;
+		int			i;
+		char		name[NAMEDATALEN];
+		Oid			part_oid;
+		Oid			conns_oid;
+		Oid			conrel_oid;
+		Oid			contyp_oid;
+		Oid			con_oid;
+		Oid			prev_oid = InvalidOid;
+
+		appendPQExpBuffer(parquery,
+						  "SELECT cc.oid, "
+						  "       p.partitiontablename AS name, "
+						  "       co.oid AS conoid, "
+						  "       co.conname, "
+						  "       co.connamespace, "
+						  "       co.conrelid, "
+						  "       co.contypid "
+						  "FROM pg_partitions p "
+						  "JOIN pg_catalog.pg_class c ON "
+						  "  (p.tablename = c.relname AND c.oid = '%u'::pg_catalog.oid) "
+						  "JOIN pg_catalog.pg_class cc ON "
+						  "  (p.partitiontablename = cc.relname) "
+						  "LEFT JOIN pg_catalog.pg_constraint co ON "
+						  "  (cc.oid = co.conrelid);",
+						  pg_rel_oid);
+
+		par_res = PQexec(conn, parquery->data);
+		check_sql_result(par_res, conn, parquery->data, PGRES_TUPLES_OK);
+
+		if (PQntuples(par_res) > 0)
+		{
+			for (i = 0; i < PQntuples(par_res); i++)
+			{
+				part_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "oid")));
+
+				/*
+				 * Partitions with multiple constraint will be on multiple
+				 * rows so ensure to only save their Oids once.
+				 */
+				if (part_oid != prev_oid)
+				{
+					strlcpy(name, PQgetvalue(par_res, i, PQfnumber(par_res, "name")), sizeof(name));
+					preassign_type_oids_by_rel_oid(conn, fout, AH, part_oid, name);
+					preassign_pg_class_oids(conn, AH, part_oid);
+				}
+
+				if (!PQgetisnull(par_res, i, PQfnumber(par_res, "conname")))
+				{
+					strlcpy(name, PQgetvalue(par_res, i, PQfnumber(par_res, "conname")), sizeof(name));
+					con_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "conoid")));
+					conns_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "connamespace")));
+					conrel_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "conrelid")));
+					contyp_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "contypid")));
+
+					preassign_constraint_oid(AH, con_oid, conns_oid, name, conrel_oid, contyp_oid);
+				}
+
+				prev_oid = part_oid;
+			}
+		}
+
+		PQclear(par_res);
+		destroyPQExpBuffer(parquery);
+	}
+
+	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "aosegrel")))
+	{
+		/* AO segment tables do not have pg_type array rows */
+		Oid			pg_type_aosegments_oid = atooid(PQgetvalue(upgrade_res, 0,
+											PQfnumber(upgrade_res, "aosegrel")));
+		Oid			pg_type_aonamespace_oid = atooid(PQgetvalue(upgrade_res, 0,
+											PQfnumber(upgrade_res, "aonamespace")));
+
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
+																   "'pg_ao%sseg_%u'::text, "
+																   "'%u'::pg_catalog.oid);\n",
+						  pg_type_aosegments_oid, (columnstore ? "cs" : ""), pg_rel_oid, pg_type_aonamespace_oid);
+	}
+
+	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "aoblkdirrel")))
+	{
+		/* AO blockdir tables do not have pg_type array rows */
+		Oid			pg_type_aoblockdir_oid = atooid(PQgetvalue(upgrade_res, 0,
+											PQfnumber(upgrade_res, "aoblkdirrel")));
+		Oid			pg_type_aoblockdir_namespace = atooid(PQgetvalue(upgrade_res, 0,
+											PQfnumber(upgrade_res, "aoblkdirnamespace")));
+
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
+																   "'pg_aoblkdir_%u'::text, "
+																   "'%u'::pg_catalog.oid);\n",
+						  pg_type_aoblockdir_oid, pg_rel_oid, pg_type_aoblockdir_namespace);
+	}
+
+	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "aovisimaprel")))
+	{
+		/* AO visimap tables do not have pg_type array rows */
+		Oid			pg_type_aovisimap_oid = atooid(PQgetvalue(upgrade_res, 0,
+											PQfnumber(upgrade_res, "aovisimaprel")));
+		Oid			pg_type_aovisimap_namespace = atooid(PQgetvalue(upgrade_res, 0,
+											PQfnumber(upgrade_res, "aovisimapnamespace")));
+
+		appendPQExpBuffer(upgrade_buffer,
+						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
+																   "'pg_aovisimap_%u'::text, "
+																   "'%u'::pg_catalog.oid);\n",
+						  pg_type_aovisimap_oid, pg_rel_oid, pg_type_aovisimap_namespace);
+	}
+
+	PQclear(upgrade_res);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 objname,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", upgrade_buffer->data, "", NULL,
+				 NULL, 0,
+				 NULL, NULL);
+
+	destroyPQExpBuffer(upgrade_query);
+	destroyPQExpBuffer(upgrade_buffer);
+}

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -35,6 +35,26 @@ static void preassign_attrdefs_oid(Archive *AH, Oid attrdefoid, Oid attreloid, i
 static void preassign_pg_class_oids(PGconn *conn, Archive *AH, Oid pg_class_oid);
 static void preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_rel_oid, char *objname);
 
+void
+dumpOperatorOid(Archive *AH, OprInfo *info)
+{
+	/* Skip if not to be dumped */
+	if (!info->dobj.dump)
+		return;
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT binary_upgrade.preassign_operator_oid("
+			 "'%u'::pg_catalog.oid, '%u'::pg_catalog.oid, '%s'::text);\n",
+			 info->dobj.catId.oid, info->dobj.namespace->dobj.catId.oid,
+			 info->dobj.name);
+
+	ArchiveEntry(AH, nilCatalogId, createDumpId(),
+				 info->dobj.name,
+				 NULL, NULL, "",
+				 false, "BINARY UPGRADE", query_buffer, NULL, NULL,
+				 NULL, 0,
+				 NULL, NULL);
+}
 
 void
 dumpNamespaceOid(Archive *AH, NamespaceInfo *info)

--- a/src/bin/pg_dump/binary_upgrade.h
+++ b/src/bin/pg_dump/binary_upgrade.h
@@ -26,6 +26,7 @@ extern void dumpTableOid(PGconn *conn, Archive *fout, Archive *AH, TableInfo *in
 extern void dumpIndexOid(PGconn *conn, Archive *AH, IndxInfo *info);
 extern void dumpAttrDefsOid(Archive *AH, AttrDefInfo *info);
 extern void dumpConversionOid(PGconn *conn, Archive *AH, ConvInfo *info);
+extern void dumpOperatorOid(Archive *AH, OprInfo *info);
 extern void dumpOpFamilyOid(PGconn *conn, Archive *AH, OpfamilyInfo *info);
 extern void dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info);
 extern void dumpExternalProtocolOid(Archive *AH, ExtProtInfo *info);

--- a/src/bin/pg_dump/binary_upgrade.h
+++ b/src/bin/pg_dump/binary_upgrade.h
@@ -1,0 +1,41 @@
+/*-------------------------------------------------------------------------
+ *
+ * binary_upgrade.h
+ *		Functions to create ArchiveEntries for Oid preassignment in dumps
+ *
+ * Portions Copyright 2017 Pivotal Software, Inc.
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  src/bin/pg_dump/binary_upgrade.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef BINARY_UPGRADE_H
+#define BINARY_UPGRADE_H
+
+#define QUERY_ALLOC 8192
+
+#include "postgres_fe.h"
+#include "pg_backup_archiver.h"
+#include "libpq/libpq-fs.h"
+
+extern void dumpTableOid(PGconn *conn, Archive *fout, Archive *AH, TableInfo *info);
+extern void dumpIndexOid(PGconn *conn, Archive *AH, IndxInfo *info);
+extern void dumpAttrDefsOid(Archive *AH, AttrDefInfo *info);
+extern void dumpConversionOid(PGconn *conn, Archive *AH, ConvInfo *info);
+extern void dumpOpFamilyOid(PGconn *conn, Archive *AH, OpfamilyInfo *info);
+extern void dumpOpClassOid(PGconn *conn, Archive *AH, OpclassInfo *info);
+extern void dumpExternalProtocolOid(Archive *AH, ExtProtInfo *info);
+extern void dumpProcedureOid(Archive *AH, FuncInfo *info);
+extern void dumpShellTypeOid(PGconn *conn, Archive *fout, Archive *AH, ShellTypeInfo *info);
+extern void dumpTypeOid(PGconn *conn, Archive *fout, Archive *AH, TypeInfo *info);
+extern void dumpNamespaceOid(Archive *AH, NamespaceInfo *info);
+extern void dumpRuleOid(Archive *AH, RuleInfo *info);
+extern void dumpConstraintOid(PGconn *conn, Archive *AH, ConstraintInfo *info);
+extern void dumpProcLangOid(Archive *AH, ProcLangInfo *info);
+extern void dumpCastOid(Archive *AH, CastInfo *info);
+
+#endif /* BINARY_UPGRADE_H */

--- a/src/bin/pg_dump/binary_upgradeall.c
+++ b/src/bin/pg_dump/binary_upgradeall.c
@@ -1,0 +1,165 @@
+/*-------------------------------------------------------------------------
+ *
+ * binary_upgradeall.c
+ *		Functions to dump Oid dispatch commands from pg_dumpall
+ *
+ * Portions Copyright 2017 Pivotal Software, Inc.
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  src/bin/pg_dump/binary_upgradeall.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+
+#include <unistd.h>
+
+#include "binary_upgradeall.h"
+#include "pqexpbuffer.h"
+
+static char query_buffer[QUERY_ALLOC];
+
+void
+dumpFilespaceOid(FILE *OPF, PGconn *conn, char *fsname)
+{
+	PGresult   *catalog_res;
+	int			ntups;
+	Oid			fs_oid;
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT oid FROM pg_filespace WHERE fsname = '%s'::text;",
+			 fsname);
+
+	catalog_res = PQexec(conn, query_buffer);
+	if (PQresultStatus(catalog_res) != PGRES_TUPLES_OK)
+	{
+		fprintf(stderr, "ERROR: query returned error: \"%s\"",
+				PQresultErrorMessage(catalog_res));
+		PQfinish(conn);
+		exit(1);
+	}
+
+	ntups = PQntuples(catalog_res);
+	if (ntups != 1)
+	{
+		fprintf(stderr, "ERROR: query returned %d rows instead of one: %s\n",
+				ntups, query_buffer);
+		PQfinish(conn);
+		exit(1);
+	}
+
+	fs_oid = atooid(PQgetvalue(catalog_res, 0, PQfnumber(catalog_res, "oid")));
+
+	fprintf(OPF,
+			"SELECT binary_upgrade.preassign_filespace_oid("
+			"'%u'::pg_filespace.oid, '%s'::text);\n",
+			fs_oid, fsname);
+
+	PQclear(catalog_res);
+}
+
+void
+dumpTablespaceOid(FILE *OPF, PGconn *conn, char *tsname)
+{
+	PGresult   *catalog_res;
+	int			ntups;
+	Oid			ts_oid;
+
+	snprintf(query_buffer, sizeof(query_buffer),
+			 "SELECT oid FROM pg_tablespace WHERE spcname = '%s'::text;",
+			 tsname);
+	catalog_res = PQexec(conn, query_buffer);
+	if (PQresultStatus(catalog_res) != PGRES_TUPLES_OK)
+	{
+		fprintf(stderr, "ERROR: query returned error: \"%s\"",
+				PQresultErrorMessage(catalog_res));
+		PQfinish(conn);
+		exit(1);
+	}
+
+	ntups = PQntuples(catalog_res);
+	if (ntups != 1)
+	{
+		fprintf(stderr, "ERROR: query returned %d rows instead of one: %s\n",
+				ntups, query_buffer);
+		PQfinish(conn);
+		exit(1);
+	}
+
+	ts_oid = atooid(PQgetvalue(catalog_res, 0, PQfnumber(catalog_res, "oid")));
+
+	fprintf(OPF,
+			"SELECT binary_upgrade.preassign_tablespace_oid("
+			"'%u'::pg_tablespace.oid, '%s'::text);\n",
+			ts_oid, tsname);
+
+	PQclear(catalog_res);
+}
+
+void
+dumpResqueueOid(FILE *OPF, PGconn *conn, int server_version, Oid rqoid, char *rsqname)
+{
+	PQExpBuffer catalog_query;
+	PGresult   *catalog_res;
+	int			ntups;
+	int			i;
+
+	if (server_version >= 80214)
+	{
+		catalog_query = createPQExpBuffer();
+		appendPQExpBuffer(catalog_query, "SELECT oid, restypid "
+										 "FROM pg_resqueuecapability "
+										 "WHERE resqueueid = '%u'::pg_catalog.oid;",
+										 rqoid);
+
+		catalog_res = PQexec(conn, catalog_query->data);
+		if (PQresultStatus(catalog_res) != PGRES_TUPLES_OK)
+		{
+			fprintf(stderr, "ERROR: query returned error: \"%s\"",
+					PQresultErrorMessage(catalog_res));
+			PQfinish(conn);
+			exit(1);
+		}
+
+		ntups = PQntuples(catalog_res);
+
+		for (i = 0; i < ntups; i++)
+		{
+			Oid rqcapoid = atooid(PQgetvalue(catalog_res, i, 0));
+			Oid restypid = atooid(PQgetvalue(catalog_res, i, 1));
+
+			fprintf(OPF,
+					"SELECT binary_upgrade.preassign_resqueuecb_oid("
+					"'%u'::pg_catalog.oid, '%u'::pg_catalog.oid, '%u'::pg_catalog.oid);\n",
+					rqcapoid, rqoid, restypid);
+		}
+
+		destroyPQExpBuffer(catalog_query);
+		PQclear(catalog_res);
+	}
+
+	fprintf(OPF,
+			"SELECT binary_upgrade.preassign_resqueue_oid("
+			"'%u'::pg_catalog.oid, '%s'::text);\n",
+			rqoid, rsqname);
+}
+
+void
+dumpRoleOid(FILE *OPF, Oid roleoid, const char *rolename)
+{
+	fprintf(OPF,
+			"SELECT binary_upgrade.preassign_authid_oid("
+			"'%u'::pg_catalog.oid, '%s'::text);\n",
+			roleoid, rolename);
+}
+
+void
+dumpDatabaseOid(FILE *OPF, Oid dboid, const char *fdbname)
+{
+	fprintf(OPF,
+			"SELECT binary_upgrade.preassign_database_oid("
+			"'%u'::pg_catalog.oid, '%s'::text);\n",
+			dboid, fdbname);
+}

--- a/src/bin/pg_dump/binary_upgradeall.h
+++ b/src/bin/pg_dump/binary_upgradeall.h
@@ -1,0 +1,36 @@
+/*-------------------------------------------------------------------------
+ *
+ * binary_upgradeall.h
+ *		Functions to dump Oid dispatch commands from pg_dumpall
+ *
+ * Portions Copyright 2017 Pivotal Software, Inc.
+ * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  src/bin/pg_dump/binary_upgradeall.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef BINARY_UPGRADEALL_H
+#define BINARY_UPGRADEALL_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "postgres_fe.h"
+#include "libpq-fe.h"
+#include "libpq/libpq-fs.h"
+
+#define QUERY_ALLOC 8192
+
+#define atooid(x)  ((Oid) strtoul((x), NULL, 10))
+
+extern void dumpFilespaceOid(FILE *OPF, PGconn *conn, char *fsname);
+extern void dumpTablespaceOid(FILE *OPF, PGconn *conn, char *tsname);
+extern void dumpResqueueOid(FILE *OPF, PGconn *conn, int server_version, Oid rqoid, char *rsqname);
+extern void dumpRoleOid(FILE *OPF, Oid roleoid, const char *rolename);
+extern void dumpDatabaseOid(FILE *OPF, Oid dboid, const char *fdbname);
+
+#endif /* BINARY_UPGRADEALL_H */

--- a/src/bin/pg_dump/dumputils.h
+++ b/src/bin/pg_dump/dumputils.h
@@ -6,7 +6,6 @@
  *
  *
  * Portions Copyright (c) 1996-2009, PostgreSQL Global Development Group
- * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * $PostgreSQL: pgsql/src/bin/pg_dump/dumputils.h,v 1.21 2008/01/01 19:45:55 momjian Exp $

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -316,6 +316,13 @@ RestoreArchive(Archive *AHX, RestoreOptions *ropt)
 
 		defnDumped = false;
 
+		if (strcmp(te->desc, "BINARY UPGRADE") == 0)
+		{
+			_printTocEntry(AH, te, ropt, false, false);
+			defnDumped = true;
+			continue;
+		}
+
 		if ((reqs & REQ_SCHEMA) != 0)	/* We want the schema */
 		{
 			ahlog(AH, 1, "creating %s %s\n", te->desc, te->tag);
@@ -2089,6 +2096,10 @@ _tocEntryRequired(TocEntry *te, RestoreOptions *ropt, bool include_acls)
 {
 	teReqs		res = REQ_ALL;
 
+	/* BINARY UPGRADE items are dumped specially so always reject */
+	if (strcmp(te->desc, "BINARY UPGRADE") == 0)
+		return 0;
+
 	/* ENCODING and STDSTRINGS items are dumped specially, so always reject */
 	if (strcmp(te->desc, "ENCODING") == 0 ||
 		strcmp(te->desc, "STDSTRINGS") == 0)
@@ -2795,7 +2806,8 @@ _printTocEntry(ArchiveHandle *AH, TocEntry *te, RestoreOptions *ropt, bool isDat
 				 strcmp(te->desc, "INDEX") == 0 ||
 				 strcmp(te->desc, "RULE") == 0 ||
 				 strcmp(te->desc, "TRIGGER") == 0 ||
-				 strcmp(te->desc, "USER MAPPING") == 0)
+				 strcmp(te->desc, "USER MAPPING") == 0 ||
+				 strcmp(te->desc, "BINARY UPGRADE"))
 		{
 			/* these object types don't have separate owners */
 		}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -791,7 +791,7 @@ main(int argc, char **argv)
 			dumpPolicy = isGPbackend;
 			if (!isGPbackend)
 			{
-				write_msg(NULL, "Server is not a Greenplum Database instance; --gp_syntax option ignored.\n");
+				write_msg(NULL, "Server is not a Greenplum Database instance; --gp-syntax option ignored.\n");
 			}
 			break;
 	}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -5420,6 +5420,9 @@ dumpBinaryUpgrade(Archive *fout, DumpableObject **dobjs, int numObjs)
 			case DO_EXTPROTOCOL:
 				dumpExternalProtocolOid(fout, (ExtProtInfo *) dobj);
 				break;
+			case DO_OPERATOR:
+				dumpOperatorOid(fout, (OprInfo *) dobj);
+				break;
 			case DO_OPCLASS:
 				dumpOpClassOid(g_conn, fout, (OpclassInfo *) dobj);
 				break;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -65,11 +65,11 @@ int			optreset;
 
 #include "pg_backup_archiver.h"
 #include "dumputils.h"
+#include "binary_upgrade.h"
 
 extern char *optarg;
 extern int	optind,
 			opterr;
-
 
 typedef struct
 {
@@ -98,11 +98,6 @@ int			preDataSchemaOnly;	/* int because getopt_long() */
 int			postDataSchemaOnly;
 
 /* END MPP ADDITION */
-
-/* Cache for array types during binary_upgrade dumping */
-static TypeCache  	   *typecache;
-static DumpableObject **typecacheindex;
-static int				numtypecache;
 
 /* subquery used to convert user ID (eg, datdba) to user name */
 static const char *username_subquery;
@@ -208,6 +203,7 @@ static void dumpTSParser(Archive *fout, TSParserInfo *prsinfo);
 static void dumpTSDictionary(Archive *fout, TSDictInfo *dictinfo);
 static void dumpTSTemplate(Archive *fout, TSTemplateInfo *tmplinfo);
 static void dumpTSConfig(Archive *fout, TSConfigInfo *cfginfo);
+static void dumpBinaryUpgrade(Archive *fout, DumpableObject **dobj, int numObjs);
 
 static void dumpACL(Archive *fout, CatalogId objCatId, DumpId objDumpId,
 		const char *type, const char *name,
@@ -245,30 +241,9 @@ static int	dumpBlobComments(Archive *AH, void *arg __attribute__((unused)));
 static void dumpDatabase(Archive *AH);
 static void dumpEncoding(Archive *AH);
 static void dumpStdStrings(Archive *AH);
-static void binary_upgrade_preassign_procedure_oid(PQExpBuffer upgrade_buffer, Oid procoid,
-									   char *proname);
-static void binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
-								PQExpBuffer upgrade_buffer, Oid pg_type_oid, char *objname);
-static bool binary_upgrade_set_type_oids_by_rel_oid(Archive *fout,
-								 PQExpBuffer upgrade_buffer, Oid pg_rel_oid, char *objname);
-static void binary_upgrade_set_pg_class_oids(Archive *fout, PQExpBuffer upgrade_buffer,
-								 Oid pg_class_oid, bool is_index);
-static void binary_upgrade_set_extprot_oids(PQExpBuffer upgrade_buffer,
-								 Oid pg_extprot_oid, char *objname);
-static void binary_upgrade_set_opclass_oid(PQExpBuffer upgrade_buffer, char *objname);
-static void binary_upgrade_preassign_opfam_oid(PQExpBuffer upgrade_buffer, Oid opfoid,
-								char *objname, Oid opfnamespace);
-static void binary_upgrade_preassign_cast_oid(PQExpBuffer upgrade_buffer, Oid castoid,
-								  Oid castsource, Oid casttarget);
-static void binary_upgrade_preassign_constraint_oid(PQExpBuffer upgrade_buffer,
-										Oid constroid, Oid nsoid,
-										char *objname, Oid conrelid,
-										Oid contypid);
 static const char *getAttrName(int attrnum, TableInfo *tblInfo);
 static const char *fmtCopyColumnList(const TableInfo *ti);
 static void do_sql_command(PGconn *conn, const char *query);
-static void check_sql_result(PGresult *res, PGconn *conn, const char *query,
-				 ExecStatusType expected);
 
 /* START MPP ADDITION */
 static char *nextToken(register char **stringp, register const char *delim);
@@ -961,6 +936,8 @@ main(int argc, char **argv)
 	/* The database item is always next, unless we don't want it at all */
 	if (include_everything && !dataOnly)
 		dumpDatabase(g_fout);
+
+	dumpBinaryUpgrade(g_fout, dobjs, numObjs);
 
 	/* Now the rearrangeable objects. */
 	for (i = 0; i < numObjs; i++)
@@ -2200,687 +2177,7 @@ dumpBlobComments(Archive *AH, void *arg __attribute__((unused)))
 	return 1;
 }
 
-static void
-binary_upgrade_preassign_namespace_oid(PQExpBuffer upgrade_buffer, Oid nspoid,
-									   char *nspname)
-{
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_namespace_oid('%u'::pg_catalog.oid, "
-																	"'%s'::text);\n",
-					  nspoid, nspname);
-}
 
-static void
-binary_upgrade_preassign_procedure_oid(PQExpBuffer upgrade_buffer, Oid procoid,
-									   char *proname)
-{
-	PQExpBuffer	upgrade_query = createPQExpBuffer();
-	int			ntups;
-	PGresult   *upgrade_res;
-	Oid			pronamespace;
-
-	appendPQExpBuffer(upgrade_query, "SELECT pronamespace "
-									 "FROM   pg_catalog.pg_proc "
-									 "WHERE  oid = '%u'::pg_catalog.oid;",
-									 procoid);
-
-	upgrade_res = PQexec(g_conn, upgrade_query->data);
-	check_sql_result(upgrade_res, g_conn, upgrade_query->data, PGRES_TUPLES_OK);
-
-	ntups = PQntuples(upgrade_res);
-	if (ntups != 1)
-	{
-		write_msg(NULL, "ERROR: procedure %s not found in catalog", proname);
-		exit_nicely();
-	}
-	pronamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "pronamespace")));
-
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_proc oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_procedure_oid('%u'::pg_catalog.oid, "
-																	"'%s'::text, "
-																	"'%u'::pg_catalog.oid);\n",
-					  procoid, proname, pronamespace);
-
-	PQclear(upgrade_res);
-	destroyPQExpBuffer(upgrade_query);
-}
-
-static void
-binary_upgrade_preassign_language_oid(PQExpBuffer upgrade_buffer, Oid langoid,
-									  char *lanname)
-{
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_language oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_language_oid('%u'::pg_catalog.oid, "
-																   "'%s'::text);",
-					  langoid, lanname);
-}
-
-static void
-binary_upgrade_preassign_cast_oid(PQExpBuffer upgrade_buffer, Oid castoid,
-								  Oid castsource, Oid casttarget)
-{
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_cast oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_cast_oid('%u'::pg_catalog.oid, "
-															   "'%u'::pg_catalog.oid, "
-															   "'%u'::pg_catalog.oid);",
-					  castoid, castsource, casttarget);
-}
-
-static void
-binary_upgrade_preassign_conversion_oid(PQExpBuffer upgrade_buffer, Oid conoid,
-										char *objname, Oid connamespace)
-{
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_conversion oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_conversion_oid('%u'::pg_catalog.oid, "
-																	 "'%s'::text, "
-																	 "'%u'::pg_catalog.oid);",
-					  conoid, objname, connamespace);
-}
-
-static void
-binary_upgrade_preassign_rule_oid(PQExpBuffer upgrade_buffer, Oid ruleoid,
-								  Oid tableoid, char *rulename)
-{
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve the pg_rewrite oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_rule_oid('%u'::pg_catalog.oid, "
-															   "'%u'::pg_catalog.oid, "
-															   "'%s'::text);",
-					  ruleoid, tableoid, rulename);
-}
-
-static void
-binary_upgrade_set_opclass_oid(PQExpBuffer upgrade_buffer, char *objname)
-{
-	PQExpBuffer	upgrade_query = createPQExpBuffer();
-	int			ntups;
-	PGresult   *upgrade_res;
-	Oid			pg_opclass_oid;
-	Oid			opcnamespace;
-
-	appendPQExpBuffer(upgrade_query,
-					  "SELECT oid, opcnamespace "
-					  "FROM pg_catalog.pg_opclass "
-					  "WHERE opcname = '%s'::text;",
-					  objname);
-
-	upgrade_res = PQexec(g_conn, upgrade_query->data);
-	check_sql_result(upgrade_res, g_conn, upgrade_query->data, PGRES_TUPLES_OK);
-
-	ntups = PQntuples(upgrade_res);
-	if (ntups != 1)
-	{
-		write_msg(NULL, "ERROR: opclass %s not found in catalog", objname);
-		exit_nicely();
-	}
-	pg_opclass_oid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "oid")));
-	opcnamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "opcnamespace")));
-
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_opclass oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_opclass_oid('%u'::pg_opclass.oid, "
-																  "'%s'::text, "
-																  "'%u'::pg_opclass.opcnamespace);",
-					  pg_opclass_oid,
-					  objname,
-					  opcnamespace);
-
-	PQclear(upgrade_res);
-	destroyPQExpBuffer(upgrade_query);
-}
-
-static void
-binary_upgrade_preassign_opfam_oid(PQExpBuffer upgrade_buffer, Oid opfoid, char *objname, Oid opfnamespace)
-{
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pf_opfam oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_opfam_oid('%u'::pg_catalog.oid, "
-																"'%s'::text, "
-																"'%u'::pg_catalog.oid);",
-					  opfoid, objname, opfnamespace);
-}
-
-static void
-binary_upgrade_set_type_oids_by_type_oid(Archive *fout, PQExpBuffer upgrade_buffer,
-										 Oid pg_type_oid, char *objname)
-{
-	PQExpBuffer upgrade_query;
-	int			ntups;
-	PGresult   *upgrade_res;
-	int			i;
-	int			i_arr_oid;
-	int			i_arr_name;
-	int			i_arr_nsp;
-	int			i_oid;
-	int			i_name;
-	int			i_nsp;
-	TypeCache  *type;
-
-	if (typecache == NULL)
-	{
-		upgrade_query = createPQExpBuffer();
-
-		if (g_fout->remoteVersion >= 80300)
-		{
-			appendPQExpBuffer(upgrade_query,
-							  "SELECT typ.oid as typoid, typ.typname, typ.typnamespace, "
-							  "       typ.typarray as arr_typoid, arr.typname as arr_typname, arr.typnamespace as arr_typnamespace "
-							  "FROM pg_catalog.pg_type typ "
-							  "  LEFT OUTER JOIN pg_catalog.pg_type arr ON typ.typarray = arr.oid "
-							  "WHERE typ.oid NOT IN (SELECT typarray FROM pg_type)");
-		}
-		else
-		{
-			/*
-			 * Query to get the array type of a base type in GPDB 4.3, should we
-			 * need to support older versions then this would have to be extended.
-			 */
-			appendPQExpBuffer(upgrade_query,
-							  "SELECT typ.oid as typoid, typ.typname, typ.typnamespace, "
-							  "       arr.oid as arr_typoid, arr.typname as arr_typname, arr.typnamespace as arr_typnamespace "
-							  "FROM pg_catalog.pg_type typ "
-							  "  LEFT OUTER JOIN pg_catalog.pg_type arr ON arr.typname = '_' || typ.typname "
-							  "WHERE typ.oid NOT IN (SELECT oid FROM pg_type WHERE substring(typname, 1, 1) = '_')");
-		}
-
-		upgrade_res = PQexec(g_conn, upgrade_query->data);
-		check_sql_result(upgrade_res, g_conn, upgrade_query->data, PGRES_TUPLES_OK);
-
-		ntups = PQntuples(upgrade_res);
-
-		if (ntups > 0)
-		{
-			i_oid = PQfnumber(upgrade_res, "typoid");
-			i_name = PQfnumber(upgrade_res, "typname");
-			i_nsp = PQfnumber(upgrade_res, "typnamespace");
-			i_arr_oid = PQfnumber(upgrade_res, "arr_typoid");
-			i_arr_name = PQfnumber(upgrade_res, "arr_typname");
-			i_arr_nsp = PQfnumber(upgrade_res, "arr_typnamespace");
-
-			typecache = calloc(ntups, sizeof(TypeCache));
-			numtypecache = ntups;
-
-			for (i = 0; i < ntups; i++)
-			{
-				typecache[i].dobj.objType = DO_TYPE_CACHE;
-				typecache[i].dobj.catId.oid = atooid(PQgetvalue(upgrade_res, i, i_oid));
-				typecache[i].dobj.name = strdup(PQgetvalue(upgrade_res, i, i_name));
-
-				typecache[i].typnsp = atooid(PQgetvalue(upgrade_res, i, i_nsp));
-
-				/*
-				 * Before PostgreSQL 8.3 arrays for composite types weren't supported
-				 * and base relation types didn't automatically have an array type
-				 * counterpart. If an array type isn't found we need to force a new
-				 * Oid to be allocated even in binary_upgrade mode which otherwise
-				 * work by preassigning Oids. Inject InvalidOid in the preassign call
-				 * to ensure we get a new Oid.
-				 */
-				if (PQgetisnull(upgrade_res, i, i_arr_name))
-				{
-					char array_name[NAMEDATALEN];
-
-					typecache[i].arraytypoid = InvalidOid,
-					typecache[i].arraytypnsp = atooid(PQgetvalue(upgrade_res, i, i_nsp));
-
-					snprintf(array_name, NAMEDATALEN, "_%s", PQgetvalue(upgrade_res, i, i_name));
-					typecache[i].arraytypname = strdup(array_name);
-				}
-				else
-				{
-					typecache[i].arraytypoid = atooid(PQgetvalue(upgrade_res, i, i_arr_oid));
-					typecache[i].arraytypname = strdup(PQgetvalue(upgrade_res, i, i_arr_name));
-					typecache[i].arraytypnsp = atooid(PQgetvalue(upgrade_res, i, i_arr_nsp));
-				}
-			}
-
-			typecacheindex = buildIndexArray(typecache, ntups, sizeof(TypeCache));
-		}
-
-		PQclear(upgrade_res);
-		destroyPQExpBuffer(upgrade_query);
-	}
-
-	/* Query the cached type information */
-	type = (TypeCache *) findObjectByOid(pg_type_oid, typecacheindex, numtypecache);
-
-	/* This shouldn't happen.. */
-	if (!type)
-	{
-		write_msg(NULL, "ERROR: didn't find in cache\n");
-		exit_nicely();
-	}
-
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_type oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
-															   "'%s'::text, "
-															   "'%u'::pg_catalog.oid);\n\n",
-					  pg_type_oid, type->dobj.name, type->typnsp);
-
-	appendPQExpBuffer(upgrade_buffer,
-		   "\n-- For binary upgrade, must preserve pg_type array oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_arraytype_oid('%u'::pg_catalog.oid, "
-																	"'%s'::text, "
-																	"'%u'::pg_catalog.oid);\n\n",
-					  type->arraytypoid, type->arraytypname, type->arraytypnsp);
-}
-
-static bool
-binary_upgrade_set_type_oids_by_rel_oid(Archive *fout, PQExpBuffer upgrade_buffer,
-										Oid pg_rel_oid, char *objname)
-{
-	PQExpBuffer upgrade_query;
-	int			ntups;
-	PGresult   *upgrade_res;
-	Oid			pg_type_oid;
-	bool		toast_set = false;
-	bool		columnstore;
-
-	/* we only support old >= 8.3 for binary upgrades */
-	if (g_fout->remoteVersion >= 80300)
-		return false;
-
-	upgrade_query = createPQExpBuffer();
-
-	appendPQExpBuffer(upgrade_query,
-					  "SELECT c.reltype AS crel, t.reltype AS trel, "
-					  "       t.relnamespace AS trelnamespace, "
-					  "       aoseg.reltype AS aosegrel, "
-					  "       aoseg.relnamespace AS aonamespace, "
-					  "       aoblkdir.reltype AS aoblkdirrel, "
-					  "       aoblkdir.relnamespace AS aoblkdirnamespace, "
-					  "       aovisimap.reltype AS aovisimaprel, "
-					  "       aovisimap.relnamespace AS aovisimapnamespace, "
-					  "       ao.columnstore, "
-					  "       CASE WHEN c.relhassubclass THEN True "
-					  "       ELSE NULL END AS par_parent "
-					  "FROM pg_catalog.pg_class c "
-					  "LEFT JOIN pg_catalog.pg_class t ON "
-					  "  (c.reltoastrelid = t.oid) "
-					  "LEFT JOIN pg_catalog.pg_appendonly ao ON "
-					  "  (c.oid = ao.relid) "
-					  "LEFT JOIN pg_catalog.pg_class aoseg ON "
-					  "  (ao.segrelid = aoseg.oid) "
-					  "LEFT JOIN pg_catalog.pg_class aoblkdir ON "
-					  "  (ao.blkdirrelid = aoblkdir.oid) "
-					  "LEFT JOIN pg_catalog.pg_class aovisimap ON "
-					  "  (ao.visimaprelid = aovisimap.oid) "
-					  "WHERE c.oid = '%u'::pg_catalog.oid;",
-					  pg_rel_oid);
-
-	upgrade_res = PQexec(g_conn, upgrade_query->data);
-	check_sql_result(upgrade_res, g_conn, upgrade_query->data, PGRES_TUPLES_OK);
-
-	/* Expecting a single result only */
-	ntups = PQntuples(upgrade_res);
-	if (ntups != 1)
-	{
-		write_msg(NULL, ngettext("query returned %d row instead of one: %s\n",
-							   "query returned %d rows instead of one: %s\n",
-								 ntups),
-				  ntups, upgrade_query->data);
-		exit_nicely();
-	}
-
-	pg_type_oid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "crel")));
-	columnstore = (strcmp(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "columnstore")), "t") == 0) ? true : false;
-
-	binary_upgrade_set_type_oids_by_type_oid(fout, upgrade_buffer, pg_type_oid, objname);
-
-	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "trel")))
-	{
-		/* Toast tables do not have pg_type array rows */
-		Oid			pg_type_toast_oid = atooid(PQgetvalue(upgrade_res, 0,
-											PQfnumber(upgrade_res, "trel")));
-		Oid			pg_type_toast_namespace_oid = atooid(PQgetvalue(upgrade_res, 0,
-											PQfnumber(upgrade_res, "trelnamespace")));
-
-		appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_type toast oid\n");
-		appendPQExpBuffer(upgrade_buffer,
-						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
-																	   "'pg_toast_%u'::text, "
-																	   "'%u'::pg_catalog.oid);\n",
-						  pg_type_toast_oid, pg_rel_oid, pg_type_toast_namespace_oid);
-
-		toast_set = true;
-	}
-
-	/*
-	 * If the table is partitioned and is the parent, we need to dump the Oids
-	 * of the child tables as well
-	 */
-	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "par_parent")))
-	{
-		PQExpBuffer parquery = createPQExpBuffer();
-		PGresult   *par_res;
-		int			i;
-		char		name[NAMEDATALEN];
-		Oid			part_oid;
-		Oid			conns_oid;
-		Oid			conrel_oid;
-		Oid			contyp_oid;
-		Oid			con_oid;
-		Oid			prev_oid = InvalidOid;
-
-		appendPQExpBuffer(parquery,
-						  "SELECT cc.oid, "
-						  "       p.partitiontablename AS name, "
-						  "       co.oid AS conoid, "
-						  "       co.conname, "
-						  "       co.connamespace, "
-						  "       co.conrelid, "
-						  "       co.contypid "
-						  "FROM pg_partitions p "
-						  "JOIN pg_catalog.pg_class c ON "
-						  "  (p.tablename = c.relname AND c.oid = '%u'::pg_catalog.oid) "
-						  "JOIN pg_catalog.pg_class cc ON "
-						  "  (p.partitiontablename = cc.relname) "
-						  "LEFT JOIN pg_catalog.pg_constraint co ON "
-						  "  (cc.oid = co.conrelid);",
-						  pg_rel_oid);
-
-		par_res = PQexec(g_conn, parquery->data);
-		check_sql_result(par_res, g_conn, parquery->data, PGRES_TUPLES_OK);
-
-		if (PQntuples(par_res) > 0)
-		{
-			appendPQExpBuffer(upgrade_buffer,
-							  "\n-- For binary upgrade, must preserve Oids of "
-							  " induced child tables from partitioning\n");
-
-			for (i = 0; i < PQntuples(par_res); i++)
-			{
-				part_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "oid")));
-
-				/*
-				 * Partitions with multiple constraint will be on multiple
-				 * rows so ensure to only save their Oids once.
-				 */
-				if (part_oid != prev_oid)
-				{
-					strlcpy(name, PQgetvalue(par_res, i, PQfnumber(par_res, "name")), sizeof(name));
-					binary_upgrade_set_type_oids_by_rel_oid(fout, upgrade_buffer, part_oid, name);
-					binary_upgrade_set_pg_class_oids(fout, upgrade_buffer, part_oid, false);
-				}
-
-				if (!PQgetisnull(par_res, i, PQfnumber(par_res, "conname")))
-				{
-					strlcpy(name, PQgetvalue(par_res, i, PQfnumber(par_res, "conname")), sizeof(name));
-					con_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "conoid")));
-					conns_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "connamespace")));
-					conrel_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "conrelid")));
-					contyp_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "contypid")));
-
-					binary_upgrade_preassign_constraint_oid(upgrade_buffer, con_oid, conns_oid, name, conrel_oid, contyp_oid);
-				}
-
-				prev_oid = part_oid;
-			}
-		}
-
-		PQclear(par_res);
-		destroyPQExpBuffer(parquery);
-	}
-
-	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "aosegrel")))
-	{
-		/* AO segment tables do not have pg_type array rows */
-		Oid			pg_type_aosegments_oid = atooid(PQgetvalue(upgrade_res, 0,
-											PQfnumber(upgrade_res, "aosegrel")));
-		Oid			pg_type_aonamespace_oid = atooid(PQgetvalue(upgrade_res, 0,
-											PQfnumber(upgrade_res, "aonamespace")));
-
-		appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_type aosegments oid\n");
-
-		appendPQExpBuffer(upgrade_buffer,
-						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
-																   "'pg_ao%sseg_%u'::text, "
-																   "'%u'::pg_catalog.oid);\n",
-						  pg_type_aosegments_oid, (columnstore ? "cs" : ""), pg_rel_oid, pg_type_aonamespace_oid);
-	}
-
-	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "aoblkdirrel")))
-	{
-		/* AO blockdir tables do not have pg_type array rows */
-		Oid			pg_type_aoblockdir_oid = atooid(PQgetvalue(upgrade_res, 0,
-											PQfnumber(upgrade_res, "aoblkdirrel")));
-		Oid			pg_type_aoblockdir_namespace = atooid(PQgetvalue(upgrade_res, 0,
-											PQfnumber(upgrade_res, "aoblkdirnamespace")));
-
-		appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_type aoblockdir oid\n");
-		appendPQExpBuffer(upgrade_buffer,
-						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
-																   "'pg_aoblkdir_%u'::text, "
-																   "'%u'::pg_catalog.oid);\n",
-						  pg_type_aoblockdir_oid, pg_rel_oid, pg_type_aoblockdir_namespace);
-	}
-
-	if (!PQgetisnull(upgrade_res, 0, PQfnumber(upgrade_res, "aovisimaprel")))
-	{
-		/* AO visimap tables do not have pg_type array rows */
-		Oid			pg_type_aovisimap_oid = atooid(PQgetvalue(upgrade_res, 0,
-											PQfnumber(upgrade_res, "aovisimaprel")));
-		Oid			pg_type_aovisimap_namespace = atooid(PQgetvalue(upgrade_res, 0,
-											PQfnumber(upgrade_res, "aovisimapnamespace")));
-
-		appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_type aovisimap oid\n");
-		appendPQExpBuffer(upgrade_buffer,
-						  "SELECT binary_upgrade.preassign_type_oid('%u'::pg_catalog.oid, "
-																   "'pg_aovisimap_%u'::text, "
-																   "'%u'::pg_catalog.oid);\n",
-						  pg_type_aovisimap_oid, pg_rel_oid, pg_type_aovisimap_namespace);
-	}
-
-	PQclear(upgrade_res);
-	destroyPQExpBuffer(upgrade_query);
-
-	return toast_set;
-}
-
-static void
-binary_upgrade_preassign_constraint_oid(PQExpBuffer upgrade_buffer,
-										Oid constroid, Oid nsoid,
-										char *objname, Oid conrelid,
-										Oid contypid)
-{
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_constraint oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_constraint_oid('%u'::pg_catalog.oid, "
-																	 "'%u'::pg_catalog.oid, "
-																	 "'%s'::text, "
-																	 "'%u'::pg_catalog.oid, "
-																	 "'%u'::pg_catalog.oid);\n",
-					  constroid, nsoid, objname, conrelid, contypid);
-}
-
-/*
- * For external protocols the oid retrieved in getExtProtocols() is what we
- * need to instrument the CREATE .. PROTOCOL .. statement with.
- */
-static void
-binary_upgrade_set_extprot_oids(PQExpBuffer upgrade_buffer,
-										Oid pg_extprot_oid,
-										char *objname)
-{
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_extprotocol oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_extprotocol_oid('%u'::pg_catalog.oid, "
-					  												  "'%s'::text);\n\n",
-					  pg_extprot_oid, objname);
-}
-
-static void
-binary_upgrade_set_attrdefs_oid(PQExpBuffer upgrade_buffer, Oid attrdefoid, Oid attreloid, int adnum)
-{
-
-	appendPQExpBuffer(upgrade_buffer, "\n-- For binary upgrade, must preserve attrdef oid\n");
-	appendPQExpBuffer(upgrade_buffer,
-					  "SELECT binary_upgrade.preassign_attrdef_oid('%u'::pg_catalog.oid, "
-																  "'%u'::pg_catalog.oid, "
-																  "'%u'::pg_catalog.oid);\n\n",
-					  attrdefoid, attreloid, adnum);
-}
-
-static void
-binary_upgrade_set_pg_class_oids(Archive *fout, PQExpBuffer upgrade_buffer, Oid pg_class_oid,
-								 bool is_index)
-{
-	PQExpBuffer upgrade_query = createPQExpBuffer();
-	int			ntups;
-	PGresult   *upgrade_res;
-	Oid			pg_class_reltoastnamespace;
-	Oid			pg_class_reltoastrelid;
-	Oid			pg_class_reltoastidxid;
-	Oid			pg_class_relnamespace;
-	char	   *pg_class_relname;
-	Oid			pg_appendonly_segrelid;
-	Oid			pg_appendonly_blkdirrelid;
-	Oid			pg_appendonly_blkdiridxid;
-	Oid			pg_appendonly_visimaprelid;
-	Oid			pg_appendonly_visimapidxid;
-	PGresult   *aoseg_res;
-	Oid			aoseg_namespace = InvalidOid;
-	bool		columnstore;
-
-	appendPQExpBuffer(upgrade_query,
-					  "SELECT c.reltoastrelid, t.reltoastidxid, "
-					  "       t.relnamespace as toastnamespace, "
-					  "       ao.segrelid, c.relnamespace, "
-					  "       ao.blkdirrelid, ao.blkdiridxid, "
-					  "       ao.visimaprelid, ao.visimapidxid, "
-					  "       c.relname, ao.columnstore "
-					  "FROM pg_catalog.pg_class c LEFT JOIN "
-					  "pg_catalog.pg_class t ON (c.reltoastrelid = t.oid) "
-					  "LEFT JOIN pg_catalog.pg_appendonly ao ON (ao.relid = c.oid) "
-					  "WHERE c.oid = '%u'::pg_catalog.oid;",
-					  pg_class_oid);
-
-	upgrade_res = PQexec(g_conn, upgrade_query->data);
-	check_sql_result(upgrade_res, g_conn, upgrade_query->data, PGRES_TUPLES_OK);
-
-	/* Expecting a single result only */
-	ntups = PQntuples(upgrade_res);
-	if (ntups != 1)
-	{
-		write_msg(NULL, ngettext("query returned %d row instead of one: %s\n",
-							   "query returned %d rows instead of one: %s\n",
-								 ntups),
-				  ntups, upgrade_query->data);
-		exit_nicely();
-	}
-
-	pg_class_reltoastnamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "toastnamespace")));
-	pg_class_reltoastrelid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "reltoastrelid")));
-	pg_class_reltoastidxid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "reltoastidxid")));
-	pg_class_relnamespace = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "relnamespace")));
-	pg_class_relname = PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "relname"));
-	pg_appendonly_segrelid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "segrelid")));
-	pg_appendonly_blkdirrelid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "blkdirrelid")));
-	pg_appendonly_blkdiridxid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "blkdiridxid")));
-	pg_appendonly_visimaprelid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "visimaprelid")));
-	pg_appendonly_visimapidxid = atooid(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "visimapidxid")));
-	columnstore = (strcmp(PQgetvalue(upgrade_res, 0, PQfnumber(upgrade_res, "columnstore")), "t") == 0) ? true : false;
-
-	appendPQExpBuffer(upgrade_buffer,
-					"\n-- For binary upgrade, must preserve pg_class oids\n");
-
-		appendPQExpBuffer(upgrade_buffer,
-						  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-						  											   "'%s'::text, "
-																	   "'%u'::pg_catalog.oid);\n",
-						  pg_class_oid, pg_class_relname, pg_class_relnamespace);
-
-		/*
-		 * If we have an AO relation we will need the aoseg namespace so
-		 * extract and save
-		 */
-		if (OidIsValid(pg_appendonly_segrelid))
-		{
-			int oid_col;
-
-			aoseg_res = PQexec(g_conn, "SELECT oid FROM pg_namespace WHERE nspname = 'pg_aoseg'");
-			oid_col = PQfnumber(aoseg_res, "oid");
-			if (!PQgetisnull(aoseg_res, 0, oid_col))
-				aoseg_namespace = atooid(PQgetvalue(aoseg_res, 0, oid_col));
-
-			PQclear(aoseg_res);
-		}
-
-		/* only tables have toast tables, not indexes */
-		if (OidIsValid(pg_class_reltoastrelid))
-		{
-			/*
-			 * One complexity is that the table definition might not require
-			 * the creation of a TOAST table, and the TOAST table might have
-			 * been created long after table creation, when the table was
-			 * loaded with wide data.  By setting the TOAST oid we force
-			 * creation of the TOAST heap and TOAST index by the backend so we
-			 * can cleanly copy the files during binary upgrade.
-			 */
-			appendPQExpBuffer(upgrade_buffer,
-							  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																		   "'pg_toast_%u'::text, "
-																		   "'%u'::pg_catalog.oid);\n",
-							  pg_class_reltoastrelid, pg_class_oid, pg_class_reltoastnamespace);
-
-
-			/* every toast table has an index */
-			appendPQExpBuffer(upgrade_buffer,
-							  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																		   "'pg_toast_%u_index'::text, "
-																		   "'%u'::pg_catalog.oid);\n",
-							  pg_class_reltoastidxid, pg_class_oid, pg_class_reltoastnamespace);
-		}
-		if (OidIsValid(pg_appendonly_segrelid) && OidIsValid(aoseg_namespace))
-		{
-			appendPQExpBuffer(upgrade_buffer,
-							  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																		   "'pg_ao%sseg_%u'::text, "
-																		   "'%u'::pg_catalog.oid);\n",
-							  pg_appendonly_segrelid, (columnstore ? "cs" : ""), pg_class_oid, aoseg_namespace);
-		}
-		if (OidIsValid(pg_appendonly_blkdirrelid) && OidIsValid(aoseg_namespace))
-		{
-			appendPQExpBuffer(upgrade_buffer,
-							  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																		   "'pg_aoblkdir_%u'::text, "
-																		   "'%u'::pg_catalog.oid);\n",
-							  pg_appendonly_blkdirrelid, pg_class_oid, aoseg_namespace);
-
-			/* every aoblockdir table has an index */
-			appendPQExpBuffer(upgrade_buffer,
-							  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-																		   "'pg_aoblkdir_%u_index'::text, "
-																		   "'%u'::pg_catalog.oid);\n",
-							  pg_appendonly_blkdiridxid, pg_class_oid, aoseg_namespace);
-		}
-		if (OidIsValid(pg_appendonly_visimaprelid) && OidIsValid(aoseg_namespace))
-		{
-			appendPQExpBuffer(upgrade_buffer,
-							  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-							  											   "'pg_aovisimap_%u'::text, "
-																		   "'%u'::pg_catalog.oid);\n",
-							  pg_appendonly_visimaprelid, pg_class_oid, aoseg_namespace);
-
-			/* every aovisimap table has an index */
-			appendPQExpBuffer(upgrade_buffer,
-							  "SELECT binary_upgrade.preassign_relation_oid('%u'::pg_catalog.oid, "
-							  											   "'pg_aovisimap_%u_index'::text, "
-																		   "'%u'::pg_catalog.oid);\n",
-							  pg_appendonly_visimapidxid, pg_class_oid, aoseg_namespace);
-		}
-
-	appendPQExpBuffer(upgrade_buffer, "\n");
-
-	PQclear(upgrade_res);
-	destroyPQExpBuffer(upgrade_query);
-}
 
 /*
  * getNamespaces:
@@ -6089,6 +5386,110 @@ collectComments(Archive *fout, CommentItem **items)
 }
 
 /*
+ * dumpBinaryUpgrade
+ *
+ * When running in binary-upgrade mode, this function creates ArchiveEntries
+ * for all Oid preassignments.
+ */
+static void
+dumpBinaryUpgrade(Archive *fout, DumpableObject **dobjs, int numObjs)
+{
+	int			i;
+
+	if (!binary_upgrade || dataOnly)
+		return;
+
+	for (i = 0; i < numObjs; i++)
+	{
+		DumpableObject *dobj = dobjs[i];
+
+		switch (dobj->objType)
+		{
+			case DO_NAMESPACE:
+				dumpNamespaceOid(fout, (NamespaceInfo *) dobj);
+				break;
+			case DO_TYPE:
+				dumpTypeOid(g_conn, g_fout, fout, (TypeInfo *) dobj);
+				break;
+			case DO_SHELL_TYPE:
+				dumpShellTypeOid(g_conn, g_fout, fout, (ShellTypeInfo *) dobj);
+				break;
+			case DO_FUNC:
+				dumpProcedureOid(fout, (FuncInfo *) dobj);
+				break;
+			case DO_EXTPROTOCOL:
+				dumpExternalProtocolOid(fout, (ExtProtInfo *) dobj);
+				break;
+			case DO_OPCLASS:
+				dumpOpClassOid(g_conn, fout, (OpclassInfo *) dobj);
+				break;
+			case DO_OPFAMILY:
+				dumpOpFamilyOid(g_conn, fout, (OpfamilyInfo *) dobj);
+				break;
+			case DO_CONVERSION:
+				dumpConversionOid(g_conn, fout, (ConvInfo *) dobj);
+				break;
+			case DO_TABLE:
+				dumpTableOid(g_conn, g_fout, fout, (TableInfo *) dobj);
+				break;
+			case DO_ATTRDEF:
+				dumpAttrDefsOid(fout, (AttrDefInfo *) dobj);
+				break;
+			case DO_INDEX:
+				dumpIndexOid(g_conn, fout, (IndxInfo *) dobj);
+				break;
+			case DO_RULE:
+				dumpRuleOid(fout, (RuleInfo *) dobj);
+				break;
+			case DO_FK_CONSTRAINT:
+			case DO_CONSTRAINT:
+				dumpConstraintOid(g_conn, fout, (ConstraintInfo *) dobj);	
+				break;
+			case DO_PROCLANG:
+				dumpProcLangOid(fout, (ProcLangInfo *) dobj);
+				break;
+			case DO_CAST:
+				dumpCastOid(fout, (CastInfo *) dobj);
+				break;
+
+			/*
+			 * There is no binary upgrade required for the following dumpable
+			 * objects as they don't allocate any new Oids, are dumping data
+			 * only or are exempt from Oid pre-assignment due to handling Oid
+			 * synchronization in another way.
+			 */
+			case DO_AGG:
+			case DO_BLOBS:
+			case DO_BLOB_COMMENTS:
+			case DO_TRIGGER:
+			case DO_TYPE_CACHE:
+			case DO_TYPE_STORAGE_OPTIONS:
+			case DO_TABLE_DATA:
+			case DO_DUMMY_TYPE:
+				break;
+
+			/*
+			 * GPDB_84_MERGE_FIXME:  Support for binary upgrade has not yet
+			 * been added for the following dumpable objects as they were
+			 * first introduced in Greenplum 5.0. When merging PostgreSQL 8.4,
+			 * implement this oid dispatch to cover the * 5.0 -> 6.0 upgrade
+			 * cycle.
+			 *
+			 * Ideally, support should be added even before then to be able
+			 * to upgrade 5.0 -> 5.0 in order to test the GPDB version of
+			 * pg_upgrade.
+			 */
+			case DO_EXTENSION:
+			case DO_TSPARSER:
+			case DO_TSDICT:
+			case DO_TSTEMPLATE:
+			case DO_TSCONFIG:
+				break;
+		}
+	}
+}
+
+/*
  * dumpDumpableObject
  *
  * This routine and its subsidiaries are responsible for creating
@@ -6253,9 +5654,6 @@ dumpNamespace(Archive *fout, NamespaceInfo *nspinfo)
 
 	appendPQExpBuffer(delq, "DROP SCHEMA %s;\n", qnspname);
 
-	if (binary_upgrade)
-		binary_upgrade_preassign_namespace_oid(q, nspinfo->dobj.catId.oid, qnspname);
-
 	appendPQExpBuffer(q, "CREATE SCHEMA %s;\n", qnspname);
 
 	ArchiveEntry(fout, nspinfo->dobj.catId, nspinfo->dobj.dumpId,
@@ -6304,17 +5702,6 @@ dumpExtension(Archive *fout, ExtensionInfo *extinfo)
 	labelq = createPQExpBuffer();
 
 	qextname = strdup(fmtId(extinfo->dobj.name));
-
-	if (binary_upgrade)
-	{
-		/*
-		 * GPDB_84_MERGE_FIXME: dispatching oids for extensions is currently
-		 * not implemented as extensions were first introduced in Greenplum 5.0.
-		 * When merging PostgreSQL 8.4, implement this oid dispatch to cover
-		 * the 5.0 -> 6.0 upgrade cycle even though extensions aren't a part of
-		 * PostgreSQL 8.4.
-		 */
-	}
 
 	appendPQExpBuffer(delq, "DROP EXTENSION %s;\n", qextname);
 	appendPQExpBuffer(q, "CREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s;\n",
@@ -6408,16 +5795,6 @@ dumpEnumType(Archive *fout, TypeInfo *tinfo)
 					  fmtId(tinfo->dobj.namespace->dobj.name));
 	appendPQExpBuffer(delq, "%s;\n",
 					  fmtId(tinfo->dobj.name));
-
-	if (binary_upgrade)
-	{
-		/*
-		 * GPDB_84_MERGE_FIXME: dispatching oids for ENUM types is currently
-		 * not implemented as ENUM was first introduced in Greenplum 5.0. When
-		 * merging PostgreSQL 8.4, implement this oid dispatch to cover the
-		 * 5.0 -> 6.0 upgrade cycle.
-		 */
-	}
 
 	appendPQExpBuffer(q, "CREATE TYPE %s AS ENUM (\n",
 					  fmtId(tinfo->dobj.name));
@@ -6680,10 +6057,6 @@ dumpBaseType(Archive *fout, TypeInfo *tinfo)
 	appendPQExpBuffer(delq, "%s CASCADE;\n",
 					  fmtId(tinfo->dobj.name));
 
-	/* We might already have a shell type, but setting pg_type_oid is harmless */
-	if (binary_upgrade)
-		binary_upgrade_set_type_oids_by_type_oid(fout, q, tinfo->dobj.catId.oid, tinfo->dobj.name);
-
 	appendPQExpBuffer(q,
 					  "CREATE TYPE %s (\n"
 					  "    INTERNALLENGTH = %s",
@@ -6883,21 +6256,6 @@ dumpDomain(Archive *fout, TypeInfo *tinfo)
 	else
 		typdefault = NULL;
 
-	if (binary_upgrade)
-	{
-		binary_upgrade_set_type_oids_by_type_oid(fout, q, tinfo->dobj.catId.oid, tinfo->dobj.name);
-		for (i = 0; i < tinfo->nDomChecks; i++)
-		{
-			ConstraintInfo *c = &(tinfo->domChecks[i]);
-
-			binary_upgrade_preassign_constraint_oid(q, c->dobj.catId.oid,
-													c->dobj.namespace->dobj.catId.oid,
-													c->dobj.name,
-													c->contable ? c->contable->dobj.catId.oid : InvalidOid,
-													c->condomain ? c->condomain->dobj.catId.oid : InvalidOid);
-		}
-	}
-
 	appendPQExpBuffer(q,
 					  "CREATE DOMAIN %s AS %s",
 					  fmtId(tinfo->dobj.name),
@@ -7006,12 +6364,6 @@ dumpCompositeType(Archive *fout, TypeInfo *tinfo)
 	i_attname = PQfnumber(res, "attname");
 	i_atttypdefn = PQfnumber(res, "atttypdefn");
 
-	if (binary_upgrade)
-	{
-		binary_upgrade_set_type_oids_by_type_oid(fout, q, tinfo->dobj.catId.oid, tinfo->dobj.name);
-		binary_upgrade_set_pg_class_oids(fout, q, tinfo->typrelid, false);
-	}
-
 	appendPQExpBuffer(q, "CREATE TYPE %s AS (",
 					  fmtId(tinfo->dobj.name));
 
@@ -7086,10 +6438,6 @@ dumpShellType(Archive *fout, ShellTypeInfo *stinfo)
 	 * the shell type's owner immediately on creation; that should happen only
 	 * after it's filled in, otherwise the backend complains.
 	 */
-
-	if (binary_upgrade)
-		binary_upgrade_set_type_oids_by_type_oid(fout, q,
-								stinfo->baseType->dobj.catId.oid, stinfo->dobj.name);
 
 	appendPQExpBuffer(q, "CREATE TYPE %s;\n",
 					  fmtId(stinfo->dobj.name));
@@ -7205,9 +6553,6 @@ dumpProcLang(Archive *fout, ProcLangInfo *plang)
 
 	appendPQExpBuffer(delqry, "DROP PROCEDURAL LANGUAGE %s;\n",
 					  qlanname);
-
-	if (binary_upgrade)
-		binary_upgrade_preassign_language_oid(defqry, plang->dobj.catId.oid, plang->dobj.name);
 
 	appendPQExpBuffer(defqry, "CREATE %sPROCEDURAL LANGUAGE %s",
 					  (useParams && plang->lanpltrusted) ? "TRUSTED " : "",
@@ -7865,9 +7210,6 @@ dumpFunc(Archive *fout, FuncInfo *finfo)
 					  fmtId(finfo->dobj.namespace->dobj.name),
 					  funcsig);
 
-	if (binary_upgrade)
-		binary_upgrade_preassign_procedure_oid(q, finfo->dobj.catId.oid, finfo->dobj.name);
-
 	appendPQExpBuffer(q, "CREATE FUNCTION %s ", funcfullsig);
 
 	if (funcresult)
@@ -8093,9 +7435,6 @@ dumpCast(Archive *fout, CastInfo *cast)
 	appendPQExpBuffer(delqry, "DROP CAST (%s AS %s);\n",
 					  getFormattedTypeName(cast->castsource, zeroAsNone),
 					  getFormattedTypeName(cast->casttarget, zeroAsNone));
-
-	if (binary_upgrade)
-		binary_upgrade_preassign_cast_oid(defqry, cast->dobj.catId.oid, cast->castsource, cast->casttarget);
 
 	appendPQExpBuffer(defqry, "CREATE CAST (%s AS %s) ",
 					  getFormattedTypeName(cast->castsource, zeroAsNone),
@@ -8618,9 +7957,6 @@ dumpOpclass(Archive *fout, OpclassInfo *opcinfo)
 	appendPQExpBuffer(delq, " USING %s;\n",
 					  fmtId(amname));
 
-	if (binary_upgrade)
-		binary_upgrade_set_opclass_oid(q, opcinfo->dobj.name);
-
 	/* Build the fixed portion of the CREATE command */
 	appendPQExpBuffer(q, "CREATE OPERATOR CLASS %s\n    ",
 					  fmtId(opcinfo->dobj.name));
@@ -8814,7 +8150,6 @@ dumpOpfamily(Archive *fout, OpfamilyInfo *opfinfo)
 	int			i_amproc;
 	int			i_amproclefttype;
 	int			i_amprocrighttype;
-	int			i_opfnamespace;
 	char	   *amname;
 	char	   *amopstrategy;
 	char	   *amopreqcheck;
@@ -8825,7 +8160,6 @@ dumpOpfamily(Archive *fout, OpfamilyInfo *opfinfo)
 	char	   *amprocrighttype;
 	bool		needComma;
 	int			i;
-	Oid			opfnamespace;
 
 	/* Skip if not to be dumped */
 	if (!opfinfo->dobj.dump || dataOnly)
@@ -8920,7 +8254,6 @@ dumpOpfamily(Archive *fout, OpfamilyInfo *opfinfo)
 
 	appendPQExpBuffer(query, "SELECT "
 	 "(SELECT amname FROM pg_catalog.pg_am WHERE oid = opfmethod) AS amname, "
-					  "opfnamespace "
 					  "FROM pg_catalog.pg_opfamily "
 					  "WHERE oid = '%u'::pg_catalog.oid",
 					  opfinfo->dobj.catId.oid);
@@ -8938,12 +8271,9 @@ dumpOpfamily(Archive *fout, OpfamilyInfo *opfinfo)
 	}
 
 	i_amname = PQfnumber(res, "amname");
-	i_opfnamespace = PQfnumber(res, "opfnamespace");
 
 	/* amname will still be needed after we PQclear res */
 	amname = strdup(PQgetvalue(res, 0, i_amname));
-
-	opfnamespace = atooid(PQgetvalue(res, 0, i_opfnamespace));
 
 	/*
 	 * DROP must be fully qualified in case same name appears in pg_catalog
@@ -8954,9 +8284,6 @@ dumpOpfamily(Archive *fout, OpfamilyInfo *opfinfo)
 					  fmtId(opfinfo->dobj.name));
 	appendPQExpBuffer(delq, " USING %s;\n",
 					  fmtId(amname));
-
-	if (binary_upgrade)
-		binary_upgrade_preassign_opfam_oid(q, opfinfo->dobj.catId.oid, opfinfo->dobj.name, opfnamespace);
 
 	/* Build the fixed portion of the CREATE command */
 	appendPQExpBuffer(q, "CREATE OPERATOR FAMILY %s",
@@ -9077,13 +8404,11 @@ dumpConversion(Archive *fout, ConvInfo *convinfo)
 	int			i_contoencoding;
 	int			i_conproc;
 	int			i_condefault;
-	int			i_connamespace;
 	const char *conname;
 	const char *conforencoding;
 	const char *contoencoding;
 	const char *conproc;
 	bool		condefault;
-	Oid			connamespace;
 
 	/* Skip if not to be dumped */
 	if (!convinfo->dobj.dump || dataOnly)
@@ -9101,7 +8426,7 @@ dumpConversion(Archive *fout, ConvInfo *convinfo)
 	appendPQExpBuffer(query, "SELECT conname, "
 		 "pg_catalog.pg_encoding_to_char(conforencoding) AS conforencoding, "
 		   "pg_catalog.pg_encoding_to_char(contoencoding) AS contoencoding, "
-					  "conproc, condefault, connamespace "
+					  "conproc, condefault "
 					  "FROM pg_catalog.pg_conversion c "
 					  "WHERE c.oid = '%u'::pg_catalog.oid",
 					  convinfo->dobj.catId.oid);
@@ -9123,14 +8448,12 @@ dumpConversion(Archive *fout, ConvInfo *convinfo)
 	i_contoencoding = PQfnumber(res, "contoencoding");
 	i_conproc = PQfnumber(res, "conproc");
 	i_condefault = PQfnumber(res, "condefault");
-	i_connamespace = PQfnumber(res, "connamespace");
 
 	conname = PQgetvalue(res, 0, i_conname);
 	conforencoding = PQgetvalue(res, 0, i_conforencoding);
 	contoencoding = PQgetvalue(res, 0, i_contoencoding);
 	conproc = PQgetvalue(res, 0, i_conproc);
 	condefault = (PQgetvalue(res, 0, i_condefault)[0] == 't');
-	connamespace = atooid(PQgetvalue(res, 0, i_connamespace));
 
 	/*
 	 * DROP must be fully qualified in case same name appears in pg_catalog
@@ -9139,9 +8462,6 @@ dumpConversion(Archive *fout, ConvInfo *convinfo)
 					  fmtId(convinfo->dobj.namespace->dobj.name));
 	appendPQExpBuffer(delq, ".%s;\n",
 					  fmtId(convinfo->dobj.name));
-
-	if (binary_upgrade)
-		binary_upgrade_preassign_conversion_oid(q, convinfo->dobj.catId.oid, convinfo->dobj.name, connamespace);
 
 	appendPQExpBuffer(q, "CREATE %sCONVERSION %s FOR ",
 					  (condefault) ? "DEFAULT " : "",
@@ -9563,9 +8883,6 @@ dumpExtProtocol(Archive *fout, ExtProtInfo *ptcinfo)
 	}
 	destroyPQExpBuffer(nsq);
 
- 	if (binary_upgrade)
-		binary_upgrade_set_extprot_oids(q, ptcinfo->dobj.catId.oid, ptcinfo->dobj.name);
-
 	appendPQExpBuffer(q, "CREATE %s PROTOCOL %s (",
 			ptcinfo->ptctrusted == true ? "TRUSTED" : "",
 			fmtId(ptcinfo->dobj.name));
@@ -9642,16 +8959,6 @@ dumpTSParser(Archive *fout, TSParserInfo *prsinfo)
 
 	/* Make sure we are in proper schema */
 	selectSourceSchema(prsinfo->dobj.namespace->dobj.name);
-
-	if (binary_upgrade)
-	{
-		/*
-		 * GPDB_84_MERGE_FIXME: dispatching text search objects is currently
-		 * not implemented as ENUM was first introduced in Greenplum 5.0. When
-		 * merging PostgreSQL 8.4, implement this oid dispatch to cover the
-		 * 5.0 -> 6.0 upgrade cycle.
-		 */
-	}
 
 	appendPQExpBuffer(q, "CREATE TEXT SEARCH PARSER %s (\n",
 					  fmtId(prsinfo->dobj.name));
@@ -9741,16 +9048,6 @@ dumpTSDictionary(Archive *fout, TSDictInfo *dictinfo)
 	/* Make sure we are in proper schema */
 	selectSourceSchema(dictinfo->dobj.namespace->dobj.name);
 
-	if (binary_upgrade)
-	{
-		/*
-		 * GPDB_84_MERGE_FIXME: dispatching text search objects is currently
-		 * not implemented as ENUM was first introduced in Greenplum 5.0. When
-		 * merging PostgreSQL 8.4, implement this oid dispatch to cover the
-		 * 5.0 -> 6.0 upgrade cycle.
-		 */
-	}
-
 	appendPQExpBuffer(q, "CREATE TEXT SEARCH DICTIONARY %s (\n",
 					  fmtId(dictinfo->dobj.name));
 
@@ -9816,16 +9113,6 @@ dumpTSTemplate(Archive *fout, TSTemplateInfo *tmplinfo)
 
 	/* Make sure we are in proper schema */
 	selectSourceSchema(tmplinfo->dobj.namespace->dobj.name);
-
-	if (binary_upgrade)
-	{
-		/*
-		 * GPDB_84_MERGE_FIXME: dispatching text search objects is currently
-		 * not implemented as ENUM was first introduced in Greenplum 5.0. When
-		 * merging PostgreSQL 8.4, implement this oid dispatch to cover the
-		 * 5.0 -> 6.0 upgrade cycle.
-		 */
-	}
 
 	appendPQExpBuffer(q, "CREATE TEXT SEARCH TEMPLATE %s (\n",
 					  fmtId(tmplinfo->dobj.name));
@@ -9911,16 +9198,6 @@ dumpTSConfig(Archive *fout, TSConfigInfo *cfginfo)
 
 	/* Make sure we are in proper schema */
 	selectSourceSchema(cfginfo->dobj.namespace->dobj.name);
-
-	if (binary_upgrade)
-	{
-		/*
-		 * GPDB_84_MERGE_FIXME: dispatching text search objects is currently
-		 * not implemented as ENUM was first introduced in Greenplum 5.0. When
-		 * merging PostgreSQL 8.4, implement this oid dispatch to cover the
-		 * 5.0 -> 6.0 upgrade cycle.
-		 */
-	}
 
 	appendPQExpBuffer(q, "CREATE TEXT SEARCH CONFIGURATION %s (\n",
 					  fmtId(cfginfo->dobj.name));
@@ -10423,14 +9700,9 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 	char	   *storage;
 	int			j,
 				k;
-	bool		toast_set = false;
 	
 	/* Make sure we are in proper schema */
 	selectSourceSchema(tbinfo->dobj.namespace->dobj.name);
-
-	if (binary_upgrade)
-		toast_set = binary_upgrade_set_type_oids_by_rel_oid(fout, q,
-												tbinfo->dobj.catId.oid, tbinfo->dobj.name);
 
 	/* Is it a table or a view? */
 	if (tbinfo->relkind == RELKIND_VIEW)
@@ -10476,9 +9748,6 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 		appendPQExpBuffer(delq, "%s;\n",
 						  fmtId(tbinfo->dobj.name));
 
-		if (binary_upgrade)
-			binary_upgrade_set_pg_class_oids(fout, q, tbinfo->dobj.catId.oid, false);
-
 		appendPQExpBuffer(q, "CREATE VIEW %s AS\n    %s\n",
 						  fmtId(tbinfo->dobj.name), viewdef);
 
@@ -10487,9 +9756,6 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 	/* START MPP ADDITION */
 	else if (tbinfo->relstorage == RELSTORAGE_EXTERNAL)
 	{
-		if (binary_upgrade)
-			binary_upgrade_set_pg_class_oids(fout, q, tbinfo->dobj.catId.oid, false);
-
 		reltypename = "EXTERNAL TABLE";
 		dumpExternal(tbinfo, query, q, delq);
 	}
@@ -10508,31 +9774,6 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 						  fmtId(tbinfo->dobj.namespace->dobj.name));
 		appendPQExpBuffer(delq, "%s;\n",
 						  fmtId(tbinfo->dobj.name));
-
-		if (binary_upgrade)
-		{
-			binary_upgrade_set_pg_class_oids(fout, q, tbinfo->dobj.catId.oid, false);
-
-			/* Dump Oids for attribute defaults */
-			for (j = 0; j < tbinfo->numatts; j++)
-			{
-				if (tbinfo->attrdefs[j] != NULL)
-					binary_upgrade_set_attrdefs_oid(q, tbinfo->attrdefs[j]->dobj.catId.oid,
-													tbinfo->dobj.catId.oid, tbinfo->attrdefs[j]->adnum);
-			}
-
-			/* Dump Oids for constraints */
-			for (j = 0; j < tbinfo->ncheck; j++)
-			{
-				ConstraintInfo *c = &(tbinfo->checkexprs[j]);
-
-				binary_upgrade_preassign_constraint_oid(q, c->dobj.catId.oid,
-														c->dobj.namespace->dobj.catId.oid,
-														c->dobj.name,
-														c->contable ? c->contable->dobj.catId.oid : InvalidOid,
-														c->condomain ? c->condomain->dobj.catId.oid : InvalidOid);
-			}
-		}
 
 		appendPQExpBuffer(q, "CREATE TABLE %s (",
 						  fmtId(tbinfo->dobj.name));
@@ -11053,9 +10294,6 @@ dumpIndex(Archive *fout, IndxInfo *indxinfo)
 	 */
 	if (indxinfo->indexconstraint == 0)
 	{
-		if (binary_upgrade)
-			binary_upgrade_set_pg_class_oids(fout, q, indxinfo->dobj.catId.oid, true);
-
 		/* Plain secondary index */
 		appendPQExpBuffer(q, "%s;\n", indxinfo->indexdef);
 
@@ -11131,16 +10369,6 @@ dumpConstraint(Archive *fout, ConstraintInfo *coninfo)
 			write_msg(NULL, "missing index for constraint \"%s\"\n",
 					  coninfo->dobj.name);
 			exit_nicely();
-		}
-
-		if (binary_upgrade)
-		{
-			binary_upgrade_set_pg_class_oids(fout, q, indxinfo->dobj.catId.oid, true);
-			binary_upgrade_preassign_constraint_oid(q, coninfo->dobj.catId.oid,
-													coninfo->dobj.namespace->dobj.catId.oid,
-													coninfo->dobj.name,
-													coninfo->contable ? coninfo->contable->dobj.catId.oid : InvalidOid,
-													coninfo->condomain ? coninfo->condomain->dobj.catId.oid : InvalidOid);
 		}
 
 		appendPQExpBuffer(q, "ALTER TABLE ONLY %s\n",
@@ -11431,15 +10659,6 @@ dumpSequence(Archive *fout, TableInfo *tbinfo)
 						  fmtId(tbinfo->dobj.name));
 
 		resetPQExpBuffer(query);
-
-		if (binary_upgrade)
-		{
-			binary_upgrade_set_pg_class_oids(fout, query,
-											 tbinfo->dobj.catId.oid, false);
-			binary_upgrade_set_type_oids_by_rel_oid(fout, query,
-													tbinfo->dobj.catId.oid,
-													tbinfo->dobj.name);
-		}
 
 		appendPQExpBuffer(query,
 						  "CREATE SEQUENCE %s\n",
@@ -11758,9 +10977,6 @@ dumpRule(Archive *fout, RuleInfo *rinfo)
 				  rinfo->dobj.name, tbinfo->dobj.name);
 		exit_nicely();
 	}
-
-	if (binary_upgrade)
-		binary_upgrade_preassign_rule_oid(cmd, rinfo->dobj.catId.oid, tbinfo->dobj.catId.oid, rinfo->dobj.name);
 
 	printfPQExpBuffer(cmd, "%s\n", PQgetvalue(res, 0, 0));
 
@@ -12608,7 +11824,7 @@ do_sql_command(PGconn *conn, const char *query)
  * Convenience subroutine to verify a SQL command succeeded,
  * and exit with a useful error message if not.
  */
-static void
+void
 check_sql_result(PGresult *res, PGconn *conn, const char *query,
 				 ExecStatusType expected)
 {

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -17,6 +17,7 @@
 
 #include "postgres_fe.h"
 #include "pqexpbuffer.h"
+#include "libpq-fe.h"
 
 /*
  * WIN32 does not provide 64-bit off_t, but does provide the functions operating
@@ -542,6 +543,8 @@ extern void *pg_malloc(size_t size);
 extern void *pg_calloc(size_t nmemb, size_t size);
 extern void *pg_realloc(void *ptr, size_t size);
 
+extern void check_sql_result(PGresult *res, PGconn *conn, const char *query,
+				 ExecStatusType expected);
 extern void check_conn_and_db(void);
 extern void exit_nicely(void);
 

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -597,7 +597,7 @@ help(void)
 
 
 /*
- *Build the WITH clause for resource queue dump
+ * Build the WITH clause for resource queue dump
  */
 static void 
 buildWithClause(const char *resname, const char *ressetting, PQExpBuffer buf)
@@ -1106,7 +1106,7 @@ dumpFilespaces(PGconn *conn)
 	PGresult   *res;
 
 	/*
-	 * Get all filespaces execpt built-in ones (named pg_xxx)
+	 * Get all filespaces except built-in ones (named pg_xxx)
 	 */
 	if (server_version < 80214)
 	{
@@ -1143,7 +1143,7 @@ dumpFilespaces(PGconn *conn)
 		/*
 		 * Drop existing filespace if required.
 		 *
-		 * Note: this statement will fail if the an existing filespace is not
+		 * Note: this statement will fail if an existing filespace is not
 		 * empty.  But this is no different from the related code in the rest
 		 * of pg_dump.
 		 */


### PR DESCRIPTION
The binary-upgrade support was added with the pg_upgrade patch and allows for the Oids in the old cluster to be pre-assigned to their respective objects during pg_upgrade. The main motivation for this refactoring is that we need to pre-assign all Oids before object creation during restore into the new cluster since a restore can otherwise allocate an Oid which is later preassigned. This brings all pre-assignments into the head of the dumpfile such that they happen before most object creations (pg_dumpall objects are still written to the dumpfile before pg_dump has a chance). Doing this avoids upgrades breaking due to Oid collisions.

The main contributions of this patch include:

* All binary-upgrade methods are moved to `binary_upgrade.{c|h}` for pg_dump and `binary_upgradeall.{c|h}` for pg_dumpall. This greatly reduce the diff wrt upstream PostgreSQL
* Oid preassign calls are now loaded into the backup archive as TOC entries which allows for them to be sorted to be output before object creation
* Avoid usage of PQExpBuffers for trivial string construction where a fixed buffer on the stack is sufficient, or simply outputting the string directly
* Binary upgrade dumping in pg_dump is moved to a separate function which loops over the dumpable objects instead of being mixed in with the main code
* Various simplifications of the code and cleanups where possible
* Add missing binary-upgrade support for `CREATE OPERATOR`

The main commit adds no new functionality, it "just" refactors and changes things around. The new functionality for `CREATE OPERATOR` is in a separate commit.