### PR TITLE
Enable to run behave gprecoverseg on multinode cluster

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -163,8 +163,9 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
         And the information of a "mirror" segment on any host is saved
-        When user kills a mirror process with the saved information
-        And wait until the mirror is down
+        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y reset" on segment "0"
+        And user runs the command "gpfaultinjector  -f filerep_consumer  -m async -y fault" on segment "0"
+        Then the mirror with content id "0" is marked down in config
         When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
         Given at least one segment is resynchronized


### PR DESCRIPTION
This is a followup to commit 80d1fc211b6cb716ee3e8d43e0001f308e984a92 as
the previous commit only works on a single node cluster

Authors: Marbin Tan, Karen Huddleston, and Chris Hajas