### PR TITLE
Fix the calculation of hidden tuple ratio for Appendonly tables.

### DIFF
--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -81,9 +81,9 @@ AppendOnlyCompaction_DropSegmentFile(Relation aorel,
 }
 
 /*
- * Calculates the ratio of hidden tuples as an integer between 0 and 100.
+ * Calculates the ratio of hidden tuples as a double between 0 and 100
  */
-static int
+static double 
 AppendOnlyCompaction_GetHideRatio(int64 hiddenTupcount, int64 totalTupcount)
 {
 	double hideRatio;
@@ -93,7 +93,7 @@ AppendOnlyCompaction_GetHideRatio(int64 hiddenTupcount, int64 totalTupcount)
 		return 0;
 	}
 	hideRatio = ((double) hiddenTupcount) / ((double) totalTupcount) * 100.0;
-	return floor(hideRatio + 0.5);
+	return hideRatio;
 }
 
 /*
@@ -109,7 +109,7 @@ AppendOnlyCompaction_ShouldCompact(
 	bool result;
 	AppendOnlyVisimap visiMap;
 	int64 hiddenTupcount;
-	int hideRatio;
+	double hideRatio;
 
 	Assert(RelationIsAoRows(aoRelation) || RelationIsAoCols(aoRelation));
 
@@ -150,7 +150,7 @@ AppendOnlyCompaction_ShouldCompact(
 				ereportif(Debug_appendonly_print_compaction, LOG, 
 					(errmsg("Append-only compaction skipped on relation %s, segment file num %d, "
 					"hidden tupcount " INT64_FORMAT ", total tupcount " INT64_FORMAT ", " 
-					"hide ratio %d%%, threshold %d%%",
+					"hide ratio %lf%%, threshold %d%%",
 					RelationGetRelationName(aoRelation),
 					segno,
 					hiddenTupcount, segmentTotalTupcount, 
@@ -159,7 +159,7 @@ AppendOnlyCompaction_ShouldCompact(
 					(errmsg("Append-only compaction skipped on relation %s, segment file num %d",
 					RelationGetRelationName(aoRelation),
 					segno),
-					errdetail("Ratio of obsolete tuples below threshold (%d%% vs %d%%)",
+					errdetail("Ratio of obsolete tuples below threshold (%lf%% vs %d%%)",
 						hideRatio, gp_appendonly_compaction_threshold)));
 			}
 			else
@@ -167,7 +167,7 @@ AppendOnlyCompaction_ShouldCompact(
 				ereportif(Debug_appendonly_print_compaction, LOG, 
 					(errmsg("Append-only compaction skipped on relation %s, segment file num %d, "
 					"hidden tupcount " INT64_FORMAT ", total tupcount " INT64_FORMAT ", " 
-					"hide ratio %d%%, threshold %d%%",
+					"hide ratio %lf%%, threshold %d%%",
 					RelationGetRelationName(aoRelation),
 					segno,
 					hiddenTupcount, segmentTotalTupcount, 
@@ -179,7 +179,7 @@ AppendOnlyCompaction_ShouldCompact(
 			"Schedule compaction: "
 			"segno %d, "
 			"hidden tupcount " INT64_FORMAT ", total tupcount " INT64_FORMAT ", " 
-			"hide ratio %d%%, threshold %d%%",
+			"hide ratio %lf%%, threshold %d%%",
 			segno,
 			hiddenTupcount, segmentTotalTupcount, 
 			hideRatio, gp_appendonly_compaction_threshold);

--- a/src/test/regress/expected/uao_compaction/threshold.out
+++ b/src/test/regress/expected/uao_compaction/threshold.out
@@ -108,3 +108,25 @@ SELECT segno, tupcount, state FROM gp_toolkit.__gp_aoseg_name('uao_threshold');
      2 |      113 |     1
 (2 rows)
 
+-- The percentage of hidden tuples should be 10.1%
+-- The threshold guc is set to 10%
+SET gp_appendonly_compaction_threshold=10;
+SET
+CREATE TABLE uao_threshold_boundary(a int, b int) WITH(appendonly=TRUE) distributed by(a);
+CREATE TABLE
+INSERT INTO uao_threshold_boundary SELECT 1, i from generate_series(1, 1000) i;
+INSERT 0 1000
+DELETE FROM uao_threshold_boundary WHERE b < 102;
+DELETE 101
+VACUUM uao_threshold_boundary;
+VACUUM
+SELECT * FROM gp_toolkit.__gp_aovisimap_compaction_info('uao_threshold_boundary'::regclass);
+NOTICE:  gp_appendonly_compaction_threshold = 10
+ content | datafile | compaction_possible | hidden_tupcount | total_tupcount | percent_hidden 
+---------+----------+---------------------+-----------------+----------------+----------------
+       2 |        2 | f                   |               0 |              0 |           0.00
+       0 |        1 | f                   |               0 |              0 |           0.00
+       0 |        2 | f                   |               0 |            899 |           0.00
+       1 |        2 | f                   |               0 |              0 |           0.00
+(4 rows)
+

--- a/src/test/regress/expected/uaocs_compaction/threshold.out
+++ b/src/test/regress/expected/uaocs_compaction/threshold.out
@@ -107,3 +107,25 @@ SELECT DISTINCT segno, tupcount, state FROM gp_toolkit.__gp_aocsseg_name('uaocs_
      2 |      113 |     1
 (2 rows)
 
+-- The percentage of hidden tuples should be 10.1%
+-- The threshold guc is set to 10%
+SET gp_appendonly_compaction_threshold=10;
+SET
+CREATE TABLE uaocs_threshold_boundary(a int, b int) WITH(appendonly=TRUE, orientation=COLUMN) distributed by(a);
+CREATE TABLE
+INSERT INTO uaocs_threshold_boundary SELECT 1, i from generate_series(1, 1000) i;
+INSERT 0 1000
+DELETE FROM uaocs_threshold_boundary WHERE b < 102;
+DELETE 101
+VACUUM uaocs_threshold_boundary;
+VACUUM
+SELECT * FROM gp_toolkit.__gp_aovisimap_compaction_info('uaocs_threshold_boundary'::regclass);
+NOTICE:  gp_appendonly_compaction_threshold = 10
+ content | datafile | compaction_possible | hidden_tupcount | total_tupcount | percent_hidden 
+---------+----------+---------------------+-----------------+----------------+----------------
+       0 |        1 | f                   |               0 |              0 |           0.00
+       0 |        2 | f                   |               0 |            899 |           0.00
+       1 |        2 | f                   |               0 |              0 |           0.00
+       2 |        2 | f                   |               0 |              0 |           0.00
+(4 rows)
+

--- a/src/test/regress/sql/uao_compaction/threshold.sql
+++ b/src/test/regress/sql/uao_compaction/threshold.sql
@@ -36,3 +36,13 @@ DELETE FROM uao_threshold WHERE a > 100 and a < 175;
 SELECT segno, tupcount, state FROM gp_toolkit.__gp_aoseg_name('uao_threshold');
 VACUUM uao_threshold;
 SELECT segno, tupcount, state FROM gp_toolkit.__gp_aoseg_name('uao_threshold');
+
+
+-- The percentage of hidden tuples should be 10.1%
+-- The threshold guc is set to 10%
+SET gp_appendonly_compaction_threshold=10;
+CREATE TABLE uao_threshold_boundary(a int, b int) WITH(appendonly=TRUE) distributed by(a);
+INSERT INTO uao_threshold_boundary SELECT 1, i from generate_series(1, 1000) i;
+DELETE FROM uao_threshold_boundary WHERE b < 102;
+VACUUM uao_threshold_boundary;
+SELECT * FROM gp_toolkit.__gp_aovisimap_compaction_info('uao_threshold_boundary'::regclass);

--- a/src/test/regress/sql/uaocs_compaction/threshold.sql
+++ b/src/test/regress/sql/uaocs_compaction/threshold.sql
@@ -34,3 +34,12 @@ DELETE FROM uaocs_threshold WHERE a > 100 and a < 175;
 SELECT DISTINCT segno, tupcount, state FROM gp_toolkit.__gp_aocsseg_name('uaocs_threshold');
 VACUUM uaocs_threshold;
 SELECT DISTINCT segno, tupcount, state FROM gp_toolkit.__gp_aocsseg_name('uaocs_threshold');
+
+-- The percentage of hidden tuples should be 10.1%
+-- The threshold guc is set to 10%
+SET gp_appendonly_compaction_threshold=10;
+CREATE TABLE uaocs_threshold_boundary(a int, b int) WITH(appendonly=TRUE, orientation=COLUMN) distributed by(a);
+INSERT INTO uaocs_threshold_boundary SELECT 1, i from generate_series(1, 1000) i;
+DELETE FROM uaocs_threshold_boundary WHERE b < 102;
+VACUUM uaocs_threshold_boundary;
+SELECT * FROM gp_toolkit.__gp_aovisimap_compaction_info('uaocs_threshold_boundary'::regclass);


### PR DESCRIPTION
The function `AppendOnlyCompaction_GetHideRatio()` incorrectly truncated the
fractional part while calculating the ratio of hidden tuples which caused the
file to not be compacted (for e.g if the calculated threshold was 10.1% and the
guc was set to 10%, the segfile would not be compacted). This patch correctly
rounds up the calculated value to fix this issue.