### PR TITLE
Clean the gpMgmt directory more thoroughly

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -96,6 +96,7 @@ clean:
 	$(MAKE) -C contrib/pg_upgrade_support $@
 	$(MAKE) -C contrib/pg_upgrade $@
 	$(MAKE) -C gpAux/extensions $@
+	$(MAKE) -C gpMgmt $@
 # Garbage from autoconf:
 	@rm -rf autom4te.cache/
 

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -92,7 +92,8 @@ install: generate_greenplum_path_file
 #	rm -f $(prefix)/bin/gppkg
 #endif
 
-	cp -rp sbin/* $(DESTDIR)$(prefix)/sbin/.
+	$(MAKE) -C sbin $@ prefix=$(DESTDIR)$(prefix)
+
 	#cp -p extensions/gpfdist/gpfdist$(EXE_EXT) $(DESTDIR)$(prefix)/bin/
 	cp $(top_builddir)/src/test/regress/*.pl $(DESTDIR)$(prefix)/bin
 	cp $(top_builddir)/src/test/regress/*.pm $(DESTDIR)$(prefix)/bin
@@ -118,3 +119,7 @@ install: generate_greenplum_path_file
 	rm -f $(DESTDIR)$(prefix)/bin/gpchecksubnetcfg
 	rm -rf $(DESTDIR)$(prefix)/bin/gppylib
 	find $(DESTDIR)$(prefix)/lib/python/gppylib -name test -type d | xargs rm -rf
+
+clean:
+	@$(MAKE) -C bin $@
+	@$(MAKE) -C sbin $@

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -278,6 +278,7 @@ clean :
 	@rm -rf $(PYLIB_SRC_EXT)/$(LOGILAB_ASTNG_DIR)
 	@rm -rf $(STREAM_DIR)/stream lib/stream  
 	@rm -rf *.pyc lib/*.pyc
+	@rm -f gpcheckcatc gpcrondumpc gpexpandc gptransferc
 
 .PHONY: disclean
 distclean: clean

--- a/gpMgmt/sbin/Makefile
+++ b/gpMgmt/sbin/Makefile
@@ -1,0 +1,12 @@
+top_builddir=../..
+ifneq "$(wildcard $(top_builddir)/src/Makefile.global)" ""
+include $(top_builddir)/src/Makefile.global
+endif
+
+install:
+	@# Copy everything except the makefile
+	find . -not -path '*Makefile' -type f -exec cp -- {} $(prefix)/sbin/{} \;
+
+
+clean:
+	@rm -f *.pyc


### PR DESCRIPTION
We added make commands to clean up files that are gitignored, because
now git clean won't be able to delete them.

Signed-off-by: Marbin Tan <mtan@pivotal.io>