### PR TITLE
Remove deadcode of locally_opened check.

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2800,24 +2800,6 @@ afterTriggerInvokeEvents(int query_depth,
 			{
 				ResultRelInfo *rInfo;
 
-				/* GPDB_83_MERGE_FIXME: We had this in GPDB before the merge.
-				 * There are no comments on why this is needed, and I don't get it.
-				 */
-#if 0				
-				if (locally_opened)
-				{
-					/* close prior rel if any */
-					if (rel)
-						heap_close(rel, NoLock);
-					if (trigdesc)
-						FreeTriggerDesc(trigdesc);
-					if (finfo)
-						pfree(finfo);
-					Assert(instr == NULL);		/* never used in this case */
-				}
-				locally_opened = true;
-#endif
-
 				rInfo = ExecGetTriggerResultRel(estate, event->ate_relid);
 				rel = rInfo->ri_RelationDesc;
 				trigdesc = rInfo->ri_TrigDesc;


### PR DESCRIPTION
`locally_opened` is replaced by `local_estate` in postgres by the following
commit:

	commit 817946bb04e1dcac02d85572103f1e1381102a0a
	Author: Tom Lane <tgl@sss.pgh.pa.us>
	Date:   Wed Aug 15 21:39:50 2007 +0000

	    Arrange to cache a ResultRelInfo in the executor's EState for relations that
	    are not one of the query's defined result relations, but nonetheless have
	    triggers fired against them while the query is active.  This was formerly
	    impossible but can now occur because of my recent patch to fix the firing
	    order for RI triggers.  Caching a ResultRelInfo avoids duplicating work by
	    repeatedly opening and closing the same relation, and also allows EXPLAIN
	    ANALYZE to "see" and report on these extra triggers.  Use the same mechanism
	    to cache open relations when firing deferred triggers at transaction shutdown;
	    this replaces the former one-element-cache strategy used in that case, and
	    should improve performance a bit when there are deferred triggers on a number
	    of relations.

The deadcode was introduced by merge with 8.3, but the code was already removed
in the original commit.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>