### PR TITLE
Avoid initialization of relcache during recovery

### DIFF
--- a/src/backend/cdb/cdbfilerepprimaryrecovery.c
+++ b/src/backend/cdb/cdbfilerepprimaryrecovery.c
@@ -326,6 +326,12 @@ FileRepPrimary_RunChangeTrackingCompacting(void)
 		pg_usleep(50000L); /* 50 ms */	
 	}		
 
+	/*
+	 * It is safe to initialize relcache and use heap access methods
+	 * now, after crash recovery passes have finished applying xlog.
+	 */
+	FileRepSubProcess_InitHeapAccess();
+
 	ChangeTracking_DoFullCompactingRoundIfNeeded();
 
 	

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3370,6 +3370,13 @@ RelationCacheInitializePhase3(void)
 	bool		needNewCacheFile = !criticalSharedRelcachesBuilt;
 
 	/*
+	 * Relation cache initialization or any sort of heap access is
+	 * dangerous before recovery is finished.
+	 */
+	if (!IsBootstrapProcessingMode() && RecoveryInProgress())
+		elog(ERROR, "relation cache initialization during recovery or non-bootstrap processes.");
+
+	/*
 	 * switch to cache memory context
 	 */
 	oldcxt = MemoryContextSwitchTo(CacheMemoryContext);

--- a/src/include/cdb/cdbfilerepservice.h
+++ b/src/include/cdb/cdbfilerepservice.h
@@ -39,5 +39,6 @@ extern bool FileRepSubProcess_ProcessSignals(void);
 
 extern bool FileRepSubProcess_IsStateTransitionRequested(void);
 
+extern void FileRepSubProcess_InitHeapAccess(void);
 #endif   /* CDBFILEREPSERVICE_H */
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_reindex_pg_class.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_reindex_pg_class.py
@@ -72,9 +72,6 @@ class ReindexPgClass(TINCTestCase):
     def test_reindex_pg_class_template1(self):
         """Test that relcache does not contain stale refilenodes after
         crash recovery.
-
-        This used to happen before we started deleting relcache init
-        file at the end of crash recovery pass 2.
         """
         self.dbname = "template1"
         self.test_reindex_pg_class()


### PR DESCRIPTION
This patch set defers `relcache` initialization in crash recovery as well as filerep processes until after xlog replay. If `relcache` is initialized before xlog replay, this leads to inconsistencies such as results of a committed transaction lost after recovery.

A error message put in place to expose this issue. This will prevent any future regression.