### PR TITLE
Removing the fix me comment for bound in tuplesort_mk.

### DIFF
--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -1,7 +1,3 @@
-/*
- * GPDB_83_MERGE_FIXME: PostgreSQL 8.3 added "bounded" sort support to
- * tuplesort.c. It has not been ported to tuplesort_mk.c yet
- */
 /*-------------------------------------------------------------------------
  *
  * tuplesort.c


### PR DESCRIPTION
This is fixed with the commit d546351193ab2e04c27a559d31c24195e646f7c1.