### PR TITLE
Remove GPDB_83_MERGE_FIXME for Split Partition

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14571,6 +14571,7 @@ ATPExecPartSplit(Relation *rel,
 		ct->relKind = RELKIND_RELATION;
 		ct->ownerid = (*rel)->rd_rel->relowner;
 		ct->is_split_part = true;
+		/* No transformation happens for this stmt in parse_analyze() */
 		q = parse_analyze((Node *)ct, NULL, NULL, 0);
 		ProcessUtility((Node *)q->utilityStmt,
 					   synthetic_sql,
@@ -14613,6 +14614,7 @@ ATPExecPartSplit(Relation *rel,
 		mypc2->location = -1;
 		cmd->def = (Node *)mypc;
 		ats->cmds = list_make1(cmd);
+		/* No transformation happens for this stmt in parse_analyze() */
 		q = parse_analyze((Node *)ats, NULL, NULL, 0);
 
 		heap_close(*rel, NoLock);
@@ -14668,16 +14670,10 @@ ATPExecPartSplit(Relation *rel,
 		mypc->arg2 = (Node *)makeNode(AlterPartitionCmd);
 
 		cmd->def = (Node *)mypc;
+		/* No transformation happens for this stmt in parse_analyze() */
 		q = parse_analyze((Node *)ats, NULL, NULL, 0);
 		heap_close(*rel, NoLock);
 
-		/* GPDB_83_MERGE_FIXME: the original comment said:
-		 *
-		 * [result of parse_analyze] Might have expanded to multiple statements if, for example, the
-		 * master table has indexes on it.
-		 *
-		 * Can that really happen? How do we handle that nowadays?
-		 */
 		ProcessUtility((Node *)q->utilityStmt,
 					   synthetic_sql,
 					   NULL,
@@ -15036,6 +15032,7 @@ ATPExecPartSplit(Relation *rel,
 			}
 
 			ats->cmds = list_make1(cmd);
+			/* No transformation happens for this stmt in parse_analyze() */
 			q = parse_analyze((Node *)ats, NULL, NULL, 0);
 
 			heap_close(*rel, NoLock);


### PR DESCRIPTION
Transformation of `AlterTableStmt` is moved from
`parse_analyze()` to `ProcessUtility()`

GPDB4 flow:
```
ATPExecPartSplit()
    parse_analyze()
        transformStmt()
            transformAlterTableStmt()   -> may expand to multiple statements
                transformAlterTable_all_PartitionStmt()
    foreach statement in statementList
        ProcessUtility()
```

GPDB Master flow:
```
ATPExecPartSplit()
    parse_analyze()
        transformStmt()  -> no-op for AlterTableStmt
    ProcessUtility()
        transformAlterTableStmt()    -> may expand to multiple statements
            transformAlterTable_all_PartitionStmt()
        foreach statement in statementList
            AlterTable() or ProcessUtility()
```

Hence in `ATPExecPartSplit()`, it is guaranteed that
we have not expanded into multiple statements since
no transformation happened in `parse_analyze()`.

This commit removes the FIXME comment.