### PR TITLE
Update string escaping to account for standard_conforming_strings.

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -274,7 +274,7 @@ class AnalyzeDb(Operation):
             # The below object is needed for some functions imported from dump.py
             self.context = Context()
             self.context.master_port = self.pg_port
-            self.context.dump_database = self.dbname
+            self.context.target_db = self.dbname
 
             # The input_col_dict keeps track of the requested columns to analyze.
             # key: table name (e.g. 'public.foo')

--- a/gpMgmt/bin/gpcrondump
+++ b/gpMgmt/bin/gpcrondump
@@ -76,7 +76,7 @@ class GpCronDump(Operation):
         if not self.context.ddboost_hosts: self.context.ddboost_hosts = []
 
         if len(self.context.dump_databases) > 0:
-            self.context.dump_database = self.context.dump_databases[0]
+            self.context.target_db = self.context.dump_databases[0]
 
         self.include_email_file = options.include_email_file
 
@@ -593,7 +593,7 @@ class GpCronDump(Operation):
                 table_list.append(table_name)
         return create_temp_file_from_list(table_list, 'include_dump_tables_file')
 
-    def get_include_exclude_for_dump_database(self, dirty_file, dbname):
+    def get_include_exclude_for_dump_database(self, dirty_file):
         """
         This is to empty the self.include_dump_tables and self.exclude_dump_tables, write all
         include tables and exclude tables into include tables file and exclude tables file respectively.
@@ -616,18 +616,18 @@ class GpCronDump(Operation):
                 if table.startswith('pg_temp_'):
                     continue
                 dump_tables_without_pg_temp.append(table)
-            include_file = expand_partitions_and_populate_filter_file(dbname,
+            include_file = expand_partitions_and_populate_filter_file(self.context,
                                                                       dump_tables_without_pg_temp,
                                                                       'include_dump_tables_file')
             self.context.include_dump_tables = []
 
         if self.context.exclude_dump_tables:
-            exclude_file = expand_partitions_and_populate_filter_file(dbname, self.context.exclude_dump_tables, 'exclude_dump_tables_file')
+            exclude_file = expand_partitions_and_populate_filter_file(self.context, self.context.exclude_dump_tables, 'exclude_dump_tables_file')
             self.context.exclude_dump_tables = []
 
         if self.context.exclude_dump_tables_file:
             exclude_tables = get_lines_from_file(self.context.exclude_dump_tables_file)
-            exclude_file = expand_partitions_and_populate_filter_file(dbname,
+            exclude_file = expand_partitions_and_populate_filter_file(self.context,
                                                                       exclude_tables,
                                                                       'exclude_dump_tables_file')
 
@@ -728,7 +728,7 @@ class GpCronDump(Operation):
             return 0
 
         for dumpdb in self.context.dump_databases:
-            self.context.dump_database = dumpdb
+            self.context.target_db = dumpdb
 
             if not self.context.incremental:
                 self.context.generate_dump_timestamp()
@@ -738,7 +738,7 @@ class GpCronDump(Operation):
                 logger.info('Successfully listed the names of backup files and pipes')
                 return 0
             if self.list_filter_tables:
-                db = self.context.dump_database
+                db = self.context.target_db
                 self._list_filter_tables(db, get_filter_file(self.context))
                 return 0
 
@@ -761,7 +761,7 @@ class GpCronDump(Operation):
                 lock_thread.start()
 
                 LOCK_TABLE_SQL = "LOCK TABLE pg_catalog.pg_class IN EXCLUSIVE MODE;"
-                conn = dbconn.connect(dbconn.DbURL(port=self.context.master_port, dbname=self.context.dump_database), utility=True)
+                conn = dbconn.connect(dbconn.DbURL(port=self.context.master_port, dbname=self.context.target_db), utility=True)
                 dbconn.execSQL(conn, LOCK_TABLE_SQL)
 
                 ao_partition_list = get_ao_partition_state(self.context)
@@ -781,7 +781,7 @@ class GpCronDump(Operation):
                     dirty_file = write_dirty_file_to_temp(dirty_partitions)
 
                 self.generate_schema_list_file()
-                (include_file, exclude_file) = self.get_include_exclude_for_dump_database(dirty_file, self.context.dump_database)
+                (include_file, exclude_file) = self.get_include_exclude_for_dump_database(dirty_file)
                 self.context.include_dump_tables_file = include_file
                 self.context.exclude_dump_tables_file = exclude_file
 
@@ -841,7 +841,7 @@ class GpCronDump(Operation):
 
                 current_exit_status = max(dump_outcome['exit_status'], post_dump_outcome['exit_status'])
                 if self.replicate and current_exit_status == 0:
-                    self.dump_timestamps.append((self.context.dump_database, post_dump_outcome["timestamp"]))
+                    self.dump_timestamps.append((self.context.target_db, post_dump_outcome["timestamp"]))
                 final_exit_status = max(final_exit_status, current_exit_status)
 
                 if self.context.incremental:
@@ -896,20 +896,20 @@ class GpCronDump(Operation):
                     logger.warn("Dump request was incomplete, however cannot rollback since no timestamp was found.")
                     MailDumpEvent("Report from gpcrondump on host %s [FAILED]" % self.cur_host,
                                   "Failed for database %s with return code %d, dump files not rolled back, because no new timestamp was found. [Start=%s End=%s] Options passed [%s]"
-                                  % (self.context.dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
+                                  % (self.context.target_db, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
                     raise ExceptionNoStackTraceNeeded("Dump incomplete, rollback not processed")
                 elif self.rollback:
                     logger.warn("Dump request was incomplete, rolling back dump")
                     DeleteCurrentDump(self.context).run()
                     MailDumpEvent("Report from gpcrondump on host %s [FAILED]" % self.cur_host,
                                   "Failed for database %s with return code %d dump files rolled back. [Start=%s End=%s] Options passed [%s]"
-                                  % (self.context.dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
+                                  % (self.context.target_db, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
                     raise ExceptionNoStackTraceNeeded("Dump incomplete, completed rollback")
                 else:
                     logger.warn("Dump request was incomplete, not rolling back because -r option was not supplied")
                     MailDumpEvent("Report from gpcrondump on host %s [FAILED]" % self.cur_host,
                                   "Failed for database %s with return code %s dump files not rolled back. [Start=%s End=%s] Options passed [%s]"
-                                  % (self.context.dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
+                                  % (self.context.target_db, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'], self.options_list)).run()
                     raise ExceptionNoStackTraceNeeded("Dump incomplete, rollback not processed")
             else:
                 if self.context.clear_dumps:
@@ -929,7 +929,7 @@ class GpCronDump(Operation):
             if self.context.dump_config:
                 dump_info_dict = defaultdict(dict)
                 dump_info_dict['host'] = self.cur_host
-                dump_info_dict['dbname'] = self.context.dump_database
+                dump_info_dict['dbname'] = self.context.target_db
                 dump_info_dict['exit_status'] = current_exit_status
                 dump_info_dict['start_time'] = dump_outcome['time_start']
                 dump_info_dict['end_time'] = dump_outcome['time_end']
@@ -937,7 +937,7 @@ class GpCronDump(Operation):
 
                 dump_db_info_list.append(dump_info_dict)
             else:
-                self._send_email(self.context.dump_database, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'])
+                self._send_email(self.context.target_db, current_exit_status, dump_outcome['time_start'], dump_outcome['time_end'])
 
         if self.context.dump_config:
             config_outcome = DumpConfig(self.context).run()
@@ -1133,7 +1133,7 @@ class GpCronDump(Operation):
                 logger.info("---------------------------------------------------")
         else:
             logger.info("Dump type                            = Full database")
-        logger.info("Database to be dumped                = %s" % self.context.dump_database)
+        logger.info("Database to be dumped                = %s" % self.context.target_db)
         if self.context.dump_schema:
             logger.info("Schema to be dumped                  = %s" % self.context.dump_schema)
         if self.context.backup_dir:
@@ -1186,7 +1186,7 @@ class GpCronDump(Operation):
     def _status_report(self, timestamp, dump_outcome, exit_status, deleted_dump_set, dump_type):
         logger.info("Dump status report")
         logger.info("---------------------------------------------------")
-        logger.info("Target database                          = %s" % self.context.dump_database)
+        logger.info("Target database                          = %s" % self.context.target_db)
         logger.info("Dump subdirectory                        = %s" % timestamp[0:8])
         logger.info("Dump type                                = %s" % dump_type)
         if self.context.clear_dumps:
@@ -1238,7 +1238,7 @@ class GpCronDump(Operation):
             logger.info("Configuring for multiple database dump")
 
         for dumpdb in self.context.dump_databases:
-            self.context.dump_database = dumpdb
+            self.context.target_db = dumpdb
             ValidateDatabaseExists(self.context).run()
 
         if self.context.dump_schema:

--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -206,9 +206,9 @@ class GpdbRestore(Operation):
 
         if self.context.change_schema:
             check_funny_chars_in_names(self.context.change_schema, is_full_qualified_name = False)
-            if not self.context.redirected_restore_db and not check_schema_exists(self.context.change_schema, self.context.restore_db):
+            if not self.context.redirected_restore_db and not check_change_schema_exists(self.context, False):
                 raise Exception('Cannot restore tables to schema %s: schema does not exist' % self.context.change_schema)
-            elif self.context.redirected_restore_db and not check_schema_exists(self.context.change_schema, self.context.redirected_restore_db):
+            elif self.context.redirected_restore_db and not check_change_schema_exists(self.context, True):
                 raise Exception('Cannot restore tables to the database %s: schema %s does not exist' % (self.context.redirected_restore_db, self.context.change_schema))
 
         self._output_info(info, restore_type)
@@ -257,7 +257,7 @@ class GpdbRestore(Operation):
         logger.info("Restore type               = %s" % restore_type)
 
         if len(self.context.restore_tables) > 0:
-            logger.info("Database name              = %s" % self.context.restore_db)
+            logger.info("Database name              = %s" % self.context.target_db)
             logger.info("------------------------------------------")
             logger.info("Table restore list")
             logger.info("------------------------------------------")
@@ -271,7 +271,7 @@ class GpdbRestore(Operation):
                     logger.warn("Table:Row count            = %s:%s" % (table, count))
                 logger.info("------------------------------------------")
         else:
-            logger.info("Database to be restored    = %s" % self.context.restore_db)
+            logger.info("Database to be restored    = %s" % self.context.target_db)
             if self.context.drop_db:
                 logger.info("Drop and re-create db      = On")
             else:
@@ -356,7 +356,7 @@ class GpdbRestore(Operation):
         if self.context.timestamp:
             (restore_timestamp, restore_db, compress) = ValidateTimestamp(self.context).run()
             self.context.timestamp = restore_timestamp
-            self.context.restore_db = restore_db
+            self.context.target_db = restore_db
             self.context.compress = compress
         elif self.context.db_date_dir:
             self._validate_db_date_dir()
@@ -368,10 +368,10 @@ class GpdbRestore(Operation):
         if not self.context.drop_db and not self.context.redirected_restore_db:
             dburl = dbconn.DbURL(port=self.context.master_port)
             conn = dbconn.connect(dburl)
-            count = dbconn.execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" % pg.escape_string(self.context.restore_db))
+            count = dbconn.execSQLForSingleton(conn, "select count(*) from pg_database where datname='%s';" % escape_string(self.context.target_db, conn))
             # TODO: -e is needed even if the database doesn't exist yet?
             if count == 0:
-                raise ExceptionNoStackTraceNeeded("Database %s does not exist and -e option not supplied" % self.context.restore_db)
+                raise ExceptionNoStackTraceNeeded("Database %s does not exist and -e option not supplied" % self.context.target_db)
 
         table_counts = []
 
@@ -424,7 +424,7 @@ class GpdbRestore(Operation):
             match = matching[0]
             temp = match[len(prefix):]
             self.context.timestamp = temp[0:14]
-        self.context.restore_db = GetDbName(self.context.generate_filename("cdatabase")).run()
+        self.context.target_db = GetDbName(self.context.generate_filename("cdatabase")).run()
         compressed_file = self.context.generate_filename("postdata")
         self.context.compress = CheckFile(compressed_file).run()
 
@@ -460,7 +460,7 @@ class GpdbRestore(Operation):
         handle, filename = mkstemp()
         srcFile = self.context.generate_filename("cdatabase", directory=path)
         Scp('Copying cdatabase file', srcHost=host, srcFile=srcFile, dstFile=filename).run(validateAfter=True)
-        self.context.restore_db = GetDbName(filename).run()
+        self.context.target_db = GetDbName(filename).run()
         os.remove(filename)
 
         self.context.compress = CheckRemoteFile(srcFile, host).run()
@@ -487,7 +487,7 @@ class GpdbRestore(Operation):
             raise ExceptionNoStackTraceNeeded("No %s* files located with database %s" % (prefix, self.search_for_dbname))
         self.context.timestamp = str(max(timestamps))
         logger.info("Identified latest dump timestamp for %s as %s" %  (self.search_for_dbname, self.context.timestamp))
-        self.context.restore_db = self.search_for_dbname
+        self.context.target_db = self.search_for_dbname
         compressed_file = self.context.generate_filename("postdata")
         self.context.compress = CheckFile(compressed_file).run()
 

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
@@ -12,7 +12,7 @@ class DumpTestCase(unittest.TestCase):
     @patch('gppylib.operations.backup_utils.Context.get_master_port', return_value = 5432)
     def setUp(self, mock):
         context = Context()
-        context.dump_database='testdb'
+        context.target_db='testdb'
         context.dump_schema='testschema'
         context.include_dump_tables_file='/tmp/table_list.txt'
         context.master_datadir=context.backup_dir='/data/master/p1'
@@ -1126,7 +1126,7 @@ class DumpTestCase(unittest.TestCase):
         fakeContext = Mock()
         fakeContext.ddboost = False
         fakeContext.master_port = 9999
-        fakeContext.dump_database = 'db_name'
+        fakeContext.target_db= 'db_name'
 
         dump_stats = DumpStats(fakeContext)
         dump_stats.get_include_tables_from_context = Mock(return_value=['schema1.table1', 'schema2.table2'])

--- a/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_cluster_gpcrondump.py
@@ -545,7 +545,7 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
-        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
+        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile)
         self.assertEquals(inc, None)
         self.assertEquals(exc, None)
 
@@ -559,7 +559,7 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
-        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
+        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile)
         self.assertTrue(inc.startswith('/tmp/include_dump_tables_file'))
 
     @patch('gpcrondump.validate_current_timestamp')
@@ -572,7 +572,7 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
-        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
+        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile)
         self.assertTrue(inc.startswith('/tmp/include_dump_tables_file'))
 
     @patch('gpcrondump.validate_current_timestamp')
@@ -584,7 +584,7 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
-        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
+        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile)
         self.assertEquals(inc, '/tmp/dirty')
         self.assertEquals(exc, None)
 
@@ -598,7 +598,7 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
-        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
+        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile)
         self.assertTrue(exc.startswith('/tmp/exclude_dump_tables_file'))
 
     @patch('gpcrondump.validate_current_timestamp')
@@ -611,7 +611,7 @@ class GpcrondumpTestCase(unittest.TestCase):
         gpcd = GpCronDump(self.options, None)
         dirtyfile = '/tmp/dirty'
         dbname = 'foo'
-        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile, dbname)
+        (inc, exc) = gpcd.get_include_exclude_for_dump_database(dirtyfile)
         self.assertTrue(exc.startswith('/tmp/exclude_dump_tables_file'))
 
     @patch('gpcrondump.validate_current_timestamp')
@@ -981,12 +981,12 @@ class GpcrondumpTestCase(unittest.TestCase):
     @patch('gpcrondump.MailDumpEvent')
     @patch('gppylib.operations.backup_utils.Context.get_master_port')
     def test_send_email00(self, mock1, MailDumpEvent):
-        dump_database = 'testdb1'
+        target_db = 'testdb1'
         current_exit_status = 0
         time_start = '12:07:09'
         time_end = '12:08:18'
         cron = GpCronDump(self.options, None)
-        cron._send_email(dump_database, current_exit_status, time_start, time_end)
+        cron._send_email(target_db, current_exit_status, time_start, time_end)
 
     @patch('gppylib.commands.base.Command.run')
     @patch('gppylib.commands.base.Command.get_results')

--- a/gpMgmt/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup.feature
@@ -3704,6 +3704,7 @@ Feature: Validate command line arguments
         And the timestamp from gpcrondump is stored
         Then verify the metadata dump file does not contain "GRANT"
         Then verify the metadata dump file does not contain "REVOKE"
+        And the user runs "psql -c 'DROP ROLE temprole;' bkdb"
 
     Scenario: Incremental backup with use-set-session-authorization
         Given the test is initialized

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/check_metadata.ans
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/check_metadata.ans
@@ -17,7 +17,7 @@ Distributed by: (a)
  b      | integer |           | plain   | 
 Indexes:
     "idx_a" UNIQUE, btree (a)
-Triggers:
+Disabled triggers:
     before_heap_ins_trig BEFORE INSERT ON heap_table FOR EACH ROW EXECUTE PROCEDURE trigger_func()
 Has OIDs: no
 Distributed by: (a)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1558,7 +1558,7 @@ def impl(context, table, dbname, ao_table):
     try:
         backup_utils = Context()
         backup_utils.master_port = os.environ.get('PGPORT')
-        backup_utils.dump_database = dbname
+        backup_utils.target_db = dbname
         context.exception = None
         context.partition_list_res = None
         context.partition_list_res = get_partition_state(backup_utils, sch, part_info)


### PR DESCRIPTION
Because the standard_conforming_strings GUC has been updated to be
on by default, using pg.escape_string (which assumes that the GUC
is off) is no longer sufficient to escape all strings in backup
and restore.  Backup and restore now use pg.DB().escape_string,
which connects to the database so that it can use the correct value
for standard_conforming_strings.

As part of this commit, we also made some other modifications that made
passing connection parameters down to escape_string easier, including
unifying the context.dump_database and context.restore_db variables into
a context.target_db variable and refactoring some function headers, and
fixed a few testing issues we ran into.