### PR TITLE
Removed MyXactAccessedTempRel

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -947,11 +947,11 @@ relation_open(Oid relationId, LOCKMODE lockmode)
 				 errmsg("relation not found (OID %u)", relationId),
 				 errdetail("This can be validly caused by a concurrent delete operation on this object.")));
 	}
-
+#if 0 /* Upstream code not applicable to GPBD */
 	/* Make note that we've accessed a temporary relation */
 	if (r->rd_istemp)
 		MyXactAccessedTempRel = true;
-
+#endif
 	pgstat_initstats(r);
 
 	return r;
@@ -1031,11 +1031,11 @@ try_relation_open(Oid relationId, LOCKMODE lockmode, bool noWait)
 				 errmsg("relation not found (OID %u)", relationId),
 				 errdetail("This can be validly caused by a concurrent delete operation on this object.")));
 	}
-
+#if 0 /* Upstream code not applicable to GPBD */
 	/* Make note that we've accessed a temporary relation */
 	if (r->rd_istemp)
 		MyXactAccessedTempRel = true;
-
+#endif
 	pgstat_initstats(r);
 
 	return r;
@@ -1224,11 +1224,11 @@ relation_open_nowait(Oid relationId, LOCKMODE lockmode)
 				 errmsg("relation not found (OID %u)", relationId),
 				 errdetail("This can be validly caused by a concurrent delete operation on this object.")));
 	}
-
+#if 0 /* Upstream code not applicable to GPBD */
 	/* Make note that we've accessed a temporary relation */
 	if (r->rd_istemp)
 		MyXactAccessedTempRel = true;
-
+#endif
 	pgstat_initstats(r);
 
 	return r;


### PR DESCRIPTION
In Postgres, PREPARE TRANSACTION errors out if it accessed a temp relation.

In GPDB, two phase commit is always used, even for transactions accessing temp
relations, which is used by MPP query processing.

In this case, GPDB treats temp table as regular distributed table, but shorten
its life cycle to sessions or transactions.

GPDB also stores temp table information in shared buffers, hence MyXactAccessedTempRel
is not used, and we are removing it.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>