### PR TITLE
Adjust "pgstat wait timeout" message to be a translatable LOG message.

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -3614,7 +3614,9 @@ backend_read_statsfile(void)
 	}
 
 	if (count >= PGSTAT_POLL_LOOP_COUNT)
-		elog(WARNING, "pgstat wait timeout");
+		ereport(LOG,
+				(errmsg("using stale statistics instead of current ones "
+						"because stats collector is not responding")));
 
 	/* Autovacuum launcher wants stats about all databases */
 	pgStatDBHash = pgstat_read_statsfile(InvalidOid, false);


### PR DESCRIPTION
This is a request pull in the PG commit https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=75b48e1fff8a4dedd3ddd7b76f6360b5cc9bb741.

We are seeing intermittent failures on CI with the "pgstat wait timeout" warning.  The CI logs do not show anything unusual, so this seems similar to the PG CI issues discussed at https://www.postgresql.org/message-id/20141225191308.GI31801%40alap3.anarazel.de.  Hence, we would like to pull this commit.

Here is the original commit message.

Per discussion, change the log level of this message to be LOG not WARNING.
The main point of this change is to avoid causing buildfarm run failures
when the stats collector is exceptionally slow to respond, which it not
infrequently is on some of the smaller/slower buildfarm members.

This change does lose notice to an interactive user when his stats query
is looking at out-of-date stats, but the majority opinion (not necessarily
that of yours truly) is that WARNING messages would probably not get
noticed anyway on heavily loaded production systems.  A LOG message at
least ensures that the problem is recorded somewhere where bulk auditing
for the issue is possible.

Also, instead of an untranslated "pgstat wait timeout" message, provide
a translatable and hopefully more understandable message "using stale
statistics instead of current ones because stats collector is not
responding".  The original text was written hastily under the assumption
that it would never really happen in practice, which we now know to be
unduly optimistic.

Back-patch to all active branches, since we've seen the buildfarm issue
in all branches.