### PR TITLE
Make gpinitstandby use fast checkpoint during pg_basebackup

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -836,6 +836,7 @@ def copy_master_filespaces_to_standby(options, array, master_filespace_map, stan
     # slow down the speed of gpinitstandby if containing a lot of data
     cmd_str = ' '.join(['pg_basebackup',
                         '-x', '-R',
+                        '-c', 'fast',
                         '-E', './pg_log',
                         '-E', './db_dumps',
                         '-E', './gpperfmon/data',

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10158,7 +10158,8 @@ do_pg_start_backup(const char *backupidstr, bool fast, char **labelfile)
 			 * We use CHECKPOINT_IMMEDIATE only if requested by user (via
 			 * passing fast = true).  Otherwise this can take awhile.
 			 */
-			RequestCheckpoint(CHECKPOINT_FORCE | CHECKPOINT_WAIT);
+			RequestCheckpoint(CHECKPOINT_FORCE | CHECKPOINT_WAIT |
+							  (fast ? CHECKPOINT_IMMEDIATE : 0));
 
 			/*
 			 * Now we need to fetch the checkpoint record location, and also


### PR DESCRIPTION
The 8.3 merge brought in a change to BufferSync() introducing the
concept of a slow checkpoint which throttles I/O so that regular
background checkpoints do not heavily affect other operations. Our
pg_basebackup call in gpinitstandby was not changed to bypass this new
functionality so here we make it use fast checkpoint to do so. The
fast arg was not utilized yet to send CHECKPOINT_IMMEDIATE to
RequestCheckpoint() so brought in the change from upstream Postgres.

Referenced upstream Postgres commit:
https://github.com/postgres/postgres/commit/387060951e40d550d37fe0457521e900d8c60feb