### PR TITLE
Handle gpoptutils in pg_upgrade and assorted bugfixes

### DIFF
--- a/contrib/pg_upgrade/gpdb4_heap_convert.c
+++ b/contrib/pg_upgrade/gpdb4_heap_convert.c
@@ -248,6 +248,10 @@ make_room(migratorContext *ctx, char *page)
 		}
 	}
 
+	/* Ensure that we have a victim tuple here before assuming so */
+	if (victim_lp_len == -1)
+		pg_log(ctx, PG_FATAL, "victum tuple for moving wasn't found\n");
+
 	/* Cross-check */
 	if (oldhdr->pd_upper != victim_lp_off)
 		pg_log(ctx, PG_FATAL, "mismatch between lp_off in line pointers and pd_upper\n");

--- a/contrib/pg_upgrade/gpdb4_heap_convert.c
+++ b/contrib/pg_upgrade/gpdb4_heap_convert.c
@@ -213,6 +213,7 @@ make_room(migratorContext *ctx, char *page)
 			oldhdr->pd_lower -= sizeof(ItemIdData);
 
 			/* Did we make enough room? */
+			space = (int) oldhdr->pd_upper - (int) oldhdr->pd_lower;
 			if (space >= SizeOfPageHeaderData - VERSION4_SizeOfPageHeaderData)
 				return;
 		}


### PR DESCRIPTION
A few small assorted fixes to pg_upgrade, rather than spamming github with individual PR's I bundled them together as they are all related:

* Exclude gpoptutils from loadable library checks since it's no longer available in 5.0 (nor needed as it has been rolled into backend)
* Fix space calculation in page eviction
* Add suspenders to the belt to avoid errorpaths in page writing code