### PR TITLE
Fix SubPlan handling in adjust_appendrel_attrs().

### DIFF
--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -192,6 +192,36 @@ order by b,c;
      25 |     1
 (1 row)
 
+-- Test inheritance planning, when a SubPlan is duplicated for different
+-- child tables.
+create table r (a int) distributed by (a);
+create table p (a int, b int) distributed by (a);
+create table p2 (a int, b int) inherits (p) distributed by (b);
+NOTICE:  merging column "a" with inherited definition
+NOTICE:  merging column "b" with inherited definition
+insert into r values (3);
+insert into p select a, b from generate_series(1,3) a, generate_series(1,3) b;
+delete from p where b = 1 or (b=2 and a in (select r.a from r));
+select * from p;
+ a | b 
+---+---
+ 3 | 3
+ 1 | 2
+ 1 | 3
+ 2 | 2
+ 2 | 3
+(5 rows)
+
+delete from p where b = 1 or (b=2 and a in (select b from r));
+select * from p;
+ a | b 
+---+---
+ 1 | 2
+ 1 | 3
+ 2 | 3
+ 3 | 3
+(4 rows)
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -131,6 +131,23 @@ where c ='25'
 group by b, c, value2
 order by b,c;
 
+
+-- Test inheritance planning, when a SubPlan is duplicated for different
+-- child tables.
+
+create table r (a int) distributed by (a);
+create table p (a int, b int) distributed by (a);
+create table p2 (a int, b int) inherits (p) distributed by (b);
+
+insert into r values (3);
+insert into p select a, b from generate_series(1,3) a, generate_series(1,3) b;
+
+delete from p where b = 1 or (b=2 and a in (select r.a from r));
+select * from p;
+
+delete from p where b = 1 or (b=2 and a in (select b from r));
+select * from p;
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;


### PR DESCRIPTION
The old coding failed to apply the mutator to the children of a SubPlan.

While at it, try to explain in the comment *why* SubPlans need special
treatment in GPDB, while they don't in PostgreSQL. I'm not 100% I got the
reasoning correct, since I'm basically just reverse-engineering the
original thinking here. But seems plausible..

Fixes github issue #368.