### PR TITLE
Guard against duplicate table names between parallel tests.

### DIFF
--- a/src/test/regress/expected/bfv_catalog.out
+++ b/src/test/regress/expected/bfv_catalog.out
@@ -296,6 +296,3 @@ select pg_get_constraintdef(pg_constraint.oid) from pg_constraint, pg_class wher
  PRIMARY KEY (a)
 (1 row)
 
--- CLEANUP
-set client_min_messages='warning';
-drop schema bfv_catalog cascade;

--- a/src/test/regress/expected/bfv_catalog.out
+++ b/src/test/regress/expected/bfv_catalog.out
@@ -1,3 +1,5 @@
+create schema bfv_catalog;
+set search_path=bfv_catalog;
 -- count number of certain operators in a given plan
 -- start_ignore
 create language plpythonu;
@@ -114,17 +116,10 @@ order by u_vtgnr, u_zj, u_folio;
  991     | 99   | 99
 (1 row)
 
-drop table q68t792_temp;
 --
 -- Fix bug in Expression to DXL translation for correlated queries when optimizer is turned on.
 --
 set optimizer = on;
-DROP TABLE IF EXISTS t1 CASCADE;
-NOTICE:  table "t1" does not exist, skipping
-DROP TABLE IF EXISTS t2 CASCADE;
-NOTICE:  table "t2" does not exist, skipping
-DROP TABLE IF EXISTS x CASCADE;
-NOTICE:  table "x" does not exist, skipping
 CREATE TABLE t1 (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE t2 (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE x (a int) DISTRIBUTED BY (a);
@@ -135,9 +130,6 @@ select count_operator('explain select * from x where a=  (select sum(t1.a)  from
  t
 (1 row)
 
-DROP TABLE t1;
-DROP TABLE t2;
-DROP TABLE x;
 reset optimizer;
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -227,7 +219,6 @@ where
 (38 rows)
 
 -- test queries that should run on the master
-drop table if exists mpp_bfv_1;
 create table mpp_bfv_1(col1 int, col2 text, col3 numeric) distributed by (col1);
 -- this cannot go to the _setup file, because it is not propagated here
 -- start_ignore
@@ -274,7 +265,6 @@ select count_operator('explain select col2 from mpp_bfv_1;', 'Motion');
               1
 (1 row)
 
-drop table mpp_bfv_1;
 -- this cannot go to the _teardown file, because it is not propagated here
 -- start_ignore
 select enable_xform('CXformIndexGet2IndexScan');
@@ -284,7 +274,6 @@ select enable_xform('CXformIndexGet2IndexScan');
 (1 row)
 
 -- end_ignore
-drop table if exists mpp_bfv_2;
 create table mpp_bfv_2(a int, b text, primary key (a)) distributed by (a);
 -- stop falling back to planner when catalog functions are encountered
 explain select pg_column_size('mpp_bfv_2');
@@ -307,7 +296,6 @@ select pg_get_constraintdef(pg_constraint.oid) from pg_constraint, pg_class wher
  PRIMARY KEY (a)
 (1 row)
 
-drop table mpp_bfv_2;
-drop table test_r_rvv_stada_dim_konst;
-drop table test_sf_dd_land_vm;
-drop function count_operator(text,text);
+-- CLEANUP
+set client_min_messages='warning';
+drop schema bfv_catalog cascade;

--- a/src/test/regress/expected/bfv_catalog_optimizer.out
+++ b/src/test/regress/expected/bfv_catalog_optimizer.out
@@ -1,3 +1,5 @@
+create schema bfv_catalog;
+set search_path=bfv_catalog;
 -- count number of certain operators in a given plan
 -- start_ignore
 create language plpythonu;
@@ -114,17 +116,10 @@ order by u_vtgnr, u_zj, u_folio;
  991     | 99   | 99
 (1 row)
 
-drop table q68t792_temp;
 --
 -- Fix bug in Expression to DXL translation for correlated queries when optimizer is turned on.
 --
 set optimizer = on;
-DROP TABLE IF EXISTS t1 CASCADE;
-NOTICE:  table "t1" does not exist, skipping
-DROP TABLE IF EXISTS t2 CASCADE;
-NOTICE:  table "t2" does not exist, skipping
-DROP TABLE IF EXISTS x CASCADE;
-NOTICE:  table "x" does not exist, skipping
 CREATE TABLE t1 (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE t2 (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE x (a int) DISTRIBUTED BY (a);
@@ -135,9 +130,6 @@ select count_operator('explain select * from x where a=  (select sum(t1.a)  from
  t
 (1 row)
 
-DROP TABLE t1;
-DROP TABLE t2;
-DROP TABLE x;
 reset optimizer;
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -227,7 +219,6 @@ where
 (38 rows)
 
 -- test queries that should run on the master
-drop table if exists mpp_bfv_1;
 create table mpp_bfv_1(col1 int, col2 text, col3 numeric) distributed by (col1);
 -- this cannot go to the _setup file, because it is not propagated here
 -- start_ignore
@@ -274,7 +265,6 @@ select count_operator('explain select col2 from mpp_bfv_1;', 'Motion');
               1
 (1 row)
 
-drop table mpp_bfv_1;
 -- this cannot go to the _teardown file, because it is not propagated here
 -- start_ignore
 select enable_xform('CXformIndexGet2IndexScan');
@@ -284,7 +274,6 @@ select enable_xform('CXformIndexGet2IndexScan');
 (1 row)
 
 -- end_ignore
-drop table if exists mpp_bfv_2;
 create table mpp_bfv_2(a int, b text, primary key (a)) distributed by (a);
 -- stop falling back to planner when catalog functions are encountered
 explain select pg_column_size('mpp_bfv_2');
@@ -311,7 +300,6 @@ select pg_get_constraintdef(pg_constraint.oid) from pg_constraint, pg_class wher
  PRIMARY KEY (a)
 (1 row)
 
-drop table mpp_bfv_2;
-drop table test_r_rvv_stada_dim_konst;
-drop table test_sf_dd_land_vm;
-drop function count_operator(text,text);
+-- CLEANUP
+set client_min_messages='warning';
+drop schema bfv_catalog cascade;

--- a/src/test/regress/expected/bfv_catalog_optimizer.out
+++ b/src/test/regress/expected/bfv_catalog_optimizer.out
@@ -300,6 +300,3 @@ select pg_get_constraintdef(pg_constraint.oid) from pg_constraint, pg_class wher
  PRIMARY KEY (a)
 (1 row)
 
--- CLEANUP
-set client_min_messages='warning';
-drop schema bfv_catalog cascade;

--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -475,6 +475,3 @@ NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_97" for table "t252
 NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_98" for table "t25289_t4"
 NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_99" for table "t25289_t4"
 ANALYZE T25289_T4;
--- CLEANUP
-set client_min_messages='warning';
-drop schema bfv_statistic cascade;

--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -1,3 +1,5 @@
+create schema bfv_statistic;
+set search_path=bfv_statistic;
 -- start_ignore
 create language plpythonu;
 -- end_ignore
@@ -11,8 +13,6 @@ return "false"
 $$
 language plpythonu;
 set optimizer = on;
-DROP TABLE IF EXISTS foo;
-NOTICE:  table "foo" does not exist, skipping
 create table foo (a int, b int) distributed by (a);
 insert into foo values (1,1);
 insert into foo values (0,1);
@@ -33,9 +33,6 @@ select check_row_count('explain select * from foo where a is not null and b >= 1
  true
 (1 row)
 
-drop table foo;
-DROP TABLE IF EXISTS foo2;
-NOTICE:  table "foo2" does not exist, skipping
 create table foo2(a int) distributed by (a);
 insert into foo2 select generate_series(1,5);
 insert into foo2 select 1 from generate_series(1,5);
@@ -71,8 +68,6 @@ select check_row_count('explain select a from foo2 where a > 1 order by a;', 8);
 -- test missing statistics
 --
 set gp_create_table_random_default_distribution=off;
-drop table if exists foo3;
-NOTICE:  table "foo3" does not exist, skipping
 create table foo3(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -86,8 +81,6 @@ select * from gp_toolkit.gp_stats_missing where smischema = 'public' AND  smitab
 --
 set optimizer=on;
 set gp_create_table_random_default_distribution=off;
-drop table if exists bar_dml;
-NOTICE:  table "bar_dml" does not exist, skipping
 CREATE TABLE bar_dml (
     vtrg character varying(6) NOT NULL,
     tec_schuld_whg character varying(3) NOT NULL,
@@ -112,25 +105,23 @@ CREATE TABLE bar_dml (
 )
 WITH (appendonly=true) DISTRIBUTED RANDOMLY;
 update bar_dml set (zhlg_org, zhlg_typ_org) = (zhlg, zhlg_typ);
-drop table bar_dml;
 reset optimizer;
 --
 -- Cardinality estimation when there is no histogram and MCV
 --
-drop table if exists foo3;
-create table foo3 (a int);
+create table foo4 (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into foo3 select i from generate_series(1,99) i;
-insert into foo3 values (NULL);
-analyze foo3;
-select stanullfrac, stadistinct, stanumbers1 from pg_statistic where starelid='foo3'::regclass and staattnum=1;
+insert into foo4 select i from generate_series(1,99) i;
+insert into foo4 values (NULL);
+analyze foo4;
+select stanullfrac, stadistinct, stanumbers1 from pg_statistic where starelid='foo4'::regclass and staattnum=1;
  stanullfrac | stadistinct | stanumbers1 
 -------------+-------------+-------------
         0.01 |          -1 | 
 (1 row)
 
-select check_row_count('explain select a from foo3 where a > 888;', 1);
+select check_row_count('explain select a from foo4 where a > 888;', 1);
  check_row_count 
 -----------------
  true
@@ -140,8 +131,6 @@ select check_row_count('explain select a from foo3 where a > 888;', 1);
 -- Testing that the merging of memo groups inside Orca does not crash cardinality estimation inside Orca
 --
 set optimizer = on;
-drop table if exists t1 cascade;
-NOTICE:  table "t1" does not exist, skipping
 create table t1(c1 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -223,8 +212,6 @@ reset optimizer;
 --
 -- test the generation of histogram boundaries for numeric and real data types
 --
-drop table if exists foo_real;
-NOTICE:  table "foo_real" does not exist, skipping
 create table foo_real (a int4, b real) distributed randomly;
 insert into foo_real values (0, 'Infinity');
 insert into foo_real values (0, '-Infinity');
@@ -291,8 +278,6 @@ select most_common_vals from pg_stats where tablename = 'foo_real' and attname =
  {0,-Infinity,-2.49268e+07,Infinity,NaN,-8.30285e+07,-3.43385e+07,4.31,16397,74881,93901.6,7.79946e+06}
 (1 row)
 
-drop table if exists foo_numeric;
-NOTICE:  table "foo_numeric" does not exist, skipping
 create table foo_numeric (a int4, b numeric) distributed randomly;
 insert into foo_numeric values (0, 'NaN');
 insert into foo_numeric values (0, 'NaN');
@@ -360,20 +345,15 @@ reset gp_create_table_random_default_distribution;
 --
 -- Ensure that VACUUM ANALYZE does not result in incorrect statistics
 --
-DROP TABLE IF EXISTS T25289_T1;
-NOTICE:  table "t25289_t1" does not exist, skipping
 CREATE TABLE T25289_T1 (c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO T25289_T1 VALUES (1);
 DELETE FROM T25289_T1;
 ANALYZE T25289_T1;
-DROP TABLE T25289_T1;
 --
 -- expect NO more notice after customer run VACUUM FULL
 -- 
-DROP TABLE IF EXISTS T25289_T2;
-NOTICE:  table "t25289_t2" does not exist, skipping
 CREATE TABLE T25289_T2 (c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -381,23 +361,17 @@ INSERT INTO T25289_T2 VALUES (1);
 DELETE FROM T25289_T2;
 VACUUM FULL T25289_T2;
 ANALYZE T25289_T2;
-DROP TABLE T25289_T2;
 --
 -- expect NO notice during analyze if table doesn't have empty pages
 --
-DROP TABLE IF EXISTS T25289_T3;
-NOTICE:  table "t25289_t3" does not exist, skipping
 CREATE TABLE T25289_T3 (c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO T25289_T3 VALUES (1);
 ANALYZE T25289_T3;
-DROP TABLE IF EXISTS T25289_T3;
 --
 -- expect NO notice when analyzing append only tables
 -- 
-DROP TABLE IF EXISTS T25289_T4;
-NOTICE:  table "t25289_t4" does not exist, skipping
 CREATE TABLE T25289_T4 (c int, d int)
 WITH (APPENDONLY=ON) DISTRIBUTED BY (c)
 PARTITION BY RANGE(d) (START(1) END (100) EVERY(1));
@@ -501,4 +475,6 @@ NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_97" for table "t252
 NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_98" for table "t25289_t4"
 NOTICE:  CREATE TABLE will create partition "t25289_t4_1_prt_99" for table "t25289_t4"
 ANALYZE T25289_T4;
-DROP TABLE IF EXISTS T25289_T4;
+-- CLEANUP
+set client_min_messages='warning';
+drop schema bfv_statistic cascade;

--- a/src/test/regress/sql/bfv_catalog.sql
+++ b/src/test/regress/sql/bfv_catalog.sql
@@ -559,6 +559,3 @@ explain select pg_lock_status();
 
 select pg_get_constraintdef(pg_constraint.oid) from pg_constraint, pg_class where conrelid=pg_class.oid and pg_class.relname='mpp_bfv_2';
 
--- CLEANUP
-set client_min_messages='warning';
-drop schema bfv_catalog cascade;

--- a/src/test/regress/sql/bfv_statistic.sql
+++ b/src/test/regress/sql/bfv_statistic.sql
@@ -298,6 +298,3 @@ WITH (APPENDONLY=ON) DISTRIBUTED BY (c)
 PARTITION BY RANGE(d) (START(1) END (100) EVERY(1));
 ANALYZE T25289_T4;
 
--- CLEANUP
-set client_min_messages='warning';
-drop schema bfv_statistic cascade;


### PR DESCRIPTION
In addition, delete unnecessary drop statements.

@jimmyyih @oarap @ashwinstar please review.