### PR TITLE
ALTER TABLE CLUSTER commands should not be supported for AO tables.

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -171,7 +171,7 @@ ALTER TABLE <varname>name</varname>
                                                 Greenplum Database. Triggers in general have very
                                                 limited functionality due to the parallelism of
                                                 Greenplum Database.</note></li>
-                                <li id="ay137071"><b>CLUSTER/SET WITHOUT CLUSTER</b> — Selects or
+                                <li id="ay137071"><b>CLUSTER ON/SET WITHOUT CLUSTER</b> — Selects or
                                         removes the default index for future
                                                 <codeph>CLUSTER</codeph> operations. It does not
                                         actually re-cluster the table. Note that
@@ -180,7 +180,9 @@ ALTER TABLE <varname>name</varname>
                                         it takes so long. It is better to recreate the table with
                                                   <codeph><xref href="./CREATE_TABLE_AS.xml#topic1"
                                                   type="topic" format="dita"/></codeph> and order it
-                                        by the index column(s).</li>
+                                        by the index column(s).
+                                        <note><codeph>CLUSTER ON</codeph> is not supported on
+                                        append-optimized tables.</note></li>
                                 <li id="ay137152"><b>SET WITHOUT OIDS</b> — Removes the OID system
                                         column from the table. Note that there is no variant of
                                                 <codeph>ALTER TABLE</codeph> that allows OIDs to be

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -9076,6 +9076,15 @@ ATExecClusterOn(Relation rel, const char *indexName)
 {
 	Oid			indexOid;
 
+	if (RelationIsAoRows(rel) || RelationIsAoCols(rel))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot cluster append-only table \"%s\": not supported",
+						RelationGetRelationName(rel))));
+		return;
+	}
+
 	indexOid = get_relname_relid(indexName, rel->rd_rel->relnamespace);
 
 	if (!OidIsValid(indexOid))

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -364,9 +364,6 @@ insert into co select i, 1, 'aaa' from generate_series(1, 20) i;
 insert into co select i, 2, 'a' from generate_series(1, 20) i;
 select distinct j from co where j > -1 and j < 3 order by j;
 
--- Test clustering errors out
-cluster co_j_cluster on co_j;
-
 -- TEMP TABLES w/ INDEXES
 create temp table temp_tenk_aocs5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
     as select * from tenk_aocs5 distributed by (unique1);

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -378,9 +378,6 @@ insert into ao select i, 1, 'aaa' from generate_series(1, 20) i;
 insert into ao select i, 2, 'a' from generate_series(1, 20) i;
 select distinct j from ao where j > -1 and j < 3 order by j;
 
--- Test clustering errors out
-cluster ao_j_cluster on ao_j;
-
 -- TEMP TABLES w/ INDEXES
 create temp table temp_tenk_ao5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
     as select * from tenk_ao5 distributed by (unique1);

--- a/src/test/regress/input/qp_gist_indexes2.source
+++ b/src/test/regress/input/qp_gist_indexes2.source
@@ -496,26 +496,6 @@ SELECT id, property FROM GistTable1
  WHERE property IS NULL 
  ORDER BY id;
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
-
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
-
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -550,8 +530,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
-
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 
@@ -685,22 +663,6 @@ SELECT owner, property FROM GistTable1
  ORDER BY id
  ;
 -- end_ignore
-
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
--- end_ignore
-
 
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
@@ -933,26 +895,6 @@ SELECT id, property FROM GistTable1
  WHERE property IS NULL 
  ORDER BY id;
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
-
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
-
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -988,8 +930,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
-
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 
@@ -1123,22 +1063,6 @@ SELECT owner, property FROM GistTable1
  ORDER BY id
  ;
 -- end_ignore
-
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
--- end_ignore
-
 
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
@@ -1371,26 +1295,6 @@ SELECT id, property FROM GistTable1
  WHERE property IS NULL 
  ORDER BY id;
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
-
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
-
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -1426,8 +1330,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
-
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 
@@ -1561,22 +1463,6 @@ SELECT owner, property FROM GistTable1
  ORDER BY id
  ;
 -- end_ignore
-
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
--- end_ignore
-
 
 -- ----------------------------------------------------------------------
 -- Test: test13Vacuum.sql
@@ -1810,26 +1696,6 @@ SELECT id, property FROM GistTable1
  WHERE property IS NULL 
  ORDER BY id;
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
--- end_ignore
-
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
-
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -1865,8 +1731,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- ----------------------------------------------------------------------
 
 SET enable_seqscan = FALSE;
-
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 
@@ -1997,21 +1861,6 @@ SELECT owner, property FROM GistTable1
 EXPLAIN 
 SELECT owner, property FROM GistTable1 
  WHERE property IS NULL
- ORDER BY id
- ;
--- end_ignore
-
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
  ORDER BY id
  ;
 -- end_ignore

--- a/src/test/regress/input/uao_ddl/alter_ao_table_index.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_index.source
@@ -25,17 +25,13 @@ set gp_select_invisible = true;
 select * from sto_alt_uao3_idx where bigint_col = 11;
 set gp_select_invisible = false;
 
--- Alter table cluster on indexname
+-- Verify that alter table cluster on indexname is not allowed
 Alter table sto_alt_uao3_idx cluster on sto_alt_uao3_idx_idx;
-select * from sto_alt_uao3_idx where bigint_col = 7 order by numeric_col;
-update sto_alt_uao3_idx set numeric_col = 111 where text_col = '1_zero';
-select * from sto_alt_uao3_idx where text_col = '1_zero';
-delete from sto_alt_uao3_idx where bigint_col = 7;
-select * from sto_alt_uao3_idx where bigint_col = 7;
-set gp_select_invisible = true;
-select count(*) > 200 AS passed from sto_alt_uao3_idx;
-set gp_select_invisible = false;
+select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::regclass;
+Alter table sto_alt_uao3_idx set without cluster;
+select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::regclass;
 -- Verify that cluster is not allowed
 CLUSTER sto_alt_uao3_idx using sto_alt_uao3_idx_idx;
+select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::regclass;
 -- Verify that unique index is not allowed
 CREATE UNIQUE INDEX uni_index ON sto_alt_uao3_idx (text_col);

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -756,9 +756,6 @@ select distinct j from co where j > -1 and j < 3 order by j;
  2
 (3 rows)
 
--- Test clustering errors out
-cluster co_j_cluster on co_j;
-ERROR:  "co_j" is an index
 -- TEMP TABLES w/ INDEXES
 create temp table temp_tenk_aocs5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
     as select * from tenk_aocs5 distributed by (unique1);

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -822,9 +822,6 @@ select distinct j from ao where j > -1 and j < 3 order by j;
  2
 (3 rows)
 
--- Test clustering errors out
-cluster ao_j_cluster on ao_j;
-ERROR:  "ao_j" is an index
 -- TEMP TABLES w/ INDEXES
 create temp table temp_tenk_ao5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
     as select * from tenk_ao5 distributed by (unique1);

--- a/src/test/regress/output/qp_gist_indexes2.source
+++ b/src/test/regress/output/qp_gist_indexes2.source
@@ -780,56 +780,6 @@ SELECT id, property FROM GistTable1
   8 | 
 (1 row)
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-  owner  |       property       
----------+----------------------
- Hypatia | (7052,250),(6050,20)
-  Patty  | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
-   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
-         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(7 rows)
-
--- end_ignore
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
- id | property 
-----+----------
-  8 | 
-(1 row)
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -877,7 +827,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -1105,40 +1054,6 @@ SELECT owner, property FROM GistTable1
    ->  Sort  (cost=200.28..200.28 rows=1 width=51)
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
-               Recheck Cond: property IS NULL
-               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(9 rows)
-
--- end_ignore
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
- id | property 
-----+----------
-  8 | 
- 77 | 
- 86 | 
- 99 | 
-(4 rows)
-
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
-   Merge Key: id
-   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
-         Sort Key: id
-         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=36)
                Recheck Cond: property IS NULL
                ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
  Settings:  enable_seqscan=off
@@ -1493,56 +1408,6 @@ SELECT id, property FROM GistTable1
   8 | 
 (1 row)
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-  owner  |       property       
----------+----------------------
- Hypatia | (7052,250),(6050,20)
-  Patty  | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
-   ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
-         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(7 rows)
-
--- end_ignore
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
- id | property 
-----+----------
-  8 | 
-(1 row)
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -1590,7 +1455,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -1818,40 +1682,6 @@ SELECT owner, property FROM GistTable1
    ->  Sort  (cost=200.28..200.28 rows=1 width=51)
          Sort Key: id
          ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
-               Recheck Cond: property IS NULL
-               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(9 rows)
-
--- end_ignore
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
- id | property 
-----+----------
-  8 | 
- 77 | 
- 86 | 
- 99 | 
-(4 rows)
-
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
-   Merge Key: id
-   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
-         Sort Key: id
-         ->  Bitmap Append-Only Row-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=36)
                Recheck Cond: property IS NULL
                ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
  Settings:  enable_seqscan=off
@@ -2206,56 +2036,6 @@ SELECT id, property FROM GistTable1
   8 | 
 (1 row)
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-  owner  |       property       
----------+----------------------
- Hypatia | (7052,250),(6050,20)
-  Patty  | (7052,250),(6050,20)
-(2 rows)
-
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
-   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
-         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(7 rows)
-
--- end_ignore
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
- id | property 
-----+----------
-  8 | 
-(1 row)
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -2303,7 +2083,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -2531,40 +2310,6 @@ SELECT owner, property FROM GistTable1
    ->  Sort  (cost=200.28..200.28 rows=1 width=51)
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
-               Recheck Cond: property IS NULL
-               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(9 rows)
-
--- end_ignore
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
- id | property 
-----+----------
-  8 | 
- 77 | 
- 86 | 
- 99 | 
-(4 rows)
-
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
-   Merge Key: id
-   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
-         Sort Key: id
-         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=36)
                Recheck Cond: property IS NULL
                ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
  Settings:  enable_seqscan=off
@@ -2919,56 +2664,6 @@ SELECT id, property FROM GistTable1
   8 | 
 (1 row)
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-  owner  |       property       
----------+----------------------
- Hypatia | (7052,250),(6050,20)
-  Patty  | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=100.26..200.27 rows=1 width=47)
-   ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=47)
-         Recheck Cond: property ~= '(7052,250),(6050,20)'::box
-         ->  Bitmap Index Scan on propertyboxindex  (cost=0.00..100.26 rows=1 width=0)
-               Index Cond: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(7 rows)
-
--- end_ignore
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
- id | property 
-----+----------
-  8 | 
-(1 row)
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -3016,7 +2711,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -3244,40 +2938,6 @@ SELECT owner, property FROM GistTable1
    ->  Sort  (cost=200.28..200.28 rows=1 width=51)
          Sort Key: id
          ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=51)
-               Recheck Cond: property IS NULL
-               ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
- Settings:  enable_seqscan=off
- Optimizer status: legacy query optimizer
-(9 rows)
-
--- end_ignore
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
- id | property 
-----+----------
-  8 | 
- 77 | 
- 86 | 
- 99 | 
-(4 rows)
-
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=200.28..200.28 rows=2 width=36)
-   Merge Key: id
-   ->  Sort  (cost=200.28..200.28 rows=1 width=36)
-         Sort Key: id
-         ->  Bitmap Append-Only Column-Oriented Scan on gisttable1  (cost=100.26..200.27 rows=1 width=36)
                Recheck Cond: property IS NULL
                ->  Bitmap Index Scan on propertyisnullindex  (cost=0.00..100.26 rows=1 width=0)
  Settings:  enable_seqscan=off

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -782,54 +782,6 @@ SELECT id, property FROM GistTable1
   8 | 
 (1 row)
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
-         Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
-
--- end_ignore
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
- id | property 
-----+----------
-  8 | 
-(1 row)
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -877,7 +829,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -1111,39 +1062,6 @@ SELECT owner, property FROM GistTable1
  Settings:  enable_seqscan=off; optimizer=on
  Optimizer status: PQO version 1.624
 (10 rows)
-
--- end_ignore
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
- id | property 
-----+----------
-  8 | 
- 77 | 
- 86 | 
- 99 | 
-(4 rows)
-
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
-   Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
-               Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
 
 -- end_ignore
 -- ----------------------------------------------------------------------
@@ -1484,54 +1402,6 @@ SELECT id, property FROM GistTable1
   8 | 
 (1 row)
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-  owner  |       property       
----------+----------------------
- Hypatia | (7052,250),(6050,20)
-  Patty  | (7052,250),(6050,20)
-(2 rows)
-
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
-         Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
-
--- end_ignore
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
- id | property 
-----+----------
-  8 | 
-(1 row)
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -1579,7 +1449,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -1813,39 +1682,6 @@ SELECT owner, property FROM GistTable1
  Settings:  enable_seqscan=off; optimizer=on
  Optimizer status: PQO version 1.624
 (10 rows)
-
--- end_ignore
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
- id | property 
-----+----------
-  8 | 
- 77 | 
- 86 | 
- 99 | 
-(4 rows)
-
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
-   Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
-               Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
 
 -- end_ignore
 -- ----------------------------------------------------------------------
@@ -2186,54 +2022,6 @@ SELECT id, property FROM GistTable1
   8 | 
 (1 row)
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-  owner  |       property       
----------+----------------------
- Hypatia | (7052,250),(6050,20)
-  Patty  | (7052,250),(6050,20)
-(2 rows)
-
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
-         Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
-
--- end_ignore
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
- id | property 
-----+----------
-  8 | 
-(1 row)
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -2281,7 +2069,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -2515,39 +2302,6 @@ SELECT owner, property FROM GistTable1
  Settings:  enable_seqscan=off; optimizer=on
  Optimizer status: PQO version 1.624
 (10 rows)
-
--- end_ignore
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
- id | property 
-----+----------
-  8 | 
- 77 | 
- 86 | 
- 99 | 
-(4 rows)
-
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
-   Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
-               Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
 
 -- end_ignore
 -- ----------------------------------------------------------------------
@@ -2888,54 +2642,6 @@ SELECT id, property FROM GistTable1
   8 | 
 (1 row)
 
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT owner, property FROM GistTable1 
- WHERE property ~= '((7052,250),(6050,20))';
-  owner  |       property       
----------+----------------------
- Hypatia | (7052,250),(6050,20)
-  Patty  | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1 
- WHERE property ~= ' ( ( 7052, 250 ) , (6050, 20) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-  owner  |       property       
----------+----------------------
-  Patty  | (7052,250),(6050,20)
- Hypatia | (7052,250),(6050,20)
-(2 rows)
-
--- start_ignore
-EXPLAIN
-SELECT owner, property FROM GistTable1
- WHERE property ~= '( (6050, 20), (7052, 250) )';
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=47)
-   ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=47)
-         Filter: property ~= '(7052,250),(6050,20)'::box
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(5 rows)
-
--- end_ignore
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id;
- id | property 
-----+----------
-  8 | 
-(1 row)
-
 -- ----------------------------------------------------------------------
 -- Test: test04Insert.sql
 -- ----------------------------------------------------------------------
@@ -2983,7 +2689,6 @@ SELECT id, owner, description, property, poli, bullseye FROM GistTable1
 -- Test: test06IllegalonAO.sql
 -- ----------------------------------------------------------------------
 SET enable_seqscan = FALSE;
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
 ALTER INDEX propertyBoxIndex RENAME TO propIndex;
 UPDATE GistTable1
  SET description = 'Where''s Johnny?', bullseye = NULL
@@ -3217,39 +2922,6 @@ SELECT owner, property FROM GistTable1
  Settings:  enable_seqscan=off; optimizer=on
  Optimizer status: PQO version 1.624
 (10 rows)
-
--- end_ignore
--- Alter the table and see if we get the same results.
-ALTER TABLE GistTable1 CLUSTER ON propertyBoxIndex;
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
- id | property 
-----+----------
-  8 | 
- 77 | 
- 86 | 
- 99 | 
-(4 rows)
-
--- start_ignore
-EXPLAIN
-SELECT id, property FROM GistTable1 
- WHERE property IS NULL 
- ORDER BY id
- ;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=36)
-   Merge Key: id
-   ->  Sort  (cost=0.00..431.00 rows=3 width=36)
-         Sort Key: id
-         ->  Table Scan on gisttable1  (cost=0.00..431.00 rows=3 width=36)
-               Filter: property IS NULL
- Settings:  enable_seqscan=off; optimizer=on
- Optimizer status: PQO version 1.624
-(8 rows)
 
 -- end_ignore
 -- ----------------------------------------------------------------------

--- a/src/test/regress/output/uao_ddl/alter_ao_table_index.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_index.source
@@ -48,46 +48,31 @@ select * from sto_alt_uao3_idx where bigint_col = 11;
 (1 row)
 
 set gp_select_invisible = false;
--- Alter table cluster on indexname
+-- Verify that alter table cluster on indexname is not allowed
 Alter table sto_alt_uao3_idx cluster on sto_alt_uao3_idx_idx;
-select * from sto_alt_uao3_idx where bigint_col = 7 order by numeric_col;
- text_col | bigint_col | char_vary_col | numeric_col 
-----------+------------+---------------+-------------
- abc_7    |          7 | pqr7          |           7
- abc_18   |          7 | pqr18         |          18
- abc_29   |          7 | pqr29         |          29
- abc_40   |          7 | pqr40         |          40
- abc_51   |          7 | pqr51         |          51
- abc_62   |          7 | pqr62         |          62
- abc_73   |          7 | pqr73         |          73
- abc_84   |          7 | pqr84         |          84
- abc_95   |          7 | pqr95         |          95
-(9 rows)
-
-update sto_alt_uao3_idx set numeric_col = 111 where text_col = '1_zero';
-select * from sto_alt_uao3_idx where text_col = '1_zero';
- text_col | bigint_col | char_vary_col | numeric_col 
-----------+------------+---------------+-------------
- 1_zero   |          1 | 1_zero        |         111
+ERROR:  cannot cluster append-only table "sto_alt_uao3_idx": not supported
+select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::regclass;
+ indisclustered
+----------------
+ f
 (1 row)
 
-delete from sto_alt_uao3_idx where bigint_col = 7;
-select * from sto_alt_uao3_idx where bigint_col = 7;
- text_col | bigint_col | char_vary_col | numeric_col 
-----------+------------+---------------+-------------
-(0 rows)
-
-set gp_select_invisible = true;
-select count(*) > 200 AS passed from sto_alt_uao3_idx;
- passed 
---------
- t
+Alter table sto_alt_uao3_idx set without cluster;
+select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::regclass;
+ indisclustered
+----------------
+ f
 (1 row)
 
-set gp_select_invisible = false;
 -- Verify that cluster is not allowed
 CLUSTER sto_alt_uao3_idx using sto_alt_uao3_idx_idx;
 ERROR:  cannot cluster append-only table "sto_alt_uao3_idx": not supported
+select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::regclass;
+ indisclustered
+----------------
+ f
+(1 row)
+
 -- Verify that unique index is not allowed
 CREATE UNIQUE INDEX uni_index ON sto_alt_uao3_idx (text_col);
 ERROR:  append-only tables do not support unique indexes

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/expected/other_tests/ao_co_alter_table.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/expected/other_tests/ao_co_alter_table.ans
@@ -148,10 +148,6 @@ SELECT out_of_character FROM carp_die WHERE id = 122;
  
 (1 row)
 
--- The table cannot have already been clustered, since we do not allow indexes 
--- on AO/COT tables, but let's just see what happens when we run this command.
-ALTER TABLE carp_die SET WITHOUT CLUSTER;
-ALTER TABLE
 DROP FUNCTION IF EXISTS money_to_text(MONEY) CASCADE;
 psql:/path/sql_file:1: NOTICE:  function money_to_text(money) does not exist, skipping
 DROP FUNCTION

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/other_tests/ao_co_alter_table.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/other_tests/ao_co_alter_table.sql
@@ -129,12 +129,6 @@ ALTER TABLE carp_die ALTER out_of_character DROP DEFAULT;
 INSERT INTO carp_die (id, wealth, timeless) VALUES (122, '122', '2010-03-02 15:46:00');
 SELECT out_of_character FROM carp_die WHERE id = 122;
 
-
--- The table cannot have already been clustered, since we do not allow indexes 
--- on AO/COT tables, but let's just see what happens when we run this command.
-ALTER TABLE carp_die SET WITHOUT CLUSTER;
-
-
 DROP FUNCTION IF EXISTS money_to_text(MONEY) CASCADE;
 CREATE FUNCTION money_to_text(MONEY) RETURNS TEXT AS
   $$

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/basebackup/switch/alter_ao_tables.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/basebackup/switch/alter_ao_tables.sql
@@ -125,15 +125,6 @@ select * from sto_alt_ao2 order by bigint_col;
 Alter table sto_alt_ao3  alter column before_rename_col set statistics 3;
 select * from sto_alt_ao3 order by bigint_col;
 
--- Alter table cluster on indexname
-Create index sto_alt_ao3_idx on sto_alt_ao3(bigint_col);
-Alter table sto_alt_ao3 cluster on sto_alt_ao3_idx;
-select * from sto_alt_ao3 order by bigint_col;
-
--- Alter table SET without cluster
-Alter table sto_alt_ao3 set without cluster;
-select * from sto_alt_ao3 order by bigint_col;
-
 --Alter table SET without OIDs
 Alter table sto_alt_ao3 SET without oids;
 select * from sto_alt_ao3 order by bigint_col;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/expected/alter_ao_tables.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/expected/alter_ao_tables.ans
@@ -312,30 +312,6 @@ select * from sto_alt_ao3 order by bigint_col;
  2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
 (3 rows)
 
--- Alter table cluster on indexname
-Create index sto_alt_ao3_idx on sto_alt_ao3(bigint_col);
-CREATE INDEX
-Alter table sto_alt_ao3 cluster on sto_alt_ao3_idx;
-ALTER TABLE
-select * from sto_alt_ao3 order by bigint_col;
- text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
-----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
- 0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0
- 1_zero   |          1 | 1_zero        |           1 |       1 |         1 | {1}           |                 1 |                   1 | 2005-10-19 10:23:54 | 2005-10-19 01:23:54-07 | 2001-01-01  |               1
- 2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
-(3 rows)
-
--- Alter table SET without cluster
-Alter table sto_alt_ao3 set without cluster;
-ALTER TABLE
-select * from sto_alt_ao3 order by bigint_col;
- text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
-----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
- 0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0
- 1_zero   |          1 | 1_zero        |           1 |       1 |         1 | {1}           |                 1 |                   1 | 2005-10-19 10:23:54 | 2005-10-19 01:23:54-07 | 2001-01-01  |               1
- 2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
-(3 rows)
-
 --Alter table SET without OIDs
 Alter table sto_alt_ao3 SET without oids;
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/expected/alter_co_tables.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/expected/alter_co_tables.ans
@@ -308,30 +308,6 @@ select * from sto_alt_co3 order by bigint_col;
  2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
 (3 rows)
 
--- Alter table cluster on indexname
-Create index sto_alt_co3_idx on sto_alt_co3(bigint_col);
-CREATE INDEX
-Alter table sto_alt_co3 cluster on sto_alt_co3_idx;
-ALTER TABLE
-select * from sto_alt_co3 order by bigint_col;
- text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
-----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
- 0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0
- 1_zero   |          1 | 1_zero        |           1 |       1 |         1 | {1}           |                 1 |                   1 | 2005-10-19 10:23:54 | 2005-10-19 01:23:54-07 | 2001-01-01  |               1
- 2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
-(3 rows)
-
--- Alter table SET without cluster
-Alter table sto_alt_co3 set without cluster;
-ALTER TABLE
-select * from sto_alt_co3 order by bigint_col;
- text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
-----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
- 0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0
- 1_zero   |          1 | 1_zero        |           1 |       1 |         1 | {1}           |                 1 |                   1 | 2005-10-19 10:23:54 | 2005-10-19 01:23:54-07 | 2001-01-01  |               1
- 2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
-(3 rows)
-
 --Alter table SET without OIDs
 Alter table sto_alt_co3 SET without oids;
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/sql/alter_ao_tables.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/sql/alter_ao_tables.sql
@@ -136,15 +136,6 @@ select * from sto_alt_ao2 order by bigint_col;
 Alter table sto_alt_ao3  alter column before_rename_col set statistics 3;
 select * from sto_alt_ao3 order by bigint_col;
 
--- Alter table cluster on indexname
-Create index sto_alt_ao3_idx on sto_alt_ao3(bigint_col);
-Alter table sto_alt_ao3 cluster on sto_alt_ao3_idx;
-select * from sto_alt_ao3 order by bigint_col;
-
--- Alter table SET without cluster
-Alter table sto_alt_ao3 set without cluster;
-select * from sto_alt_ao3 order by bigint_col;
-
 --Alter table SET without OIDs
 Alter table sto_alt_ao3 SET without oids;
 select * from sto_alt_ao3 order by bigint_col;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/sql/alter_co_tables.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/crash/ddl/sql/alter_co_tables.sql
@@ -135,15 +135,6 @@ select * from sto_alt_co2 order by bigint_col;
 Alter table sto_alt_co3  alter column before_rename_col set statistics 3;
 select * from sto_alt_co3 order by bigint_col;
 
--- Alter table cluster on indexname
-Create index sto_alt_co3_idx on sto_alt_co3(bigint_col);
-Alter table sto_alt_co3 cluster on sto_alt_co3_idx;
-select * from sto_alt_co3 order by bigint_col;
-
--- Alter table SET without cluster
-Alter table sto_alt_co3 set without cluster;
-select * from sto_alt_co3 order by bigint_col;
-
 --Alter table SET without OIDs
 Alter table sto_alt_co3 SET without oids;
 select * from sto_alt_co3 order by bigint_col;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_ao_tables.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_ao_tables.ans
@@ -308,30 +308,6 @@ select * from sto_alt_ao3 order by bigint_col;
  2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
 (3 rows)
 
--- Alter table cluster on indexname
-Create index sto_alt_ao3_idx on sto_alt_ao3(bigint_col);
-CREATE INDEX
-Alter table sto_alt_ao3 cluster on sto_alt_ao3_idx;
-ALTER TABLE
-select * from sto_alt_ao3 order by bigint_col;
- text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
-----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
- 0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0
- 1_zero   |          1 | 1_zero        |           1 |       1 |         1 | {1}           |                 1 |                   1 | 2005-10-19 10:23:54 | 2005-10-19 01:23:54-07 | 2001-01-01  |               1
- 2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
-(3 rows)
-
--- Alter table SET without cluster
-Alter table sto_alt_ao3 set without cluster;
-ALTER TABLE
-select * from sto_alt_ao3 order by bigint_col;
- text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
-----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
- 0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0
- 1_zero   |          1 | 1_zero        |           1 |       1 |         1 | {1}           |                 1 |                   1 | 2005-10-19 10:23:54 | 2005-10-19 01:23:54-07 | 2001-01-01  |               1
- 2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
-(3 rows)
-
 --Alter table SET without OIDs
 Alter table sto_alt_ao3 SET without oids;
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_ao_tables.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_ao_tables.sql
@@ -133,15 +133,6 @@ select * from sto_alt_ao2 order by bigint_col;
 Alter table sto_alt_ao3  alter column before_rename_col set statistics 3;
 select * from sto_alt_ao3 order by bigint_col;
 
--- Alter table cluster on indexname
-Create index sto_alt_ao3_idx on sto_alt_ao3(bigint_col);
-Alter table sto_alt_ao3 cluster on sto_alt_ao3_idx;
-select * from sto_alt_ao3 order by bigint_col;
-
--- Alter table SET without cluster
-Alter table sto_alt_ao3 set without cluster;
-select * from sto_alt_ao3 order by bigint_col;
-
 --Alter table SET without OIDs
 Alter table sto_alt_ao3 SET without oids;
 select * from sto_alt_ao3 order by bigint_col;

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_co_tables.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_co_tables.ans
@@ -308,30 +308,6 @@ select * from sto_alt_co3 order by bigint_col;
  2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
 (3 rows)
 
--- Alter table cluster on indexname
-Create index sto_alt_co3_idx on sto_alt_co3(bigint_col);
-CREATE INDEX
-Alter table sto_alt_co3 cluster on sto_alt_co3_idx;
-ALTER TABLE
-select * from sto_alt_co3 order by bigint_col;
- text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
-----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
- 0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0
- 1_zero   |          1 | 1_zero        |           1 |       1 |         1 | {1}           |                 1 |                   1 | 2005-10-19 10:23:54 | 2005-10-19 01:23:54-07 | 2001-01-01  |               1
- 2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
-(3 rows)
-
--- Alter table SET without cluster
-Alter table sto_alt_co3 set without cluster;
-ALTER TABLE
-select * from sto_alt_co3 order by bigint_col;
- text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
-----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
- 0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0
- 1_zero   |          1 | 1_zero        |           1 |       1 |         1 | {1}           |                 1 |                   1 | 2005-10-19 10:23:54 | 2005-10-19 01:23:54-07 | 2001-01-01  |               1
- 2_zero   |          2 | 2_zero        |           2 |       2 |         2 | {2}           |                 2 |                   2 | 2006-10-19 10:23:54 | 2006-10-19 01:23:54-07 | 2002-01-01  |               2
-(3 rows)
-
 --Alter table SET without OIDs
 Alter table sto_alt_co3 SET without oids;
 ALTER TABLE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_co_tables.sql
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/load/sql/alter_co_tables.sql
@@ -133,15 +133,6 @@ select * from sto_alt_co2 order by bigint_col;
 Alter table sto_alt_co3  alter column before_rename_col set statistics 3;
 select * from sto_alt_co3 order by bigint_col;
 
--- Alter table cluster on indexname
-Create index sto_alt_co3_idx on sto_alt_co3(bigint_col);
-Alter table sto_alt_co3 cluster on sto_alt_co3_idx;
-select * from sto_alt_co3 order by bigint_col;
-
--- Alter table SET without cluster
-Alter table sto_alt_co3 set without cluster;
-select * from sto_alt_co3 order by bigint_col;
-
 --Alter table SET without OIDs
 Alter table sto_alt_co3 SET without oids;
 select * from sto_alt_co3 order by bigint_col;


### PR DESCRIPTION
Append-optimized tables do not support CLUSTER command. For some
unknown reason, the ALTER TABLE..CLUSTER and ALTER TABLE..SET WITHOUT
CLUSTER commands were left alone. This commit will properly disable
both commands for append-optimized (row and column orientated) tables
and report an error message when used.