### PR TITLE
Backport the pg_upgrade-related changes from upstream commit 3d21a0f300.

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4117,7 +4117,8 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
 
 			case 'b':
 				/* Undocumented flag used for binary upgrades */
-				IsBinaryUpgrade = true;
+				if (secure)
+					IsBinaryUpgrade = true;
 				break;
 
 			case 'D':
@@ -4130,7 +4131,8 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
 				break;
 
 			case 'E':
-				EchoQuery = true;
+				if (secure)
+					EchoQuery = true;
 				break;
 
 			case 'e':
@@ -4155,7 +4157,8 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
 				break;
 
 			case 'j':
-				UseNewLine = 0;
+				if (secure)
+					UseNewLine = 0;
 				break;
 
 			case 'k':


### PR DESCRIPTION
This patch was backported earlier already, but now that we cherry-picked
the binary-upgrade work from 9.0, we must also pick the related parts
of 3d21a0f300, that were not applicable earlier.

In the passing, also pick the "if (secure)" checks to EchoQuery and
UseNewLine from the upstream commit. I don't know why those were not
picked earlier.