### PR TITLE
Setup limits for gpadmin user in CI.

### DIFF
--- a/concourse/scripts/regression_tests_gpcloud.bash
+++ b/concourse/scripts/regression_tests_gpcloud.bash
@@ -54,7 +54,6 @@ function _main() {
 	ln -s "$(pwd)/gpdb_src/gpAux/ext/rhel5_x86_64/python-2.6.2" /opt
 
 	time configure
-	sed -i s/1024/unlimited/ /etc/security/limits.d/90-nproc.conf
 	time install_gpdb
 	time setup_gpadmin_user
 	time make_cluster

--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -39,6 +39,19 @@ transfer_ownership() {
   chown -R gpadmin:gpadmin /home/gpadmin
 }
 
+set_limits() {
+  # Currently same as what's recommended in install guide
+  if [ -d /etc/security/limits.d ]; then
+    cat > /etc/security/limits.d/gpadmin-limits.conf <<-EOF
+		gpadmin soft core unlimited
+		gpadmin soft nproc 131072
+		gpadmin soft nofile 65536
+	EOF
+  fi
+  # Print now effective limits for gpadmin
+  su gpadmin -c 'ulimit -a'
+}
+
 setup_gpadmin_user() {
   /usr/sbin/useradd gpadmin
   echo -e "password\npassword" | passwd gpadmin
@@ -47,6 +60,7 @@ setup_gpadmin_user() {
   usermod -a -G tty gpadmin
   setup_ssh_for_user gpadmin
   transfer_ownership
+  set_limits
 }
 
 setup_sshd() {


### PR DESCRIPTION
Centos 6 defaults nprocs as 1024 for users. Many times in CI seen failure as
cannot fork process, hence better to set reasonable limits (currently equivalent
to what's recommended by admin guide) while creating gpadmin user.