### PR TITLE
Remove order from flow

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -1045,14 +1045,14 @@ make_one_stage_agg_plan(PlannerInfo *root,
 			break;
 			
 	case MPP_GRP_PREP_FOCUS_QE:
-			result_plan = (Plan*)make_motion_gather_to_QE(result_plan, (current_pathkeys != NIL));
+			result_plan = (Plan*)make_motion_gather_to_QE(root, result_plan, current_pathkeys);
 			result_plan->total_cost += 
 				incremental_motion_cost(result_plan->plan_rows, 
 										result_plan->plan_rows * root->config->cdbpath_segments);
 			break;
 			
 	case MPP_GRP_PREP_FOCUS_QD:
-			result_plan = (Plan*)make_motion_gather_to_QD(result_plan, (current_pathkeys != NIL));	
+			result_plan = (Plan*)make_motion_gather_to_QD(root, result_plan, current_pathkeys);
 			result_plan->total_cost += 
 				incremental_motion_cost(result_plan->plan_rows, 
 										result_plan->plan_rows * root->config->cdbpath_segments);
@@ -1184,8 +1184,7 @@ make_one_stage_agg_plan(PlannerInfo *root,
 	{
 		Assert(!IsA(result_plan, Motion));
 		result_plan->flow = pull_up_Flow(result_plan,
-										 result_plan->lefttree,
-										 (current_pathkeys != NIL));
+										 result_plan->lefttree);
 	}
 
 	/* Marshal implicit results. Return explicit result. */
@@ -1471,7 +1470,7 @@ make_two_stage_agg_plan(PlannerInfo *root,
 		break;
 			
 	case MPP_GRP_TYPE_PLAIN_2STAGE:
-		result_plan = (Plan*)make_motion_gather_to_QE(result_plan, false);
+		result_plan = (Plan*)make_motion_gather_to_QE(root, result_plan, false);
 		result_plan->total_cost += 
 			incremental_motion_cost(result_plan->plan_rows,
 									result_plan->plan_rows * root->config->cdbpath_segments);
@@ -1759,9 +1758,7 @@ make_three_stage_agg_plan(PlannerInfo *root, MppGroupContext *ctx)
 		 * Reconstruct the flow since the targetlist for the result_plan may have
 		 * changed.
 		 */
-		result_plan->flow = pull_up_Flow(result_plan,
-										 result_plan->lefttree,
-										 true);
+		result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 		
 		/* Need to adjust root.  Is this enuf?  I think so. */
 		root->parse->rtable = rtable;
@@ -2061,7 +2058,7 @@ make_plan_for_one_dqa(PlannerInfo *root, MppGroupContext *ctx, int dqa_index,
 	
 	dqaduphazard = (aggstrategy == AGG_HASHED && stream_bottom_agg);
 
-	result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree, (aggstrategy == AGG_SORTED));
+	result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 	
 	current_pathkeys = NIL;
 	
@@ -2240,7 +2237,7 @@ make_plan_for_one_dqa(PlannerInfo *root, MppGroupContext *ctx, int dqa_index,
 		Assert(ctx->numGroupCols == 0); /* No grouping columns */
 		Assert(n == 1);
 
-		result_plan = (Plan*)make_motion_gather_to_QE(result_plan, false);
+		result_plan = (Plan*)make_motion_gather_to_QE(root, result_plan, false);
 		result_plan->total_cost += 
 				incremental_motion_cost(result_plan->plan_rows,
 						result_plan->plan_rows * root->config->cdbpath_segments);
@@ -2485,7 +2482,7 @@ join_dqa_coplan(PlannerInfo *root, MppGroupContext *ctx, Plan *outer, int dqa_in
 	join_plan->total_cost = outer->total_cost + inner->total_cost;
 	join_plan->total_cost += cpu_tuple_cost * join_plan->plan_rows;
 	
-	join_plan->flow = pull_up_Flow(join_plan, join_plan->lefttree, true);
+	join_plan->flow = pull_up_Flow(join_plan, join_plan->lefttree);
 	
 	return join_plan;
 }
@@ -4060,10 +4057,7 @@ add_second_stage_agg(PlannerInfo *root,
 	/*
 	 * Agg will not change the sort order unless it is hashed.
 	 */
-	agg_node->flow = pull_up_Flow(agg_node, 
-								  agg_node->lefttree, 
-								  (*p_current_pathkeys != NIL)
-								   && aggstrategy != AGG_HASHED );
+	agg_node->flow = pull_up_Flow(agg_node, agg_node->lefttree);
 
 	/* 
 	 * Since the rtable has changed, we had better recreate a RelOptInfo entry
@@ -5852,7 +5846,7 @@ within_agg_add_outer_sort(PlannerInfo *root,
 		}
 		if (outer_plan->flow->flotype != FLOW_SINGLETON)
 		{
-			outer_plan = (Plan *) make_motion_gather_to_QE(outer_plan, true);
+			outer_plan = (Plan *) make_motion_gather_to_QE(root, outer_plan, wag_context->current_pathkeys);
 			outer_plan->total_cost +=
 				incremental_motion_cost(outer_plan->plan_rows,
 							outer_plan->plan_rows * root->config->cdbpath_segments);
@@ -6956,9 +6950,7 @@ within_agg_planner(PlannerInfo *root,
 		 * Reconstruct the flow since the targetlist for the result_plan may have
 		 * changed.
 		 */
-		result_plan->flow = pull_up_Flow(result_plan,
-										 result_plan->lefttree,
-										 true);
+		result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 		/* Need to adjust root->parse for upper plan. */
 		root->parse->rtable = rtable;
 		root->parse->targetList = copyObject(result_plan->targetlist);

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -960,15 +960,6 @@ pull_up_Flow(Plan *plan, Plan *subplan, bool withSort)
                                                      &new_flow->sortColIdx);
 
 			/* preserve subplan sort attributes*/
-			if (new_flow->numSortCols < model_flow->numOrderbyCols)
-			{
-				new_flow->numOrderbyCols = new_flow->numSortCols;
-			}
-			else
-			{
-				new_flow->numOrderbyCols = model_flow->numOrderbyCols;
-			}
-
 		    if (new_flow->numSortCols > 0)
 			{
                 ARRAYCOPY(new_flow->sortOperators,
@@ -992,9 +983,6 @@ pull_up_Flow(Plan *plan, Plan *subplan, bool withSort)
             ARRAYCOPY(new_flow->nullsFirst,
                       model_flow->nullsFirst,
                       new_flow->numSortCols);
-
-			/* preserve subplan sort attributes*/
-            new_flow->numOrderbyCols = model_flow->numOrderbyCols;
 	    }
 	}   /* withSort */
 

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -248,20 +248,19 @@ cdbparallelize(PlannerInfo *root,
 	 * information in the profile stucture.
 	 */
 	prescan(plan, context);
-	
+
 	if ( context->dispatchParallel )
 	{
-		
-		/* From this point on, since part of plan is parallel, we have to
-		 * regard the whole plan as parallel. */
-		plan->dispatch = DISPATCH_PARALLEL;
-
 		/*
 		 * Implement the parallelizing directions in the Flow nodes attached
 		 * to the root plan node of each root slice of the plan.
 		 */
 		Assert(root->parse == query);
 		plan = apply_motion(root, plan, query);
+
+		/* From this point on, since part of plan is parallel, we have to
+		 * regard the whole plan as parallel. */
+		plan->dispatch = DISPATCH_PARALLEL;
 	}
 
 	if (gp_enable_motion_deadlock_sanity)
@@ -406,7 +405,7 @@ ParallelizeCorrelatedSubPlanUpdateFlowMutator(Node *node)
 		case T_Result:
 		{
 			if(((Plan *)node)->lefttree && ((Plan *)node)->lefttree->flow)
-				((Plan *)node)->flow = pull_up_Flow((Plan *)node, ((Plan *)node)->lefttree, true);
+				((Plan *)node)->flow = pull_up_Flow((Plan *)node, ((Plan *)node)->lefttree);
 			break;
 		}
 		case T_Append:
@@ -416,8 +415,7 @@ ParallelizeCorrelatedSubPlanUpdateFlowMutator(Node *node)
 				break;
 			Plan *first_append = (Plan *) (lfirst(list_head(append_list)));
 			Assert(first_append && first_append->flow);
-			bool with_sort = list_length(append_list) == 1 ? true : false;
-			((Plan *)node)->flow = pull_up_Flow((Plan *)node, first_append, with_sort);
+			((Plan *)node)->flow = pull_up_Flow((Plan *)node, first_append);
 			break;
 		}
 		default:
@@ -602,7 +600,7 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		((Plan *) res)->extParam = saveExtParam;
 
 		Assert(((Plan *) res)->lefttree && ((Plan *) res)->lefttree->flow);
-		((Plan *) res)->flow = pull_up_Flow((Plan *) res, ((Plan *)res)->lefttree, true);
+		((Plan *) res)->flow = pull_up_Flow((Plan *) res, ((Plan *)res)->lefttree);
 
 		/**
 		 * It is possible that there is an additional level of correlation in the result node.
@@ -896,7 +894,7 @@ makeFlow(FlowType flotype)
  * want to use mark_passthru_locus (after make_subqueryscan) instead.
  */
 Flow *
-pull_up_Flow(Plan *plan, Plan *subplan, bool withSort)
+pull_up_Flow(Plan *plan, Plan *subplan)
 {
 	Flow	   *model_flow = NULL;
 	Flow	   *new_flow = NULL;
@@ -931,60 +929,6 @@ pull_up_Flow(Plan *plan, Plan *subplan, bool withSort)
                                                 plan->targetlist))
             new_flow->hashExpr = copyObject(model_flow->hashExpr);
 	}
-
-	/* Pull up sort key info if requested. */
-    if (withSort)
-	{
-        if (IsA(plan, Sort))
-        {
-	        Sort   *sort = (Sort *)plan;
-       	
-	        new_flow->numSortCols = sort->numCols;
-	        ARRAYCOPY(new_flow->sortColIdx, sort->sortColIdx, sort->numCols);
-	        ARRAYCOPY(new_flow->sortOperators, sort->sortOperators, sort->numCols);
-	        ARRAYCOPY(new_flow->nullsFirst, sort->nullsFirst, sort->numCols);
-        }
-        else if (model_flow->numSortCols == 0)
-            new_flow->numSortCols = 0;
-        else if (is_projection_capable_plan(plan))
-	    {
-		    /*
-             * Try to derive a sortColIdx to align with projected targetlist.
-             * It might be shorter than the subplan's sortColIdx, maybe even
-             * empty, if not all of the subplan's sort cols are projected.
-             */
-		    new_flow->numSortCols = cdbpullup_colIdx(plan,
-                                                     subplan,
-                                                     model_flow->numSortCols,
-                                                     model_flow->sortColIdx,
-                                                     &new_flow->sortColIdx);
-
-			/* preserve subplan sort attributes*/
-		    if (new_flow->numSortCols > 0)
-			{
-                ARRAYCOPY(new_flow->sortOperators,
-                          model_flow->sortOperators,
-                          new_flow->numSortCols);
-                ARRAYCOPY(new_flow->nullsFirst,
-                          model_flow->nullsFirst,
-                          new_flow->numSortCols);
-			}
-	    }
-	    else
-	    {
-		    /* Non-projecting so sort attributes are the same. */
-            new_flow->numSortCols = model_flow->numSortCols;
-		    ARRAYCOPY(new_flow->sortColIdx,
-                      model_flow->sortColIdx,
-                      new_flow->numSortCols);
-            ARRAYCOPY(new_flow->sortOperators,
-                      model_flow->sortOperators,
-                      new_flow->numSortCols);
-            ARRAYCOPY(new_flow->nullsFirst,
-                      model_flow->nullsFirst,
-                      new_flow->numSortCols);
-	    }
-	}   /* withSort */
 
 	new_flow->locustype = model_flow->locustype;
 	
@@ -1234,15 +1178,6 @@ adjustPlanFlow(Plan        *plan,
         flow->hashExpr = copyObject(kidflow->hashExpr);
 		plan->dispatch = plan->lefttree->dispatch;
 
-        /* Zap sort cols if motion has destroyed the ordering. */
-        if (disorder && !reorder)
-        {
-            flow->numSortCols = 0;
-            flow->sortColIdx = NULL;
-            flow->sortOperators = NULL;
-			flow->nullsFirst = NULL;
-        }
-
 		return true;  /* success */
 	}
 
@@ -1311,15 +1246,6 @@ adjustPlanFlow(Plan        *plan,
             Assert(0);
     }
 
-    /* Discard ordering info if the motion will disturb the order. */
-    if (disorder)
-    {
-        flow->numSortCols = 0;
-        flow->sortColIdx = NULL;
-        flow->sortOperators = NULL;
-		flow->nullsFirst = NULL;
-    }
-	
 	/* Since we added Motion, dispatch must be parallel. */
 	plan->dispatch = DISPATCH_PARALLEL;
 

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -82,16 +82,11 @@ pre_dispatch_function_evaluation_mutator(Node *node,
 static void assignMotionID(Node *newnode, ApplyMotionState * context, Node *oldnode);
 
 static int *makeDefaultSegIdxArray(int numSegs);
-
-static Motion *
-make_motion(Plan       *lefttree,
-            bool        sendSorted,
-            int         numSortCols,
-            AttrNumber *sortColIdx,
-            Oid        *sortOperators,
-			bool	   *nullsFirst,
-            bool		useExecutorVarFormat);
 	
+static void add_slice_to_motion(Motion *motion,
+								MotionType motionType, List *hashExpr, List *sortPathKeys,
+								int numOutputSegs, int *outputSegIdx);
+
 static Node *apply_motion_mutator(Node *node, ApplyMotionState * context);
 
 static void request_explicit_motion(Plan *plan, Index resultRelationIdx, List *rtable);
@@ -474,12 +469,8 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
                  * degenerate (on constant exprs) or the result is known to
                  * have at most one row. 
                  */
-                if (query->sortClause &&
-                    plan->flow->numSortCols > 0)
+                if (query->sortClause)
                 {
-                    if (plan->flow->numSortCols > list_length(query->sortClause))
-                        plan->flow->numSortCols = list_length(query->sortClause);
-
                     Insist(focusPlan(plan, true, false));
                 }
 
@@ -833,6 +824,9 @@ apply_motion_mutator(Node *node, ApplyMotionState * context)
     int     saveNextMotionID;
     int     saveNumInitPlans;
     int     saveSliceDepth;
+	PlannerInfo *root = (PlannerInfo *) context->base.node;
+
+	Assert(root && IsA(root, PlannerInfo));
 
 	if (node == NULL)
 		return NULL;
@@ -876,7 +870,6 @@ apply_motion_mutator(Node *node, ApplyMotionState * context)
 
         foreach(cell, plan->initPlan)
         {
-        	PlannerInfo *root = (PlannerInfo *) context->base.node;
             subplan = (SubPlan *)lfirst(cell);
             Assert(IsA(subplan, SubPlan));
             Assert(root);
@@ -890,16 +883,21 @@ apply_motion_mutator(Node *node, ApplyMotionState * context)
     }
 
     /* Pre-existing Motion nodes must be renumbered. */
+	if (IsA(newnode, Motion) && flow->req_move != MOVEMENT_NONE)
+	{
+		plan = ((Motion *) newnode)->plan.lefttree;
+		flow = plan->flow;
+		newnode = (Node *) plan;
+	}
+
     if (IsA(newnode, Motion))
     {
-        Motion *motion = (Motion *)newnode;
+        Motion *motion = (Motion *) newnode;
 
-#ifdef USE_ASSERT_CHECKING
 		/* Sanity check */
 		/* Sub plan must have flow */
         Assert(flow && motion->plan.lefttree->flow);
 		Assert(flow->req_move == MOVEMENT_NONE && !flow->flow_before_req_move);
-#endif
 
         /* Assign unique node number to the new node. */
         assignMotionID(newnode, context, node);
@@ -936,22 +934,9 @@ apply_motion_mutator(Node *node, ApplyMotionState * context)
                 context->sliceDepth == 0)
                 flow->segindex = -1;
 
-            if (flow->numSortCols > 0)
-            {
-                newnode = (Node *)make_sorted_union_motion(plan,
-                                                           flow->segindex,
-                                                           flow->numSortCols,
-                                                           flow->sortColIdx,
-                                                           flow->sortOperators,
-                                                           flow->nullsFirst,
-                                                           true /* useExecutorVarFormat */);
-            }
-            else
-            {
-                newnode = (Node *)make_union_motion(plan,
-                                                    flow->segindex,
-                                                    true /* useExecutorVarFormat */);
-            }
+			newnode = (Node *)make_union_motion(plan,
+												flow->segindex,
+												true /* useExecutorVarFormat */);
             break;
 
         case MOVEMENT_BROADCAST:
@@ -1057,66 +1042,10 @@ assignMotionID(Node *newnode, ApplyMotionState * context, Node *oldnode)
 	}
 }
 
-
-/* --------------------------------------------------------------------
- * make_motion -- creates a Motion node.
- * Caller must have built the pHashDefn, pFixedDefn,
- * and pSortDefn structs already.
- * useExecutorVarFormat is true if make_motion is called after setrefs
- * This call only make a motion node, without filling in flow info
- * After calling this function, caller need to call add_slice_to_motion
- * --------------------------------------------------------------------
- */
-Motion *
-make_motion(Plan       *lefttree,
-            bool        sendSorted,
-			int         numSortCols,
-            AttrNumber *sortColIdx,
-            Oid        *sortOperators,
-			bool	   *nullsFirst,
-            bool        useExecutorVarFormat)
-{
-    Motion *node = makeNode(Motion);
-    Plan   *plan = &node->plan;
-
-	Assert(lefttree);
-	Assert(!IsA(lefttree, Motion));
-	AssertImply(sendSorted, (numSortCols > 0 && sortColIdx != NULL && sortOperators != NULL));
-	AssertImply(!sendSorted, (numSortCols == 0 && sortColIdx == NULL && sortOperators == NULL));
-
-	plan->startup_cost = lefttree->startup_cost;
-	plan->total_cost = lefttree->total_cost;
-	plan->plan_rows = lefttree->plan_rows;
-	plan->plan_width = lefttree->plan_width;
-
-	plan->targetlist = cdbpullup_targetlist(lefttree, useExecutorVarFormat);
-	plan->qual = NIL;
-	plan->lefttree = lefttree;
-	plan->righttree = NULL;
-	plan->dispatch = DISPATCH_PARALLEL;
-
-	node->sendSorted = sendSorted;
-
-	node->numSortCols = numSortCols;
-	node->sortColIdx = sortColIdx;
-	node->sortOperators = sortOperators;
-	node->nullsFirst = nullsFirst;
-	Assert(numSortCols == 0 || nullsFirst);
-
-	plan->extParam = bms_copy(lefttree->extParam);
-	plan->allParam = bms_copy(lefttree->allParam);
-
-	plan->flow = NULL;
-
-	node->outputSegIdx = NULL;
-	node->numOutputSegs = 0;
-	
-	return node;
-}
-
-void add_slice_to_motion(Motion *motion,
-		MotionType motionType, List *hashExpr,
-		int numOutputSegs, int *outputSegIdx)
+static void
+add_slice_to_motion(Motion *motion,
+					MotionType motionType, List *hashExpr, List *sortPathKeys,
+					int numOutputSegs, int *outputSegIdx)
 {
 	/* sanity checks */
 	/* check numOutputSegs and outputSegIdx are in sync.  */
@@ -1217,23 +1146,6 @@ void add_slice_to_motion(Motion *motion,
 	}
 
 	Assert(motion->plan.flow);
-
-	/* if the motion has a sort order, preserve it in each route */
-	if(motion->sendSorted && motion->numSortCols > 0)
-	{
-		int i, n;
-		n = motion->numSortCols;
-		motion->plan.flow->numSortCols = n;
-		motion->plan.flow->sortColIdx = palloc(n * sizeof(AttrNumber));
-		motion->plan.flow->sortOperators = palloc (n * sizeof(Oid));
-		motion->plan.flow->nullsFirst = palloc (n * sizeof(bool));
-		for ( i = 0; i < n; i++ )
-		{
-			motion->plan.flow->sortColIdx[i] = motion->sortColIdx[i];
-			motion->plan.flow->sortOperators[i] = motion->sortOperators[i];
-			motion->plan.flow->nullsFirst[i] = motion->nullsFirst[i];
-		}
-	}
 }
 
 Motion *
@@ -1243,30 +1155,24 @@ make_union_motion(Plan *lefttree, int destSegIndex, bool useExecutorVarFormat)
 	int		*outSegIdx = (int *) palloc(sizeof(int)); 
 	outSegIdx[0] = destSegIndex; 
 
-	motion = make_motion(lefttree, false,
-						 0, NULL, NULL, NULL, /* numSortCols, sortColIdx, sortOperators, nullsFirst */
-						 useExecutorVarFormat);
-	add_slice_to_motion(motion, MOTIONTYPE_FIXED, 
-			NULL, 1, outSegIdx);
+	motion = make_motion(NULL, lefttree, NIL, useExecutorVarFormat);
+	add_slice_to_motion(motion, MOTIONTYPE_FIXED, NULL, NIL, 1, outSegIdx);
 	return motion;
 }
 
 Motion *
-make_sorted_union_motion(Plan *lefttree,
+make_sorted_union_motion(PlannerInfo *root,
+						 Plan *lefttree,
                          int destSegIndex,
-						 int numSortCols, AttrNumber *sortColIdx,
-						 Oid *sortOperators, bool *nullsFirst,
+						 List *sortPathKeys,
 						 bool useExecutorVarFormat)
 {
 	Motion 	*motion;
 	int		*outSegIdx = (int *) palloc(sizeof(int)); 
 	outSegIdx[0] = destSegIndex; 
 
-	motion = make_motion(lefttree, true,
-						 numSortCols, sortColIdx, sortOperators, nullsFirst,
-						 useExecutorVarFormat);
-	add_slice_to_motion(motion, MOTIONTYPE_FIXED,
-			NULL, 1, outSegIdx); 
+	motion = make_motion(root, lefttree, sortPathKeys, useExecutorVarFormat);
+	add_slice_to_motion(motion, MOTIONTYPE_FIXED, NULL, sortPathKeys, 1, outSegIdx); 
 	return motion;
 }
 
@@ -1276,11 +1182,8 @@ make_hashed_motion(Plan *lefttree,
 {
 	Motion *motion;
 
-	motion = make_motion(lefttree, false,
-						 0, NULL, NULL, NULL, useExecutorVarFormat);
-	add_slice_to_motion(motion, MOTIONTYPE_HASH, 
-			hashExpr,
-			0, NULL);
+	motion = make_motion(NULL, lefttree, NIL, useExecutorVarFormat);
+	add_slice_to_motion(motion, MOTIONTYPE_HASH, hashExpr, NIL, 0, NULL);
 	return motion;
 }
 
@@ -1289,12 +1192,9 @@ make_broadcast_motion(Plan *lefttree, bool useExecutorVarFormat)
 {
 	Motion *motion;
 
-	motion = make_motion(lefttree, false,
-						 0, NULL, NULL, NULL,
-						 useExecutorVarFormat);
+	motion = make_motion(NULL, lefttree, NIL, useExecutorVarFormat);
 
-	add_slice_to_motion(motion, MOTIONTYPE_FIXED,
-			NULL, 0, NULL);
+	add_slice_to_motion(motion, MOTIONTYPE_FIXED, NULL, NIL, 0, NULL);
 	return motion;
 }
 
@@ -1303,16 +1203,13 @@ make_explicit_motion(Plan *lefttree, AttrNumber segidColIdx, bool useExecutorVar
 {
 	Motion *motion;
 
-	motion = make_motion(lefttree, false,
-						 0, NULL, NULL, NULL, /* numSortCols, sortColIdx, sortOperators, nullsFirst */
-						 useExecutorVarFormat);
+	motion = make_motion(NULL, lefttree, NIL, useExecutorVarFormat);
 
 	Assert(segidColIdx > 0 && segidColIdx <= list_length(lefttree->targetlist));
 	
 	motion->segidColIdx = segidColIdx;
 	
-	add_slice_to_motion(motion, MOTIONTYPE_EXPLICIT,
-			NULL, 0, NULL); /* hashExpr, numOutputSegs, outputSegIdx */
+	add_slice_to_motion(motion, MOTIONTYPE_EXPLICIT, NULL, NIL, 0, NULL);
 	return motion;
 }
 

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -482,13 +482,6 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 
                     Insist(focusPlan(plan, true, false));
                 }
-                else if (plan->flow->numOrderbyCols > 0 && plan->flow->numSortCols > 0)
-                {
-                    if (plan->flow->numSortCols > plan->flow->numOrderbyCols)
-                        plan->flow->numSortCols = plan->flow->numOrderbyCols;
-
-                    Insist(focusPlan(plan, true, false));
-                }
 
                 /* Use UNION RECEIVE.  Does not preserve ordering. */
                 else

--- a/src/backend/cdb/cdbpathtoplan.c
+++ b/src/backend/cdb/cdbpathtoplan.c
@@ -68,25 +68,6 @@ cdbpathtoplan_create_flow(PlannerInfo  *root,
         flow = makeFlow(FLOW_PARTITIONED);
     else
         Insist(0);
-	
-    /*
-     * Describe the ordering of the result rows.  The ordering info will be
-     * truncated upon encountering an expr which is not already present in the
-     * plan's targetlist.  Duplicate cols and constant cols will be omitted.
-     */
-    if (pathkeys)
-    {
-        Sort   *sort = make_sort_from_pathkeys(root, plan, pathkeys, -1.0, false);
-
-        if (sort)
-        {
-            flow->numSortCols = sort->numCols;
-            flow->sortColIdx = sort->sortColIdx;
-            flow->sortOperators = sort->sortOperators;
-			flow->nullsFirst = sort->nullsFirst;
-			Assert(flow->nullsFirst);
-        }
-    }
 
     flow->req_move = MOVEMENT_NONE;
 	flow->locustype = locus.locustype;
@@ -131,12 +112,10 @@ cdbpathtoplan_create_motion_plan(PlannerInfo   *root,
             {
                 /* Result node might have been added below the Sort */
                 subplan = sort->plan.lefttree; 
-                motion = make_sorted_union_motion(subplan,
+                motion = make_sorted_union_motion(root,
+												  subplan,
                                                   destSegIndex,
-                                                  sort->numCols,
-                                                  sort->sortColIdx,
-                                                  sort->sortOperators,
-												  sort->nullsFirst,
+												  path->path.pathkeys,
                                                   false /* useExecutorVarFormat */
                                                   );
             }

--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -681,9 +681,6 @@ plan_tree_mutator(Node *node,
 
 				FLATCOPY(newflow, flow, Flow);
 				MUTATE(newflow->hashExpr, flow->hashExpr, List *);
-				COPYARRAY(newflow, flow, numSortCols, sortColIdx);
-				COPYARRAY(newflow, flow, numSortCols, sortOperators);
-				COPYARRAY(newflow, flow, numSortCols, nullsFirst);
 				return (Node *) newflow;
 			}
 			break;

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -104,7 +104,8 @@ GpSetOpType choose_setop_type(List *planlist)
 }
 
 
-void adjust_setop_arguments(List *planlist, GpSetOpType setop_type)
+void
+adjust_setop_arguments(PlannerInfo *root, List *planlist, GpSetOpType setop_type)
 {
 	ListCell *cell;
 	Plan *subplan;
@@ -161,12 +162,12 @@ void adjust_setop_arguments(List *planlist, GpSetOpType setop_type)
 				case CdbLocusType_HashedOJ:
 				case CdbLocusType_Strewn:
 					Assert( subplanflow->flotype == FLOW_PARTITIONED );
-					adjusted_plan = (Plan*)make_motion_gather_to_QD(subplan, false);				
+					adjusted_plan = (Plan*)make_motion_gather_to_QD(root, subplan, false);
 					break;
 					
 				case CdbLocusType_SingleQE:
 					Assert( subplanflow->flotype == FLOW_SINGLETON && subplanflow->segindex == 0 );
-					adjusted_plan = (Plan*)make_motion_gather_to_QD(subplan, false);				
+					adjusted_plan = (Plan*)make_motion_gather_to_QD(root, subplan, false);
 					break;
 
 				case CdbLocusType_Entry:
@@ -191,7 +192,7 @@ void adjust_setop_arguments(List *planlist, GpSetOpType setop_type)
 				case CdbLocusType_Strewn:
 					Assert( subplanflow->flotype == FLOW_PARTITIONED );
 					/* Gather to QE.  No need to keep ordering. */
-					adjusted_plan = (Plan*)make_motion_gather_to_QE(subplan, false);				
+					adjusted_plan = (Plan*)make_motion_gather_to_QE(root, subplan, false);
 					break;
 					
 				case CdbLocusType_SingleQE:
@@ -277,24 +278,6 @@ Flow *copyFlow(Flow *model_flow, bool withExprs, bool withSort)
 		return NULL;
 	}
 
-	/* Propogate sort attributes, if wanted and available. */
-	if (withSort && model_flow->numSortCols > 0)
-	{
-		new_flow->numSortCols = model_flow->numSortCols;
-		ARRAYCOPY(
-			new_flow->sortColIdx,
-			model_flow->sortColIdx,
-			model_flow->numSortCols * sizeof(AttrNumber) );
-		ARRAYCOPY(
-			new_flow->sortOperators,
-			model_flow->sortOperators,
-			model_flow->numSortCols * sizeof(Oid) );
-		ARRAYCOPY(
-			new_flow->nullsFirst,
-			model_flow->nullsFirst,
-			model_flow->numSortCols * sizeof(bool) );
-	}
-
 	return new_flow;
 }
 
@@ -306,9 +289,9 @@ Flow *copyFlow(Flow *model_flow, bool withExprs, bool withSort)
  *      a non-replicated, non-root subplan.
  */
 Motion *
-make_motion_gather_to_QD(Plan *subplan, bool keep_ordering)
+make_motion_gather_to_QD(PlannerInfo *root, Plan *subplan, List *sortPathKeys)
 {
-	return make_motion_gather(subplan, -1, keep_ordering);
+	return make_motion_gather(root, subplan, -1, sortPathKeys);
 }
 
 /*
@@ -318,9 +301,9 @@ make_motion_gather_to_QD(Plan *subplan, bool keep_ordering)
  *      subplan.
  */
 Motion *
-make_motion_gather_to_QE(Plan *subplan, bool keep_ordering)
+make_motion_gather_to_QE(PlannerInfo *root, Plan *subplan, List *sortPathKeys)
 {
-	return make_motion_gather(subplan, gp_singleton_segindex, keep_ordering);
+	return make_motion_gather(root, subplan, gp_singleton_segindex, sortPathKeys);
 }	
 
 /*
@@ -330,7 +313,7 @@ make_motion_gather_to_QE(Plan *subplan, bool keep_ordering)
  *      subplan.
  */
 Motion *
-make_motion_gather(Plan *subplan, int segindex, bool keep_ordering)
+make_motion_gather(PlannerInfo *root, Plan *subplan, int segindex, List *sortPathKeys)
 {
 	Motion *motion;
 
@@ -338,17 +321,12 @@ make_motion_gather(Plan *subplan, int segindex, bool keep_ordering)
 	Assert(subplan->flow->flotype == FLOW_PARTITIONED ||
 		   (subplan->flow->flotype == FLOW_SINGLETON && subplan->flow->segindex == 0));
 
-	if ( keep_ordering && subplan->flow->numSortCols > 0 )
+	if (sortPathKeys)
 	{
-		Flow *flow = subplan->flow;
-			
-		motion = make_sorted_union_motion(
+		motion = make_sorted_union_motion(root,
 			subplan,
 			segindex,
-			flow->numSortCols, /* Motion and Flow can share arrays. */
-			flow->sortColIdx,
-			flow->sortOperators,
-			flow->nullsFirst,
+			sortPathKeys,
 			false /* useExecutorVarFormat */);
 	}
 	else
@@ -500,7 +478,7 @@ void mark_passthru_locus(Plan *plan, bool with_hash, bool with_sort)
 
 void mark_sort_locus(Plan *plan)
 {
-	plan->flow = pull_up_Flow(plan, plan->lefttree, true);
+	plan->flow = pull_up_Flow(plan, plan->lefttree);
 }	
 
 void mark_plan_general(Plan* plan)

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2010,7 +2010,6 @@ _copyFlow(Flow *from)
 	COPY_POINTER_FIELD(sortColIdx, from->numSortCols*sizeof(AttrNumber));
 	COPY_POINTER_FIELD(sortOperators, from->numSortCols*sizeof(Oid));
 	COPY_POINTER_FIELD(nullsFirst, from->numSortCols*sizeof(bool));
-	COPY_SCALAR_FIELD(numOrderbyCols);
 	COPY_NODE_FIELD(hashExpr);
 	COPY_NODE_FIELD(flow_before_req_move);
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2006,10 +2006,6 @@ _copyFlow(Flow *from)
 	COPY_SCALAR_FIELD(req_move);
 	COPY_SCALAR_FIELD(locustype);
 	COPY_SCALAR_FIELD(segindex);
-	COPY_SCALAR_FIELD(numSortCols);
-	COPY_POINTER_FIELD(sortColIdx, from->numSortCols*sizeof(AttrNumber));
-	COPY_POINTER_FIELD(sortOperators, from->numSortCols*sizeof(Oid));
-	COPY_POINTER_FIELD(nullsFirst, from->numSortCols*sizeof(bool));
 	COPY_NODE_FIELD(hashExpr);
 	COPY_NODE_FIELD(flow_before_req_move);
 

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -731,9 +731,6 @@ _equalFlow(Flow *a, Flow *b)
 	COMPARE_SCALAR_FIELD(req_move);
 	COMPARE_SCALAR_FIELD(locustype);
 	COMPARE_SCALAR_FIELD(segindex);
-	COMPARE_SCALAR_FIELD(numSortCols);
-	COMPARE_POINTER_FIELD(sortColIdx, a->numSortCols*sizeof(AttrNumber));
-	COMPARE_POINTER_FIELD(sortOperators, a->numSortCols*sizeof(Oid));
 	COMPARE_NODE_FIELD(hashExpr);
 
 	return true;

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -639,8 +639,6 @@ _outFlow(StringInfo str, Flow *node)
 	WRITE_OID_ARRAY(sortOperators, node->numSortCols);
 	WRITE_BOOL_ARRAY(nullsFirst, node->numSortCols);
 
-	WRITE_INT_FIELD(numOrderbyCols);
-
 	WRITE_NODE_FIELD(hashExpr);
 
 	WRITE_NODE_FIELD(flow_before_req_move);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -621,29 +621,6 @@ _outJoinExpr(StringInfo str, JoinExpr *node)
 	WRITE_INT_FIELD(rtindex);
 }
 
-static void
-_outFlow(StringInfo str, Flow *node)
-{
-
-	WRITE_NODE_TYPE("FLOW");
-
-	WRITE_ENUM_FIELD(flotype, FlowType);
-	WRITE_ENUM_FIELD(req_move, Movement);
-	WRITE_ENUM_FIELD(locustype, CdbLocusType);
-	WRITE_INT_FIELD(segindex);
-
-	/* This array format as in Group and Sort nodes. */
-	WRITE_INT_FIELD(numSortCols);
-
-	WRITE_INT_ARRAY(sortColIdx, node->numSortCols, AttrNumber);
-	WRITE_OID_ARRAY(sortOperators, node->numSortCols);
-	WRITE_BOOL_ARRAY(nullsFirst, node->numSortCols);
-
-	WRITE_NODE_FIELD(hashExpr);
-
-	WRITE_NODE_FIELD(flow_before_req_move);
-}
-
 /*****************************************************************************
  *
  *	Stuff from relation.h.

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1693,8 +1693,6 @@ _outFlow(StringInfo str, Flow *node)
 				appendStringInfo(str, " %u", node->sortOperators[i]);
 		}
 	}
-	WRITE_INT_FIELD(numOrderbyCols);
-
 	WRITE_NODE_FIELD(hashExpr);
 
 	WRITE_NODE_FIELD(flow_before_req_move);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1660,12 +1660,9 @@ _outFromExpr(StringInfo str, FromExpr *node)
 	WRITE_NODE_FIELD(quals);
 }
 
-#ifndef COMPILING_BINARY_FUNCS
 static void
 _outFlow(StringInfo str, Flow *node)
 {
-	int i;
-
 	WRITE_NODE_TYPE("FLOW");
 
 	WRITE_ENUM_FIELD(flotype, FlowType);
@@ -1673,31 +1670,10 @@ _outFlow(StringInfo str, Flow *node)
 	WRITE_ENUM_FIELD(locustype, CdbLocusType);
 	WRITE_INT_FIELD(segindex);
 
-	/* This array format as in Group and Sort nodes. */
-	WRITE_INT_FIELD(numSortCols);
-	if(node->numSortCols > 0)
-	{
-		appendStringInfoLiteral(str, " :sortColIdx");
-		if(node->sortColIdx == NULL)
-			appendStringInfoString(str, " <>");
-		else {
-			for ( i = 0; i < node->numSortCols; i++ )
-				appendStringInfo(str, " %d", node->sortColIdx[i]);
-		}
-
-		appendStringInfoLiteral(str, " :sortOperators");
-		if(node->sortOperators == NULL)
-			appendStringInfoString(str, " <>");
-		else {
-			for ( i = 0; i < node->numSortCols; i++ )
-				appendStringInfo(str, " %u", node->sortOperators[i]);
-		}
-	}
 	WRITE_NODE_FIELD(hashExpr);
 
 	WRITE_NODE_FIELD(flow_before_req_move);
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
 /*****************************************************************************
  *

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2143,10 +2143,7 @@ _readFlow(void)
 	READ_ENUM_FIELD(locustype, CdbLocusType);
 	READ_INT_FIELD(segindex);
 
-	READ_INT_FIELD(numSortCols);
-	READ_INT_ARRAY(sortColIdx, local_node->numSortCols, AttrNumber);
-	READ_OID_ARRAY(sortOperators, local_node->numSortCols);
-	READ_BOOL_ARRAY(nullsFirst, local_node->numSortCols);
+	//READ_NODE_FIELD(sortPathKeys);
 
 	READ_NODE_FIELD(hashExpr);
 	READ_NODE_FIELD(flow_before_req_move);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2148,8 +2148,6 @@ _readFlow(void)
 	READ_OID_ARRAY(sortOperators, local_node->numSortCols);
 	READ_BOOL_ARRAY(nullsFirst, local_node->numSortCols);
 
-	READ_INT_FIELD(numOrderbyCols);
-
 	READ_NODE_FIELD(hashExpr);
 	READ_NODE_FIELD(flow_before_req_move);
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4715,6 +4715,7 @@ make_sort_from_groupcols(PlannerInfo *root,
 }
 
 
+
 /*
  * make_sort_from_reordered_groupcols
  *	  Create sort plan to sort based on re-ordered grouping columns.
@@ -4727,102 +4728,33 @@ make_sort_from_groupcols(PlannerInfo *root,
  *	  into the sorting list.
  */
 Sort *
-make_sort_from_reordered_groupcols(PlannerInfo *root,
-								   List *groupcls,
-								   AttrNumber *orig_grpColIdx,
-								   AttrNumber *new_grpColIdx,
-								   TargetEntry *grouping,
-								   TargetEntry *groupid,
-								   int req_ngrpkeys,
-								   Plan *lefttree)
+make_sort_from_pathkeys_and_groupingcol(PlannerInfo *root,
+										Plan *lefttree,
+										List *pathkeys,
+										TargetEntry *grouping,
+										TargetEntry *groupid)
 {
-	List	   *sub_tlist = lefttree->targetlist;
-	int			grpno = 0;
-	int			numgrpkeys,
-				numsortkeys;
-	AttrNumber *sortColIdx;
-	Oid		   *sortOperators;
-	bool	   *nullsFirst;
-	List	   *flat_groupcls;
+	Sort	   *sort;
+	Oid			sort_op;
 
-	/*
-	 * We will need at most list_length(groupcls) sort columns; possibly less
-	 */
-	numgrpkeys = num_distcols_in_grouplist(groupcls);
+	sort = make_sort_from_pathkeys(root, lefttree, pathkeys, -1, false);
 
-	Assert(req_ngrpkeys <= numgrpkeys);
+	sort->sortColIdx = repalloc(sort->sortColIdx, (sort->numCols + 2) * sizeof(AttrNumber));
+	sort->sortOperators = repalloc(sort->sortOperators, (sort->numCols + 2) * sizeof(Oid));
+	sort->nullsFirst = repalloc(sort->nullsFirst, (sort->numCols + 2) * sizeof(bool));
 
-	if (grouping != NULL)
-	{
-		Assert(groupid != NULL);
+	sort_op = ordering_oper_opid(exprType((Node *) grouping->expr));
 
-		sortColIdx = (AttrNumber *) palloc((numgrpkeys + 2) * sizeof(AttrNumber));
-		sortOperators = (Oid *) palloc((numgrpkeys + 2) * sizeof(Oid));
-		nullsFirst = (bool *) palloc((numgrpkeys + 2) * sizeof(bool));
-	}
-	else
-	{
-		sortColIdx = (AttrNumber *) palloc(numgrpkeys * sizeof(AttrNumber));
-		sortOperators = (Oid *) palloc(numgrpkeys * sizeof(Oid));
-		nullsFirst = (bool *) palloc(numgrpkeys * sizeof(bool));
-	}
+	sort->numCols = add_sort_column(grouping->resno, sort_op, false,
+								  sort->numCols,
+								  sort->sortColIdx, sort->sortOperators, sort->nullsFirst);
 
-	numsortkeys = 0;
+	sort_op = ordering_oper_opid(exprType((Node *) groupid->expr));
 
-	flat_groupcls = flatten_grouping_list(groupcls);
-
-	for (grpno = 0; grpno < req_ngrpkeys; grpno++)
-	{
-		GroupClause *grpcl;
-		TargetEntry *tle;
-		int			pos;
-
-		/*
-		 * Find the index position in orig_grpColIdx, in which the element is
-		 * equal to new_grpColIdx[grpno]. This index position points to the
-		 * place that the corresponding GroupClause in flat_groupcls.
-		 */
-		for (pos = 0; pos < numgrpkeys; pos++)
-		{
-			if (orig_grpColIdx[pos] == new_grpColIdx[grpno])
-				break;
-		}
-
-		Assert(pos < numgrpkeys);
-
-		grpcl = (GroupClause *) list_nth(flat_groupcls, pos);
-		tle = get_tle_by_resno(sub_tlist, new_grpColIdx[grpno]);
-
-		/*
-		 * Check for the possibility of duplicate group-by clauses --- the
-		 * parser should have removed 'em, but no point in sorting
-		 * redundantly.
-		 */
-		numsortkeys = add_sort_column(tle->resno, grpcl->sortop, false,
-									  numsortkeys,
-									  sortColIdx, sortOperators, nullsFirst);
-	}
-
-	if (grouping != NULL)
-	{
-		Oid			sort_op = ordering_oper_opid(exprType((Node *) grouping->expr));
-
-		numsortkeys = add_sort_column(grouping->resno, sort_op, false,
-									  numsortkeys,
-									  sortColIdx, sortOperators, nullsFirst);
-
-		sort_op = ordering_oper_opid(exprType((Node *) groupid->expr));
-
-		numsortkeys = add_sort_column(groupid->resno, sort_op, false,
-									  numsortkeys,
-									  sortColIdx, sortOperators, nullsFirst);
-	}
-
-
-	Assert(numsortkeys > 0);
-
-	return make_sort(root, lefttree, numsortkeys,
-					 sortColIdx, sortOperators, nullsFirst, -1.0);
+	sort->numCols = add_sort_column(groupid->resno, sort_op, false,
+								  sort->numCols,
+								  sort->sortColIdx, sort->sortOperators, sort->nullsFirst);
+	return sort;
 }
 
 /*
@@ -4860,6 +4792,75 @@ reconstruct_group_clause(List *orig_groupClause, List *tlist, AttrNumber *grpCol
 	}
 
 	return new_groupClause;
+}
+
+/* --------------------------------------------------------------------
+ * make_motion -- creates a Motion node.
+ * Caller must have built the pHashDefn, pFixedDefn,
+ * and pSortDefn structs already.
+ * useExecutorVarFormat is true if make_motion is called after setrefs
+ * This call only make a motion node, without filling in flow info
+ * After calling this function, caller need to call add_slice_to_motion
+ * --------------------------------------------------------------------
+ */
+Motion *
+make_motion(PlannerInfo *root, Plan *lefttree, List *sortPathKeys, bool useExecutorVarFormat)
+{
+    Motion *node = makeNode(Motion);
+    Plan   *plan = &node->plan;
+
+	Assert(lefttree);
+	Assert(!IsA(lefttree, Motion));
+
+	plan->startup_cost = lefttree->startup_cost;
+	plan->total_cost = lefttree->total_cost;
+	plan->plan_rows = lefttree->plan_rows;
+	plan->plan_width = lefttree->plan_width;
+
+	plan->targetlist = cdbpullup_targetlist(lefttree, useExecutorVarFormat);
+	plan->qual = NIL;
+	plan->lefttree = lefttree;
+	plan->righttree = NULL;
+	plan->dispatch = DISPATCH_PARALLEL;
+
+	if (sortPathKeys)
+	{
+		Sort *sort;
+
+		/* FIXME: add_keys_to_targetlist, or not? */
+		sort = make_sort_from_pathkeys(root, lefttree, sortPathKeys, -1, true);
+
+		node->numSortCols = sort->numCols;
+		node->sortColIdx = sort->sortColIdx;
+		node->sortOperators = sort->sortOperators;
+		node->nullsFirst = sort->nullsFirst;
+
+#ifdef USE_ASSERT_CHECKING
+		/*
+		 * If the child node was a Sort, then surely the order the caller gave us
+		 * must match that of the underlying sort.
+		 */
+		if (IsA(lefttree, Sort))
+		{
+			Sort	   *childsort = (Sort *) lefttree;
+			Assert(childsort->numCols >= node->numSortCols);
+			Assert(memcmp(childsort->sortColIdx, node->sortColIdx, node->numSortCols * sizeof(AttrNumber)) == 0);
+			Assert(memcmp(childsort->sortOperators, node->sortOperators, node->numSortCols * sizeof(Oid)) == 0);
+			Assert(memcmp(childsort->nullsFirst, node->nullsFirst, node->numSortCols * sizeof(bool)) == 0);
+		}
+#endif
+	}
+	node->sendSorted = (node->numSortCols > 0);
+
+	plan->extParam = bms_copy(lefttree->extParam);
+	plan->allParam = bms_copy(lefttree->allParam);
+
+	plan->flow = NULL;
+
+	node->outputSegIdx = NULL;
+	node->numOutputSegs = 0;
+	
+	return node;
 }
 
 Material *
@@ -5501,7 +5502,7 @@ plan_pushdown_tlist(PlannerInfo *root, Plan *plan, List *tlist)
 		/* Fix up annotation of plan's distribution and ordering properties. */
 		if (plan->flow)
 			plan->flow = pull_up_Flow((Plan *) make_result(root, tlist, NULL, plan),
-									  plan, true);
+									  plan);
 
 		/* Install the new targetlist. */
 		plan->targetlist = tlist;
@@ -5513,9 +5514,9 @@ plan_pushdown_tlist(PlannerInfo *root, Plan *plan, List *tlist)
 		/* Insert a Result node to evaluate the targetlist. */
 		plan = (Plan *) make_result(root, tlist, NULL, subplan);
 
-		/* Propagate the subplan's distribution and ordering properties. */
+		/* Propagate the subplan's distribution. */
 		if (subplan->flow)
-			plan->flow = pull_up_Flow(plan, subplan, true);
+			plan->flow = pull_up_Flow(plan, subplan);
 	}
 	return plan;
 }	/* plan_pushdown_tlist */

--- a/src/backend/optimizer/plan/planagg.c
+++ b/src/backend/optimizer/plan/planagg.c
@@ -581,7 +581,7 @@ make_agg_subplan(PlannerInfo *root, MinMaxAggInfo *info)
 							   0, 1);
 
     /* Decorate the Limit node with a Flow node. */
-    plan->flow = pull_up_Flow(plan, plan->lefttree, false);
+    plan->flow = pull_up_Flow(plan, plan->lefttree);
 
 	/*
 	 * Convert the plan into an InitPlan, and make a Param for its result.

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -209,6 +209,46 @@ static TargetEntry *tlist_member_by_ressortgroupref(List *targetList, int ressor
 	return NULL;
 }
 
+
+/*
+ * Reorder a path key, using given column mappings.
+ */
+static List *
+reorder_pathkeys(PlannerInfo *root,
+				 List *pathkeys,
+				 AttrNumber *orig_grpColIdx,
+				 AttrNumber *new_grpColIdx)
+{
+	List	   *result = NIL;
+	int			grpno;
+	int			numgrpkeys = list_length(pathkeys);
+
+	for (grpno = 0; grpno < numgrpkeys; grpno++)
+	{
+		PathKey	   *pk;
+		int			pos;
+
+		/*
+		 * Find the index position in orig_grpColIdx, in which the element is
+		 * equal to new_grpColIdx[grpno]. This index position points to the
+		 * place that the corresponding PathKey in pathkeys.
+		 */
+		for (pos = 0; pos < numgrpkeys; pos++)
+		{
+			if (orig_grpColIdx[pos] == new_grpColIdx[grpno])
+				break;
+		}
+
+		Assert(pos < numgrpkeys);
+
+		pk = (PathKey *) list_nth(pathkeys, pos);
+
+		result = lappend(result, pk);
+	}
+
+	return result;
+}
+
 /**
  * Grouping extension planner does not correctly support a scenario where multiple grouping sets contain
  * references to expressions where one of which subsumes another in the select targetlist.
@@ -505,6 +545,7 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 	/* The query has a non-empty set group clause */
 	bool has_groups = (root->parse->groupClause != NIL);
 	bool need_repeat_node = false;
+	List	   *group_pathkeys;
 
 	TargetEntry *tle;
 	uint64    input_grouping = 0;
@@ -623,19 +664,16 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 			/* Add sort node if needed, and set AggStrategy */
 			if (root->parse->groupClause)
 			{
-				if (!pathkeys_contained_in(root->group_pathkeys,
+				group_pathkeys =  reorder_pathkeys(root, root->group_pathkeys,
+												   orig_grpColIdx,
+												   groupColIdx);
+				if (!pathkeys_contained_in(group_pathkeys,
 										   context->current_pathkeys))
 				{
 					current_lefttree = (Plan *)
-						make_sort_from_reordered_groupcols(root,
-														   root->parse->groupClause,
-														   orig_grpColIdx,
-														   groupColIdx,
-														   NULL,
-														   NULL,
-														   context->current_rollup->numcols - group_no,
-														   current_lefttree);
-					context->current_pathkeys = root->group_pathkeys;
+						make_sort_from_pathkeys(root, current_lefttree, group_pathkeys,
+												-1, false);
+					context->current_pathkeys = group_pathkeys;
 					mark_sort_locus(current_lefttree);
 
 					if (!context->is_agg)
@@ -862,6 +900,10 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 			for (attno=0; attno<context->numGroupCols -1; attno++)
 				orig_prelimGroupColIdx[attno] = attno+1;
 
+			group_pathkeys =  reorder_pathkeys(root, root->group_pathkeys,
+											   orig_prelimGroupColIdx,
+											   prelimGroupColIdx);
+
 			grouping_entry =
 				get_tle_by_resno(agg_node->targetlist,
 								 prelimGroupColIdx[context->numGroupCols - 2]);
@@ -869,14 +911,8 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 				get_tle_by_resno(agg_node->targetlist,
 								 prelimGroupColIdx[context->numGroupCols - 1]);
 			agg_node = (Plan *)
-				make_sort_from_reordered_groupcols(root,
-												   root->parse->groupClause,
-												   orig_prelimGroupColIdx,
-												   prelimGroupColIdx,
-												   grouping_entry,
-												   groupid_entry,
-												   context->numGroupCols - 2,
-												   agg_node);
+				make_sort_from_pathkeys_and_groupingcol(root, agg_node, group_pathkeys,
+														grouping_entry, groupid_entry);
 			pfree(orig_prelimGroupColIdx);
 			mark_sort_locus(agg_node);
 		}
@@ -930,8 +966,7 @@ make_list_aggs_for_rollup(PlannerInfo *root,
  * added and the first subplan is returned.
  */
 static Plan *
-add_append_node(List *subplans,
-				GroupExtContext *context)
+add_append_node(PlannerInfo *root, List *subplans, GroupExtContext *context)
 {
 	Plan *result_plan;
 	GpSetOpType optype = PSETOP_NONE;
@@ -942,7 +977,7 @@ add_append_node(List *subplans,
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
 			optype = choose_setop_type(subplans);
-			adjust_setop_arguments(subplans, optype);
+			adjust_setop_arguments(root, subplans, optype);
 		}
 		
 		/* Append all agg_plans together */
@@ -1190,7 +1225,7 @@ generate_dqa_plan(PlannerInfo *root,
 		root->parse = orig_query;
 		root->parse->groupClause = new_groupClause;
 		root->parse->havingQual = (Node *)new_qual;
-		
+
 		/* Add an explicit sort if we couldn't make the path
 		 * come out the way the Agg/Group node needs it.
 		 */
@@ -1198,11 +1233,8 @@ generate_dqa_plan(PlannerInfo *root,
 								   pathkeys_copy))
 		{
 			subplan = (Plan *)
-				make_sort_from_groupcols(root,
-										 root->parse->groupClause,
-										 context->grpColIdx,
-										 false,
-										 subplan);
+				make_sort_from_pathkeys(root, subplan, root->group_pathkeys,
+										-1, false);
 			pathkeys_copy = root->group_pathkeys;
 			mark_sort_locus(subplan);
 			
@@ -1335,30 +1367,30 @@ plan_append_aggs_with_gather(PlannerInfo *root,
 	AttrNumber *orig_grpColIdx;
 	Oid		   *orig_grpOperators;
 	double      motion_cost_per_row;
+	List	   *group_pathkeys;
 
 	orig_grpColIdx = context->grpColIdx;
 	orig_grpOperators = context->grpOperators;
 	context->grpColIdx = context->current_rollup->colIdx;
 	context->grpOperators = context->current_rollup->operators;
-	
+
+	group_pathkeys = reorder_pathkeys(root,
+									  root->group_pathkeys,
+									  orig_grpColIdx,
+									  context->grpColIdx);
+
 	/* Add an explicit sort if we couldn't make the path
 	 * come out the way the Agg/Group node needs it.
 	 */
-	if (!pathkeys_contained_in(root->group_pathkeys,
+	if (!pathkeys_contained_in(group_pathkeys,
 							   context->current_pathkeys))
 	{
 		lefttree = (Plan *)
-			make_sort_from_reordered_groupcols(root,
-											   root->parse->groupClause,
-											   orig_grpColIdx,
-											   context->grpColIdx,
-											   NULL,
-											   NULL,
-											   context->numGroupCols,
-											   lefttree);
-		context->current_pathkeys = root->group_pathkeys;
+			make_sort_from_pathkeys(root, lefttree, group_pathkeys,
+									-1, false);
+		context->current_pathkeys = group_pathkeys;
 		mark_sort_locus(lefttree);
-		
+
 		/* If this is a Group node, pass DISTINCT to sort */
 		if (!context->is_agg &&
 			IsA(lefttree, Sort) &&
@@ -1388,7 +1420,7 @@ plan_append_aggs_with_gather(PlannerInfo *root,
 	if (lefttree->flow->flotype != FLOW_SINGLETON)
 	{
 		gather_subplan =
-			(Plan *)make_motion_gather_to_QE(lefttree, (context->current_pathkeys != NIL));
+			(Plan *)make_motion_gather_to_QE(root, lefttree, context->current_pathkeys);
 		gather_subplan->total_cost +=
 			motion_cost_per_row * gather_subplan->plan_rows;
 	}
@@ -1434,15 +1466,12 @@ plan_append_aggs_with_gather(PlannerInfo *root,
 			/* Add an explicit sort if we couldn't make the path
 			 * come out the way the Agg/Group node needs it.
 			 */
-			if (!pathkeys_contained_in(root->group_pathkeys,
+			if (!pathkeys_contained_in(group_pathkeys,
 									   pathkeys))
 			{
 				subplan = (Plan *)
-					make_sort_from_groupcols(root,
-											 root->parse->groupClause,
-											 context->grpColIdx,
-											 false,
-											 subplan);
+					make_sort_from_pathkeys(root, subplan, group_pathkeys,
+											-1, false);
 				mark_sort_locus(subplan);
 
 				/* If this is a Group node, pass DISTINCT to sort */
@@ -1489,7 +1518,7 @@ plan_append_aggs_with_gather(PlannerInfo *root,
 		}
 	}
 
-	result_plan = add_append_node(agg_plans, context);
+	result_plan = add_append_node(root, agg_plans, context);
 
 	return result_plan;
 }
@@ -1655,7 +1684,7 @@ plan_append_aggs_with_rewrite(PlannerInfo *root,
 	root->simple_rel_array_size = orig_rel_array_size;
 	memcpy(root->parse, final_query, sizeof(Query));
 
-	result_plan = add_append_node(agg_plans, context);
+	result_plan = add_append_node(root, agg_plans, context);
 	
 	return result_plan;
 }
@@ -1729,9 +1758,7 @@ add_first_agg(PlannerInfo *root,
 			current_lefttree);
 
 	/* Pull up the Flow from the subplan */
-	agg_node->flow =
-		pull_up_Flow(agg_node, agg_node->lefttree,
-					 context->aggstrategy == AGG_SORTED);
+	agg_node->flow = pull_up_Flow(agg_node, agg_node->lefttree);
 
 	/* Simply pulling up the Flow from the subplan is not enough.
 	 * We set hash->hashExpr to NULL since we can not be sure that
@@ -2131,7 +2158,7 @@ plan_list_rollup_plans(PlannerInfo *root,
 		{
 			Plan *plan = (Plan *) make_result(root, lefttree->targetlist, NULL, lefttree);
 			if (lefttree->flow)
-				plan->flow = pull_up_Flow(plan, lefttree, true);
+				plan->flow = pull_up_Flow(plan, lefttree);
 			lefttree = plan;
 		}
 	
@@ -2286,7 +2313,7 @@ plan_list_rollup_plans(PlannerInfo *root,
 		if ( Gp_role == GP_ROLE_DISPATCH )
 		{
 			optype = choose_setop_type(rollup_plans);
-			adjust_setop_arguments(rollup_plans, optype);
+			adjust_setop_arguments(root, rollup_plans, optype);
 		}
 
 		/* Append all rollup_plans together */

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2210,12 +2210,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			current_pathkeys = sort_pathkeys;
 			mark_sort_locus(result_plan);
 		}
-
-		/*
-		 * Update numOrderbyCols to length of sort_pathkeys. For cdb: decide
-		 * which sort attribute should be preserved by merge gather motion
-		 */
-		result_plan->flow->numOrderbyCols = list_length(sort_pathkeys);
 	}
 
 	/*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1762,15 +1762,6 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				}
 			}
 
-			if (result_plan != NULL && result_plan->flow->numSortCols == 0)
-			{
-				/*
-				 * cdb_grouping_planner generated the full plan, with the the
-				 * right tlist.  And it has no sort order
-				 */
-				current_pathkeys = NIL;
-			}
-
 			if (result_plan != NULL && querynode_changed)
 			{
 				/*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1905,9 +1905,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 					canonical_grpsets->grpset_counts != NULL &&
 					canonical_grpsets->grpset_counts[0] > 1)
 				{
-					result_plan->flow = pull_up_Flow(result_plan,
-													 result_plan->lefttree,
-												  (current_pathkeys != NIL));
+					result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 					result_plan = add_repeat_node(result_plan,
 										 canonical_grpsets->grpset_counts[0],
 												  0);
@@ -1974,9 +1972,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 					canonical_grpsets->grpset_counts != NULL &&
 					canonical_grpsets->grpset_counts[0] > 1)
 				{
-					result_plan->flow = pull_up_Flow(result_plan,
-													 result_plan->lefttree,
-												  (current_pathkeys != NIL));
+					result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 					result_plan = add_repeat_node(result_plan,
 										 canonical_grpsets->grpset_counts[0],
 												  0);
@@ -2072,9 +2068,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	 * which we can obtain the distribution info.)
 	 */
 	if (!result_plan->flow)
-		result_plan->flow = pull_up_Flow(result_plan,
-										 getAnySubplan(result_plan),
-										 (current_pathkeys != NIL));
+		result_plan->flow = pull_up_Flow(result_plan, getAnySubplan(result_plan));
 
 	/*
 	 * MPP: If there's a DISTINCT clause and we're not collocated on the
@@ -2141,9 +2135,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 
 					result_plan = (Plan *) make_unique(result_plan, parse->distinctClause);
 
-					result_plan->flow = pull_up_Flow(result_plan,
-													 result_plan->lefttree,
-													 true);
+					result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 
 					result_plan->plan_rows = numDistinct;
 
@@ -2201,6 +2193,21 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			current_pathkeys = sort_pathkeys;
 			mark_sort_locus(result_plan);
 		}
+
+		/*
+		 * An ORDER BY doesn't make much sense, unless we bring all the data to
+		 * a single node. Otherwise it's just a partial order.
+		 */
+		if (result_plan->flow->flotype != FLOW_SINGLETON)
+		{
+			if (parse->limitCount || parse->limitOffset)
+			{
+				/* pushdown the first phase of multi-phase limit (which takes offset into account) */
+				result_plan = pushdown_preliminary_limit(result_plan, parse->limitCount, count_est, parse->limitOffset, offset_est);
+			}
+
+			result_plan = (Plan *) make_motion_gather(root, result_plan, -1, sort_pathkeys);
+		}
 	}
 
 	/*
@@ -2211,9 +2218,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		if (IsA(result_plan, Sort) &&gp_enable_sort_distinct)
 			((Sort *) result_plan)->noduplicates = true;
 		result_plan = (Plan *) make_unique(result_plan, parse->distinctClause);
-		result_plan->flow = pull_up_Flow(result_plan,
-										 result_plan->lefttree,
-										 true);
+		result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 
 		/*
 		 * If there was grouping or aggregation, leave plan_rows as-is (ie,
@@ -2235,7 +2240,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			result_plan = pushdown_preliminary_limit(result_plan, parse->limitCount, count_est, parse->limitOffset, offset_est);
 			
 			/* Focus on QE [merge to preserve order], prior to final LIMIT. */
-			result_plan = (Plan *) make_motion_gather_to_QE(result_plan, current_pathkeys != NIL);
+			result_plan = (Plan *) make_motion_gather_to_QE(root, result_plan, current_pathkeys);
 			result_plan->total_cost += motion_cost_per_row * result_plan->plan_rows;
 		}
 			
@@ -2254,9 +2259,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 										  parse->limitCount,
 										  offset_est,
 										  count_est);
-		result_plan->flow = pull_up_Flow(result_plan,
-										 result_plan->lefttree,
-										 true);
+		result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 	}
 
 	Insist(result_plan->flow);
@@ -3811,9 +3814,7 @@ pushdown_preliminary_limit(Plan *plan, Node *limitCount, int64 count_est, Node *
 										  0,
 										  precount_est);
 
-		result_plan->flow = pull_up_Flow(result_plan,
-										 result_plan->lefttree,
-										 true);
+		result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);
 	}
 
 	return result_plan;

--- a/src/backend/optimizer/plan/planpartition.c
+++ b/src/backend/optimizer/plan/planpartition.c
@@ -775,7 +775,8 @@ static void AdjustVarno(PlannerInfo *root, Node *node, int offset)
 /**
  * Ensure that all rows are gathered on QD.
  */
-static Plan* GatherToQD(Plan *outerPlan)
+static Plan *
+GatherToQD(PlannerInfo *root, Plan *outerPlan)
 {
 	bool gatheredOnMaster = outerPlan->flow
 			&& outerPlan->flow->flotype == FLOW_SINGLETON
@@ -795,7 +796,7 @@ static Plan* GatherToQD(Plan *outerPlan)
 		mark_plan_strewn(outerPlan);
 	}
 
-	return (Plan *) make_motion_gather_to_QD(outerPlan, false);
+	return (Plan *) make_motion_gather_to_QD(root, outerPlan, false);
 }
 
 /**
@@ -807,7 +808,7 @@ static void ConstructInitPlan(PartitionJoinMutatorContext *ctx)
 
 	ctx->outerPlan = plan_pushdown_tlist(ctx->root, ctx->outerPlan, ctx->outerTargetList);
 
-	ctx->outerPlan = GatherToQD(ctx->outerPlan);
+	ctx->outerPlan = GatherToQD(ctx->root, ctx->outerPlan);
 
 	/* single tlist entry that is the aggregate target */
 	TargetEntry *tle = ConstructAggTLE(ctx);
@@ -830,7 +831,7 @@ static void ConstructInitPlan(PartitionJoinMutatorContext *ctx)
 					ctx->outerPlan);
 
 	/* Pull up the Flow from the subplan */
-	ctx->outerPlan->flow = pull_up_Flow(ctx->outerPlan, ctx->outerPlan->lefttree, false);
+	ctx->outerPlan->flow = pull_up_Flow(ctx->outerPlan, ctx->outerPlan->lefttree);
 
 	//elog(NOTICE, "modified outer plan is %s", nodeToString(ctx->outerPlan));
 

--- a/src/backend/optimizer/plan/planshare.c
+++ b/src/backend/optimizer/plan/planshare.c
@@ -18,7 +18,6 @@
 #include "cdb/cdbgroup.h"					/* cdbpathlocus_collocates() */
 #include "cdb/cdbpath.h"
 #include "cdb/cdbsetop.h"					/* make_motion... routines */
-#include "cdb/cdbmutate.h" 					/* add_slice_to_motion */
 #include "cdb/cdbvars.h"
 
 int get_plan_share_id(Plan *p)

--- a/src/include/cdb/cdbllize.h
+++ b/src/include/cdb/cdbllize.h
@@ -27,7 +27,7 @@ extern bool is_plan_node(Node *node);
 
 extern Flow *makeFlow(FlowType flotype);
 
-extern Flow *pull_up_Flow(Plan *plan, Plan *subplan, bool withSort);
+extern Flow *pull_up_Flow(Plan *plan, Plan *subplan);
 
 extern bool focusPlan(Plan *plan, bool stable, bool rescannable);
 extern bool repartitionPlan(Plan *plan, bool stable, bool rescannable, List *hashExpr);

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -18,9 +18,8 @@ extern Plan *apply_motion(struct PlannerInfo *root, Plan *plan, Query *query);
 
 extern Motion *make_union_motion(Plan *lefttree,
 		                                int destSegIndex, bool useExecutorVarFormat);
-extern Motion *make_sorted_union_motion(Plan *lefttree, int destSegIndex,
-						 int numSortCols, AttrNumber *sortColIdx,
-						 Oid *sortOperators, bool *nullsFirst,
+extern Motion *make_sorted_union_motion(PlannerInfo *root, Plan *lefttree, int destSegIndex,
+										List *sortPathKeys,
 						 bool useExecutorVarFormat);
 extern Motion *make_hashed_motion(Plan *lefttree,
 				    List *hashExpr, bool useExecutorVarFormat);
@@ -31,11 +30,6 @@ extern Motion *make_explicit_motion(Plan *lefttree, AttrNumber segidColIdx, bool
 
 void 
 cdbmutate_warn_ctid_without_segid(struct PlannerInfo *root, struct RelOptInfo *rel);
-
-extern void add_slice_to_motion(Motion *m,
-		MotionType motionType, List *hashExpr, 
-		int numOutputSegs, int *outputSegIdx 
-		);
 
 extern Plan *zap_trivial_result(PlannerInfo *root, Plan *plan); 
 extern Plan *apply_shareinput_dag_to_tree(PlannerGlobal *glob, Plan *plan, List *rtable);

--- a/src/include/cdb/cdbsetop.h
+++ b/src/include/cdb/cdbsetop.h
@@ -57,7 +57,7 @@ extern
 GpSetOpType choose_setop_type(List *planlist); 
 
 extern
-void adjust_setop_arguments(List *planlist, GpSetOpType setop_type);
+void adjust_setop_arguments(PlannerInfo *root, List *planlist, GpSetOpType setop_type);
 
 
 extern
@@ -70,16 +70,16 @@ extern
 Motion* make_motion_multiplex(PlannerInfo *root, Plan *subplan);
 
 extern
-Motion* make_motion_gather_to_QD(Plan *subplan, bool keep_ordering);
+Motion* make_motion_gather_to_QD(PlannerInfo *root, Plan *subplan, List *sortPathKeys);
 
 extern
-Motion* make_motion_gather_to_QE(Plan *subplan, bool keep_ordering);
+Motion* make_motion_gather_to_QE(PlannerInfo *root, Plan *subplan, List *sortPathKeys);
 
 extern
 Motion* make_motion_cull_to_QE(Plan *subplan);
 
 extern
-Motion* make_motion_gather(Plan *subplan, int segindex, bool keep_ordering);
+Motion* make_motion_gather(PlannerInfo *root, Plan *subplan, int segindex, List *sortPathKeys);
 
 extern
 void mark_append_locus(Plan *plan, GpSetOpType optype);

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1352,8 +1352,6 @@ typedef struct Flow
 	Oid			*sortOperators;		/* OID of operators to sort them by */
 	bool		*nullsFirst;
 
-	int			numOrderbyCols;		/* number of explicit order-by columns */
-	
 	/* If req_move is MOVEMENT_REPARTITION, these express the desired 
      * partitioning for a hash motion.  Else if flotype is FLOW_PARTITIONED,
      * this is the partitioning key.  Otherwise NIL. 

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1345,12 +1345,6 @@ typedef struct Flow
 	 * the desired segment for the resulting singleton flow.
 	 */
 	int			segindex;		/* Segment index of singleton flow. */
-	
-	/* Sort specifications. */
-	int			numSortCols;		/* number of sort key columns */
-	AttrNumber	*sortColIdx;		/* their indexes in target list */
-	Oid			*sortOperators;		/* OID of operators to sort them by */
-	bool		*nullsFirst;
 
 	/* If req_move is MOVEMENT_REPARTITION, these express the desired 
      * partitioning for a hash motion.  Else if flotype is FLOW_PARTITIONED,

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -139,16 +139,15 @@ extern Sort *make_sort_from_sortclauses(PlannerInfo *root, List *sortcls,
 extern Sort *make_sort_from_groupcols(PlannerInfo *root, List *groupcls,
 									  AttrNumber *grpColIdx, bool appendGrouping,
 									  Plan *lefttree);
-extern Sort *make_sort_from_reordered_groupcols(PlannerInfo *root,
-												List *groupcls,
-												AttrNumber *orig_grpColIdx,
-												AttrNumber *new_grpColIdx,
-												TargetEntry *grouping,
-												TargetEntry *groupid,
-												int req_ngrpkeys,
-												Plan *lefttree);
+extern Sort *make_sort_from_pathkeys_and_groupingcol(PlannerInfo *root,
+										Plan *lefttree,
+										List *pathkeys,
+										TargetEntry *grouping,
+										TargetEntry *groupid);
 extern List *reconstruct_group_clause(List *orig_groupClause, List *tlist,
 						 AttrNumber *grpColIdx, int numcols);
+
+extern Motion *make_motion(PlannerInfo *root, Plan *lefttree, List *sortPathKeys, bool useExecutorVarFormat);
 
 extern Agg *make_agg(PlannerInfo *root, List *tlist, List *qual,
 					 AggStrategy aggstrategy, bool streaming,

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -192,9 +192,31 @@ order by b,c;
      25 |     1
 (1 row)
 
+-- Test agg on top of join subquery on partition table with ORDER-BY clause
+CREATE TABLE bfv_planner_t1 (a int, b int, c int) distributed by (c);
+CREATE TABLE bfv_planner_t2 (f int,g int) DISTRIBUTED BY (f) PARTITION BY RANGE(g)
+(
+PARTITION "201612" START (1) END (10)
+);
+NOTICE:  CREATE TABLE will create partition "bfv_planner_t2_1_prt_201612" for table "bfv_planner_t2"
+insert into bfv_planner_t1 values(1,2,3), (2,3,4), (3,4,5);
+insert into bfv_planner_t2 values(3,1), (4,2), (5,2);
+select count(*) from
+(select a,b,c from bfv_planner_t1 order by c) T1
+join
+(select f,g from bfv_planner_t2) T2
+on
+T1.a=T2.g and T1.c=T2.f;
+ count 
+-------
+     2
+(1 row)
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;
 drop table if exists bfv_planner_foo;
 drop table if exists testmedian;
+drop table if exists bfv_planner_t1;
+drop table if exists bfv_planner_t2;
 -- end_ignore

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -545,9 +545,9 @@ group by f1,f2,fs;
 -- but PostgreSQL executor defers typmod assignment to ExecEvalWholeRowVar()
 -- which is too late for Greenplum since the plan has already been dispatched.
 -- This should be fixed but requires new infrastructure.
+-- TODO: Add this test back once issue #618 is fixed.
 --
-select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
-ERROR:  record type has not been registered
+-- select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
 --
 -- Test case for sublinks pushed down into subselects via join alias expansion
 --

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -556,9 +556,9 @@ group by f1,f2,fs;
 -- but PostgreSQL executor defers typmod assignment to ExecEvalWholeRowVar()
 -- which is too late for Greenplum since the plan has already been dispatched.
 -- This should be fixed but requires new infrastructure.
+-- TODO: Add this test back once issue #618 is fixed.
 --
-select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
-ERROR:  record type has not been registered
+-- select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
 --
 -- Test case for sublinks pushed down into subselects via join alias expansion
 --

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -1632,15 +1632,17 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example SCATTER RANDOMLY)
 (5 rows)
 
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b) );
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
-         ->  Sort  (cost=2.27..2.29 rows=5 width=16)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Table Function Scan on multiset_5  (cost=2.27..2.42 rows=10 width=36)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.29 rows=10 width=16)
+         Merge Key: example.a, example.b
+         ->  Sort  (cost=2.27..2.29 rows=4 width=16)
                Sort Key: example.a, example.b
-               ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
+               ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
  Settings:  gp_segments_for_planner=8
-(6 rows)
+ Optimizer status: legacy query optimizer
+(8 rows)
 
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b SCATTER BY a) );
                                  QUERY PLAN                                  
@@ -1654,28 +1656,27 @@ explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b SCA
 (6 rows)
 
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCATTER BY b) );
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
-         ->  Sort  (cost=2.27..2.29 rows=5 width=16)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.42 rows=10 width=36)
+   ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=4 width=36)
+         ->  Sort  (cost=2.27..2.29 rows=4 width=16)
                Sort Key: example.b, example.a
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
-                     Hash Key: example.b
-                     ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
+               ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
  Settings:  gp_segments_for_planner=8
-(8 rows)
+ Optimizer status: legacy query optimizer
+(7 rows)
 
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY b, a SCATTER RANDOMLY) );
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice2; segments: 2)  (cost=2.27..2.42 rows=5 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=36)
-         ->  Sort  (cost=2.27..2.29 rows=5 width=16)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.42 rows=10 width=36)
+   ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=4 width=36)
+         ->  Sort  (cost=2.27..2.29 rows=4 width=16)
                Sort Key: example.b, example.a
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.10 rows=5 width=16)
-                     ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
+               ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
  Settings:  gp_segments_for_planner=8
+ Optimizer status: legacy query optimizer
 (7 rows)
 
 explain SELECT * FROM multiset_5( TABLE (SELECT * FROM example ORDER BY a, b LIMIT 10 SCATTER BY a) );
@@ -1743,17 +1744,19 @@ explain SELECT ARRAY(SELECT a FROM multiset_5( TABLE ( SELECT a, b from example)
 (9 rows)
 
 explain SELECT ARRAY(SELECT a FROM multiset_5( TABLE ( SELECT a, b from example order by a)));
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Result  (cost=2.42..2.43 rows=1 width=0)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Result  (cost=4.83..4.84 rows=1 width=0)
    InitPlan  (slice2)
-     ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=2.27..2.42 rows=5 width=4)
-           ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=5 width=4)
-                 ->  Sort  (cost=2.27..2.29 rows=5 width=16)
+     ->  Table Function Scan on multiset_5  (cost=2.27..2.42 rows=10 width=4)
+           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.29 rows=10 width=16)
+                 Merge Key: example.a
+                 ->  Sort  (cost=2.27..2.29 rows=4 width=16)
                        Sort Key: example.a
-                       ->  Seq Scan on example  (cost=0.00..2.10 rows=5 width=16)
+                       ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
  Settings:  gp_segments_for_planner=8
-(8 rows)
+ Optimizer status: legacy query optimizer
+(10 rows)
 
 explain SELECT * FROM example where (a,b) in (select * from multiset_5( TABLE(SELECT a, b from example) ));
                                                QUERY PLAN                                               

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -131,9 +131,27 @@ where c ='25'
 group by b, c, value2
 order by b,c;
 
+-- Test agg on top of join subquery on partition table with ORDER-BY clause
+CREATE TABLE bfv_planner_t1 (a int, b int, c int) distributed by (c);
+CREATE TABLE bfv_planner_t2 (f int,g int) DISTRIBUTED BY (f) PARTITION BY RANGE(g)
+(
+PARTITION "201612" START (1) END (10)
+);
+insert into bfv_planner_t1 values(1,2,3), (2,3,4), (3,4,5);
+insert into bfv_planner_t2 values(3,1), (4,2), (5,2);
+
+select count(*) from
+(select a,b,c from bfv_planner_t1 order by c) T1
+join
+(select f,g from bfv_planner_t2) T2
+on
+T1.a=T2.g and T1.c=T2.f;
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;
 drop table if exists bfv_planner_foo;
 drop table if exists testmedian;
+drop table if exists bfv_planner_t1;
+drop table if exists bfv_planner_t2;
 -- end_ignore

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -329,9 +329,9 @@ group by f1,f2,fs;
 -- but PostgreSQL executor defers typmod assignment to ExecEvalWholeRowVar()
 -- which is too late for Greenplum since the plan has already been dispatched.
 -- This should be fixed but requires new infrastructure.
+-- TODO: Add this test back once issue #618 is fixed.
 --
-
-select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
+-- select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
 
 --
 -- Test case for sublinks pushed down into subselects via join alias expansion


### PR DESCRIPTION
Motion node often needs to "merge" the incoming streams, to preserve the
overall sort order. Instead of carrying sort order information throughout
the later stages of planning, in the Flow struct, pass it as argument
directly to make_motion() and other functions, where a Motion node is
created. This simplifies things.

To make that work, we can no longer rely on apply_motion() to add the final
Motion on top of the plan, when the (sub-)query contains an ORDER BY. That's
because we no longer have that information available at apply_motion(). Add
the Motion node in grouping_planner() instead, where we still have that
information, as a path key.

This fixes a bug, where the sortColIdx of plan flow node may refer to wrong
resno. A test case for that is included.

There are a few plan changes after the refactoring of sort ordering code
in Motion nodes. This commit also updates the expected files.

Also, after this following query in subselect.sql does not error out and
produces results which are not in correct format :

```
select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
```
We already have issue #618 in gpdb master to track this query. We need
to add this test case back once issue #618 is fixed. Ideally this query
should produce results.