### PR TITLE
Perl code cleanup

### DIFF
--- a/configure
+++ b/configure
@@ -5871,6 +5871,12 @@ if grep '##' $GP_BASH_VERSION_IN > /dev/null 2>&1 ; then
     sed "s,##.*##,$GP_VERSION," $GP_BASH_VERSION_IN > $GP_BASH_VERSION_SH
 fi
 
+GPTEST_IN="src/test/regress/GPTest.pm.in"
+GPTEST_PM="src/test/regress/GPTest.pm"
+if grep '##' $GPTEST_IN > /dev/null 2>&1 ; then
+    sed "s,##.*##,$GP_VERSION," $GPTEST_IN > $GPTEST_PM
+fi
+
 # Create compiler version string
 if test x"$GCC" = x"yes" ; then
   cc_string="GCC `${CC} --version | sed q`"

--- a/configure.in
+++ b/configure.in
@@ -614,6 +614,12 @@ if grep '##' $GP_BASH_VERSION_IN > /dev/null 2>&1 ; then
     sed "s,##.*##,$GP_VERSION," $GP_BASH_VERSION_IN > $GP_BASH_VERSION_SH
 fi
 
+GPTEST_IN="src/test/regress/GPTest.pm.in"
+GPTEST_PM="src/test/regress/GPTest.pm"
+if grep '##' $GPTEST_IN > /dev/null 2>&1 ; then
+    sed "s,##.*##,$GP_VERSION," $GPTEST_IN > $GPTEST_PM
+fi
+
 # Create compiler version string
 if test x"$GCC" = x"yes" ; then
   cc_string="GCC `${CC} --version | sed q`"

--- a/src/test/isolation/Makefile
+++ b/src/test/isolation/Makefile
@@ -27,8 +27,11 @@ pg_regress.o:
 gpstringsubs.pl:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpstringsubs.pl
 
-gpdiff.pl: atmsort.pm explain.pm
+gpdiff.pl: atmsort.pm explain.pm GPTest.pm
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpdiff.pl
+
+GPTest.pm:
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/GPTest.pm
 
 atmsort.pm:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/atmsort.pm
@@ -75,7 +78,7 @@ endif
 clean distclean:
 	rm -f isolationtester$(X) pg_isolation_regress$(X) $(OBJS) isolation_main.o
 	rm -f pg_regress.o
-	rm -f gpstringsubs.pl gpdiff.pl atmsort.pm explain.pm
+	rm -f gpstringsubs.pl gpdiff.pl atmsort.pm explain.pm GPTest.pm
 	rm -rf $(pg_regress_clean_files)
 
 maintainer-clean: distclean

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -29,8 +29,11 @@ pg_regress.o:
 gpstringsubs.pl:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpstringsubs.pl
 
-gpdiff.pl: atmsort.pm explain.pm
+gpdiff.pl: atmsort.pm explain.pm GPTest.pm
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpdiff.pl
+
+GPTest.pm:
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/GPTest.pm
 
 atmsort.pm:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/atmsort.pm

--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -12,6 +12,7 @@ pgbouncer.pid
 # Local binaries
 /pg_regress
 /twophase_pqexecparams
+GPTest.pm
 
 # Generated subdirectories
 /tmp_check/

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -87,6 +87,7 @@ install: all installdirs
 	$(INSTALL_PROGRAM) atmsort.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/atmsort.pm'
 	$(INSTALL_PROGRAM) explain.pl '$(DESTDIR)$(pgxsdir)/$(subdir)/explain.pl'
 	$(INSTALL_PROGRAM) explain.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/explain.pm'
+	$(INSTALL_PROGRAM) GPTest.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/GPTest.pm'
 
 uninstall:
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/pg_regress$(X)'
@@ -96,6 +97,7 @@ uninstall:
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/atmsort.pm'
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/explain.pl'
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/explain.pm'
+	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/GPTest.pm'
 
 
 # Build dynamically-loaded object file for CREATE FUNCTION ... LANGUAGE C.

--- a/src/test/regress/GPTest.pm.in
+++ b/src/test/regress/GPTest.pm.in
@@ -1,0 +1,41 @@
+
+=pod
+
+=head1 NAME
+
+GPTest - Generic functionality for Greenplum test tools
+
+=head1 SYNOPSIS
+
+  use GPTest;
+
+  print $VERSION;
+
+=head1 DESCRIPTION
+
+GPTest is intended to contain generic functionality for the Greenplum test
+tools written in Perl. At the moment the module contains the Greenplum
+database VERSION.
+
+=cut
+
+package GPTest;
+
+use strict;
+use warnings;
+use File::Basename qw(basename);
+
+use Exporter;
+
+our @ISA = 'Exporter';
+our @EXPORT = qw($VERSION print_version);
+
+our $VERSION = '##Version: ##';
+
+sub print_version
+{
+	print basename($0) . ' ' . $VERSION . "\n";
+	exit(1);
+}
+
+1;

--- a/src/test/regress/atmsort.pl
+++ b/src/test/regress/atmsort.pl
@@ -21,6 +21,7 @@ use File::Spec;
 use FindBin;
 use lib "$FindBin::Bin";
 use atmsort;
+use GPTest qw(print_version);
 
 =head1 NAME
 
@@ -368,7 +369,8 @@ GetOptions(
     'gpd_init|gp_init|init:s' => \@init_file,
     'do_equiv:s' => \$do_equiv,
     'order_warn|orderwarn' => \$orderwarn,
-    'verbose' => \$verbose
+    'verbose' => \$verbose,
+    'version|v' => \&print_version
     )
     or lazy_pod2usage(2);
 

--- a/src/test/regress/explain.pl
+++ b/src/test/regress/explain.pl
@@ -14,6 +14,7 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin";
 use explain;
+use GPTest qw(print_version);
 
 =head1 NAME
 
@@ -276,7 +277,8 @@ GetOptions(
     "prune:s" => \$prune,
     "output:s" => \$outfile,
     "statcolor:s" => \$statcol,
-    "edge:s" => \$edgescheme)
+    "edge:s" => \$edgescheme,
+    'version|v' => \&print_version)
     or pod2usage(2);
 
     

--- a/src/test/regress/get_ereport.pl
+++ b/src/test/regress/get_ereport.pl
@@ -8,10 +8,15 @@
 #
 use Pod::Usage;
 use Getopt::Long;
+Getopt::Long::Configure qw(pass_through);
 use Data::Dumper;
 use File::Spec;
 use strict;
 use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin";
+use GPTest qw(print_version);
 
 =head1 NAME
 
@@ -96,78 +101,16 @@ if (1)
 	my $bFullname = 0;
 	my $bElog	  = 0;
 
-    # check for man or help args
-    if (scalar(@ARGV))
-    {
-		while ($ARGV[0] =~ m/^\-/)
-		{
-			if ($ARGV[0] =~ m/^\-(\-)*(v|version)$/)
-			{
-				$verzion = 1;
-				goto L_wWhile;
-			}
-			elsif ($ARGV[0] =~ m/^\-(\-)*(man|h|help|\?)$/i)
-			{
-				if ($ARGV[0] =~ m/man/i)
-				{
-					$man = 1;
-				}
-				else
-				{
-					$help = 1;
-				}
-				goto L_wWhile;
-			}
-			elsif ($ARGV[0] =~ m/^\-(\-)*quiet$/i)			
-			{
-				$bQuiet = 1;
-				goto L_wWhile;
-			}
-			elsif ($ARGV[0] =~ m/^\-(\-)*lax$/i)
-			{
-				$bLax = 1;
-				goto L_wWhile;
-			}
-			elsif ($ARGV[0] =~ m/^\-(\-)*fullname$/i)
-			{
-				$bFullname = 1;
-				goto L_wWhile;
-			}
-			elsif ($ARGV[0] =~ m/^\-(\-)*elog$/i)
-			{
-				$bElog = 1;
-				goto L_wWhile;
-			}
+GetOptions(
+    'help|h|?' => \$help, man => \$man, 
+    'quiet' => \$bQuiet,
+    'lax' => \$bLax,
+    'fullname' => \$bFullname,
+    'elog' => \$bElog,
+    'version|v' => \&print_version
+    );
 
-			last;
-			
-
-		  L_wWhile:
-			shift @ARGV;
-			next;
-        }
-    }
-    else
-    {
-        $pmsg = "missing an operand after \`get_ereport.pl\'";
-        $help = 1;
-    }
-
-    if ((1 == scalar(@ARGV)) && 
-        ($ARGV[0] =~ m/^\-(\-)*/) &&
-        (!($help || $man || $verzion)))
-    {
-        $pmsg = "unknown operand: $ARGV[0]";
-        $help = 1;
-    }
-
-    if ($verzion)
-    {
-        my $VERSION = do { my @r = (q$Revision$ =~ /\d+/g); sprintf "%d.". "%02d" x $#r, @r }; # must be all one line, for MakeMaker
-
-        print "$0 version $VERSION\n";
-        exit(1);
-    }
+    pod2usage(-msg => $pmsg, -exitstatus => 1) unless (scalar(@ARGV) >= 1);
 
     pod2usage(-msg => $pmsg, -exitstatus => 1) if $help;
     pod2usage(-msg => $pmsg, -exitstatus => 0, -verbose => 2) if $man;

--- a/src/test/regress/gpdiff.pl
+++ b/src/test/regress/gpdiff.pl
@@ -21,6 +21,7 @@ Getopt::Long::Configure qw(pass_through);
 use FindBin;
 use lib "$FindBin::Bin";
 use atmsort;
+use GPTest qw(print_version);
 
 =head1 NAME
 
@@ -142,16 +143,6 @@ my %glob_atmsort_args;
 
 my $glob_ignore_plans;
 my $glob_init_file = [];
-
-sub print_version
-{
-    my $VERSION = do { my @r = ('4.3.99.00' =~ /\d+/g); sprintf "%d."."%02d" x $#r, @r }; # must be all one line, for MakeMaker
-
-    print "$0 version $VERSION\n";
-    print "Type \'gpdiff.pl --help\' for more information on the standard options\n";
-
-    exit(1);
-}
 
 sub gpdiff_files
 {

--- a/src/test/regress/gpstringsubs.pl
+++ b/src/test/regress/gpstringsubs.pl
@@ -14,6 +14,10 @@ use File::Spec;
 use Env;
 use Data::Dumper;
 
+use FindBin;
+use lib "$FindBin::Bin";
+use GPTest qw(print_version);
+
 =head1 NAME
 
 B<gpstringsubs.pl> - GreenPlum string substitution 
@@ -112,7 +116,8 @@ BEGIN {
 
     GetOptions(
                'help|?' => \$help, man => \$man,
-               "connect=s" => \$conn
+               "connect=s" => \$conn,
+               'version|v' => \&print_version
                )
         or pod2usage(2);
 


### PR DESCRIPTION
~~In commit f7a5d2468a762d1542f79dc02d8273902eccf32d we bumped the version to 5.0.0 and at the same time started using [semver](http://semver.org) versioning. This set of commits cleans out a few more 4.3isms and also implements semver for the autoconf variable `GP_MAJORVERSION`.~~ This part of the PR has been moved to #1989 and is now rebased away from here.

 The Perl testcode was either: reporting 4.3.99, being completely broken, or not handling `--version` at all. While not the most important thing in the world, being able to report version is handy so moved to support `--version|-v` for all relevant scripts pulling in the version number from autoconf to avoid hardcoding.

During hacking, the option parsing in `get_ereport.pl` came in via  a 🐰 :hole: so it's included in this PR as well.

See commitmessages for more information.