### PR TITLE
Make ANALYZE behavior consistent with GUCs about root/midlevel partitions

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1503,6 +1503,8 @@ get_rel_oids(List *relids, VacuumStmt *vacstmt, bool isVacuum)
 	}
 	else
 	{
+		ereport(NOTICE, (errmsg("Hello")));
+
 		/* Process all plain relations listed in pg_class */
 		Relation	pgclass;
 		HeapScanDesc scan;
@@ -1553,6 +1555,14 @@ get_rel_oids(List *relids, VacuumStmt *vacstmt, bool isVacuum)
 			{
 				continue;
 			}
+
+			// skip mid-level partition tables if we have disabled collecting statistics for them
+			PartStatus ps = rel_part_status(candidateOid);
+			if (!optimizer_analyze_midlevel_partition && ps == PART_STATUS_INTERIOR)
+			{
+				continue;
+			}
+
 			oldcontext = MemoryContextSwitchTo(vac_context);
 			oid_list = lappend_oid(oid_list, candidateOid);
 			MemoryContextSwitchTo(oldcontext);

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1503,8 +1503,6 @@ get_rel_oids(List *relids, VacuumStmt *vacstmt, bool isVacuum)
 	}
 	else
 	{
-		ereport(NOTICE, (errmsg("Hello")));
-
 		/* Process all plain relations listed in pg_class */
 		Relation	pgclass;
 		HeapScanDesc scan;

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -151,7 +151,7 @@ select * from pg_stats where tablename like 'p3_sales%' order by tablename, attn
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
--- Case 4: Analyzing the database with the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should update stats for all table except root tables
+-- Case 4: Analyzing the database with the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should only update stats for leaf partition tables
 set optimizer_analyze_root_partition=off;
 set optimizer_analyze_midlevel_partition=off;
 DROP TABLE if exists p3_sales;
@@ -176,43 +176,33 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
  p3_sales                                                        |         0 |        1
- p3_sales_1_prt_2                                                |         2 |        1
- p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
  schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
 ------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales_1_prt_2                   | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
-(15 rows)
+(5 rows)
 
--- Case 5: Vacuum analyzing the database should vacuum all the tables for p3_sales and should update the stats for all partitions for p3_sales except root partition
+-- Case 5: Vacuum analyzing the database should vacuum all the tables for p3_sales and should only update the stats for all leaf partitions of p3_sales
 set optimizer_analyze_root_partition=off;
 set optimizer_analyze_midlevel_partition=off;
 DROP TABLE if exists p3_sales;
@@ -237,46 +227,36 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
  p3_sales                                                        |         0 |        1
- p3_sales_1_prt_2                                                |         0 |        1
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        1
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
  schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
 ------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales_1_prt_2                   | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
  public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
-(15 rows)
+(5 rows)
 
 select count(*) from pg_stat_last_operation pgl, pg_class pgc where pgl.objid=pgc.oid and pgc.relname like 'p3_sales%';
  count 
 -------
-    59
+    47
 (1 row)
 
 -- Case 6: Analyzing root table with ROOTPARTITION keyword should only update the stats of the root table when the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition are set off

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -75,7 +75,7 @@ analyze p3_sales_1_prt_2_2_prt_2_3_prt_usa;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
 
--- Case 4: Analyzing the database with the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should update stats for all table except root tables
+-- Case 4: Analyzing the database with the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should only update stats for leaf partition tables
 set optimizer_analyze_root_partition=off;
 set optimizer_analyze_midlevel_partition=off;
 DROP TABLE if exists p3_sales;
@@ -99,7 +99,7 @@ analyze;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
 
--- Case 5: Vacuum analyzing the database should vacuum all the tables for p3_sales and should update the stats for all partitions for p3_sales except root partition
+-- Case 5: Vacuum analyzing the database should vacuum all the tables for p3_sales and should only update the stats for all leaf partitions of p3_sales
 set optimizer_analyze_root_partition=off;
 set optimizer_analyze_midlevel_partition=off;
 DROP TABLE if exists p3_sales;


### PR DESCRIPTION
ANALYZE should only produce leaf partitions stats when gucs optimizer_analyze_midlevel_partition and optimizer_analyze_root_partition are set to off.

This fix makes the behavior of ANALYZE consistent with the intent of the GUCs.

@d @danielgustafsson @hsyuan @oarap @bhuvnesh2703 etc. please review