### PR TITLE
Silence warning on duplicate typedef.

### DIFF
--- a/src/include/access/relscan.h
+++ b/src/include/access/relscan.h
@@ -94,8 +94,6 @@ typedef struct IndexScanDescData
 
 typedef IndexScanDescData *IndexScanDesc;
 
-typedef struct URL_FILE URL_FILE;
-
 /*
  * used for scan of external relations with the file protocol
  */
@@ -104,7 +102,7 @@ typedef struct FileScanDescData
 	/* scan parameters */
 	Relation	fs_rd;			/* target relation descriptor */
 	Index       fs_scanrelid;
-	URL_FILE   *fs_file;		/* the file pointer to our URI */
+	struct URL_FILE *fs_file;	/* the file pointer to our URI */
 	char	   *fs_uri;			/* the URI string */
 	bool		fs_noop;		/* no op. this segdb has no file to scan */
 	uint32      fs_scancounter;	/* copied from struct ExternalScan in plan */


### PR DESCRIPTION
Instead of having a duplicate typedef in url.h and relscan.h, use
"struct URL_FILE" rather than just "URL_FILE" in FileScanDescData. We
handled CopyStateData in the same struct like this already.

This silences compiler warning that Daniel Gustafsson reported offlist,
when building with clang with -Wtypedef-redefinition.