### PR TITLE
Remove circular dependency on gpstringsubs

### DIFF
--- a/src/test/isolation/Makefile
+++ b/src/test/isolation/Makefile
@@ -24,7 +24,7 @@ pg_regress.o:
 	$(MAKE) -C $(top_builddir)/src/test/regress pg_regress.o
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/pg_regress.o .
 
-gpstringsubs.pl: gpstringsubs.pl
+gpstringsubs.pl:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpstringsubs.pl
 
 gpdiff.pl: atmsort.pm explain.pm


### PR DESCRIPTION
The gpstringsubs.pl rule depends on gpstringsubs.pl which cause errors like the following when building: `make[1]: Circular gpstringsubs.pl <- gpstringsubs.pl dependency dropped.`