### PR TITLE
ANALYZE ROOTPARTITION should only collect statistics for the root partition

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1472,12 +1472,13 @@ get_rel_oids(List *relids, VacuumStmt *vacstmt, bool isVacuum)
 				if (!vacstmt->rootonly)
 				{
 					oid_list = all_leaf_partition_relids(pn); /* all leaves */
+
+					if (optimizer_analyze_midlevel_partition)
+					{
+						oid_list = list_concat(oid_list, all_interior_partition_relids(pn)); /* interior partitions */
+					}
 				}
 				oid_list = lappend_oid(oid_list, relationOid); /* root partition */
-				if (optimizer_analyze_midlevel_partition)
-				{
-					oid_list = list_concat(oid_list, all_interior_partition_relids(pn)); /* interior partitions */
-				}
 			}
 			else if (ps == PART_STATUS_INTERIOR) /* analyze an interior partition directly */
 			{

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -597,7 +597,7 @@ select * from pg_stats where tablename like 'p3_sales%' order by tablename, attn
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (20 rows)
 
--- Case 12: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should update the stats for root and midlevel partitions only.
+-- Case 12: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should only update the stats for root partition.
 set optimizer_analyze_root_partition=on;
 set optimizer_analyze_midlevel_partition=on;
 DROP TABLE if exists p3_sales;
@@ -622,41 +622,31 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
  p3_sales                                                        |         2 |        1
- p3_sales_1_prt_2                                                |         2 |        1
- p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname |        tablename         | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+--------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales                 | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales                 | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales                 | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales                 | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales                 | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
-(15 rows)
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(5 rows)
 
 -- Case 13: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should update the stats for root partition only.
 set optimizer_analyze_root_partition=on;
@@ -770,7 +760,7 @@ select * from pg_stats where tablename like 'p3_sales%' order by tablename, attn
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (15 rows)
 
--- Case 15: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to On should update the stats for root, midlevel and leaf partition only.
+-- Case 15: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to ON should only update the stats for root only.
 set optimizer_analyze_root_partition=off;
 set optimizer_analyze_midlevel_partition=on;
 DROP TABLE if exists p3_sales;
@@ -795,41 +785,31 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
  p3_sales                                                        |         2 |        1
- p3_sales_1_prt_2                                                |         2 |        1
- p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname |        tablename         | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+--------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales                 | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales                 | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales                 | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales                 | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales                 | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2         | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2 | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
-(15 rows)
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+(5 rows)
 
 -- start_ignore
 DROP TABLE IF EXISTS p3_sales;

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -268,7 +268,7 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
 
--- Case 12: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should update the stats for root and midlevel partitions only.
+-- Case 12: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should only update the stats for root partition.
 set optimizer_analyze_root_partition=on;
 set optimizer_analyze_midlevel_partition=on;
 DROP TABLE if exists p3_sales;
@@ -340,7 +340,7 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
 
--- Case 15: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to On should update the stats for root, midlevel and leaf partition only.
+-- Case 15: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to ON should only update the stats for root only.
 set optimizer_analyze_root_partition=off;
 set optimizer_analyze_midlevel_partition=on;
 DROP TABLE if exists p3_sales;


### PR DESCRIPTION
Analyze root partition should not generate statistics for the leaf or midlevel partitions, immaterial of the value of the GUC **optimizer_analyze_midlevel_partition**.

This fix makes it consistent with our docs.

@d @oarap @foyzur @bhuvnesh2703 @khannaekta @hsyuan please take a look.