### PR TITLE
Fix typos in PersistentEndXactUntyped type

### DIFF
--- a/src/backend/access/transam/persistentendxactrec.c
+++ b/src/backend/access/transam/persistentendxactrec.c
@@ -172,7 +172,7 @@ static void PersistentEndXactRec_SetObjectInfo(
 
 	int32 len)
 {
-	PeristentEndXaxtUntyped *untyped = &objects->untyped[objKind-1];
+	PersistentEndXactUntyped *untyped = &objects->untyped[objKind-1];
 
 	untyped->data = data;
 	untyped->count = count;
@@ -190,7 +190,7 @@ static void PersistentEndXactRec_GetObjectInfo(
 
 	int32 *len)
 {
-	PeristentEndXaxtUntyped *untyped = &objects->untyped[objKind-1];
+	PersistentEndXactUntyped *untyped = &objects->untyped[objKind-1];
 
 	*data = untyped->data;
 	*count = untyped->count;

--- a/src/include/access/persistentendxactrec.h
+++ b/src/include/access/persistentendxactrec.h
@@ -91,21 +91,21 @@ typedef struct PersistentEndXactAppendOnlyMirrorResyncEofs
 } PersistentEndXactAppendOnlyMirrorResyncEofs;
 
 
-typedef struct PeristentEndXaxtUntyped
+typedef struct PersistentEndXactUntyped
 {
 	void 		*data;
 
 	int32		len;
 
 	int32		count;
-} PeristentEndXaxtUntyped;
+} PersistentEndXactUntyped;
 
 /*
  * Structure containing the objects read.
  */
 typedef union PersistentEndXactRecObjects
 {
-	PeristentEndXaxtUntyped		untyped[MaxPersistentEndXactObjKind];
+	PersistentEndXactUntyped		untyped[MaxPersistentEndXactObjKind];
 
 	struct typed
 	{

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -1703,7 +1703,6 @@ Perl_check_t
 Perl_ppaddr_t
 PerfmonNodeStatus
 PerfmonNodeType
-PeristentEndXaxtUntyped
 PersistentDatabaseData
 PersistentDatabaseSharedData
 PersistentEndXactAppendOnlyMirrorResyncEofs
@@ -1712,6 +1711,7 @@ PersistentEndXactFileSysActionInfo
 PersistentEndXactObjKind
 PersistentEndXactRecObjects
 PersistentEndXactRecObjHdr
+PersistentEndXactUntyped
 PersistentFilespaceData
 PersistentFilespaceSharedData
 PersistentFileSysObjData


### PR DESCRIPTION
Small cleanup to the proper name, unless I'm missing something and the original name was intentional? Also update all uses of the name in the code as well as pgindent file.