### PR TITLE
Add GUC gp_allow_rename_relation_without_lock for renamerel().

### DIFF
--- a/gpdb-doc/dita/relnotes/GPDB_500_README.xml
+++ b/gpdb-doc/dita/relnotes/GPDB_500_README.xml
@@ -28,18 +28,11 @@
         information about this release.</p>
       <ul class="- topic/ul " id="ul_j1t_psl_fp">
         <li><xref href="#topic_yxx_bq2_lx" format="dita"/></li>
+        <li><xref href="#topic_epl_slm_5y" format="dita"/></li>
+        <li><xref href="#topic_osh_g4m_5y" format="dita"/></li>
         <li><xref href="#topic21" format="dita"/>
         </li>
-        <li id="pm437579" class="- topic/li "><xref href="#topic31" type="topic" format="dita"
-            class="- topic/xref "/>
-        </li>
-        <li id="pm437583" class="- topic/li "><xref href="#topic34" type="topic" format="dita"
-            class="- topic/xref "/>
-        </li>
         <li id="pm437587" class="- topic/li "><xref href="#topic36" type="topic" format="dita"
-            class="- topic/xref "/>
-        </li>
-        <li id="pm190573" class="- topic/li "><xref href="#topic37" type="topic" format="dita"
             class="- topic/xref "/>
         </li>
       </ul>
@@ -50,9 +43,37 @@
     <body>
       <p>Greenplum Database 5.0.0 includes these new features:</p>
       <ul id="ul_t5j_wbz_my">
+        <li>&lt;new features here></li>
+      </ul>
+    </body>
+  </topic>
+  <topic id="topic_epl_slm_5y">
+    <title>Changed Features</title>
+    <body>
+      <p>Greenplum Database 5.0.0 includes these changed features:</p>
+      <ul id="ul_fpl_slm_5y">
         <li>
-          <p>&lt;new features here></p>
-        </li>
+		  <p>For the <codeph>ALTER TABLE RENAME</codeph> command, renaming a relation acquires an
+		  Exclusive lock on the relation.</p>
+		  <p>In previous releases, a lock was not acquired when the <codeph>ALTER TABLE
+		  RENAME</codeph> command renamed a table. This violated the isolation level required when
+		  concurrent transactions occurred on the table. For example, without a lock, renaming a
+		  table while concurrently inserting data into a table could fail or insert data into the
+		  incorrect table.</p>
+		</li>
+      </ul>
+    </body>
+  </topic>
+  <topic id="topic_osh_g4m_5y">
+    <title>Removed and Deprecated Features</title>
+    <body>
+      <p>Greenplum Database 5.0.0 has removed these features:</p>
+      <ul id="ul_psh_g4m_5y">
+        <li>&lt;features here></li>
+      </ul>
+      <p>Greenplum Database 5.0.0 has deprecated these features:</p>
+      <ul id="ul_n35_m4m_5y">
+        <li>&lt;features here></li>
       </ul>
     </body>
   </topic>
@@ -79,7 +100,7 @@
             <row>
               <entry/>
               <entry/>
-              <entry>5.0.0</entry>
+              <entry/>
               <entry/>
             </row>
           </tbody>

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -418,6 +418,7 @@ int			gp_max_partition_level;
 bool		gp_maintenance_mode;
 bool		gp_maintenance_conn;
 bool		allow_segment_DML;
+bool		gp_allow_rename_relation_without_lock = false;
 
 /* ignore EXCLUDE clauses in window spec for backwards compatibility */
 bool		gp_ignore_window_exclude = false;
@@ -628,6 +629,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&allow_segment_DML,
+		false, NULL, NULL
+	},
+	{
+		{"gp_allow_rename_relation_without_lock", PGC_USERSET, CUSTOM_OPTIONS,
+			gettext_noop("Allow ALTER TABLE RENAME without AccessExclusiveLock"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_allow_rename_relation_without_lock,
 		false, NULL, NULL
 	},
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -267,6 +267,7 @@ extern bool gp_upgrade_mode;
 extern bool gp_maintenance_mode;
 extern bool gp_maintenance_conn;
 extern bool allow_segment_DML;
+extern bool gp_allow_rename_relation_without_lock;
 
 extern bool gp_ignore_window_exclude;
 

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -138,6 +138,7 @@ DROP TABLE tmp_new;
 DROP TABLE tmp_new2;
 -- ALTER TABLE ... RENAME on corrupted relations
 SET allow_system_table_mods = dml;
+SET gp_allow_rename_relation_without_lock = ON;
 -- missing entry
 CREATE TABLE cor (a int, b float);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -164,6 +165,7 @@ ALTER TABLE othercor RENAME TO tmpcor;
 ALTER TABLE tmpcor RENAME TO cor;
 DROP TABLE cor;
 RESET allow_system_table_mods;
+RESET gp_allow_rename_relation_without_lock;
 -- ALTER TABLE ... RENAME on non-table relations
 -- renaming indexes (FIXME: this should probably test the index's functionality)
 ALTER INDEX onek_unique1 RENAME TO tmp_onek_unique1;

--- a/src/test/regress/expected/alter_table_optimizer.out
+++ b/src/test/regress/expected/alter_table_optimizer.out
@@ -139,6 +139,7 @@ DROP TABLE tmp_new;
 DROP TABLE tmp_new2;
 -- ALTER TABLE ... RENAME on corrupted relations
 SET allow_system_table_mods = dml;
+SET gp_allow_rename_relation_without_lock = ON;
 -- missing entry
 CREATE TABLE cor (a int, b float);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -165,6 +166,7 @@ ALTER TABLE othercor RENAME TO tmpcor;
 ALTER TABLE tmpcor RENAME TO cor;
 DROP TABLE cor;
 RESET allow_system_table_mods;
+RESET gp_allow_rename_relation_without_lock;
 -- ALTER TABLE ... RENAME on non-table relations
 -- renaming indexes (FIXME: this should probably test the index's functionality)
 ALTER INDEX onek_unique1 RENAME TO tmp_onek_unique1;

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -166,6 +166,7 @@ DROP TABLE tmp_new2;
 
 -- ALTER TABLE ... RENAME on corrupted relations
 SET allow_system_table_mods = dml;
+SET gp_allow_rename_relation_without_lock = ON;
 -- missing entry
 CREATE TABLE cor (a int, b float);
 INSERT INTO cor SELECT i, i+1 FROM generate_series(1,100)i;
@@ -189,6 +190,7 @@ ALTER TABLE tmpcor RENAME TO cor;
 DROP TABLE cor;
 
 RESET allow_system_table_mods;
+RESET gp_allow_rename_relation_without_lock;
 
 -- ALTER TABLE ... RENAME on non-table relations
 -- renaming indexes (FIXME: this should probably test the index's functionality)


### PR DESCRIPTION
Originally, we don't hold AccessExclusiveLock while renaming relations to provide
supportability for altering relation name while directly modifying system catalogs.

However, this breaks the isolation semantics of ALTER TABLE. Hence, we add the lock
to make it consistent with upstream behavior.  The original behavior is now
possible with the GUC.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>