### PR TITLE
Remove long since deprecated GUCs

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -178,10 +178,12 @@ bool		gp_enable_slow_writer_testmode = false;
  */
 bool		gp_enable_slow_cursor_testmode = false;
 
-/**
- * Hash-join node releases hash table when it returns last tuple.
+/*
+ * TCP port the Interconnect listens on for incoming connections from other
+ * backends.  Assigned by initMotionLayerIPC() at process startup.  This port
+ * is used for the duration of this process and should never change.
  */
-bool		gp_eager_hashtable_release = true;
+int			Gp_listener_port;
 
 int			Gp_max_packet_size; /* max Interconnect packet size */
 

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -310,7 +310,6 @@ int			gp_max_plan_size = 0;
 
 /* Disable setting of tuple hints while reading */
 bool		gp_disable_tuple_hints = false;
-int			gp_hashagg_compress_spill_files = 0;
 
 int			gp_workfile_compress_algorithm = 0;
 bool		gp_workfile_checksumming = false;

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -84,7 +84,6 @@ static Oid GetIndexOpClass(List *opclass, Oid attrType,
 static bool relationHasPrimaryKey(Relation rel);
 static bool relationHasUniqueIndex(Relation rel);
 
-
 /*
  * DefineIndex
  *		Creates a new index.

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -1347,14 +1347,12 @@ ExecHashTableExplainEnd(PlanState *planstate, struct StringInfoData *buf)
 	}
 	else
 	{
-		/**
+		/*
 		 * Memory has been eagerly released. We can't get statistics
 		 * from the memory context. We approximate from stats structure.
 		 */
 
-		Assert(gp_eager_hashtable_release);
-		jinstrument->execmemused +=
-				(double) stats->workmem_max;
+		jinstrument->execmemused += (double) stats->workmem_max;
 	}
 	
     /* Report actual work_mem high water mark. */

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -219,10 +219,9 @@ ExecHashJoin(HashJoinState *node)
 			 */
 			ExecSquelchNode(outerNode);
 			/* end of join */
-			if (gp_eager_hashtable_release)
-			{
-				ExecEagerFreeHashJoin(node);
-			}
+
+			ExecEagerFreeHashJoin(node);
+
 			return NULL;
 		}
 
@@ -249,10 +248,9 @@ ExecHashJoin(HashJoinState *node)
 			 */
 			ExecSquelchNode(outerNode);
 			/* end of join */
-			if (gp_eager_hashtable_release)
-			{
-				ExecEagerFreeHashJoin(node);
-			}
+
+			ExecEagerFreeHashJoin(node);
+
 			return NULL;
 		}
 
@@ -283,10 +281,9 @@ ExecHashJoin(HashJoinState *node)
 			if (TupIsNull(outerTupleSlot))
 			{
 				/* end of join */
-				if (gp_eager_hashtable_release)
-				{
-					ExecEagerFreeHashJoin(node);
-				}
+
+				ExecEagerFreeHashJoin(node);
+
 				return NULL;
 			}
 
@@ -1189,8 +1186,6 @@ ExecReScanHashJoin(HashJoinState *node, ExprContext *exprCtxt)
 static void
 ReleaseHashTable(HashJoinState *node)
 {
-	Assert(gp_eager_hashtable_release);
-
 	if (node->hj_HashTable)
 	{
 		HashState  *hashState = (HashState *) innerPlanState(node);

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -107,7 +107,6 @@ bool		allowSystemTableModsDDL = false;
 bool		allowSystemTableModsDML = false;
 int			planner_work_mem = 32768;
 int			work_mem = 32768;
-int			max_work_mem = 1024000;
 int			statement_mem = 256000;
 int			max_statement_mem = 2048000;
 /*

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -4862,34 +4862,6 @@ set_config_option(const char *name, const char *value,
 										newval, name, conf->min, conf->max)));
 						return false;
 					}
-
-					/*
-					 * If this is for "work_mem", its value also has to be smaller than or equal to
-					 * max_work_mem setting.
-					 */
-					if (strcmp(conf->gen.name, "work_mem") == 0 &&
-						newval > max_work_mem)
-					{
-						ereport(elevel,
-								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-								 errmsg("%d is outside the valid range for parameter \"%s\" (%d .. %d)",
-										newval, name, conf->min, max_work_mem)));
-						return false;
-					}
-
-					/*
-					 * If this is for "max_work_mem", its value has to be greater than or equal to
-					 * current work_mem setting.
-					 */
-					if (strcmp(conf->gen.name, "max_work_mem") == 0 &&
-						newval < work_mem)
-					{
-						ereport(elevel,
-								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-								 errmsg("%d is outside the valid range for parameter \"%s\" (%d .. %d)",
-										newval, name, work_mem, conf->max)));
-						return false;
-					}
 				}
 				else if (source == PGC_S_DEFAULT)
 					newval = conf->boot_val;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2126,16 +2126,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&gp_statistics_use_fkeys,
 		true, NULL, NULL
 	},
-
-	{
-		{"gp_eager_hashtable_release", PGC_USERSET, DEPRECATED_OPTIONS,
-			gettext_noop("This guc determines if a hash-join eagerly releases its hash table."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
-		},
-		&gp_eager_hashtable_release,
-		true, NULL, NULL
-	},
 	{
 		{"gp_resqueue_priority", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("Enables priority scheduling."),
@@ -3524,16 +3514,6 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&planner_work_mem,
 		32768, 2 * BLCKSZ / 1024, MAX_KILOBYTES, NULL, NULL
-	},
-
-	{
-		{"max_work_mem", PGC_SUSET, DEPRECATED_OPTIONS,
-			gettext_noop("Sets the maximum value for work_mem setting."),
-			NULL,
-			GUC_UNIT_KB | GUC_GPDB_ADDOPT
-		},
-		&max_work_mem,
-		1024000, 8 * BLCKSZ / 1024, MAX_KILOBYTES, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -69,7 +69,6 @@ static double defunct_double = 0;
 /*
  * Assign/Show hook functions defined in this module
  */
-static const char *assign_hashagg_compress_spill_files(const char *newval, bool doit, GucSource source);
 static const char *assign_gp_workfile_compress_algorithm(const char *newval, bool doit, GucSource source);
 static const char *assign_gp_workfile_type_hashjoin(const char *newval, bool doit, GucSource source);
 static const char *assign_debug_persistent_print_level(const char *newval,
@@ -354,7 +353,6 @@ static char *gp_interconnect_fc_method_str;
  * cases provide the value for SHOW to display.  The real state is elsewhere
  * and is kept in sync by assign_hooks.
  */
-static char *gp_hashagg_compress_spill_files_str;
 static char *gp_workfile_compress_algorithm_str;
 static char *gp_workfile_type_hashjoin_str;
 static char *optimizer_log_failure_str;
@@ -4958,16 +4956,6 @@ struct config_real ConfigureNamesReal_gp[] =
 struct config_string ConfigureNamesString_gp[] =
 {
 	{
-		{"gp_hashagg_compress_spill_files", PGC_USERSET, DEPRECATED_OPTIONS,
-			gettext_noop("Specify if spill files in HashAggregate should be compressed."),
-			gettext_noop("Valid values are \"NONE\"(or \"NOTHING\"), \"ZLIB\"."),
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&gp_hashagg_compress_spill_files_str,
-		"none", assign_hashagg_compress_spill_files, NULL
-	},
-
-	{
 		{"gp_workfile_compress_algorithm", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Specify the compression algorithm that work files in the query executor use."),
 			gettext_noop("Valid values are \"NONE\", \"ZLIB\"."),
@@ -5895,24 +5883,6 @@ assign_gp_idf_deduplicate(const char *newval, bool doit, GucSource source)
 		return newval;
 	}
 	return NULL;
-}
-
-
-static const char *
-assign_hashagg_compress_spill_files(const char *newval, bool doit, GucSource source)
-{
-	int			i;
-	const char *val = newval;
-
-	if (pg_strcasecmp(newval, "nothing") == 0)
-		val = "none";
-
-	i = bfz_string_to_compression(val);
-	if (i == -1)
-		return NULL;			/* fail */
-	if (doit)
-		gp_hashagg_compress_spill_files = i;
-	return newval;				/* OK */
 }
 
 static const char *

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -206,11 +206,6 @@ extern bool           gp_enable_slow_writer_testmode;
  */
 #define GP_DEFAULT_RESOURCE_QUEUE_NAME "pg_default"
 
-/**
- * Hash-join node releases hash table when it returns last tuple.
- */
-extern bool gp_eager_hashtable_release;
-
 /* Parameter gp_debug_pgproc
  *
  * This run-time parameter requests to print out detailed info relevant to

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -934,7 +934,6 @@ extern const char *gpvars_assign_gp_gpperfmon_log_alert_level(const char *newval
 extern const char *gpvars_show_gp_gpperfmon_log_alert_level(void);
 
 
-extern int gp_hashagg_compress_spill_files;
 extern int gp_workfile_compress_algorithm;
 extern bool gp_workfile_checksumming;
 extern double gp_workfile_limit_per_segment;

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -307,7 +307,6 @@ extern bool allowSystemTableModsDDL;
 extern bool allowSystemTableModsDML;
 extern PGDLLIMPORT int planner_work_mem;
 extern PGDLLIMPORT int work_mem;
-extern PGDLLIMPORT int max_work_mem;
 extern PGDLLIMPORT int maintenance_work_mem;
 extern PGDLLIMPORT int statement_mem;
 extern PGDLLIMPORT int max_statement_mem;

--- a/src/test/regress/expected/hash_index.out
+++ b/src/test/regress/expected/hash_index.out
@@ -200,9 +200,3 @@ SELECT h.seqno AS f20000
 --   WHERE x = 90;
 -- SELECT count(*) AS i988 FROM hash_ovfl_heap
 --  WHERE x = 1000;
--- test that we can disable hash index
-create table hash_test(i int);
-create index hash_test_idx on hash_test using hash (i);
-ERROR:  hash indexes are not supported
-drop table hash_test;
-reset all;

--- a/src/test/regress/sql/hash_index.sql
+++ b/src/test/regress/sql/hash_index.sql
@@ -151,10 +151,3 @@ SELECT h.seqno AS f20000
 
 -- SELECT count(*) AS i988 FROM hash_ovfl_heap
 --  WHERE x = 1000;
-
-
--- test that we can disable hash index
-create table hash_test(i int);
-create index hash_test_idx on hash_test using hash (i);
-drop table hash_test;
-reset all;


### PR DESCRIPTION
This removes a set of GUCs which were marked as deprecated around 6 years ago (most in the closed source 4.2 release): `gp_hashagg_compress_spill_files`, `gp_eager_hashtable_release`, `max_work_mem` and `gp_hash_index`. Neither of these have any functionality remaining, they have merely been left to avoid breaking production configurations but given that they are long since undocumented and there have been 6 years to tidy up configs, it seems about time to cut these with the upcoming 5.0 release. No new deprecations are performed here, only removal of old deprecations (a new deprecation is in #1484 *nudge nudge* *wink wink*).

See individual commit messages for further explanations on each GUC.

Ping @ivannovick @Eulerizeit @schubert