### PR TITLE
Revamp gp_fastsequence handling.

### DIFF
--- a/src/backend/cdb/cdbpersistentrelation.c
+++ b/src/backend/cdb/cdbpersistentrelation.c
@@ -19,7 +19,6 @@
 #include "catalog/pg_tablespace.h"
 #include "catalog/pg_database.h"
 #include "catalog/gp_persistent.h"
-#include "catalog/gp_fastsequence.h"
 #include "cdb/cdbsharedoidsearch.h"
 #include "access/persistentfilesysobjname.h"
 #include "cdb/cdbdirectopen.h"
@@ -38,9 +37,6 @@
 #include "storage/ipc.h"
 #include "utils/builtins.h"
 #include "utils/faultinjector.h"
-#include "utils/fmgroids.h"
-#include "utils/lsyscache.h"
-
 
 /*
  * This module is for generic relation file create and drop.
@@ -872,52 +868,6 @@ PersistentFileSysObjStateChangeResult PersistentRelation_MarkAbortingCreate(
 
 		return false;	// The initdb process will load the persistent table once we out of bootstrap mode.
 	}
-
-	/* MPP-16543: When inserting tuples into AO table, row numbers will be
-	 * generated from gp_fastsequence catalog table, as part of the design,
-	 * these sequence numbers are not reusable, even if the AO insert 
-	 * transaction is aborted. The entry in gp_fastsequence was inserted
-	 * using frozen_heap_insert, which means it's always visible. 
-
-	 * Aborted AO insert transaction will cause inconsistency between 
-	 * gp_fastsequence and pg_class, the solution is to introduce "frozen 
-	 * delete" - inplace update tuple's MVCC header to make it invisible.
-	 */
-
-	Relation gp_fastsequence_rel = heap_open(FastSequenceRelationId, RowExclusiveLock);
-	HeapTuple   tup;
-	SysScanDesc scan;
-	ScanKeyData skey; 
-	ScanKeyInit(&skey,
-				Anum_gp_fastsequence_objid,
-				BTEqualStrategyNumber,
-				F_OIDEQ,
-				relFileNode->relNode);
-
-	scan = systable_beginscan(gp_fastsequence_rel,
-							  InvalidOid,
-							  false,
-							  SnapshotNow,
-							  1,
-							  &skey);
-	while (HeapTupleIsValid(tup = systable_getnext(scan)))
-	{
-		Form_gp_fastsequence found = (Form_gp_fastsequence) GETSTRUCT(tup);
-		if (found->objid == relFileNode->relNode) 
-		{	
-			if (Debug_persistent_print)
-			{
-			elog(LOG, "frozen deleting gp_fastsequence entry for aborted AO insert transaction on relation %s", relpath(*relFileNode));
-			}
-
-			frozen_heap_inplace_delete(gp_fastsequence_rel, tup);
-		}
-	}						
-	systable_endscan(scan);
-	heap_close(gp_fastsequence_rel, RowExclusiveLock);
-	
-
-	
 
 	PersistentRelation_VerifyInitScan();
 

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -34,7 +34,6 @@
 #include "cdb/cdbpersistenttablespace.h"
 #include "cdb/cdbpersistentdatabase.h"
 #include "cdb/cdbpersistentrelation.h"
-#include "cdb/cdbpersistentrecovery.h"
 #include "cdb/cdbpersistentcheck.h"
 #include "cdb/cdbresynchronizechangetracking.h"
 #include "cdb/cdbvars.h"
@@ -174,7 +173,6 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		size = add_size(size, PersistentTablespace_ShmemSize());
 		size = add_size(size, PersistentDatabase_ShmemSize());
 		size = add_size(size, PersistentRelation_ShmemSize());
-		size = add_size(size, Pass2Recovery_ShmemSize());
 
 		/*Add shared memory for PT verification checks*/
 		if (Gp_role == GP_ROLE_DISPATCH && debug_persistent_ptcat_verification)
@@ -319,7 +317,6 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	PersistentTablespace_ShmemInit();
 	PersistentDatabase_ShmemInit();
 	PersistentRelation_ShmemInit();
-	Pass2Recovery_ShmemInit();
 
 	if (Gp_role == GP_ROLE_DISPATCH && debug_persistent_ptcat_verification)
 		Persistent_PostDTMRecv_ShmemInit();

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -269,7 +269,6 @@ extern HTSU_Result heap_lock_tuple(Relation relation, HeapTuple tuple,
 				LockTupleMode mode, LockTupleWaitType waittype);
 extern void heap_inplace_update(Relation relation, HeapTuple tuple);
 extern void frozen_heap_inplace_update(Relation relation, HeapTuple tuple);
-extern void frozen_heap_inplace_delete(Relation relation, HeapTuple tuple);
 extern bool heap_freeze_tuple(HeapTupleHeader tuple, TransactionId cutoff_xid,
 				  Buffer buf);
 

--- a/src/include/cdb/cdbpersistentrecovery.h
+++ b/src/include/cdb/cdbpersistentrecovery.h
@@ -13,29 +13,6 @@
 #include "access/xlog.h"
 #include "cdb/cdbpersistentstore.h"
 
-typedef struct Pass2RecoveryHashShmem_s {
-
-	HTAB    *hash;
-
-} Pass2RecoveryHashShmem_s; 
-
-typedef struct Pass2RecoveryHashEntry_s {
-	
-	Oid objid;
-
-	int32 segmentFileNum;
-
-} Pass2RecoveryHashEntry_s;
-
-extern Pass2RecoveryHashShmem_s *pass2RecoveryHashShmem;
-
-extern void Pass2Recovery_ShmemInit(void);
-
-extern Size Pass2Recovery_ShmemSize(void);
-
-/* max number of AbortingCreate entry tracked in shared memory hash table */
-#define GP_MAX_PASS2RECOVERY_ABORTINGCREATE 128
-
 inline static int PersistentRecovery_DebugPrintLevel(void)
 {
 	if (Debug_persistent_bootstrap_print && IsBootstrapProcessingMode())
@@ -43,7 +20,6 @@ inline static int PersistentRecovery_DebugPrintLevel(void)
 	else
 		return Debug_persistent_recovery_print_level;
 }
-
 
 extern bool
 PersistentRecovery_ShouldHandlePass1XLogRec(

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -266,7 +266,30 @@ begin;
 insert into addcol6 select i,i from generate_series(1,10)i;
 -- abort the first insert, so as to advance gp_fastsequence for this
 -- relation.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='addcol6'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ FrozenXid |      1 |           100 |             0
+ FrozenXid |      1 |           100 |             1
+ FrozenXid |      1 |           100 |             2
+(3 rows)
+
 abort;
+-- check gp_fastsequence remains advanced.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='addcol6'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ FrozenXid |      1 |           100 |             1
+ FrozenXid |      1 |           100 |             2
+ FrozenXid |      1 |           100 |             0
+(3 rows)
+
 insert into addcol6 select i,i/2 from generate_series(1,20)i;
 alter table addcol6 add column c float default 1.2;
 select a,c from addcol6 where b > 5 order by a;
@@ -282,6 +305,18 @@ select a,c from addcol6 where b > 5 order by a;
  19 | 1.2
  20 | 1.2
 (9 rows)
+
+-- Lets validate after alter gp_fastsequence reflects correctly.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='addcol6'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ FrozenXid |      1 |           200 |             2
+ FrozenXid |      1 |           200 |             0
+ FrozenXid |      1 |           200 |             1
+(3 rows)
 
 -- add column with default value as sequence
 alter table addcol6 add column d serial;

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -55,6 +55,15 @@ SELECT * FROM distxact1_1;
 ---
 (0 rows)
 
+-- Reindex on pg_class or reindex database hung if encountered ERROR, due to a
+-- bug. Lets have coverage to validate doesn't happen now.
+\c postgres
+SET debug_abort_after_distributed_prepared = true;
+reindex table pg_class;
+NOTICE:  Releasing segworker groups to retry broadcast.
+ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
+SET debug_abort_after_distributed_prepared = false;
+\c regression
 --
 -- We want to have an error during the prepare which will cause a Abort-Some-Prepared broadcast 
 -- to cleanup.

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -141,6 +141,10 @@ SELECT aototal('tenk_aocs1'), aototal('tenk_aocs2'), aototal('tenk_aocs3'), aoto
 -------------------- 
 -- transactionality
 --------------------
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_aocs1'));
 
 -- rollback
 BEGIN;
@@ -149,6 +153,13 @@ SELECT count(*) FROM tenk_aocs1; -- should show new count
 ROLLBACK;
 SELECT count(*) FROM tenk_aocs1; -- should show previous count
 SELECT aototal('tenk_aocs1');
+
+-- gp_fastsequence should reflect bump in lastsequence, even if above
+-- transaction aborted as its tuples is in place updated.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_aocs1'));
 
 -- commit
 BEGIN;
@@ -215,6 +226,12 @@ DROP TABLE tenk_aocs4;
 
 -- CTAS
 CREATE TABLE tenk_aocs1 with(appendonly=true, orientation=column, checksum=true) AS SELECT * FROM tenk_heap_for_aocs;
+-- Incase of CTAS, gp_fastsequence must use create table's transaction id to
+-- insert into gp_fastsequence which is NormalXid and not FrozenXid.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_aocs1'));
 CREATE TABLE tenk_aocs2 with(appendonly=true, orientation=column, compresslevel=0, blocksize=262144) AS SELECT * FROM tenk_heap_for_aocs;
 CREATE TABLE tenk_aocs3 with(appendonly=true, orientation=column, compresslevel=6, blocksize=1048576, checksum=true) AS SELECT * FROM tenk_heap_for_aocs;
 CREATE TABLE tenk_aocs4 with(appendonly=true, orientation=column, compresslevel=1, compresstype=zlib) AS SELECT * FROM tenk_heap_for_aocs;
@@ -291,9 +308,23 @@ SELECT count(*) FROM tenk_aocs1 t1 LEFT OUTER JOIN empty_aocs_table_for_join t2 
 SELECT unique1 FROM tenk_aocs1 EXCEPT SELECT unique1 FROM tenk_aocs1;
 SELECT unique1 FROM tenk_heap_for_aocs EXCEPT SELECT unique1 FROM tenk_aocs3;
 
+-- Get gp_fastsequence details before truncate
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_aocs2'));
+
 -- TRUNCATE
 TRUNCATE tenk_aocs2;
 SELECT count(*) FROM tenk_aocs2;
+
+-- Truncate changes relfilnode, as a result old pg_aocsseg table is dropped and
+-- frehsly created. Hence validate post truncate gp_fastsequence entries are
+-- cleaned-up.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao2;'));
 
 -- OID with aocs NYI
 -- OIDS

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -133,7 +133,10 @@ SELECT aototal('tenk_ao1'), aototal('tenk_ao2'), aototal('tenk_ao3'), aototal('t
 -------------------- 
 -- transactionality
 --------------------
-
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao1'));
 -- rollback
 BEGIN;
 INSERT INTO tenk_ao1 SELECT * FROM tenk_heap;
@@ -141,6 +144,12 @@ SELECT count(*) FROM tenk_ao1; -- should show new count
 ROLLBACK;
 SELECT count(*) FROM tenk_ao1; -- should show previous count
 SELECT aototal('tenk_ao1');
+-- gp_fastsequence should reflect bump in lastsequence, even if above
+-- transaction aborted as its tuples is in place updated.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao1'));
 
 -- commit
 BEGIN;
@@ -207,6 +216,12 @@ DROP TABLE tenk_ao4;
 
 -- CTAS
 CREATE TABLE tenk_ao1 with(appendonly=true, checksum=true) AS SELECT * FROM tenk_heap;
+-- Incase of CTAS, gp_fastsequence must use create table's transaction id to
+-- insert into gp_fastsequence which is NormalXid and not FrozenXid.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao1'));
 CREATE TABLE tenk_ao2 with(appendonly=true, compresslevel=0, blocksize=262144) AS SELECT * FROM tenk_heap;
 CREATE TABLE tenk_ao3 with(appendonly=true, compresslevel=6, blocksize=1048576, checksum=true) AS SELECT * FROM tenk_heap;
 CREATE TABLE tenk_ao4 with(appendonly=true, compresslevel=1, compresstype=zlib) AS SELECT * FROM tenk_heap;
@@ -216,6 +231,22 @@ SELECT count(*) FROM tenk_ao1;
 SELECT count(*) FROM tenk_ao2;
 SELECT count(*) FROM tenk_ao3;
 SELECT count(*) FROM tenk_ao4;
+
+-- Perform same transaction CREATE, followed by INSERT to validate
+-- gp_fastseqeunce is using normal xid and not frozen transaction id.
+BEGIN;
+CREATE TABLE appendonly_sametxn_create_insert(a int, b int) with (appendonly=true);
+INSERT INTO appendonly_sametxn_create_insert select * from generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_sametxn_create_insert'));
+INSERT INTO appendonly_sametxn_create_insert select * from generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_sametxn_create_insert'));
+ABORT;
 
 -- test get_ao_compression_ratio. use uncompressed table, so result is always 1.
 SELECT get_ao_compression_ratio('tenk_ao2');
@@ -255,8 +286,22 @@ SELECT count(*) FROM tenk_ao1 t1 LEFT OUTER JOIN empty_ao_table_for_join t2 ON (
 SELECT unique1 FROM tenk_ao1 EXCEPT SELECT unique1 FROM tenk_ao1;
 SELECT unique1 FROM tenk_heap EXCEPT SELECT unique1 FROM tenk_ao3;
 
+-- Get gp_fastsequence details before truncate
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao2'));
+
 -- TRUNCATE
 TRUNCATE tenk_ao2;
+
+-- Truncate changes relfilnode, as a result old pg_aoseg table is dropped and
+-- frehsly created. Hence validate post truncate gp_fastsequence entries are
+-- cleaned-up.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao2;'));
 
 -- OIDS
 CREATE TABLE aowithoids(a int, b int) WITH (appendonly=true,oids=true);
@@ -398,12 +443,14 @@ UPDATE tenk_ao1 SET two = 2;
 select count(*) from gp_toolkit.__gp_aoseg_name('tenk_ao1') where modcount > 1;
 select count(*) from tenk_ao1 where unique2 < 0;
 
--------------------- 
--- unsupported sql 
---------------------
 -- ALTER
 ALTER TABLE tenk_ao1 RENAME TO tenk_renamed;
 ALTER TABLE tenk_renamed ADD COLUMN newcol int default 10;
+-- Validate post alter gp_fastsequence reflects correctly
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_renamed'));
 ALTER TABLE tenk_renamed ALTER COLUMN twothousand SET NOT NULL;
 ALTER TABLE tenk_renamed ADD COLUMN sercol serial; -- MPP-10015
 ALTER TABLE tenk_renamed ADD COLUMN newcol2 int NOT NULL; -- should fail
@@ -442,9 +489,17 @@ DROP TABLE aosizetest_2;
 DROP TABLE IF EXISTS ao_selection;
 CREATE TABLE ao_selection (a INT, b INT) WITH (appendonly=true);
 INSERT INTO ao_selection VALUES (generate_series(1,100000), generate_series(1,10000));
-SELECT count(*) from gp_fastsequence WHERE objid IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class WHERE relname='ao_selection'));
+-- Validates insert is using single segfile and FrozenXid is used to perform the
+-- insert to gp_fastsequence.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='ao_selection'));
 INSERT INTO ao_selection values (generate_series(1,100000), generate_series(1,10000));
-SELECT count(*) FROM gp_fastsequence WHERE objid IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class WHERE relname='ao_selection'));
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='ao_selection'));
 
 -- Check compression and distribution
 create table ao_compress_table (id int, v varchar)
@@ -477,3 +532,85 @@ DROP TABLE tenk_ao4;
 DROP TABLE tenk_ao5;
 DROP TABLE aowithoids;
 DROP TABLE ao_selection;
+
+---------------------------------------------------------------
+-- Sub-transaction tests to validate working of gp_fastsequence
+---------------------------------------------------------------
+-- create table in sub-transaction aborts but top transaction commits
+BEGIN;
+SAVEPOINT sp1;
+CREATE TABLE appendonly_subxans_test(a int, b int) WITH (appendonly=true);
+INSERT INTO appendonly_subxans_test SELECT * FROM generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+ROLLBACK TO SAVEPOINT sp1;
+COMMIT;
+
+-- create table and insert in nested subtransaction, to validate insert to
+-- gp_fastsequence is using NormalXid and not FrozenXid.
+BEGIN;
+SAVEPOINT sp1;
+CREATE TABLE appendonly_subxans_test(a int, b int) WITH (appendonly=true);
+SAVEPOINT sp2;
+INSERT INTO appendonly_subxans_test SELECT * FROM generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+ROLLBACK TO SAVEPOINT sp1;
+COMMIT;
+
+-- create table and insert in independent subtransactions, validate insert to
+-- gp_fastsequence is using NormalXid and not FrozenXid and stays despite
+-- inserting subtransaction aborting.
+BEGIN;
+SAVEPOINT sp1;
+CREATE TABLE appendonly_subxans_test1(a int, b int) WITH (appendonly=true);
+RELEASE SAVEPOINT sp1;
+SAVEPOINT sp2;
+INSERT INTO appendonly_subxans_test1 SELECT * FROM generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test1'));
+ROLLBACK TO SAVEPOINT sp2;
+COMMIT;
+SELECT * FROM appendonly_subxans_test1;
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test1'));
+
+-- create table in top transaction but first insert in sub-transaction
+BEGIN;
+CREATE TABLE appendonly_subxans_test(a int, b int) WITH (appendonly=true);
+create index appendonly_subxans_test_idx on appendonly_subxans_test using btree(a);
+SAVEPOINT sp1;
+insert into appendonly_subxans_test select * from generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+ROLLBACK TO SAVEPOINT sp1;
+insert into appendonly_subxans_test select * from generate_series(11, 20);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+COMMIT;
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+-- Validation to make sure gp_fastsequence is not broken. If gp_fastsequence is
+-- malfunctioning then this will return wrong result.
+SELECT * FROM appendonly_subxans_test WHERE a < 10;
+
+--------------------------------------------------------------------------------
+-- Finally check to detect if any dangling gp_fastsequence entries are left
+-- behind by this SQL file
+--------------------------------------------------------------------------------
+SELECT objid FROM gp_fastsequence AS gfs LEFT OUTER JOIN (SELECT oid FROM
+pg_class) AS pgc ON (gfs.objid = pgc.oid) WHERE pgc.oid IS NULL;

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -228,6 +228,17 @@ SELECT aototal('tenk_aocs1'), aototal('tenk_aocs2'), aototal('tenk_aocs3'), aoto
 -------------------- 
 -- transactionality
 --------------------
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_aocs1'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ FrozenXid |      1 |         13500 |             1
+ FrozenXid |      1 |         13500 |             0
+ FrozenXid |      1 |         13600 |             2
+(3 rows)
+
 -- rollback
 BEGIN;
 INSERT INTO tenk_aocs1 SELECT * FROM tenk_heap_for_aocs;
@@ -249,6 +260,19 @@ SELECT aototal('tenk_aocs1');
 ---------
    40000
 (1 row)
+
+-- gp_fastsequence should reflect bump in lastsequence, even if above
+-- transaction aborted as its tuples is in place updated.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_aocs1'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ FrozenXid |      1 |         16900 |             1
+ FrozenXid |      1 |         16900 |             0
+ FrozenXid |      1 |         17000 |             2
+(3 rows)
 
 -- commit
 BEGIN;
@@ -381,6 +405,19 @@ DROP TABLE tenk_aocs3;
 DROP TABLE tenk_aocs4;
 -- CTAS
 CREATE TABLE tenk_aocs1 with(appendonly=true, orientation=column, checksum=true) AS SELECT * FROM tenk_heap_for_aocs;
+-- Incase of CTAS, gp_fastsequence must use create table's transaction id to
+-- insert into gp_fastsequence which is NormalXid and not FrozenXid.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_aocs1'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      0 |          3400 |             0
+ NormalXid |      0 |          3400 |             1
+ NormalXid |      0 |          3400 |             2
+(3 rows)
+
 CREATE TABLE tenk_aocs2 with(appendonly=true, orientation=column, compresslevel=0, blocksize=262144) AS SELECT * FROM tenk_heap_for_aocs;
 CREATE TABLE tenk_aocs3 with(appendonly=true, orientation=column, compresslevel=6, blocksize=1048576, checksum=true) AS SELECT * FROM tenk_heap_for_aocs;
 CREATE TABLE tenk_aocs4 with(appendonly=true, orientation=column, compresslevel=1, compresstype=zlib) AS SELECT * FROM tenk_heap_for_aocs;
@@ -578,6 +615,21 @@ SELECT unique1 FROM tenk_heap_for_aocs EXCEPT SELECT unique1 FROM tenk_aocs3;
 ---------
 (0 rows)
 
+-- Get gp_fastsequence details before truncate
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_aocs2'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      0 |          3400 |             2
+ FrozenXid |      1 |           100 |             2
+ NormalXid |      0 |          3400 |             0
+ FrozenXid |      1 |           100 |             0
+ NormalXid |      0 |          3400 |             1
+ FrozenXid |      1 |           100 |             1
+(6 rows)
+
 -- TRUNCATE
 TRUNCATE tenk_aocs2;
 SELECT count(*) FROM tenk_aocs2;
@@ -585,6 +637,17 @@ SELECT count(*) FROM tenk_aocs2;
 -------
      0
 (1 row)
+
+-- Truncate changes relfilnode, as a result old pg_aocsseg table is dropped and
+-- frehsly created. Hence validate post truncate gp_fastsequence entries are
+-- cleaned-up.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao2;'));
+ case | objmod | last_sequence | gp_segment_id 
+------+--------+---------------+---------------
+(0 rows)
 
 -- OID with aocs NYI
 -- OIDS

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -217,6 +217,17 @@ SELECT aototal('tenk_ao1'), aototal('tenk_ao2'), aototal('tenk_ao3'), aototal('t
 -------------------- 
 -- transactionality
 --------------------
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao1'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ FrozenXid |      1 |         13500 |             0
+ FrozenXid |      1 |         13500 |             1
+ FrozenXid |      1 |         13600 |             2
+(3 rows)
+
 -- rollback
 BEGIN;
 INSERT INTO tenk_ao1 SELECT * FROM tenk_heap;
@@ -238,6 +249,19 @@ SELECT aototal('tenk_ao1');
 ---------
    40000
 (1 row)
+
+-- gp_fastsequence should reflect bump in lastsequence, even if above
+-- transaction aborted as its tuples is in place updated.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao1'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ FrozenXid |      1 |         16900 |             1
+ FrozenXid |      1 |         17000 |             2
+ FrozenXid |      1 |         16900 |             0
+(3 rows)
 
 -- commit
 BEGIN;
@@ -372,6 +396,19 @@ DROP TABLE tenk_ao4;
 CREATE TABLE tenk_ao1 with(appendonly=true, checksum=true) AS SELECT * FROM tenk_heap;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'unique1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Incase of CTAS, gp_fastsequence must use create table's transaction id to
+-- insert into gp_fastsequence which is NormalXid and not FrozenXid.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao1'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      0 |          3400 |             0
+ NormalXid |      0 |          3400 |             1
+ NormalXid |      0 |          3400 |             2
+(3 rows)
+
 CREATE TABLE tenk_ao2 with(appendonly=true, compresslevel=0, blocksize=262144) AS SELECT * FROM tenk_heap;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'unique1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -416,6 +453,37 @@ SELECT count(*) FROM tenk_ao4;
  10000
 (1 row)
 
+-- Perform same transaction CREATE, followed by INSERT to validate
+-- gp_fastseqeunce is using normal xid and not frozen transaction id.
+BEGIN;
+CREATE TABLE appendonly_sametxn_create_insert(a int, b int) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO appendonly_sametxn_create_insert select * from generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_sametxn_create_insert'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      1 |           100 |             2
+ NormalXid |      1 |           100 |             0
+ NormalXid |      1 |           100 |             1
+(3 rows)
+
+INSERT INTO appendonly_sametxn_create_insert select * from generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_sametxn_create_insert'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      1 |           200 |             0
+ NormalXid |      1 |           200 |             1
+ NormalXid |      1 |           200 |             2
+(3 rows)
+
+ABORT;
 -- test get_ao_compression_ratio. use uncompressed table, so result is always 1.
 SELECT get_ao_compression_ratio('tenk_ao2');
  get_ao_compression_ratio 
@@ -541,8 +609,34 @@ SELECT unique1 FROM tenk_heap EXCEPT SELECT unique1 FROM tenk_ao3;
 ---------
 (0 rows)
 
+-- Get gp_fastsequence details before truncate
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao2'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      0 |          3400 |             0
+ FrozenXid |      1 |           100 |             0
+ NormalXid |      0 |          3400 |             1
+ FrozenXid |      1 |           100 |             1
+ NormalXid |      0 |          3400 |             2
+ FrozenXid |      1 |           100 |             2
+(6 rows)
+
 -- TRUNCATE
 TRUNCATE tenk_ao2;
+-- Truncate changes relfilnode, as a result old pg_aoseg table is dropped and
+-- frehsly created. Hence validate post truncate gp_fastsequence entries are
+-- cleaned-up.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_ao2;'));
+ case | objmod | last_sequence | gp_segment_id 
+------+--------+---------------+---------------
+(0 rows)
+
 -- OIDS
 CREATE TABLE aowithoids(a int, b int) WITH (appendonly=true,oids=true);
 NOTICE:  OIDS=TRUE is not recommended for user-created tables. Use OIDS=FALSE to prevent wrap-around of the OID counter
@@ -886,12 +980,21 @@ select count(*) from tenk_ao1 where unique2 < 0;
      6
 (1 row)
 
--------------------- 
--- unsupported sql 
---------------------
 -- ALTER
 ALTER TABLE tenk_ao1 RENAME TO tenk_renamed;
 ALTER TABLE tenk_renamed ADD COLUMN newcol int default 10;
+-- Validate post alter gp_fastsequence reflects correctly
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='tenk_renamed'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      0 |          3400 |             0
+ NormalXid |      0 |          3400 |             1
+ NormalXid |      0 |          3400 |             2
+(3 rows)
+
 ALTER TABLE tenk_renamed ALTER COLUMN twothousand SET NOT NULL;
 ALTER TABLE tenk_renamed ADD COLUMN sercol serial; -- MPP-10015
 NOTICE:  ALTER TABLE will create implicit sequence "tenk_renamed_sercol_seq" for serial column "tenk_renamed.sercol"
@@ -955,18 +1058,30 @@ DROP TABLE aosizetest_2;
 DROP TABLE IF EXISTS ao_selection;
 CREATE TABLE ao_selection (a INT, b INT) WITH (appendonly=true);
 INSERT INTO ao_selection VALUES (generate_series(1,100000), generate_series(1,10000));
-SELECT count(*) from gp_fastsequence WHERE objid IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class WHERE relname='ao_selection'));
- count 
--------
-     1
-(1 row)
+-- Validates insert is using single segfile and FrozenXid is used to perform the
+-- insert to gp_fastsequence.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='ao_selection'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ FrozenXid |      1 |         33400 |             2
+ FrozenXid |      1 |         33400 |             0
+ FrozenXid |      1 |         33400 |             1
+(3 rows)
 
 INSERT INTO ao_selection values (generate_series(1,100000), generate_series(1,10000));
-SELECT count(*) FROM gp_fastsequence WHERE objid IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class WHERE relname='ao_selection'));
- count 
--------
-     1
-(1 row)
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='ao_selection'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ FrozenXid |      1 |         66800 |             1
+ FrozenXid |      1 |         66800 |             2
+ FrozenXid |      1 |         66800 |             0
+(3 rows)
 
 -- Check compression and distribution
 create table ao_compress_table (id int, v varchar)
@@ -1009,3 +1124,149 @@ DROP TABLE tenk_ao4;
 DROP TABLE tenk_ao5;
 DROP TABLE aowithoids;
 DROP TABLE ao_selection;
+---------------------------------------------------------------
+-- Sub-transaction tests to validate working of gp_fastsequence
+---------------------------------------------------------------
+-- create table in sub-transaction aborts but top transaction commits
+BEGIN;
+SAVEPOINT sp1;
+CREATE TABLE appendonly_subxans_test(a int, b int) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO appendonly_subxans_test SELECT * FROM generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      1 |           100 |             0
+ NormalXid |      1 |           100 |             2
+ NormalXid |      1 |           100 |             1
+(3 rows)
+
+ROLLBACK TO SAVEPOINT sp1;
+COMMIT;
+-- create table and insert in nested subtransaction, to validate insert to
+-- gp_fastsequence is using NormalXid and not FrozenXid.
+BEGIN;
+SAVEPOINT sp1;
+CREATE TABLE appendonly_subxans_test(a int, b int) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SAVEPOINT sp2;
+INSERT INTO appendonly_subxans_test SELECT * FROM generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      1 |           100 |             0
+ NormalXid |      1 |           100 |             1
+ NormalXid |      1 |           100 |             2
+(3 rows)
+
+ROLLBACK TO SAVEPOINT sp1;
+COMMIT;
+-- create table and insert in independent subtransactions, validate insert to
+-- gp_fastsequence is using NormalXid and not FrozenXid and stays despite
+-- inserting subtransaction aborting.
+BEGIN;
+SAVEPOINT sp1;
+CREATE TABLE appendonly_subxans_test1(a int, b int) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+RELEASE SAVEPOINT sp1;
+SAVEPOINT sp2;
+INSERT INTO appendonly_subxans_test1 SELECT * FROM generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test1'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      1 |           100 |             2
+ NormalXid |      1 |           100 |             0
+ NormalXid |      1 |           100 |             1
+(3 rows)
+
+ROLLBACK TO SAVEPOINT sp2;
+COMMIT;
+SELECT * FROM appendonly_subxans_test1;
+ a | b 
+---+---
+(0 rows)
+
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test1'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      1 |           100 |             1
+ NormalXid |      1 |           100 |             2
+ NormalXid |      1 |           100 |             0
+(3 rows)
+
+-- create table in top transaction but first insert in sub-transaction
+BEGIN;
+CREATE TABLE appendonly_subxans_test(a int, b int) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index appendonly_subxans_test_idx on appendonly_subxans_test using btree(a);
+SAVEPOINT sp1;
+insert into appendonly_subxans_test select * from generate_series(1, 10);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      1 |           100 |             0
+ NormalXid |      1 |           100 |             2
+ NormalXid |      1 |           100 |             1
+(3 rows)
+
+ROLLBACK TO SAVEPOINT sp1;
+insert into appendonly_subxans_test select * from generate_series(11, 20);
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      1 |           200 |             1
+ NormalXid |      1 |           200 |             2
+ NormalXid |      1 |           200 |             0
+(3 rows)
+
+COMMIT;
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='appendonly_subxans_test'));
+   case    | objmod | last_sequence | gp_segment_id 
+-----------+--------+---------------+---------------
+ NormalXid |      1 |           200 |             0
+ NormalXid |      1 |           200 |             1
+ NormalXid |      1 |           200 |             2
+(3 rows)
+
+-- Validation to make sure gp_fastsequence is not broken. If gp_fastsequence is
+-- malfunctioning then this will return wrong result.
+SELECT * FROM appendonly_subxans_test WHERE a < 10;
+ a | b 
+---+---
+(0 rows)
+
+--------------------------------------------------------------------------------
+-- Finally check to detect if any dangling gp_fastsequence entries are left
+-- behind by this SQL file
+--------------------------------------------------------------------------------
+SELECT objid FROM gp_fastsequence AS gfs LEFT OUTER JOIN (SELECT oid FROM
+pg_class) AS pgc ON (gfs.objid = pgc.oid) WHERE pgc.oid IS NULL;
+ objid 
+-------
+(0 rows)
+

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -181,11 +181,27 @@ begin;
 insert into addcol6 select i,i from generate_series(1,10)i;
 -- abort the first insert, so as to advance gp_fastsequence for this
 -- relation.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='addcol6'));
 abort;
+
+-- check gp_fastsequence remains advanced.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='addcol6'));
 
 insert into addcol6 select i,i/2 from generate_series(1,20)i;
 alter table addcol6 add column c float default 1.2;
 select a,c from addcol6 where b > 5 order by a;
+
+-- Lets validate after alter gp_fastsequence reflects correctly.
+SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
+last_sequence, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
+WHERE relname='addcol6'));
 
 -- add column with default value as sequence
 alter table addcol6 add column d serial;

--- a/src/test/regress/sql/distributed_transactions.sql
+++ b/src/test/regress/sql/distributed_transactions.sql
@@ -49,6 +49,13 @@ RESET debug_abort_after_distributed_prepared;
 
 SELECT * FROM distxact1_1;
 
+-- Reindex on pg_class or reindex database hung if encountered ERROR, due to a
+-- bug. Lets have coverage to validate doesn't happen now.
+\c postgres
+SET debug_abort_after_distributed_prepared = true;
+reindex table pg_class;
+SET debug_abort_after_distributed_prepared = false;
+\c regression
 --
 -- We want to have an error during the prepare which will cause a Abort-Some-Prepared broadcast 
 -- to cleanup.


### PR DESCRIPTION
Context:
gp_fastsequence is used to generate and keep track of row numbers for AO and CO
tables. Row numbers for AO/CO tables act as a component to form TID, stored in
index tuples and used during index scans to lookup intended tuple. Hence this
number must be monotonically incrementing value. Also should not rollback
irrespective of insert/update transaction aborting for AO/CO table, as reusing
row numbers even across aborted transactions would yield wrong results for index
scans. Also, entries in gp_fastsequence only must exist for lifespan of the
corresponding table.

Change:
Given those special needs inserts to gp_fastsequence are performed either using
frozen xids or normal xids now. Frozen xids are used in majority of
scenarios. Only for CTAS or same transaction create and insert, normal
transaction id is used to leverage MVCC mechanism to clean out gp_fastsequence
tuple in case of failures / aborts. Xmin of pg_class tuple for
pg_aoseg/pg_aocsseg table is used to check if insert to gp_fastseqeunce is part
of same transaction which created the table or not.

With that change in logic to leverage MVCC to handle cleanup of entries for
gp_fastseqeunce, enables to get rid of special recovery and abort code
performing frozen deletes. With that code gone also fixes issue of `REINDEX
DATABASE` or `REINDEX TABLE pg_class` hang on segment nodes if encounters error
after Prepare Transaction.

Output of helpful interaction with Heikki Linnakangas and Asim R P.
See discussion on gpdb-dev, thread 'reindex database abort hang':
https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/ASml6lN0qRE