### PR TITLE
Avoid clearing 10 MB of memory when planning each query with ORCA.

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -539,14 +539,15 @@ COptTasks::Execute
 {
 	Assert(pfunc);
 
+	CHAR *err_buf = (CHAR *) palloc(GPOPT_ERROR_BUFFER_SIZE);
+	err_buf[0] = '\0';
+
 	// initialize DXL support
 	InitDXL();
 
 	bool abort_flag = false;
 
 	CAutoMemoryPool amp(CAutoMemoryPool::ElcNone, CMemoryPoolManager::EatTracker, false /* fThreadSafe */);
-	IMemoryPool *pmp = amp.Pmp();
-	CHAR *err_buf = SzAllocate(pmp, GPOPT_ERROR_BUFFER_SIZE);
 
 	gpos_exec_params params;
 	params.func = pfunc;
@@ -578,7 +579,7 @@ COptTasks::LogErrorAndDelete(CHAR* err_buf) {
 		elog(LOG, "%s", SzFromWsz((WCHAR *)err_buf));
 	}
 
-	GPOS_DELETE_ARRAY(err_buf);
+	pfree(err_buf);
 }
 
 


### PR DESCRIPTION
It's not necessary to clear the error buffer on every call. Also,
GPOS_NEW_ARRAY() is a pretty slow way of clearing memory. This greatly
reduces the overhead of planning simple queries with ORCA.

On my laptop, this reduces the time for planning "SELECT 123;" from
about 60 ms to 5 ms.