### PR TITLE
TINC: avoid running catalog repair script.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_alter/aoco_alter_scenario_test/aocoAlterColumn.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_alter/aoco_alter_scenario_test/aocoAlterColumn.py
@@ -87,20 +87,6 @@ class AOCOAlterColumn(MPPTestCase):
         outfile = local_path("gpcheckcat_"+datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%d%H%M%S')+".out")
         self.dbstate.check_catalog(outputFile=outfile)
 
-    def check_catalog(self):
-        iteration = 0 
-        errorCode = 1 
-        while(errorCode > 0 and iteration < 5):
-            (errorCode, hasError, gpcheckcat_output, repairScript) =  self.dbstate.gpcheckcat(alldb = False)
-            tinctest.logger.info(" %s Gpcheckcat iteration . ErrorCode: %s " % (iteration,errorCode))
-            if (errorCode > 0):
-                self.dbstate.run_repairScript(repairScript)
-                iteration = iteration + 1 
-        if not (errorCode == 0 and iteration < 5):
-            raise Exception('GpCheckcat failed')
-
-         
-        
     def run_test_ChangeTracking(self,filename):
         # Log the segment state before starting the test
         # Expectation is a SYNC state

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/lib/dbstate.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/lib/dbstate.py
@@ -47,23 +47,11 @@ class DbStateClass(MPPTestCase):
         else:
             tinctest.logger.info("\n Starting New Test: System is up and in sync .........")
 
-    def check_catalog(self,dbname=None, alldb=True, online=False, testname=None, outputFile=None, run_repair=True, host=None, port=None, expected_rc=0):
-        '''1. Run gpcheckcat 2. Run repairscript if present 3. Run gpcheckcat again. Repeat this 5 times'''
-        errorCode = 1
-        if run_repair:
-            i = 0
-            while i < 5:
-                (errorCode, hasError, gpcheckcat_output, repairScriptDir) =  self.gpverify.gpcheckcat(dbname=dbname, alldb=alldb, online=online, testname=testname, outputFile=outputFile, host=host, port=port)
-                tinctest.logger.info(" %s Gpcheckcat iteration . ErrorCode: %s " % (i,errorCode))
-                if errorCode == 0:
-                    break
-                else:
-                    self.gpverify.run_repair_script(repairScriptDir,dbname=dbname, alldb=alldb, online=online, testname=testname, outputFile=outputFile, host=host, port=port)
-                    i = i+1
-        else:
-            (errorCode, hasError, gpcheckcat_output, repairScriptDir) =  self.gpverify.gpcheckcat(dbname=dbname, alldb=alldb, online=online, testname=testname, outputFile=outputFile, host=host, port=port)
-        if errorCode != expected_rc:
-            raise Exception('GpCheckcat failed, %s != %s '% (errorCode, expected_rc))
+    def check_catalog(self,dbname=None, alldb=True, online=False, testname=None, outputFile=None, host=None, port=None):
+        '''1. Run gpcheckcat'''
+        (errorCode, hasError, gpcheckcat_output, repairScriptDir) =  self.gpverify.gpcheckcat(dbname=dbname, alldb=alldb, online=online, testname=testname, outputFile=outputFile, host=host, port=port)
+        if errorCode != 0:
+            raise Exception('GpCheckcat failed with errcode %s '% (errorCode))
 
     def check_mirrorintegrity(self, master=False):
         '''Runs checkmirrorintegrity(default), check_mastermirrorintegrity(when master=True) '''


### PR DESCRIPTION
For historical reasons after catalog check, repair script was run and looped 5 times. Don't see rational for performing the same. Any catalog inconsistency should be flagged right away. There shouldn't be a need to run repair. gp_fastsequence was one reason for which repair script was generated and required to be run but that's fixed now.