### PR TITLE
Ensure that gpfaultinjector is invoked correctly in ICG tests

### DIFF
--- a/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
@@ -51,7 +51,7 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         return self
 
 
-    def loadSystemConfig( self, useUtilityMode ) :
+    def loadSystemConfig( self, useUtilityMode, verbose=True ) :
         """
         Load all segment information from the configuration source.
 
@@ -61,7 +61,8 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         # ensure initializeProvider() was called
         checkNotNone("masterDbUrl", self.__masterDbUrl) 
 
-        logger.info("Obtaining Segment details from master...")
+        if verbose :
+            logger.info("Obtaining Segment details from master...")
 
         array = GpArray.initFromCatalog(self.__masterDbUrl, useUtilityMode)
         

--- a/gpMgmt/bin/gppylib/system/environment.py
+++ b/gpMgmt/bin/gppylib/system/environment.py
@@ -20,7 +20,7 @@ class GpMasterEnvironment:
 
     """
 
-    def __init__(self, masterDataDir, readFromMasterCatalog, timeout=None, retries=None):
+    def __init__(self, masterDataDir, readFromMasterCatalog, timeout=None, retries=None, verbose=True):
         """
         masterDataDir: if None then we try to find it from the system environment
         readFromMasterCatalog: if True then we will connect to the master in utility mode and fetch some more
@@ -40,7 +40,9 @@ class GpMasterEnvironment:
 
         self.__gpHome = gp.get_gphome()
         self.__gpVersion = gp.GpVersion.local('local GP software version check',self.__gpHome)
-        logger.info("local Greenplum Version: '%s'" % self.__gpVersion)
+        
+        if verbose:
+            logger.info("local Greenplum Version: '%s'" % self.__gpVersion)
 
         # read collation settings from master
         if readFromMasterCatalog:

--- a/src/test/regress/expected/query_finish_pending_optimizer.out
+++ b/src/test/regress/expected/query_finish_pending_optimizer.out
@@ -62,10 +62,10 @@ LIMIT 2;
 (2 rows)
 
 \! gpfaultinjector -f execshare_input_next -y status --seg_dbid 2
-20170125:11:06:28:003059 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f execshare_input_next -y status --seg_dbid 2
-20170125:11:06:28:003059 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
-20170125:11:06:28:003059 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
-20170125:11:06:28:003059 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
+20170125:11:16:02:005049 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f execshare_input_next -y status --seg_dbid 2
+20170125:11:16:02:005049 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:16:02:005049 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'set'  num times hit:'0' 
+20170125:11:16:02:005049 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node and sort_mk algorithm is used
 set gp_enable_mk_sort=on;
@@ -89,10 +89,10 @@ LIMIT 2;
 (2 rows)
 
 \! gpfaultinjector -f execshare_input_next -y status --seg_dbid 2
-20170125:11:06:28:003095 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f execshare_input_next -y status --seg_dbid 2
-20170125:11:06:28:003095 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
-20170125:11:06:28:003095 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
-20170125:11:06:28:003095 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
+20170125:11:16:03:005085 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f execshare_input_next -y status --seg_dbid 2
+20170125:11:16:03:005085 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:16:03:005085 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'execshare_input_next' fault type:'finish_pending' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'set'  num times hit:'0' 
+20170125:11:16:03:005085 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 reset gp_enable_mk_sort;
 -- Disable faultinjectors
 \! gpfaultinjector -f execsort_mksort_mergeruns -y reset --seg_dbid 2

--- a/src/test/regress/expected/segspace.out
+++ b/src/test/regress/expected/segspace.out
@@ -28,10 +28,14 @@ ANALYZE segspace_test_hj_skew;
 --
 ------------ Interrupting SELECT query that spills -------------------
 -- enable the fault injector
---start_ignore
 \! gpfaultinjector -f exec_hashjoin_new_batch -y reset --seg_dbid 2
+20170125:11:06:30:003151 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y reset --seg_dbid 2
+20170125:11:06:30:003151 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:30:003151 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f exec_hashjoin_new_batch -y interrupt --seg_dbid 2
---end_ignore
+20170125:11:06:30:003163 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y interrupt --seg_dbid 2
+20170125:11:06:30:003163 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:30:003163 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 set gp_workfile_type_hashjoin=buffile;
 set statement_mem=2048;
 set gp_autostats_mode = none;
@@ -40,6 +44,11 @@ begin;
 SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE t1.i1=t2.i2;
 ERROR:  canceling MPP operation  (seg0 slice2 127.0.0.1:25432 pid=26876)
 rollback;
+\! gpfaultinjector -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:31:003178 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:31:003178 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:31:003178 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:31:003178 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- check used segspace after test
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;
  max | min 
@@ -75,15 +84,24 @@ set statement_mem=2048;
 set gp_autostats_mode = none;
 set gp_hashjoin_metadata_memory_percent=0;
 -- enable the fault injector
---start_ignore
 \! gpfaultinjector -f exec_hashjoin_new_batch -y reset --seg_dbid 2
+20170125:11:06:32:003198 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y reset --seg_dbid 2
+20170125:11:06:32:003198 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:32:003198 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f exec_hashjoin_new_batch -y interrupt --seg_dbid 2
---end_ignore
+20170125:11:06:32:003210 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y interrupt --seg_dbid 2
+20170125:11:06:32:003210 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:32:003210 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 begin;
 insert into segspace_t1_created
 SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE t1.i1=t2.i2;
 ERROR:  canceling MPP operation  (seg0 127.0.0.1:25432 pid=26876)
 rollback;
+\! gpfaultinjector -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:33:003224 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:33:003224 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:33:003224 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:33:003224 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- check used segspace after test
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;
  max | min 
@@ -115,10 +133,14 @@ set statement_mem=2048;
 set gp_autostats_mode = none;
 set gp_hashjoin_metadata_memory_percent=0;
 -- enable the fault injector
---start_ignore
 \! gpfaultinjector -f exec_hashjoin_new_batch -y reset --seg_dbid 2
+20170125:11:06:34:003244 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y reset --seg_dbid 2
+20170125:11:06:34:003244 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:34:003244 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f exec_hashjoin_new_batch -y interrupt --seg_dbid 2
---end_ignore
+20170125:11:06:35:003256 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y interrupt --seg_dbid 2
+20170125:11:06:35:003256 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:35:003256 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 begin;
 create table segspace_t1_created AS
 SELECT t1.* FROM segspace_test_hj_skew AS t1, segspace_test_hj_skew AS t2 WHERE t1.i1=t2.i2;
@@ -126,6 +148,11 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i1
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  canceling MPP operation  (seg0 127.0.0.1:25432 pid=26876)
 rollback;
+\! gpfaultinjector -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:35:003270 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:35:003270 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:35:003270 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:35:003270 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- check used segspace after test
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;
  max | min 
@@ -167,10 +194,14 @@ set gp_resqueue_print_operator_memory_limits=on;
 set gp_enable_mk_sort=on;
 set gp_cte_sharing=on;
 -- enable the fault injector
---start_ignore
 \! gpfaultinjector -f workfile_write_failure -y reset --seg_dbid 2
+20170125:11:06:37:003290 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_write_failure -y reset --seg_dbid 2
+20170125:11:06:37:003290 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:37:003290 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f workfile_write_failure -y error --seg_dbid 2
---end_ignore
+20170125:11:06:37:003302 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_write_failure -y error --seg_dbid 2
+20170125:11:06:37:003302 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:37:003302 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- LEAK in UPDATE: update with sisc xslice sort
 update foo set j=m.cc1 from (
   with ctesisc as
@@ -178,7 +209,12 @@ update foo set j=m.cc1 from (
   select t1.i1 as cc1, t1.i2 as cc2
   from ctesisc as t1, ctesisc as t2
   where t1.i1 = t2.i2 ) as m;
-ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice3 127.0.0.1:25432 pid=26908)
+ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice3 127.0.0.1:25432 pid=3175)
+\! gpfaultinjector -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:38:003328 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:38:003328 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:38:003328 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:38:003328 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;
  max | min 
 -----+-----
@@ -221,16 +257,25 @@ insert into foo select i, i % 1000 from
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
 set statement_mem=1024; -- 1mb for 3 segment to get leak.
 -- enable the fault injector
---start_ignore
 \! gpfaultinjector -f workfile_write_failure -y reset --seg_dbid 2
+20170125:11:06:39:003348 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_write_failure -y reset --seg_dbid 2
+20170125:11:06:39:003348 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:39:003348 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f workfile_write_failure -y error --seg_dbid 2
---end_ignore
+20170125:11:06:39:003360 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_write_failure -y error --seg_dbid 2
+20170125:11:06:39:003360 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:39:003360 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- LEAK in DELETE with APPEND ONLY tables
 delete from testsisc using (
   select *
   from foo
 ) src  where testsisc.i1 = src.i;
-ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 127.0.0.1:25432 pid=26876)
+ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 127.0.0.1:25432 pid=3143)
+\! gpfaultinjector -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:39:003374 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:39:003374 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:39:003374 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:39:003374 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;
  max | min 
 -----+-----
@@ -264,10 +309,14 @@ create table foo (c int, d int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- enable the fault injector
---start_ignore
 \! gpfaultinjector -f workfile_write_failure -y reset --seg_dbid 2
+20170125:11:06:41:003394 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_write_failure -y reset --seg_dbid 2
+20170125:11:06:41:003394 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:41:003394 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f workfile_write_failure -y error --seg_dbid 2
---end_ignore
+20170125:11:06:42:003406 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_write_failure -y error --seg_dbid 2
+20170125:11:06:42:003406 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:42:003406 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- expect to see leak if we hit error
 update foo set d = i1 from (select i1,i2 from testsort order by i2) x;
 ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice1 127.0.0.1:25432 pid=27014)
@@ -278,6 +327,11 @@ select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used
    0 |   0
 (1 row)
 
+\! gpfaultinjector -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:42:003430 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:42:003430 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:42:003430 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:42:003430 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- Run the test without fault injection
 -- expect to see leak if we hit error
 update foo set d = i1 from (select i1,i2 from testsort order by i2) x;
@@ -303,15 +357,24 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- expect to see leak if we hit error
 -- enable the fault injector
---start_ignore
 \! gpfaultinjector -f workfile_write_failure -y reset --seg_dbid 2
+20170125:11:06:45:003446 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_write_failure -y reset --seg_dbid 2
+20170125:11:06:45:003446 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:45:003446 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f workfile_write_failure -y error --seg_dbid 2
---end_ignore
+20170125:11:06:45:003458 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_write_failure -y error --seg_dbid 2
+20170125:11:06:45:003458 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:45:003458 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 update foo set d = i1 from (with ctesisc as (select * from testsisc order by i2)
 select * from
 (select count(*) from ctesisc) x(a), ctesisc
 where x.a = ctesisc.i1) y;
-ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice1 127.0.0.1:25432 pid=26908)
+ERROR:  fault triggered, fault name:'workfile_write_failure' fault type:'error'  (seg0 slice1 127.0.0.1:25432 pid=3175)
+\! gpfaultinjector -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:45:003477 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f exec_hashjoin_new_batch -y status --seg_dbid 2
+20170125:11:06:45:003477 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:45:003477 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'exec_hashjoin_new_batch' fault type:'interrupt' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:45:003477 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- check counter leak
 select max(bytes) as max, min(bytes) as min from gp_toolkit.gp_workfile_mgr_used_diskspace;
  max | min 

--- a/src/test/regress/expected/zlib.out
+++ b/src/test/regress/expected/zlib.out
@@ -8,24 +8,21 @@ SET gp_workfile_type_hashjoin=bfz;
 SET gp_workfile_compress_algorithm=zlib;
 SET statement_mem=5000;
 --Fail after workfile creation and before add it to workfile set
---start_ignore
 \! gpfaultinjector -f workfile_creation_failure -y reset --seg_dbid 2
-20160527:09:53:03:034973 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y reset --seg_dbid 2
-20160527:09:53:03:034973 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20160527:09:53:03:034973 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
-20160527:09:53:03:034973 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
-20160527:09:53:03:034973 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20160527:09:53:03:034973 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
+20170125:11:06:19:002833 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y reset --seg_dbid 2
+20170125:11:06:19:002833 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:19:002833 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f workfile_creation_failure -y error --seg_dbid 2
-20160527:09:53:03:034985 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y error --seg_dbid 2
-20160527:09:53:03:034985 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20160527:09:53:03:034985 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
-20160527:09:53:04:034985 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
-20160527:09:53:04:034985 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20160527:09:53:04:034985 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
---end_ignore
+20170125:11:06:19:002845 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y error --seg_dbid 2
+20170125:11:06:19:002845 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:19:002845 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 SELECT COUNT(t1.*) FROM test_zlib_hashjoin AS t1, test_zlib_hashjoin AS t2 WHERE t1.i1=t2.i2;
-ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=34971)
+ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=2829)
+\! gpfaultinjector -f workfile_creation_failure -y status --seg_dbid 2
+20170125:11:06:20:002864 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y status --seg_dbid 2
+20170125:11:06:20:002864 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:20:002864 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:20:002864 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 RESET statement_mem;
 DROP TABLE IF EXISTS test_zlib_hagg; 
 NOTICE:  table "test_zlib_hagg" does not exist, skipping
@@ -37,34 +34,26 @@ INSERT INTO test_zlib_hagg SELECT i,i,i,i FROM
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
 SET statement_mem=2000;
 --Fail after workfile creation and before add it to workfile set
---start_ignore
 \! gpfaultinjector -f workfile_creation_failure -y reset --seg_dbid 2
-20160527:09:53:04:035000 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y reset --seg_dbid 2
-20160527:09:53:05:035000 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20160527:09:53:05:035000 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
-20160527:09:53:05:035000 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
-20160527:09:53:05:035000 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20160527:09:53:05:035000 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
+20170125:11:06:21:002876 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y reset --seg_dbid 2
+20170125:11:06:21:002876 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:21:002876 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f workfile_creation_failure -y error --seg_dbid 2
-20160527:09:53:05:035012 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y error --seg_dbid 2
-20160527:09:53:05:035012 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20160527:09:53:05:035012 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
-20160527:09:53:05:035012 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
-20160527:09:53:05:035012 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20160527:09:53:05:035012 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
---end_ignore
+20170125:11:06:21:002891 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y error --seg_dbid 2
+20170125:11:06:21:002891 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:21:002891 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 SELECT MAX(i1) FROM test_zlib_hagg GROUP BY i2;
-ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=34971)
+ERROR:  fault triggered, fault name:'workfile_creation_failure' fault type:'error'  (seg0 slice2 127.0.0.1:25432 pid=2829)
+\! gpfaultinjector -f workfile_creation_failure -y status --seg_dbid 2
+20170125:11:06:22:002907 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y status --seg_dbid 2
+20170125:11:06:22:002907 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:22:002907 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'workfile_creation_failure' fault type:'error' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:22:002907 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 -- Reset faultinjectors
---start_ignore
 \! gpfaultinjector -f workfile_creation_failure -y reset --seg_dbid 2
-20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y reset --seg_dbid 2
-20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Obtaining Segment details from master...
-20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on 1 segment(s)
-20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on nikos-mac:/Users/narmenatzoglou/gitdev/gpdb/github_updated/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20160621:09:07:09:042201 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
---end_ignore
+20170125:11:06:22:002919 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_creation_failure -y reset --seg_dbid 2
+20170125:11:06:22:002919 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:22:002919 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 create table t (i int, j text);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -87,22 +76,14 @@ EXCEPTION WHEN others THEN
 end
 $body$ language plpgsql;
 -- Inject fault before we close workfile in ExecHashJoinNewBatch
---start_ignore
 \! gpfaultinjector -f workfile_hashjoin_failure -y reset --seg_dbid 2
-20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y reset --seg_dbid 2
-20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
-20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
-20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20161206:08:28:57:047522 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
+20170125:11:06:24:002931 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y reset --seg_dbid 2
+20170125:11:06:24:002931 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:24:002931 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 \! gpfaultinjector -f workfile_hashjoin_failure -y error --seg_dbid 2
-20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y error --seg_dbid 2
-20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
-20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
-20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20161206:08:28:57:047534 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
---end_ignore
+20170125:11:06:24:002943 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y error --seg_dbid 2
+20170125:11:06:24:002943 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:24:002943 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 select FuncA();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -118,15 +99,15 @@ select * from t1;
 ---+---
 (0 rows)
 
+\! gpfaultinjector -f workfile_hashjoin_failure -y status --seg_dbid 2
+20170125:11:06:25:002955 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y status --seg_dbid 2
+20170125:11:06:25:002955 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:25:002955 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-fault name:'workfile_hashjoin_failure' fault type:'error' ddl statement:'' database name:'' table name:'' occurrence:'1' sleep time:'10' fault injection state:'completed'  num times hit:'1' 
+20170125:11:06:25:002955 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE
 drop function FuncA();
 drop table t;
 drop table t1;
---start_ignore
 \! gpfaultinjector -f workfile_hashjoin_failure -y reset --seg_dbid 2
-20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y reset --seg_dbid 2
-20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 4.3.99.00 build dev'
-20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Obtaining Segment details from master...
-20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on 1 segment(s)
-20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-Injecting fault on krajaraman:/Users/krajaraman/gitdev/gpdb64/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0:content=0:dbid=2:mode=s:status=u
-20161206:08:28:59:047553 gpfaultinjector:krajaraman:krajaraman-[INFO]:-DONE
---end_ignore
+20170125:11:06:26:002967 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Starting gpfaultinjector with args: -f workfile_hashjoin_failure -y reset --seg_dbid 2
+20170125:11:06:26:002967 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170125:11:06:26:002967 gpfaultinjector:nikos-mac:narmenatzoglou-[INFO]:-DONE

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -82,4 +82,7 @@ s/overlaps existing partition "r\d+"/partition "r##########"/
 m/Table "pg_temp_\d+.temp/
 s/Table "pg_temp_\d+.temp/Table "pg_temp_#####/
 
+# Mask out timestamp and whoami message for gpfaultinjector
+m/^\d+.*gpfaultinjector.*-\[INFO\]:-/
+s/^\d+.*gpfaultinjector.*-\[INFO\]:-//
 -- end_matchsubs

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -7,15 +7,14 @@ set statement_mem="2MB";
 set gp_enable_mk_sort=on;
 set gp_cte_sharing=on;
 
-
---start_ignore
 \! gpfaultinjector -f execsort_mksort_mergeruns -y reset --seg_dbid 2
 -- set QueryFinishPending=true in sort mergeruns. This will stop sort and set result_tape to NULL
 \! gpfaultinjector -f execsort_mksort_mergeruns -y finish_pending --seg_dbid 2
---end_ignore
 
 -- return results although sort will be interrupted in one of the segments 
 select DISTINCT S from (select row_number() over(partition by i1 order by i2) AS T, count(*) over (partition by i1) AS S from _tmp_table) AS TMP;
+
+\! gpfaultinjector -f execsort_mksort_mergeruns -y status --seg_dbid 2
 
 -- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node
@@ -29,37 +28,34 @@ set gp_resqueue_print_operator_memory_limits=on;
 set statement_mem='2MB';
 set gp_enable_mk_sort=off;
 
---start_ignore
 \! gpfaultinjector -f execshare_input_next -y reset --seg_dbid 2
 -- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
 -- This will eagerly free the memory context of shared input scan's child node.  
 \! gpfaultinjector -f execshare_input_next -y finish_pending --seg_dbid 2
---end_ignore
 
 select COUNT(i2) over(partition by i1)
 from testsisc
 LIMIT 2;
 
+\! gpfaultinjector -f execshare_input_next -y status --seg_dbid 2
 
 -- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node and sort_mk algorithm is used
 
 set gp_enable_mk_sort=on;
 
---start_ignore
 \! gpfaultinjector -f execshare_input_next -y reset --seg_dbid 2
 -- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
 -- This will eagerly free the memory context of shared input scan's child node.  
 \! gpfaultinjector -f execshare_input_next -y finish_pending --seg_dbid 2
---end_ignore
 
 select COUNT(i2) over(partition by i1)
 from testsisc
 LIMIT 2;
 
+\! gpfaultinjector -f execshare_input_next -y status --seg_dbid 2
+
 reset gp_enable_mk_sort;
 -- Disable faultinjectors
---start_ignore
 \! gpfaultinjector -f execsort_mksort_mergeruns -y reset --seg_dbid 2
 \! gpfaultinjector -f execshare_input_next -y reset --seg_dbid 2
---end_ignore


### PR DESCRIPTION
As per our discussion in https://github.com/greenplum-db/gpdb/issues/627, in this PR we move `gpfaultinjector` calls out of `---start_ignore` and `---end_ignore` blocks, to ensure that a fault has been injected successfully. 