### PR TITLE
[#134494357] Handle ANYENUM in Translator

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2598,21 +2598,22 @@ gpdb::PnodeCoerceToCommonType
 	return NULL;
 }
 
-Oid
-gpdb::OidResolveGenericType
+bool
+gpdb::FResolvePolymorphicType
 	(
-	Oid declared_type,
-	Oid context_actual_type,
-	Oid context_declared_type
+	int numargs,
+	Oid *argtypes,
+	char *argmodes,
+	FuncExpr *call_expr
 	)
 {
 	GP_WRAP_START;
 	{
-		/* catalog tables: pg_type */
-		return resolve_generic_type(declared_type, context_actual_type, context_declared_type);
+		/* catalog tables: pg_proc */
+		return resolve_polymorphic_argtypes(numargs, argtypes, argmodes, (Node *)call_expr);
 	}
 	GP_WRAP_END;
-	return 0;
+	return false;
 }
 
 // hash a const value with GPDB's hash function

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -566,8 +566,8 @@ namespace gpdb {
 
 	Node *PnodeCoerceToCommonType(ParseState *pstate, Node *pnode, Oid oidTargetType, const char *context);
 
-	// deduce an individual actual datatype on the assumption that the rules for ANYARRAY/ANYELEMENT are being followed
-	Oid OidResolveGenericType(Oid declared_type, Oid context_actual_type, Oid context_declared_type);
+	// replace any polymorphic type with correct data type deduced from input arguments
+	bool FResolvePolymorphicType(int numargs, Oid *argtypes, char *argmodes, FuncExpr *call_expr);
 	
 	// hash a const value with GPDB's hash function
 	int32 ICdbHash(Const *pconst, int iSegments);

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -78,14 +78,6 @@ namespace gpdxl
 			static
 			BOOL FContainsPolymorphicTypes(DrgPmdid *pdrgpmdidTypes);
 
-			// check if the given type mdid is the "ANYELEMENT" type
-			static
-			BOOL FAnyElement(IMDId *pmdidType);
-
-			// check if the given type mdid is the "ANYARRAY" type
-			static
-			BOOL FAnyArray(IMDId *pmdidType);
-
 			// resolve polymorphic types in the given array of type ids, replacing
 			// them with the actual types obtained from the query
 			static
@@ -94,7 +86,7 @@ namespace gpdxl
 						IMemoryPool *pmp,
 						DrgPmdid *pdrgpmdidTypes,
 						List *plArgTypes,
-						List *plArgsFromQuery
+						FuncExpr *pfuncexpr
 						);
 			
 			// update grouping col position mappings

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -65,6 +65,7 @@ extern "C" {
 #include "parser/parse_coerce.h"
 #include "utils/selfuncs.h"
 #include "utils/faultinjector.h"
+#include "funcapi.h"
 
 extern
 Query *preprocess_query_optimizer(Query *pquery, ParamListInfo boundParams);

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -10158,6 +10158,87 @@ LOG:  Planner produced plan :0
 
 reset client_min_messages;
 LOG:  statement: reset client_min_messages;
+-- TVF accepts ANYENUM, ANYELEMENT returns ANYENUM, ANYARRAY
+CREATE TYPE rainbow AS ENUM('red','yellow','blue');
+CREATE FUNCTION func_enum_element(ANYENUM, ANYELEMENT) RETURNS TABLE(a ANYENUM, b ANYARRAY)
+AS $$ SELECT $1, ARRAY[$2] $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_enum_element('red'::rainbow, 'blue'::rainbow::anyelement);
+  a  |   b
+-----+--------
+ red | {blue}
+(1 row)
+
+DROP FUNCTION IF EXISTS func_enum_element(ANYENUM, ANYELEMENT);
+-- TVF accepts ANYELEMENT, ANYARRAY returns ANYELEMENT, ANYENUM
+CREATE FUNCTION func_element_array(ANYELEMENT, ANYARRAY) RETURNS TABLE(a ANYELEMENT, b ANYENUM)
+AS $$ SELECT $1, $2[1]$$ LANGUAGE SQL STABLE;
+SELECT * FROM func_element_array('red'::rainbow, ARRAY['blue'::rainbow]);
+  a  |  b
+-----+------
+ red | blue
+(1 row)
+
+DROP FUNCTION IF EXISTS func_element_array(ANYELEMENT, ANYARRAY);
+-- TVF accepts ANYARRAY, ANYENUM returns ANYELEMENT
+CREATE FUNCTION func_element_array(ANYARRAY, ANYENUM) RETURNS TABLE(a ANYELEMENT, b ANYELEMENT)
+AS $$ SELECT $1[1], $2 $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_element_array(ARRAY['blue'::rainbow], 'blue'::rainbow);
+  a   |  b
+------+------
+ blue | blue
+(1 row)
+
+DROP FUNCTION IF EXISTS func_element_array(ANYARRAY, ANYENUM);
+-- TVF accepts ANYARRAY argument returns ANYELEMENT, ANYENUM
+CREATE FUNCTION func_array(ANYARRAY) RETURNS TABLE(a ANYELEMENT, b ANYENUM)
+AS $$ SELECT $1[1], $1[2] $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_array(ARRAY['blue'::rainbow, 'yellow'::rainbow]);
+  a   |   b
+------+--------
+ blue | yellow
+(1 row)
+
+DROP FUNCTION IF EXISTS func_array(ANYARRAY);
+-- TVF accepts ANYELEMENT, VARIADIC ARRAY returns ANYARRAY
+CREATE FUNCTION func_element_variadic(ANYELEMENT, VARIADIC ANYARRAY) RETURNS TABLE(a ANYARRAY)
+AS $$ SELECT array_prepend($1, $2); $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_element_variadic(1.1, 1.1, 2.2, 3.3);
+         a
+-------------------
+ {1.1,1.1,2.2,3.3}
+(1 row)
+
+DROP FUNCTION IF EXISTS func_element_variadic(ANYELEMENT, VARIADIC ANYARRAY);
+-- TVF accepts ANYNONARRAY returns ANYNONARRAY
+CREATE FUNCTION func_nonarray(ANYNONARRAY) RETURNS TABLE(a ANYNONARRAY)
+AS $$ SELECT $1; $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_nonarray(5);
+ a
+---
+ 5
+(1 row)
+
+DROP FUNCTION IF EXISTS func_nonarray(ANYNONARRAY);
+-- TVF accepts ANYNONARRAY, ANYENUM returns ANYARRAY
+CREATE FUNCTION func_nonarray_enum(ANYNONARRAY, ANYENUM) RETURNS TABLE(a ANYARRAY)
+AS $$ SELECT ARRAY[$1, $2]; $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_nonarray_enum('blue'::rainbow, 'red'::rainbow);
+     a
+------------
+ {blue,red}
+(1 row)
+
+DROP FUNCTION IF EXISTS func_nonarray_enum(ANYNONARRAY, ANYENUM);
+-- TVF accepts ANYARRAY, ANYNONARRAY, ANYENUM returns ANYNONARRAY
+CREATE FUNCTION func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM) RETURNS TABLE(a ANYNONARRAY)
+AS $$ SELECT $1[1]; $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_array_nonarray_enum(ARRAY['blue'::rainbow, 'red'::rainbow], 'red'::rainbow, 'yellow'::rainbow);
+  a
+------
+ blue
+(1 row)
+
+DROP FUNCTION IF EXISTS func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM);
 -- start_ignore
 drop table foo;
 -- end_ignore

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -1375,6 +1375,55 @@ set client_min_messages='log';
 select count(*) from foo group by cube(a,b);
 reset client_min_messages;
 
+-- TVF accepts ANYENUM, ANYELEMENT returns ANYENUM, ANYARRAY
+CREATE TYPE rainbow AS ENUM('red','yellow','blue');
+CREATE FUNCTION func_enum_element(ANYENUM, ANYELEMENT) RETURNS TABLE(a ANYENUM, b ANYARRAY)
+AS $$ SELECT $1, ARRAY[$2] $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_enum_element('red'::rainbow, 'blue'::rainbow::anyelement);
+DROP FUNCTION IF EXISTS func_enum_element(ANYENUM, ANYELEMENT);
+
+-- TVF accepts ANYELEMENT, ANYARRAY returns ANYELEMENT, ANYENUM
+CREATE FUNCTION func_element_array(ANYELEMENT, ANYARRAY) RETURNS TABLE(a ANYELEMENT, b ANYENUM)
+AS $$ SELECT $1, $2[1]$$ LANGUAGE SQL STABLE;
+SELECT * FROM func_element_array('red'::rainbow, ARRAY['blue'::rainbow]);
+DROP FUNCTION IF EXISTS func_element_array(ANYELEMENT, ANYARRAY);
+
+-- TVF accepts ANYARRAY, ANYENUM returns ANYELEMENT
+CREATE FUNCTION func_element_array(ANYARRAY, ANYENUM) RETURNS TABLE(a ANYELEMENT, b ANYELEMENT)
+AS $$ SELECT $1[1], $2 $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_element_array(ARRAY['blue'::rainbow], 'blue'::rainbow);
+DROP FUNCTION IF EXISTS func_element_array(ANYARRAY, ANYENUM);
+
+-- TVF accepts ANYARRAY argument returns ANYELEMENT, ANYENUM
+CREATE FUNCTION func_array(ANYARRAY) RETURNS TABLE(a ANYELEMENT, b ANYENUM)
+AS $$ SELECT $1[1], $1[2] $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_array(ARRAY['blue'::rainbow, 'yellow'::rainbow]);
+DROP FUNCTION IF EXISTS func_array(ANYARRAY);
+
+-- TVF accepts ANYELEMENT, VARIADIC ARRAY returns ANYARRAY
+CREATE FUNCTION func_element_variadic(ANYELEMENT, VARIADIC ANYARRAY) RETURNS TABLE(a ANYARRAY)
+AS $$ SELECT array_prepend($1, $2); $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_element_variadic(1.1, 1.1, 2.2, 3.3);
+DROP FUNCTION IF EXISTS func_element_variadic(ANYELEMENT, VARIADIC ANYARRAY);
+
+-- TVF accepts ANYNONARRAY returns ANYNONARRAY
+CREATE FUNCTION func_nonarray(ANYNONARRAY) RETURNS TABLE(a ANYNONARRAY)
+AS $$ SELECT $1; $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_nonarray(5);
+DROP FUNCTION IF EXISTS func_nonarray(ANYNONARRAY);
+
+-- TVF accepts ANYNONARRAY, ANYENUM returns ANYARRAY
+CREATE FUNCTION func_nonarray_enum(ANYNONARRAY, ANYENUM) RETURNS TABLE(a ANYARRAY)
+AS $$ SELECT ARRAY[$1, $2]; $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_nonarray_enum('blue'::rainbow, 'red'::rainbow);
+DROP FUNCTION IF EXISTS func_nonarray_enum(ANYNONARRAY, ANYENUM);
+
+-- TVF accepts ANYARRAY, ANYNONARRAY, ANYENUM returns ANYNONARRAY
+CREATE FUNCTION func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM) RETURNS TABLE(a ANYNONARRAY)
+AS $$ SELECT $1[1]; $$ LANGUAGE SQL STABLE;
+SELECT * FROM func_array_nonarray_enum(ARRAY['blue'::rainbow, 'red'::rainbow], 'red'::rainbow, 'yellow'::rainbow);
+DROP FUNCTION IF EXISTS func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM);
+
 -- start_ignore
 drop table foo;
 -- end_ignore


### PR DESCRIPTION
After 8.3 merge, gpdb has new polymorphic type, ANYENUM.

This fix adds support for ANYENUM in Translator.

As per postgreSQL, when a function has polymorphic arguments and results;
in the function call they must have the same actual type.
For example, a function declared as `f(ANYARRAY) returns ANYENUM`
will only accept arrays of enum types.

We already have this resolution logic implemented in `resolve_polymorphic_argtypes()`.

Refactor the code in `PdrgpmdidResolvePolymorphicTypes()` to use `resolve_polymorphic_argtypes()` to deduce the correct data type for function argument and return type, based on function call.

Signed-off-by: Ekta Khanna <ekhanna@pivotal.io>