### PR TITLE
Revert PortalCleanup stuff the way it is in upstream.

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -397,15 +397,8 @@ external_endscan(FileScanDesc scan)
 	 */
 	if (!scan->fs_noop && scan->fs_file)
 	{
-		URL_FILE *f = scan->fs_file;
-
-		/*
-		 * Mark the handle as NULL before closing it, so that if something
-		 * goes wrong while closing, and we get called again during abort
-		 * processing, we will not try to close the source twice.
-		 */
+		url_fclose(scan->fs_file, true, relname);
 		scan->fs_file = NULL;
-		url_fclose(f, true, relname);
 	}
 
 	pfree(relname);
@@ -424,15 +417,8 @@ external_stopscan(FileScanDesc scan)
 	 */
 	if (!scan->fs_noop && scan->fs_file)
 	{
-		URL_FILE *f = scan->fs_file;
-
-		/*
-		 * Mark the handle as NULL before closing it, so that if something
-		 * goes wrong while closing, and we get called again during abort
-		 * processing, we will not try to close the source twice.
-		 */
+		url_fclose(scan->fs_file, false, RelationGetRelationName(scan->fs_rd));
 		scan->fs_file = NULL;
-		url_fclose(f, false, RelationGetRelationName(scan->fs_rd));
 	}
 }
 
@@ -702,18 +688,10 @@ external_insert_finish(ExternalInsertDesc extInsertDesc)
 	 */
 	if (extInsertDesc->ext_file)
 	{
-		char	   *relname = pstrdup(RelationGetRelationName(extInsertDesc->ext_rel));
-		URL_FILE   *f = extInsertDesc->ext_file;
+		char	   *relname = RelationGetRelationName(extInsertDesc->ext_rel);
 
-		/*
-		 * Mark the handle as NULL before closing it, so that if something
-		 * goes wrong while closing, and we get called again during abort
-		 * processing, we will not try to close the source twice.
-		 */
-		extInsertDesc->ext_file = NULL;
-		url_fflush(f, extInsertDesc->ext_pstate);
-		url_fclose(f, true, relname);
-		pfree(relname);
+		url_fflush(extInsertDesc->ext_file, extInsertDesc->ext_pstate);
+		url_fclose(extInsertDesc->ext_file, true, relname);
 	}
 
 	if (extInsertDesc->ext_formatter_data)

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -751,60 +751,43 @@ process_ordered_aggregate_multi(AggState *aggstate,
 	TupleTableSlot *slot = peraggstate->evalslot;
 	int			numArguments = peraggstate->numArguments;
 	int			i;
-	
-	if(gp_enable_mk_sort)
+
+	if (gp_enable_mk_sort)
 		tuplesort_performsort_mk((Tuplesortstate_mk *) peraggstate->sortstate);
 	else
 		tuplesort_performsort((Tuplesortstate *) peraggstate->sortstate);
-	
-	ExecClearTuple(slot);
-	
-	PG_TRY();
-	{
-		while (
-			gp_enable_mk_sort ? 
-			tuplesort_gettupleslot_mk((Tuplesortstate_mk *)peraggstate->sortstate, true, slot)
-			:
-			tuplesort_gettupleslot((Tuplesortstate *)peraggstate->sortstate, true, slot)
-			)
-		{
-			/*
-			 * Extract the first numArguments as datums to pass to the transfn.
-			 * (This will help execTuplesMatch too, so do it immediately.)
-			 */
-			slot_getsomeattrs(slot, numArguments);
-			
-			/* Load values into fcinfo */
-			/* Start from 1, since the 0th arg will be the transition value */
-			for (i = 0; i < numArguments; i++)
-			{
-				fcinfo.arg[i + 1] = slot_get_values(slot)[i];
-				fcinfo.argnull[i + 1] = slot_get_isnull(slot)[i];
-			}
-		
-			advance_transition_function(aggstate, peraggstate, pergroupstate,
-										&fcinfo, &(aggstate->mem_manager));
-		
-			/* Reset context each time */
-			MemoryContextReset(workcontext);
-		
-			ExecClearTuple(slot);
-		}
-	}
-	PG_CATCH();
-	{
-		/* 
-		 * The tuple is stored in a memory context that will be released during 
-		 * the error handling.  If we don't clear it here we will attempt to 
-		 * clear it later after the memory context has been released which would
-		 * be a memory context error.
-		 */
-		ExecClearTuple(slot);
 
-		/* Carry on with error handling. */
-		PG_RE_THROW();
+	ExecClearTuple(slot);
+
+	while (
+		gp_enable_mk_sort ?
+		tuplesort_gettupleslot_mk((Tuplesortstate_mk *)peraggstate->sortstate, true, slot)
+		:
+		tuplesort_gettupleslot((Tuplesortstate *)peraggstate->sortstate, true, slot)
+		)
+	{
+		/*
+		 * Extract the first numArguments as datums to pass to the transfn.
+		 * (This will help execTuplesMatch too, so do it immediately.)
+		 */
+		slot_getsomeattrs(slot, numArguments);
+
+		/* Load values into fcinfo */
+		/* Start from 1, since the 0th arg will be the transition value */
+		for (i = 0; i < numArguments; i++)
+		{
+			fcinfo.arg[i + 1] = slot_get_values(slot)[i];
+			fcinfo.argnull[i + 1] = slot_get_isnull(slot)[i];
+		}
+
+		advance_transition_function(aggstate, peraggstate, pergroupstate,
+									&fcinfo, &(aggstate->mem_manager));
+
+		/* Reset context each time */
+		MemoryContextReset(workcontext);
+
+		ExecClearTuple(slot);
 	}
-	PG_END_TRY();
 
 	if (gp_enable_mk_sort)
 		tuplesort_end_mk((Tuplesortstate_mk *) peraggstate->sortstate);


### PR DESCRIPTION
Now that external tables use resource owners to clean up on abort, we
no longer need to ensure that ExecutorEnd gets called on failed portals.

Remove PG_TRY-CATCH block in nodeAgg.c that's no longer needed. This
demonstrates well why we should not call ExecutorEnd on abort; there
might well have been more places that previously needed a PG_TRY-CATCH
block like this, but didn't have one.