### PR TITLE
Fix memory allocation error when request size is near MaxAllocSize

### DIFF
--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -362,7 +362,6 @@ MemoryContextNoteAlloc(MemoryContext context, Size nbytes)
     Size            held;
 
     AssertArg(MemoryContextIsValid(context));
-    AssertArg(AllocSizeIsValid(nbytes));
 
     for (;;)
     {
@@ -394,7 +393,6 @@ MemoryContextNoteFree(MemoryContext context, Size nbytes)
     Size    held;
 
 	AssertArg(MemoryContextIsValid(context));
-	AssertArg(AllocSizeIsValid(nbytes));
 
     while (context)
     {


### PR DESCRIPTION
palloc and repalloc will check request size is under MaxAllocSize,
but the implementation(AllocSetAllocImpl, AllocSetReallocImpl) allocs
ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ more bytes to store block
information. Later MemoryContextNoteAlloc is called with block size.
If palloc request size is between MaxAllocSize - (ALLOC_BLOCKHDRSZ +
ALLOC_CHUNKHDRSZ) and MaxAllocSize, an internal error occurs.

Fix: ensure block size is smaller than MaxAllocSize in AllocSetAllocImpl
and AllocSetReallocImpl.

This resolves https://github.com/greenplum-db/gpdb/issues/1090.

Signed-off-by: Peifeng Qiu <pqiu@pivotal.io>
Signed-off-by: Yuan Zhao <yuzhao@pivotal.io>