### PR TITLE
Fix walsender handling of postmaster shutdown to remove long loop.

### DIFF
--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -638,8 +638,11 @@ WalSndLoop(void)
 				if (caughtup && XLByteEQ(sentPtr, MyWalSnd->flush) &&
 					!pq_is_send_pending())
 				{
-					ProcDiePending = true;
-					continue;	/* don't want to wait more */
+					/* Inform the standby that XLOG streaming is done */
+					pq_puttextmessage('C', "COPY 0");
+					pq_flush();
+
+					proc_exit(0);
 				}
 			}
 		}


### PR DESCRIPTION
Issue was introduced in 5b0d517b53cfb69c2eea9f0f49b282feccd2aba2.
After that commit was backported, gpstop -a -M smart would result in a
2 minute delay before a SIGQUIT was sent to the walsender. This
backport completes the patch originally intended by Heikki.

Original Postgres commit 9c0e2b918252e753ea648dd6a7c18a054bed951b:
Fix walsender handling of postmaster shutdown, to not go into endless
loop.

This bug was introduced by my patch to use the regular die/quickdie
signal handlers in walsender processes. I tried to make walsender exit
at next CHECK_FOR_INTERRUPTS() by setting ProcDiePending, but that's
not enough, you need to set InterruptPending too. On second thoght, it
was not a very good way to make walsender exit anyway, so use
proc_exit(0) instead.

Also, send a CommandComplete message before exiting; that's what we
did before, and you get a nicer error message in the standby that way.

Reported by Thom Brown.

Without this commit, `gpstop -a -M smart` with an active standby master would give the following:
```
20170112:20:07:09:079179 gpstop:Jimmy:jyih-[INFO]:-Commencing Master instance shutdown with mode=smart
20170112:20:07:09:079179 gpstop:Jimmy:jyih-[INFO]:-Master segment instance directory=/Users/jyih/gitdir/github/gpdb4/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
20170112:20:09:10:079179 gpstop:Jimmy:jyih-[INFO]:-Failed to shutdown master with pg_ctl.
20170112:20:09:10:079179 gpstop:Jimmy:jyih-[INFO]:-Sending SIGQUIT signal...
```