### PR TITLE
Remove mention of GPOS from ORCA building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ PGPORT=15432 make installcheck-good
 You must first install the below libraries in the below order (see the READMEs on each repository):
 
 1. https://github.com/greenplum-db/gp-xerces
-2. https://github.com/greenplum-db/gpos
-3. https://github.com/greenplum-db/gporca
+2. https://github.com/greenplum-db/gporca
 
 Next, change your `configure` command to have the additional option `--enable-orca`.
 ```


### PR DESCRIPTION
The GPOS library has been imported into the GPORCA repository so there is no need to install it separately anymore. Was this missed when importing such that it can be removed from the instructions or should it remain? @vraghavan78