### PR TITLE
qualify quicklz references

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -173,13 +173,14 @@
             <row>
               <entry colname="col1">Row</entry>
               <entry colname="col2">Table</entry>
-              <entry colname="col3"><codeph>ZLIB</codeph> and <codeph>QUICKLZ</codeph></entry>
+              <entry colname="col3"><codeph>ZLIB</codeph> and
+                <codeph>QUICKLZ</codeph><sup>1</sup></entry>
             </row>
             <row>
               <entry colname="col1">Column</entry>
               <entry colname="col2">Column and Table</entry>
               <entry colname="col3"><codeph>RLE_TYPE</codeph>, <codeph>ZLIB</codeph>, and
-                  <codeph>QUICKLZ</codeph></entry>
+                  <codeph>QUICKLZ</codeph><sup>1</sup></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -184,6 +184,10 @@
           </tbody>
         </tgroup>
       </table>
+      <p>
+        <note type="note"><sup>1</sup>QuickLZ compression is available only in the commercial
+          release of Pivotal Greenplum Database.</note>
+      </p>
       <p>When choosing a compression type and level for append-optimized tables, consider these
         factors:</p>
       <ul id="ul_xlg_1wy_sp">

--- a/gpdb-doc/dita/common/pivotal-gpdb-features.xml
+++ b/gpdb-doc/dita/common/pivotal-gpdb-features.xml
@@ -25,8 +25,10 @@
       <li>To use GPORCA with open source Greenplum Database the
         software must be compiled with GPORCA enabled. Refer to the build instructions in the README
         file in the Greenplum Database repository.</li>
-      <li>The QuickLZ compression method is not supported in Greenplum Database and is ignored if
-        specified. </li>
+      <li>The QuickLZ compression method is not available in Greenplum Database. QuickLZ
+          <codeph>compresstype</codeph>s are ignored when specified in a <codeph>CREATE TABLE
+          [AS]</codeph> operation, but will cause an error on subsequent <codeph>INSERT</codeph> or
+          <codeph>SELECT</codeph> operations on the table.</li>
       <li>The deprecated <codeph>gpcheck</codeph> management utility and its replacement
           <codeph>gpsupport</codeph> are only supported with Pivotal Greenplum Database. </li>
       <li>Suggestions to contact Pivotal Technical Support in this documentation are intended only

--- a/gpdb-doc/dita/common/pivotal-gpdb-features.xml
+++ b/gpdb-doc/dita/common/pivotal-gpdb-features.xml
@@ -26,7 +26,7 @@
         software must be compiled with GPORCA enabled. Refer to the build instructions in the README
         file in the Greenplum Database repository.</li>
       <li>The QuickLZ compression method is not available in Greenplum Database. QuickLZ
-          <codeph>compresstype</codeph>s are ignored when specified in a <codeph>CREATE TABLE
+          <codeph>compresstype</codeph> values are ignored when specified in a <codeph>CREATE TABLE
           [AS]</codeph> operation, but will cause an error on subsequent <codeph>INSERT</codeph> or
           <codeph>SELECT</codeph> operations on the table.</li>
       <li>The deprecated <codeph>gpcheck</codeph> management utility and its replacement

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2859,8 +2859,8 @@
                   2097152 </p><p><cmdname>CHECKSUM</cmdname>= <codeph>TRUE</codeph> |
                     <codeph>FALSE</codeph>
                 </p><p><cmdname>COMPRESSTYPE</cmdname>= <codeph>ZLIB</codeph> |
-                    <codeph>QUICKLZ</codeph> | <codeph>RLE</codeph>_<codeph>TYPE</codeph> |
-                    <codeph>NONE</codeph>
+                    <codeph>QUICKLZ</codeph><sup>2</sup> |
+                    <codeph>RLE</codeph>_<codeph>TYPE</codeph> | <codeph>NONE</codeph>
                 </p><p><cmdname>COMPRESSLEVEL</cmdname>= integer between 0 and
                     9</p><p><cmdname>ORIENTATION</cmdname>= <codeph>ROW</codeph> |
                     <codeph>COLUMN</codeph>
@@ -2879,6 +2879,9 @@
       <note>
         <sup>1</sup>The set classification when the parameter is set at the system level with the
           <cmdname>gpconfig</cmdname> utility.</note>
+      <note>
+        <sup>2</sup>QuickLZ compression is available only in the commercial release of Pivotal
+        Greenplum Database.</note>
     </body>
   </topic>
   <topic id="gp_dynamic_partition_pruning">

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -385,12 +385,15 @@
             disable checksum validation, checking the table data for on-disk corruption will not be
             performed.</pd>
           <pd><b>COMPRESSTYPE</b> — Set to <codeph>ZLIB</codeph> (the default),
-              <codeph>RLE-TYPE</codeph>, or <codeph>QUICKLZ</codeph> to specify the type of
-            compression used. The value <codeph>NONE</codeph>disables compression. QuickLZ uses less
-            CPU power and compresses data faster at a lower compression ratio than zlib. Conversely,
-            zlib provides more compact compression ratios at lower speeds. This option is only valid
-            if <codeph>APPENDONLY=TRUE</codeph>.<p>The value <codeph>RLE_TYPE</codeph> is supported
-              only if <codeph>ORIENTATION</codeph> =<codeph>column</codeph> is specified, Greenplum
+              <codeph>RLE-TYPE</codeph>, or <codeph>QUICKLZ</codeph><sup>1</sup> to specify the type
+            of compression used. The value <codeph>NONE</codeph>disables compression. QuickLZ uses
+            less CPU power and compresses data faster at a lower compression ratio than zlib.
+            Conversely, zlib provides more compact compression ratios at lower speeds. This option
+            is only valid if <codeph>APPENDONLY=TRUE</codeph>.<p>
+              <note type="note"><sup>1</sup>QuickLZ compression is available only in the commercial
+                release of Pivotal Greenplum Database.</note>
+            </p><p>The value <codeph>RLE_TYPE</codeph> is supported only if
+                <codeph>ORIENTATION</codeph> =<codeph>column</codeph> is specified, Greenplum
               Database uses the run-length encoding (RLE) compression algorithm. RLE compresses data
               better than the zlib or QuickLZ compression algorithm when the same data value occurs
               in many consecutive rows.</p><p>For columns of type <codeph>BIGINT</codeph>,

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE_AS.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE_AS.xml
@@ -80,11 +80,13 @@
           <pd>ORIENTATION — Set to <codeph>column</codeph> for column-oriented storage, or
               <codeph>row</codeph> (the default) for row-oriented storage. This option is only valid
             if <codeph>APPENDONLY=TRUE</codeph>. Heap-storage tables can only be row-oriented.</pd>
-          <pd>COMPRESSTYPE — Set to <codeph>ZLIB</codeph> (the default) or <codeph>QUICKLZ</codeph>
-            to specify the type of compression used. QuickLZ uses less CPU power and compresses data
-            faster at a lower compression ratio than zlib. Conversely, zlib provides more compact
-            compression ratios at lower speeds. This option is only valid if
-              <codeph>APPENDONLY=TRUE</codeph>.</pd>
+          <pd>COMPRESSTYPE — Set to <codeph>ZLIB</codeph> (the default) or
+              <codeph>QUICKLZ</codeph><sup>1</sup> to specify the type of compression used. QuickLZ
+            uses less CPU power and compresses data faster at a lower compression ratio than zlib.
+            Conversely, zlib provides more compact compression ratios at lower speeds. This option
+            is only valid if <codeph>APPENDONLY=TRUE</codeph>. <note type="note"><sup>1</sup>QuickLZ
+              compression is available only in the commercial release of Pivotal Greenplum
+              Database.</note></pd>
           <pd>COMPRESSLEVEL — For zlib compression of append-optimized tables, set to a value
             between 1 (fastest compression) to 9 (highest compression ratio). QuickLZ compression
             level can only be set to 1. If not declared, the default is 1. This option is only valid

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_appendonly.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_appendonly.xml
@@ -57,8 +57,8 @@
             <entry colname="col2">smallint</entry>
             <entry colname="col3"/>
             <entry colname="col4">The compression level, with compression ratio increasing from 1 to
-              9. When <codeph>quicklz</codeph> is specified for compresstype, valid values are 1 or
-              3. With <codeph>zlib</codeph> specified, valid values are 1-9. </entry>
+              9. When <codeph>quicklz</codeph><sup>1</sup> is specified for compresstype, valid
+              values are 1 or 3. With <codeph>zlib</codeph> specified, valid values are 1-9. </entry>
           </row>
           <row>
             <entry colname="col1">
@@ -93,7 +93,7 @@
             <entry colname="col3"/>
             <entry colname="col4">Type of compression used to compress append-optimized tables.
               Valid values are <codeph>zlib</codeph> (gzip compression) and
-              <codeph>quicklz</codeph>.</entry>
+                <codeph>quicklz</codeph><sup>1</sup>. </entry>
           </row>
           <row>
             <entry colname="col1">
@@ -155,5 +155,7 @@
         </tbody>
       </tgroup>
     </table>
+    <note type="note"><sup>1</sup>QuickLZ compression is available only in the commercial release of
+      Pivotal Greenplum Database.</note>
   </body>
 </topic>

--- a/gpdb-doc/dita/relnotes/GPDB_500_README.xml
+++ b/gpdb-doc/dita/relnotes/GPDB_500_README.xml
@@ -146,10 +146,10 @@
         <li>
           <p>GPDB 5.0.0 does not provide QuickLZ compression, but accepts <codeph>CREATE TABLE
               [AS]</codeph> operations with table-, partition-, and/or column-level
-              <codeph>compresstype</codeph>s identifying QuickLZ. <codeph>INSERT</codeph> and
-              <codeph>SELECT</codeph> operations on such tables will fail, returning "ERROR: quicklz
-            compression not supported". To work around this issue, first <codeph>DROP</codeph> then
-            recreate the table without QuickLZ compression. </p>
+              <codeph>compresstype</codeph> values identifying QuickLZ. <codeph>INSERT</codeph> and
+              <codeph>SELECT</codeph> operations on such tables will fail, returning <codeph>ERROR:
+              quicklz compression not supported</codeph>. To work around this issue, first
+              <codeph>DROP</codeph> then recreate the table without QuickLZ compression. </p>
         </li>
       </ul>
     </body>

--- a/gpdb-doc/dita/relnotes/GPDB_500_README.xml
+++ b/gpdb-doc/dita/relnotes/GPDB_500_README.xml
@@ -24,13 +24,14 @@
     <title class="- topic/title ">About Greenplum Database 5.0.0</title>
     <body class="- topic/body ">
       <p>Greenplum Database 5.0.0 is a major new release that includes product changes and
-        integrates many features from PostgreSQL 8.3. Please refer to the following sections for more
-        information about this release.</p>
+        integrates many features from PostgreSQL 8.3. Please refer to the following sections for
+        more information about this release.</p>
       <ul class="- topic/ul " id="ul_j1t_psl_fp">
         <li><xref href="#topic_yxx_bq2_lx" format="dita"/></li>
-        <li><xref href="#topic_epl_slm_5y" format="dita"/></li>
-        <li><xref href="#topic_osh_g4m_5y" format="dita"/></li>
-        <li><xref href="#topic21" format="dita"/>
+        <li><xref href="#topic20" format="dita"/></li>
+        <li id="pm437579" class="- topic/li "><xref href="#topic21" format="dita"/>
+        </li>
+        <li id="pm437583" class="- topic/li "><xref href="#id_qc5_pyd_wy" format="dita"/>
         </li>
         <li id="pm437587" class="- topic/li "><xref href="#topic36" type="topic" format="dita"
             class="- topic/xref "/>
@@ -135,6 +136,22 @@
           </tbody>
         </tgroup>
       </table>
+    </body>
+  </topic>
+  <topic id="id_qc5_pyd_wy">
+    <title>Limitations in Greenplum Database 5.0.0</title>
+    <body>
+      <p>Greenplum Database 5.0.0 has these limitations:</p>
+      <ul id="ul_lg5_pyd_wy">
+        <li>
+          <p>GPDB 5.0.0 does not provide QuickLZ compression, but accepts <codeph>CREATE TABLE
+              [AS]</codeph> operations with table-, partition-, and/or column-level
+              <codeph>compresstype</codeph>s identifying QuickLZ. <codeph>INSERT</codeph> and
+              <codeph>SELECT</codeph> operations on such tables will fail, returning "ERROR: quicklz
+            compression not supported". To work around this issue, first <codeph>DROP</codeph> then
+            recreate the table without QuickLZ compression. </p>
+        </li>
+      </ul>
     </body>
   </topic>
   <topic id="topic36">


### PR DESCRIPTION
trying out the gpdb docs PR process with the changes for qualifying quicklz.  also my first edits with oxygen. (i am not really sure how to interpret the diffs and tell if my editting is ok.)  local build looked ok.  i don't expect this PR to be accepted as is.

anyway, i approached the changes in a couple of different ways, the first time quicklz was referenced on the page outside of reference page syntax definition:
- added a numbered superscript and note
- added just a note
- ALTER TABLE had one reference to quicklz in a syntax definition and no further discussion.  this page may be missing a section?  in any case, i didn't do anything on this page because because no discussion in which to add the qualifier.

also, wasn't sure if i needed to qualify every time quicklz was used.  input welcome!  thanks.