### PR TITLE
Fix FailedAssertion("!(!((proc->xid) != ((TransactionId) 0)))", File: "procarray.c"

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -496,6 +496,13 @@ AssignTransactionId(TransactionState s)
 	Assert(!TransactionIdIsValid(s->transactionId));
 	Assert(s->state == TRANS_INPROGRESS);
 
+	if (DistributedTransactionContext == DTX_CONTEXT_QE_READER ||
+		DistributedTransactionContext == DTX_CONTEXT_QE_ENTRY_DB_SINGLETON)
+	{
+		elog(ERROR, "AssignTransactionId() called by %s process",
+			 DtxContextToString(DistributedTransactionContext));
+	}
+
 	/*
 	 * Ensure parent(s) have XIDs, so that a child always has an XID later
 	 * than its parent.  Musn't recurse here, or we might get a stack overflow

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -952,6 +952,44 @@ AlterTableSpaceOwner(const char *name, Oid newOwnerId)
  * Routines for handling the GUC variable 'default_tablespace'.
  */
 
+/*
+ * Returns true if tablespace exists, false otherwise
+ */
+static bool
+check_tablespace(const char *tablespacename)
+{
+	bool		result;
+	Relation	rel;
+	HeapScanDesc scandesc;
+	HeapTuple	tuple;
+	ScanKeyData entry[1];
+
+	/*
+	 * Search pg_tablespace. We use a heapscan here even though there is an
+	 * index on name, on the theory that pg_tablespace will usually have just
+	 * a few entries and so an indexed lookup is a waste of effort.
+	 */
+	rel = heap_open(TableSpaceRelationId, AccessShareLock);
+
+	ScanKeyInit(&entry[0],
+				Anum_pg_tablespace_spcname,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(tablespacename));
+	scandesc = heap_beginscan(rel, SnapshotNow, 1, entry);
+	tuple = heap_getnext(scandesc, ForwardScanDirection);
+
+	/* If nothing matches then the tablespace doesn't exist */
+	if (HeapTupleIsValid(tuple))
+		result = true;
+	else
+		result = false;
+
+	heap_endscan(scandesc);
+	heap_close(rel, AccessShareLock);
+
+	return result;
+}
+
 /* assign_hook: validate new default_tablespace, do extra actions as needed */
 const char *
 assign_default_tablespace(const char *newval, bool doit, GucSource source)
@@ -962,8 +1000,13 @@ assign_default_tablespace(const char *newval, bool doit, GucSource source)
 	 */
 	if (IsTransactionState())
 	{
+		/*
+		 * get_tablespace_oid cannot be used because it acquires lock hence
+		 * ends up allocating xid (maybe in reader gang too) instead
+		 * check_tablespace is used.
+		 */
 		if (newval[0] != '\0' &&
-			!OidIsValid(get_tablespace_oid(newval, true)))
+			!check_tablespace(newval))
 		{
 			/*
 			 * When source == PGC_S_TEST, we are checking the argument of an


### PR DESCRIPTION
SET default_tablespace ideally should just be read-only transaction and
shouldn't allocate xid. Currently get_tablespace_oid() is acquiring lock for
other purposes to protect for concurrency, ends up assigning transaction IDs to
take the lock. Setting the GUC doesn't need to acquire the lock, plus it creates
the problem as multiple readers and a writer in a gang all end-up assigning
independent xid when dispatched this GUC. This happens because SET runs as
QE_AUTO_COMMIT_IMPLICIT for writer and hence has deferred allocation of
transaction ID. The filespace ICW tests detected this case since hits assert
FailedAssertion("!(!((proc->xid) != ((TransactionId) 0)))", File: "procarray.c"
without the fix.

Simplest scenario the problem can be demostrated is:
- DROP TABLE a;
- CREATE TABLE a(a INT, b INT);
- INSERT INTO a VALUES (generate_series(1,2), generate_series(3,4)); -- generates 1 reader and 1 writer gang
- SET default_tablespace='pg_default';

**Also, add Assert AssignTransactionId should not be called by QE Reader.**
