### PR TITLE
CI: Stop packaging, upload and download of sync_tools.

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -42,15 +42,6 @@ resources:
     secret_access_key: {{bucket-secret-access-key}}
     versioned_file: {{bin_gpdb_centos_versioned_file}}
 
-- name: sync_tools_gpdb_centos
-  type: s3
-  source:
-    access_key_id: {{bucket-access-key-id}}
-    bucket: {{bucket-name}}
-    region_name: {{aws-region}}
-    secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: {{sync_tools_gpdb_centos_versioned_file}}
-
 - name: installer_rhel6_gpdb_rc
   type: s3
   source:
@@ -160,9 +151,6 @@ jobs:
     - put: bin_gpdb_centos
       params:
         file: gpdb_artifacts/bin_gpdb.tar.gz
-    - put: sync_tools_gpdb_centos
-      params:
-        file: sync_tools_gpdb/sync_tools_gpdb.tar.gz
 
 - name: compile_gpdb_custom_config_centos6
   serial: true
@@ -221,9 +209,6 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb
-      resource: sync_tools_gpdb_centos
-      passed: [compile_gpdb_centos6]
     - get: bin_gpdb
       resource: bin_gpdb_centos
       passed: [compile_gpdb_centos6]
@@ -242,9 +227,6 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb
-      resource: sync_tools_gpdb_centos
       passed: [compile_gpdb_centos6]
     - get: bin_gpdb
       resource: bin_gpdb_centos
@@ -265,9 +247,6 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb
-      resource: sync_tools_gpdb_centos
-      passed: [compile_gpdb_centos6]
     - get: bin_gpdb
       resource: bin_gpdb_centos
       passed: [compile_gpdb_centos6]
@@ -287,9 +266,6 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb
-      resource: sync_tools_gpdb_centos
-      passed: [compile_gpdb_centos6]
     - get: bin_gpdb
       resource: bin_gpdb_centos
       passed: [compile_gpdb_centos6]
@@ -308,9 +284,6 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb
-      resource: sync_tools_gpdb_centos
-      passed: [compile_gpdb_centos6]
     - get: bin_gpdb
       resource: bin_gpdb_centos
       passed: [compile_gpdb_centos6]
@@ -326,9 +299,6 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb
-      resource: sync_tools_gpdb_centos
       passed: [compile_gpdb_centos6]
     - get: bin_gpdb
       resource: bin_gpdb_centos
@@ -697,8 +667,6 @@ jobs:
     - get: gpdb_src
       passed: [gpdb_rc_packaging_centos]
       trigger: true
-    - get: sync_tools_gpdb
-      resource: sync_tools_gpdb_centos
     - get: bin_gpdb
       resource: bin_gpdb_centos
     - get: centos-gpdb-dev-6

--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -24,15 +24,6 @@ resources:
       username: {{docker_username}}
       password: {{docker_password}}
 
-  - name: sync_tools_gpdb_centos
-    type: s3
-    source:
-      access_key_id: {{bucket-access-key-id}}
-      bucket: {{bucket-name}}
-      region_name: {{aws-region}}
-      secret_access_key: {{bucket-secret-access-key}}
-      versioned_file: gpdb_pr/sync_tools_gpdb/sync_tools_gpdb.tar.gz
-
   - name: installer_rhel6_gpdb_rc
     type: s3
     source:
@@ -110,9 +101,6 @@ jobs:
       - put: bin_gpdb_centos
         params:
           file: gpdb_artifacts/bin_gpdb.tar.gz
-      - put: sync_tools_gpdb_centos
-        params:
-          file: sync_tools_gpdb/sync_tools_gpdb.tar.gz
 
   - name: compile_gpdb_custom_config_centos6
     public: true
@@ -137,9 +125,6 @@ jobs:
     plan:
     - aggregate:
       - get: gpdb_pr
-        passed: [compile_gpdb_centos6]
-      - get: sync_tools_gpdb
-        resource: sync_tools_gpdb_centos
         passed: [compile_gpdb_centos6]
       - get: bin_gpdb
         resource: bin_gpdb_centos

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -18,10 +18,6 @@ function install_gpdb() {
     tar -xzf bin_gpdb/bin_gpdb.tar.gz -C /usr/local/greenplum-db-devel
 }
 
-function install_sync_tools() {
-    tar -xzf sync_tools_gpdb/sync_tools_gpdb.tar.gz -C gpdb_src/gpAux
-}
-
 function configure() {
   source /opt/gcc_env.sh
   pushd gpdb_src

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -66,8 +66,6 @@ function make_sync_tools() {
     # the zlib downloaded from artifacts.  Therefore, remove the zlib
     # downloaded from artifacts in order to use the native zlib.
     find ext -name 'libz.*' -exec rm -f {} \;
-    tar -czf ../../sync_tools_gpdb/sync_tools_gpdb.tar.gz ext
-
   popd
 }
 

--- a/concourse/scripts/gpMgmt_check_gpdb.bash
+++ b/concourse/scripts/gpMgmt_check_gpdb.bash
@@ -47,7 +47,6 @@ function setup_gpadmin_user() {
 
 function _main() {
 
-    install_sync_tools
     configure
     install_gpdb
     setup_gpadmin_user

--- a/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
+++ b/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
@@ -33,9 +33,6 @@ function setup_gpadmin_user() {
 }
 
 function _main() {
-	time install_sync_tools
-	ln -s "$(pwd)/gpdb_src/gpAux/ext/rhel5_x86_64/python-2.6.2" /opt
-
 	time configure
         sed -i s/1024/unlimited/ /etc/security/limits.d/90-nproc.conf
 	time install_gpdb

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -59,7 +59,6 @@ function _main() {
         exit 1
     fi
 
-    time install_sync_tools
     time configure
     time install_gpdb
     time setup_gpadmin_user

--- a/concourse/scripts/regression_tests_gpcloud.bash
+++ b/concourse/scripts/regression_tests_gpcloud.bash
@@ -50,9 +50,6 @@ function _main() {
 		exit 1
 	fi
 
-	time install_sync_tools
-	ln -s "$(pwd)/gpdb_src/gpAux/ext/rhel5_x86_64/python-2.6.2" /opt
-
 	time configure
 	time install_gpdb
 	time setup_gpadmin_user

--- a/concourse/scripts/regression_tests_gphdfs.bash
+++ b/concourse/scripts/regression_tests_gphdfs.bash
@@ -66,9 +66,6 @@ function _main() {
 		exit 1
 	fi
 
-	time install_sync_tools
-	ln -s "$(pwd)/gpdb_src/gpAux/ext/rhel5_x86_64/python-2.6.2" /opt
-
 	time configure
 	sed -i s/1024/unlimited/ /etc/security/limits.d/90-nproc.conf
 	time install_gpdb

--- a/concourse/scripts/staging_server_gpcloud.bash
+++ b/concourse/scripts/staging_server_gpcloud.bash
@@ -44,9 +44,6 @@ function push_to_staging_server() {
 }
 
 function _main() {
-	time install_sync_tools
-	ln -s "$(pwd)/gpdb_src/gpAux/ext/rhel5_x86_64/python-2.6.2" /opt
-
 	time configure
 	time install_gpdb
 	time setup_gpadmin_user

--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -6,7 +6,6 @@ inputs:
   - name: gpaddon_src
 outputs:
   - name: gpdb_artifacts
-  - name: sync_tools_gpdb
 run:
   path: gpdb_src/concourse/scripts/compile_gpdb.bash
 params:

--- a/concourse/tasks/gpMgmt_check_gpdb.yml
+++ b/concourse/tasks/gpMgmt_check_gpdb.yml
@@ -4,7 +4,6 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
-  - name: sync_tools_gpdb
 outputs:
 params:
   TEST_OS: ""

--- a/concourse/tasks/gpcheckcloud_tests_gpcloud.yml
+++ b/concourse/tasks/gpcheckcloud_tests_gpcloud.yml
@@ -9,7 +9,6 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
-  - name: sync_tools_gpdb
 params:
   s3conf:
 run:

--- a/concourse/tasks/ic_gpdb.yml
+++ b/concourse/tasks/ic_gpdb.yml
@@ -4,7 +4,6 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
-  - name: sync_tools_gpdb
 outputs:
 params:
   MAKE_TEST_COMMAND: ""

--- a/concourse/tasks/regression_tests_gpcloud.yml
+++ b/concourse/tasks/regression_tests_gpcloud.yml
@@ -9,7 +9,6 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
-  - name: sync_tools_gpdb
 params:
   s3conf:
 run:

--- a/concourse/tasks/regression_tests_gphdfs.yml
+++ b/concourse/tasks/regression_tests_gphdfs.yml
@@ -8,6 +8,5 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
-  - name: sync_tools_gpdb
 run:
   path: gpdb_src/concourse/scripts/regression_tests_gphdfs.bash

--- a/concourse/tasks/staging_server_gpcloud.yml
+++ b/concourse/tasks/staging_server_gpcloud.yml
@@ -9,7 +9,6 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
-  - name: sync_tools_gpdb
 params:
   EC2_PRIVATE_KEY:
   EC2_INSTANCE_IP:

--- a/concourse/tasks/tinc_gpdb.yml
+++ b/concourse/tasks/tinc_gpdb.yml
@@ -4,7 +4,6 @@ image_resource:
 inputs:
   - name: gpdb_src
   - name: bin_gpdb
-  - name: sync_tools_gpdb
 outputs:
 params:
   MAKE_TEST_COMMAND: ""


### PR DESCRIPTION
sync_tools currently is being tar'd in compile job, uploaded to S3 and download
by whole bunch of jobs. Seems not required, so lets stop performing the same and
cut down time and resource wastage.

Please let me know if its really needed for something ?