### PR TITLE
[#137300893] Window query with subq appear in function scan

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -3111,7 +3111,7 @@ void remove_unused_initplans(Plan *plan, PlannerInfo *root)
 	 * RTEs may have params as well, so we need to get param IDs from them
 	 * before walking the plan to remove unused initplans
 	 */
-	Bitmapset *rte_params = params_in_rtable(plan, root->parse->rtable);
+	Bitmapset *rte_params = params_in_rtable(plan, root->glob->finalrtable);
 
 	/* now do the actual cleanup */
 	Bitmapset *params = NULL;

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1305,3 +1305,14 @@ select * from nested_in_tbl t1  where tc1 in
 (0 rows)
 
 drop table nested_in_tbl;
+--
+-- Window query with a function scan that has non-correlated subquery.
+--
+SELECT rank() over (partition by min(c) order by min(c)) AS p_rank FROM (SELECT d AS c FROM (values(1)) d1, generate_series(0,(SELECT 2)) AS d) tt GROUP BY c;
+ p_rank 
+--------
+      1
+      1
+      1
+(3 rows)
+ 

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1289,3 +1289,14 @@ select * from nested_in_tbl t1  where tc1 in
 (0 rows)
 
 drop table nested_in_tbl;
+--
+-- Window query with a function scan that has non-correlated subquery.
+--
+SELECT rank() over (partition by min(c) order by min(c)) AS p_rank FROM (SELECT d AS c FROM (values(1)) d1, generate_series(0,(SELECT 2)) AS d) tt GROUP BY c;
+ p_rank 
+--------
+      1
+      1
+      1
+(3 rows)
+ 

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -588,3 +588,8 @@ select * from nested_in_tbl t1  where tc1 in
   (select 1 from nested_in_tbl t2 where tc1 in
     (select 1 from nested_in_tbl t3 where t3.tc2 = t2.tc2));
 drop table nested_in_tbl;
+
+--
+-- Window query with a function scan that has non-correlated subquery.
+--
+SELECT rank() over (partition by min(c) order by min(c)) AS p_rank FROM (SELECT d AS c FROM (values(1)) d1, generate_series(0,(SELECT 2)) AS d) tt GROUP BY c;


### PR DESCRIPTION
The legacy query planner might generate a plan that returns incorrect results
for window queries that have a subquery that contains a table valued function
and the function contains a non-correlated subquery. This pull request fixes this issue.

Root Cause: Before the fix, `params_in_rtable` was searching for `paramids` in
unchanged `root->parse->rtable` instead of flattened `root->glob->finaltable`. This
was causing `paramids` not found and marking initPlans unused.

Signed-off-by: Bhunvesh Chaudhary <bchaudhary@pivotal.io>