### PR TITLE
Remember the actual sha-256 output in the role test

### DIFF
--- a/src/test/regress/expected/role.out
+++ b/src/test/regress/expected/role.out
@@ -84,9 +84,12 @@ DROP SCHEMA common_schema;
 set password_hash_algorithm to "SHA-256";
 create role sha256 password 'abc';
 NOTICE:  resource queue required -- using default resource queue "pg_default"
--- MPP-15865
--- OpenSSL SHA2 returning a different SHA2 to RSA BSAFE!
---select rolname, rolpassword from pg_authid where rolname = 'sha256';
+select rolname, rolpassword from pg_authid where rolname = 'sha256';
+ rolname |                              rolpassword                               
+---------+------------------------------------------------------------------------
+ sha256  | sha256b0cec85177f91ffcdc8f9b4ca25f8f24f310b0898d33074d1c37f063b87fd193
+(1 row)
+
 drop role sha256;
 create role superuser;
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/src/test/regress/sql/role.sql
+++ b/src/test/regress/sql/role.sql
@@ -57,9 +57,7 @@ DROP SCHEMA common_schema;
 -- SHA-256 testing
 set password_hash_algorithm to "SHA-256";
 create role sha256 password 'abc';
--- MPP-15865
--- OpenSSL SHA2 returning a different SHA2 to RSA BSAFE!
---select rolname, rolpassword from pg_authid where rolname = 'sha256';
+select rolname, rolpassword from pg_authid where rolname = 'sha256';
 drop role sha256;
 
 create role superuser;


### PR DESCRIPTION
To avoid silent breakage in the password generation, remember the pg_authid output in the output file. Not sure why the query was commented out but it seems somewhat silly to not expose the result.