### PR TITLE
Properly set attribute inheritance for external tables

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -10662,7 +10662,7 @@ MergeAttributesIntoExisting(Relation child_rel, Relation parent_rel, List *inhAt
 			 * not locally defined.  (Default/standard behaviour is to leave the
 			 * attribute locally defined.)
 			 */
-			if (childatt->attislocal)
+			if (childatt->attislocal && !RelationIsExternal(child_rel))
 			{
 				/* never local when we're doing partitioning */
 				if (is_partition)

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -46,10 +46,19 @@ FORMAT 'text' (delimiter '|');
 -- used to be entries created for non custom protocol tables with refobjid=0.
 SELECT * FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and refobjid = 0;
 
+create table nation (n_nationkey integer, n_name char(25), n_regionkey integer, n_comment varchar(152))
+distributed by (n_nationkey)
+partition by range (n_regionkey) (partition nation_1 start (5) inclusive, partition nation_2 start (10) inclusive);
+alter table nation add partition nation_0 start (0) inclusive end (4) exclusive;
+alter table nation exchange partition for (0) with table ext_nation without validation;
+select count(*) from nation;
+
 -- drop tables
 
-DROP EXTERNAL TABLE EXT_NATION;
+DROP TABLE EXT_NATION;
 DROP EXTERNAL TABLE EXT_REGION;
+DROP TABLE nation;
+
 -- start_ignore
 -- --------------------------------------
 -- check platform

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -46,9 +46,21 @@ SELECT * FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and refobj
 ---------+-------+----------+------------+----------+-------------+---------
 (0 rows)
 
+create table nation (n_nationkey integer, n_name char(25), n_regionkey integer, n_comment varchar(152))
+distributed by (n_nationkey)
+partition by range (n_regionkey) (partition nation_1 start (5) inclusive, partition nation_2 start (10) inclusive);
+alter table nation add partition nation_0 start (0) inclusive end (4) exclusive;
+alter table nation exchange partition for (0) with table ext_nation without validation;
+select count(*) from nation;
+ count 
+-------
+    20
+(1 row)
+
 -- drop tables
-DROP EXTERNAL TABLE EXT_NATION;
+DROP TABLE EXT_NATION;
 DROP EXTERNAL TABLE EXT_REGION;
+DROP TABLE nation;
 -- start_ignore
 -- --------------------------------------
 -- check platform


### PR DESCRIPTION
External tables doesn't support attribute inheritance, and while there is no syntax to trick plain inheritance into happening it was possible to get inherited attributes by injecting an external table into a partition hierarchy via partition exchange. Commit fcdd85390 attempted to fix this but was erroneous and subsequently reverted with 7cfaed3. The pg_dump portion of the original patch was however not reverted and wasn't affecting the issue at hand.

The problem with that commit was that it broke off the inheritance chain too early, the partition still need inheritance to become part of the hierarchy. This commit essentially does the same thing but deeper into the inheritance code path such that it only affects the attislocal attribute in pg_attribute. There was [discussion on gpdb-dev](https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/0I0T6tu5N6M/K6mbYM8OCQAJ) covering this.

Also extend the external_tables ICW suite with a test covering this path.