### PR TITLE
Enable Sort operator to print sort method on explain analyze.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1642,8 +1642,6 @@ explain_outNode(StringInfo str,
 						   ((Sort *) plan)->sortColIdx,
 						   SortKeystr,
 						   str, indent, es);
-			show_sort_info((SortState *) planstate,
-						   str, indent, es);
 		}
 			break;
 		case T_Result:

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -38,6 +38,9 @@ typedef struct Instrumentation
 	instr_time	firststart;		/* CDB: Start time of first iteration of node */
 	bool		workfileCreated;/* TRUE if workfiles are created in this node */
 	int		numPartScanned; /* Number of part tables scanned */
+	const char* sortMethod;	/* CDB: Type of sort */
+	const char* sortSpaceType; /*CDB: Sort space type (Memory / Disk) */
+	long			  sortSpaceUsed; /* CDB: Memory / Disk used by sort(KBytes) */
     struct CdbExplain_NodeSummary  *cdbNodeSummary; /* stats from all qExecs */
 } Instrumentation;
 

--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -138,9 +138,6 @@ extern void tuplesort_flush_mk(Tuplesortstate_mk *state);
 extern void tuplesort_finalize_stats(Tuplesortstate *state);
 extern void tuplesort_finalize_stats_mk(Tuplesortstate_mk *state);
 
-extern char *tuplesort_explain(Tuplesortstate *state);
-extern char *tuplesort_explain_mk(Tuplesortstate_mk *state);
-
 extern int	tuplesort_merge_order(long allowedMem);
 
 /*

--- a/src/test/regress/expected/sort.out
+++ b/src/test/regress/expected/sort.out
@@ -1,0 +1,81 @@
+create schema sort_schema;
+set search_path to sort_schema;
+ 
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+ 
+-- Check if analyze output has Sort Method
+ create or replace function sort_schema.has_sortmethod(explain_analyze_query text)
+ returns setof int as
+ $$
+ rv = plpy.execute(explain_analyze_query)
+ search_text = 'Sort Method'
+ result = []
+ for i in range(len(rv)):
+     cur_line = rv[i]['QUERY PLAN']
+     if search_text.lower() in cur_line.lower():
+         result.append(1)
+ return result
+ $$
+ language plpythonu;
+ 
+ set gp_enable_mk_sort = on;
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g limit 100;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ set gp_enable_mk_sort = off;
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g limit 100;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ -- start_ignore
+ create table sort_a(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ insert into sort_a values(1, 2);
+ -- end_ignore
+ 
+ set gp_enable_mk_sort = on;
+ select sort_schema.has_sortmethod('explain analyze select i from sort_a order by i;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ set gp_enable_mk_sort = off;
+ select sort_schema.has_sortmethod('explain analyze select i from sort_a order by i;');
+ has_sortmethod 
+----------------
+              1
+(1 row)
+
+ 
+ 
+ -- start_ignore
+ drop schema sort_schema cascade;
+NOTICE:  drop cascades to table sort_a
+NOTICE:  drop cascades to function has_sortmethod(text)
+ -- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -106,7 +106,7 @@ test: bfv_catalog bfv_index bfv_olap bfv_aggregate bfv_partition DML_over_joins 
  
 test: aggregate_with_groupingsets 
 
-test: nested_case_null
+test: nested_case_null sort
 
 test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy
 

--- a/src/test/regress/sql/sort.sql
+++ b/src/test/regress/sql/sort.sql
@@ -1,0 +1,47 @@
+create schema sort_schema;
+set search_path to sort_schema;
+ 
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+ 
+-- Check if analyze output has Sort Method
+ create or replace function sort_schema.has_sortmethod(explain_analyze_query text)
+ returns setof int as
+ $$
+ rv = plpy.execute(explain_analyze_query)
+ search_text = 'Sort Method'
+ result = []
+ for i in range(len(rv)):
+     cur_line = rv[i]['QUERY PLAN']
+     if search_text.lower() in cur_line.lower():
+         result.append(1)
+ return result
+ $$
+ language plpythonu;
+ 
+ set gp_enable_mk_sort = on;
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g limit 100;');
+ 
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g;');
+ 
+ set gp_enable_mk_sort = off;
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g limit 100;');
+ 
+ select sort_schema.has_sortmethod('explain analyze select * from generate_series(1, 100) g order by g;');
+ 
+ -- start_ignore
+ create table sort_a(i int, j int);
+ insert into sort_a values(1, 2);
+ -- end_ignore
+ 
+ set gp_enable_mk_sort = on;
+ select sort_schema.has_sortmethod('explain analyze select i from sort_a order by i;');
+ 
+ set gp_enable_mk_sort = off;
+ select sort_schema.has_sortmethod('explain analyze select i from sort_a order by i;');
+ 
+ 
+ -- start_ignore
+ drop schema sort_schema cascade;
+ -- end_ignore


### PR DESCRIPTION
This PR is about addressing the issue https://github.com/greenplum-db/gpdb/issues/1646 .

I closed the PR #1734 and reopening this new PR to address the comment for tuplesort.c changes.

Porting only the function`tuplesort_get_stats` in tuplesort.c from the Postgres commit
https://github.com/postgres/postgres/blob/9bd27b7c9e998087f390774bd0f43916813a2847/src/backend/utils/sort/tuplesort.c as part of this PR.

With this enhancement, now we can see the sort method will print. Some of the examples are shown below.

**Sort in Master**
```
krajaraman=# explain analyze select * from generate_series(1, 100) g order by g limit 100;
                                                QUERY PLAN
----------------------------------------------------------------------------------------------------------
 Limit  (cost=50.72..50.97 rows=100 width=4)
   Rows out:  100 rows with 0.597 ms to first row, 0.620 ms to end, start offset by 0.489 ms.
   ->  Sort  (cost=50.72..53.22 rows=1000 width=4)
         Sort Key: g
         Sort Method:  top-N heapsort  Memory: 25KB
         Rows out:  100 rows with 0.594 ms to first row, 0.607 ms to end, start offset by 0.492 ms.
         Executor memory:  58K bytes.
         Work_mem used:  58K bytes. Workfile: (0 spilling)
         ->  Function Scan on generate_series g  (cost=0.00..12.50 rows=1000 width=4)
               Rows out:  100 rows with 0.250 ms to first row, 0.261 ms to end, start offset by 0.590 ms.
               Work_mem used:  9K bytes.
 Slice statistics:
   (slice0)    Executor memory: 118K bytes.  Work_mem: 58K bytes max.
 Statement statistics:
   Memory used: 128000K bytes
 Total runtime: 1.121 ms
(16 rows)
```

**Sort in Master without limit**
```
krajaraman=# explain analyze select * from generate_series(1, 100) g order by g;
                                             QUERY PLAN
----------------------------------------------------------------------------------------------------
 Sort  (cost=62.33..64.83 rows=1000 width=4)
   Sort Key: g
   Sort Method:  quicksort  Memory: 49KB
   Rows out:  100 rows with 0.133 ms to first row, 0.144 ms to end, start offset by 0.049 ms.
   Executor memory:  49K bytes.
   Work_mem used:  49K bytes. Workfile: (0 spilling)
   ->  Function Scan on generate_series g  (cost=0.00..12.50 rows=1000 width=4)
         Rows out:  100 rows with 0.041 ms to first row, 0.050 ms to end, start offset by 0.076 ms.
         Work_mem used:  9K bytes.
 Slice statistics:
   (slice0)    Executor memory: 118K bytes.  Work_mem: 49K bytes max.
 Statement statistics:
   Memory used: 128000K bytes
 Total runtime: 0.202 ms
(14 rows)
```

**Sort In segment**
```
krajaraman=# explain analyze select i from sort_a order by i;
                                                   QUERY PLAN
-------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..1.02 rows=1 width=4)
   Merge Key: i
   Rows out:  1 rows at destination with 397 ms to end, start offset by 1111 ms.
   ->  Sort  (cost=1.02..1.02 rows=1 width=4)
         Sort Key: i
         Sort Method:  quicksort  Max Memory: 49KB  Avg Memory: 49KB (3 segments)
         Rows out:  1 rows (seg0) with 52 ms to end, start offset by 1457 ms.
         Executor memory:  74K bytes avg, 74K bytes max (seg0).
         Work_mem used:  74K bytes avg, 74K bytes max (seg0). Workfile: (0 spilling)
         ->  Seq Scan on sort_a  (cost=0.00..1.01 rows=1 width=4)
               Rows out:  1 rows (seg0) with 13 ms to end, start offset by 1495 ms.
 Slice statistics:
   (slice0)    Executor memory: 318K bytes.
   (slice1)    Executor memory: 143K bytes avg x 3 workers, 143K bytes max (seg0).  Work_mem: 74K bytes max.
 Statement statistics:
   Memory used: 128000K bytes
 Total runtime: 1509.179 ms
(17 rows)
```

**Different Sort in Segment**
```
krajaraman=# explain analyze select a from foo order by b;
                                                                      QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..1.02 rows=1 width=8)
   Merge Key: b
   Rows out:  46035 rows at destination with 68 ms to first row, 112 ms to end, start offset by 0.265 ms.
   ->  Sort  (cost=1.02..1.02 rows=1 width=8)
         Sort Key: b
         Sort Method:  quicksort  Max Memory: 697KB  Avg Memory: 365KB (2 segments)
         Sort Method:  external merge  Disk: 640KB
         Rows out:  Avg 15345.0 rows x 3 workers.  Max 39001 rows (seg2) with 67 ms to first row, 91 ms to end, start offset by 0.481 ms.
         Executor memory:  742K bytes avg, 1497K bytes max (seg2).
         Work_mem used:  742K bytes avg, 1497K bytes max (seg2). Workfile: (1 spilling)
         Work_mem wanted: 5750K bytes avg, 5750K bytes max (seg2) to lessen workfile I/O affecting 1 workers.
         ->  Seq Scan on foo  (cost=0.00..1.01 rows=1 width=8)
               Rows out:  Avg 15345.0 rows x 3 workers.  Max 39001 rows (seg2) with 0.034 ms to first row, 5.317 ms to end, start offset by 0.508 ms.
 Slice statistics:
   (slice0)    Executor memory: 325K bytes.
   (slice1)  * Executor memory: 831K bytes avg x 3 workers, 1590K bytes max (seg2).  Work_mem: 1497K bytes max, 5750K bytes wanted.
 Statement statistics:
   Memory used: 1024K bytes
   Memory wanted: 5949K bytes
 Total runtime: 121.740 ms
(20 rows)                                   
```

Here is the link to gpdb-dev discussion - https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/V-zIshnNzyE

@hlinnaka @foyzur @hardikar @hsyuan @vraghavan78  Please have a look when you get chance.
