### PR TITLE
Fix lost PlannedStmt handling from the 8.3 merge

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -2819,9 +2819,9 @@ CreateCommandTag(Node *parsetree)
 			break;
 
 		default:
-			Assert(false);
 			elog(WARNING, "unrecognized node type: %d",
 				 (int) nodeTag(parsetree));
+			Assert(false);
 			tag = "???";
 			break;
 	}

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -54,17 +54,17 @@ begin
 	select relname from pg_class into v_name where oid=$1;
 	return v_name;
 end;
-$$ language plpgsql;
+$$ language plpgsql READS SQL DATA;
 select proname, proargnames, prodataaccess from pg_proc where proname = 'func1';
  proname | proargnames | prodataaccess 
 ---------+-------------+---------------
- func1   |             | n
+ func1   |             | r
 (1 row)
 
 create function func4(int, int) returns int as
 $$
   select $1 + $2;
-$$ language sql;
+$$ language sql CONTAINS SQL;
 -- check prodataaccess column
 select proname, proargnames, prodataaccess from pg_proc where proname = 'func4';
  proname | proargnames | prodataaccess 
@@ -155,7 +155,20 @@ $$
 $$ language sql immutable reads sql data;
 ERROR:  conflicting options
 HINT:  IMMUTABLE conflicts with READS SQL DATA.
+-- stable function with modifies data_access
+create table bar (c int, d int);
+create function func1_mod_int_stb(x int) returns int as $$
+begin
+	update bar set d = d+1 where c = $1;
+	return $1 + 1;
+end
+$$ language plpgsql stable modifies sql data;
+select * from func1_mod_int_stb(5) order by 1;
+ERROR:  UPDATE is not allowed in a non-volatile function
+CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c =  $1 "
+PL/pgSQL function "func1_mod_int_stb" line 2 at SQL statement
 drop function func2(anyelement, anyelement, bool);
 drop function func3();
 drop function func4(int, int);
 drop function func5(int);
+drop function func1_mod_int_stb(int);

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,7 +15,7 @@
 #   hitting max_connections limit on segments.
 #
 
-test: variadic_parameters default_parameters
+test: variadic_parameters default_parameters function_extensions
 
 # test workfiles compressed using zlib
 # 'zlib' utilizes fault injectors so it needs to be in a group by itself

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -117,7 +117,18 @@ $$
   select $1 + $2;
 $$ language sql immutable reads sql data;
 
+-- stable function with modifies data_access
+create table bar (c int, d int);
+create function func1_mod_int_stb(x int) returns int as $$
+begin
+	update bar set d = d+1 where c = $1;
+	return $1 + 1;
+end
+$$ language plpgsql stable modifies sql data;
+select * from func1_mod_int_stb(5) order by 1;
+
 drop function func2(anyelement, anyelement, bool);
 drop function func3();
 drop function func4(int, int);
 drop function func5(int);
+drop function func1_mod_int_stb(int);


### PR DESCRIPTION
Commit 9cbd0c1 which was a part of the 8.3 merge removed the Query structure from the executor API and replaced with PlannedStmt. This hunk seems to have gone missing in the merge causing updates in non-volatile functions to hit the assertion failure. Re-added the missing code and added the reported query as a test case for it. While poking at the test I found that the function_extensions testsuite wasn't executed which seemed odd, this PR fixes the issues in it and re-adds it to greenplum_schedule.

Reported in #1600.

@hlinnaka was this left out from the merge intentionally or did we drop it by accident? I can't see a reason for not including it off the cuff.