### PR TITLE
Prune non-visible system cols for appendonly partition tables

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1634,6 +1634,20 @@ gpdb::FMotionGather
 }
 
 bool
+gpdb::FAppendOnlyPartitionTable
+	(
+	Oid rootOid
+	)
+{
+	GP_WRAP_START;
+	{
+		return rel_has_appendonly_partition(rootOid);
+	}
+	GP_WRAP_END;
+	return false;
+}
+
+bool
 gpdb::FMultilevelPartitionUniform
 	(
 	Oid rootOid

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -701,7 +701,7 @@ CTranslatorRelcacheToDXL::Pdrgpmdcol
 	{
 		BOOL fAOTable = IMDRelation::ErelstorageAppendOnlyRows == erelstorage ||
 				IMDRelation::ErelstorageAppendOnlyCols == erelstorage;
-		AddSystemColumns(pmp, pdrgpmdcol, rel->rd_att->tdhasoid, fAOTable);
+		AddSystemColumns(pmp, pdrgpmdcol, rel, fAOTable);
 	}
 
 	return pdrgpmdcol;
@@ -870,10 +870,13 @@ CTranslatorRelcacheToDXL::AddSystemColumns
 	(
 	IMemoryPool *pmp,
 	DrgPmdcol *pdrgpmdcol,
-	BOOL fHasOid,
+	Relation rel,
 	BOOL fAOTable
 	)
 {
+	BOOL fHasOid = rel->rd_att->tdhasoid;
+	fAOTable = fAOTable || gpdb::FAppendOnlyPartitionTable(rel->rd_id);
+
 	for (INT i= SelfItemPointerAttributeNumber; i > FirstLowInvalidHeapAttributeNumber; i--)
 	{
 		AttrNumber attno = AttrNumber(i);
@@ -883,13 +886,13 @@ CTranslatorRelcacheToDXL::AddSystemColumns
 		{
 			continue;
 		}
-		
+
 		if (FTransactionVisibilityAttribute(i) && fAOTable)
 		{
 			// skip transaction attrbutes like xmin, xmax, cmin, cmax for AO tables
 			continue;
 		}
-		
+
 		// get system name for that attribute
 		const CWStringConst *pstrSysColName = CTranslatorUtils::PstrSystemColName(attno);
 		GPOS_ASSERT(NULL != pstrSysColName);

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -71,6 +71,8 @@ extern bool rel_has_external_partition(Oid relid);
 
 extern bool query_has_external_partition(Query *query);
 
+extern bool rel_has_appendonly_partition(Oid relid);
+
 extern bool rel_is_child_partition(Oid relid);
 
 extern bool rel_is_leaf_partition(Oid relid);

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -375,7 +375,10 @@ namespace gpdb {
 
 	// is this a Gather motion
 	bool FMotionGather(const Motion *pmotion);
-	
+
+	// does a partition table have an appendonly child
+	bool FAppendOnlyPartitionTable(Oid rootOid);
+
 	// does a multi-level partitioned table have uniform partitioning hierarchy
 	bool FMultilevelPartitionUniform(Oid rootOid);
 

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -410,7 +410,7 @@ namespace gpdxl
 
 			// add system columns (oid, tid, xmin, etc) in table descriptors
 			static
-			void AddSystemColumns(IMemoryPool *pmp, DrgPmdcol *pdrgpmdcol, BOOL fhasOid, BOOL fAOTable);
+			void AddSystemColumns(IMemoryPool *pmp, DrgPmdcol *pdrgpmdcol, Relation rel, BOOL fAOTable);
 
 			// retrieve an index from the relcache
 			static

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1672,3 +1672,142 @@ reset optimizer_segments;
 drop function if exists find_operator(query text, operator_name text);
 drop function if exists count_operator(query text, operator_name text);
 -- end_ignore
+---
+--- Partition table with appendonly leaf, full join
+---
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+DROP TABLE IF EXISTS bar;
+NOTICE:  table "bar" does not exist, skipping
+CREATE TABLE foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE bar (b int, c int)
+PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE 
+  (
+    START (1) END (10) WITH (appendonly=true),
+    START (10) END (20)
+  ) 
+( 
+  START (1) END (10) ,
+  START (10) END (20)
+); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_1" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_2" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_1" for table "bar_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_2" for table "bar_1_prt_2"
+INSERT INTO foo VALUES (1);
+INSERT INTO bar VALUES (2,3);
+-- end_ignore
+SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
+ a | b | c 
+---+---+---
+ 1 |   |  
+   | 2 | 3
+(2 rows)
+
+-- CLEANUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+-- end_ignore
+---
+--- Partition table with appendonly set at middlevel partition, full join
+---
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+DROP TABLE IF EXISTS bar;
+NOTICE:  table "bar" does not exist, skipping
+CREATE TABLE foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE bar (b int, c int)
+PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE 
+  (
+    START (1) END (10),
+    START (10) END (20)
+  ) 
+( 
+  START (1) END (10) WITH (appendonly=true),
+  START (10) END (20)
+); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_1" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_2" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_1" for table "bar_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_2" for table "bar_1_prt_2"
+INSERT INTO foo VALUES (1);
+INSERT INTO bar VALUES (2,3);
+-- end_ignore
+SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
+ a | b | c 
+---+---+---
+ 1 |   |  
+   | 2 | 3
+(2 rows)
+
+-- CLEANUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+-- end_ignore
+---
+--- Partition table with appendonly set at root partition, full join
+---
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+DROP TABLE IF EXISTS bar;
+NOTICE:  table "bar" does not exist, skipping
+CREATE TABLE foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE bar (b int, c int) WITH (appendonly=true)
+PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE 
+  (
+    START (1) END (10),
+    START (10) END (20)
+  ) 
+( 
+  START (1) END (10),
+  START (10) END (20)
+); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_1" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_2" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_1" for table "bar_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_2" for table "bar_1_prt_2"
+INSERT INTO foo VALUES (1);
+INSERT INTO bar VALUES (2,3);
+-- end_ignore
+SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
+ a | b | c 
+---+---+---
+ 1 |   |  
+   | 2 | 3
+(2 rows)
+
+-- CLEANUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+drop schema if exists bfv_partition;
+-- end_ignore

--- a/src/test/regress/expected/bfv_partition_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_optimizer.out
@@ -1673,3 +1673,142 @@ drop function if exists find_operator(query text, operator_name text);
 drop function if exists count_operator(query text, operator_name text);
 drop schema if exists bfv_partition;
 -- end_ignore
+---
+--- Partition table with appendonly leaf, full join
+---
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+DROP TABLE IF EXISTS bar;
+NOTICE:  table "bar" does not exist, skipping
+CREATE TABLE foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE bar (b int, c int)
+PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE 
+  (
+    START (1) END (10) WITH (appendonly=true),
+    START (10) END (20)
+  ) 
+( 
+  START (1) END (10) ,
+  START (10) END (20)
+); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_1" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_2" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_1" for table "bar_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_2" for table "bar_1_prt_2"
+INSERT INTO foo VALUES (1);
+INSERT INTO bar VALUES (2,3);
+-- end_ignore
+SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
+ a | b | c 
+---+---+---
+ 1 |   |  
+   | 2 | 3
+(2 rows)
+
+-- CLEANUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+-- end_ignore
+---
+--- Partition table with appendonly set at middlevel partition, full join
+---
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+DROP TABLE IF EXISTS bar;
+NOTICE:  table "bar" does not exist, skipping
+CREATE TABLE foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE bar (b int, c int)
+PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE 
+  (
+    START (1) END (10),
+    START (10) END (20)
+  ) 
+( 
+  START (1) END (10) WITH (appendonly=true),
+  START (10) END (20)
+); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_1" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_2" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_1" for table "bar_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_2" for table "bar_1_prt_2"
+INSERT INTO foo VALUES (1);
+INSERT INTO bar VALUES (2,3);
+-- end_ignore
+SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
+ a | b | c 
+---+---+---
+ 1 |   |  
+   | 2 | 3
+(2 rows)
+
+-- CLEANUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+-- end_ignore
+---
+--- Partition table with appendonly set at root partition, full join
+---
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+NOTICE:  table "foo" does not exist, skipping
+DROP TABLE IF EXISTS bar;
+NOTICE:  table "bar" does not exist, skipping
+CREATE TABLE foo (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE bar (b int, c int) WITH (appendonly=true)
+PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE 
+  (
+    START (1) END (10),
+    START (10) END (20)
+  ) 
+( 
+  START (1) END (10),
+  START (10) END (20)
+); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_1" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1_2_prt_2" for table "bar_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_1" for table "bar_1_prt_2"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2_2_prt_2" for table "bar_1_prt_2"
+INSERT INTO foo VALUES (1);
+INSERT INTO bar VALUES (2,3);
+-- end_ignore
+SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
+ a | b | c 
+---+---+---
+ 1 |   |  
+   | 2 | 3
+(2 rows)
+
+-- CLEANUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+drop schema if exists bfv_partition;
+-- end_ignore

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -642,5 +642,109 @@ reset optimizer_segments;
 
 drop function if exists find_operator(query text, operator_name text);
 drop function if exists count_operator(query text, operator_name text);
+-- end_ignore
+
+---
+--- Partition table with appendonly leaf, full join
+---
+
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+
+CREATE TABLE foo (a int);
+
+CREATE TABLE bar (b int, c int)
+PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE 
+  (
+    START (1) END (10) WITH (appendonly=true),
+    START (10) END (20)
+  ) 
+( 
+  START (1) END (10) ,
+  START (10) END (20)
+); 
+-- end_ignore
+INSERT INTO foo VALUES (1);
+INSERT INTO bar VALUES (2,3);
+
+SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
+
+-- CLEANUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+-- end_ignore
+
+---
+--- Partition table with appendonly set at middlevel partition, full join
+---
+
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+
+CREATE TABLE foo (a int);
+
+CREATE TABLE bar (b int, c int)
+PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE 
+  (
+    START (1) END (10),
+    START (10) END (20)
+  ) 
+( 
+  START (1) END (10) WITH (appendonly=true),
+  START (10) END (20)
+); 
+-- end_ignore
+INSERT INTO foo VALUES (1);
+INSERT INTO bar VALUES (2,3);
+
+SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
+
+-- CLEANUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+-- end_ignore
+
+---
+--- Partition table with appendonly set at root partition, full join
+---
+
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
+
+CREATE TABLE foo (a int);
+
+CREATE TABLE bar (b int, c int) WITH (appendonly=true)
+PARTITION BY RANGE (b)
+  SUBPARTITION BY RANGE (c) SUBPARTITION TEMPLATE 
+  (
+    START (1) END (10),
+    START (10) END (20)
+  ) 
+( 
+  START (1) END (10),
+  START (10) END (20)
+); 
+-- end_ignore
+INSERT INTO foo VALUES (1);
+INSERT INTO bar VALUES (2,3);
+
+SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
+
+-- CLEANUP
+-- start_ignore
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS bar;
 drop schema if exists bfv_partition;
 -- end_ignore
+
+


### PR DESCRIPTION
Previously gporca translator was only pruning the system columns from
the table descriptor for non-partition `appendonly` tables or if the
paritition table is marked as `appendonly` at the root level.

If one of the leaf partitions in is marked as `appendonly` but the root
is not, the system columns still appears in the table descriptor.

This commit fixes the issue by checking if the root table has
`appendonly` paritions and pruning system columns if it has.