### PR TITLE
Remove Sort's limitOffset and limitCount

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1630,18 +1630,11 @@ explain_outNode(StringInfo str,
 			break;
 		case T_Sort:
 		{
-			bool bLimit = (((Sort *) plan)->limitCount
-						   || ((Sort *) plan)->limitOffset);
-
 			bool bNoDup = ((Sort *) plan)->noduplicates;
 
 			char *SortKeystr = "Sort Key";
 
-			if ((bLimit && bNoDup))
-				SortKeystr = "Sort Key (Limit Distinct)";
-			else if (bLimit)
-				SortKeystr = "Sort Key (Limit)";
-			else if (bNoDup)
+			if (bNoDup)
 				SortKeystr = "Sort Key (Distinct)";
 
 			show_sort_keys(plan,

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -312,8 +312,6 @@ initialize_aggregates(AggState *aggstate,
 
 			/* CDB: Set enhanced sort options. */
 			{
-				int64 		limit = 0;
-				int64 		offset = 0;
 				int 		unique = peragg->aggref->aggdistinct &&
 									 ( gp_enable_sort_distinct ? 1 : 0) ;
 				int 		sort_flags = gp_sort_flags; /* get the guc */
@@ -321,11 +319,11 @@ initialize_aggregates(AggState *aggstate,
 
 				if(gp_enable_mk_sort)
 					cdb_tuplesort_init_mk((Tuplesortstate_mk *) peraggstate->sortstate, 
-							offset, limit, unique, 
+							unique,
 							sort_flags, maxdistinct);
 				else
 					cdb_tuplesort_init((Tuplesortstate *) peraggstate->sortstate, 
-							offset, limit, unique, 
+							unique,
 							sort_flags, maxdistinct);
 			}
 		}

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -327,7 +327,7 @@ recompute_limits(LimitState *node)
 		int64		tuples_needed = node->count + node->offset;
 
 		/* negative test checks for overflow */
-		if (node->noCount || tuples_needed < 0)
+		if (node->noCount || tuples_needed < 0 || !gp_enable_sort_limit)
 		{
 			/* make sure flag gets reset if needed upon rescan */
 			sortState->bounded = false;

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3093,41 +3093,6 @@ CTranslatorDXLToPlStmt::PsortFromDXLSort
 
 	TranslateSortCols(pdxlnSortColList, &dxltrctxChild, psort->sortColIdx, psort->sortOperators, psort->nullsFirst);
 
-	// translate limit information
-	if (0 < pdxlnLimitCount->UlArity())
-	{
-		GPOS_ASSERT(1 == pdxlnLimitCount->UlArity());
-		const CDXLNode *pdxlnLimitCountExpr = (*pdxlnLimitCount)[0];
-		CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
-																(
-																m_pmp,
-																NULL,
-																pdrgpdxltrctx,
-																pdxltrctxOut,
-																m_pctxdxltoplstmt,
-																pplan
-																);
-
-		psort->limitCount = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnLimitCountExpr, &mapcidvarplstmt);
-	}
-
-	if (0 < pdxlnLimitOffset->UlArity())
-	{
-		GPOS_ASSERT(1 == pdxlnLimitOffset->UlArity());
-		const CDXLNode *pdxlnLimitOffsetExpr = (*pdxlnLimitOffset)[0];
-
-		CMappingColIdVarPlStmt mapcidvarplstmt = CMappingColIdVarPlStmt
-																(
-																m_pmp,
-																NULL,
-																pdrgpdxltrctx,
-																pdxltrctxOut,
-																m_pctxdxltoplstmt,
-																pplan
-																);
-
-		psort->limitOffset = (Node *) m_pdxlsctranslator->PexprFromDXLNodeScalar(pdxlnLimitOffsetExpr, &mapcidvarplstmt);
-	}
 	SetParamIds(pplan);
 
 	// cleanup

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -878,8 +878,6 @@ _copySort(Sort *from)
 	COPY_POINTER_FIELD(nullsFirst, from->numCols * sizeof(bool));
 
     /* CDB */
-	COPY_NODE_FIELD(limitOffset);
-	COPY_NODE_FIELD(limitCount);
 	COPY_SCALAR_FIELD(noduplicates);
 
 	COPY_SCALAR_FIELD(share_type);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -457,8 +457,6 @@ _outSort(StringInfo str, Sort *node)
 	WRITE_BOOL_ARRAY(nullsFirst, node->numCols);
 
     /* CDB */
-	WRITE_NODE_FIELD(limitOffset);
-	WRITE_NODE_FIELD(limitCount);
     WRITE_BOOL_FIELD(noduplicates);
 
 	WRITE_ENUM_FIELD(share_type, ShareType);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -893,8 +893,6 @@ _outSort(StringInfo str, Sort *node)
 		appendStringInfo(str, " %s", booltostr(node->nullsFirst[i]));
 
 	/* CDB */
-	WRITE_NODE_FIELD(limitOffset);
-	WRITE_NODE_FIELD(limitCount);
     WRITE_BOOL_FIELD(noduplicates);
 
 	WRITE_ENUM_FIELD(share_type, ShareType);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2050,8 +2050,6 @@ _readSort(void)
 	READ_BOOL_ARRAY(nullsFirst, local_node->numCols);
 
     /* CDB */
-	READ_NODE_FIELD(limitOffset);
-	READ_NODE_FIELD(limitCount);
 	READ_BOOL_FIELD(noduplicates);
 
 	READ_ENUM_FIELD(share_type, ShareType);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4286,8 +4286,6 @@ make_sort(PlannerInfo *root, Plan *lefttree, int numCols,
 
 	Assert(sortColIdx[0] != 0);
 
-	node->limitOffset = NULL;	/* CDB */
-	node->limitCount = NULL;	/* CDB */
 	node->noduplicates = false; /* CDB */
 
 	node->share_type = SHARE_NOTSHARED;
@@ -5367,15 +5365,6 @@ make_limit(Plan *lefttree, Node *limitOffset, Node *limitCount,
 
 	node->limitOffset = limitOffset;
 	node->limitCount = limitCount;
-
-	/* CDB */	/* pass limit struct to sort */
-	if (IsA(lefttree, Sort) &&gp_enable_sort_limit)
-	{
-		Sort	   *pSort = (Sort *) lefttree;
-
-		pSort->limitOffset = copyObject(limitOffset);
-		pSort->limitCount = copyObject(limitCount);
-	}
 
 	return node;
 }

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -685,20 +685,6 @@ set_plan_refs(PlannerGlobal *glob, Plan *plan, int rtoffset)
 			break;
 
 		case T_Sort:
-			/* GPDB has limit/offset in the sort node as well. */
-			{
-				Sort	   *splan = (Sort *) plan;
-
-				set_dummy_tlist_references(plan, rtoffset);
-				Assert(splan->plan.qual == NIL);
-
-				splan->limitOffset =
-					fix_scan_expr(glob, splan->limitOffset, rtoffset);
-				splan->limitCount =
-					fix_scan_expr(glob, splan->limitCount, rtoffset);
-			}
-			break;
-
 		case T_Hash:
 		case T_Material:
 		case T_Unique:

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2284,11 +2284,6 @@ typedef struct SortState
 	bool		bounded_Done;	/* value of bounded we did the sort with */
 	int64		bound_Done;		/* value of bound we did the sort with */
 	GenericTupStore *tuplesortstate; /* private state of tuplesort.c */
-	/* CDB */ /* limit state */
-
-	/* GPDB_83_MERGE_FIXME: Are these redundant with the "bound" fields? */
-	ExprState  *limitOffset;	/* OFFSET parameter, or NULL if none */
-	ExprState  *limitCount;		/* COUNT parameter, or NULL if none */
 	bool		noduplicates;	/* true if discard duplicate rows */
 
 	void	   *share_lk_ctxt;

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -852,9 +852,7 @@ typedef struct Sort
 	AttrNumber *sortColIdx;		/* their indexes in the target list */
 	Oid		   *sortOperators;	/* OIDs of operators to sort them by */
 	bool	   *nullsFirst;		/* NULLS FIRST/LAST directions */
-    /* CDB */ /* add limit node, distinct */
-	Node	   *limitOffset;	/* OFFSET parameter, or NULL if none */
-	Node	   *limitCount;		/* COUNT parameter, or NULL if none */
+    /* CDB */
 	bool		noduplicates;   /* TRUE if sort should discard duplicates */
 
 	/* Sort node can be shared */

--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -96,12 +96,10 @@ extern Tuplesortstate_mk *tuplesort_begin_datum_mk(ScanState * ss,
 					  Oid sortOperator, bool nullsFirstFlag,
 					  int workMem, bool randomAccess);
 
-extern void cdb_tuplesort_init(Tuplesortstate *state, 
-							   int64 offset, int64 limit, int unique,
+extern void cdb_tuplesort_init(Tuplesortstate *state, int unique,
 							   int sort_flags,
 							   int64 maxdistinct);
-extern void cdb_tuplesort_init_mk(Tuplesortstate_mk *state, 
-							   int64 offset, int64 limit, int unique,
+extern void cdb_tuplesort_init_mk(Tuplesortstate_mk *state, int unique,
 							   int sort_flags,
 							   int64 maxdistinct);
 

--- a/src/include/utils/tuplesort_mk.h
+++ b/src/include/utils/tuplesort_mk.h
@@ -274,8 +274,9 @@ typedef struct MKContext {
     Relation indexRel;
     MemTupleBinding *mt_bind;
 
-    /* Limit the sort?  If 0 then we sort all input values, else we keep only the first limit-many values */
-    int32 limit;
+    bool		bounded;		/* did caller specify a maximum number of tuples to return? */
+    bool		boundUsed;		/* true if we made use of a bounded heap */
+    int			bound;			/* if bounded, the maximum number of tuples */
 
     /* Bit trick: this mask will be set so it can be used to negate a return value.  See comments on usage */
     int32 limitmask;


### PR DESCRIPTION
SortState.limitOffset and limitCount fields seem redundant with the "bound" field, that was merged from PostgreSQL 8.3.

In this PR, this has been refactored to eliminate the redundancy. 

@hlinnaka @foyzur @armenatzoglou @hardikar @hsyuan @vraghavan78  Please have a look when you get chance. 


@hlinnaka FYI - the last commit changed `mksort` to use bound instead of limit. It looks like `mksort` is `on` by default and I thought it is good to have top N optimization. Let me know if we have different plan to tackle this later. I can drop that commit. 
