### PR TITLE
Async gang recreation should PQconnectPoll on bad fd poll.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -239,7 +239,8 @@ create_gang_retry:
 					Assert(PQsocket(segdbDesc->conn) > 0);
 					Assert(PQsocket(segdbDesc->conn) == fds[currentFdNumber].fd);
 
-					if (fds[currentFdNumber].revents & fds[currentFdNumber].events)
+					if (fds[currentFdNumber].revents & fds[currentFdNumber].events ||
+						fds[currentFdNumber].revents & (POLLERR | POLLHUP | POLLNVAL))
 						pollingStatus[i] = PQconnectPoll(segdbDesc->conn);
 
 					currentFdNumber++;


### PR DESCRIPTION
There are segment recovery scenarios where revent would be POLLNVAL
and event as POLLOUT. This would cause an infinite loop until the
default 10 minute timeout is reached. Because of this, the FTS portion
at the bottom of the createGang_async() function does not get
correctly executed. This patch adds checking the fd poll revent for
POLLERR, POLLHUP, and POLLNVAL to call a PQconnectPoll so that polling
status PGRES_POLLING_WRITING can correctly update to
PGRES_POLLING_FAILED. It will then be able to exit the loop and
execute the FTS stuff.