### PR TITLE
Properly handle unlink failure for RemoveOldXlogFiles

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -3197,7 +3197,7 @@ RemoveOldXlogFiles(uint32 log, uint32 seg, XLogRecPtr endptr)
 				else
 				{
 					/* No need for any more future segments... */
-					//int rc;
+					int rc = 0;
 
 					ereport(DEBUG2,
 							(errmsg("removing transaction log file \"%s\"",
@@ -3227,22 +3227,19 @@ RemoveOldXlogFiles(uint32 log, uint32 seg, XLogRecPtr endptr)
 						continue;
 					}
 					snprintf(newfilename, MAXPGPATH, "%s.deleted", xlde->d_name);
-					MirroredFlatFile_Drop(
+					rc = MirroredFlatFile_Drop(
 										  XLOGDIR,
 										  newfilename,
 										  /* suppressError */ true,
 										  /*isMirrorRecovery */ false);
 #else
-					MirroredFlatFile_Drop(
+					rc = MirroredFlatFile_Drop(
 										  XLOGDIR,
 										  xlde->d_name,
 										  /* suppressError */ true,
 										  /*isMirrorRecovery */ false);
 #endif
 
-					/* GPDB_83_MERGE_FIXME: MirroredFlatFile_Drop doesn't return a return
-					 * code */
-#if 0
 					if (rc != 0)
 					{
 						ereport(LOG,
@@ -3251,7 +3248,7 @@ RemoveOldXlogFiles(uint32 log, uint32 seg, XLogRecPtr endptr)
 										path)));
 						continue;
 					}
-#endif
+
 					CheckpointStats.ckpt_segs_removed++;
 				}
 

--- a/src/backend/cdb/cdbmirroredflatfile.c
+++ b/src/backend/cdb/cdbmirroredflatfile.c
@@ -851,6 +851,7 @@ int MirroredFlatFile_Drop(
 	char *path;
 	bool mirrorDrop = TRUE;
 	int	 save_errno = 0;
+	int	return_value = 0;
 	char *dir = NULL, *mirrorDir = NULL;
 	
 	if (isTxnDir(subDirectory))
@@ -884,10 +885,12 @@ int MirroredFlatFile_Drop(
 	
 	if (! isMirrorRecovery) {
 		errno = 0;
-		if (unlink(path) < 0 && !suppressError)
+		return_value = unlink(path);
+		if (return_value < 0 && !suppressError){
 			ereport(ERROR,
 					(errcode_for_file_access(),
 					 errmsg("could not unlink file \"%s\": %m", path)));
+		}
 		save_errno = errno;
 	}
 	
@@ -905,7 +908,8 @@ int MirroredFlatFile_Drop(
 	pfree(dir);
 	pfree(mirrorDir);
 
-	return save_errno;
+	errno = save_errno;
+	return return_value;
 }
 
 


### PR DESCRIPTION
Originally, the return code was ignored. Now, if unlink failed for any
reason, the error message will be logged, and also adjust the
CheckpointStats properly.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>