### PR TITLE
Replace escape_string with escape_bytea in behave tests

### DIFF
--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -262,7 +262,7 @@ def get_table_data_to_file(filename, tablename, dbname):
                                 where (n.nspname || '.' || c.relname = E'%s')
                                     or c.relname = E'%s'
                         ) as q;
-                """ % (pg.escape_string(tablename), pg.escape_string(tablename))
+                """ % (pg.escape_bytea(tablename), pg.escape_bytea(tablename))
     query = order_sql
     conn = dbconn.connect(dbconn.DbURL(dbname=dbname))
     try:


### PR DESCRIPTION
- The behavior of escape_string has changed with the new version
  of Postgres. escape_bytea gives us the correct escaping functionality
  with an active dbconn connection.

Authors: Chris Hajas and Karen Huddleston