### PR TITLE
Fix wrong result query during MergeJoin

### DIFF
--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1540,6 +1540,7 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 {
 	MergeJoinState *mergestate;
 	int markflag;
+	int rewindflag;
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
@@ -1585,6 +1586,8 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 
 	mergestate->prefetch_inner = node->join.prefetch_inner;
 	mergestate->mj_squelchInner = true;
+	/* Prepare inner operators for rewind after the prefetch */
+	rewindflag = mergestate->prefetch_inner ? EXEC_FLAG_REWIND : 0;
 
 	/* mergeclauses are handled below */
 
@@ -1597,7 +1600,7 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 	markflag = node->unique_outer ? 0 : EXEC_FLAG_MARK;
 	outerPlanState(mergestate) = ExecInitNode(outerPlan(node), estate, eflags);
 	innerPlanState(mergestate) = ExecInitNode(innerPlan(node), estate,
-											  eflags | markflag);
+											  eflags | markflag | rewindflag);
 
 	/*
 	 * For certain types of inner child nodes, it is advantageous to issue

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -50,6 +50,33 @@ select count(*) from hjtest a1, hjtest a2 where a2.i = least (a1.i,4) and a2.j =
 (1 row)
 
 --
+-- Test for correct behavior when there is a Merge Join on top of Materialize
+-- on top of a Motion :
+-- 1. Use FULL OUTER JOIN to induce a Merge Join
+-- 2. Use a large tuple size to induce a Materialize
+-- 3. Use gp_dist_random() to induce a Redistribute
+---
+set enable_hashjoin to off;
+set enable_mergejoin to on;
+set enable_nestloop to off;
+CREATE TABLE alpha (i int, j int);
+CREATE TABLE theta (i int, j char(10000000));
+DROP TABLE IF EXISTS alpha;
+DROP TABLE IF EXISTS theta;
+INSERT INTO alpha values (1, 1), (2, 2);
+INSERT INTO theta values (1, 'f'), (2, 'g');
+SELECT *
+FROM gp_dist_random('alpha') FULL OUTER JOIN gp_dist_random('theta')
+  ON (alpha.i = theta.i)
+WHERE (alpha.j IS NULL or theta.j IS NULL);
+ i | j | i | j 
+---+---+---+---
+(0 rows)
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;
+--
 -- Predicate propagation over equality conditions
 --
 drop schema if exists pred;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -50,6 +50,33 @@ select count(*) from hjtest a1, hjtest a2 where a2.i = least (a1.i,4) and a2.j =
 (1 row)
 
 --
+-- Test for correct behavior when there is a Merge Join on top of Materialize
+-- on top of a Motion :
+-- 1. Use FULL OUTER JOIN to induce a Merge Join
+-- 2. Use a large tuple size to induce a Materialize
+-- 3. Use gp_dist_random() to induce a Redistribute
+---
+  ON (alpha.i = theta.i)
+ i | j | i | j 
+---+---+---+---
+CREATE TABLE alpha (i int, j int);
+CREATE TABLE theta (i int, j char(10000000));
+DROP TABLE IF EXISTS alpha;
+DROP TABLE IF EXISTS theta;
+FROM gp_dist_random('alpha') FULL OUTER JOIN gp_dist_random('theta')
+INSERT INTO alpha values (1, 1), (2, 2);
+INSERT INTO theta values (1, 'f'), (2, 'g');
+SELECT *
+WHERE (alpha.j IS NULL or theta.j IS NULL);
+set enable_hashjoin to off;
+set enable_mergejoin to on;
+set enable_nestloop to off;
+(0 rows)
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_nestloop;
+--
 -- Predicate propagation over equality conditions
 --
 drop schema if exists pred;


### PR DESCRIPTION
Consider the query and corresponding plan below : 

```
shardikar=# explain select * FROM gp_dist_random('alpha') FULL OUTER JOIN gp_dist_random('theta') ON (alpha.i = theta.i) WHERE (alpha.j IS NULL or theta.j ISNULL);
                                                   QUERY PLAN
-----------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice3; segments: 3)  (cost=1000377240.02..1000377240.14 rows=5 width=40000016)
   ->  Merge Full Join  (cost=1000377240.02..1000377240.14 rows=2 width=40000016)
         Merge Cond: alpha.i = theta.i
         Filter: alpha.j IS NULL OR theta.j IS NULL
         ->  Sort  (cost=1.26..1.27 rows=2 width=8)
               Sort Key: alpha.i
               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.18 rows=2 width=8)
                     Hash Key: alpha.i
                     ->  Seq Scan on alpha  (cost=0.00..1.06 rows=2 width=8)
         ->  Materialize  (cost=377238.76..377238.83 rows=2 width=40000008)
               ->  Sort  (cost=377238.76..377238.77 rows=2 width=40000008)
                     Sort Key: theta.i
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.18 rows=2 width=40000008)
                           Hash Key: theta.i
                           ->  Seq Scan on theta  (cost=0.00..1.06 rows=2 width=40000008)
 Optimizer status: legacy query optimizer
(16 rows)
```

When the size of the inner tuple in a MergeJoin is large, planner
decides to place a Materialize on the top of the inner Sort operator.
Furthemore if there is any Motion below the MergeJoin,
mjnode->prefetch_inner is set to true.


During execution of plan that has a Motion underneath a Materialize
underneath a MJ, MJ retrieves one tuple from the Motion (via
Materialize) and then resets the stream (by calling ExecReScan). Since
the Materialize underneath is initialized with incorrect eflags, it
deletes its tuplestore, instead of rewinding its cursor.  This fix sets
the right eflags value during Init (see comments in ExecMaterialReScan).

@foyzur @hlinnaka @karthijrk Please take a look.