### PR TITLE
fail fast when an invalid command line argument is passed in

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4297,6 +4297,8 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
 				errs++;
 				break;
 		}
+		if (errs)
+			break;
 	}
 
 


### PR DESCRIPTION
This will correctly report the invalid argument instead of
the last one passed in