### PR TITLE
Bring LockTagIsTemp() back for 2PC

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -329,8 +329,7 @@ TwoPhaseFindRecoverPostCheckpointPreparedTransactionsMapEntry(TransactionId xid,
          caller);
 
   return true;
-}  /* end add_recover_post_checkpoint_prepared_transactions_map_entry */
-
+}
 
 /*
  * Remove a mapping from the recover post checkpoint prepared transactions hash table.

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -2054,11 +2054,8 @@ AtPrepare_Locks(void)
 		 * destroyed at the end of the session, while the transaction will be
 		 * committed from another session.
 		 */
-		/* GPDB_83_MERGE_FIXME: see previous comments on removing LockTagIsTemp */
-#if 0
 		if (LockTagIsTemp(&locallock->tag.lock))
 			continue;
-#endif
 
 		/*
 		 * Create a 2PC record.
@@ -2145,17 +2142,8 @@ PostPrepare_Locks(TransactionId xid)
 		 * objects. MPP-1094: NOTE THIS CALL MAY ADD LOCKS TO OUR
 		 * TABLE!
 		 */
-		/* GPDB_83_MERGE_FIXME: LockTagIsTemp() was removed in the merge,
-		 * by upstream commit f3032cbe377ecc570989e1bd2fe1aea455c12cc3. It's
-		 * not clear to me if it's still safe to skip over temp objects. I'm
-		 * pretty sure we must allow modifying temp tables in GPDB, because
-		 * every transaction uses 2PC, but how? Do we need to resurrect
-		 * LockTagIsTemp? Needs investigation...
-		 */
-#if 0
 		if (LockTagIsTemp(&locallock->tag.lock))
 			continue;
-#endif
 
 		/* since our temp-check may be modifying our lock table, we
 		 * just mark these as requiring more work */

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -89,4 +89,7 @@ extern void UnlockSharedObject(Oid classid, Oid objid, uint16 objsubid,
 /* Describe a locktag for error messages */
 extern void DescribeLockTag(StringInfo buf, const LOCKTAG *tag);
 
+/* Knowledge about which locktags describe temp objects */
+extern bool LockTagIsTemp(const LOCKTAG *tag);
+
 #endif   /* LMGR_H */


### PR DESCRIPTION
In Postgres, it's not supported to have temp table as part of PREPARE
TRANSACTION. Hence, the method `LockTagIsTemp()` to check whether a lock is on
temp table or not got removed from upstream.

It's a requirement for GPDB to allow access to temp table for MPP transactions,
and all transactions go through 2PC.

If we remove the `LockTagIsTemp()`, then the locks on the temp table will be
captured as part of `TwoPhaseRecordOnDisk`, and held during the prepare of 2PC.
That caused a concern during `xact_redo()` if segment crashed before commit. In
that case, the `xact_redo()` will lock and release the locks on the temp table,
which is already deleted by GPDB when handling the crash. That results in a
redundant operations of lock and release on a non-existent temp table object.

To prevent that from happening, we shouldn't copy the lock information on the
temp table to the `TwoPhaseRecordOnDisk`. Hence, we still need the
`LockTagIsTemp()` method.

This commit brings it back.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>