### PR TITLE
Ensure that a StreamNode is always owned by only one StreamBitmap

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -35,6 +35,7 @@ static bool words_get_match(BMBatchWords *words, BMIterateResult *result,
 							bool newentry);
 static IndexScanDesc copy_scan_desc(IndexScanDesc scan);
 static void stream_free(StreamNode *self);
+static void indexstream_free(StreamNode *self);
 static bool pull_stream(StreamNode *self, PagetableEntry *e);
 static void cleanup_pos(BMScanPosition pos);
 
@@ -210,7 +211,7 @@ bmgetmulti(PG_FUNCTION_ARGS)
 		is->type = BMS_INDEX;
 		is->pull = pull_stream;
 		is->nextblock = 0;
-		is->free = stream_free;
+		is->free = indexstream_free;
 		is->set_instrument = NULL;
 		is->upd_instrument = NULL;
 
@@ -641,6 +642,16 @@ stream_free(StreamNode *self)
 		pfree(scan);
 		pfree(so);
 	}
+}
+
+/*
+ * free the memory associated with an IndexStream
+ */
+static void
+indexstream_free(StreamNode *self) {
+	stream_free(self);
+
+	pfree(self);
 }
 
 static void

--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -109,6 +109,14 @@ ExecCountSlotsBitmapAnd(BitmapAnd *node)
 
 /* ----------------------------------------------------------------
  *	   MultiExecBitmapAnd
+ *
+ *	   BitmapAnd node gets the bitmaps generated from BitmapIndexScan
+ *	   nodes and outputs a bitmap that ANDs all input bitmaps.
+ *
+ *	   The first input bitmap is utilized to store the result of the
+ *	   AND and returned to the caller. In addition, the output points
+ *	   to a newly created OpStream node of type BMS_AND, where all
+ *	   StreamNodes of input bitmaps are added as input streams.
  * ----------------------------------------------------------------
  */
 Node *

--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -203,6 +203,8 @@ MultiExecBitmapAnd(BitmapAndState *node)
 	   				StreamBitmap *s = (StreamBitmap *)subresult;
 		   			stream_add_node((StreamBitmap *)node->bitmap,
 									s->streamNode, BMS_AND);
+		   			/* node->bitmap should be the only owner of the newly created AND StreamNode */
+		   			s->streamNode = NULL;
 
 					/*
 					 * Don't free subresult here, as we are still using the StreamNode inside it.

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -39,6 +39,19 @@
 
 /* ----------------------------------------------------------------
  *		MultiExecBitmapIndexScan(node)
+ *
+ *		If IndexScanState's iss_NumArrayKeys = 0, then BitmapIndexScan
+ *		node returns a StreamBitmap that stores all the interesting rows.
+ *		The returning StreamBitmap will point to an IndexStream that contains
+ *		pointers to functions for handling the output.
+ *
+ *		If IndexScanState's iss_NumArrayKeys > 0 (e.g., WHERE clause contains
+ *		`d in (0,1)` condition and a bitmap index has been created on column d),
+ *		then iss_NumArrayKeys StreamBitmaps will be created, where every bitmap
+ *		points to an individual IndexStream. BitmapIndexScan node
+ *		returns a StreamBitmap that ORs all the above StreamBitmaps. Also, the
+ *		returning StreamBitmap will point to an OpStream of type BMS_OR whose input
+ *		streams are the IndexStreams created for every array key.
  * ----------------------------------------------------------------
  */
 Node *

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -181,6 +181,8 @@ MultiExecBitmapOr(BitmapOrState *node)
 					StreamBitmap *s = (StreamBitmap *)subresult;
 					stream_add_node((StreamBitmap *)node->bitmap, 
 									s->streamNode, BMS_OR);
+					/* node->bitmap should be the only owner of the newly created OR StreamNode */
+					s->streamNode = NULL;
 
 					/*
 					 * Don't free subresult here, as we are still using the StreamNode inside it.

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -109,6 +109,14 @@ ExecCountSlotsBitmapOr(BitmapOr *node)
 
 /* ----------------------------------------------------------------
  *	   MultiExecBitmapOr
+ *
+ *	   BitmapOr node gets the bitmaps generated from BitmapIndexScan
+ *	   nodes and outputs a bitmap that ORs all input bitmaps.
+ *
+ *	   The first input bitmap is utilized to store the result of the
+ *	   OR and returned to the caller. In addition, the output points
+ *	   to a newly created OpStream node of type BMS_OR, where all
+ *	   StreamNodes of input bitmaps are added as input streams.
  * ----------------------------------------------------------------
  */
 Node *

--- a/src/test/regress/expected/bitmapscan.out
+++ b/src/test/regress/expected/bitmapscan.out
@@ -1005,3 +1005,38 @@ SELECT COUNT(DISTINCT(highCardinalityHighDomain)) AS distinct_hchd FROM card_hea
 (1 row)
 
 drop table if exists bm_test;
+-- Test if StreamNodes and StreamBitmaps are freed correctly.
+create table foo (c int, d int) distributed by (c);
+create index ie_foo on foo using bitmap(d);
+insert into foo values (1, 1);
+insert into foo values (2, 2);
+-- Next queries will create additional StreamNodes. In particular,
+-- d in (1, 2) will be transformed into an OR with two BMS_INDEX input streams.
+select * from foo where d in (1, 2) and (d = 1 or d = 2);
+ c | d 
+---+---
+ 1 | 1
+ 2 | 2
+(2 rows)
+
+select * from foo where (d = 1 or d = 2) and d in (1, 2);
+ c | d 
+---+---
+ 1 | 1
+ 2 | 2
+(2 rows)
+
+-- This query will eliminate StreamNodes since there is no tuple where d =3.
+select * from foo where d = 3 and (d = 1 or d = 2);
+ c | d 
+---+---
+(0 rows)
+
+-- If a segment contains tuples with d in (1, 2), then it will create the whole StreamNode tree, 
+-- otherwise segments will eliminate nodes.
+select * from foo where d = 2 and (d = 1 or d = 2);
+ c | d 
+---+---
+ 2 | 2
+(1 row)
+

--- a/src/test/regress/expected/bitmapscan_ao.out
+++ b/src/test/regress/expected/bitmapscan_ao.out
@@ -193,6 +193,48 @@ select count(1) from bmcrash where bitmap_col = '999' AND btree_col1 = 'abcdefg9
     23
 (1 row)
 
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND bitmap_col = '999';
+ count 
+-------
+    10
+(1 row)
+
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' OR bitmap_col = '999' AND btree_col2 = '2015-01-01';
+ count 
+-------
+    10
+(1 row)
+
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND bitmap_col = '999' OR btree_col2 = '2015-01-01';
+ count 
+-------
+    23
+(1 row)
+
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND btree_col2 = '2015-01-01' OR bitmap_col = '999';
+ count 
+-------
+    10
+(1 row)
+
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND btree_col2 = '2015-01-01' AND bitmap_col = '999';
+ count 
+-------
+     0
+(1 row)
+
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' OR btree_col2 = '2015-01-01' AND bitmap_col = '999';
+ count 
+-------
+    10
+(1 row)
+
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' OR btree_col2 = '2015-01-01' OR bitmap_col = '999';
+ count 
+-------
+    23
+(1 row)
+
 -- start_ignore
 drop schema bm_ao cascade;
 NOTICE:  drop cascades to append only table bmcrash

--- a/src/test/regress/sql/bitmapscan_ao.sql
+++ b/src/test/regress/sql/bitmapscan_ao.sql
@@ -173,6 +173,13 @@ select count(1) from bmcrash where bitmap_col = '999' OR btree_col1 = 'abcdefg99
 select count(1) from bmcrash where bitmap_col = '999' OR btree_col1 = 'abcdefg999' AND btree_col2 = '2015-01-01';
 select count(1) from bmcrash where bitmap_col = '999' AND btree_col1 = 'abcdefg999' OR btree_col2 = '2015-01-01';
 
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND bitmap_col = '999';
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' OR bitmap_col = '999' AND btree_col2 = '2015-01-01';
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND bitmap_col = '999' OR btree_col2 = '2015-01-01';
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND btree_col2 = '2015-01-01' OR bitmap_col = '999';
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND btree_col2 = '2015-01-01' AND bitmap_col = '999';
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' OR btree_col2 = '2015-01-01' AND bitmap_col = '999';
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' OR btree_col2 = '2015-01-01' OR bitmap_col = '999';
 
 -- start_ignore
 drop schema bm_ao cascade;


### PR DESCRIPTION
in a `Bitmap Table Scan`, there are cases where more than one bitmaps point to the same `StreamNode`. Thus, when we free the bitmaps and the `StreamNodes` that they point, we end up to a double free of a `StreamNode`.

This is a repro:
```
set optimizer=on;
create table foo (c int, d int) distributed by (c);
create index ie_foo on foo using bitmap(d);
insert into foo values (1, 1);
insert into foo values (2, 2);

explain select * from foo where d = 2 and (d = 1 or d = 2);
                                      QUERY PLAN
---------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.09 rows=1 width=8)
   ->  Bitmap Table Scan on foo  (cost=0.00..0.09 rows=1 width=8)
         Recheck Cond: d = 2 AND (d = 1 OR d = 2)
         ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
               ->  Bitmap Index Scan on ie_foo  (cost=0.00..0.00 rows=0 width=0)
                     Index Cond: d = 2
               ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
                     ->  Bitmap Index Scan on ie_foo  (cost=0.00..0.00 rows=0 width=0)
                           Index Cond: d = 1
                     ->  Bitmap Index Scan on ie_foo  (cost=0.00..0.00 rows=0 width=0)
                           Index Cond: d = 2
 Settings:  optimizer=on
 Optimizer status: PQO version 2.1
(13 rows)

select * from foo where d = 2 and (d = 1 or d = 2);
```

In the above scenario, when GPDB frees `BitmapAND`, it will also free bitmap's associated `StreamNode` and all latter's input streams that include the `StreamNode` of OR. Consequently, when we free `BitmapOR`, GPDB will also attempt to free OR's `StreamNode`. Thus, we have a double free. 

In this PR, we change the ownership of a `StreamNode`, so that when a `StreamNode` A is added as an input to a `StreamNode` B, the bitmap that was pointing to A abandons the ownership and the pointer is set to NULL. In the above example, when GPDB frees BitmapOR, it will not attempt to free OR's `StreamNode`. 

In addition, if a `StreamNode` is an `OpStream`, then `opstream_free` function is used to free the memory used by the `StreamNode`, which actually uses `pfree`. On the other hand, if a StreamNode is an IndexStream, then `stream_free` function is invoked, which does not pfree the StreamNode. For consistency, we add function `indexstream_free` to always pfree a `StreamNode` of `IndexStream` type.  