### PR TITLE
Add back resultRelations in PlannedStmt

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -297,6 +297,7 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_BOOL_FIELD(transientPlan);
 	WRITE_NODE_FIELD(planTree);
 	WRITE_NODE_FIELD(rtable);
+	WRITE_NODE_FIELD(resultRelations);
 	WRITE_NODE_FIELD(utilityStmt);
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(subplans);


### PR DESCRIPTION
This commit adds back `resultRelations` to the out func for `PlannedStmt`. The omission affects `debug_print_plan` and `explain verbose` (Until 8.4+ I guess)

This seems to be an unintended omission introduced during the back-and-forth between 4e01c159 and 35f25e89.