### PR TITLE
Remove obsolete "pg_on_solaris" code.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -1609,13 +1609,8 @@ int gp_pthread_create(pthread_t * thread, void *(*start_routine)(void *),
 		return pthread_err;
 	}
 
-#ifdef pg_on_solaris
-	/* Solaris doesn't have PTHREAD_STACK_MIN ? */
-	pthread_err = pthread_attr_setstacksize(&t_atts, (256 * 1024));
-#else
 	pthread_err = pthread_attr_setstacksize(&t_atts,
 			Max(PTHREAD_STACK_MIN, (256 * 1024)));
-#endif
 	if (pthread_err != 0)
 	{
 		elog(LOG, "%s: pthread_attr_setstacksize failed.  Error %d", caller, pthread_err);

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1400,12 +1400,7 @@ InitMotionUDPIFC(int *listenerSocketFd, uint16 *listenerPort)
 	 * size are large (1M+) */
 	pthread_attr_init(&t_atts);
 
-#ifdef pg_on_solaris
-	/* Solaris doesn't have PTHREAD_STACK_MIN ? */
-	pthread_attr_setstacksize(&t_atts, (128*1024));
-#else
 	pthread_attr_setstacksize(&t_atts, Max(PTHREAD_STACK_MIN, (128*1024)));
-#endif
 	pthread_err = pthread_create(&ic_control_info.threadHandle, &t_atts, rxThreadFunc, NULL);
 
 	pthread_attr_destroy(&t_atts);

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -2201,7 +2201,7 @@ authident(hbaPort *port)
  */
 
 
-#if defined(pg_on_solaris) || defined(_AIX)
+#if defined(_AIX)
 static int
 pam_passwd_conv_proc(int num_msg, struct pam_message **msg,
 					struct pam_response **resp, void *appdata_ptr)

--- a/src/backend/libpq/test/pqcomm_test.c
+++ b/src/backend/libpq/test/pqcomm_test.c
@@ -145,15 +145,6 @@ pqcomm_accept_mock(int accept_sock, struct sockaddr *restrict address,
 	return test_accept_socket;
 }
 
-
-/*
- * Solaris doesn't support setting the SO_SNDTIMEO Socket option. Disable all
- * the corresponding unit tests on Solaris
- */
-
-#if !defined(pg_on_solaris)
-
-
 /*
  * Test for StreamConnection that verifies that the socket has the SO_SNDTIMEO
  * timeout set for it when the connection is through a TCP/IP socket (AF_INET)
@@ -241,8 +232,6 @@ test__StreamConnection_set_SNDTIMEO_segment(void **state)
 	close(test_accept_socket);
 }
 
-#endif /* #if !defined(pg_on_solaris) */
-
 /* ==================== main ==================== */
 int
 main(int argc, char* argv[])
@@ -253,11 +242,9 @@ main(int argc, char* argv[])
 		unit_test(test__internal_flush_succesfulSend),
 		unit_test(test__internal_flush_failedSendEINTR),
 		unit_test(test__internal_flush_failedSendEPIPE),
-#if !defined(pg_on_solaris)
 		unit_test(test__StreamConnection_set_SNDTIMEO_AF_INET),
 		unit_test(test__StreamConnection_set_SNDTIMEO_AF_UNIX),
 		unit_test(test__StreamConnection_set_SNDTIMEO_segment)
-#endif
 	};
 
 	return run_tests(tests);

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5560,12 +5560,6 @@ ResetUsage(void)
 	/* ResetTupleCount(); */
 }
 
-#ifdef  pg_on_solaris
-#if defined(_LP64) || _FILE_OFFSET_BITS != 64
-#include <procfs.h>
-#endif 
-#endif 
-
 void
 ShowUsage(const char *title)
 {
@@ -5595,39 +5589,6 @@ ShowUsage(const char *title)
 		r.ru_stime.tv_sec--;
 		r.ru_stime.tv_usec += 1000000;
 	}
-
-#ifdef  pg_on_solaris
-#if defined(_LP64) || _FILE_OFFSET_BITS != 64
-	{
-		char pathname[100];
-		int fd;
-		psinfo_t psinfo;
-		psinfo_t *psi = &psinfo;
-
-		(void) sprintf(pathname, "/proc/%d/psinfo", (int)getpid());
-		if ((fd = open(pathname, O_RDONLY)) >= 0)
-		{
-			if (read(fd, &psinfo, sizeof (psinfo)) == sizeof (psinfo))
-			{
-				uint_t value; /* need 32 bits to compute with */
-
-				elog(LOG,"Process size:..............%ld KB",(long)psi->pr_size);
-				elog(LOG,"Resident Set Size:.........%ld KB",(long)psi->pr_rssize);
-
-				value = psi->pr_pctmem;
-				value = ((value * 1000) + 0x7000) >> 15; /* [0 .. 1000] */
-				elog(LOG,"Percent of memory:.........%3u.%u%%", value / 10, value % 10);
-
-			}
-		}
-
-		(void) close(fd);
-
-	}
-
-
-#endif 
-#endif 
 
 	/*
 	 * the only stats we don't show here are for memory usage -- i can't

--- a/src/include/cdb/cdbselect.h
+++ b/src/include/cdb/cdbselect.h
@@ -13,8 +13,7 @@
 #ifndef CDBSELECT_H
 #define CDBSELECT_H
 
-#if !defined(_WIN32) && \
-	!(defined(pg_on_solaris) && defined(__sparc) && defined(_LP64))
+#if !defined(_WIN32)
 
 /* 8-bit bytes 32 or 64-bit ints */
 

--- a/src/include/port/solaris.h
+++ b/src/include/port/solaris.h
@@ -36,25 +36,3 @@
  * still use our own fix for the buggy version.
  */
 #define HAVE_BUGGY_SOLARIS_STRTOD
-
-
-/*
- * Make sure that we have an easy way to check that we're actually on
- * Solaris in the olden days this was built into gcc -- but it appears
- * that it isn't there any longer.
- */
-#ifndef pg_on_solaris
-#if defined(__sun__) && defined(__unix__) && defined(__svr4__)
-#define pg_on_solaris 1
-#endif
-#endif
-
-/* this is defined by pg_config.h, which is included by the time we get here. */
-#ifdef ENABLE_THREAD_SAFETY
-/*
- * MPP-2105: Make sure that multithreaded code can get the right errno.
- * (any such code also needs to explicitly include /usr/include/errno.h)
- */
-#define _REENTRANT 1
-#include <errno.h>
-#endif

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -559,11 +559,6 @@ write_stderr(const char *fmt,...)
    the supplied arguments. */
 __attribute__((format(printf, 1, 2)));
 
-#if defined(pg_on_solaris)
-extern size_t backtrace(void **buffer, int size);
-extern char **backtrace_symbols(void *const *buffer, int size);
-#endif
-
 extern void write_message_to_server_log(int elevel,
 										int sqlerrcode,
 										const char *message,


### PR DESCRIPTION
This hasn't been tested for a while. And if someone wants to build GPDB on
Solaris, should use autoconf tests and upstream "#ifdef _sparc" method to
guard platform-dependent code, rather than the GPDB-specific "pg_on_solaris"
flag.