### PR TITLE
Taking upstream behavior on IndexBuildHeapScan

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2055,21 +2055,6 @@ IndexBuildHeapScan(Relation heapRelation,
 					if (!TransactionIdIsCurrentTransactionId(
 								  HeapTupleHeaderGetXmax(heapTuple->t_data)))
 					{
-						/*
-						 * GPDB_83_MERGE_FIXME:
-						 *
-						 * Before the 8.3 merge, we also didn't throw an error if
-						 * it was a bitmap index. The old comment didn't explain why,
-						 * however. I don't understand why bitmap indexes would behave
-						 * differently here; indexes contain no visibility information,
-						 * this is all about how the heap works.
-						 *
-						 * I'm leaving this as it's in upstream, with no special handling
-						 * for bitmap indexes, to see what breaks. But if someone reports
-						 * a "concurrent delete in progress" error while creating a bitmap
-						 * index on a heap table, then we possibly need to put that
-						 * exception back.
-						 */
 						if (!IsSystemRelation(heapRelation))
 							elog(ERROR, "concurrent delete in progress");
 						else


### PR DESCRIPTION
In GPDB if there was a heap tuple which was being deleted, i.e
HEAPTUPLE_DELETE_IN_PROGRESS, it would error out during index rebuild, except
for three scenarios:
- Scenario 1: it's deleted within its own transaction
- Scenario 2: it's a system catalog tuple
- Scenario 3: there was a bitmap index being rebuilt

The 3rd scenario is introduced long time ago in 3.3.

In Postgres, the upstream behavior only handling the first 2 scenarios, and
never bother with the 3rd scenario.

We cannot repro the Scenario 3 on current code base using concurrent update on
bitmap index with vacuum, and this scenario is already covered by test at
`src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/reindex/concurrency/`.

It's confident that scenario 3 is also protected. Hence we take upstream
behavior.

[ci skip]

Signed-off-by: Xin Zhang <xzhang@pivotal.io>