### PR TITLE
Stop ignoring lazy vacuum from RecentXmin calculation.

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -782,9 +782,13 @@ DefineIndex(RangeVar *heapRelation,
 	 * Also, GetCurrentVirtualXIDs never reports our own vxid, so we need not
 	 * check for that.
 	 */
+#if 0  /* Upstream code not applicable to GPDB */
 	old_snapshots = GetCurrentVirtualXIDs(ActiveSnapshot->xmax, false,
 										  PROC_IS_AUTOVACUUM | PROC_IN_VACUUM);
-
+#else
+	old_snapshots = GetCurrentVirtualXIDs(ActiveSnapshot->xmax, false,
+										  PROC_IS_AUTOVACUUM);
+#endif
 	while (VirtualTransactionIdIsValid(*old_snapshots))
 	{
 		VirtualXactLockTableWait(*old_snapshots);

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1417,9 +1417,11 @@ GetSnapshotData(Snapshot snapshot, bool serializable)
 		volatile PGPROC *proc = arrayP->procs[index];
 		TransactionId xid;
 
+#if 0 /* Upstream code not applicable to GPDB, why explained in vacuumStatement_Relation */
 		/* Ignore procs running LAZY VACUUM */
 		if (proc->vacuumFlags & PROC_IN_VACUUM)
 			continue;
+#endif
 
 		/* Update globalxmin to be the smallest valid xmin */
 		xid = proc->xmin;               /* fetch just once */

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -46,7 +46,9 @@ struct XidCache
 
 /* Flags for PGPROC->vacuumFlags */
 #define		PROC_IS_AUTOVACUUM	0x01	/* is it an autovac worker? */
+#if 0 /* Upstream code not applicable to GPDB */
 #define		PROC_IN_VACUUM		0x02	/* currently running lazy vacuum */
+#endif
 #define		PROC_IN_ANALYZE		0x04	/* currently running analyze */
 #define		PROC_VACUUM_FOR_WRAPAROUND 0x08		/* set by autovac only */
 


### PR DESCRIPTION
As part of 8.3 merge via this upstream commit
92c2ecc130239b38580b5c11c532d2e027fc2d06, code to ignore lazy vacuum from
calculating RecentXmin and RecentGlobalXmin was introduced.

In GPDB as part of lazy vacuum, reindex is performed for bitmap indexes, which
generates tuples in pg_class with lazy vacuum's transaction ID. Ignoring lazy
vacuum from RecentXmin and RecentGlobalXmin during GetSnapshotData caused
incorrect setting of hintbits to `HEAP_XMAX_INVALID` for tuple intended to be
deletd by lazy vacuum and breaking HOT chain. This transaction visibility issue
was encountered in CI many times with parallel schedule `bitmap_index, analyze`
failing with error `could not find pg_class tuple for index` at commit time of
lazy vacuum. Hence this commit stops tracking lazy vacuum in MyProc and
performing any specific action related to same.