### PR TITLE
Enhance Explain Analyze to have sort method

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1642,8 +1642,6 @@ explain_outNode(StringInfo str,
 						   ((Sort *) plan)->sortColIdx,
 						   SortKeystr,
 						   str, indent, es);
-			show_sort_info((SortState *) planstate,
-						   str, indent, es);
 		}
 			break;
 		case T_Result:

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -377,6 +377,8 @@ struct Tuplesortstate_mk
 	int		   *gpmon_sort_tick;
 };
 
+static void tuplesort_get_stats_mk(Tuplesortstate_mk* state, ExplainSortMethod *sortMethod, double *spaceUsed);
+
 static bool
 is_sortstate_rwfile(Tuplesortstate_mk *state)
 {
@@ -1093,6 +1095,7 @@ tuplesort_finalize_stats_mk(Tuplesortstate_mk *state)
 		}
 
 		state->statsFinalized = true;
+		tuplesort_get_stats_mk(state, &state->instrument->sortMethod, &state->instrument->sortSpaceUsed);
 	}
 }
 
@@ -2625,19 +2628,17 @@ tuplesort_restorepos_mk(Tuplesortstate_mk *state)
 
 
 /*
- * tuplesort_explain - produce a line of information for EXPLAIN ANALYZE
+ * tuplesort_get_stats_mk - extract summary statistics
  *
- * This can be called after tuplesort_performsort() finishes to obtain
+ * This can be called after tuplesort_performsort_mk() finishes to obtain
  * printable summary information about how the sort was performed.
- *
- * The result is a palloc'd string.
+ * spaceUsed is measured in kilobytes.
  */
-char *
-tuplesort_explain_mk(Tuplesortstate_mk *state)
+static void
+tuplesort_get_stats_mk(Tuplesortstate_mk* state, ExplainSortMethod *sortMethod, double *spaceUsed)
 {
-	char	   *result = (char *) palloc(100);
-	long		spaceUsed;
-
+	Assert(sortMethod);
+	Assert(spaceUsed);
 	/*
 	 * Note: it might seem we should print both memory and disk usage for a
 	 * disk-based sort.  However, the current code doesn't track memory space
@@ -2648,38 +2649,28 @@ tuplesort_explain_mk(Tuplesortstate_mk *state)
 	 * tell us how much is actually used in sortcontext?
 	 */
 	if (state->tapeset)
-		spaceUsed = LogicalTapeSetBlocks(state->tapeset);
+		*spaceUsed = LogicalTapeSetBlocks(state->tapeset);
 	else
-		spaceUsed = (MemoryContextGetCurrentSpace(state->sortcontext) + 1024) / 1024;
+		*spaceUsed = (MemoryContextGetCurrentSpace(state->sortcontext) + 1024) / 1024;
 
 	switch (state->status)
 	{
-		case TSS_SORTEDINMEM:
-			if (state->mkctxt.boundUsed)
-				snprintf(result, 100,
-						"Sort Method:  top-N heapsort  Memory: %ldkB",
-						spaceUsed);
-			else
-				snprintf(result, 100,
-						"Sort Method:  quicksort  Memory: %ldkB",
-						spaceUsed);
-			break;
-		case TSS_SORTEDONTAPE:
-			snprintf(result, 100,
-					 "Sort Method:  external sort  Disk: %ldkB",
-					 spaceUsed);
-			break;
-		case TSS_FINALMERGE:
-			snprintf(result, 100,
-					 "Sort Method:  external merge  Disk: %ldkB",
-					 spaceUsed);
-			break;
-		default:
-			snprintf(result, 100, "sort still in progress");
-			break;
+	case TSS_SORTEDINMEM:
+		if (state->mkctxt.boundUsed)
+			*sortMethod = TOP_N_HEAP_SORT;
+		else
+			*sortMethod = QUICK_SORT;
+		break;
+	case TSS_SORTEDONTAPE:
+		*sortMethod = EXTERNAL_SORT;
+		break;
+	case TSS_FINALMERGE:
+		*sortMethod = EXTERNAL_MERGE;
+		break;
+	default:
+		*sortMethod = IN_PROGRESS_SORT;
 	}
-
-	return result;
+	return;
 }
 
 /*

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -18,6 +18,24 @@
 
 struct CdbExplain_NodeSummary;          /* private def in cdb/cdbexplain.c */
 
+#define NUM_SORT_METHOD 5
+
+/*
+ * Different sort method in GPDB.
+ *
+ * Make sure to update NUM_SORT_METHOD when this enum changes.
+ * This enum value is used an index in the array sortSpaceUsed
+ * in struct CdbExplain_NodeSummary.
+ */
+typedef enum
+{
+	UNINITALIZED_SORT = 0,
+	TOP_N_HEAP_SORT = 1,
+	QUICK_SORT = 2,
+	EXTERNAL_SORT = 3,
+	EXTERNAL_MERGE = 4,
+	IN_PROGRESS_SORT = 5
+} ExplainSortMethod;
 
 typedef struct Instrumentation
 {
@@ -38,6 +56,8 @@ typedef struct Instrumentation
 	instr_time	firststart;		/* CDB: Start time of first iteration of node */
 	bool		workfileCreated;/* TRUE if workfiles are created in this node */
 	int		numPartScanned; /* Number of part tables scanned */
+	ExplainSortMethod sortMethod;	/* CDB: Type of sort */
+	double			  sortSpaceUsed; /* CDB: Memory / Disk used by sort(KBytes) */
     struct CdbExplain_NodeSummary  *cdbNodeSummary; /* stats from all qExecs */
 } Instrumentation;
 

--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -138,9 +138,6 @@ extern void tuplesort_flush_mk(Tuplesortstate_mk *state);
 extern void tuplesort_finalize_stats(Tuplesortstate *state);
 extern void tuplesort_finalize_stats_mk(Tuplesortstate_mk *state);
 
-extern char *tuplesort_explain(Tuplesortstate *state);
-extern char *tuplesort_explain_mk(Tuplesortstate_mk *state);
-
 extern int	tuplesort_merge_order(long allowedMem);
 
 /*

--- a/src/test/regress/expected/sort.out
+++ b/src/test/regress/expected/sort.out
@@ -1,0 +1,81 @@
+create schema sort_schema;
+set search_path to sort_schema;
+ 
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+ 
+-- Check if analyze output has Sort Method
+ create or replace function sort_schema.has_sortmethod(explain_analyze_query text)
+ returns setof int as
+ $$
+ rv = plpy.execute(explain_analyze_query)
+ search_text = 'Sort Method'
+ result = []
+ for i in range(len(rv)):
+     cur_line = rv[i]['QUERY PLAN']
+     if search_text.lower() in cur_line.lower():
+         result.append(1)
+ return result
+ $$
+ language plpythonu;
+ 
+ set gp_enable_mk_sort = on;
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g limit 100;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ set gp_enable_mk_sort = off;
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g limit 100;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ -- start_ignore
+ create table sort_a(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ insert into sort_a values(1, 2);
+ -- end_ignore
+ 
+ set gp_enable_mk_sort = on;
+ select sort_schema.has_sortmethod('explain analyze select i from sort_a order by i;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ set gp_enable_mk_sort = off;
+ select sort_schema.has_sortmethod('explain analyze select i from sort_a order by i;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ 
+ -- start_ignore
+ drop schema sort_schema cascade;
+NOTICE:  drop cascades to table sort_a
+NOTICE:  drop cascades to function has_sortmethod(text)
+ -- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -105,7 +105,7 @@ test: bfv_catalog bfv_index bfv_olap bfv_aggregate bfv_partition DML_over_joins 
  
 test: aggregate_with_groupingsets 
 
-test: nested_case_null
+test: nested_case_null sort
 
 test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy
 

--- a/src/test/regress/sql/sort.sql
+++ b/src/test/regress/sql/sort.sql
@@ -1,0 +1,47 @@
+create schema sort_schema;
+set search_path to sort_schema;
+ 
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+ 
+-- Check if analyze output has Sort Method
+ create or replace function sort_schema.has_sortmethod(explain_analyze_query text)
+ returns setof int as
+ $$
+ rv = plpy.execute(explain_analyze_query)
+ search_text = 'Sort Method'
+ result = []
+ for i in range(len(rv)):
+     cur_line = rv[i]['QUERY PLAN']
+     if search_text.lower() in cur_line.lower():
+         result.append(1)
+ return result
+ $$
+ language plpythonu;
+ 
+ set gp_enable_mk_sort = on;
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g limit 100;');
+ 
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g;');
+ 
+ set gp_enable_mk_sort = off;
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g limit 100;');
+ 
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g;');
+ 
+ -- start_ignore
+ create table sort_a(i int, j int);
+ insert into sort_a values(1, 2);
+ -- end_ignore
+ 
+ set gp_enable_mk_sort = on;
+ select sort_schema.has_sortmethod('explain analyze select i from sort_a order by i;');
+ 
+ set gp_enable_mk_sort = off;
+ select sort_schema.has_sortmethod('explain analyze select i from sort_a order by i;');
+ 
+ 
+ -- start_ignore
+ drop schema sort_schema cascade;
+ -- end_ignore


### PR DESCRIPTION
This PR is about addressing the issue https://github.com/greenplum-db/gpdb/issues/1646 .

With this enhance now we can see the sort method will print. Some of the examples are shown below.

**Sort in Master**
```
krajaraman=# explain analyze select * from generate_series(1, 100) g order by g limit 100;
                                                QUERY PLAN
----------------------------------------------------------------------------------------------------------
 Limit  (cost=50.72..50.97 rows=100 width=4)
   Rows out:  100 rows with 0.305 ms to first row, 0.336 ms to end, start offset by 0.131 ms.
   ->  Sort  (cost=50.72..53.22 rows=1000 width=4)
         Sort Key: g
         Sort Method:  top-N heapsort  Memory: 25KB
         Rows out:  100 rows with 0.302 ms to first row, 0.316 ms to end, start offset by 0.133 ms.
         Executor memory:  58K bytes.
         Work_mem used:  58K bytes. Workfile: (0 spilling)
         ->  Function Scan on generate_series g  (cost=0.00..12.50 rows=1000 width=4)
               Rows out:  100 rows with 0.059 ms to first row, 0.072 ms to end, start offset by 0.246 ms.
               Work_mem used:  9K bytes.
 Slice statistics:
   (slice0)    Executor memory: 118K bytes.  Work_mem: 58K bytes max.
 Statement statistics:
   Memory used: 128000K bytes
 Optimizer status: legacy query optimizer
 Total runtime: 0.484 ms
(17 rows)
```

**Sort in Master without limit**
```
krajaraman=# explain analyze select * from generate_series(1, 100) g order by g;
                                             QUERY PLAN
----------------------------------------------------------------------------------------------------
 Sort  (cost=62.33..64.83 rows=1000 width=4)
   Sort Key: g
   Sort Method:  quicksort  Memory: 49KB
   Rows out:  100 rows with 0.190 ms to first row, 0.201 ms to end, start offset by 0.066 ms.
   Executor memory:  49K bytes.
   Work_mem used:  49K bytes. Workfile: (0 spilling)
   ->  Function Scan on generate_series g  (cost=0.00..12.50 rows=1000 width=4)
         Rows out:  100 rows with 0.064 ms to first row, 0.080 ms to end, start offset by 0.105 ms.
         Work_mem used:  9K bytes.
 Slice statistics:
   (slice0)    Executor memory: 118K bytes.  Work_mem: 49K bytes max.
 Statement statistics:
   Memory used: 128000K bytes
 Optimizer status: legacy query optimizer
 Total runtime: 0.280 ms
(15 rows)
```

**Sort In segment**
```
krajaraman=# explain analyze select i from sort_a order by i;
                                                  QUERY PLAN
---------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..1.02 rows=1 width=4)
   Merge Key: i
   Rows out:  1 rows at destination with 29 ms to end, start offset by 0.473 ms.
   ->  Sort  (cost=1.02..1.02 rows=1 width=4)
         Sort Key: i
         Sort Method:  quicksort  Max Memory: 49KB  Avg Memory: 49KB (3 segments)
         Rows out:  1 rows (seg0) with 2.601 ms to first row, 2.611 ms to end, start offset by 0.883 ms.
         Executor memory:  74K bytes avg, 74K bytes max (seg0).
         Work_mem used:  74K bytes avg, 74K bytes max (seg0). Workfile: (0 spilling)
         ->  Seq Scan on sort_a  (cost=0.00..1.01 rows=1 width=4)
               Rows out:  1 rows (seg0) with 0.021 ms to first row, 0.023 ms to end, start offset by 3.451 ms.
 Slice statistics:
   (slice0)    Executor memory: 318K bytes.
   (slice1)    Executor memory: 193K bytes avg x 3 workers, 193K bytes max (seg0).  Work_mem: 74K bytes max.
 Statement statistics:
   Memory used: 128000K bytes
 Optimizer status: legacy query optimizer
 Total runtime: 30.204 ms
(18 rows)
```

**Different Sort in Segment**
```
krajaraman=# explain analyze select a from foo order by b;
                                                                      QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..1.02 rows=1 width=8)
   Merge Key: b
   Rows out:  46035 rows at destination with 64 ms to first row, 101 ms to end, start offset by 0.454 ms.
   ->  Sort  (cost=1.02..1.02 rows=1 width=8)
         Sort Key: b
         Sort Method:  quicksort  Max Memory: 697KB  Avg Memory: 365KB (2 segments)
         Sort Method:  external merge  Memory: 1209KB
         Rows out:  Avg 15345.0 rows x 3 workers.  Max 39001 rows (seg2) with 63 ms to first row, 83 ms to end, start offset by 0.829 ms.
         Executor memory:  742K bytes avg, 1497K bytes max (seg2).
         Work_mem used:  742K bytes avg, 1497K bytes max (seg2). Workfile: (1 spilling)
         Work_mem wanted: 5750K bytes avg, 5750K bytes max (seg2) to lessen workfile I/O affecting 1 workers.
         ->  Seq Scan on foo  (cost=0.00..1.01 rows=1 width=8)
               Rows out:  Avg 15345.0 rows x 3 workers.  Max 39001 rows (seg2) with 0.074 ms to first row, 5.759 ms to end, start offset by 0.862 ms.
 Slice statistics:
   (slice0)    Executor memory: 407K bytes.
   (slice1)  * Executor memory: 913K bytes avg x 3 workers, 1672K bytes max (seg2).  Work_mem: 1497K bytes max, 5750K bytes wanted.
 Statement statistics:
   Memory used: 1024K bytes
   Memory wanted: 5949K bytes
 Optimizer status: legacy query optimizer
 Total runtime: 108.894 ms
(21 rows)
```

Here is the link to gpdb-dev discussion - https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/V-zIshnNzyE

@hlinnaka @foyzur @hardikar @hsyuan @vraghavan78  Please have a look when you get chance.
