### PR TITLE
Make DML_over_joins deterministic by adding a constraint.

### DIFF
--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -394,7 +394,7 @@ delete from s where b = (select min(a) from r where b = s.b);
 -- end_ignore
 update p set c = c + 1;
 ERROR:  moving tuple from partition "p_1_prt_extra" to partition "p_1_prt_2" not supported  (seg1 rhel62-vm1:25433 pid=19028)
-update p set c = c + 1 where b in (select b from s);
+update p set c = c + 1 where b in (select b from s) and c = 0;
 ERROR:  moving tuple from partition "p_1_prt_extra" to partition "p_1_prt_2" not supported  (seg2 rhel62-vm1:25434 pid=19030)
 -- ----------------------------------------------------------------------
 -- Test: unsupported_cases1.sql

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -398,7 +398,7 @@ delete from s where b = (select min(a) from r where b = s.b);
 ------------------------------------------------------------
 -- end_ignore
 update p set c = c + 1;
-update p set c = c + 1 where b in (select b from s);
+update p set c = c + 1 where b in (select b from s) and c = 0;
 -- ----------------------------------------------------------------------
 -- Test: unsupported_cases1.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/sql/DML_over_joins.sql
+++ b/src/test/regress/sql/DML_over_joins.sql
@@ -521,7 +521,7 @@ delete from s where b = (select min(a) from r where b = s.b);
 
 update p set c = c + 1;
 
-update p set c = c + 1 where b in (select b from s);
+update p set c = c + 1 where b in (select b from s) and c = 0;
 -- ----------------------------------------------------------------------
 -- Test: unsupported_cases1.sql
 -- ----------------------------------------------------------------------


### PR DESCRIPTION

Consider a similar SELECT query instead of the UPDATE and its plan :
```
shardikar=# explain select b, c, c+1 from p where b in (select b from s);
                                                   QUERY PLAN
-----------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice3; segments: 3)  (cost=10.50..5963.50 rows=38950 width=8)
   ->  Hash Join  (cost=10.50..5963.50 rows=12984 width=8)
         Hash Cond: public.p.b = s.b
         ->  Append  (cost=0.00..4395.00 rows=129834 width=8)
               ->  Seq Scan on p_1_prt_extra p  (cost=0.00..879.00 rows=25967 width=8)
               ->  Seq Scan on p_1_prt_2 p  (cost=0.00..879.00 rows=25967 width=8)
               ->  Seq Scan on p_1_prt_3 p  (cost=0.00..879.00 rows=25967 width=8)
               ->  Seq Scan on p_1_prt_4 p  (cost=0.00..879.00 rows=25967 width=8)
               ->  Seq Scan on p_1_prt_5 p  (cost=0.00..879.00 rows=25967 width=8)
         ->  Hash  (cost=9.25..9.25 rows=34 width=4)
               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=6.25..9.25 rows=34 width=4)
                     ->  HashAggregate  (cost=6.25..7.25 rows=34 width=4)
                           Group By: s.b
                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=4)
                                 Hash Key: s.b
                                 ->  Seq Scan on s  (cost=0.00..4.00 rows=34 width=4)
 Settings:  enable_hashjoin=on; optimizer=off
 Optimizer status: legacy query optimizer
(18 rows)
```

In this we construct a hash table on the inner side of a hash join. Since the order of data coming in from the Motion is not deterministic, the hash table constructed will not be deterministic. And this means that error will change based on the specific row considered.

```
shardikar=#  select c from p where b in (select b from s order by b) group by c;
 c
---
 0
 2
 4
(3 rows)
```

There are 3 possible source partitions. One solution that seems acceptable is to just add another constraint on c in the query. That way only one partition is selection, but we'll still keep the join.


Signed-off-by: Haisheng Yuan <hyuan@pivotal.io>