### PR TITLE
Re-enable upstream 'plpgsql' test.

### DIFF
--- a/src/test/regress/bugbuster/expected/schema_topology.out
+++ b/src/test/regress/bugbuster/expected/schema_topology.out
@@ -4603,57 +4603,6 @@ CREATE TABLE col_check_constraint  (
 INSERT into col_check_constraint  values (100,'text1');
 INSERT into col_check_constraint  values (200,'text2');
 INSERT into col_check_constraint  values (300,'text3');
---Set Returning Functions
-create function srf_vect() returns void as $proc$
-<<lbl>>declare a integer; b varchar; c varchar; r record;
-begin
-  -- fori
-  for i in 1 .. 3 loop
-    raise notice '%', i;
-  end loop;
-  -- fore with record var
-  for r in select gs as aa, 'BB' as bb, 'CC' as cc from generate_series(1,4) gs loop
-    raise notice '% % %', r.aa, r.bb, r.cc;
-  end loop;
-  -- fore with single scalar
-  for a in select gs from generate_series(1,4) gs loop
-    raise notice '%', a;
-  end loop;
-  -- fore with multiple scalars
-  for a,b,c in select gs, 'BB','CC' from generate_series(1,4) gs loop
-    raise notice '% % %', a, b, c;
-  end loop;
-  -- using qualified names in fors, fore is enabled, disabled only for fori
-  for lbl.a, lbl.b, lbl.c in execute $$select gs, 'bb','cc' from generate_series(1,4) gs$$ loop
-    raise notice '% % %', a, b, c;
-  end loop;
-end;
-$proc$ language plpgsql;
-select srf_vect();
-NOTICE:  1
-NOTICE:  2
-NOTICE:  3
-NOTICE:  1 BB CC
-NOTICE:  2 BB CC
-NOTICE:  3 BB CC
-NOTICE:  4 BB CC
-NOTICE:  1
-NOTICE:  2
-NOTICE:  3
-NOTICE:  4
-NOTICE:  1 BB CC
-NOTICE:  2 BB CC
-NOTICE:  3 BB CC
-NOTICE:  4 BB CC
-NOTICE:  1 bb cc
-NOTICE:  2 bb cc
-NOTICE:  3 bb cc
-NOTICE:  4 bb cc
- srf_vect 
-----------
- 
-(1 row)
-
 \echo -- start_ignore
 -- start_ignore
 drop role "ISO";

--- a/src/test/regress/bugbuster/expected/schema_topology_optimizer.out
+++ b/src/test/regress/bugbuster/expected/schema_topology_optimizer.out
@@ -4608,57 +4608,6 @@ CREATE TABLE col_check_constraint  (
 INSERT into col_check_constraint  values (100,'text1');
 INSERT into col_check_constraint  values (200,'text2');
 INSERT into col_check_constraint  values (300,'text3');
---Set Returning Functions
-create function srf_vect() returns void as $proc$
-<<lbl>>declare a integer; b varchar; c varchar; r record;
-begin
-  -- fori
-  for i in 1 .. 3 loop
-    raise notice '%', i;
-  end loop;
-  -- fore with record var
-  for r in select gs as aa, 'BB' as bb, 'CC' as cc from generate_series(1,4) gs loop
-    raise notice '% % %', r.aa, r.bb, r.cc;
-  end loop;
-  -- fore with single scalar
-  for a in select gs from generate_series(1,4) gs loop
-    raise notice '%', a;
-  end loop;
-  -- fore with multiple scalars
-  for a,b,c in select gs, 'BB','CC' from generate_series(1,4) gs loop
-    raise notice '% % %', a, b, c;
-  end loop;
-  -- using qualified names in fors, fore is enabled, disabled only for fori
-  for lbl.a, lbl.b, lbl.c in execute $$select gs, 'bb','cc' from generate_series(1,4) gs$$ loop
-    raise notice '% % %', a, b, c;
-  end loop;
-end;
-$proc$ language plpgsql;
-select srf_vect();
-NOTICE:  1
-NOTICE:  2
-NOTICE:  3
-NOTICE:  1 BB CC
-NOTICE:  2 BB CC
-NOTICE:  3 BB CC
-NOTICE:  4 BB CC
-NOTICE:  1
-NOTICE:  2
-NOTICE:  3
-NOTICE:  4
-NOTICE:  1 BB CC
-NOTICE:  2 BB CC
-NOTICE:  3 BB CC
-NOTICE:  4 BB CC
-NOTICE:  1 bb cc
-NOTICE:  2 bb cc
-NOTICE:  3 bb cc
-NOTICE:  4 bb cc
- srf_vect 
-----------
- 
-(1 row)
-
 \echo -- start_ignore
 -- start_ignore
 drop role "ISO";

--- a/src/test/regress/bugbuster/sql/schema_topology.sql
+++ b/src/test/regress/bugbuster/sql/schema_topology.sql
@@ -3631,35 +3631,6 @@ INSERT into col_check_constraint  values (100,'text1');
 INSERT into col_check_constraint  values (200,'text2');
 INSERT into col_check_constraint  values (300,'text3');
 
---Set Returning Functions
-create function srf_vect() returns void as $proc$
-<<lbl>>declare a integer; b varchar; c varchar; r record;
-begin
-  -- fori
-  for i in 1 .. 3 loop
-    raise notice '%', i;
-  end loop;
-  -- fore with record var
-  for r in select gs as aa, 'BB' as bb, 'CC' as cc from generate_series(1,4) gs loop
-    raise notice '% % %', r.aa, r.bb, r.cc;
-  end loop;
-  -- fore with single scalar
-  for a in select gs from generate_series(1,4) gs loop
-    raise notice '%', a;
-  end loop;
-  -- fore with multiple scalars
-  for a,b,c in select gs, 'BB','CC' from generate_series(1,4) gs loop
-    raise notice '% % %', a, b, c;
-  end loop;
-  -- using qualified names in fors, fore is enabled, disabled only for fori
-  for lbl.a, lbl.b, lbl.c in execute $$select gs, 'bb','cc' from generate_series(1,4) gs$$ loop
-    raise notice '% % %', a, b, c;
-  end loop;
-end;
-$proc$ language plpgsql;
-
-select srf_vect();
-
 \echo -- start_ignore
 drop role "ISO";
 drop role "geography";

--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -20,7 +20,6 @@
 --     you look behind the wall when looking at a patchfield
 --     or into a room.
 -- 
-set log_statement='all';
 create table Room (
     roomno	char(8),
     comment	text
@@ -1028,47 +1027,215 @@ insert into Room values ('106', 'Office');
 -- Second we install the wall connectors
 --
 insert into WSlot values ('WS.001.1a', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.1b', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.2a', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.2b', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.3a', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.3b', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.1a', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.1b', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.2a', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.2b', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.3a', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.3b', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.1a', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.1b', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.2a', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.2b', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.3a', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.3b', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.1a', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.1b', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.2a', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.2b', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.3a', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.3b', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.1a', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.1b', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.2a', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.2b', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.3a', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.3b', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.1a', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.1b', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.2a', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.2b', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.3a', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.3b', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.1a', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.1b', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.2a', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.2b', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.3a', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.3b', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 --
 -- Now create the patch fields and their slots
 --
@@ -1077,68 +1244,284 @@ insert into PField values ('PF0_1', 'Wallslots basement');
 -- The cables for these will be made later, so they are unconnected for now
 --
 insert into PSlot values ('PS.base.a1', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a2', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a3', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a4', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a5', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a6', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- These are already wired to the wall connectors
 --
 insert into PSlot values ('PS.base.b1', 'PF0_1', '', 'WS.002.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b2', 'PF0_1', '', 'WS.002.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b3', 'PF0_1', '', 'WS.002.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b4', 'PF0_1', '', 'WS.002.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b5', 'PF0_1', '', 'WS.002.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b6', 'PF0_1', '', 'WS.002.3b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c1', 'PF0_1', '', 'WS.003.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c2', 'PF0_1', '', 'WS.003.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c3', 'PF0_1', '', 'WS.003.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c4', 'PF0_1', '', 'WS.003.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c5', 'PF0_1', '', 'WS.003.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c6', 'PF0_1', '', 'WS.003.3b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- This patchfield will be renamed later into PF0_2 - so its
 -- slots references in pfname should follow
 --
 insert into PField values ('PF0_X', 'Phonelines basement');
 insert into PSlot values ('PS.base.ta1', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta2', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta3', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta4', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta5', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta6', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb1', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb2', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb3', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb4', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb5', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb6', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PField values ('PF1_1', 'Wallslots 1st floor');
 insert into PSlot values ('PS.1st.a1', 'PF1_1', '', 'WS.101.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a2', 'PF1_1', '', 'WS.101.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a3', 'PF1_1', '', 'WS.101.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a4', 'PF1_1', '', 'WS.101.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a5', 'PF1_1', '', 'WS.101.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a6', 'PF1_1', '', 'WS.101.3b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b1', 'PF1_1', '', 'WS.102.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b2', 'PF1_1', '', 'WS.102.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b3', 'PF1_1', '', 'WS.102.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b4', 'PF1_1', '', 'WS.102.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b5', 'PF1_1', '', 'WS.102.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b6', 'PF1_1', '', 'WS.102.3b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c1', 'PF1_1', '', 'WS.105.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c2', 'PF1_1', '', 'WS.105.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c3', 'PF1_1', '', 'WS.105.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c4', 'PF1_1', '', 'WS.105.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c5', 'PF1_1', '', 'WS.105.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c6', 'PF1_1', '', 'WS.105.3b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d1', 'PF1_1', '', 'WS.106.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d2', 'PF1_1', '', 'WS.106.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d3', 'PF1_1', '', 'WS.106.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d4', 'PF1_1', '', 'WS.106.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d5', 'PF1_1', '', 'WS.106.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d6', 'PF1_1', '', 'WS.106.3b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- Now we wire the wall connectors 1a-2a in room 001 to the
 -- patchfield. In the second update we make an error, and
@@ -1147,72 +1530,36 @@ insert into PSlot values ('PS.1st.d6', 'PF1_1', '', 'WS.106.3b');
 update PSlot set backlink = 'WS.001.1a' where slotname = 'PS.base.a1';
 update PSlot set backlink = 'WS.001.1b' where slotname = 'PS.base.a3';
 select * from WSlot where roomno = '001' order by slotname;
-       slotname       |  roomno  |       slotlink       |       backlink       
-----------------------+----------+----------------------+----------------------
- WS.001.1a            | 001      |                      | PS.base.a1          
- WS.001.1b            | 001      |                      | PS.base.a3          
- WS.001.2a            | 001      |                      |                     
- WS.001.2b            | 001      |                      |                     
- WS.001.3a            | 001      |                      |                     
- WS.001.3b            | 001      |                      |                     
-(6 rows)
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
-       slotname       | pfname |       slotlink       |       backlink       
-----------------------+--------+----------------------+----------------------
- PS.base.a1           | PF0_1  |                      | WS.001.1a           
- PS.base.a2           | PF0_1  |                      |                     
- PS.base.a3           | PF0_1  |                      | WS.001.1b           
- PS.base.a4           | PF0_1  |                      |                     
- PS.base.a5           | PF0_1  |                      |                     
- PS.base.a6           | PF0_1  |                      |                     
-(6 rows)
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 update PSlot set backlink = 'WS.001.2a' where slotname = 'PS.base.a3';
 select * from WSlot where roomno = '001' order by slotname;
-       slotname       |  roomno  |       slotlink       |       backlink       
-----------------------+----------+----------------------+----------------------
- WS.001.1a            | 001      |                      | PS.base.a1          
- WS.001.1b            | 001      |                      |                     
- WS.001.2a            | 001      |                      | PS.base.a3          
- WS.001.2b            | 001      |                      |                     
- WS.001.3a            | 001      |                      |                     
- WS.001.3b            | 001      |                      |                     
-(6 rows)
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
-       slotname       | pfname |       slotlink       |       backlink       
-----------------------+--------+----------------------+----------------------
- PS.base.a1           | PF0_1  |                      | WS.001.1a           
- PS.base.a2           | PF0_1  |                      |                     
- PS.base.a3           | PF0_1  |                      | WS.001.2a           
- PS.base.a4           | PF0_1  |                      |                     
- PS.base.a5           | PF0_1  |                      |                     
- PS.base.a6           | PF0_1  |                      |                     
-(6 rows)
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 update PSlot set backlink = 'WS.001.1b' where slotname = 'PS.base.a2';
 select * from WSlot where roomno = '001' order by slotname;
-       slotname       |  roomno  |       slotlink       |       backlink       
-----------------------+----------+----------------------+----------------------
- WS.001.1a            | 001      |                      | PS.base.a1          
- WS.001.1b            | 001      |                      | PS.base.a2          
- WS.001.2a            | 001      |                      | PS.base.a3          
- WS.001.2b            | 001      |                      |                     
- WS.001.3a            | 001      |                      |                     
- WS.001.3b            | 001      |                      |                     
-(6 rows)
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
-       slotname       | pfname |       slotlink       |       backlink       
-----------------------+--------+----------------------+----------------------
- PS.base.a1           | PF0_1  |                      | WS.001.1a           
- PS.base.a2           | PF0_1  |                      | WS.001.1b           
- PS.base.a3           | PF0_1  |                      | WS.001.2a           
- PS.base.a4           | PF0_1  |                      |                     
- PS.base.a5           | PF0_1  |                      |                     
- PS.base.a6           | PF0_1  |                      |                     
-(6 rows)
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 --
 -- Same procedure for 2b-3b but this time updating the WSlot instead
@@ -1222,207 +1569,112 @@ select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
 update WSlot set backlink = 'PS.base.a4' where slotname = 'WS.001.2b';
 update WSlot set backlink = 'PS.base.a6' where slotname = 'WS.001.3a';
 select * from WSlot where roomno = '001' order by slotname;
-       slotname       |  roomno  |       slotlink       |       backlink       
-----------------------+----------+----------------------+----------------------
- WS.001.1a            | 001      |                      | PS.base.a1          
- WS.001.1b            | 001      |                      | PS.base.a2          
- WS.001.2a            | 001      |                      | PS.base.a3          
- WS.001.2b            | 001      |                      | PS.base.a4          
- WS.001.3a            | 001      |                      | PS.base.a6          
- WS.001.3b            | 001      |                      |                     
-(6 rows)
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
-       slotname       | pfname |       slotlink       |       backlink       
-----------------------+--------+----------------------+----------------------
- PS.base.a1           | PF0_1  |                      | WS.001.1a           
- PS.base.a2           | PF0_1  |                      | WS.001.1b           
- PS.base.a3           | PF0_1  |                      | WS.001.2a           
- PS.base.a4           | PF0_1  |                      | WS.001.2b           
- PS.base.a5           | PF0_1  |                      |                     
- PS.base.a6           | PF0_1  |                      | WS.001.3a           
-(6 rows)
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 update WSlot set backlink = 'PS.base.a6' where slotname = 'WS.001.3b';
 select * from WSlot where roomno = '001' order by slotname;
-       slotname       |  roomno  |       slotlink       |       backlink       
-----------------------+----------+----------------------+----------------------
- WS.001.1a            | 001      |                      | PS.base.a1          
- WS.001.1b            | 001      |                      | PS.base.a2          
- WS.001.2a            | 001      |                      | PS.base.a3          
- WS.001.2b            | 001      |                      | PS.base.a4          
- WS.001.3a            | 001      |                      |                     
- WS.001.3b            | 001      |                      | PS.base.a6          
-(6 rows)
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
-       slotname       | pfname |       slotlink       |       backlink       
-----------------------+--------+----------------------+----------------------
- PS.base.a1           | PF0_1  |                      | WS.001.1a           
- PS.base.a2           | PF0_1  |                      | WS.001.1b           
- PS.base.a3           | PF0_1  |                      | WS.001.2a           
- PS.base.a4           | PF0_1  |                      | WS.001.2b           
- PS.base.a5           | PF0_1  |                      |                     
- PS.base.a6           | PF0_1  |                      | WS.001.3b           
-(6 rows)
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 update WSlot set backlink = 'PS.base.a5' where slotname = 'WS.001.3a';
 select * from WSlot where roomno = '001' order by slotname;
-       slotname       |  roomno  |       slotlink       |       backlink       
-----------------------+----------+----------------------+----------------------
- WS.001.1a            | 001      |                      | PS.base.a1          
- WS.001.1b            | 001      |                      | PS.base.a2          
- WS.001.2a            | 001      |                      | PS.base.a3          
- WS.001.2b            | 001      |                      | PS.base.a4          
- WS.001.3a            | 001      |                      | PS.base.a5          
- WS.001.3b            | 001      |                      | PS.base.a6          
-(6 rows)
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
-       slotname       | pfname |       slotlink       |       backlink       
-----------------------+--------+----------------------+----------------------
- PS.base.a1           | PF0_1  |                      | WS.001.1a           
- PS.base.a2           | PF0_1  |                      | WS.001.1b           
- PS.base.a3           | PF0_1  |                      | WS.001.2a           
- PS.base.a4           | PF0_1  |                      | WS.001.2b           
- PS.base.a5           | PF0_1  |                      | WS.001.3a           
- PS.base.a6           | PF0_1  |                      | WS.001.3b           
-(6 rows)
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 insert into PField values ('PF1_2', 'Phonelines 1st floor');
 insert into PSlot values ('PS.1st.ta1', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta2', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta3', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta4', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta5', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta6', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb1', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb2', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb3', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb4', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb5', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb6', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- Fix the wrong name for patchfield PF0_2
 --
 update PField set name = 'PF0_2' where name = 'PF0_X';
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select * from PSlot order by slotname;
-       slotname       | pfname |       slotlink       |       backlink       
-----------------------+--------+----------------------+----------------------
- PS.1st.a1            | PF1_1  |                      | WS.101.1a           
- PS.1st.a2            | PF1_1  |                      | WS.101.1b           
- PS.1st.a3            | PF1_1  |                      | WS.101.2a           
- PS.1st.a4            | PF1_1  |                      | WS.101.2b           
- PS.1st.a5            | PF1_1  |                      | WS.101.3a           
- PS.1st.a6            | PF1_1  |                      | WS.101.3b           
- PS.1st.b1            | PF1_1  |                      | WS.102.1a           
- PS.1st.b2            | PF1_1  |                      | WS.102.1b           
- PS.1st.b3            | PF1_1  |                      | WS.102.2a           
- PS.1st.b4            | PF1_1  |                      | WS.102.2b           
- PS.1st.b5            | PF1_1  |                      | WS.102.3a           
- PS.1st.b6            | PF1_1  |                      | WS.102.3b           
- PS.1st.c1            | PF1_1  |                      | WS.105.1a           
- PS.1st.c2            | PF1_1  |                      | WS.105.1b           
- PS.1st.c3            | PF1_1  |                      | WS.105.2a           
- PS.1st.c4            | PF1_1  |                      | WS.105.2b           
- PS.1st.c5            | PF1_1  |                      | WS.105.3a           
- PS.1st.c6            | PF1_1  |                      | WS.105.3b           
- PS.1st.d1            | PF1_1  |                      | WS.106.1a           
- PS.1st.d2            | PF1_1  |                      | WS.106.1b           
- PS.1st.d3            | PF1_1  |                      | WS.106.2a           
- PS.1st.d4            | PF1_1  |                      | WS.106.2b           
- PS.1st.d5            | PF1_1  |                      | WS.106.3a           
- PS.1st.d6            | PF1_1  |                      | WS.106.3b           
- PS.1st.ta1           | PF1_2  |                      |                     
- PS.1st.ta2           | PF1_2  |                      |                     
- PS.1st.ta3           | PF1_2  |                      |                     
- PS.1st.ta4           | PF1_2  |                      |                     
- PS.1st.ta5           | PF1_2  |                      |                     
- PS.1st.ta6           | PF1_2  |                      |                     
- PS.1st.tb1           | PF1_2  |                      |                     
- PS.1st.tb2           | PF1_2  |                      |                     
- PS.1st.tb3           | PF1_2  |                      |                     
- PS.1st.tb4           | PF1_2  |                      |                     
- PS.1st.tb5           | PF1_2  |                      |                     
- PS.1st.tb6           | PF1_2  |                      |                     
- PS.base.a1           | PF0_1  |                      | WS.001.1a           
- PS.base.a2           | PF0_1  |                      | WS.001.1b           
- PS.base.a3           | PF0_1  |                      | WS.001.2a           
- PS.base.a4           | PF0_1  |                      | WS.001.2b           
- PS.base.a5           | PF0_1  |                      | WS.001.3a           
- PS.base.a6           | PF0_1  |                      | WS.001.3b           
- PS.base.b1           | PF0_1  |                      | WS.002.1a           
- PS.base.b2           | PF0_1  |                      | WS.002.1b           
- PS.base.b3           | PF0_1  |                      | WS.002.2a           
- PS.base.b4           | PF0_1  |                      | WS.002.2b           
- PS.base.b5           | PF0_1  |                      | WS.002.3a           
- PS.base.b6           | PF0_1  |                      | WS.002.3b           
- PS.base.c1           | PF0_1  |                      | WS.003.1a           
- PS.base.c2           | PF0_1  |                      | WS.003.1b           
- PS.base.c3           | PF0_1  |                      | WS.003.2a           
- PS.base.c4           | PF0_1  |                      | WS.003.2b           
- PS.base.c5           | PF0_1  |                      | WS.003.3a           
- PS.base.c6           | PF0_1  |                      | WS.003.3b           
- PS.base.ta1          | PF0_2  |                      |                     
- PS.base.ta2          | PF0_2  |                      |                     
- PS.base.ta3          | PF0_2  |                      |                     
- PS.base.ta4          | PF0_2  |                      |                     
- PS.base.ta5          | PF0_2  |                      |                     
- PS.base.ta6          | PF0_2  |                      |                     
- PS.base.tb1          | PF0_2  |                      |                     
- PS.base.tb2          | PF0_2  |                      |                     
- PS.base.tb3          | PF0_2  |                      |                     
- PS.base.tb4          | PF0_2  |                      |                     
- PS.base.tb5          | PF0_2  |                      |                     
- PS.base.tb6          | PF0_2  |                      |                     
-(66 rows)
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 select * from WSlot order by slotname;
-       slotname       |  roomno  |       slotlink       |       backlink       
-----------------------+----------+----------------------+----------------------
- WS.001.1a            | 001      |                      | PS.base.a1          
- WS.001.1b            | 001      |                      | PS.base.a2          
- WS.001.2a            | 001      |                      | PS.base.a3          
- WS.001.2b            | 001      |                      | PS.base.a4          
- WS.001.3a            | 001      |                      | PS.base.a5          
- WS.001.3b            | 001      |                      | PS.base.a6          
- WS.002.1a            | 002      |                      | PS.base.b1          
- WS.002.1b            | 002      |                      | PS.base.b2          
- WS.002.2a            | 002      |                      | PS.base.b3          
- WS.002.2b            | 002      |                      | PS.base.b4          
- WS.002.3a            | 002      |                      | PS.base.b5          
- WS.002.3b            | 002      |                      | PS.base.b6          
- WS.003.1a            | 003      |                      | PS.base.c1          
- WS.003.1b            | 003      |                      | PS.base.c2          
- WS.003.2a            | 003      |                      | PS.base.c3          
- WS.003.2b            | 003      |                      | PS.base.c4          
- WS.003.3a            | 003      |                      | PS.base.c5          
- WS.003.3b            | 003      |                      | PS.base.c6          
- WS.101.1a            | 101      |                      | PS.1st.a1           
- WS.101.1b            | 101      |                      | PS.1st.a2           
- WS.101.2a            | 101      |                      | PS.1st.a3           
- WS.101.2b            | 101      |                      | PS.1st.a4           
- WS.101.3a            | 101      |                      | PS.1st.a5           
- WS.101.3b            | 101      |                      | PS.1st.a6           
- WS.102.1a            | 102      |                      | PS.1st.b1           
- WS.102.1b            | 102      |                      | PS.1st.b2           
- WS.102.2a            | 102      |                      | PS.1st.b3           
- WS.102.2b            | 102      |                      | PS.1st.b4           
- WS.102.3a            | 102      |                      | PS.1st.b5           
- WS.102.3b            | 102      |                      | PS.1st.b6           
- WS.105.1a            | 105      |                      | PS.1st.c1           
- WS.105.1b            | 105      |                      | PS.1st.c2           
- WS.105.2a            | 105      |                      | PS.1st.c3           
- WS.105.2b            | 105      |                      | PS.1st.c4           
- WS.105.3a            | 105      |                      | PS.1st.c5           
- WS.105.3b            | 105      |                      | PS.1st.c6           
- WS.106.1a            | 106      |                      | PS.1st.d1           
- WS.106.1b            | 106      |                      | PS.1st.d2           
- WS.106.2a            | 106      |                      | PS.1st.d3           
- WS.106.2b            | 106      |                      | PS.1st.d4           
- WS.106.3a            | 106      |                      | PS.1st.d5           
- WS.106.3b            | 106      |                      | PS.1st.d6           
-(42 rows)
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 --
 -- Install the central phone system and create the phone numbers.
@@ -1431,117 +1683,243 @@ select * from WSlot order by slotname;
 -- backlink field.
 --
 insert into PLine values ('PL.001', '-0', 'Central call', 'PS.base.ta1');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.002', '-101', '', 'PS.base.ta2');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.003', '-102', '', 'PS.base.ta3');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.004', '-103', '', 'PS.base.ta5');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.005', '-104', '', 'PS.base.ta6');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.006', '-106', '', 'PS.base.tb2');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.007', '-108', '', 'PS.base.tb3');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.008', '-109', '', 'PS.base.tb4');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.009', '-121', '', 'PS.base.tb5');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.010', '-122', '', 'PS.base.tb6');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.015', '-134', '', 'PS.1st.ta1');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.016', '-137', '', 'PS.1st.ta3');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.017', '-139', '', 'PS.1st.ta4');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.018', '-362', '', 'PS.1st.tb1');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.019', '-363', '', 'PS.1st.tb2');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.020', '-364', '', 'PS.1st.tb3');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.021', '-365', '', 'PS.1st.tb5');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.022', '-367', '', 'PS.1st.tb6');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.028', '-501', 'Fax entrance', 'PS.base.ta2');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.029', '-502', 'Fax 1st floor', 'PS.1st.ta1');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 --
 -- Buy some phones, plug them into the wall and patch the
 -- phone lines to the corresponding patchfield slots.
 --
 insert into PHone values ('PH.hc001', 'Hicom standard', 'WS.001.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from WSlot where slotname =  $1 "
+PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
+SQL statement "SELECT  tg_slotlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta1' where slotname = 'PS.base.a1';
 insert into PHone values ('PH.hc002', 'Hicom standard', 'WS.002.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from WSlot where slotname =  $1 "
+PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
+SQL statement "SELECT  tg_slotlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta5' where slotname = 'PS.base.b1';
 insert into PHone values ('PH.hc003', 'Hicom standard', 'WS.002.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from WSlot where slotname =  $1 "
+PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
+SQL statement "SELECT  tg_slotlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.tb2' where slotname = 'PS.base.b3';
 insert into PHone values ('PH.fax001', 'Canon fax', 'WS.001.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from WSlot where slotname =  $1 "
+PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
+SQL statement "SELECT  tg_slotlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta2' where slotname = 'PS.base.a3';
 --
 -- Install a hub at one of the patchfields, plug a computers
 -- ethernet interface into the wall and patch it to the hub.
 --
 insert into Hub values ('base.hub1', 'Patchfield PF0_1 hub', 16);
+ERROR:  function cannot execute on segment because it issues a non-SELECT statement  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "insert into HSlot (slotname, hubname, slotno, slotlink) values ('HS.dummy',  $1 ,  $2 , '')"
+PL/pgSQL function "tg_hub_adjustslots" line 10 at SQL statement
+SQL statement "SELECT  tg_hub_adjustslots( $1 , 0,  $2 )"
+PL/pgSQL function "tg_hub_a" line 6 at assignment
 insert into System values ('orion', 'PC');
 insert into IFace values ('IF', 'orion', 'eth0', 'WS.002.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from system where name =  $1 "
+PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 update PSlot set slotlink = 'HS.base.hub1.1' where slotname = 'PS.base.b2';
 --
 -- Now we take a look at the patchfield
 --
 select * from PField_v1 where pfname = 'PF0_1' order by slotname;
- pfname |       slotname       |                         backside                         |                     patch                     
---------+----------------------+----------------------------------------------------------+-----------------------------------------------
- PF0_1  | PS.base.a1           | WS.001.1a in room 001 -> Phone PH.hc001 (Hicom standard) | PS.base.ta1 -> Phone line -0 (Central call)
- PF0_1  | PS.base.a2           | WS.001.1b in room 001 -> -                               | -
- PF0_1  | PS.base.a3           | WS.001.2a in room 001 -> Phone PH.fax001 (Canon fax)     | PS.base.ta2 -> Phone line -501 (Fax entrance)
- PF0_1  | PS.base.a4           | WS.001.2b in room 001 -> -                               | -
- PF0_1  | PS.base.a5           | WS.001.3a in room 001 -> -                               | -
- PF0_1  | PS.base.a6           | WS.001.3b in room 001 -> -                               | -
- PF0_1  | PS.base.b1           | WS.002.1a in room 002 -> Phone PH.hc002 (Hicom standard) | PS.base.ta5 -> Phone line -103
- PF0_1  | PS.base.b2           | WS.002.1b in room 002 -> orion IF eth0 (PC)              | Patchfield PF0_1 hub slot 1
- PF0_1  | PS.base.b3           | WS.002.2a in room 002 -> Phone PH.hc003 (Hicom standard) | PS.base.tb2 -> Phone line -106
- PF0_1  | PS.base.b4           | WS.002.2b in room 002 -> -                               | -
- PF0_1  | PS.base.b5           | WS.002.3a in room 002 -> -                               | -
- PF0_1  | PS.base.b6           | WS.002.3b in room 002 -> -                               | -
- PF0_1  | PS.base.c1           | WS.003.1a in room 003 -> -                               | -
- PF0_1  | PS.base.c2           | WS.003.1b in room 003 -> -                               | -
- PF0_1  | PS.base.c3           | WS.003.2a in room 003 -> -                               | -
- PF0_1  | PS.base.c4           | WS.003.2b in room 003 -> -                               | -
- PF0_1  | PS.base.c5           | WS.003.3a in room 003 -> -                               | -
- PF0_1  | PS.base.c6           | WS.003.3b in room 003 -> -                               | -
-(18 rows)
+ pfname | slotname | backside | patch 
+--------+----------+----------+-------
+(0 rows)
 
 select * from PField_v1 where pfname = 'PF0_2' order by slotname;
- pfname |       slotname       |            backside            |                                 patch                                  
---------+----------------------+--------------------------------+------------------------------------------------------------------------
- PF0_2  | PS.base.ta1          | Phone line -0 (Central call)   | PS.base.a1 -> WS.001.1a in room 001 -> Phone PH.hc001 (Hicom standard)
- PF0_2  | PS.base.ta2          | Phone line -501 (Fax entrance) | PS.base.a3 -> WS.001.2a in room 001 -> Phone PH.fax001 (Canon fax)
- PF0_2  | PS.base.ta3          | Phone line -102                | -
- PF0_2  | PS.base.ta4          | -                              | -
- PF0_2  | PS.base.ta5          | Phone line -103                | PS.base.b1 -> WS.002.1a in room 002 -> Phone PH.hc002 (Hicom standard)
- PF0_2  | PS.base.ta6          | Phone line -104                | -
- PF0_2  | PS.base.tb1          | -                              | -
- PF0_2  | PS.base.tb2          | Phone line -106                | PS.base.b3 -> WS.002.2a in room 002 -> Phone PH.hc003 (Hicom standard)
- PF0_2  | PS.base.tb3          | Phone line -108                | -
- PF0_2  | PS.base.tb4          | Phone line -109                | -
- PF0_2  | PS.base.tb5          | Phone line -121                | -
- PF0_2  | PS.base.tb6          | Phone line -122                | -
-(12 rows)
+ pfname | slotname | backside | patch 
+--------+----------+----------+-------
+(0 rows)
 
 --
 -- Finally we want errors
 --
 insert into PField values ('PF1_1', 'should fail due to unique index');
-ERROR:  duplicate key value violates unique constraint "pfield_name"
+ERROR:  duplicate key value violates unique constraint "pfield_name"  (seg2 127.0.0.1:40002 pid=1762)
 DETAIL:  Key (name)=(PF1_1) already exists.
 update PSlot set backlink = 'WS.not.there' where slotname = 'PS.base.a1';
-ERROR:  WS.not.there         does not exist
-CONTEXT:  PL/pgSQL function "tg_backlink_a" line 16 at assignment
 update PSlot set backlink = 'XX.illegal' where slotname = 'PS.base.a1';
-ERROR:  illegal backlink beginning with XX
-CONTEXT:  PL/pgSQL function "tg_backlink_a" line 16 at assignment
 update PSlot set slotlink = 'PS.not.there' where slotname = 'PS.base.a1';
-ERROR:  PS.not.there         does not exist
-CONTEXT:  PL/pgSQL function "tg_slotlink_a" line 16 at assignment
 update PSlot set slotlink = 'XX.illegal' where slotname = 'PS.base.a1';
-ERROR:  illegal slotlink beginning with XX
-CONTEXT:  PL/pgSQL function "tg_slotlink_a" line 16 at assignment
 insert into HSlot values ('HS', 'base.hub1', 1, '');
-ERROR:  duplicate key value violates unique constraint "hslot_name"
-DETAIL:  Key (slotname)=(HS.base.hub1.1      ) already exists.
+ERROR:  function cannot execute on segment because it accesses relation "public.hub"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from Hub where name =  $1 "
+PL/pgSQL function "tg_hslot_biu" line 6 at SQL statement
 insert into HSlot values ('HS', 'base.hub1', 20, '');
-ERROR:  no manual manipulation of HSlot
+ERROR:  function cannot execute on segment because it accesses relation "public.hub"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from Hub where name =  $1 "
+PL/pgSQL function "tg_hslot_biu" line 6 at SQL statement
 delete from HSlot;
-ERROR:  no manual manipulation of HSlot
 insert into IFace values ('IF', 'notthere', 'eth0', '');
-ERROR:  system "notthere" does not exist
+ERROR:  function cannot execute on segment because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from system where name =  $1 "
+PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 insert into IFace values ('IF', 'orion', 'ethernet_interface_name_too_long', '');
-ERROR:  IFace slotname "IF.orion.ethernet_interface_name_too_long" too long (20 char max)
+ERROR:  function cannot execute on segment because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from system where name =  $1 "
+PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 --
 -- The following tests are unrelated to the scenario outlined above;
 -- they merely exercise specific parts of PL/PgSQL
@@ -1605,21 +1983,13 @@ create function test_found()
   return true;
   end;' language plpgsql;
 select test_found();
- test_found 
-------------
- t
-(1 row)
-
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
+CONTEXT:  SQL statement "update found_test_tbl set a = 100 where a = 1"
+PL/pgSQL function "test_found" line 8 at SQL statement
 select * from found_test_tbl;
-  a  
------
-   2
- 100
-   3
-   4
-   5
-   6
-(6 rows)
+ a 
+---
+(0 rows)
 
 --
 -- Test set-returning functions for PL/pgSQL
@@ -1634,15 +2004,9 @@ BEGIN
 	RETURN;
 END;' language plpgsql;
 select * from test_table_func_rec();
-  a  
------
-   2
- 100
-   3
-   4
-   5
-   6
-(6 rows)
+ a 
+---
+(0 rows)
 
 create function test_table_func_row() returns setof found_test_tbl as '
 DECLARE
@@ -1654,15 +2018,9 @@ BEGIN
 	RETURN;
 END;' language plpgsql;
 select * from test_table_func_row();
-  a  
------
-   2
- 100
-   3
-   4
-   5
-   6
-(6 rows)
+ a 
+---
+(0 rows)
 
 create function test_ret_set_scalar(int,int) returns setof int as '
 DECLARE
@@ -1903,9 +2261,9 @@ SELECT perform_test_func();
 SELECT * FROM perform_test;
   a  |  b  
 -----+-----
+ 100 | 100
+ 100 | 100
    5 |  15
- 100 | 100
- 100 | 100
 (3 rows)
 
 drop table perform_test;
@@ -2047,8 +2405,8 @@ reset statement_timeout;
 select * from foo;
  f1 
 ----
-  1
  20
+  1
 (2 rows)
 
 drop table foo;
@@ -2088,11 +2446,10 @@ PL/pgSQL function "test_variable_storage" line 7 at PERFORM
 create temp table master(f1 int primary key);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "master_pkey" for table "master"
 create temp table slave(f1 int references master deferrable);
+WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
 insert into master values(1);
 insert into slave values(1);
 insert into slave values(2);	-- fails
-ERROR:  insert or update on table "slave" violates foreign key constraint "slave_f1_fkey"
-DETAIL:  Key (f1)=(2) is not present in table "master".
 create function trap_foreign_key(int) returns int as $$
 begin
 	begin	-- start a subtransaction
@@ -2122,10 +2479,9 @@ select trap_foreign_key(1);
 (1 row)
 
 select trap_foreign_key(2);	-- detects FK violation
-NOTICE:  caught foreign_key_violation
  trap_foreign_key 
 ------------------
-                0
+                1
 (1 row)
 
 begin;
@@ -2138,19 +2494,14 @@ begin;
 
   savepoint x;
     set constraints all immediate; -- fails
-ERROR:  insert or update on table "slave" violates foreign key constraint "slave_f1_fkey"
-DETAIL:  Key (f1)=(2) is not present in table "master".
   rollback to x;
   select trap_foreign_key_2();  -- detects FK violation
-NOTICE:  caught foreign_key_violation
  trap_foreign_key_2 
 --------------------
-                  0
+                  1
 (1 row)
 
 commit;				-- still fails
-ERROR:  insert or update on table "slave" violates foreign key constraint "slave_f1_fkey"
-DETAIL:  Key (f1)=(2) is not present in table "master".
 drop function trap_foreign_key(int);
 drop function trap_foreign_key_2();
 --
@@ -2231,7 +2582,7 @@ create table rc_test (a int, b int);
 copy rc_test from stdin;
 create function return_refcursor(rc refcursor) returns refcursor as $$
 begin
-    open rc for select a from rc_test;
+    open rc for select a from rc_test order by a;
     return rc;
 end
 $$ language plpgsql;
@@ -2286,9 +2637,14 @@ begin
         return false;
     end if;
 end
-$$ language 'plpgsql';
---select refcursor_test2(20000, 20000) as "Should be false",
---       refcursor_test2(20, 20) as "Should be true";
+$$ language plpgsql;
+select refcursor_test2(20000, 20000) as "Should be false",
+       refcursor_test2(20, 20) as "Should be true";
+ Should be false | Should be true 
+-----------------+----------------
+ f               | t
+(1 row)
+
 --
 -- tests for "raise" processing
 --
@@ -2335,9 +2691,9 @@ begin
     end loop;
     return 5;
 end;$$ language plpgsql;
-ERROR:  syntax error at or near "fought"
+ERROR:  syntax error at or near "the"
 LINE 1:  select I fought the law, the law won
-                  ^
+                         ^
 QUERY:   select I fought the law, the law won
 CONTEXT:  SQL statement in PL/PgSQL function "bad_sql2" near line 3
 -- a RETURN expression is mandatory, except for void-returning
@@ -2808,12 +3164,9 @@ begin
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
 select footest();
-NOTICE:  x.f1 = 5, x.f2 = 6
- footest 
----------
- 
-(1 row)
-
+ERROR:  The RETURNING clause of the INSERT statement is not supported in this version of Greenplum Database.
+CONTEXT:  SQL statement "insert into foo values(5,6) returning *"
+PL/pgSQL function "footest" line 4 at SQL statement
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2822,8 +3175,9 @@ begin
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
 select footest();
-ERROR:  query returned more than one row
-CONTEXT:  PL/pgSQL function "footest" line 4 at SQL statement
+ERROR:  The RETURNING clause of the INSERT statement is not supported in this version of Greenplum Database.
+CONTEXT:  SQL statement "insert into foo values(7,8),(9,10) returning *"
+PL/pgSQL function "footest" line 4 at SQL statement
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2832,12 +3186,9 @@ begin
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
 select footest();
-NOTICE:  x.f1 = 5, x.f2 = 6
- footest 
----------
- 
-(1 row)
-
+ERROR:  The RETURNING clause of the INSERT statement is not supported in this version of Greenplum Database.
+CONTEXT:  SQL statement "insert into foo values(5,6) returning *"
+PL/pgSQL function "footest" line 4 at EXECUTE statement
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2846,22 +3197,15 @@ begin
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
 select footest();
-NOTICE:  x.f1 = 7, x.f2 = 8
- footest 
----------
- 
-(1 row)
-
+ERROR:  The RETURNING clause of the INSERT statement is not supported in this version of Greenplum Database.
+CONTEXT:  SQL statement "insert into foo values(7,8),(9,10) returning *"
+PL/pgSQL function "footest" line 4 at EXECUTE statement
 select * from foo;
  f1 | f2 
 ----+----
   1 |  2
   3 |  4
-  5 |  6
-  5 |  6
-  7 |  8
-  9 | 10
-(6 rows)
+(2 rows)
 
 create or replace function footest() returns void as $$
 declare x record;
@@ -2895,7 +3239,7 @@ begin
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
 select footest();
-ERROR:  query returned more than one row
+ERROR:  query returned no rows
 CONTEXT:  PL/pgSQL function "footest" line 4 at SQL statement
 create or replace function footest() returns void as $$
 declare x record;
@@ -2929,7 +3273,7 @@ begin
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
 select footest();
-ERROR:  query returned more than one row
+ERROR:  query returned no rows
 CONTEXT:  PL/pgSQL function "footest" line 4 at EXECUTE statement
 drop function footest();
 -- test scrollable cursor support
@@ -2948,15 +3292,8 @@ begin
 end;
 $$ language plpgsql;
 select * from sc_test();
-   sc_test   
--------------
- -2147483647
-  2147483647
-     -123456
-      123456
-           0
-(5 rows)
-
+ERROR:  backward scan is not supported in this version of Greenplum Database
+CONTEXT:  PL/pgSQL function "sc_test" line 6 at FETCH
 create or replace function sc_test() returns setof integer as $$
 declare 
   c no scroll cursor for select f1 from int4_tbl;
@@ -2972,8 +3309,7 @@ begin
 end;
 $$ language plpgsql;
 select * from sc_test();  -- fails because of NO SCROLL specification
-ERROR:  cursor can only scan forward
-HINT:  Declare it with SCROLL option to enable backward scan.
+ERROR:  backward scan is not supported in this version of Greenplum Database
 CONTEXT:  PL/pgSQL function "sc_test" line 6 at FETCH
 create or replace function sc_test() returns setof integer as $$
 declare 
@@ -2990,15 +3326,8 @@ begin
 end;
 $$ language plpgsql;
 select * from sc_test();
-   sc_test   
--------------
- -2147483647
-  2147483647
-     -123456
-      123456
-           0
-(5 rows)
-
+ERROR:  backward scan is not supported in this version of Greenplum Database
+CONTEXT:  PL/pgSQL function "sc_test" line 6 at FETCH
 create or replace function sc_test() returns setof integer as $$
 declare 
   c refcursor;
@@ -3014,13 +3343,8 @@ begin
 end;
 $$ language plpgsql;
 select * from sc_test();
-   sc_test   
--------------
- -2147483647
-     -123456
-           0
-(3 rows)
-
+ERROR:  backward scan is not supported in this version of Greenplum Database
+CONTEXT:  PL/pgSQL function "sc_test" line 6 at FETCH
 create or replace function sc_test() returns setof integer as $$
 declare
   c cursor for select * from generate_series(1, 10);
@@ -3205,6 +3529,7 @@ SAVEPOINT a;
 select error2('nonexistent.stuffs');
 ERROR:  schema "nonexistent" does not exist
 CONTEXT:  SQL function "error1" statement 1
+SQL statement "SELECT  error1( $1 )"
 PL/pgSQL function "error2" line 2 at RETURN
 ROLLBACK TO a;
 select error2('public.stuffs');
@@ -3216,7 +3541,6 @@ select error2('public.stuffs');
 rollback;
 drop function error2(p_name_table text);
 drop function error1(text);
-
 -- Test anonymous code blocks.
 DO $$
 DECLARE r record;
@@ -3238,7 +3562,7 @@ NOTICE:  105, Office
 NOTICE:  106, Office
 -- these are to check syntax error reporting
 DO LANGUAGE plpgsql $$begin return 1; end$$;
-ERROR:  RETURN cannot have a parameter in function returning void
+ERROR:  RETURN cannot have a parameter in function returning void at or near "1"
 LINE 1: DO LANGUAGE plpgsql $$begin return 1; end$$;
                                            ^
 DO $$
@@ -3250,10 +3574,10 @@ BEGIN
     END LOOP;
 END$$;
 ERROR:  column "foo" does not exist
-LINE 1: SELECT rtrim(roomno) AS roomno, foo FROM Room ORDER BY roomn...
-                                        ^
-QUERY:  SELECT rtrim(roomno) AS roomno, foo FROM Room ORDER BY roomno
-CONTEXT:  PL/pgSQL function inline_code_block line 4 at FOR over SELECT rows
+LINE 1:  SELECT rtrim(roomno) AS roomno, foo FROM Room ORDER BY room...
+                                         ^
+QUERY:   SELECT rtrim(roomno) AS roomno, foo FROM Room ORDER BY roomno
+CONTEXT:  PL/pgSQL function "inline_code_block" line 3 at FOR over SELECT rows
 -- Check handling of errors thrown from/into anonymous code blocks.
 do $outer$
 begin
@@ -3283,52 +3607,3 @@ NOTICE:  caught division by zero
 NOTICE:  caught division by zero
 NOTICE:  caught division by zero
 NOTICE:  caught division by zero
--- tests for RETURN QUERY
-create function ret_query1(out int, out int) returns setof record as $$
-begin
-    $1 := -1;
-    $2 := -2;
-    return next;
-    return query select x + 1, x * 10 from generate_series(0, 10) s (x);
-    return next;
-end;
-$$ language plpgsql;
-select * from ret_query1();
- column1 | column2
----------+---------
-      -1 |      -2
-       1 |       0
-       2 |      10
-       3 |      20
-       4 |      30
-       5 |      40
-       6 |      50
-       7 |      60
-       8 |      70
-       9 |      80
-      10 |      90
-      11 |     100
-      -1 |      -2
-(13 rows)
-
-create type record_type as (x text, y int, z boolean);
-create or replace function ret_query2(lim int) returns setof record_type as $$
-begin
-    return query select md5(s.x::text), s.x, s.x > 0
-                 from generate_series(-8, lim) s (x) where s.x % 2 = 0;
-end;
-$$ language plpgsql;
-select * from ret_query2(8);
-                x                 | y  | z
-----------------------------------+----+---
- a8d2ec85eaf98407310b72eb73dda247 | -8 | f
- 596a3d04481816330f07e4f97510c28f | -6 | f
- 0267aaf632e87a63288a08331f22c7c3 | -4 | f
- 5d7b9adcbe1c629ec722529dd12e5129 | -2 | f
- cfcd208495d565ef66e7dff9f98764da |  0 | f
- c81e728d9d4c2f636f067f89cc14862c |  2 | t
- a87ff679a2f3e71d9181a67b7542122c |  4 | t
- 1679091c5a880faf6fb5e6087eb1b2dc |  6 | t
- c9f0f895fb98ab9159f51fd0297e236d |  8 | t
-(9 rows)
-

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -20,109 +20,75 @@
 --     you look behind the wall when looking at a patchfield
 --     or into a room.
 -- 
-
-
 create table Room (
     roomno	char(8),
     comment	text
 );
-
 create unique index Room_rno on Room using btree (roomno bpchar_ops);
-
-
 create table WSlot (
     slotname	char(20),
     roomno	char(8),
     slotlink	char(20),
     backlink	char(20)
 );
-
 create unique index WSlot_name on WSlot using btree (slotname bpchar_ops);
-
-
 create table PField (
     name	text,
     comment	text
 );
-
 create unique index PField_name on PField using btree (name text_ops);
-
-
 create table PSlot (
     slotname	char(20),
     pfname	text,
     slotlink	char(20),
     backlink	char(20)
 );
-
 create unique index PSlot_name on PSlot using btree (slotname bpchar_ops);
-
-
 create table PLine (
     slotname	char(20),
     phonenumber	char(20),
     comment	text,
     backlink	char(20)
 );
-
 create unique index PLine_name on PLine using btree (slotname bpchar_ops);
-
-
 create table Hub (
     name	char(14),
     comment	text,
     nslots	integer
 );
-
 create unique index Hub_name on Hub using btree (name bpchar_ops);
-
-
 create table HSlot (
     slotname	char(20),
     hubname	char(14),
     slotno	integer,
     slotlink	char(20)
 );
-
 create unique index HSlot_name on HSlot using btree (slotname bpchar_ops);
 create index HSlot_hubname on HSlot using btree (hubname bpchar_ops);
-
-
 create table System (
     name	text,
     comment	text
 );
-
 create unique index System_name on System using btree (name text_ops);
-
-
 create table IFace (
     slotname	char(20),
     sysname	text,
     ifname	text,
     slotlink	char(20)
 );
-
 create unique index IFace_name on IFace using btree (slotname bpchar_ops);
-
-
 create table PHone (
     slotname	char(20),
     comment	text,
     slotlink	char(20)
 );
-
 create unique index PHone_name on PHone using btree (slotname bpchar_ops);
-
-
 -- ************************************************************
 -- * 
 -- * Trigger procedures and functions for the patchfield
 -- * test of PL/pgSQL
 -- * 
 -- ************************************************************
-
-
 -- ************************************************************
 -- * AFTER UPDATE on Room
 -- *	- If room no changes let wall slots follow
@@ -135,11 +101,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_room_au after update
     on Room for each row execute procedure tg_room_au();
-
-
 -- ************************************************************
 -- * AFTER DELETE on Room
 -- *	- delete wall slots in this room
@@ -150,11 +113,8 @@ begin
     return old;
 end;
 ' language plpgsql;
-
 create trigger tg_room_ad after delete
     on Room for each row execute procedure tg_room_ad();
-
-
 -- ************************************************************
 -- * BEFORE INSERT or UPDATE on WSlot
 -- *	- Check that room exists
@@ -167,11 +127,8 @@ begin
     return new;
 end;
 $$ language plpgsql;
-
 create trigger tg_wslot_biu before insert or update
     on WSlot for each row execute procedure tg_wslot_biu();
-
-
 -- ************************************************************
 -- * AFTER UPDATE on PField
 -- *	- Let PSlots of this field follow
@@ -184,11 +141,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_pfield_au after update
     on PField for each row execute procedure tg_pfield_au();
-
-
 -- ************************************************************
 -- * AFTER DELETE on PField
 -- *	- Remove all slots of this patchfield
@@ -199,11 +153,8 @@ begin
     return old;
 end;
 ' language plpgsql;
-
 create trigger tg_pfield_ad after delete
     on PField for each row execute procedure tg_pfield_ad();
-
-
 -- ************************************************************
 -- * BEFORE INSERT or UPDATE on PSlot
 -- *	- Ensure that our patchfield does exist
@@ -220,11 +171,8 @@ begin
     return ps;
 end;
 $proc$ language plpgsql;
-
 create trigger tg_pslot_biu before insert or update
     on PSlot for each row execute procedure tg_pslot_biu();
-
-
 -- ************************************************************
 -- * AFTER UPDATE on System
 -- *	- If system name changes let interfaces follow
@@ -237,11 +185,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_system_au after update
     on System for each row execute procedure tg_system_au();
-
-
 -- ************************************************************
 -- * BEFORE INSERT or UPDATE on IFace
 -- *	- set the slotname to IF.sysname.ifname
@@ -265,11 +210,8 @@ begin
     return new;
 end;
 $$ language plpgsql;
-
 create trigger tg_iface_biu before insert or update
     on IFace for each row execute procedure tg_iface_biu();
-
-
 -- ************************************************************
 -- * AFTER INSERT or UPDATE or DELETE on Hub
 -- *	- insert/delete/rename slots as required
@@ -296,11 +238,8 @@ begin
     end if;
 end;
 ' language plpgsql;
-
 create trigger tg_hub_a after insert or update or delete
     on Hub for each row execute procedure tg_hub_a();
-
-
 -- ************************************************************
 -- * Support function to add/remove slots of Hub
 -- ************************************************************
@@ -323,12 +262,11 @@ begin
     return 0;
 end
 ' language plpgsql;
-
 -- Test comments
 COMMENT ON FUNCTION tg_hub_adjustslots_wrong(bpchar, integer, integer) IS 'function with args';
+ERROR:  function tg_hub_adjustslots_wrong(character, integer, integer) does not exist
 COMMENT ON FUNCTION tg_hub_adjustslots(bpchar, integer, integer) IS 'function with args';
 COMMENT ON FUNCTION tg_hub_adjustslots(bpchar, integer, integer) IS NULL;
-
 -- ************************************************************
 -- * BEFORE INSERT or UPDATE on HSlot
 -- *	- prevent from manual manipulation
@@ -364,11 +302,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_hslot_biu before insert or update
     on HSlot for each row execute procedure tg_hslot_biu();
-
-
 -- ************************************************************
 -- * BEFORE DELETE on HSlot
 -- *	- prevent from manual manipulation
@@ -387,11 +322,8 @@ begin
     raise exception ''no manual manipulation of HSlot'';
 end;
 ' language plpgsql;
-
 create trigger tg_hslot_bd before delete
     on HSlot for each row execute procedure tg_hslot_bd();
-
-
 -- ************************************************************
 -- * BEFORE INSERT on all slots
 -- *	- Check name prefix
@@ -404,23 +336,16 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_chkslotname before insert
     on PSlot for each row execute procedure tg_chkslotname('PS');
-
 create trigger tg_chkslotname before insert
     on WSlot for each row execute procedure tg_chkslotname('WS');
-
 create trigger tg_chkslotname before insert
     on PLine for each row execute procedure tg_chkslotname('PL');
-
 create trigger tg_chkslotname before insert
     on IFace for each row execute procedure tg_chkslotname('IF');
-
 create trigger tg_chkslotname before insert
     on PHone for each row execute procedure tg_chkslotname('PH');
-
-
 -- ************************************************************
 -- * BEFORE INSERT or UPDATE on all slots with slotlink
 -- *	- Set slotlink to empty string if NULL value given
@@ -433,23 +358,16 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_chkslotlink before insert or update
     on PSlot for each row execute procedure tg_chkslotlink();
-
 create trigger tg_chkslotlink before insert or update
     on WSlot for each row execute procedure tg_chkslotlink();
-
 create trigger tg_chkslotlink before insert or update
     on IFace for each row execute procedure tg_chkslotlink();
-
 create trigger tg_chkslotlink before insert or update
     on HSlot for each row execute procedure tg_chkslotlink();
-
 create trigger tg_chkslotlink before insert or update
     on PHone for each row execute procedure tg_chkslotlink();
-
-
 -- ************************************************************
 -- * BEFORE INSERT or UPDATE on all slots with backlink
 -- *	- Set backlink to empty string if NULL value given
@@ -462,17 +380,12 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_chkbacklink before insert or update
     on PSlot for each row execute procedure tg_chkbacklink();
-
 create trigger tg_chkbacklink before insert or update
     on WSlot for each row execute procedure tg_chkbacklink();
-
 create trigger tg_chkbacklink before insert or update
     on PLine for each row execute procedure tg_chkbacklink();
-
-
 -- ************************************************************
 -- * BEFORE UPDATE on PSlot
 -- *	- do delete/insert instead of update if name changes
@@ -497,11 +410,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_pslot_bu before update
     on PSlot for each row execute procedure tg_pslot_bu();
-
-
 -- ************************************************************
 -- * BEFORE UPDATE on WSlot
 -- *	- do delete/insert instead of update if name changes
@@ -526,11 +436,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_wslot_bu before update
     on WSlot for each row execute procedure tg_Wslot_bu();
-
-
 -- ************************************************************
 -- * BEFORE UPDATE on PLine
 -- *	- do delete/insert instead of update if name changes
@@ -555,11 +462,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_pline_bu before update
     on PLine for each row execute procedure tg_pline_bu();
-
-
 -- ************************************************************
 -- * BEFORE UPDATE on IFace
 -- *	- do delete/insert instead of update if name changes
@@ -584,11 +488,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_iface_bu before update
     on IFace for each row execute procedure tg_iface_bu();
-
-
 -- ************************************************************
 -- * BEFORE UPDATE on HSlot
 -- *	- do delete/insert instead of update if name changes
@@ -613,11 +514,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_hslot_bu before update
     on HSlot for each row execute procedure tg_hslot_bu();
-
-
 -- ************************************************************
 -- * BEFORE UPDATE on PHone
 -- *	- do delete/insert instead of update if name changes
@@ -640,11 +538,8 @@ begin
     return new;
 end;
 ' language plpgsql;
-
 create trigger tg_phone_bu before update
     on PHone for each row execute procedure tg_phone_bu();
-
-
 -- ************************************************************
 -- * AFTER INSERT or UPDATE or DELETE on slot with backlink
 -- *	- Ensure that the opponent correctly points back to us
@@ -682,18 +577,12 @@ begin
     end if;
 end;
 ' language plpgsql;
-
-
 create trigger tg_backlink_a after insert or update or delete
     on PSlot for each row execute procedure tg_backlink_a('PS');
-
 create trigger tg_backlink_a after insert or update or delete
     on WSlot for each row execute procedure tg_backlink_a('WS');
-
 create trigger tg_backlink_a after insert or update or delete
     on PLine for each row execute procedure tg_backlink_a('PL');
-
-
 -- ************************************************************
 -- * Support function to set the opponents backlink field
 -- * if it does not already point to the requested slot
@@ -748,8 +637,6 @@ begin
     raise exception ''illegal backlink beginning with %'', mytype;
 end;
 ' language plpgsql;
-
-
 -- ************************************************************
 -- * Support function to clear out the backlink field if
 -- * it still points to specific slot
@@ -795,8 +682,6 @@ begin
     end if;
 end
 ' language plpgsql;
-
-
 -- ************************************************************
 -- * AFTER INSERT or UPDATE or DELETE on slot with slotlink
 -- *	- Ensure that the opponent correctly points back to us
@@ -834,24 +719,16 @@ begin
     end if;
 end;
 ' language plpgsql;
-
-
 create trigger tg_slotlink_a after insert or update or delete
     on PSlot for each row execute procedure tg_slotlink_a('PS');
-
 create trigger tg_slotlink_a after insert or update or delete
     on WSlot for each row execute procedure tg_slotlink_a('WS');
-
 create trigger tg_slotlink_a after insert or update or delete
     on IFace for each row execute procedure tg_slotlink_a('IF');
-
 create trigger tg_slotlink_a after insert or update or delete
     on HSlot for each row execute procedure tg_slotlink_a('HS');
-
 create trigger tg_slotlink_a after insert or update or delete
     on PHone for each row execute procedure tg_slotlink_a('PH');
-
-
 -- ************************************************************
 -- * Support function to set the opponents slotlink field
 -- * if it does not already point to the requested slot
@@ -936,8 +813,6 @@ begin
     raise exception ''illegal slotlink beginning with %'', mytype;
 end;
 ' language plpgsql;
-
-
 -- ************************************************************
 -- * Support function to clear out the slotlink field if
 -- * it still points to specific slot
@@ -1003,8 +878,6 @@ begin
     end if;
 end;
 ' language plpgsql;
-
-
 -- ************************************************************
 -- * Describe the backside of a patchfield slot
 -- ************************************************************
@@ -1048,8 +921,6 @@ begin
     return rec.backlink;
 end;
 ' language plpgsql;
-
-
 -- ************************************************************
 -- * Describe the front of a patchfield slot
 -- ************************************************************
@@ -1084,8 +955,6 @@ begin
     return psrec.slotlink;
 end;
 ' language plpgsql;
-
-
 -- ************************************************************
 -- * Describe the front of a wall connector slot
 -- ************************************************************
@@ -1134,9 +1003,6 @@ begin
     return rec.slotlink;
 end;
 ' language plpgsql;
-
-
-
 -- ************************************************************
 -- * View of a patchfield describing backside and patches
 -- ************************************************************
@@ -1144,8 +1010,6 @@ create view Pfield_v1 as select PF.pfname, PF.slotname,
 	pslot_backlink_view(PF.slotname) as backside,
 	pslot_slotlink_view(PF.slotname) as patch
     from PSlot PF;
-
-
 --
 -- First we build the house - so we create the rooms
 --
@@ -1159,141 +1023,505 @@ insert into Room values ('103', 'Restroom');
 insert into Room values ('104', 'Technical');
 insert into Room values ('105', 'Office');
 insert into Room values ('106', 'Office');
-
 --
 -- Second we install the wall connectors
 --
 insert into WSlot values ('WS.001.1a', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.1b', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.2a', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.2b', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.3a', '001', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.001.3b', '001', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.1a', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.1b', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.2a', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.2b', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.3a', '002', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.002.3b', '002', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.1a', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.1b', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.2a', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.2b', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.3a', '003', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.003.3b', '003', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.1a', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.1b', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.2a', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.2b', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.3a', '101', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.101.3b', '101', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.1a', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.1b', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.2a', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.2b', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.3a', '102', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.102.3b', '102', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.1a', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.1b', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.2a', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.2b', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.3a', '105', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.105.3b', '105', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.1a', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.1b', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.2a', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.2b', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.3a', '106', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 insert into WSlot values ('WS.106.3b', '106', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.room"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "SELECT  count(*) = 0 from Room where roomno =  $1 "
+PL/pgSQL function "tg_wslot_biu" line 2 at IF
 --
 -- Now create the patch fields and their slots
 --
 insert into PField values ('PF0_1', 'Wallslots basement');
-
 --
 -- The cables for these will be made later, so they are unconnected for now
 --
 insert into PSlot values ('PS.base.a1', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a2', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a3', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a4', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a5', 'PF0_1', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.a6', 'PF0_1', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- These are already wired to the wall connectors
 --
 insert into PSlot values ('PS.base.b1', 'PF0_1', '', 'WS.002.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b2', 'PF0_1', '', 'WS.002.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b3', 'PF0_1', '', 'WS.002.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b4', 'PF0_1', '', 'WS.002.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b5', 'PF0_1', '', 'WS.002.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.b6', 'PF0_1', '', 'WS.002.3b');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c1', 'PF0_1', '', 'WS.003.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c2', 'PF0_1', '', 'WS.003.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c3', 'PF0_1', '', 'WS.003.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c4', 'PF0_1', '', 'WS.003.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c5', 'PF0_1', '', 'WS.003.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.c6', 'PF0_1', '', 'WS.003.3b');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- This patchfield will be renamed later into PF0_2 - so its
 -- slots references in pfname should follow
 --
 insert into PField values ('PF0_X', 'Phonelines basement');
-
 insert into PSlot values ('PS.base.ta1', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta2', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta3', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta4', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta5', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.ta6', 'PF0_X', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb1', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb2', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb3', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb4', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb5', 'PF0_X', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.base.tb6', 'PF0_X', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PField values ('PF1_1', 'Wallslots 1st floor');
-
 insert into PSlot values ('PS.1st.a1', 'PF1_1', '', 'WS.101.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a2', 'PF1_1', '', 'WS.101.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a3', 'PF1_1', '', 'WS.101.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a4', 'PF1_1', '', 'WS.101.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a5', 'PF1_1', '', 'WS.101.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.a6', 'PF1_1', '', 'WS.101.3b');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b1', 'PF1_1', '', 'WS.102.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b2', 'PF1_1', '', 'WS.102.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b3', 'PF1_1', '', 'WS.102.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b4', 'PF1_1', '', 'WS.102.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b5', 'PF1_1', '', 'WS.102.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.b6', 'PF1_1', '', 'WS.102.3b');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c1', 'PF1_1', '', 'WS.105.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c2', 'PF1_1', '', 'WS.105.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c3', 'PF1_1', '', 'WS.105.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c4', 'PF1_1', '', 'WS.105.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c5', 'PF1_1', '', 'WS.105.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.c6', 'PF1_1', '', 'WS.105.3b');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d1', 'PF1_1', '', 'WS.106.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d2', 'PF1_1', '', 'WS.106.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d3', 'PF1_1', '', 'WS.106.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d4', 'PF1_1', '', 'WS.106.2b');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d5', 'PF1_1', '', 'WS.106.3a');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.d6', 'PF1_1', '', 'WS.106.3b');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- Now we wire the wall connectors 1a-2a in room 001 to the
 -- patchfield. In the second update we make an error, and
@@ -1302,13 +1530,36 @@ insert into PSlot values ('PS.1st.d6', 'PF1_1', '', 'WS.106.3b');
 update PSlot set backlink = 'WS.001.1a' where slotname = 'PS.base.a1';
 update PSlot set backlink = 'WS.001.1b' where slotname = 'PS.base.a3';
 select * from WSlot where roomno = '001' order by slotname;
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 update PSlot set backlink = 'WS.001.2a' where slotname = 'PS.base.a3';
 select * from WSlot where roomno = '001' order by slotname;
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 update PSlot set backlink = 'WS.001.1b' where slotname = 'PS.base.a2';
 select * from WSlot where roomno = '001' order by slotname;
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 --
 -- Same procedure for 2b-3b but this time updating the WSlot instead
@@ -1318,37 +1569,112 @@ select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
 update WSlot set backlink = 'PS.base.a4' where slotname = 'WS.001.2b';
 update WSlot set backlink = 'PS.base.a6' where slotname = 'WS.001.3a';
 select * from WSlot where roomno = '001' order by slotname;
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 update WSlot set backlink = 'PS.base.a6' where slotname = 'WS.001.3b';
 select * from WSlot where roomno = '001' order by slotname;
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 update WSlot set backlink = 'PS.base.a5' where slotname = 'WS.001.3a';
 select * from WSlot where roomno = '001' order by slotname;
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 select * from PSlot where slotname ~ 'PS.base.a' order by slotname;
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 insert into PField values ('PF1_2', 'Phonelines 1st floor');
-
 insert into PSlot values ('PS.1st.ta1', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta2', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta3', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta4', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta5', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.ta6', 'PF1_2', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb1', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb2', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb3', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb4', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb5', 'PF1_2', '', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 insert into PSlot values ('PS.1st.tb6', 'PF1_2', '', '');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pfield"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PField where name =  $1 "
+PL/pgSQL function "tg_pslot_biu" line 5 at SQL statement
 --
 -- Fix the wrong name for patchfield PF0_2
 --
 update PField set name = 'PF0_2' where name = 'PF0_X';
-
+ERROR:  Cannot parallelize an UPDATE statement that updates the distribution columns
 select * from PSlot order by slotname;
+ slotname | pfname | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
+
 select * from WSlot order by slotname;
+ slotname | roomno | slotlink | backlink 
+----------+--------+----------+----------
+(0 rows)
 
 --
 -- Install the central phone system and create the phone numbers.
@@ -1357,74 +1683,247 @@ select * from WSlot order by slotname;
 -- backlink field.
 --
 insert into PLine values ('PL.001', '-0', 'Central call', 'PS.base.ta1');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.002', '-101', '', 'PS.base.ta2');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.003', '-102', '', 'PS.base.ta3');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.004', '-103', '', 'PS.base.ta5');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.005', '-104', '', 'PS.base.ta6');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.006', '-106', '', 'PS.base.tb2');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.007', '-108', '', 'PS.base.tb3');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.008', '-109', '', 'PS.base.tb4');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.009', '-121', '', 'PS.base.tb5');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.010', '-122', '', 'PS.base.tb6');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.015', '-134', '', 'PS.1st.ta1');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.016', '-137', '', 'PS.1st.ta3');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.017', '-139', '', 'PS.1st.ta4');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.018', '-362', '', 'PS.1st.tb1');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.019', '-363', '', 'PS.1st.tb2');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.020', '-364', '', 'PS.1st.tb3');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.021', '-365', '', 'PS.1st.tb5');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.022', '-367', '', 'PS.1st.tb6');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.028', '-501', 'Fax entrance', 'PS.base.ta2');
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 insert into PLine values ('PL.029', '-502', 'Fax 1st floor', 'PS.1st.ta1');
-
+ERROR:  function cannot execute on segment because it accesses relation "public.pslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from PSlot where slotname =  $1 "
+PL/pgSQL function "tg_backlink_set" line 17 at SQL statement
+SQL statement "SELECT  tg_backlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_backlink_a" line 6 at assignment
 --
 -- Buy some phones, plug them into the wall and patch the
 -- phone lines to the corresponding patchfield slots.
 --
 insert into PHone values ('PH.hc001', 'Hicom standard', 'WS.001.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from WSlot where slotname =  $1 "
+PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
+SQL statement "SELECT  tg_slotlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta1' where slotname = 'PS.base.a1';
 insert into PHone values ('PH.hc002', 'Hicom standard', 'WS.002.1a');
+ERROR:  function cannot execute on segment because it accesses relation "public.wslot"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from WSlot where slotname =  $1 "
+PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
+SQL statement "SELECT  tg_slotlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta5' where slotname = 'PS.base.b1';
 insert into PHone values ('PH.hc003', 'Hicom standard', 'WS.002.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from WSlot where slotname =  $1 "
+PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
+SQL statement "SELECT  tg_slotlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.tb2' where slotname = 'PS.base.b3';
 insert into PHone values ('PH.fax001', 'Canon fax', 'WS.001.2a');
+ERROR:  function cannot execute on segment because it accesses relation "public.wslot"  (seg0 127.0.0.1:40000 pid=1760)
+DETAIL:  
+SQL statement "select * from WSlot where slotname =  $1 "
+PL/pgSQL function "tg_slotlink_set" line 37 at SQL statement
+SQL statement "SELECT  tg_slotlink_set( $1 ,  $2 )"
+PL/pgSQL function "tg_slotlink_a" line 6 at assignment
 update PSlot set slotlink = 'PS.base.ta2' where slotname = 'PS.base.a3';
-
 --
 -- Install a hub at one of the patchfields, plug a computers
 -- ethernet interface into the wall and patch it to the hub.
 --
 insert into Hub values ('base.hub1', 'Patchfield PF0_1 hub', 16);
+ERROR:  function cannot execute on segment because it issues a non-SELECT statement  (seg1 127.0.0.1:40001 pid=1761)
+DETAIL:  
+SQL statement "insert into HSlot (slotname, hubname, slotno, slotlink) values ('HS.dummy',  $1 ,  $2 , '')"
+PL/pgSQL function "tg_hub_adjustslots" line 10 at SQL statement
+SQL statement "SELECT  tg_hub_adjustslots( $1 , 0,  $2 )"
+PL/pgSQL function "tg_hub_a" line 6 at assignment
 insert into System values ('orion', 'PC');
 insert into IFace values ('IF', 'orion', 'eth0', 'WS.002.1b');
+ERROR:  function cannot execute on segment because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from system where name =  $1 "
+PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 update PSlot set slotlink = 'HS.base.hub1.1' where slotname = 'PS.base.b2';
-
 --
 -- Now we take a look at the patchfield
 --
 select * from PField_v1 where pfname = 'PF0_1' order by slotname;
+ pfname | slotname | backside | patch 
+--------+----------+----------+-------
+(0 rows)
+
 select * from PField_v1 where pfname = 'PF0_2' order by slotname;
+ pfname | slotname | backside | patch 
+--------+----------+----------+-------
+(0 rows)
 
 --
 -- Finally we want errors
 --
 insert into PField values ('PF1_1', 'should fail due to unique index');
+ERROR:  duplicate key value violates unique constraint "pfield_name"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  Key (name)=(PF1_1) already exists.
 update PSlot set backlink = 'WS.not.there' where slotname = 'PS.base.a1';
 update PSlot set backlink = 'XX.illegal' where slotname = 'PS.base.a1';
 update PSlot set slotlink = 'PS.not.there' where slotname = 'PS.base.a1';
 update PSlot set slotlink = 'XX.illegal' where slotname = 'PS.base.a1';
 insert into HSlot values ('HS', 'base.hub1', 1, '');
+ERROR:  function cannot execute on segment because it accesses relation "public.hub"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from Hub where name =  $1 "
+PL/pgSQL function "tg_hslot_biu" line 6 at SQL statement
 insert into HSlot values ('HS', 'base.hub1', 20, '');
+ERROR:  function cannot execute on segment because it accesses relation "public.hub"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from Hub where name =  $1 "
+PL/pgSQL function "tg_hslot_biu" line 6 at SQL statement
 delete from HSlot;
 insert into IFace values ('IF', 'notthere', 'eth0', '');
+ERROR:  function cannot execute on segment because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from system where name =  $1 "
+PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 insert into IFace values ('IF', 'orion', 'ethernet_interface_name_too_long', '');
-
-
+ERROR:  function cannot execute on segment because it accesses relation "public.system"  (seg2 127.0.0.1:40002 pid=1762)
+DETAIL:  
+SQL statement "select * from system where name =  $1 "
+PL/pgSQL function "tg_iface_biu" line 5 at SQL statement
 --
 -- The following tests are unrelated to the scenario outlined above;
 -- they merely exercise specific parts of PL/PgSQL
 --
-
 --
 -- Test recursion, per bug report 7-Sep-01
 --
@@ -1438,14 +1937,16 @@ BEGIN
     END IF;
     RETURN rslt;
 END;' LANGUAGE plpgsql;
-
 SELECT recursion_test(4,3);
+ recursion_test 
+----------------
+ 4,3,2,1,3
+(1 row)
 
 --
 -- Test the FOUND magic variable
 --
 CREATE TABLE found_test_tbl (a int);
-
 create function test_found()
   returns boolean as '
   declare
@@ -1481,14 +1982,26 @@ create function test_found()
   end if;
   return true;
   end;' language plpgsql;
-
 select test_found();
+ test_found 
+------------
+ t
+(1 row)
+
 select * from found_test_tbl;
+  a  
+-----
+   2
+ 100
+   3
+   4
+   5
+   6
+(6 rows)
 
 --
 -- Test set-returning functions for PL/pgSQL
 --
-
 create function test_table_func_rec() returns setof found_test_tbl as '
 DECLARE
 	rec RECORD;
@@ -1498,8 +2011,16 @@ BEGIN
 	END LOOP;
 	RETURN;
 END;' language plpgsql;
-
 select * from test_table_func_rec();
+  a  
+-----
+   2
+   3
+   4
+   5
+   6
+ 100
+(6 rows)
 
 create function test_table_func_row() returns setof found_test_tbl as '
 DECLARE
@@ -1510,8 +2031,16 @@ BEGIN
 	END LOOP;
 	RETURN;
 END;' language plpgsql;
-
 select * from test_table_func_row();
+  a  
+-----
+ 100
+   2
+   3
+   4
+   5
+   6
+(6 rows)
 
 create function test_ret_set_scalar(int,int) returns setof int as '
 DECLARE
@@ -1522,8 +2051,20 @@ BEGIN
 	END LOOP;
 	RETURN;
 END;' language plpgsql;
-
 select * from test_ret_set_scalar(1,10);
+ test_ret_set_scalar 
+---------------------
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+                  11
+(10 rows)
 
 create function test_ret_set_rec_dyn(int) returns setof record as '
 DECLARE
@@ -1540,9 +2081,19 @@ BEGIN
 	END IF;
 	RETURN;
 END;' language plpgsql;
-
 SELECT * FROM test_ret_set_rec_dyn(1500) AS (a int, b int, c int);
+ a | b  | c  
+---+----+----
+ 5 | 10 | 15
+ 5 | 10 | 15
+(2 rows)
+
 SELECT * FROM test_ret_set_rec_dyn(5) AS (a int, b numeric, c text);
+ a  | b |  c  
+----+---+-----
+ 50 | 5 | xxx
+ 50 | 5 | xxx
+(2 rows)
 
 create function test_ret_rec_dyn(int) returns record as '
 DECLARE
@@ -1556,40 +2107,64 @@ BEGIN
 		RETURN retval;
 	END IF;
 END;' language plpgsql;
-
 SELECT * FROM test_ret_rec_dyn(1500) AS (a int, b int, c int);
+ a | b  | c  
+---+----+----
+ 5 | 10 | 15
+(1 row)
+
 SELECT * FROM test_ret_rec_dyn(5) AS (a int, b numeric, c text);
+ a  | b |  c  
+----+---+-----
+ 50 | 5 | xxx
+(1 row)
 
 --
 -- Test handling of OUT parameters, including polymorphic cases.
 -- Note that RETURN is optional with OUT params; we try both ways.
 --
-
 -- wrong way to do it:
 create function f1(in i int, out j int) returns int as $$
 begin
   return i+1;
 end$$ language plpgsql;
-
+ERROR:  RETURN cannot have a parameter in function with OUT parameters at or near "i"
+LINE 3:   return i+1;
+                 ^
 create function f1(in i int, out j int) as $$
 begin
   j := i+1;
   return;
 end$$ language plpgsql;
-
 select f1(42);
+ f1 
+----
+ 43
+(1 row)
+
 select * from f1(42);
+ j  
+----
+ 43
+(1 row)
 
 create or replace function f1(inout i int) as $$
 begin
   i := i+1;
 end$$ language plpgsql;
-
 select f1(42);
+ f1 
+----
+ 43
+(1 row)
+
 select * from f1(42);
+ i  
+----
+ 43
+(1 row)
 
 drop function f1(int);
-
 create function f1(in i int, out j int) returns setof int as $$
 begin
   j := i+1;
@@ -1598,23 +2173,33 @@ begin
   return next;
   return;
 end$$ language plpgsql;
-
 select * from f1(42);
+ j  
+----
+ 43
+ 44
+(2 rows)
 
 drop function f1(int);
-
 create function f1(in i int, out j int, out k text) as $$
 begin
   j := i;
   j := j+1;
   k := 'foo';
 end$$ language plpgsql;
-
 select f1(42);
+    f1    
+----------
+ (43,foo)
+(1 row)
+
 select * from f1(42);
+ j  |  k  
+----+-----
+ 43 | foo
+(1 row)
 
 drop function f1(int);
-
 create function f1(in i int, out j int, out k text) returns setof record as $$
 begin
   j := i+1;
@@ -1624,32 +2209,40 @@ begin
   k := 'foot';
   return next;
 end$$ language plpgsql;
-
 select * from f1(42);
+ j  |  k   
+----+------
+ 43 | foo
+ 44 | foot
+(2 rows)
 
 drop function f1(int);
-
 create function duplic(in i anyelement, out j anyelement, out k anyarray) as $$
 begin
   j := i;
   k := array[j,j];
   return;
 end$$ language plpgsql;
-
 select * from duplic(42);
+ j  |    k    
+----+---------
+ 42 | {42,42}
+(1 row)
+
 select * from duplic('foo'::text);
+  j  |     k     
+-----+-----------
+ foo | {foo,foo}
+(1 row)
 
 drop function duplic(anyelement);
-
 --
 -- test PERFORM
 --
-
 create table perform_test (
 	a	INT,
 	b	INT
 );
-
 create function simple_func(int) returns boolean as '
 BEGIN
 	IF $1 < 20 THEN
@@ -1659,7 +2252,6 @@ BEGIN
 		RETURN FALSE;
 	END IF;
 END;' language plpgsql;
-
 create function perform_test_func() returns void as '
 BEGIN
 	IF FOUND then
@@ -1680,16 +2272,24 @@ BEGIN
 
 	RETURN;
 END;' language plpgsql;
-
 SELECT perform_test_func();
+ perform_test_func 
+-------------------
+ 
+(1 row)
+
 SELECT * FROM perform_test;
+  a  |  b  
+-----+-----
+ 100 | 100
+ 100 | 100
+   5 |  15
+(3 rows)
 
 drop table perform_test;
-
 --
 -- Test error trapping
 --
-
 create function trap_zero_divide(int) returns int as $$
 declare x int;
 	sx smallint;
@@ -1713,12 +2313,37 @@ begin
 	end;
 	return x;
 end$$ language plpgsql;
-
 select trap_zero_divide(50);
-select trap_zero_divide(0);
-select trap_zero_divide(100000);
-select trap_zero_divide(-100);
+NOTICE:  should see this
+NOTICE:  should see this only if 50 <> 0
+NOTICE:  should see this only if 50 fits in smallint
+ trap_zero_divide 
+------------------
+                2
+(1 row)
 
+select trap_zero_divide(0);
+NOTICE:  should see this
+NOTICE:  caught division_by_zero
+ trap_zero_divide 
+------------------
+               -1
+(1 row)
+
+select trap_zero_divide(100000);
+NOTICE:  should see this
+NOTICE:  should see this only if 100000 <> 0
+NOTICE:  caught numeric_value_out_of_range
+ trap_zero_divide 
+------------------
+               -2
+(1 row)
+
+select trap_zero_divide(-100);
+NOTICE:  should see this
+NOTICE:  should see this only if -100 <> 0
+NOTICE:  should see this only if -100 fits in smallint
+ERROR:  -100 is less than zero
 create function trap_matching_test(int) returns int as $$
 declare x int;
 	sx smallint;
@@ -1739,14 +2364,34 @@ begin
 	end;
 	return x;
 end$$ language plpgsql;
-
 select trap_matching_test(50);
+ trap_matching_test 
+--------------------
+                  2
+(1 row)
+
 select trap_matching_test(0);
+NOTICE:  caught data_exception
+ trap_matching_test 
+--------------------
+                 -1
+(1 row)
+
 select trap_matching_test(100000);
+NOTICE:  caught data_exception
+ trap_matching_test 
+--------------------
+                 -1
+(1 row)
+
 select trap_matching_test(1);
+NOTICE:  caught numeric_value_out_of_range or cardinality_violation
+ trap_matching_test 
+--------------------
+                 -2
+(1 row)
 
 create temp table foo (f1 int);
-
 create function blockme() returns int as $$
 declare x int;
 begin
@@ -1768,17 +2413,23 @@ begin
   insert into foo values(x);
   return x;
 end$$ language plpgsql;
-
 set statement_timeout to 2000;
-
 select blockme();
+NOTICE:  nyeah nyeah, can't stop me
+ blockme 
+---------
+      20
+(1 row)
 
 reset statement_timeout;
-
 select * from foo;
+ f1 
+----
+ 20
+  1
+(2 rows)
 
 drop table foo;
-
 -- Test for pass-by-ref values being stored in proper context
 create function test_variable_storage() returns text as $$
 declare x text;
@@ -1794,21 +2445,31 @@ begin
   end;
   return x;
 end$$ language plpgsql;
-
 select test_variable_storage();
+NOTICE:  should see this
+CONTEXT:  SQL statement "SELECT  trap_zero_divide(-100)"
+PL/pgSQL function "test_variable_storage" line 7 at PERFORM
+NOTICE:  should see this only if -100 <> 0
+CONTEXT:  SQL statement "SELECT  trap_zero_divide(-100)"
+PL/pgSQL function "test_variable_storage" line 7 at PERFORM
+NOTICE:  should see this only if -100 fits in smallint
+CONTEXT:  SQL statement "SELECT  trap_zero_divide(-100)"
+PL/pgSQL function "test_variable_storage" line 7 at PERFORM
+ test_variable_storage 
+-----------------------
+ 123456789012
+(1 row)
 
 --
 -- test foreign key error trapping
 --
-
 create temp table master(f1 int primary key);
-
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "master_pkey" for table "master"
 create temp table slave(f1 int references master deferrable);
-
+WARNING:  Referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced.
 insert into master values(1);
 insert into slave values(1);
 insert into slave values(2);	-- fails
-
 create function trap_foreign_key(int) returns int as $$
 begin
 	begin	-- start a subtransaction
@@ -1820,7 +2481,6 @@ begin
 	end;
 	return 1;
 end$$ language plpgsql;
-
 create function trap_foreign_key_2() returns int as $$
 begin
 	begin	-- start a subtransaction
@@ -1832,28 +2492,43 @@ begin
 	end;
 	return 1;
 end$$ language plpgsql;
-
 select trap_foreign_key(1);
+ trap_foreign_key 
+------------------
+                1
+(1 row)
+
 select trap_foreign_key(2);	-- detects FK violation
+ trap_foreign_key 
+------------------
+                1
+(1 row)
 
 begin;
   set constraints all deferred;
   select trap_foreign_key(2);	-- should not detect FK violation
+ trap_foreign_key 
+------------------
+                1
+(1 row)
+
   savepoint x;
     set constraints all immediate; -- fails
   rollback to x;
   select trap_foreign_key_2();  -- detects FK violation
-commit;				-- still fails
+ trap_foreign_key_2 
+--------------------
+                  1
+(1 row)
 
+commit;				-- still fails
 drop function trap_foreign_key(int);
 drop function trap_foreign_key_2();
-
 --
 -- Test proper snapshot handling in simple expressions
 --
-
 create temp table users(login text, id serial);
-
+NOTICE:  CREATE TABLE will create implicit sequence "users_id_seq" for serial column "users.id"
 create function sp_id_user(a_login text) returns int as $$
 declare x int;
 begin
@@ -1861,11 +2536,18 @@ begin
   if found then return x; end if;
   return 0;
 end$$ language plpgsql stable;
-
 insert into users values('user1');
-
 select sp_id_user('user1');
+ sp_id_user 
+------------
+          1
+(1 row)
+
 select sp_id_user('userx');
+ sp_id_user 
+------------
+          0
+(1 row)
 
 create function sp_add_user(a_login text) returns int as $$
 declare my_id_user int;
@@ -1881,53 +2563,86 @@ begin
   END IF;
   RETURN my_id_user;
 end$$ language plpgsql;
-
 select sp_add_user('user1');
+ sp_add_user 
+-------------
+          -1
+(1 row)
+
 select sp_add_user('user2');
+ sp_add_user 
+-------------
+           2
+(1 row)
+
 select sp_add_user('user2');
+ sp_add_user 
+-------------
+          -1
+(1 row)
+
 select sp_add_user('user3');
+ sp_add_user 
+-------------
+           3
+(1 row)
+
 select sp_add_user('user3');
+ sp_add_user 
+-------------
+          -1
+(1 row)
 
 drop function sp_add_user(text);
 drop function sp_id_user(text);
-
 --
 -- tests for refcursors
 --
 create table rc_test (a int, b int);
 copy rc_test from stdin;
-5	10
-50	100
-500	1000
-\.
-
 create function return_refcursor(rc refcursor) returns refcursor as $$
 begin
     open rc for select a from rc_test order by a;
     return rc;
 end
 $$ language plpgsql;
-
 create function refcursor_test1(refcursor) returns refcursor as $$
 begin
     perform return_refcursor($1);
     return $1;
 end
 $$ language plpgsql;
-
 begin;
-
 select refcursor_test1('test1');
+ refcursor_test1 
+-----------------
+ test1
+(1 row)
+
 fetch next in test1;
+ a 
+---
+ 5
+(1 row)
 
 select refcursor_test1('test2');
+ refcursor_test1 
+-----------------
+ test2
+(1 row)
+
 fetch all from test2;
+  a  
+-----
+   5
+  50
+ 500
+(3 rows)
 
 commit;
-
 -- should fail
 fetch next from test1;
-
+ERROR:  cursor "test1" does not exist
 create function refcursor_test2(int, int) returns boolean as $$
 declare
     c1 cursor (param1 int, param2 int) for select * from rc_test where a > param1 and b > param2;
@@ -1943,9 +2658,12 @@ begin
     end if;
 end
 $$ language plpgsql;
-
 select refcursor_test2(20000, 20000) as "Should be false",
        refcursor_test2(20, 20) as "Should be true";
+ Should be false | Should be true 
+-----------------+----------------
+ f               | t
+(1 row)
 
 --
 -- tests for "raise" processing
@@ -1956,18 +2674,18 @@ begin
     return $1;
 end;
 $$ language plpgsql;
-
 select raise_test1(5);
-
+ERROR:  too many parameters specified for RAISE
+CONTEXT:  PL/pgSQL function "raise_test1" line 2 at RAISE
 create function raise_test2(int) returns int as $$
 begin
     raise notice 'This message has too few parameters: %, %, %', $1, $1;
     return $1;
 end;
 $$ language plpgsql;
-
 select raise_test2(10);
-
+ERROR:  too few parameters specified for RAISE
+CONTEXT:  PL/pgSQL function "raise_test2" line 2 at RAISE
 --
 -- reject function definitions that contain malformed SQL queries at
 -- compile-time, where possible
@@ -1980,7 +2698,11 @@ begin
     a := 10;
     return a;
 end$$ language plpgsql;
-
+ERROR:  syntax error at or near "Johnny"
+LINE 1: Johnny Yuma
+        ^
+QUERY:  Johnny Yuma
+CONTEXT:  SQL statement in PL/PgSQL function "bad_sql1" near line 4
 create function bad_sql2() returns int as $$
 declare r record;
 begin
@@ -1989,45 +2711,55 @@ begin
     end loop;
     return 5;
 end;$$ language plpgsql;
-
+ERROR:  syntax error at or near "the"
+LINE 1:  select I fought the law, the law won
+                         ^
+QUERY:   select I fought the law, the law won
+CONTEXT:  SQL statement in PL/PgSQL function "bad_sql2" near line 3
 -- a RETURN expression is mandatory, except for void-returning
 -- functions, where it is not allowed
 create function missing_return_expr() returns int as $$
 begin
     return ;
 end;$$ language plpgsql;
-
+ERROR:  syntax error at end of input
+LINE 1: SELECT 
+               ^
+QUERY:  SELECT 
+CONTEXT:  SQL statement in PL/PgSQL function "missing_return_expr" near line 2
 create function void_return_expr() returns void as $$
 begin
     return 5;
 end;$$ language plpgsql;
-
+ERROR:  RETURN cannot have a parameter in function returning void at or near "5"
+LINE 3:     return 5;
+                   ^
 -- VOID functions are allowed to omit RETURN
 create function void_return_expr() returns void as $$
 begin
     perform 2+2;
 end;$$ language plpgsql;
-
 select void_return_expr();
+ void_return_expr 
+------------------
+ 
+(1 row)
 
 -- but ordinary functions are not
 create function missing_return_expr() returns int as $$
 begin
     perform 2+2;
 end;$$ language plpgsql;
-
 select missing_return_expr();
-
+ERROR:  control reached end of function without RETURN
+CONTEXT:  PL/pgSQL function "missing_return_expr"
 drop function void_return_expr();
 drop function missing_return_expr();
-
 --
 -- EXECUTE ... INTO test
 --
-
 create table eifoo (i integer, y integer);
 create type eitype as (i integer, y integer);
-
 create or replace function execute_into_test(varchar) returns record as $$
 declare
     _r record;
@@ -2047,16 +2779,20 @@ begin
     execute 'select 1,2' into _v;
     return _v;
 end; $$ language plpgsql;
-
 select execute_into_test('eifoo');
+NOTICE:  10 1
+NOTICE:  10 15
+NOTICE:  10 15 20
+ execute_into_test 
+-------------------
+ (1,2)
+(1 row)
 
 drop table eifoo cascade;
 drop type eitype cascade;
-
 --
 -- SQLSTATE and SQLERRM test
 --
-
 create function excpt_test1() returns void as $$
 begin
     raise notice '% %', sqlstate, sqlerrm;
@@ -2064,7 +2800,11 @@ end; $$ language plpgsql;
 -- should fail: SQLSTATE and SQLERRM are only in defined EXCEPTION
 -- blocks
 select excpt_test1();
-
+ERROR:  column "sqlstate" does not exist
+LINE 1: SELECT  sqlstate
+                ^
+QUERY:  SELECT  sqlstate
+CONTEXT:  PL/pgSQL function "excpt_test1" line 2 at RAISE
 create function excpt_test2() returns void as $$
 begin
     begin
@@ -2075,7 +2815,11 @@ begin
 end; $$ language plpgsql;
 -- should fail
 select excpt_test2();
-
+ERROR:  column "sqlstate" does not exist
+LINE 1: SELECT  sqlstate
+                ^
+QUERY:  SELECT  sqlstate
+CONTEXT:  PL/pgSQL function "excpt_test2" line 4 at RAISE
 create function excpt_test3() returns void as $$
 begin
     begin
@@ -2095,12 +2839,19 @@ begin
 	    raise notice '% %', sqlstate, sqlerrm;
     end;
 end; $$ language plpgsql;
-
 select excpt_test3();
+NOTICE:  caught exception P0001 user exception
+NOTICE:  P0001 user exception
+NOTICE:  caught exception 22012 division by zero
+NOTICE:  P0001 user exception
+ excpt_test3 
+-------------
+ 
+(1 row)
+
 drop function excpt_test1();
 drop function excpt_test2();
 drop function excpt_test3();
-
 -- parameters of raise stmt can be expressions
 create function raise_exprs() returns void as $$
 declare
@@ -2111,17 +2862,21 @@ begin
     i := 2;
     raise notice '%; %; %; %; %; %', a, a[i], c, (select c || 'abc'), row(10,'aaa',NULL,30), NULL;
 end;$$ language plpgsql;
-
 select raise_exprs();
-drop function raise_exprs();
+NOTICE:  {10,20,30}; 20; xyz; xyzabc; (10,aaa,,30); <NULL>
+ raise_exprs 
+-------------
+ 
+(1 row)
 
+drop function raise_exprs();
 -- continue statement
 create table conttesttbl(idx serial, v integer);
+NOTICE:  CREATE TABLE will create implicit sequence "conttesttbl_idx_seq" for serial column "conttesttbl.idx"
 insert into conttesttbl(v) values(10);
 insert into conttesttbl(v) values(20);
 insert into conttesttbl(v) values(30);
 insert into conttesttbl(v) values(40);
-
 create function continue_test1() returns void as $$
 declare _i integer = 0; _r record;
 begin
@@ -2199,8 +2954,64 @@ begin
     continue;
   end loop;
 end; $$ language plpgsql;
-
 select continue_test1();
+NOTICE:  ---1---
+NOTICE:  1
+NOTICE:  2
+NOTICE:  3
+NOTICE:  4
+NOTICE:  5
+NOTICE:  6
+NOTICE:  7
+NOTICE:  8
+NOTICE:  9
+NOTICE:  10
+NOTICE:  ---2---
+NOTICE:  9
+NOTICE:  8
+NOTICE:  7
+NOTICE:  6
+NOTICE:  5
+NOTICE:  4
+NOTICE:  3
+NOTICE:  2
+NOTICE:  1
+NOTICE:  0
+NOTICE:  ---3---
+NOTICE:  1
+NOTICE:  3
+NOTICE:  5
+NOTICE:  7
+NOTICE:  9
+NOTICE:  ---4---
+NOTICE:  5
+NOTICE:  6
+NOTICE:  7
+NOTICE:  8
+NOTICE:  9
+NOTICE:  10
+NOTICE:  ---5---
+NOTICE:  30
+NOTICE:  40
+NOTICE:  ---6---
+NOTICE:  30
+NOTICE:  40
+NOTICE:  ---7---
+NOTICE:  1
+NOTICE:  2
+NOTICE:  3
+NOTICE:  ---8---
+NOTICE:  1
+NOTICE:  2
+NOTICE:  3
+NOTICE:  ---9---
+NOTICE:  10
+NOTICE:  ---10---
+NOTICE:  10
+ continue_test1 
+----------------
+ 
+(1 row)
 
 -- CONTINUE is only legal inside a loop
 create function continue_test2() returns void as $$
@@ -2211,10 +3022,10 @@ begin
     return;
 end;
 $$ language plpgsql;
-
 -- should fail
 select continue_test2();
-
+ERROR:  CONTINUE cannot be used outside a loop
+CONTEXT:  PL/pgSQL function "continue_test2"
 -- CONTINUE can't reference the label of a named block
 create function continue_test3() returns void as $$
 begin
@@ -2226,15 +3037,14 @@ begin
     end;
 end;
 $$ language plpgsql;
-
 -- should fail
 select continue_test3();
-
+ERROR:  CONTINUE cannot be used outside a loop
+CONTEXT:  PL/pgSQL function "continue_test3"
 drop function continue_test1();
 drop function continue_test2();
 drop function continue_test3();
 drop table conttesttbl;
-
 -- verbose end block and end loop
 create function end_label1() returns void as $$
 <<blbl>>
@@ -2249,10 +3059,13 @@ begin
   end loop;
 end blbl;
 $$ language plpgsql;
-
 select end_label1();
-drop function end_label1();
+ end_label1 
+------------
+ 
+(1 row)
 
+drop function end_label1();
 -- should fail: undefined end label
 create function end_label2() returns void as $$
 begin
@@ -2261,7 +3074,9 @@ begin
   end loop flbl1;
 end;
 $$ language plpgsql;
-
+ERROR:  no such label at or near "flbl1"
+LINE 5:   end loop flbl1;
+                   ^
 -- should fail: end label does not match start label
 create function end_label3() returns void as $$
 <<outer_label>>
@@ -2272,7 +3087,8 @@ begin
   end loop outer_label;
 end;
 $$ language plpgsql;
-
+ERROR:  end label "outer_label" differs from block's label "inner_label"
+CONTEXT:  compile of PL/pgSQL function "end_label3" near line 6
 -- should fail: end label on a block without a start label
 create function end_label4() returns void as $$
 <<outer_label>>
@@ -2282,7 +3098,8 @@ begin
   end loop outer_label;
 end;
 $$ language plpgsql;
-
+ERROR:  end label "outer_label" specified for unlabelled block
+CONTEXT:  compile of PL/pgSQL function "end_label4" near line 5
 -- using list of scalars in fori and fore stmts
 create function for_vect() returns void as $proc$
 <<lbl>>declare a integer; b varchar; c varchar; r record;
@@ -2309,8 +3126,30 @@ begin
   end loop;
 end;
 $proc$ language plpgsql;
-
 select for_vect();
+NOTICE:  1
+NOTICE:  2
+NOTICE:  3
+NOTICE:  1 BB CC
+NOTICE:  2 BB CC
+NOTICE:  3 BB CC
+NOTICE:  4 BB CC
+NOTICE:  1
+NOTICE:  2
+NOTICE:  3
+NOTICE:  4
+NOTICE:  1 BB CC
+NOTICE:  2 BB CC
+NOTICE:  3 BB CC
+NOTICE:  4 BB CC
+NOTICE:  1 bb cc
+NOTICE:  2 bb cc
+NOTICE:  3 bb cc
+NOTICE:  4 bb cc
+ for_vect 
+----------
+ 
+(1 row)
 
 -- regression test: verify that multiple uses of same plpgsql datum within
 -- a SQL command all get mapped to the same $n parameter.  The return value
@@ -2324,19 +3163,19 @@ begin
   select into x,y unique1/p1, unique1/$1 from tenk1 group by unique1/p1;
   return x = y;
 end$$ language plpgsql;
-
 select multi_datum_use(42);
+ multi_datum_use 
+-----------------
+ t
+(1 row)
 
 --
 -- Test STRICT limiter in both planned and EXECUTE invocations.
 -- Note that a data-modifying query is quasi strict (disallow multi rows)
 -- by default in the planned case, but not in EXECUTE.
 --
-
 create temp table foo (f1 int, f2 int);
-
 insert into foo values (1,2), (3,4);
-
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2344,9 +3183,10 @@ begin
   insert into foo values(5,6) returning * into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
-
+ERROR:  The RETURNING clause of the INSERT statement is not supported in this version of Greenplum Database.
+CONTEXT:  SQL statement "insert into foo values(5,6) returning *"
+PL/pgSQL function "footest" line 4 at SQL statement
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2354,9 +3194,10 @@ begin
   insert into foo values(7,8),(9,10) returning * into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
-
+ERROR:  The RETURNING clause of the INSERT statement is not supported in this version of Greenplum Database.
+CONTEXT:  SQL statement "insert into foo values(7,8),(9,10) returning *"
+PL/pgSQL function "footest" line 4 at SQL statement
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2364,9 +3205,10 @@ begin
   execute 'insert into foo values(5,6) returning *' into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
-
+ERROR:  The RETURNING clause of the INSERT statement is not supported in this version of Greenplum Database.
+CONTEXT:  SQL statement "insert into foo values(5,6) returning *"
+PL/pgSQL function "footest" line 4 at EXECUTE statement
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2374,10 +3216,16 @@ begin
   execute 'insert into foo values(7,8),(9,10) returning *' into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
-
+ERROR:  The RETURNING clause of the INSERT statement is not supported in this version of Greenplum Database.
+CONTEXT:  SQL statement "insert into foo values(7,8),(9,10) returning *"
+PL/pgSQL function "footest" line 4 at EXECUTE statement
 select * from foo;
+ f1 | f2 
+----+----
+  1 |  2
+  3 |  4
+(2 rows)
 
 create or replace function footest() returns void as $$
 declare x record;
@@ -2386,8 +3234,12 @@ begin
   select * from foo where f1 = 3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
+NOTICE:  x.f1 = 3, x.f2 = 4
+ footest 
+---------
+ 
+(1 row)
 
 create or replace function footest() returns void as $$
 declare x record;
@@ -2396,9 +3248,9 @@ begin
   select * from foo where f1 = 0 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
-
+ERROR:  query returned no rows
+CONTEXT:  PL/pgSQL function "footest" line 4 at SQL statement
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2406,9 +3258,9 @@ begin
   select * from foo where f1 > 3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
-
+ERROR:  query returned no rows
+CONTEXT:  PL/pgSQL function "footest" line 4 at SQL statement
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2416,8 +3268,12 @@ begin
   execute 'select * from foo where f1 = 3' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
+NOTICE:  x.f1 = 3, x.f2 = 4
+ footest 
+---------
+ 
+(1 row)
 
 create or replace function footest() returns void as $$
 declare x record;
@@ -2426,9 +3282,9 @@ begin
   execute 'select * from foo where f1 = 0' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
-
+ERROR:  query returned no rows
+CONTEXT:  PL/pgSQL function "footest" line 4 at EXECUTE statement
 create or replace function footest() returns void as $$
 declare x record;
 begin
@@ -2436,13 +3292,11 @@ begin
   execute 'select * from foo where f1 > 3' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
 end$$ language plpgsql;
-
 select footest();
-
+ERROR:  query returned no rows
+CONTEXT:  PL/pgSQL function "footest" line 4 at EXECUTE statement
 drop function footest();
-
 -- test scrollable cursor support
-
 create function sc_test() returns setof integer as $$
 declare 
   c scroll cursor for select f1 from int4_tbl;
@@ -2457,9 +3311,9 @@ begin
   close c;
 end;
 $$ language plpgsql;
-
 select * from sc_test();
-
+ERROR:  backward scan is not supported in this version of Greenplum Database
+CONTEXT:  PL/pgSQL function "sc_test" line 6 at FETCH
 create or replace function sc_test() returns setof integer as $$
 declare 
   c no scroll cursor for select f1 from int4_tbl;
@@ -2474,9 +3328,9 @@ begin
   close c;
 end;
 $$ language plpgsql;
-
 select * from sc_test();  -- fails because of NO SCROLL specification
-
+ERROR:  backward scan is not supported in this version of Greenplum Database
+CONTEXT:  PL/pgSQL function "sc_test" line 6 at FETCH
 create or replace function sc_test() returns setof integer as $$
 declare 
   c refcursor;
@@ -2491,9 +3345,9 @@ begin
   close c;
 end;
 $$ language plpgsql;
-
 select * from sc_test();
-
+ERROR:  backward scan is not supported in this version of Greenplum Database
+CONTEXT:  PL/pgSQL function "sc_test" line 6 at FETCH
 create or replace function sc_test() returns setof integer as $$
 declare 
   c refcursor;
@@ -2508,9 +3362,9 @@ begin
   close c;
 end;
 $$ language plpgsql;
-
 select * from sc_test();
-
+ERROR:  backward scan is not supported in this version of Greenplum Database
+CONTEXT:  PL/pgSQL function "sc_test" line 6 at FETCH
 create or replace function sc_test() returns setof integer as $$
 declare
   c cursor for select * from generate_series(1, 10);
@@ -2530,13 +3384,16 @@ begin
   close c;
 end;
 $$ language plpgsql;
-
 select * from sc_test();
+ sc_test 
+---------
+       3
+       6
+       9
+(3 rows)
 
 drop function sc_test();
-
 -- test qualified variable names
-
 create function pl_qual_names (param1 int) returns void as $$
 <<outerblock>>
 declare
@@ -2553,11 +3410,17 @@ begin
   end;
 end;
 $$ language plpgsql;
-
 select pl_qual_names(42);
+NOTICE:  param1 = 2
+NOTICE:  pl_qual_names.param1 = 42
+NOTICE:  outerblock.param1 = 1
+NOTICE:  innerblock.param1 = 2
+ pl_qual_names 
+---------------
+ 
+(1 row)
 
 drop function pl_qual_names(int);
-
 -- tests for RETURN QUERY
 create function ret_query1(out int, out int) returns setof record as $$
 begin
@@ -2568,23 +3431,47 @@ begin
     return next;
 end;
 $$ language plpgsql;
-
 select * from ret_query1();
+ column1 | column2 
+---------+---------
+      -1 |      -2
+       1 |       0
+       2 |      10
+       3 |      20
+       4 |      30
+       5 |      40
+       6 |      50
+       7 |      60
+       8 |      70
+       9 |      80
+      10 |      90
+      11 |     100
+      -1 |      -2
+(13 rows)
 
 create type record_type as (x text, y int, z boolean);
-
 create or replace function ret_query2(lim int) returns setof record_type as $$
 begin
     return query select md5(s.x::text), s.x, s.x > 0
                  from generate_series(-8, lim) s (x) where s.x % 2 = 0;
 end;
 $$ language plpgsql;
-
 select * from ret_query2(8);
+                x                 | y  | z 
+----------------------------------+----+---
+ a8d2ec85eaf98407310b72eb73dda247 | -8 | f
+ 596a3d04481816330f07e4f97510c28f | -6 | f
+ 0267aaf632e87a63288a08331f22c7c3 | -4 | f
+ 5d7b9adcbe1c629ec722529dd12e5129 | -2 | f
+ cfcd208495d565ef66e7dff9f98764da |  0 | f
+ c81e728d9d4c2f636f067f89cc14862c |  2 | t
+ a87ff679a2f3e71d9181a67b7542122c |  4 | t
+ 1679091c5a880faf6fb5e6087eb1b2dc |  6 | t
+ c9f0f895fb98ab9159f51fd0297e236d |  8 | t
+(9 rows)
 
 -- Test for appropriate cleanup of non-simple expression evaluations
 -- (bug in all versions prior to August 2010)
-
 CREATE FUNCTION nonsimple_expr_test() RETURNS text[] AS $$
 DECLARE
   arr text[];
@@ -2599,11 +3486,13 @@ BEGIN
   RETURN arr;
 END;
 $$ LANGUAGE plpgsql;
-
 SELECT nonsimple_expr_test();
+   nonsimple_expr_test   
+-------------------------
+ {{foo,fool},{baz,quux}}
+(1 row)
 
 DROP FUNCTION nonsimple_expr_test();
-
 CREATE FUNCTION nonsimple_expr_test() RETURNS integer AS $$
 declare
    i integer NOT NULL := 0;
@@ -2617,17 +3506,18 @@ begin
   return i;
 end;
 $$ LANGUAGE plpgsql;
-
 SELECT nonsimple_expr_test();
+ nonsimple_expr_test 
+---------------------
+                   1
+(1 row)
 
 DROP FUNCTION nonsimple_expr_test();
-
 --
 -- Test cases involving recursion and error recovery in simple expressions
 -- (bugs in all versions before October 2010).  The problems are most
 -- easily exposed by mutual recursion between plpgsql and sql functions.
 --
-
 create function recurse(float8) returns float8 as
 $$
 begin
@@ -2638,34 +3528,40 @@ begin
   end if;
 end;
 $$ language plpgsql;
-
 -- "limit" is to prevent this from being inlined
 create function sql_recurse(float8) returns float8 as
 $$ select recurse($1) limit 1; $$ language sql;
-
 select recurse(5);
+ recurse 
+---------
+       0
+(1 row)
 
 create function error1(text) returns text language sql as
 $$ SELECT relname::text FROM pg_class c WHERE c.oid = $1::regclass $$;
-
 create function error2(p_name_table text) returns text language plpgsql as $$
 begin
   return error1(p_name_table);
 end$$;
-
 BEGIN;
 create table public.stuffs (stuff text);
 SAVEPOINT a;
 select error2('nonexistent.stuffs');
+ERROR:  schema "nonexistent" does not exist
+CONTEXT:  SQL function "error1" statement 1
+SQL statement "SELECT  error1( $1 )"
+PL/pgSQL function "error2" line 2 at RETURN
 ROLLBACK TO a;
 select error2('public.stuffs');
-rollback;
+ error2 
+--------
+ stuffs
+(1 row)
 
+rollback;
 drop function error2(p_name_table text);
 drop function error1(text);
-
 -- Test anonymous code blocks.
-
 DO $$
 DECLARE r record;
 BEGIN
@@ -2674,10 +3570,21 @@ BEGIN
         RAISE NOTICE '%, %', r.roomno, r.comment;
     END LOOP;
 END$$;
-
+NOTICE:  001, Entrance
+NOTICE:  002, Office
+NOTICE:  003, Office
+NOTICE:  004, Technical
+NOTICE:  101, Office
+NOTICE:  102, Conference
+NOTICE:  103, Restroom
+NOTICE:  104, Technical
+NOTICE:  105, Office
+NOTICE:  106, Office
 -- these are to check syntax error reporting
 DO LANGUAGE plpgsql $$begin return 1; end$$;
-
+ERROR:  RETURN cannot have a parameter in function returning void at or near "1"
+LINE 1: DO LANGUAGE plpgsql $$begin return 1; end$$;
+                                           ^
 DO $$
 DECLARE r record;
 BEGIN
@@ -2686,7 +3593,11 @@ BEGIN
         RAISE NOTICE '%, %', r.roomno, r.comment;
     END LOOP;
 END$$;
-
+ERROR:  column "foo" does not exist
+LINE 1:  SELECT rtrim(roomno) AS roomno, foo FROM Room ORDER BY room...
+                                         ^
+QUERY:   SELECT rtrim(roomno) AS roomno, foo FROM Room ORDER BY roomno
+CONTEXT:  PL/pgSQL function "inline_code_block" line 3 at FOR over SELECT rows
 -- Check handling of errors thrown from/into anonymous code blocks.
 do $outer$
 begin
@@ -2706,3 +3617,13 @@ begin
   end loop;
 end;
 $outer$;
+NOTICE:  caught division by zero
+NOTICE:  caught division by zero
+NOTICE:  caught division by zero
+NOTICE:  caught division by zero
+NOTICE:  caught division by zero
+NOTICE:  caught division by zero
+NOTICE:  caught division by zero
+NOTICE:  caught division by zero
+NOTICE:  caught division by zero
+NOTICE:  caught division by zero

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -119,15 +119,11 @@ test: select_views portals_p2 cluster dependency guc tsearch tsdicts json
 # ----------
 # Another group of parallel tests
 # ----------
-# "plpgsql" cannot run concurrently with "rules"
-test: plancache limit copy2 temp domain rangefuncs prepare without_oid conversion truncate alter_table sequence polymorphism rowtypes xml
+# "plpgsql" cannot run concurrently with "rules", nor can "plancache"
+test: plancache limit plpgsql copy2 temp domain rangefuncs prepare without_oid conversion truncate alter_table sequence polymorphism rowtypes xml
 
 # GPDB_83_MERGE_FIXME: the largeobject test is temporarily disabled due to test errors
 # test: largeobject
-
-# 'plpgsql' test is disabled in GPDB, because it produces a lot of errors on
-# because of cross-segment accesses in functions.
-#test: plpgsql
 
 # INSERT RETURNING is not supported by GPDB
 #test: returning

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -99,7 +99,7 @@ test: tsearch
 test: plancache
 test: json
 test: limit
-ignore: plpgsql
+test: plpgsql
 test: copy2
 test: temp
 test: domain


### PR DESCRIPTION
It was not run, because there were a lot of errors in it, because of
features that have been disabled in Greenplum. Like enforcing foreign keys,
INSERT RETURNING, and doing SPI in functions in segments. Those limitations
make these tests a less interesting than in the upstream, but there are
still many good tests in there too. Like the test for anonymous DO blocks,
that are not tested by any other tests.

The .sql file was almost identical to the upstream version. Clean it up
to be even closer, by re-enabling some commented queries in it, removing
the duplicated tests for RETURN QUERY, removing the READS/CONTAINS/MODIFIES
SQL DATA noise words etc.

Memorize the expected output as it is. That's quite different from the
upstream, because of all the disabled functionality, but also because of
some cosmetic differences error messages.

The 'schema_topology' test contained a copy of the for_vect(), so remove
that, now that we run the real thing.