### PR TITLE
Take upstream lazy_truncate_heap locking behavior

### DIFF
--- a/src/backend/commands/vacuumlazy.c
+++ b/src/backend/commands/vacuumlazy.c
@@ -1158,18 +1158,6 @@ lazy_truncate_heap(Relation onerel, LVRelStats *vacrelstats)
 	vacrelstats->rel_pages = new_rel_pages;
 	vacrelstats->pages_removed = old_rel_pages - new_rel_pages;
 
-/*
- * GPDB_83_MERGE_FIXME: The PostgreSQL commit above explains why we *must*
- * keep the lock. But in GDPB, we just drop it. Either the upstream comment
- * is wrong (unlikely), or GPDB is playing dangerous fast-and-loose with the
- * lock, and the deadlock needs to be fixed some other way (likely)
- */
-	/*
-	 * We can't keep the exclusive lock until commit, since this will cause
-	 * deadlock, see MPP-5733.
-	 */
-	UnlockRelation(onerel, AccessExclusiveLock);
-
 	ereport(elevel,
 			(errmsg("\"%s\": truncated %u to %u pages",
 					RelationGetRelationName(onerel),


### PR DESCRIPTION
During lazy_truncate_heap, an exclusive lock is taken on the heap to be
truncated. This lock is required to prevent other concurrent transactions
reading an invalid rd_targblock which is going to be propogated to other
backends as part of cache invalidation at commit time.

This lock need to be held till the end of commit, hence we remove the
UnlockRelation() added for GPDB, which is introduced to avoid a deadlock
situation caused by concurrent vacuums.

However, we cannot repro this deadlock on latest GPDB, where this deadlock was
found in a very early version of GPDB (back to 3.3).

Signed-off-by: Xin Zhang <xzhang@pivotal.io>