### PR TITLE
Updated gpversion format, fixed gpmigrator_util tests

### DIFF
--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_gpmigrator_util.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_gpmigrator_util.py
@@ -11,19 +11,19 @@ from mock import patch, MagicMock, Mock
 
 class IsSupportedVersionTestCase(unittest.TestCase):
     def test_is_supported_version_major_version_upgrade(self):
-        v = GpVersion('4.2.0.0')
+        v = GpVersion('4.3.0.0')
         self.assertTrue(is_supported_version(v))
 
     def test_is_supported_minor_version_upgrade(self):
-        v = GpVersion('4.2.8.0')
+        v = GpVersion('4.3.8.0')
         self.assertTrue(is_supported_version(v))
 
     def test_is_supported_dev_build_version_upgrade(self):
-        v = GpVersion('4.2 build dev')
+        v = GpVersion('4.3 build dev')
         self.assertTrue(is_supported_version(v))
 
     def test_is_supported_version_hotfix_upgrade(self):
-        v = GpVersion('4.2.7.3MS7')
+        v = GpVersion('4.3.7.3EC7')
         self.assertTrue(is_supported_version(v))
 
     def test_is_supported_version_major_version_unsupported_upgrade(self):
@@ -32,27 +32,27 @@ class IsSupportedVersionTestCase(unittest.TestCase):
             is_supported_version(v)
 
     def test_is_supported_version_awesome_build_upgrade(self):
-        v = GpVersion('4.2.3.4__AWESOME_BUILD__')
+        v = GpVersion('4.3.3.4__AWESOME_BUILD__')
         self.assertTrue(is_supported_version(v))
 
     def test_is_supported_version_space_in_build_upgrade(self):
-        v = GpVersion('4.2.3.4 MS7')
+        v = GpVersion('4.3.3.4 EC7')
         self.assertTrue(is_supported_version(v))
 
     def test_is_supported_version_major_version_downgrade(self):
-        v = GpVersion('4.2.0.0')
+        v = GpVersion('4.3.0.0')
         self.assertTrue(is_supported_version(v, False))
 
     def test_is_supported_minor_version_downgrade(self):
-        v = GpVersion('4.2.8.0')
+        v = GpVersion('4.3.8.0')
         self.assertTrue(is_supported_version(v, False))
 
     def test_is_supported_dev_build_version_downgrade(self):
-        v = GpVersion('4.2 build dev')
+        v = GpVersion('4.3 build dev')
         self.assertTrue(is_supported_version(v, False))
 
     def test_is_supported_version_hotfix_downgrade(self):
-        v = GpVersion('4.2.7.3MS7')
+        v = GpVersion('4.3.7.3EC7')
         self.assertTrue(is_supported_version(v, False))
 
     def test_is_supported_version_major_version_unsupported_downgrade(self):
@@ -61,10 +61,10 @@ class IsSupportedVersionTestCase(unittest.TestCase):
             is_supported_version(v, False)
 
     def test_is_supported_version_awesome_build_downgrade(self):
-        v = GpVersion('4.2.3.4__AWESOME_BUILD__')
+        v = GpVersion('4.3.3.4__AWESOME_BUILD__')
         self.assertTrue(is_supported_version(v, False))
 
     def test_is_supported_version_space_in_build_downgrade(self):
-        v = GpVersion('4.2.3.4 MS7')
+        v = GpVersion('4.3.3.4 EC7')
         self.assertTrue(is_supported_version(v))
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpversion.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpversion.py
@@ -94,7 +94,7 @@ class GpVersionTestCase(unittest.TestCase):
         self.assertEqual(v_1 << 1, v_2)
         self.assertLess(v_1, v)
         self.assertLess(v_2, v)
-        self.assertEqual(v.getVersionRelease(), "5.0")
+        self.assertEqual(v.getVersionRelease(), "5")
         self.assertEqual(v_1.getVersionRelease(), "4.3")
         self.assertEqual(v_2.getVersionRelease(), "4.2")
        
@@ -102,7 +102,7 @@ class GpVersionTestCase(unittest.TestCase):
         vLong = GpVersion("PostgreSQL 8.3.23 (Greenplum Database 5.0.0 build dev) on x86_64-pc-linux-gnu, compiled by GCC gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-17) compiled on Feb  9 2017 23:06:31")
         self.assertTrue(vLong.isVersionCurrentRelease() == True )
         self.assertTrue(vLong.getVersionBuild() == 'dev')
-        self.assertTrue(vLong.getVersionRelease() == "5.0")
+        self.assertTrue(vLong.getVersionRelease() == "5")
         self.assertTrue(vLong.isVersionRelease("5.0"))
         self.assertTrue(vLong.isVersionRelease("3.2") == False)
         self.assertTrue(vLong > "4.0.0")


### PR DESCRIPTION
This commit expands on 2ccdfbf25dc991632659a3c5f8519f65c5091d16, as
the gpversion helper functions also needed to be modified to account
for the 4-digits-to-3-digits conversion; with 3 digits, the major
version is 5, not 5.0.

It also updates the gpmigrator_util tests to use 4.3 as the previous
version, instead of 4.2, and removes some references to customers in
the test version strings.