### PR TITLE
Clean up OptVersion().

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -50,7 +50,7 @@
 
 #ifdef USE_ORCA
 extern char *SzDXLPlan(Query *parse);
-extern StringInfo OptVersion();
+extern const char *OptVersion();
 #endif
 
 
@@ -680,10 +680,7 @@ ExplainOnePlan(PlannedStmt *plannedstmt, ParamListInfo params,
     	}
     	else /* PLANGEN_OPTIMIZER */
     	{
-    		StringInfo str = OptVersion();
-			appendStringInfo(&buf, "PQO version %s\n", str->data);
-			pfree(str->data);
-			pfree(str);
+			appendStringInfo(&buf, "PQO version %s\n", OptVersion());
     	}
     }
 #endif

--- a/src/backend/gpopt/utils/funcs.cpp
+++ b/src/backend/gpopt/utils/funcs.cpp
@@ -119,12 +119,9 @@ LibraryVersion()
 }
 
 extern "C" {
-StringInfo
+const char *
 OptVersion()
 {
-	StringInfo str = gpdb::SiMakeStringInfo();
-	appendStringInfo(str, "%s", GPORCA_VERSION_STRING);
-
-	return str;
+	return GPORCA_VERSION_STRING;
 }
 }


### PR DESCRIPTION
Using a StringInfo just to copy a string is quite pointless. Simplify by
changing OptVersion() to return a plain palloc'd string instead.

This fixes a memory management bug too: OptVersion() is called like a
normal Postgres C function, not as a subroutine of PplStmtOptimize. As a
result, if OptVersion() throws a C++ exception, there is nothing to catch
it, and it will cause the process to exit, bringing down the server.
The gpdb::SiMakeStringInfo() wrapper, used in OptVersion(), would translate
any ereport() (e.g. out-of-memory error) into a C++ error, but that's not
what we want in this context. A plain makeStringInfo() would be correct
here, and LibraryVersion() got that right, but for OptVersion it's simpler
to just return a plain string anyway.