### PR TITLE
Retry monitoring pulse if there's a hiccup

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -733,6 +733,7 @@ jobs:
       PULSE_USERNAME: {{pulse_username}}
       PULSE_PASSWORD: {{pulse_password}}
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params: *pulse_properties
@@ -765,6 +766,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "GPDB-BehaveBackupRestore"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -782,6 +784,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "GPDB-BehaveGPCheckcat"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -799,6 +802,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "GPDB-BehaveGPRecoverseg"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -816,6 +820,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "GPDB-kerberos_smoke"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -835,6 +840,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "GPDB-gpexpand-parallel"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -854,6 +860,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "GPDB-behave_gptransfer_43x_to_5x"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -871,6 +878,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "GPDB-behave_gptransfer_5x_to_5x"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -889,6 +897,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "cs-pg-two-phase"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -906,6 +915,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "cs-walrepl-multinode"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -925,6 +935,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "cs-aoco-compression"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -942,6 +953,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "mpp-interconnect"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:
@@ -961,6 +973,7 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "GPDB-5-CCLE"
   - task: monitor_pulse
+    attempts: 2
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/monitor_pulse.yml
     params:


### PR DESCRIPTION
There's retry logic within the monitoring pulse script, but we still
occasionally get hiccups (just network because the monitoring lasts for
a while).

Signed-off-by: Marbin Tan <mtan@pivotal.io>