### PR TITLE
Error out when activeWeight <= 0 in BackoffSweeper

### DIFF
--- a/src/backend/postmaster/backoff.c
+++ b/src/backend/postmaster/backoff.c
@@ -817,6 +817,15 @@ BackoffSweeper()
 					const BackoffBackendSharedEntry *gl = getBackoffEntryRO(se->groupLeaderIndex);
 
 					Assert(gl->numFollowersActive > 0);
+
+					if (activeWeight <= 0.0) {
+						/*
+						 * If activeWeight <= 0.0, it should be considered unexpected
+						 * behavior. Error out here instead of risking an underflow.
+						 */
+						elog(ERROR, "activeWeight underflow!");
+					}
+
 					Assert(activeWeight > 0.0);
 					Assert(se->weight > 0.0);
 
@@ -834,18 +843,6 @@ BackoffSweeper()
 						se->noBackoff = true;
 						activeWeight -= (se->weight / gl->numFollowersActive);
 
-						/*
-						 * GPDB_83_MERGE_FIXME: I saw the Assert(activeWeight
-						 * > 0.0) above to fail every now and then, when
-						 * running "make installcheck-good". Something's
-						 * wrong, not sure what, but let's just silence that
-						 * failure for now
-						 */
-						if (activeWeight <= 0)
-						{
-							elog(LOG, "activeWeight underflow!");
-							activeWeight = 0.001;
-						}
 						CPUAvailable -= maxCPU;
 						found = true;
 					}


### PR DESCRIPTION
There is a similar assertion that has been observered to fail once in a
while, but is no longer reproducible. Since this is an exceptional case
we should error our sooner rather than later.

@hlinnaka @foyzur @karthijrk Please take a look.