### PR TITLE
Add a preset GUC containing the server version number

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1425,14 +1425,21 @@
                   <xref href="#gp_num_contents_in_cluster" type="section"
                     >gp_num_contents_in_cluster</xref>
                 </p>
+              </stentry>
+              <stentry>
                 <p>
                   <xref href="#gp_role" type="section">gp_role</xref>
                 </p>
                 <p>
                   <xref href="#gp_session_id" type="section">gp_session_id</xref>
                 </p>
+                <p>
+                  <xref href="#gp_server_version" type="section">gp_server_version</xref>
+                </p>
+                <p>
+                  <xref href="#gp_server_version_num" type="section">gp_server_version_num</xref>
+                </p>
               </stentry>
-              <stentry/>
             </strow>
           </simpletable>
         </body>
@@ -1918,6 +1925,12 @@
               </li>
               <li>
                 <xref href="#gp_segments_for_planner"/>
+              </li>
+              <li>
+                <xref href="#gp_server_version"/>
+              </li>
+              <li>
+                <xref href="#gp_server_version_num"/>
               </li>
               <li>
                 <xref href="#gp_session_id"/>
@@ -6410,6 +6423,69 @@
                 <entry colname="col1">0-<i>n</i></entry>
                 <entry colname="col2">0</entry>
                 <entry colname="col3">master<p>session</p><p>reload</p></entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="gp_server_version">
+      <title>gp_server_version</title>
+      <body>
+        <p>Reports the version number of the server as a string. A version
+          modifier argument might be appended to the numeric portion of the
+          version string, example: <i>5.0.0 beta</i></p>.
+        <table id="gp_server_version_table">
+          <tgroup cols="3">
+            <colspec colnum="1" colname="col1" colwidth="1*"/>
+            <colspec colnum="2" colname="col2" colwidth="1*"/>
+            <colspec colnum="3" colname="col3" colwidth="1*"/>
+            <thead>
+              <row>
+                <entry colname="col1">Value Range</entry>
+                <entry colname="col2">Default</entry>
+                <entry colname="col3">Set Classifications</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry colname="col1">String. Examples: <i>5.0.0</i></entry>
+                <entry colname="col2">n/a</entry>
+                <entry colname="col3">read only</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </body>
+    </topic>
+    <topic id="gp_server_version_num">
+      <title>gp_server_version_num</title>
+      <body>
+        <p>Reports the version number of the server as an integer. The number
+          is guaranteed to always be increasing for each version and can be
+          used for numeric comparisons. The major version is represented as
+          is, the minor and patch versions are zero-padded to always be
+          double digit wide.</p>
+        <table id="gp_server_version_num_table">
+          <tgroup cols="3">
+            <colspec colnum="1" colname="col1" colwidth="1*"/>
+            <colspec colnum="2" colname="col2" colwidth="1*"/>
+            <colspec colnum="3" colname="col3" colwidth="1*"/>
+            <thead>
+              <row>
+                <entry colname="col1">Value Range</entry>
+                <entry colname="col2">Default</entry>
+                <entry colname="col3">Set Classifications</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry colname="col1"><i>Mmmpp</i> where <i>M</i> is the major
+                  version, <i>mm</i> is the minor version zero-padded and
+                  <i>pp</i> is the patch version zero-padded. Example: 50000
+                  </entry>
+                <entry colname="col2">n/a</entry>
+                <entry colname="col3">read only</entry>
               </row>
             </tbody>
           </tgroup>

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -581,6 +581,9 @@ int		codegen_varlen_tolerance;
 int		codegen_optimization_level;
 static char 	*codegen_optimization_level_str = NULL;
 
+/* System Information */
+static int	gp_server_version_num;
+static char *gp_server_version_string;
 
 /* Security */
 bool		gp_reject_internal_tcp_conn = true;
@@ -4759,6 +4762,17 @@ struct config_int ConfigureNamesInt_gp[] =
 		2, 0, 10, NULL, NULL
 	},
 
+	{
+		/* Can't be set in postgresql.conf */
+		{"gp_server_version_num", PGC_INTERNAL, PRESET_OPTIONS,
+			gettext_noop("Shows the Greenplum server version as an integer."),
+			NULL,
+			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+		},
+		&gp_server_version_num,
+		GP_VERSION_NUM, GP_VERSION_NUM, GP_VERSION_NUM, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, 0, 0, 0, NULL, NULL
@@ -5537,6 +5551,17 @@ struct config_string ConfigureNamesString_gp[] =
 		"",
 #endif
 		assign_codegen_optimization_level, NULL
+	},
+
+	{
+		/* Can't be set in postgresql.conf */
+		{"gp_server_version", PGC_INTERNAL, PRESET_OPTIONS,
+			gettext_noop("Shows the Greenplum server version."),
+			NULL,
+			GUC_REPORT | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+		},
+		&gp_server_version_string,
+		GP_VERSION, NULL, NULL
 	},
 
 	/* End-of-list marker */


### PR DESCRIPTION
Issue #1169 requested a machine readable form of the Greenplum server version. There is already a preset GUC for the PostgreSQL version number in machine readable form: `server_version_num`. This adds a Greenplum counterpart as `gp_server_version_num` which reports the server version number as an integer.
```
template1=# show server_version_num;
 server_version_num
--------------------
 80323
(1 row)

template1=# show gp_server_version_num;
 gp_server_version_num
-----------------------
 50000
(1 row)
```
Ping  @larham 