### PR TITLE
Enable gptransfer from 43x to 5x

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -964,7 +964,8 @@ class SingletonSideEffect:
             "select c.oid": ["oid1", "oid1"],
             "select parisdefault, parruleord, parrangestartincl,": ["f", "1", "t", "t", 100, 10, "", ""],
             "select n.nspname, c.relname": ["public", "my_table_partition1"],
-            "SELECT count(*) FROM": [20]
+            "SELECT count(*) FROM": [20],
+            "SELECT version()": ["PostgreSQL 8.3.23 (Greenplum Database 5.0.0 build fdafasdf"],
         }
 
         self.counters = dict((key, 0) for key in self.values.keys())

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -19,20 +19,21 @@ transfer will include dependent roles, UDFs, UDTs, views, resource queues,
 and possibly a subset of system configuration of specified tables.
 """
 
-import sys
+import datetime
+import hashlib
+import inspect
 import os
 import re
-import time
 import signal
-import inspect
-import hashlib
-import datetime
-from collections import defaultdict
-from threading import Thread, Event, Lock
+import sys
 import thread
+import time
+from collections import defaultdict
 from optparse import OptionGroup, SUPPRESS_HELP
+from threading import Thread, Event, Lock
 
-from gpversion import GpVersion
+from gppylib.gpversion import GpVersion
+from gptransfer_modules.partition_comparators import PartitionComparatorFactory
 
 try:
     from gppylib.mainUtils import simple_main, addStandardLoggingAndHelpOptions, \
@@ -4054,25 +4055,23 @@ class GpTransfer(object):
 
     def _has_same_range_partition_value(self, source_partition_info, dest_partition_info, part_transfer_pair_msg):
         comparator = PartitionComparatorFactory().get(source_partition_info, dest_partition_info)
-        result = comparator.isSame(source_partition_info, dest_partition_info)
+        result = comparator.is_same(source_partition_info, dest_partition_info)
         if not result:
             logger.error('Range partition value is different between %s' % part_transfer_pair_msg)
 
         return result
 
     def _has_same_list_partition_value(self, source_partition_info, dest_partition_info, part_transfer_pair_msg):
-        source_partition_values = self._process_list_partition_value(source_partition_info['parlistvalues'])
-        dest_partition_values = self._process_list_partition_value(dest_partition_info['parlistvalues'])
-
-        # Sort the partition values/constraints
-        if sorted(source_partition_values) != sorted(dest_partition_values):
+        comparator = PartitionComparatorFactory().get(source_partition_info, dest_partition_info)
+        result = comparator.is_same(source_partition_info, dest_partition_info)
+        if not result:
             logger.error('List partition value is different between %s' % part_transfer_pair_msg)
-            return False
-        return True
+
+        return result
 
     def _process_list_partition_value(self, partition_info):
         """
-        In the scenario of multiple partition colums, the partition values will
+        In the scenario of multiple partition columns, the partition values will
         be in the format: (({constraint1} {constraint2})) in pg_catalog.pg_partition_rule
         """
         partition_values = partition_info[2: len(partition_info) - 2].split('} {')
@@ -4080,7 +4079,7 @@ class GpTransfer(object):
         return partition_values
 
     def _get_oid(self, db, schema, table, host, port, user):
-        get_oid_sql = ''' select c.oid
+        get_oid_sql = '''select c.oid
                      from pg_catalog.pg_class c, pg_catalog.pg_namespace n
                      where c.relname = '%s'
                            and n.oid = c.relnamespace
@@ -4096,7 +4095,7 @@ class GpTransfer(object):
         partition_info = dict()
         oid = self._get_oid(db, schema, table, host, port, user)
 
-        get_partition_type = ''' select partitiontype
+        get_partition_type = '''select partitiontype
                                  from pg_catalog.pg_partitions
                                  where partitionschemaname = '%s'
                                        and partitiontablename = '%s';''' % (
@@ -4108,7 +4107,7 @@ class GpTransfer(object):
         get_partition_info_sql = '''select parisdefault, parruleord, parrangestartincl, parrangeendincl, parrangestart,
                                            parrangeend, parrangeevery, parlistvalues
                                     from pg_catalog.pg_partition_rule
-                                    where parchildrelid = %s;''' % oid
+                                    where parchildrelid = %s''' % oid
 
         with dbconn.connect(dbconn.DbURL(host, port, db, user)) as conn:
             row = execSQLForSingletonRow(conn, get_partition_info_sql)
@@ -4214,23 +4213,6 @@ class GpTransfer(object):
                 raise Exception('Hostname %s missing from map file' % seg_host)
             if len(self._host_map[seg_host]) == 0:
                 raise Exception('No addresses for hostname %s' % seg_host)
-
-class SameVersionPartitionComparator:
-    def isSame(self, source_partition_info, dest_partition_info):
-
-        return source_partition_info['version'] == dest_partition_info['version'] and \
-               source_partition_info['parrangestartincl'] == dest_partition_info['parrangestartincl'] and \
-               source_partition_info['parrangestart'] == dest_partition_info['parrangestart'] and \
-               source_partition_info['parrangeend'] == dest_partition_info['parrangeend'] and \
-               source_partition_info['parrangeevery'] == dest_partition_info['parrangeevery']
-
-class PartitionComparatorFactory:
-    def get(self, source, dest):
-        if source['version'] == dest['version']:
-            return SameVersionPartitionComparator()
-
-        raise Exception("cannot determine comparator for unmatched source and dest versions within: %s \n\n %s" %
-                        (source, dest))
 
 
 # --------------------------------------------------------------------------

--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -32,6 +32,8 @@ from threading import Thread, Event, Lock
 import thread
 from optparse import OptionGroup, SUPPRESS_HELP
 
+from gpversion import GpVersion
+
 try:
     from gppylib.mainUtils import simple_main, addStandardLoggingAndHelpOptions, \
         ProgramArgumentValidationException
@@ -110,6 +112,7 @@ DEFAULT_GPFDIST_LAST_PORT = -1
 MIN_GPFDIST_TIMEOUT = 2
 MAX_GPFDIST_TIMEOUT = 600
 GPFDIST_PORT_REGEX = r"Serving HTTP on port (\d+)"
+VERSION_REGEX_PATTERN = re.compile(".*Greenplum Database (\d).*")
 
 # --------------------------------------------------------------------------
 # Logging
@@ -4050,13 +4053,12 @@ class GpTransfer(object):
             raise Exception('Unknown partitioning type %s found, %s' % (part_type, part_transfer_pair_msg))
 
     def _has_same_range_partition_value(self, source_partition_info, dest_partition_info, part_transfer_pair_msg):
-        if (source_partition_info['parrangestartincl'] != dest_partition_info['parrangestartincl'] or
-                    source_partition_info['parrangestart'] != dest_partition_info['parrangestart'] or
-                    source_partition_info['parrangeend'] != dest_partition_info['parrangeend'] or
-                    source_partition_info['parrangeevery'] != dest_partition_info['parrangeevery']):
+        comparator = PartitionComparatorFactory().get(source_partition_info, dest_partition_info)
+        result = comparator.isSame(source_partition_info, dest_partition_info)
+        if not result:
             logger.error('Range partition value is different between %s' % part_transfer_pair_msg)
-            return False
-        return True
+
+        return result
 
     def _has_same_list_partition_value(self, source_partition_info, dest_partition_info, part_transfer_pair_msg):
         source_partition_values = self._process_list_partition_value(source_partition_info['parlistvalues'])
@@ -4118,6 +4120,10 @@ class GpTransfer(object):
             partition_info['parrangeend'] = row[5]
             partition_info['parrangeevery'] = row[6]
             partition_info['parlistvalues'] = row[7]
+
+            row = execSQLForSingletonRow(conn, 'SELECT version()')
+            version = GpVersion(row[0])
+            partition_info['version'] = version.getVersionRelease()
         return partition_info
 
     def _check_leaf_partition_set(self, table_pair):
@@ -4208,6 +4214,23 @@ class GpTransfer(object):
                 raise Exception('Hostname %s missing from map file' % seg_host)
             if len(self._host_map[seg_host]) == 0:
                 raise Exception('No addresses for hostname %s' % seg_host)
+
+class SameVersionPartitionComparator:
+    def isSame(self, source_partition_info, dest_partition_info):
+
+        return source_partition_info['version'] == dest_partition_info['version'] and \
+               source_partition_info['parrangestartincl'] == dest_partition_info['parrangestartincl'] and \
+               source_partition_info['parrangestart'] == dest_partition_info['parrangestart'] and \
+               source_partition_info['parrangeend'] == dest_partition_info['parrangeend'] and \
+               source_partition_info['parrangeevery'] == dest_partition_info['parrangeevery']
+
+class PartitionComparatorFactory:
+    def get(self, source, dest):
+        if source['version'] == dest['version']:
+            return SameVersionPartitionComparator()
+
+        raise Exception("cannot determine comparator for unmatched source and dest versions within: %s \n\n %s" %
+                        (source, dest))
 
 
 # --------------------------------------------------------------------------

--- a/gpMgmt/bin/gptransfer_modules/partition_comparators.py
+++ b/gpMgmt/bin/gptransfer_modules/partition_comparators.py
@@ -1,0 +1,88 @@
+import re
+
+PARTITION_METADATA_PATTERN = re.compile('.*CONST (:.*) \[')
+KEY_WITH_METADATA_43X_TO_5X = ["parrangestart", "parrangeend", "parrangeevery", "parlistvalues"]
+KEY_WITH_METADATA_5X_TO_5X = ["version", "parrangestartincl"] + KEY_WITH_METADATA_43X_TO_5X
+
+
+class PartitionComparator(object):
+    def _parse_value(self, partition_info_dict, column_list):
+        """
+        input like:
+        (({CONST :consttype 1042 :constlen -1 :constbyval false :constisnull false :constvalue 5 [ 0 0 0 5 77 ]}
+          {CONST :consttype 23 :constlen 4 :constbyval true :constisnull false :constvalue 4 [ 1 0 0 0 0 0 0 0 ]}))
+
+        break into chunks, sort the chunks by alpha,
+        :returns a list of all text chunks split by a space
+        """
+        result = dict(partition_info_dict)
+        for column_key in column_list:
+            value = result[column_key]
+            # removing enclosing parenthesis and curly braces '(({' and '}))'
+            value = value[3:-3]
+            chunks = value.split("} {")
+            alpha_chunks = sorted(chunks)
+            result[column_key] = []
+            for chunk in alpha_chunks:
+                result[column_key].extend(chunk.split(" "))
+        return result
+
+
+class Version4to5PartitionComparator(PartitionComparator):
+
+    def _parse_value(self, partition_info_dict):
+        return super(Version4to5PartitionComparator, self)._parse_value(partition_info_dict,
+                                                                        KEY_WITH_METADATA_43X_TO_5X)
+
+    def _remove_key_and_value(self, list_info, key_to_remove):
+        while key_to_remove in list_info:
+            index = list_info.index(key_to_remove)
+            # delete also removes the corresponding value
+            del list_info[index:index+2]
+
+    def is_same(self, source_partition_info, dest_partition_info):
+        """
+        TODO: compare attributes not used for list or range, e.g., parisdefault
+        """
+        src_dict = self._parse_value(source_partition_info)
+        dest_dict = self._parse_value(dest_partition_info)
+
+        for key in KEY_WITH_METADATA_43X_TO_5X:
+            version5_info = dest_dict[key]
+            # greenplum 5 added a 'consttypmod' attribute.
+            # remove it so as to compare all other attributes
+            self._remove_key_and_value(version5_info, ':consttypmod')
+            if src_dict[key] != dest_dict[key]:
+                return False
+        return True
+
+
+class SameVersionPartitionComparator(PartitionComparator):
+
+    ALLOW_UNORDERED_COLUMNS_LIST = ['parlistvalues']
+
+    def _parse_value(self, partition_info_dict):
+        return super(SameVersionPartitionComparator, self)._parse_value(partition_info_dict,
+                                                                        self.ALLOW_UNORDERED_COLUMNS_LIST)
+
+    def is_same(self, source_partition_info, dest_partition_info):
+        src_dict = self._parse_value(source_partition_info)
+        dest_dict = self._parse_value(dest_partition_info)
+
+        for key in KEY_WITH_METADATA_5X_TO_5X:
+            if src_dict[key] != dest_dict[key]:
+                return False
+        return True
+
+
+class PartitionComparatorFactory:
+    def get(self, source, dest):
+        source_ver = source['version']
+        dest_ver = dest['version']
+        if source_ver == dest_ver:
+            return SameVersionPartitionComparator()
+        elif source_ver == '4.3' and dest_ver[0] == '5':
+            return Version4to5PartitionComparator()
+
+        raise Exception("No comparator defined for source "
+                        "and dest versions\n: %s \n\n %s" % (source, dest))


### PR DESCRIPTION
Issue:
  There are new partition information in 5x that's not in 43x and this causes our validation in gptransfer to fail. So far, we found that list and range partition table has been affected.

Fix:
  Remove the extra information from 5x partition table before comparing to 43x partition table.


Update same version check for gptransfer
   * Update same version column partition check to allow multiple partition
      columns to be in different order for list partition tables.
adapt partition validation to skip a metadata attribute only present in 5.x
Add comparator class for same version partition validation

Authors: Marbin, Chumki and Larry