### PR TITLE
Fixed MirroredAppendOnly_Create issue

### DIFF
--- a/src/backend/cdb/cdbmirroredappendonly.c
+++ b/src/backend/cdb/cdbmirroredappendonly.c
@@ -519,7 +519,7 @@ void MirroredAppendOnly_Create(
 					/* traceOpenFlags */ false,
 					primaryError,
 					mirrorDataLossOccurred);
-	if (primaryError != 0)
+	if ((*primaryError) != 0)
 		return;
 
 	MirroredAppendOnly_FlushAndClose(


### PR DESCRIPTION
It seems there is a typo error in the implementation of the function MirroredAppendOnly_Create. Based on the context of the function, (primaryError != 0) is always TRUE, which means MirroredAppendOnly_FlushAndClose is never called.