### PR TITLE
Fix error position in the errors reported from gp_dump_query_oids()

### DIFF
--- a/src/test/regress/expected/gp_dump_query_oids.out
+++ b/src/test/regress/expected/gp_dump_query_oids.out
@@ -31,3 +31,14 @@ SELECT gp_dump_query_oids('SELECT length(proname) FROM pg_proc; SELECT abs(relpa
  {"relids": "1255,1259", "funcids": "1317,406,1397"}
 (1 row)
 
+-- Test error reporting on an invalid query.
+SELECT gp_dump_query_oids('SELECT * FROM nonexistent_table');
+ERROR:  relation "nonexistent_table" does not exist
+LINE 1: SELECT * FROM nonexistent_table
+                      ^
+QUERY:  SELECT * FROM nonexistent_table
+SELECT gp_dump_query_oids('SELECT with syntax error');
+ERROR:  syntax error at or near "with syntax"
+LINE 1: SELECT with syntax error
+               ^
+QUERY:  SELECT with syntax error

--- a/src/test/regress/sql/gp_dump_query_oids.sql
+++ b/src/test/regress/sql/gp_dump_query_oids.sql
@@ -8,3 +8,7 @@ SELECT gp_dump_query_oids('explain SELECT length(proname) FROM pg_proc');
 
 -- with a multi-query statement
 SELECT gp_dump_query_oids('SELECT length(proname) FROM pg_proc; SELECT abs(relpages) FROM pg_class');
+
+-- Test error reporting on an invalid query.
+SELECT gp_dump_query_oids('SELECT * FROM nonexistent_table');
+SELECT gp_dump_query_oids('SELECT with syntax error');


### PR DESCRIPTION
If an invalid query is passed to gp_dump_query_oids(), the error position
would incorrectly point at the location in the original query, containing
the call to gp_dump_query_oids() call, rather than the query passed as
argument to it. For example:

regression=# select gp_dump_query_oids('select * from invalid');
ERROR:  relation "invalid" does not exist
LINE 1: select gp_dump_query_oids('select * from invalid');
                      ^

To fix, set up error context information correctly before parsing the
query.

This fixes github issue #854.