### PR TITLE
External table attribute inheritance

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -12970,7 +12970,12 @@ exchange_part_inheritance(Oid oldrelid, Oid newrelid)
 					     RelationGetRelationName(parent), -1),
 			true);
 
-	inherit_parent(parent, newrel, true /* it's a partition */, NIL);
+	/*
+	 * External relations doesn't support inheritance so keep the attributes
+	 * local even when used in a partition hierarchy.
+	 */
+	if (!RelationIsExternal(newrel))
+		inherit_parent(parent, newrel, true /* it's a partition */, NIL);
 	heap_close(parent, NoLock);
 	heap_close(oldrel, NoLock);
 	heap_close(newrel, NoLock);

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -6134,8 +6134,8 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 		int j;
 		for (j = 0; j < tbinfo->numatts; j++)
 		{
-			/* Is this one of the table's own attrs, and not dropped ? */
-			if (tbinfo->attislocal[j] && !tbinfo->attisdropped[j])
+			/* Is the attribute not dropped? */
+			if (!tbinfo->attisdropped[j])
 			{
 				/* Format properly if not first attr */
 				if (actual_atts > 0)

--- a/src/bin/pg_dump/cdb/cdb_dump_include.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_include.c
@@ -3236,6 +3236,14 @@ getTableAttrs(TableInfo *tblinfo, int numTables)
 				tbinfo->attencoding[j] = strdup(PQgetvalue(res, j, i_attencoding));
 			else
 				tbinfo->attencoding[j] = NULL;
+
+			/*
+			 * External table doesn't support inheritance so ensure that all
+			 * attributes are marked as local.  Applicable to partitioned
+			 * tables where a partition is exhanged for an external table.
+			 */
+			if (tbinfo->relstorage == RELSTORAGE_EXTERNAL && tbinfo->attislocal[j])
+				tbinfo->attislocal[j] = false;
 		}
 
 		PQclear(res);


### PR DESCRIPTION
Attribute inheritance in pg_dump was cleaned up in upstream commit 02e6418 which was part of the 8.3 merge, and as an effect of this external tables were dumped as inheriting the partition parent attributes. In a scenario like the one below, the external relation gets dumped with an empty attribute list:
```SQL
  create table t (a integer, b integer, c integer)
  distributed by (a) partition by range (a)
  (start (2002) end (2010) every (1), default partition outlying_years);

  create external table t_1_prt_2_external
  (a integer, b integer, c integer)
  location ('gpfdist://foo:123/bar')
  format ‘csv’ (delimiter E',' null E'' escape '"' quote E'"')
  encoding 'utf8';

  alter table t exchange partition for ('2002’)
  with table t_1_prt_2_external without validation;
```
When exchanging a partition for an external relation, the inheritance information should not be propagated as external tables doesn't support attribute inheritance.

Fix existing cluster by always setting the attributes as local for external tables and make it even more explicit by altering the attribute check in dumpExternal to only consider dropped attributes. Apply the fix to both pg_dump and cdb_dump_agent albeit a tad differently as pg_dump has abstracted the logic for printing column names.

Per report and debugging by @larham @khuddlefish @chrishajas