### PR TITLE
Fix EXPLAIN grouping keys, if the child of the Agg is a Sequence node.

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -3077,30 +3077,14 @@ push_plan(deparse_namespace *dpns, Plan *subplan)
 		dpns->outer_plan = (Plan *) linitial(((Append *) subplan)->appendplans);
 	else if (IsA(subplan, Sequence))
 	{
-		ListCell *child;
-
 		/*
-		 * A Sequence node often has a PartitionSelector node as its first
-		 * subplan. A PartitionSelector is special, because it doesn't return
-		 * any tuples. Instead, it tells its sibling subplans which partitions
-		 * they need to scan. The PartitionSelector doesn't have a proper
-		 * target list so look at the first regular subplan instead.
+		 * A Sequence node returns tuples from the *last* child node only.
+		 * The other subplans can even have a different, incompatible tuple
+		 * descriptor. A typical case is to have a PartitionSelector node
+		 * as the first subplan, and the Dynamic Table Scan as the second
+		 * subplan.
 		 */
-		child = list_head(((Sequence *) subplan)->subplans);
-		if (child != NULL && IsA(lfirst(child), PartitionSelector))
-			child = lnext(child);
-
-		if (child)
-			dpns->outer_plan = (Plan *) lfirst(child);
-		else
-		{
-			/*
-			 * ORCA probably never produces Sequence plans with no children, other
-			 * than the PartitionSelector, but cope with it just in case. (Only
-			 * ORCA produces Sequence nodes in the first place.)
-			 */
-			dpns->outer_plan = NULL;
-		}
+		dpns->outer_plan = (Plan *) llast(((Sequence *) subplan)->subplans);
 	}
 	else
 		dpns->outer_plan = outerPlan(subplan);

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1805,6 +1805,62 @@ SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
    | 2 | 3
 (2 rows)
 
+---
+--- Test EXPLAIN on a hash agg that has a Sequence + Partition Selector below it.
+---
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS bar;
+-- end_ignore
+CREATE TABLE bar (b int, c int)
+PARTITION BY RANGE (b)
+(
+  START (0) END (10),
+  START (10) END (20)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2" for table "bar"
+INSERT INTO bar SELECT g % 20, g % 20 from generate_series(1, 1000) g;
+ANALYZE bar;
+SELECT b FROM bar GROUP BY b;
+ b  
+----
+  7
+  4
+ 19
+  3
+  5
+ 18
+  6
+ 11
+  9
+  8
+ 12
+ 10
+ 17
+  1
+  0
+  2
+ 16
+ 15
+ 14
+ 13
+(20 rows)
+
+EXPLAIN SELECT b FROM bar GROUP BY b;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=18.50..18.60 rows=10 width=4)
+   ->  HashAggregate  (cost=18.50..18.60 rows=4 width=4)
+         Group By: bfv_partition.bar.b
+         ->  Append  (cost=0.00..16.00 rows=334 width=4)
+               ->  Seq Scan on bar_1_prt_1 bar  (cost=0.00..8.00 rows=167 width=4)
+               ->  Seq Scan on bar_1_prt_2 bar  (cost=0.00..8.00 rows=167 width=4)
+ Optimizer status: legacy query optimizer
+(7 rows)
+
 -- CLEANUP
 -- start_ignore
 DROP TABLE IF EXISTS foo;

--- a/src/test/regress/expected/bfv_partition_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_optimizer.out
@@ -1806,6 +1806,64 @@ SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
    | 2 | 3
 (2 rows)
 
+---
+--- Test EXPLAIN on a hash agg that has a Sequence + Partition Selector below it.
+---
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS bar;
+-- end_ignore
+CREATE TABLE bar (b int, c int)
+PARTITION BY RANGE (b)
+(
+  START (0) END (10),
+  START (10) END (20)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_1" for table "bar"
+NOTICE:  CREATE TABLE will create partition "bar_1_prt_2" for table "bar"
+INSERT INTO bar SELECT g % 20, g % 20 from generate_series(1, 1000) g;
+ANALYZE bar;
+SELECT b FROM bar GROUP BY b;
+ b  
+----
+  7
+  4
+ 19
+  3
+  5
+ 18
+  6
+ 11
+  9
+  8
+ 12
+ 10
+ 17
+  1
+  0
+  2
+ 16
+ 15
+ 14
+ 13
+(20 rows)
+
+EXPLAIN SELECT b FROM bar GROUP BY b;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.05 rows=20 width=4)
+   ->  HashAggregate  (cost=0.00..431.05 rows=7 width=4)
+         Group By: b
+         ->  Sequence  (cost=0.00..431.01 rows=334 width=4)
+               ->  Partition Selector for bar (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                     Partitions selected: 2 (out of 2)
+               ->  Dynamic Table Scan on bar (dynamic scan id: 1)  (cost=0.00..431.01 rows=334 width=4)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.5.0
+(9 rows)
+
 -- CLEANUP
 -- start_ignore
 DROP TABLE IF EXISTS foo;

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -740,6 +740,30 @@ INSERT INTO bar VALUES (2,3);
 
 SELECT * FROM foo FULL JOIN bar ON foo.a = bar.b;
 
+
+---
+--- Test EXPLAIN on a hash agg that has a Sequence + Partition Selector below it.
+---
+
+-- SETUP
+-- start_ignore
+DROP TABLE IF EXISTS bar;
+-- end_ignore
+CREATE TABLE bar (b int, c int)
+PARTITION BY RANGE (b)
+(
+  START (0) END (10),
+  START (10) END (20)
+);
+
+INSERT INTO bar SELECT g % 20, g % 20 from generate_series(1, 1000) g;
+ANALYZE bar;
+
+SELECT b FROM bar GROUP BY b;
+
+EXPLAIN SELECT b FROM bar GROUP BY b;
+
+
 -- CLEANUP
 -- start_ignore
 DROP TABLE IF EXISTS foo;


### PR DESCRIPTION
It's not clear to me why show_grouping_keys() needs to dig into the
child like this, when e.g. show_sort_keys() does not. However, this code
is going to be replaced with upstream code once we catch up with PostgreSQL
9.4, commit f26099057a2, so I'm not going worry about that right now.

Fixes github issue #1708.