### PR TITLE
Remove StreamBitmap-related dead code

### DIFF
--- a/src/backend/access/gin/ginget.c
+++ b/src/backend/access/gin/ginget.c
@@ -485,13 +485,6 @@ gingetmulti(PG_FUNCTION_ARGS)
  		else
  			break;
 	}	
- 
-	if(n && IsA(n, StreamBitmap))
-	{
-		stream_add_node((StreamBitmap *)n,
-			tbm_create_stream_node(hashBitmap), BMS_OR);
-		PG_RETURN_POINTER(n);
-	}
 
 	PG_RETURN_POINTER(hashBitmap);
 }

--- a/src/backend/access/gin/ginget.c
+++ b/src/backend/access/gin/ginget.c
@@ -465,10 +465,12 @@ gingetmulti(PG_FUNCTION_ARGS)
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
 	Node 		   *n = (Node *) PG_GETARG_POINTER(1);
 	HashBitmap	   *hashBitmap;
- 
-	if (n == NULL || IsA(n, StreamBitmap))
+
+	if (n == NULL)
 		/* XXX should we use less than work_mem for this? */
 		hashBitmap = tbm_create(work_mem * 1024L);
+	else if (!IsA(n, HashBitmap))
+		elog(ERROR, "non hash bitmap");
 	else
 		hashBitmap = (HashBitmap *)n;
  

--- a/src/backend/access/gist/gistget.c
+++ b/src/backend/access/gist/gistget.c
@@ -126,12 +126,6 @@ gistgetmulti(PG_FUNCTION_ARGS)
 	while ((ntids = gistnext(scan, ForwardScanDirection, tids, MAX_TIDS, false)) > 0)
 		tbm_add_tuples(hashBitmap, tids, ntids);
 
-	if(n && IsA(n, StreamBitmap))
-	{
-		stream_add_node((StreamBitmap *)n,
-			tbm_create_stream_node(hashBitmap), BMS_OR);
-		PG_RETURN_POINTER(n);
-	}
 	PG_RETURN_POINTER(hashBitmap);
 }
 

--- a/src/backend/access/gist/gistget.c
+++ b/src/backend/access/gist/gistget.c
@@ -115,8 +115,10 @@ gistgetmulti(PG_FUNCTION_ARGS)
 	ItemPointer tids;
 	int ntids;
 
-	if (n == NULL || IsA(n, StreamBitmap))
+	if (n == NULL)
 		hashBitmap = tbm_create(work_mem * 1024L);
+	else if (!IsA(n, HashBitmap))
+		elog(ERROR, "non hash bitmap");
 	else
 		hashBitmap = (HashBitmap *)n;
 

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -318,14 +318,6 @@ hashgetmulti(PG_FUNCTION_ARGS)
 	
 	MIRROREDLOCK_BUFMGR_UNLOCK;
 	// -------- MirroredLock ----------
-	
-	if(n && IsA(n, StreamBitmap))
-	{
-		stream_add_node((StreamBitmap *)n,
-			tbm_create_stream_node(hashBitmap), BMS_OR);
-		PG_RETURN_POINTER(n);
-	}
-
 
 	PG_RETURN_POINTER(hashBitmap);
 }

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -261,8 +261,10 @@ hashgetmulti(PG_FUNCTION_ARGS)
 	HashScanOpaque	so = (HashScanOpaque) scan->opaque;
 	Relation		rel = scan->indexRelation;
 
-	if (n == NULL || IsA(n, StreamBitmap))
+	if (n == NULL)
 		hashBitmap = tbm_create(work_mem * 1024L);
+	else if (!IsA(n, HashBitmap))
+		elog(ERROR, "non hash bitmap");
 	else
 		hashBitmap = (HashBitmap *)n;
 

--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -709,8 +709,15 @@ index_getnext_indexitem(IndexScanDesc scan,
 	return found;
 }
 
-/*
+/* ----------------
  *		index_getmulti - get the next bitmap from an index scan.
+ *
+ *		it invokes am's getmulti function to get a bitmap. If am is an on-disk
+ *		bitmap index access method (see bitmap.h), then a StreamBitmap is
+ *		returned; a HashBitmap otherwise. Note that an index am's getmulti
+ *		function can assume that the bitmap that it's given as argument is of
+ *		the same type as what the function constructs itself.
+ * ----------------
  */
 Node *
 index_getmulti(IndexScanDesc scan, Node *bitmap)

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -627,13 +627,6 @@ btgetmulti(PG_FUNCTION_ARGS)
 					   1);
 	}
 
-	if(n && IsA(n, StreamBitmap))
-	{
-		stream_add_node((StreamBitmap *)n,
-			tbm_create_stream_node(hashBitmap), BMS_OR);
-		PG_RETURN_POINTER(n);
-	}
-
 	MIRROREDLOCK_BUFMGR_VERIFY_NO_LOCK_LEAK_EXIT;
 
 	PG_RETURN_POINTER(hashBitmap);

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -587,10 +587,14 @@ btgetmulti(PG_FUNCTION_ARGS)
 
 	MIRROREDLOCK_BUFMGR_VERIFY_NO_LOCK_LEAK_ENTER;
 
-	if (n == NULL || IsA(n, StreamBitmap))
+	if (n == NULL)
 	{
 		/* XXX should we use less than work_mem for this? */
 		hashBitmap = tbm_create(work_mem * 1024L);
+	}
+	else if (!IsA(n, HashBitmap))
+	{
+		elog(ERROR, "non hash bitmap");
 	}
 	else
 	{


### PR DESCRIPTION
If GPDB evaluates a query that needs to access an index, e.g., btree, then at least one `Bitmap Index Scan` will appear in query's plan. `MultiExecBitmapIndexScan` function will be invoked to construct the bitmap. If a query contains a `WHERE` clause similar to `d in (1,2)`, where a bitmap index has been created on column `d`), then instead of creating a simple bitmap, `MultiExecBitmapIndexScan` will generate a composite bitmap that ORs all the bitmaps that satisfy the query condition. In our example, `MultiExecBitmapIndexScan` (in particular `bmgetmulti`) will OR the bitmaps of `d = 1` and `d = 2`. 

To OR two bitmaps `A` and `B`, `A` should be a `StreamBitmap` (and not a `HashBitmap`). 

In this PR, we remove code that was executed when `MultiExecBitmapIndexScan` has to generate a composite bitmap of `A` and `B`, where `A` is a `StreamBitmap` and `B` is a `HashBitmap` generated when accessing either a btree or a gin or a gist or a hash index. It seems that this is not a possible scenario because i) `A` can be a `StreamBitmap` only if a bitmap index has been constructed on a particular column, and ii) to the best of our knowledge we cannot have a single `Bitmap Index Scan` that will access both a Bitmap index and an index of another type e.g., btree. 

We cannot find a query that exercises the deleted code. Also, the code is not exercised in ICG, which is green after the deletion of the code. Please let us know if you are aware of a scenario where this code is exercised or if you agree that is dead code.

 @foyzur @ashwinstar @asimrp @d @hlinnaka 