### PR TITLE
gpcloud: Optimize gpcloud makefile

### DIFF
--- a/gpAux/extensions/Makefile
+++ b/gpAux/extensions/Makefile
@@ -44,8 +44,8 @@ mkgphdfs:
 
 .PHONY:
 mkgpcloud:
-	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -B -C gpcloud USE_PGXS=1 install
-	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -B -C gpcloud/bin/gpcheckcloud USE_PGXS=1 install
+	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gpcloud USE_PGXS=1 install
+	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gpcloud/bin/gpcheckcloud
 	ln -sf $(pkglibdir)/gpcloud.so $(pkglibdir)/gps3ext.so
 
 # Only include include these files when running enterprise build

--- a/gpAux/extensions/gpcloud/Makefile
+++ b/gpAux/extensions/gpcloud/Makefile
@@ -21,7 +21,7 @@ PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
 
 gpcheckcloud:
-	@$(MAKE) -C bin/gpcheckcloud
+	@$(MAKE) -C bin/gpcheckcloud gpcheckcloud
 
 test: format
 	@$(MAKE) -C test test

--- a/gpAux/extensions/gpcloud/bin/gpcheckcloud/Makefile
+++ b/gpAux/extensions/gpcloud/bin/gpcheckcloud/Makefile
@@ -4,18 +4,25 @@ include ../../include/makefile.inc
 # Options
 DEBUG_S3_SYMBOL = y
 
-# Flags
-PG_LIBS += $(COMMON_LINK_OPTIONS)
-PG_CPPFLAGS += $(COMMON_CPP_FLAGS) -I../../include -I../../lib -I$(libpq_srcdir) -I$(libpq_srcdir)/postgresql/server/utils -DS3_STANDALONE -DS3_STANDALONE_CHECKCLOUD
+CPPFLAGS = $(COMMON_CPP_FLAGS) -I../../include -I../../lib -DS3_STANDALONE -DS3_STANDALONE_CHECKCLOUD
+LDFLAGS = $(COMMON_LINK_OPTIONS)
 
 ifeq ($(DEBUG_S3_SYMBOL),y)
-	PG_CPPFLAGS += -g
+       CPPFLAGS += -g
 endif
 
 # Targets
 PROGRAM = gpcheckcloud
-OBJS = gpcheckcloud.o ../../lib/http_parser.o ../../lib/ini.o $(addprefix ../../src/,$(COMMON_OBJS))
 
-# Launch
-PGXS := $(shell pg_config --pgxs)
-include $(PGXS)
+%.o: ../../src/%.cpp
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+
+http_parser.o: ../../lib/http_parser.cpp
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+
+ini.o: ../../lib/ini.cpp
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+
+gpcheckcloud: gpcheckcloud.o http_parser.o ini.o $(COMMON_OBJS)
+
+install:


### PR DESCRIPTION
Remove -B from gpcloud makefile, to avoid recompile source code for gpcheckcloud everytime.
Modify gpcheckcloud makefile to put all objects at gpcheckcloud directory.