### PR TITLE
Replace gptransfer behave tests with unit tests

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -904,7 +904,6 @@ class GpTransfer(GpTestCase):
 
         self.subject.GpTransfer(Mock(**options), [])
 
-
     def test__validate_good_multi_column_swapped_column_ordering_list_partition_from_43x_to_5x(self):
         options = self.setup_partition_validation()
 
@@ -932,6 +931,30 @@ class GpTransfer(GpTestCase):
 
         self.assertIn("Validating partition table transfer set...", self.get_info_messages())
 
+    def test__validate_max_line_length_below_minimum(self):
+        options = self.setup_partition_to_normal_validation()
+        options.update(max_line_length=1024*16)
+        MIN_GPFDIST_MAX_LINE_LENGTH = 1024 * 32  # (32KB)
+        MAX_GPFDIST_MAX_LINE_LENGTH = 1024 * 1024 * 256  # (256MB)
+        with self.assertRaisesRegexp(Exception, "Invalid --max-line-length option.  Value must be between %d and %d" % (MIN_GPFDIST_MAX_LINE_LENGTH,
+                                                                                                                        MAX_GPFDIST_MAX_LINE_LENGTH)):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_max_line_length_above_maximum(self):
+        options = self.setup_partition_to_normal_validation()
+        options.update(max_line_length=1024*1024*512)
+        MIN_GPFDIST_MAX_LINE_LENGTH = 1024 * 32  # (32KB)
+        MAX_GPFDIST_MAX_LINE_LENGTH = 1024 * 1024 * 256  # (256MB)
+        with self.assertRaisesRegexp(Exception, "Invalid --max-line-length option.  Value must be between %d and %d" % (MIN_GPFDIST_MAX_LINE_LENGTH,
+                                                                                                                        MAX_GPFDIST_MAX_LINE_LENGTH)):
+            self.subject.GpTransfer(Mock(**options), [])
+
+    def test__validate_max_line_length_valid(self):
+        options = self.setup_partition_to_normal_validation()
+        options.update(max_line_length=1024*1024)
+        MIN_GPFDIST_MAX_LINE_LENGTH = 1024 * 32  # (32KB)
+        MAX_GPFDIST_MAX_LINE_LENGTH = 1024 * 1024 * 256  # (256MB)
+        self.subject.GpTransfer(Mock(**options), [])
 
     ####################################################################################################################
     # End of tests, start of private methods/objects

--- a/gpMgmt/test/behave/mgmt_utils/gptransfer.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gptransfer.feature
@@ -1400,51 +1400,6 @@ Feature: gptransfer tests
         And the temporary table file "wide_row_16384.sql" is removed
         And drop the table "wide_row_16384" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
 
-    @T339868
-    Scenario: gptransfer with max-line-length of 32KB
-        Given the database is running
-        And the database "gptransfer_destdb" does not exist
-        And the database "gptransfer_testdb1" does not exist
-        And the database "gptransfer_testdb3" does not exist
-        And the database "gptransfer_testdb4" does not exist
-        And the database "gptransfer_testdb5" does not exist
-        And a table is created containing rows of length "32768" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
-        And the user runs "gptransfer -t gptransfer_testdb5.public.wide_row_32768 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --max-line-length 33792 --batch-size=10"
-        Then gptransfer should return a return code of 0
-        And verify that table "wide_row_32768" in "gptransfer_testdb5" has "10" rows
-        And the temporary table file "wide_row_32768.sql" is removed
-        And drop the table "wide_row_32768" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
-
-    @T339869
-    Scenario: gptransfer with max-line-length of 256MB
-        Given the database is running
-        And the database "gptransfer_destdb" does not exist
-        And the database "gptransfer_testdb1" does not exist
-        And the database "gptransfer_testdb3" does not exist
-        And the database "gptransfer_testdb4" does not exist
-        And the database "gptransfer_testdb5" does not exist
-        And a table is created containing rows of length "267386880" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
-        And the user runs "gptransfer -t gptransfer_testdb5.public.wide_row_267386880 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --max-line-length 268435456 --batch-size=10"
-        Then gptransfer should return a return code of 0
-        And verify that table "wide_row_267386880" in "gptransfer_testdb5" has "10" rows
-        And the temporary table file "wide_row_267386880.sql" is removed
-        And drop the table "wide_row_267386880" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
-
-    @T339871
-    Scenario: gptransfer with max-line-length of 257MB
-        Given the database is running
-        And the database "gptransfer_destdb" does not exist
-        And the database "gptransfer_testdb1" does not exist
-        And the database "gptransfer_testdb3" does not exist
-        And the database "gptransfer_testdb4" does not exist
-        And the database "gptransfer_testdb5" does not exist
-        And a table is created containing rows of length "269484032" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
-        And the user runs "gptransfer -t gptransfer_testdb5.public.wide_row_269484032 --source-port $GPTRANSFER_SOURCE_PORT --source-host $GPTRANSFER_SOURCE_HOST --source-user $GPTRANSFER_SOURCE_USER --dest-user $GPTRANSFER_DEST_USER --dest-port $GPTRANSFER_DEST_PORT --dest-host $GPTRANSFER_DEST_HOST --source-map-file $GPTRANSFER_MAP_FILE --max-line-length 269484032 --batch-size=10"
-        Then gptransfer should return a return code of 2
-        And gptransfer should print Value must be between 32768 and 268435456 to stdout
-        And the temporary table file "wide_row_269484032.sql" is removed
-        And drop the table "wide_row_269484032" with connection "psql -p $GPTRANSFER_SOURCE_PORT -h $GPTRANSFER_SOURCE_HOST -U $GPTRANSFER_SOURCE_USER -d gptransfer_testdb5"
-
     Scenario: Negative test for gptransfer full with invalid delimiter and format option
         Given the database is running
         And the database "gptransfer_destdb" does not exist


### PR DESCRIPTION
Replaces long running behave tests in gptransfer suite with unit tests
since they're only testing argument parsing. This shortens the gptransfer
suite by about 15 minutes.

Authors: Chris Hajas and Jamie McAtamney