### PR TITLE
updates to language create/alter/drop allowing db owners

### DIFF
--- a/gpdb-doc/dita/ref_guide/extensions/pl_python.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_python.xml
@@ -59,7 +59,7 @@
       <body>
         <p>For each database that requires its use, register the PL/Python language with the SQL
           command <codeph>CREATE LANGUAGE</codeph> or the Greenplum Database utility
-            <codeph>createlang</codeph>. Only superusers can register the PL/Python language with a
+            <codeph>createlang</codeph>. Because PL/Python is an untrusted language, only superusers can register PL/Python with a
           database. For example, running this command as the <codeph>gpadmin</codeph> system user
           registers PL/Python with the database named <codeph>testdb</codeph>:</p>
         <codeblock>$ createlang plpythonu -d testdb</codeblock>
@@ -71,7 +71,7 @@
       <body>
         <p>For a database that no longer requires the PL/Python language, remove support for
           PL/Python with the SQL command <codeph>DROP LANGUAGE</codeph> or the Greenplum Database
-            <codeph>droplang</codeph> utility. Only superusers can remove support for the PL/Python
+            <codeph>droplang</codeph> utility. Because PL/Python is an untrusted language, only superusers can remove support for the PL/Python
           language from a database. For example, running this command as the
             <codeph>gpadmin</codeph> system user removes support for PL/Python from the database
           named <codeph>testdb</codeph>:</p>

--- a/gpdb-doc/dita/ref_guide/extensions/pl_python.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_python.xml
@@ -59,9 +59,9 @@
       <body>
         <p>For each database that requires its use, register the PL/Python language with the SQL
           command <codeph>CREATE LANGUAGE</codeph> or the Greenplum Database utility
-            <codeph>createlang</codeph>. For example, running this command as the
-            <codeph>gpadmin</codeph> system user registers PL/Python for the database
-            <codeph>testdb</codeph>:</p>
+            <codeph>createlang</codeph>. Only superusers can register the PL/Python language with a
+          database. For example, running this command as the <codeph>gpadmin</codeph> system user
+          registers PL/Python with the database named <codeph>testdb</codeph>:</p>
         <codeblock>$ createlang plpythonu -d testdb</codeblock>
         <p>PL/Python is registered as an untrusted language.</p>
       </body>
@@ -69,11 +69,12 @@
     <topic id="topic6" xml:lang="en">
       <title>Removing PL/Python Support</title>
       <body>
-        <p>For a database that no long requires the PL/Python language, remove support for PL/Python
-          with the SQL command <codeph>DROP LANGUAGE</codeph> or the Greenplum Database
-            <codeph>droplang</codeph> utility. For example, running this command run as the
+        <p>For a database that no longer requires the PL/Python language, remove support for
+          PL/Python with the SQL command <codeph>DROP LANGUAGE</codeph> or the Greenplum Database
+            <codeph>droplang</codeph> utility. Only superusers can remove support for the PL/Python
+          language from a database. For example, running this command as the
             <codeph>gpadmin</codeph> system user removes support for PL/Python from the database
-            <codeph>testdb</codeph>:</p>
+          named <codeph>testdb</codeph>:</p>
         <codeblock>$ droplang plpythonu -d testdb</codeblock>
         <p>When you remove support for PL/Python, the PL/Python user-defined functions that you
           created in the database will no longer work. </p>

--- a/gpdb-doc/dita/ref_guide/extensions/pl_r.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_r.xml
@@ -101,7 +101,7 @@
         <body>
           <p>For each database that requires its use, register the PL/R language with the SQL
             command <codeph>CREATE LANGUAGE</codeph> or the utility <codeph>createlang</codeph>.
-            Only superusers can register the PL/R language with a database. For example, running
+            Because PL/R is an untrusted language, only superusers can register PL/R with a database. For example, running
             this command as the <codeph>gpadmin</codeph> system user registers the language with the
             database named <i>testdb</i>:</p>
           <codeblock>$ createlang plr -d testdb</codeblock>
@@ -128,7 +128,7 @@
         <body>
           <p>For a database that no longer requires the PL/R language, remove support for PL/R with
             the SQL command <codeph>DROP LANGUAGE</codeph> or the Greenplum Database
-              <codeph>droplang</codeph> utility. Only superusers can remove support for the PL/R
+              <codeph>droplang</codeph> utility. Because PL/R is an untrusted language, only superusers can remove support for the PL/R
             language from a database.  For example, running this command as the gpadmin user removes
             support for PL/R from the database named <i>testdb</i>:</p>
           <codeblock>$ droplang plr -d testdb</codeblock>

--- a/gpdb-doc/dita/ref_guide/extensions/pl_r.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_r.xml
@@ -100,8 +100,10 @@
         <title>Enabling PL/R Language Support</title>
         <body>
           <p>For each database that requires its use, register the PL/R language with the SQL
-            command <codeph>CREATE LANGUAGE</codeph> or the utility <codeph>createlang</codeph>. For
-            example, this command registers the language for the database <i>testdb</i>:</p>
+            command <codeph>CREATE LANGUAGE</codeph> or the utility <codeph>createlang</codeph>.
+            Only superusers can register the PL/R language with a database. For example, running
+            this command as the <codeph>gpadmin</codeph> system user registers the language with the
+            database named <i>testdb</i>:</p>
           <codeblock>$ createlang plr -d testdb</codeblock>
           <p>PL/R is registered as an untrusted language.</p>
         </body>
@@ -124,10 +126,11 @@
       <topic id="topic7" xml:lang="en">
         <title id="py216910">Remove PL/R Support for a Database</title>
         <body>
-          <p>For a database that no long requires the PL/R language, remove support for PL/R with
+          <p>For a database that no longer requires the PL/R language, remove support for PL/R with
             the SQL command <codeph>DROP LANGUAGE</codeph> or the Greenplum Database
-              <codeph>droplang</codeph> utility. For example, running this command run as the
-            gpadmin user removes support for PL/R from the database <i>testdb</i>:</p>
+              <codeph>droplang</codeph> utility. Only superusers can remove support for the PL/R
+            language from a database.  For example, running this command as the gpadmin user removes
+            support for PL/R from the database named <i>testdb</i>:</p>
           <codeblock>$ droplang plr -d testdb</codeblock>
         </body>
       </topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_LANGUAGE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_LANGUAGE.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="aq20941">ALTER LANGUAGE</title><body><p id="sql_command_desc">Changes the name of a procedural language.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">ALTER LANGUAGE <varname>name</varname> RENAME TO <varname>newname</varname></codeblock></section><section id="section3"><title>Description</title><p><codeph>ALTER LANGUAGE</codeph> changes the name of a procedural language.
-Only a superuser can rename languages.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>Name of a language. </pd></plentry><plentry><pt><varname>newname</varname></pt><pd>The new name of the language.</pd></plentry></parml></section><section id="section5"><title>Compatibility</title><p>There is no <codeph>ALTER LANGUAGE</codeph> statement in the SQL standard.
+<topic id="topic1"><title id="aq20941">ALTER LANGUAGE</title><body><p id="sql_command_desc">Changes the name of a procedural language.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">ALTER LANGUAGE <varname>name</varname> RENAME TO <varname>newname</varname>
+ALTER LANGUAGE <varname>name</varname> OWNER TO <varname>new_owner</varname></codeblock></section><section id="section3"><title>Description</title><p><codeph>ALTER LANGUAGE</codeph> changes the definition of a procedural language for a specific
+        database. Definition changes supported include renaming the language or assigning a new
+        owner. You must be superuser or the owner of the language to use <codeph>ALTER
+          LANGUAGE</codeph>.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>Name of a language. </pd></plentry><plentry><pt><varname>newname</varname></pt><pd>The new name of the language.</pd></plentry></parml></section>
+    <bodydiv>
+      <parml>
+        <plentry>
+          <pt>
+            <varname>new_owner</varname></pt>
+          <pd>   The new owner of the language.</pd>
+        </plentry>
+      </parml>
+    </bodydiv><section id="section5"><title>Compatibility</title><p>There is no <codeph>ALTER LANGUAGE</codeph> statement in the SQL standard.
 </p></section><section id="section6"><title>See Also</title><p><codeph><xref href="./CREATE_LANGUAGE.xml#topic1" type="topic" format="dita"/></codeph>,
             <codeph><xref href="./DROP_LANGUAGE.xml#topic1" type="topic" format="dita"
         /></codeph></p></section></body></topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_LANGUAGE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_LANGUAGE.xml
@@ -16,8 +16,15 @@ CREATE [TRUSTED] [PROCEDURAL] LANGUAGE <varname>name</varname>
             <title>Description</title>
             <p><codeph>CREATE LANGUAGE</codeph> registers a new procedural language with a Greenplum
                 database. Subsequently, functions and trigger procedures can be defined in this new
-                language. You must be a superuser to register a new language. The PL/pgSQL language
-                is already registered in all databases by default.</p>
+                language. The PL/pgSQL language is already registered in all databases by
+                default.</p>
+            <p>Superusers can register a new language with a Greenplum database. A database owner
+                can also register within that database any language listed in the
+                    <codeph>pg_pltemplate</codeph> catalog in which the
+                    <codeph>tmpldbacreate</codeph> field is true. The default configuration allows
+                only trusted languages to be registered by database owners. The creator of a
+                language becomes its owner and can later drop it, rename it, or assign ownership to
+                a new user.</p>
             <p><codeph>CREATE LANGUAGE</codeph> effectively associates the language name with a call
                 handler that is responsible for executing functions written in that language. For a
                 function written in a procedural language (a language other than C or SQL), the

--- a/gpdb-doc/dita/ref_guide/sql_commands/DROP_LANGUAGE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DROP_LANGUAGE.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="cy20941">DROP LANGUAGE</title><body><p id="sql_command_desc">Removes a procedural language.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DROP [PROCEDURAL] LANGUAGE [IF EXISTS] <varname>name</varname> [CASCADE | RESTRICT]</codeblock></section><section id="section3"><title>Description</title><p><codeph>DROP LANGUAGE</codeph> will remove the definition of the previously
-registered procedural language. You must be a superuser to drop a language.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt>PROCEDURAL</pt><pd>Optional keyword - has no effect.</pd></plentry><plentry><pt>IF EXISTS</pt><pd>Do not throw an error if the language does not exist. A notice is
+<topic id="topic1"><title id="cy20941">DROP LANGUAGE</title><body><p id="sql_command_desc">Removes a procedural language.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DROP [PROCEDURAL] LANGUAGE [IF EXISTS] <varname>name</varname> [CASCADE | RESTRICT]</codeblock></section><section id="section3"><title>Description</title><p><codeph>DROP LANGUAGE</codeph> will remove the definition of the previously registered procedural
+        language. You must be a superuser or owner of the language to drop a language.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt>PROCEDURAL</pt><pd>Optional keyword - has no effect.</pd></plentry><plentry><pt>IF EXISTS</pt><pd>Do not throw an error if the language does not exist. A notice is
 issued in this case. </pd></plentry><plentry><pt><varname>name</varname></pt><pd>The name of an existing procedural language. For backward compatibility,
 the name may be enclosed by single quotes. </pd></plentry><plentry><pt>CASCADE</pt><pd>Automatically drop objects that depend on the language (such as functions
 written in that language). </pd></plentry><plentry><pt>RESTRICT</pt><pd>Refuse to drop the language if any objects depend on it. This is


### PR DESCRIPTION
changes related to language registration and database ownership.

question:  createlang and droplang ref pages are currently aligned with the 8.3 postgres docs which do not include any statements at all about privileges required.  these pages identify the utilities as wrappers for the associated SQL command.  privileges are discussed on the SQL command page.  is that enough?