### PR TITLE
Clean up comments regarding to GUC temp_tablespaces

### DIFF
--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -85,8 +85,17 @@
 
 /* GUC variables */
 char	   *default_tablespace = NULL;
-/* GPDB_83_MERGE_FIXME: this is NULL in upstream, but because I removed this from guc.c,
- * the guc machinery isn't initializing it to "".
+/* In Postgres, this GUC was originally introduced by commit acfce502.
+ * This GUC applied on both locations of temp files as well as temp tables.
+ *
+ * In GPDB, we already provide `filespace` to specify a different location
+ * for temp files, e.g. `gpfilespace --movetempfilespace`. As well as the
+ * temp tables can be created on tablespaces with different filespaces.
+ * Hence we don't have this GUC and it is initialized to "".
+ *
+ * In future, it's valuable to add this GUC back to let GPDB provide
+ * easy way for users to randomly put the temp table on the `temp_tablespaces`
+ * through GUC instead of specifying for each temp table.
  */
 char	   *temp_tablespaces = "";
 

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -907,15 +907,14 @@ FileNameOpenFile(FileName fileName, int fileFlags, int fileMode)
 	return fd;
 }
 
-/* GPDB_83_MERGE_FIXME: Commit acfce502 changed things so that PostgreSQL
+/* Commit acfce502 changed things so that PostgreSQL
  * no longer stores temporary files in the database directories, but in
- * $PGDATA/pgsql_tmp, or within a tablespace's pgsql_tmp dir. But
- * GPDB also has a concept of "temp filespaces", and there's something
- * funny going on with mirroring, as we used "getCurrentTempFilePath"
- * (which is a macro!) instead of straight DatabasePath in GPDB.
+ * $PGDATA/pgsql_tmp, or within a tablespace's pgsql_tmp dir.
  *
- * So I just left this code as it was, i.e. I didn't merge the upstream
- * changes. This will need to be investigated.
+ * GPDB also has a concept of "temp filespace", and GPDB used
+ * "getCurrentTempFilePath" instead of DatabasePath.
+ *
+ * So this upstream commit is not merged.
  */
 /*
  * Open a temporary file that will (optionally) disappear when we close it.


### PR DESCRIPTION
Original comments is regarding to merging upstream Postgres commit
https://github.com/postgres/postgres/commit/acfce502#diff-82589fcf3640eac3ba54e51e998ec6f5.

There are two parts controled by this GUC `temp_tablespaces`:
- temporary file location
- temporary table location

If there are more than one tablespace described in this GUC, a random one will be chosen.

In GPDB, we already provide `filespace`, and using the `gpfilespace --movetempfilespace`,
user can set temp file location. However, GPDB doesn't have an easy way to create temp
tables on different tablespaces.

It is valuable to add this feature in GPDB to honor the GUC `temp_tablespaces` partially
to change the temporary table location, but need significant validations to ensure
correctness like permissions, etc.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>