### PR TITLE
CI: Loose out serial=true usage from pipeline.

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -138,7 +138,6 @@ resources:
 jobs:
 
 - name: compile_gpdb_centos6
-  serial: true
   plan:
   - aggregate:
     - get: gpdb_src
@@ -165,7 +164,6 @@ jobs:
         file: sync_tools_gpdb/sync_tools_gpdb.tar.gz
 
 - name: compile_gpdb_custom_config_centos6
-  serial: true
   public: true
   plan:
   - aggregate:
@@ -177,7 +175,6 @@ jobs:
     image: centos-gpdb-dev-6
 
 - name: compile_gpdb_centos7
-  serial: true
   plan:
   - aggregate:
     - get: gpdb_src
@@ -216,7 +213,6 @@ jobs:
 
 # Stage 2: Run regression tests (make installcheck-world)
 - name: icw_planner_centos6
-  serial: true
   plan:
   - aggregate:
     - get: gpdb_src
@@ -238,7 +234,6 @@ jobs:
       TEST_OS: centos
 
 - name: icw_gporca_centos6
-  serial: true
   plan:
   - aggregate:
     - get: gpdb_src
@@ -260,7 +255,6 @@ jobs:
       TEST_OS: centos
 
 - name: icw_planner_codegen_centos6
-  serial: true
   plan:
   - aggregate:
     - get: gpdb_src
@@ -282,7 +276,6 @@ jobs:
       TEST_OS: centos
 
 - name: icw_gporca_codegen_centos6
-  serial: true
   plan:
   - aggregate:
     - get: gpdb_src
@@ -346,7 +339,6 @@ jobs:
 # Stage 3: Packaging
 
 - name: gpdb_rc_packaging_centos
-  serial: true
   plan:
   - aggregate:
     - get: gpdb_src
@@ -622,7 +614,6 @@ jobs:
       PULSE_PROJECT_NAME: "cs-storage"
 
 - name: mpp_interconnect
-  serial: true
   plan:
   - aggregate: *pulse_trigger_resource
   - task: trigger_pulse
@@ -640,7 +631,6 @@ jobs:
       PULSE_PROJECT_NAME: "mpp-interconnect"
 
 - name: unite_ccle_gpdb5
-  serial: true
   plan:
   - aggregate: *pulse_trigger_resource
   - task: trigger_pulse

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -169,7 +169,6 @@ jobs:
 
   # Stage 3: Packaging
   - name: gpdb_rc_packaging_centos
-    serial: true
     plan:
     - aggregate:
       - get: gpdb_pr


### PR DESCRIPTION
Don't see rational for serializing job runs. Multiple commits should be able to
run the job in parallel to help gain faster feedbacks.