### PR TITLE
Move patterns used only by a particular test out of global init_file.

### DIFF
--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -275,12 +275,6 @@ s/\s+\(seg.*pid.*\)//
 m/^(?:ERROR|WARNING|CONTEXT|NOTICE):.*gid\s+=\s+(?:\d+)/
 s/gid.*/gid DUMMY/
 
-m/^(?:ERROR|WARNING|CONTEXT|NOTICE):.*DTM error.*gathered (?:\d+) results from cmd.*/
-s/gathered.*results/gathered SOME_NUMBER_OF results/
-
-m/^(?:ERROR|WARNING|CONTEXT|NOTICE):\s+Could not .* savepoint/
-s/\.c\:\d+\)/\.c\:SOME_LINE\)/
-
 m/^(?:ERROR|WARNING|CONTEXT|NOTICE):.*connection.*failed.*(?:http|gpfdist)/
 s/connection.*failed.*(http|gpfdist).*/connection failed dummy_protocol\:\/\/DUMMY_LOCATION/
 

--- a/src/test/regress/expected/gp_optimizer.out
+++ b/src/test/regress/expected/gp_optimizer.out
@@ -8,6 +8,11 @@ SELECT count(*) from gp_opt_version();
      1
 (1 row)
 
+-- Mask out Log & timestamp for orca message that has feature not supported.
+-- start_matchsubs
+-- m/^LOG.*\"Feature/
+-- s/^LOG.*\"Feature/\"Feature/
+-- end_matchsubs
 -- fix the number of segments for Orca
 set optimizer_segments = 3;
 set optimizer_enable_master_only_queries = on;

--- a/src/test/regress/expected/gp_optimizer_1.out
+++ b/src/test/regress/expected/gp_optimizer_1.out
@@ -8,6 +8,11 @@ SELECT count(*) from gp_opt_version();
      1
 (1 row)
 
+-- Mask out Log & timestamp for orca message that has feature not supported.
+-- start_matchsubs
+-- m/^LOG.*\"Feature/
+-- s/^LOG.*\"Feature/\"Feature/
+-- end_matchsubs
 -- fix the number of segments for Orca
 set optimizer_segments = 3;
 set optimizer_enable_master_only_queries = on;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -1,3 +1,7 @@
+-- This file contains global patterns of messages that should be ignored or
+-- masked out, when comparing test results with the expected output.
+-- Individual tests can contain additional patterns specific to the test.
+
 -- start_matchignore
 # match ignore the gpmon WARNING message
 m/^WARNING:  gpmon:.*Connection refused.*/
@@ -78,14 +82,4 @@ s/overlaps existing partition "r\d+"/partition "r##########"/
 m/Table "pg_temp_\d+.temp/
 s/Table "pg_temp_\d+.temp/Table "pg_temp_#####/
 
-# Mask out Log & timestamp for orca message that has feature not supported.
-m/^LOG.*\"Feature/
-s/^LOG.*\"Feature/\"Feature/
-
-m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
-s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)//
-
-# Mask out whoami message for dispatch
-m/^ \(seg\d .*:\d+\)/
-s/^ \(seg\d .*:\d+\)//
 -- end_matchsubs

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -1,5 +1,13 @@
 -- Misc tests related to dispatching queries to segments.
 
+-- Mask out the whoami message
+-- start_matchsubs
+-- m/^ \(seg\d .*:\d+\)/
+-- s/^ \(seg\d .*:\d+\)//
+-- m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
+-- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
+-- end_matchsubs
+
 -- Test quoting of GUC values and databse names when they're sent to segments
 
 -- There used to be a bug in the quoting when the search_path setting was sent

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1,4 +1,11 @@
 -- Misc tests related to dispatching queries to segments.
+-- Mask out the whoami message
+-- start_matchsubs
+-- m/^ \(seg\d .*:\d+\)/
+-- s/^ \(seg\d .*:\d+\)//
+-- m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
+-- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
+-- end_matchsubs
 -- Test quoting of GUC values and databse names when they're sent to segments
 -- There used to be a bug in the quoting when the search_path setting was sent
 -- to the segment. It was not easily visible when search_path was set with a

--- a/src/test/regress/sql/gp_optimizer.sql
+++ b/src/test/regress/sql/gp_optimizer.sql
@@ -5,6 +5,12 @@
 -- show version
 SELECT count(*) from gp_opt_version();
 
+-- Mask out Log & timestamp for orca message that has feature not supported.
+-- start_matchsubs
+-- m/^LOG.*\"Feature/
+-- s/^LOG.*\"Feature/\"Feature/
+-- end_matchsubs
+
 -- fix the number of segments for Orca
 set optimizer_segments = 3;
 


### PR DESCRIPTION
This reduces the risk of accidentally masking out messages in a test that's
not supposed to produce such messages in the first place, and is just
nicer in general, IMHO.

While we're at it, add a brief comment to init_file to explain what it's
for.