### PR TITLE
Silence compiler warnings when building without codegen.

### DIFF
--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -796,7 +796,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 				isExplainAnalyzeCodegenOnMaster ||
 				isExplainCodegenOnMaster)
 		{
-			CodeGeneratorManagerGenerateCode(CodegenManager);
+			(void) CodeGeneratorManagerGenerateCode(CodegenManager);
 			if (isExplainAnalyzeCodegenOnMaster ||
 					isExplainCodegenOnMaster)
 			{
@@ -804,7 +804,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 			}
 			if (!isExplainCodegenOnMaster)
 			{
-				CodeGeneratorManagerPrepareGeneratedFunctions(CodegenManager);
+				(void) CodeGeneratorManagerPrepareGeneratedFunctions(CodegenManager);
 			}
 		}
 	}

--- a/src/include/codegen/codegen_wrapper.h
+++ b/src/include/codegen/codegen_wrapper.h
@@ -48,16 +48,16 @@ typedef Datum (*SlotGetAttrFn) (struct TupleTableSlot *slot, int attnum, bool *i
 
 #ifndef USE_CODEGEN
 
-#define InitCodegen();
-#define CodeGeneratorManagerCreate(module_name) NULL
-#define CodeGeneratorManagerGenerateCode(manager);
-#define CodeGeneratorManagerPrepareGeneratedFunctions(manager) 1
-#define CodeGeneratorManagerNotifyParameterChange(manager) 1
-#define CodeGeneratorManagerAccumulateExplainString(manager) 1
-#define CodeGeneratorManagerGetExplainString(manager) 1
-#define CodeGeneratorManagerDestroy(manager);
-#define GetActiveCodeGeneratorManager() NULL
-#define SetActiveCodeGeneratorManager(manager);
+#define InitCodegen() ((void) 1)
+#define CodeGeneratorManagerCreate(module_name) ((void *) NULL)
+#define CodeGeneratorManagerGenerateCode(manager) ((unsigned int) 1)
+#define CodeGeneratorManagerPrepareGeneratedFunctions(manager) ((unsigned int) 1)
+#define CodeGeneratorManagerNotifyParameterChange(manager) ((unsigned int) 1)
+#define CodeGeneratorManagerAccumulateExplainString(manager) ((void) 1)
+#define CodeGeneratorManagerGetExplainString(manager) ((char *) NULL)
+#define CodeGeneratorManagerDestroy(manager) ((void) 1)
+#define GetActiveCodeGeneratorManager() ((void *) NULL)
+#define SetActiveCodeGeneratorManager(manager) ((void) 1)
 
 #define START_CODE_GENERATOR_MANAGER(newManager)
 #define END_CODE_GENERATOR_MANAGER()


### PR DESCRIPTION
I'm seeing these warnings:

```
execProcnode.c: In function ‘ExecInitNode’:
../../../src/include/codegen/codegen_wrapper.h:56:62: warning: statement with no effect [-Wunused-value]
 #define CodeGeneratorManagerAccumulateExplainString(manager) 1
                                                              ^
execProcnode.c:803:5: note: in expansion of macro ‘CodeGeneratorManagerAccumulateExplainString’
     CodeGeneratorManagerAccumulateExplainString(CodegenManager);
     ^
../../../src/include/codegen/codegen_wrapper.h:54:64: warning: statement with no effect [-Wunused-value]
 #define CodeGeneratorManagerPrepareGeneratedFunctions(manager) 1
                                                                ^
execProcnode.c:807:5: note: in expansion of macro ‘CodeGeneratorManagerPrepareGeneratedFunctions’
     CodeGeneratorManagerPrepareGeneratedFunctions(CodegenManager);
     ^
```

To fix, define each dummy macro to return a value that's consistent with
the actual function. For functions returning void, use "((void) 1)" to hint
the compiler that it's OK to ignore the result. The void functions is what
the warnings actually complained about, but fix them all for tidyness.