### PR TITLE
Silence "role does not exist, skipping" messages from segments on DROPP USER

### DIFF
--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -1338,7 +1338,7 @@ DropRole(DropRoleStmt *stmt)
 						(errcode(ERRCODE_UNDEFINED_OBJECT),
 						 errmsg("role \"%s\" does not exist", role)));
 			}
-			else
+			if (Gp_role != GP_ROLE_EXECUTE)
 			{
 				ereport(NOTICE,
 						(errmsg("role \"%s\" does not exist, skipping",

--- a/src/test/regress/bugbuster/expected/schema_topology.out
+++ b/src/test/regress/bugbuster/expected/schema_topology.out
@@ -3855,9 +3855,6 @@ select count(*) from st_foo1,st_foo2 where st_foo1.j = st_foo2.j;
 
 DROP USER IF EXISTS testuser;
 NOTICE:  role "testuser" does not exist, skipping
-NOTICE:  role "testuser" does not exist, skipping  (seg0 rh55-qavm103:18506 pid=13677)
-NOTICE:  role "testuser" does not exist, skipping  (seg2 rh55-qavm103:18508 pid=13681)
-NOTICE:  role "testuser" does not exist, skipping  (seg1 rh55-qavm103:18507 pid=13679)
 CREATE USER testuser WITH LOGIN DENY BETWEEN DAY 'Monday' TIME '01:00:00' AND DAY 'Monday' TIME '01:30:00';;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT r.rolname, d.start_day, d.start_time, d.end_day, d.end_time
@@ -4489,16 +4486,10 @@ revoke all on protocol gphdfs from _hadoop_perm_test_role;
 ERROR:  role "_hadoop_perm_test_role" does not exist
 DROP ROLE IF EXISTS _hadoop_perm_test_role;
 NOTICE:  role "_hadoop_perm_test_role" does not exist, skipping
-NOTICE:  role "_hadoop_perm_test_role" does not exist, skipping  (seg0 rh55-qavm103:18506 pid=13677)
-NOTICE:  role "_hadoop_perm_test_role" does not exist, skipping  (seg2 rh55-qavm103:18508 pid=13681)
-NOTICE:  role "_hadoop_perm_test_role" does not exist, skipping  (seg1 rh55-qavm103:18507 pid=13679)
 revoke all on protocol gphdfs from _hadoop_perm_test_role2;
 ERROR:  role "_hadoop_perm_test_role2" does not exist
 DROP ROLE IF EXISTS _hadoop_perm_test_role2;
 NOTICE:  role "_hadoop_perm_test_role2" does not exist, skipping
-NOTICE:  role "_hadoop_perm_test_role2" does not exist, skipping  (seg1 rh55-qavm103:18507 pid=13679)
-NOTICE:  role "_hadoop_perm_test_role2" does not exist, skipping  (seg0 rh55-qavm103:18506 pid=13677)
-NOTICE:  role "_hadoop_perm_test_role2" does not exist, skipping  (seg2 rh55-qavm103:18508 pid=13681)
 \echo -- end_ignore
 -- end_ignore
 /* Now create a new role. Initially this role should NOT

--- a/src/test/regress/bugbuster/expected/schema_topology_optimizer.out
+++ b/src/test/regress/bugbuster/expected/schema_topology_optimizer.out
@@ -3860,9 +3860,6 @@ select count(*) from st_foo1,st_foo2 where st_foo1.j = st_foo2.j;
 
 DROP USER IF EXISTS testuser;
 NOTICE:  role "testuser" does not exist, skipping
-NOTICE:  role "testuser" does not exist, skipping  (seg0 rh55-qavm68:18506 pid=26114)
-NOTICE:  role "testuser" does not exist, skipping  (seg1 rh55-qavm68:18507 pid=26116)
-NOTICE:  role "testuser" does not exist, skipping  (seg2 rh55-qavm68:18508 pid=26118)
 CREATE USER testuser WITH LOGIN DENY BETWEEN DAY 'Monday' TIME '01:00:00' AND DAY 'Monday' TIME '01:30:00';;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT r.rolname, d.start_day, d.start_time, d.end_day, d.end_time
@@ -4494,16 +4491,10 @@ revoke all on protocol gphdfs from _hadoop_perm_test_role;
 ERROR:  role "_hadoop_perm_test_role" does not exist
 DROP ROLE IF EXISTS _hadoop_perm_test_role;
 NOTICE:  role "_hadoop_perm_test_role" does not exist, skipping
-NOTICE:  role "_hadoop_perm_test_role" does not exist, skipping  (seg2 rh55-qavm68:18508 pid=26118)
-NOTICE:  role "_hadoop_perm_test_role" does not exist, skipping  (seg0 rh55-qavm68:18506 pid=26114)
-NOTICE:  role "_hadoop_perm_test_role" does not exist, skipping  (seg1 rh55-qavm68:18507 pid=26116)
 revoke all on protocol gphdfs from _hadoop_perm_test_role2;
 ERROR:  role "_hadoop_perm_test_role2" does not exist
 DROP ROLE IF EXISTS _hadoop_perm_test_role2;
 NOTICE:  role "_hadoop_perm_test_role2" does not exist, skipping
-NOTICE:  role "_hadoop_perm_test_role2" does not exist, skipping  (seg1 rh55-qavm68:18507 pid=26116)
-NOTICE:  role "_hadoop_perm_test_role2" does not exist, skipping  (seg0 rh55-qavm68:18506 pid=26114)
-NOTICE:  role "_hadoop_perm_test_role2" does not exist, skipping  (seg2 rh55-qavm68:18508 pid=26118)
 \echo -- end_ignore
 -- end_ignore
 /* Now create a new role. Initially this role should NOT

--- a/src/test/regress/expected/caqlcov.out
+++ b/src/test/regress/expected/caqlcov.out
@@ -18,8 +18,6 @@ drop function if exists trig();
 NOTICE:  function trig() does not exist, skipping
 drop user if exists cm_user;
 NOTICE:  role "cm_user" does not exist, skipping
-NOTICE:  role "cm_user" does not exist, skipping  (seg0 usxxreddyr3mbp1.corp.emc.com:40000 pid=58541)
-NOTICE:  role "cm_user" does not exist, skipping  (seg1 usxxreddyr3mbp1.corp.emc.com:40001 pid=58542)
 drop view if exists tview;
 NOTICE:  view "tview" does not exist, skipping
 -- end_ignore

--- a/src/test/regress/expected/qp_resource_queue.out
+++ b/src/test/regress/expected/qp_resource_queue.out
@@ -11,14 +11,8 @@ set search_path to qp_resource_queue;
 -- start_ignore
 drop role if exists tbl16369_user1;
 NOTICE:  role "tbl16369_user1" does not exist, skipping
-NOTICE:  role "tbl16369_user1" does not exist, skipping  (seg1 nikos-mac:25433 pid=58771)
-NOTICE:  role "tbl16369_user1" does not exist, skipping  (seg0 nikos-mac:25432 pid=58769)
-NOTICE:  role "tbl16369_user1" does not exist, skipping  (seg2 nikos-mac:25434 pid=58772)
 drop role if exists tbl16369_user3;
 NOTICE:  role "tbl16369_user3" does not exist, skipping
-NOTICE:  role "tbl16369_user3" does not exist, skipping  (seg1 nikos-mac:25433 pid=58771)
-NOTICE:  role "tbl16369_user3" does not exist, skipping  (seg0 nikos-mac:25432 pid=58769)
-NOTICE:  role "tbl16369_user3" does not exist, skipping  (seg2 nikos-mac:25434 pid=58772)
 drop resource queue tbl16369_resq1;
 ERROR:  resource queue "tbl16369_resq1" does not exist
 drop resource queue tbl16369_resq3;

--- a/src/test/regress/expected/role.out
+++ b/src/test/regress/expected/role.out
@@ -4,8 +4,6 @@
 -- MPP-15479: ALTER ROLE SET statement
 DROP ROLE IF EXISTS role_112911;
 NOTICE:  role "role_112911" does not exist, skipping
-NOTICE:  role "role_112911" does not exist, skipping  (seg0 localhost:12001 pid=20806)
-NOTICE:  role "role_112911" does not exist, skipping  (seg1 localhost:12002 pid=20807)
 CREATE ROLE role_112911 WITH LOGIN;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE SCHEMA common_schema;


### PR DESCRIPTION
If you did "DROP USER IF EXISTS not_there", you got a notice from every
segment:

postgres=# DROP USER IF EXISTS testuser;
NOTICE:  role "testuser" does not exist, skipping
NOTICE:  role "testuser" does not exist, skipping  (seg0 127.0.0.1:40000 pid=1554)
NOTICE:  role "testuser" does not exist, skipping  (seg1 127.0.0.1:40001 pid=1556)
NOTICE:  role "testuser" does not exist, skipping  (seg2 127.0.0.1:40002 pid=1555)

That was quite noisy. Suppress the notices from the segments, so that you
only get one NOTICE, from the master. We had done this for all other object
types that support IF EXISTS, like tables, functions, etc.