### PR TITLE
Error out when dispatching dtx commands to busy gangs

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -117,8 +117,10 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 
 	if (primaryGang->dispatcherActive)
 	{
-		elog(LOG, "CdbDispatchDtxProtocolCommand: primary gang marked active re-marking");
-		primaryGang->dispatcherActive = false;
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("query plan with multiple segworker groups is not supported"),
+				 errhint("dispatching DTX commands to a busy gang")));
 	}
 
 	/*

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -256,3 +256,27 @@ CREATE OR REPLACE FUNCTION udf_raise_info() RETURNS BOOL
 AS '@abs_builddir@/regress@DLSUFFIX@', 'gangRaiseInfo' LANGUAGE C;
 
 SELECT udf_raise_info() FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0;
+
+--
+-- Error out when dispatching DTX command to busy primary writer gang
+--
+CREATE TABLE dtx_dispatch_t AS SELECT i AS c1 FROM generate_series(1,10) i;
+
+CREATE or REPLACE FUNCTION dtx_dispatch_f(integer)
+RETURNS INTEGER
+AS
+$$
+BEGIN
+        return $1 + 1;
+EXCEPTION
+        WHEN division_by_zero THEN
+        RAISE NOTICE 'caught division_by_zero';
+        return 0;
+END
+$$
+LANGUAGE plpgSQL READS SQL DATA;
+
+SELECT dtx_dispatch_f(foo.c1) FROM (SELECT c1 FROM dtx_dispatch_t WHERE c1='1' limit 1) foo;
+
+DROP FUNCTION dtx_dispatch_f(integer);
+DROP TABLE dtx_dispatch_t;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -346,3 +346,28 @@ CONTEXT:  PL/C function defined in regress.c
  t
 (1 row)
 
+--
+-- Error out when dispatching DTX command to busy primary writer gang
+--
+CREATE TABLE dtx_dispatch_t AS SELECT i AS c1 FROM generate_series(1,10) i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE or REPLACE FUNCTION dtx_dispatch_f(integer)
+RETURNS INTEGER
+AS
+$$
+BEGIN
+        return $1 + 1;
+EXCEPTION
+        WHEN division_by_zero THEN
+        RAISE NOTICE 'caught division_by_zero';
+        return 0;
+END
+$$
+LANGUAGE plpgSQL READS SQL DATA;
+SELECT dtx_dispatch_f(foo.c1) FROM (SELECT c1 FROM dtx_dispatch_t WHERE c1='1' limit 1) foo;
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  dispatching DTX commands to a busy gang
+CONTEXT:  PL/pgSQL function "dtx_dispatch_f" line 1 during statement block entry
+DROP FUNCTION dtx_dispatch_f(integer);
+DROP TABLE dtx_dispatch_t;


### PR DESCRIPTION
Formerly, GPDB kept quite when dispatching DTX command to a busy gang in which cases GPDB is
not suppose to support, it hidden some bugs of the planner and even worse cause SIGSEGV because
dispatch threads may access and modify same connections without protections.