### PR TITLE
Port runaway-query TINC tests into GPDB

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -905,6 +905,25 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "QP_memory-accounting"
 
+- name: QP_runaway-query
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [gpdb_rc_packaging_centos]
+      trigger: true
+    - get: bin_gpdb
+      passed: [gpdb_rc_packaging_centos]
+      resource: bin_gpdb_centos6
+    - get: centos-gpdb-dev-6
+  - task: runaway-query
+    timeout: 3h
+    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      MAKE_TEST_COMMAND: runaway_query
+      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      TEST_OS: "centos"
+
 - name: regression_tests_gphdfs_centos
   plan:
   - aggregate:

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -342,3 +342,12 @@ crash_recovery_schema_topology:
 	-s tincrepo/mpp/gpdb/tests/storage/crashrecovery \
 	-p test_crash_recovery_schema_topology.py \
 	-p test_reindex_pg_class.py
+
+runaway_query:
+	$(TESTER) \
+		resource_management.runaway_query.runaway_query_scenario.test_runaway_query_scenario.RQTScenarioTestCase \
+		resource_management.runaway_query.runaway_detector.test_runaway_detector.RunawayDetectorTestCase \
+		resource_management.runaway_query.runaway_query_limits.test_runaway_query.RunawayQueryTestCase \
+		resource_management.runaway_query.runaway_query_multisession.test_runaway_multisession.RunawayMultiSessionTestCase \
+		resource_management.runaway_query.runaway_query_vmem_memoryaccounting.test_runaway_query_vmem_memoryaccounting.RQTMemoryAccountingTestCase \
+		resource_management.runaway_query.runaway_query_stress.test_runaway_query_stress.RunawayQueryStressTestCase

--- a/src/test/tinc/tincrepo/mpp/lib/datagen/databases.py
+++ b/src/test/tinc/tincrepo/mpp/lib/datagen/databases.py
@@ -57,3 +57,6 @@ __databases__['queryfinish'] = DispatchSkewDatabase()
 
 # Database for Memory Accounting Tests
 __databases__['memory_accounting'] = DataSetDatabase(database_name='memory_accounting')
+
+# Database for Runaway query termination
+__databases__['runaway_query'] = DataSetDatabase(database_name='runaway_query')

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/expected/runaway_detected_by_other.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/expected/runaway_detected_by_other.ans
@@ -1,0 +1,61 @@
+-- @Description Two sessions, one lightweight session detects the runaway
+-- @author George Caragea
+-- @vlimMB 900
+-- @slimMB 0
+-- @redzone 80
+
+-- Check to see that there is only one session running
+1: select count(*) from session_state.session_level_memory_consumption where segid = -1;
+count
+-----
+1    
+(1 row)
+
+-- check that exactly no backend is marked as runaway
+1: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+count
+-----
+0    
+(1 row)
+
+-- content/segment = 0; size = 650MB; sleep = 30 sec; crit_section = false
+1&: select gp_allocate_palloc_test_all_segs(0, 650 * 1024 * 1024, 30, false);  <waiting ...>
+
+-- give session 1 enough time to do the allocation
+2: select pg_sleep(3);
+pg_sleep
+--------
+        
+(1 row)
+
+-- check that no backend is marked as runaway
+2: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+count
+-----
+0    
+(1 row)
+
+-- content/segment = 0; size = 100MB; sleep = 0 sec; crit_section = false
+2: select gp_allocate_palloc_test_all_segs(0, 100 * 1024 * 1024, 0, false);
+gp_allocate_palloc_test_all_segs
+--------------------------------
+104857600                       
+0                               
+0                               
+(3 rows)
+
+-- check that exactly one backend is marked as runaway
+2: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+count
+-----
+1    
+(1 row)
+
+1<:  <... completed>
+gp_allocate_palloc_test_all_segs
+--------------------------------
+0                               
+681574400                       
+0                               
+(3 rows)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/expected/runaway_detects_itself.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/expected/runaway_detects_itself.ans
@@ -1,0 +1,41 @@
+-- @Description Only one session, runaway query detects itself as runaway
+-- @author George Caragea
+-- @vlimMB 900
+-- @slimMB 0
+-- @redzone 80
+
+-- Check to see that there is only one session running
+1: select count(*) from session_state.session_level_memory_consumption where segid = -1;
+count
+-----
+1    
+(1 row)
+
+-- check that exactly no backend is marked as runaway
+1: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+count
+-----
+0    
+(1 row)
+
+-- content/segment = 0; size = 455MB; sleep = 20 sec; crit_section = false
+1&: select gp_allocate_palloc_test_all_segs(0, 870 * 1024 * 1024, 20, false);  <waiting ...>
+
+-- give session 1 enough time to do the allocation
+2: select pg_sleep(3);
+pg_sleep
+--------
+        
+(1 row)
+
+-- check that exactly one backend is marked as runaway
+2: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+count
+-----
+1    
+(1 row)
+
+1<:  <... completed>
+ERROR:  Canceling query because of high VMEM usage. Used: 871MB, available 29MB, red zone: 720MB (runaway_cleaner.c:109)  (seg0 slice1 gcaragea-mbp.local:40090 pid=74101) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_test_all_segs" statement 1
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/sql/init_file
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/sql/init_file
@@ -1,0 +1,12 @@
+-- start_matchsubs
+m/DETAIL:  Per-query VM protect limit reached/
+s/DETAIL:  Per-query VM protect limit reached.*/DETAIL:  Per-query VM protect limit reached/g
+
+
+m/DETAIL:  VM Protect failed to allocate/
+s/DETAIL:  VM Protect failed to allocate.*/DETAIL:  VM Protect failed to allocate/g
+
+m/ERROR:  Canceling query because of high VMEM usage/
+s/ERROR:  Canceling query because of high VMEM usage.*/ERROR:  Canceling query because of high VMEM usage/g
+
+-- end_matchsubs

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/sql/runaway_detected_by_other.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/sql/runaway_detected_by_other.sql
@@ -1,0 +1,29 @@
+-- @Description Two sessions, one lightweight session detects the runaway
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 0
+-- @redzone 80
+
+-- Check to see that there is only one session running
+1: select count(*) from session_state.session_level_memory_consumption where segid = -1;
+
+-- check that exactly no backend is marked as runaway
+1: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+
+-- content/segment = 0; size = 650MB; sleep = 30 sec; crit_section = false
+1&: select gp_allocate_palloc_test_all_segs(0, 650 * 1024 * 1024, 30, false);
+
+-- give session 1 enough time to do the allocation
+2: select pg_sleep(3);
+
+-- check that no backend is marked as runaway
+2: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+
+-- content/segment = 0; size = 100MB; sleep = 0 sec; crit_section = false
+2: select gp_allocate_palloc_test_all_segs(0, 100 * 1024 * 1024, 0, false);
+
+-- check that exactly one backend is marked as runaway
+2: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+
+1<:
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/sql/runaway_detects_itself.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/sql/runaway_detects_itself.sql
@@ -1,0 +1,23 @@
+-- @Description Only one session, runaway query detects itself as runaway
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 0
+-- @redzone 80
+
+-- Check to see that there is only one session running
+1: select count(*) from session_state.session_level_memory_consumption where segid = -1;
+
+-- check that exactly no backend is marked as runaway
+1: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+
+-- content/segment = 0; size = 455MB; sleep = 20 sec; crit_section = false
+1&: select gp_allocate_palloc_test_all_segs(0, 870 * 1024 * 1024, 20, false);
+
+-- give session 1 enough time to do the allocation
+2: select pg_sleep(3);
+
+-- check that exactly one backend is marked as runaway
+2: select count(*) from session_state.session_level_memory_consumption where is_runaway='t';
+
+1<:
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/test_runaway_detector.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_detector/test_runaway_detector.py
@@ -1,0 +1,95 @@
+import tinctest
+
+from mpp.gpdb.tests.storage.lib.sql_isolation_testcase import SQLIsolationTestCase
+from gppylib.commands.base import Command
+from resource_management.runaway_query.runaway_udf import *
+from mpp.lib.PSQL import PSQL
+
+def _set_VLIM_SLIM_REDZONEPERCENT(vlimMB, slimMB, activationPercent):
+
+    # Set up GUCs for VLIM (gp_vmem_protect_limit), SLIM (gp_vmem_limit_per_query) and RQT activation percent (runaway_detector_activation_percent)
+    tinctest.logger.info('Setting GUCs for VLIM gp_vmem_protect_limit=%dMB, SLIM gp_vmem_limit_per_query=%dMB and RQT activation percent runaway_detector_activation_percent=%s'%(vlimMB, slimMB, activationPercent))
+    Command('Run gpconfig to set GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v %d' % vlimMB).run(validateAfter=True)
+    Command('Run gpconfig to set GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_limit_per_query -v %d --skipvalidation' % (slimMB * 1024)).run(validateAfter=True)
+    Command('Run gpconfig to set GUC runaway_detector_activation_percent',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c runaway_detector_activation_percent -v %d --skipvalidation' % activationPercent).run(validateAfter=True)
+
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+def _reset_VLIM_SLIM_REDZONEPERCENT():
+
+    # Reset GUCs for VLIM (gp_vmem_protect_limit), SLIM (gp_vmem_limit_per_query) and RQT activation percent (runaway_detector_activation_percent)
+    tinctest.logger.info('Resetting GUCs for VLIM gp_vmem_protect_limit, SLIM gp_vmem_limit_per_query, and RQT activation percent runaway_detector_activation_percent')
+    Command('Run gpconfig to reset GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v 8192').run(validateAfter=True)
+    Command('Run gpconfig to reset GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -r gp_vmem_limit_per_query --skipvalidation').run(validateAfter=True)
+    Command('Run gpconfig to reset GUC runaway_detector_activation_percent',
+            'source $GPHOME/greenplum_path.sh;gpconfig -r runaway_detector_activation_percent --skipvalidation').run(validateAfter=True)
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+class RunawayDetectorTestCase(SQLIsolationTestCase):
+    """
+    @tags runaway_query_termination
+    """
+
+    '''
+    Test for Runaway Query Termination that require concurrent sessions
+    '''
+
+    def _infer_metadata(self):
+        super(RunawayDetectorTestCase, self)._infer_metadata()
+        try:
+            self.vlimMB = int(self._metadata.get('vlimMB', '8192')) # Default is 8192
+            self.slimMB = int(self._metadata.get('slimMB', '0')) # Default is 0
+            self.activationPercent = int(self._metadata.get('redzone', '80')) # Default is 80
+        except Exception:
+            tinctest.logger.info("Error getting the testcase related metadata")
+            raise
+        
+    def faultInjector(self, faultIdentifier, faultType, segId, sleepTime=10, numOccurences=1):
+        tinctest.logger.info('Injecting fault: id=%s, fault=%s, segId=%d' %
+            (faultIdentifier, faultType, segId))
+        finjectCmd = 'source $GPHOME/greenplum_path.sh; '\
+                                  'gpfaultinjector -f %s '\
+                                  '-y %s --seg_dbid %d ' \
+                                  '--sleep_time_s=%d '\
+                                  '-o %d ' % (faultIdentifier, faultType, segId, sleepTime, numOccurences)
+        tinctest.logger.info('Fault injector command: ' + finjectCmd)
+        gpfaultinjector = Command('fault injector', finjectCmd)
+        gpfaultinjector.run()
+
+    def setUp(self):
+        _set_VLIM_SLIM_REDZONEPERCENT(self.vlimMB, self.slimMB, self.activationPercent)
+        # segid = 2, sleepTime = 20, numOccurences = 0 
+        # numOccurences = 0 means we'll keep triggering the fault until we reset it
+        self.faultInjector('runaway_cleanup', 'sleep', 2, 20, 0)
+        return super(RunawayDetectorTestCase, self).setUp()
+
+    def tearDown(self):
+        self.faultInjector('runaway_cleanup', 'reset', 2)        
+        return super(RunawayDetectorTestCase, self).tearDown()
+
+    @classmethod
+    def setUpClass(cls):
+        super(RunawayDetectorTestCase, cls).setUpClass()
+        create_runaway_udf()
+        create_session_state_view()
+        
+    @classmethod
+    def tearDownClass(cls):
+        drop_session_state_view()
+        drop_runaway_udf()
+        _reset_VLIM_SLIM_REDZONEPERCENT()
+ 
+    
+    sql_dir = 'sql/'
+    ans_dir = 'expected'
+    out_dir = 'output/'
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/disable_rqt.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/disable_rqt.ans
@@ -1,0 +1,13 @@
+-- start_ignore
+-- end_ignore
+-- @Description Disable runaway query termination
+-- @author Zhongxian Gu
+-- @vlimMB 400 
+-- @slimMB 0
+-- @redzone 0
+-- will hit OOM
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20);
+psql:/Users/guz4/dev/tincrepo/private/gacaragea/resource_management/runaway_query/runaway_query_limits/output/disable_rqt.sql:11: ERROR:  Out of memory  (seg0 slice1 usxxguz4m1.corp.emc.com:40000 pid=60004)
+DETAIL:  VM Protect failed to allocate 10485804 bytes, 9 MB available
+CONTEXT:  SQL function "gp_allocate_palloc_gradual_test_all_segs" statement 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/enable_rqt.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/enable_rqt.ans
@@ -1,0 +1,10 @@
+-- @Description Enable runaway query termination
+-- @author Zhongxian Gu
+-- @vlimMB 400 
+-- @slimMB 0
+-- @redzone 80
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20);
+psql:/Users/guz4/dev/tincrepo/private/gacaragea/resource_management/runaway_query/runaway_query_limits/output/enable_rqt.sql:12: ERROR:  Canceling query because of high VMEM usage. Used: 321MB, available 79MB, red zone: 320MB (runaway_cleaner.c:99)  (seg0 slice1 usxxguz4m1.corp.emc.com:40000 pid=67730) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_gradual_test_all_segs" statement 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/enable_rqt_in_transaction.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/enable_rqt_in_transaction.ans
@@ -1,0 +1,14 @@
+-- @Description Testing TRQ: A query within a transaction block, all QEs active, terminates correctly after being detected as Run-away
+-- @author Zhongxian Gu
+-- @vlimMB 400 
+-- @slimMB 0
+-- @redzone 80
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+begin;
+BEGIN
+select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20);
+psql:/Users/guz4/dev/tincrepo/private/gacaragea/resource_management/runaway_query/runaway_query_limits/output/enable_rqt_in_transaction.sql:13: ERROR:  Canceling query because of high VMEM usage. Used: 321MB, available 79MB, red zone: 320MB (runaway_cleaner.c:99)  (seg0 slice1 usxxguz4m1.corp.emc.com:40000 pid=78859) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_gradual_test_all_segs" statement 1
+commit;
+ROLLBACK

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/hit_slim.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/hit_slim.ans
@@ -1,0 +1,13 @@
+-- start_ignore
+SET optimizer=off;
+SET
+-- end_ignore
+-- @Description Ensures that one session hits SLIM
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 600
+-- content/segment = 0; size = 601MB; sleep = 0 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 601 * 1024 * 1024, 0, false);
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/hit_slim_planner.sql:12: ERROR:  Out of memory  (seg0 slice1 gcaragea-mbp.local:40050 pid=6469)
+DETAIL:  Per-query VM protect limit reached: current limit is 614400 kB, requested 630194220 bytes, available 599 MB
+CONTEXT:  SQL function "gp_allocate_palloc_test_all_segs" statement 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/hit_slim_crit_section.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/hit_slim_crit_section.ans
@@ -1,0 +1,17 @@
+-- start_ignore
+SET optimizer=off;
+SET
+-- end_ignore
+-- @Description Ensures that one session does not hit SLIM in critical section
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 600
+-- content/segment = 0; size = 601MB; sleep = 0 sec; crit_section = true
+select gp_allocate_palloc_test_all_segs(0, 601 * 1024 * 1024, 0, true);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                        630194176
+                                0
+                                0
+(3 rows)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/hit_vlim_crit_section.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/hit_vlim_crit_section.ans
@@ -1,0 +1,17 @@
+-- start_ignore
+SET optimizer=off;
+SET
+-- end_ignore
+-- @Description One session allocating > VLIM in critical section, can proceed
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 0
+-- content/segment = 0; size = 901MB; sleep = 0 sec; crit_section = true
+select gp_allocate_palloc_test_all_segs(0, 901 * 1024 * 1024, 0, true);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                        944766976
+                                0
+(3 rows)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/hit_vlim_one_session.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/hit_vlim_one_session.ans
@@ -1,0 +1,13 @@
+-- start_ignore
+SET optimizer=off;
+SET
+-- end_ignore
+-- @Description One session allocating > VLIM hits VLIM
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 0
+-- content/segment = 0; size = 901MB; sleep = 0 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 901 * 1024 * 1024, 0, false);
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/hit_vlim_one_session_planner.sql:12: ERROR:  Out of memory  (seg0 slice1 gcaragea-mbp.local:40050 pid=7661)
+DETAIL:  VM Protect failed to allocate 944767020 bytes, 899 MB available
+CONTEXT:  SQL function "gp_allocate_palloc_test_all_segs" statement 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/rqt_in_subtransaction_cursor.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/rqt_in_subtransaction_cursor.ans
@@ -1,0 +1,135 @@
+-- start_ignore
+-- end_ignore
+-- @Description Terminating a Runaway Query in a subtransaction with cursor, aborting transaction cleanly 
+-- @author George Caragea
+-- @vlimMB 1000 
+-- @slimMB 0
+-- @redzone 80
+-- one level deep subtransaction
+BEGIN;
+BEGIN
+insert into rqt_it_iq values (1001, 1); 
+INSERT 0 1
+DECLARE cursor_rqt_hold CURSOR WITH HOLD FOR
+select * from rqt_it_iq
+where c1 > 1000
+ORDER BY c1, c2;
+DECLARE CURSOR
+DECLARE cursor_rqt_share CURSOR FOR SELECT * FROM rqt_it_iq WHERE c1 > 3 FOR SHARE;
+DECLARE CURSOR
+-- start_ignore
+FETCH 1 FROM cursor_rqt_share;
+ c1 | c2 
+----+----
+  5 |  6
+(1 row)
+
+-- end_ignore
+UPDATE rqt_it_iq SET c2 = -9 WHERE CURRENT OF cursor_rqt_share;
+UPDATE 1
+SAVEPOINT sp_1;
+SAVEPOINT
+insert into rqt_it_iq values (1002, 1); 
+INSERT 0 1
+-- start_ignore
+FETCH 1 FROM cursor_rqt_share;
+ c1 | c2 
+----+----
+  7 |  8
+(1 row)
+
+-- end_ignore
+UPDATE rqt_it_iq SET c2 = -10 WHERE CURRENT OF cursor_rqt_share;
+UPDATE 1
+FETCH FROM cursor_rqt_hold; 
+  c1  | c2 
+------+----
+ 1001 |  1
+(1 row)
+
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 850MB; sleep = 5 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 850*1024*1024, 5, false);
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:41: ERROR:  Canceling query because of high VMEM usage. Used: 851MB, available 149MB, red zone: 800MB (runaway_cleaner.c:98)  (seg0 slice1 gcaragea-mbp.local:40090 pid=30439) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_test_all_segs" statement 1
+insert into rqt_it_iq values (1003, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:43: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+RELEASE SAVEPOINT sp_1;
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:45: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+insert into rqt_it_iq values (1004, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:47: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+COMMIT;
+ROLLBACK
+select * from rqt_it_iq where c1 > 1000 or c2 < 0 order by c1, c2; 
+ c1 | c2 
+----+----
+(0 rows)
+
+-- two level deep nested subtransaction
+BEGIN;
+BEGIN
+insert into rqt_it_iq values (2001, 1); 
+INSERT 0 1
+DECLARE cursor_rqt_hold CURSOR WITH HOLD FOR
+select * from rqt_it_iq
+where c1 > 1000
+ORDER BY c1, c2;
+DECLARE CURSOR
+DECLARE cursor_rqt_share CURSOR FOR SELECT * FROM rqt_it_iq WHERE c1 > 3 FOR SHARE;
+DECLARE CURSOR
+-- start_ignore
+FETCH 1 FROM cursor_rqt_share;
+ c1 | c2 
+----+----
+  4 |  5
+(1 row)
+
+-- end_ignore
+UPDATE rqt_it_iq SET c2 = -9 WHERE CURRENT OF cursor_rqt_share;
+UPDATE 1
+SAVEPOINT sp_1;
+SAVEPOINT
+insert into rqt_it_iq values (2002, 1); 
+INSERT 0 1
+SAVEPOINT sp_2;
+SAVEPOINT
+insert into rqt_it_iq values (2003, 1); 
+INSERT 0 1
+-- start_ignore
+FETCH 1 FROM cursor_rqt_share;
+ c1 | c2 
+----+----
+  6 |  7
+(1 row)
+
+-- end_ignore
+UPDATE rqt_it_iq SET c2 = -10 WHERE CURRENT OF cursor_rqt_share;
+UPDATE 1
+FETCH FROM cursor_rqt_hold; 
+  c1  | c2 
+------+----
+ 2001 |  1
+(1 row)
+
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 850MB; sleep = 5 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 850*1024*1024, 5, false);
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:87: ERROR:  Canceling query because of high VMEM usage. Used: 851MB, available 149MB, red zone: 800MB (runaway_cleaner.c:98)  (seg0 slice1 gcaragea-mbp.local:40090 pid=30439) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_test_all_segs" statement 1
+insert into rqt_it_iq values (2004, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:89: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+RELEASE SAVEPOINT sp_2;
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:91: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+insert into rqt_it_iq values (2005, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:93: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+RELEASE SAVEPOINT sp_1; 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:95: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+insert into rqt_it_iq values (2006, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_cursor.sql:97: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+COMMIT;
+ROLLBACK
+select * from rqt_it_iq where c1 > 2000 or c2 < 0 order by c1, c2; 
+ c1 | c2 
+----+----
+(0 rows)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/rqt_in_subtransaction_no_idle.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/expected/rqt_in_subtransaction_no_idle.ans
@@ -1,0 +1,69 @@
+-- start_ignore
+-- end_ignore
+-- @Description Terminating a Runaway Query in a subtransaction, aborting transaction cleanly 
+-- @author George Caragea
+-- @vlimMB 1000 
+-- @slimMB 0
+-- @redzone 80
+-- one level deep subtransaction
+BEGIN;
+BEGIN
+insert into rqt_it_iq values (1001, 1); 
+INSERT 0 1
+SAVEPOINT sp_1;
+SAVEPOINT
+insert into rqt_it_iq values (1002, 1); 
+INSERT 0 1
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 850MB; sleep = 5 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 850*1024*1024, 5, false);
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:22: ERROR:  Canceling query because of high VMEM usage. Used: 851MB, available 149MB, red zone: 800MB (runaway_cleaner.c:98)  (seg0 slice1 gcaragea-mbp.local:40090 pid=24877) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_test_all_segs" statement 1
+insert into rqt_it_iq values (1003, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:24: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+RELEASE SAVEPOINT sp_1;
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:27: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+insert into rqt_it_iq values (1004, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:29: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+COMMIT;
+ROLLBACK
+select * from rqt_it_iq where c1 > 1000 order by c1, c2; 
+ c1 | c2 
+----+----
+(0 rows)
+
+-- two level deep nested subtransaction
+BEGIN;
+BEGIN
+insert into rqt_it_iq values (2001, 1); 
+INSERT 0 1
+SAVEPOINT sp_1;
+SAVEPOINT
+insert into rqt_it_iq values (2002, 1); 
+INSERT 0 1
+SAVEPOINT sp_2;
+SAVEPOINT
+insert into rqt_it_iq values (2003, 1); 
+INSERT 0 1
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 850MB; sleep = 5 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 850*1024*1024, 5, false);
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:49: ERROR:  Canceling query because of high VMEM usage. Used: 851MB, available 149MB, red zone: 800MB (runaway_cleaner.c:98)  (seg0 slice1 gcaragea-mbp.local:40090 pid=24877) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_test_all_segs" statement 1
+insert into rqt_it_iq values (2004, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:51: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+RELEASE SAVEPOINT sp_2;
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:54: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+insert into rqt_it_iq values (2005, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:56: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+RELEASE SAVEPOINT sp_1; 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:58: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+insert into rqt_it_iq values (2006, 1); 
+psql:/Users/gcaragea/dev/tincrepo/private/gcaragea/resource_management/runaway_query/runaway_query_limits/output/rqt_in_subtransaction_no_idle.sql:60: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+COMMIT;
+ROLLBACK
+select * from rqt_it_iq where c1 > 2000 order by c1, c2; 
+ c1 | c2 
+----+----
+(0 rows)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/disable_rqt.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/disable_rqt.sql
@@ -1,0 +1,9 @@
+-- @Description Disable runaway query termination
+-- @author Zhongxian Gu
+-- @vlimMB 400 
+-- @slimMB 0
+-- @redzone 0
+
+-- will hit OOM
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/enable_rqt.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/enable_rqt.sql
@@ -1,0 +1,9 @@
+-- @Description Enable runaway query termination
+-- @author Zhongxian Gu
+-- @vlimMB 400 
+-- @slimMB 0
+-- @redzone 80
+
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/enable_rqt_in_transaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/enable_rqt_in_transaction.sql
@@ -1,0 +1,11 @@
+-- @Description Testing TRQ: A query within a transaction block, all QEs active, terminates correctly after being detected as Run-away
+-- @author Zhongxian Gu
+-- @vlimMB 400 
+-- @slimMB 0
+-- @redzone 80
+
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+begin;
+select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20);
+commit;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_slim.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_slim.sql
@@ -1,0 +1,7 @@
+-- @Description Ensures that one session hits SLIM
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 600
+
+-- content/segment = 0; size = 601MB; sleep = 0 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 601 * 1024 * 1024, 0, false);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_slim_crit_section.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_slim_crit_section.sql
@@ -1,0 +1,7 @@
+-- @Description Ensures that one session does not hit SLIM in critical section
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 600
+
+-- content/segment = 0; size = 601MB; sleep = 0 sec; crit_section = true
+select gp_allocate_palloc_test_all_segs(0, 601 * 1024 * 1024, 0, true);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_vlim_crit_section.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_vlim_crit_section.sql
@@ -1,0 +1,7 @@
+-- @Description One session allocating > VLIM in critical section, can proceed
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 0
+
+-- content/segment = 0; size = 901MB; sleep = 0 sec; crit_section = true
+select gp_allocate_palloc_test_all_segs(0, 901 * 1024 * 1024, 0, true);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_vlim_one_session.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/hit_vlim_one_session.sql
@@ -1,0 +1,7 @@
+-- @Description One session allocating > VLIM hits VLIM
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 0
+
+-- content/segment = 0; size = 901MB; sleep = 0 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 901 * 1024 * 1024, 0, false);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/init_file
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/init_file
@@ -1,0 +1,12 @@
+-- start_matchsubs
+m/DETAIL:  Per-query VM protect limit reached/
+s/DETAIL:  Per-query VM protect limit reached.*/DETAIL:  Per-query VM protect limit reached/g
+
+
+m/DETAIL:  VM Protect failed to allocate/
+s/DETAIL:  VM Protect failed to allocate.*/DETAIL:  VM Protect failed to allocate/g
+
+m/ERROR:  Canceling query because of high VMEM usage/
+s/ERROR:  Canceling query because of high VMEM usage.*/ERROR:  Canceling query because of high VMEM usage/g
+
+-- end_matchsubs

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_cursor.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_cursor.sql
@@ -1,0 +1,97 @@
+-- @Description Terminating a Runaway Query in a subtransaction with cursor, aborting transaction cleanly 
+-- @author George Caragea
+-- @vlimMB 1000 
+-- @slimMB 0
+-- @redzone 80
+
+
+-- one level deep subtransaction
+BEGIN;
+insert into rqt_it_iq values (1001, 1); 
+
+DECLARE cursor_rqt_hold CURSOR WITH HOLD FOR
+select * from rqt_it_iq
+where c1 > 1000
+ORDER BY c1, c2;
+
+DECLARE cursor_rqt_share CURSOR FOR SELECT * FROM rqt_it_iq WHERE c1 > 3 FOR SHARE;
+-- start_ignore
+FETCH 1 FROM cursor_rqt_share;
+-- end_ignore
+
+UPDATE rqt_it_iq SET c2 = -9 WHERE CURRENT OF cursor_rqt_share;
+
+SAVEPOINT sp_1;
+insert into rqt_it_iq values (1002, 1); 
+
+-- start_ignore
+FETCH 1 FROM cursor_rqt_share;
+-- end_ignore
+
+UPDATE rqt_it_iq SET c2 = -10 WHERE CURRENT OF cursor_rqt_share;
+
+FETCH FROM cursor_rqt_hold; 
+
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 850MB; sleep = 5 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 850*1024*1024, 5, false);
+
+insert into rqt_it_iq values (1003, 1); 
+
+RELEASE SAVEPOINT sp_1;
+
+insert into rqt_it_iq values (1004, 1); 
+
+COMMIT;
+
+select * from rqt_it_iq where c1 > 1000 or c2 < 0 order by c1, c2; 
+
+-- two level deep nested subtransaction
+BEGIN;
+insert into rqt_it_iq values (2001, 1); 
+
+DECLARE cursor_rqt_hold CURSOR WITH HOLD FOR
+select * from rqt_it_iq
+where c1 > 1000
+ORDER BY c1, c2;
+
+DECLARE cursor_rqt_share CURSOR FOR SELECT * FROM rqt_it_iq WHERE c1 > 3 FOR SHARE;
+
+-- start_ignore
+FETCH 1 FROM cursor_rqt_share;
+-- end_ignore
+
+UPDATE rqt_it_iq SET c2 = -9 WHERE CURRENT OF cursor_rqt_share;
+
+SAVEPOINT sp_1;
+insert into rqt_it_iq values (2002, 1); 
+
+SAVEPOINT sp_2;
+
+insert into rqt_it_iq values (2003, 1); 
+
+-- start_ignore
+FETCH 1 FROM cursor_rqt_share;
+-- end_ignore
+
+UPDATE rqt_it_iq SET c2 = -10 WHERE CURRENT OF cursor_rqt_share;
+
+FETCH FROM cursor_rqt_hold; 
+
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 850MB; sleep = 5 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 850*1024*1024, 5, false);
+
+insert into rqt_it_iq values (2004, 1); 
+
+RELEASE SAVEPOINT sp_2;
+
+insert into rqt_it_iq values (2005, 1); 
+
+RELEASE SAVEPOINT sp_1; 
+
+insert into rqt_it_iq values (2006, 1); 
+
+COMMIT;
+
+select * from rqt_it_iq where c1 > 2000 or c2 < 0 order by c1, c2; 

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_cursor_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_cursor_setup.sql
@@ -1,0 +1,7 @@
+drop table if exists rqt_it_iq;
+
+create table rqt_it_iq(c1 int, c2 int);
+
+insert into rqt_it_iq select i, i+1 from generate_series(1,1000)i;
+
+analyze rqt_it_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_cursor_teardown.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_cursor_teardown.sql
@@ -1,0 +1,1 @@
+drop table if exists rqt_it_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_no_idle.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_no_idle.sql
@@ -1,0 +1,60 @@
+-- @Description Terminating a Runaway Query in a subtransaction, aborting transaction cleanly 
+-- @author George Caragea
+-- @vlimMB 1000 
+-- @slimMB 0
+-- @redzone 80
+
+
+-- one level deep subtransaction
+BEGIN;
+insert into rqt_it_iq values (1001, 1); 
+
+SAVEPOINT sp_1;
+insert into rqt_it_iq values (1002, 1); 
+
+
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 850MB; sleep = 5 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 850*1024*1024, 5, false);
+
+insert into rqt_it_iq values (1003, 1); 
+
+
+RELEASE SAVEPOINT sp_1;
+
+insert into rqt_it_iq values (1004, 1); 
+
+COMMIT;
+
+select * from rqt_it_iq where c1 > 1000 order by c1, c2; 
+
+
+-- two level deep nested subtransaction
+BEGIN;
+insert into rqt_it_iq values (2001, 1); 
+
+SAVEPOINT sp_1;
+insert into rqt_it_iq values (2002, 1); 
+
+SAVEPOINT sp_2;
+
+insert into rqt_it_iq values (2003, 1); 
+
+-- will hit red zone and get terminated
+-- content/segment = 0; size = 850MB; sleep = 5 sec; crit_section = false
+select gp_allocate_palloc_test_all_segs(0, 850*1024*1024, 5, false);
+
+insert into rqt_it_iq values (2004, 1); 
+
+
+RELEASE SAVEPOINT sp_2;
+
+insert into rqt_it_iq values (2005, 1); 
+
+RELEASE SAVEPOINT sp_1; 
+
+insert into rqt_it_iq values (2006, 1); 
+
+COMMIT;
+
+select * from rqt_it_iq where c1 > 2000 order by c1, c2; 

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_no_idle_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_no_idle_setup.sql
@@ -1,0 +1,7 @@
+drop table if exists rqt_it_iq;
+
+create table rqt_it_iq(c1 int, c2 int);
+
+insert into rqt_it_iq select i, i+1 from generate_series(1,1000)i;
+
+analyze rqt_it_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_no_idle_teardown.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/sql/rqt_in_subtransaction_no_idle_teardown.sql
@@ -1,0 +1,1 @@
+drop table if exists rqt_it_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/test_runaway_query.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_limits/test_runaway_query.py
@@ -1,0 +1,74 @@
+import tinctest
+
+from mpp.models import SQLTestCase
+from gppylib.commands.base import Command
+from resource_management.runaway_query.runaway_udf import *
+from mpp.lib.PSQL import PSQL
+
+def _set_VLIM_SLIM_REDZONEPERCENT(vlimMB, slimMB, activationPercent):
+
+    # Set up GUCs for VLIM (gp_vmem_protect_limit), SLIM (gp_vmem_limit_per_query) and RQT activation percent (runaway_detector_activation_percent)
+    tinctest.logger.info('Setting GUCs for VLIM gp_vmem_protect_limit=%dMB, SLIM gp_vmem_limit_per_query=%dMB and RQT activation percent runaway_detector_activation_percent=%s'%(vlimMB, slimMB, activationPercent))
+    Command('Run gpconfig to set GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v %d' % vlimMB).run(validateAfter=True)
+    Command('Run gpconfig to set GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_limit_per_query -v %d --skipvalidation' % (slimMB * 1024)).run(validateAfter=True)
+    Command('Run gpconfig to set GUC runaway_detector_activation_percent',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c runaway_detector_activation_percent -v %d --skipvalidation' % activationPercent).run(validateAfter=True)
+
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+def _reset_VLIM_SLIM_REDZONEPERCENT():
+
+    # Reset GUCs for VLIM (gp_vmem_protect_limit), SLIM (gp_vmem_limit_per_query) and RQT activation percent (runaway_detector_activation_percent)
+    tinctest.logger.info('Resetting GUCs for VLIM gp_vmem_protect_limit, SLIM gp_vmem_limit_per_query, and RQT activation percent runaway_detector_activation_percent')
+    Command('Run gpconfig to reset GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v 8192').run(validateAfter=True)
+    Command('Run gpconfig to reset GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -r gp_vmem_limit_per_query --skipvalidation').run(validateAfter=True)
+    Command('Run gpconfig to reset GUC runaway_detector_activation_percent',
+            'source $GPHOME/greenplum_path.sh;gpconfig -r runaway_detector_activation_percent --skipvalidation').run(validateAfter=True)
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+
+class RunawayQueryTestCase(SQLTestCase):
+    """
+    @tags runaway_query_termination
+    """
+
+    '''
+    SQL Test for Runaway Query Termination
+    '''
+        
+    def _infer_metadata(self):
+        super(RunawayQueryTestCase, self)._infer_metadata()
+        try:
+            self.vlimMB = int(self._metadata.get('vlimMB', '8192')) # Default is 8192
+            self.slimMB = int(self._metadata.get('slimMB', '0')) # Default is 0
+            self.activationPercent = int(self._metadata.get('redzone', '80')) # Default is 80
+        except Exception:
+            tinctest.logger.info("Error getting the testcase related metadata")
+            raise
+
+    def setUp(self):
+        _set_VLIM_SLIM_REDZONEPERCENT(self.vlimMB, self.slimMB, self.activationPercent)
+        return super(RunawayQueryTestCase, self).setUp()
+
+    @classmethod
+    def setUpClass(cls):
+        super(RunawayQueryTestCase, cls).setUpClass()
+        create_runaway_udf()
+
+    @classmethod
+    def tearDownClass(cls):
+        drop_runaway_udf()
+        _reset_VLIM_SLIM_REDZONEPERCENT()
+        
+    sql_dir = 'sql/'
+    ans_dir = 'expected'
+    out_dir = 'output/'
+        

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/delete_while_vacuum.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/delete_while_vacuum.ans
@@ -1,0 +1,24 @@
+-- @Description Ensures that a delete before a vacuum operation is ok
+-- @author Dirk Meister
+
+DELETE FROM ao WHERE a < 12;
+DELETE 11
+1: BEGIN;
+BEGIN
+1: SELECT COUNT(*) FROM ao;
+count
+-----
+89   
+(1 row)
+1>: DELETE FROM ao WHERE a < 90;COMMIT;  <waiting ...>
+2: VACUUM ao;
+VACUUM
+1<:  <... completed>
+DELETE
+1: SELECT COUNT(*) FROM ao;
+count
+-----
+11   
+(1 row)
+3: INSERT INTO ao VALUES (0);
+INSERT 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/enable_rqt_all_in_transaction_idle_qe.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/enable_rqt_all_in_transaction_idle_qe.ans
@@ -1,0 +1,62 @@
+-- @Description Testing TRQ: A query within a transaction block, some idle QEs, terminates correctly after being detected as Run-away
+-- @author Zhongxian Gu
+-- @vlimMB 400
+-- @slimMB 0
+-- @redzone 80
+
+-- session1: issue the query that has only one active QE;
+-- content/segment = 0; size = 100MB; sleep = 15 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 100*1024*1024, 15);  <waiting ...>
+
+-- session2: Check the active QE, make sure there is only one.
+2&: select pg_sleep(2);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+2: select qe_count < 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike 'select gp_allocate_palloc_gradual_test_all_segs%';
+?column?
+--------
+t       
+(1 row)
+
+-- session1: the query should finish properly
+1<:  <... completed>
+gp_allocate_palloc_gradual_test_all_segs
+----------------------------------------
+0                                       
+0                                       
+104857600                               
+(3 rows)
+
+-- session1: issue a query that has more than one active QEs
+1: begin;
+BEGIN
+1: select count(*) from rqt_it_iq a, rqt_it_iq b where a.c1 < b.c2 and a.c2 > (select count(*) from rqt_it_iq c where c.c2 >= a.c1);
+count 
+------
+125250
+(1 row)
+
+-- session2: Make sure there are more than one idle QEs
+2&: select pg_sleep(5);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+2: select qe_count > 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+?column?
+--------
+t       
+(1 row)
+
+-- session1: issue the query that has only one active QE and memory-intensive in a transaction
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20); commit;  <waiting ...>
+
+-- session1: the query should be terminated after being detected as Run-away
+1<:  <... completed>
+ERROR:  Canceling query because of high VMEM usage. Used: 330MB, available 70MB, red zone: 320MB (runaway_cleaner.c:112)  (seg0 slice1 usxxguz4m1.corp.emc.com:40000 pid=7833) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_gradual_test_all_segs" statement 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/enable_rqt_in_transaction_idle_qe.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/enable_rqt_in_transaction_idle_qe.ans
@@ -1,0 +1,60 @@
+-- @Description Testing TRQ: A query within a transaction block, some idle QEs, terminates correctly after being detected as Run-away
+-- @author Zhongxian Gu
+-- @vlimMB 400
+-- @slimMB 0
+-- @redzone 80
+
+-- session1: issue the query that has only one active QE;
+-- content/segment = 0; size = 100MB; sleep = 15 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 100*1024*1024, 15);  <waiting ...>
+
+-- session2: Check the active QE, make sure there is only one.
+2&: select pg_sleep(2);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+2: select qe_count < 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike 'select gp_allocate_palloc_gradual_test_all_segs%';
+?column?
+--------
+t       
+(1 row)
+
+-- session1: the query should finish properly
+1<:  <... completed>
+gp_allocate_palloc_gradual_test_all_segs
+----------------------------------------
+0                                       
+0                                       
+104857600                               
+(3 rows)
+
+-- session1: issue a query that has more than one active QEs
+1: select count(*) from rqt_it_iq a, rqt_it_iq b where a.c1 < b.c2 and a.c2 > (select count(*) from rqt_it_iq c where c.c2 >= a.c1);
+count 
+------
+125250
+(1 row)
+
+-- session2: Make sure there are more than one idle QEs
+2&: select pg_sleep(5);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+2: select qe_count > 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+?column?
+--------
+t       
+(1 row)
+
+-- session1: issue the query that has only one active QE and memory-intensive in a transaction
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+1&: begin; select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20); commit;  <waiting ...>
+
+-- session1: the query should be terminated after being detected as Run-away
+1<:  <... completed>
+ERROR:  Canceling query because of high VMEM usage. Used: 330MB, available 70MB, red zone: 320MB (runaway_cleaner.c:112)  (seg0 slice1 usxxguz4m1.corp.emc.com:40000 pid=6709) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_gradual_test_all_segs" statement 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/enable_rqt_no_transaction_idle_qe.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/enable_rqt_no_transaction_idle_qe.ans
@@ -1,0 +1,60 @@
+-- @Description Testing TRQ: A query outside of a transaction, some QEs idle, terminates correctly after being detected as Run-away
+-- @author Zhongxian Gu
+-- @vlimMB 400
+-- @slimMB 0
+-- @redzone 80
+
+-- session1: issue the query that has only one active QE;
+-- content/segment = 0; size = 100MB; sleep = 15 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 100*1024*1024, 15);  <waiting ...>
+
+-- session2: Check the active QE, make sure there is only one.
+2&: select pg_sleep(2);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+2: select qe_count < 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike 'select gp_allocate_palloc_gradual_test_all_segs%';
+?column?
+--------
+t       
+(1 row)
+
+-- session1: the query should finish properly
+1<:  <... completed>
+gp_allocate_palloc_gradual_test_all_segs
+----------------------------------------
+0                                       
+0                                       
+104857600                               
+(3 rows)
+
+-- session1: issue a query that has more than one active QEs
+1: select count(*) from rqt_nt_iq a, rqt_nt_iq b where a.c1 < b.c2 and a.c2 > (select count(*) from rqt_nt_iq c where c.c2 >= a.c1);
+count 
+------
+125250
+(1 row)
+
+-- session2: Make sure there are more than one idle QEs
+2&: select pg_sleep(5);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+2: select qe_count > 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+?column?
+--------
+t       
+(1 row)
+
+-- session1: issue the query that has only one active QE and memory-intensive;
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20);  <waiting ...>
+
+-- session1: the query should be terminated after being detected as Run-away
+1<:  <... completed>
+ERROR:  Canceling query because of high VMEM usage. Used: 330MB, available 70MB, red zone: 320MB (runaway_cleaner.c:112)  (seg0 slice2 usxxguz4m1.corp.emc.com:40000 pid=8839) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_palloc_gradual_test_all_segs" statement 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/hit_vlim_2sessions.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/hit_vlim_2sessions.ans
@@ -1,0 +1,30 @@
+-- @Description Ensures that two sessions together allocate more than VLIM and one of them errors out
+-- @author George Caragea
+-- @vlimMB 900
+-- @slimMB 600
+
+-- content/segment = 0; size = 455MB; sleep = 20 sec; crit_section = false
+1&: select gp_allocate_palloc_test_all_segs(0, 455 * 1024 * 1024, 20, false);  <waiting ...>
+
+-- give session 1 enough time to do the allocation
+2&: select pg_sleep(10);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+
+-- content/segment = 0; size = 450MB; sleep = 20 sec; crit_section = false
+2&: select gp_allocate_palloc_test_all_segs(0, 450 * 1024 * 1024, 20, false);  <waiting ...>
+
+1<:  <... completed>
+gp_allocate_palloc_test_all_segs
+--------------------------------
+0                               
+477102080                       
+0                               
+(3 rows)
+2<:  <... completed>
+ERROR:  Out of memory  (seg0 slice1 gcaragea-mbp.local:40050 pid=72766)
+DETAIL:  VM Protect failed to allocate 471859244 bytes, 444 MB available
+CONTEXT:  SQL function "gp_allocate_palloc_test_all_segs" statement 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/idle_rss_red_zone.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/idle_rss_red_zone.ans
@@ -1,0 +1,56 @@
+-- @Description Testing TRQ: After cleaning up an RSS, system is still in red-zone, and the same session is the top consumer, check the system is stable.
+-- @author Zhongxian Gu
+-- @vlimMB 1100
+-- @slimMB 0
+-- @redzone 10
+
+-- session1: issue a query that consumes large memory and will be terminated as a runaway query
+-- content/segment = 0; size = 120MB; sleep = 1 sec
+1: select gp_allocate_top_memory_ctxt_test_all_segs(0, 120 * 1024 * 1024, 1);
+ERROR:  Canceling query because of high VMEM usage. Used: 122MB, available 978MB, red zone: 110MB (runaway_cleaner.c:112)  (seg0 slice2 qpvm4:40000 pid=6853) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_top_memory_ctxt_test_all_segs" statement 1
+
+-- session2: query the view to make sure it's idle yet still consumes memory
+2&: select pg_sleep(2);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+
+2: select vmem_mb > 110, is_runaway from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+?column?|is_runaway
+--------+----------
+t       |f         
+(1 row)
+
+-- session2: issue queries with small usage of memory but processing many tuples to check system stability
+-- these queries should run and finish without error
+2&: select count(*) from test as a where a.c2 >= (select sum(b.c1) from test as b where a.c1 > b.c2);  <waiting ...>
+
+2<:  <... completed>
+count
+-----
+3    
+(1 row)
+
+2&: select count(*) from test as a where a.c2 >= (select sum(b.c1) from test as b where a.c1 > b.c2);  <waiting ...>
+
+2<:  <... completed>
+count
+-----
+3    
+(1 row)
+
+2&: select count(*) from test as a where a.c2 >= (select sum(b.c1) from test as b where a.c1 > b.c2);  <waiting ...>
+
+2<:  <... completed>
+count
+-----
+3    
+(1 row)
+
+-- session2: issue a query that consumes larger memory than the idle process and it should be terminated as primary-runaway query
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 125 * 1024 * 1024, 1);
+ERROR:  Canceling query because of high VMEM usage. Used: 127MB, available 851MB, red zone: 110MB (runaway_cleaner.c:112)  (seg0 slice1 qpvm4:40000 pid=6889) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_top_memory_ctxt_test_all_segs" statement 1

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/idle_rss_red_zone_non_superuser.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/idle_rss_red_zone_non_superuser.ans
@@ -1,0 +1,35 @@
+-- @Description Testing TRQ: After cleaning up an RSS, system is still in red-zone, and the same session is the top consumer
+-- @author Zhongxian Gu
+-- @vlimMB 1100
+-- @slimMB 0
+-- @redzone 10
+
+-- session1: log in as non-super use and wait to issue a query
+1: set role rqt_temp_role;
+SET
+
+-- session2: issue a query that consumes large memory and will be terminated as a runaway query
+-- content/segment = 0; size = 120MB; sleep = 1 sec
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 120 * 1024 * 1024, 1);
+ERROR:  Canceling query because of high VMEM usage. Used: 122MB, available 978MB, red zone: 110MB (runaway_cleaner.c:112)  (seg0 slice1 qpvm4:40000 pid=14616) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_allocate_top_memory_ctxt_test_all_segs" statement 1
+
+-- session3: query the view to make sure it's idle yet still consumes memory
+3&: select pg_sleep(2);  <waiting ...>
+3<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+
+3: select vmem_mb > 110, is_runaway from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+?column?|is_runaway
+--------+----------
+f       |f         
+t       |f         
+(2 rows)
+
+-- session1: A non-super user issues a query. This query should be terminated.
+1: select count(*) from test as a where a.c2 >= (select sum(b.c1) from test as b where a.c1 > b.c2);
+ERROR:  Canceling query because of high VMEM usage. Used: 1MB, available 976MB, red zone: 110MB (runaway_cleaner.c:112)  (seg0 slice1 qpvm4:40000 pid=14636) (cdbdisp.c:1526)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/recover_from_segv.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/recover_from_segv.ans
@@ -1,0 +1,90 @@
+-- @Description Testing TRQ: after a PM reset, correct reinitialization of VMEM and SessionState
+-- @author Zhongxian Gu
+-- @vlimMB 1000
+-- @slimMB 0
+-- @redzone 80
+
+-- Check that only one session is running
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+count
+-----
+1    
+(1 row)
+
+-- Check the vmem tracked for only one session running
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+?column?
+--------
+t       
+(1 row)
+
+-- Start another session; set gp_debug_linger to 0 so we clean up immediately on FATAL
+2: set gp_debug_linger = 0;
+SET
+
+-- Set the timeout to keep idle QEs around to 60 seconds so they don't get cleaned up
+2: set gp_vmem_idle_resource_timeout = 60000;
+SET
+
+-- Check the vmem tracked for when two sessions are running, second one still idle
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+?column?
+--------
+t       
+(1 row)
+
+-- content/segment = 0; size = 250MB; sleep = 1 sec
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 250 * 1024 * 1024, 1);
+gp_allocate_top_memory_ctxt_test_all_segs
+-----------------------------------------
+0                                        
+0                                        
+262144000                                
+(3 rows)
+
+1&: select pg_sleep(2);  <waiting ...>
+1<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+
+-- Check that now we have two sessions active
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+count
+-----
+2    
+(1 row)
+
+-- Check the vmem tracked for when two sessions are running, one using some memory
+1: select (vmem_mb > 745 AND vmem_mb < 751) from gp_available_vmem_mb_test_all_segs where segid = 0;
+?column?
+--------
+t       
+(1 row)
+
+
+-- Have session 2 to trigger a PM reset
+--  content/segment = 0; FAULT_TYPE_FATAL = 4 (SEGV); sleep = 0
+2: select gp_inject_fault_test_all_segs(0, 4, 0);
+ERROR:  Error on receive from seg0 slice2 usxxguz4m1.corp.emc.com:40000 pid=22234: server closed the connection unexpectedly
+DETAIL:  
+	This probably means the server terminated abnormally
+	before or while processing the request.
+CONTEXT:  SQL function "gp_inject_fault_test_all_segs" statement 1
+ERROR:  could not temporarily connect to one or more segments (cdbgang.c:2433)
+
+-- only one active session on segment 0 should be left
+3: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+count
+-----
+1    
+(1 row)
+
+-- Check that now vmem tracked is back to normal
+3: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+?column?
+--------
+t       
+(1 row)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_pincount.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_pincount.ans
@@ -1,0 +1,55 @@
+-- @Description Ensures that pinCount is released on SessionState after QE cleaned up by idle gang
+-- @author Zhongxian
+
+-- session1: issue the testing query
+1: set gp_vmem_idle_resource_timeout=20000;
+SET
+1&: select count(*), pg_sleep(5) from rp a where a.c1 > (select sum(c1) from rp b where b.c2 < a.c1);  <waiting ...>
+
+-- session2: query the view to see query in session1 is running
+2&: select pg_sleep(2);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+2: select count(*) from session_state.session_level_memory_consumption where segid= 0 and current_query ilike 'select count(*), pg_sleep(5) from rp%' and qe_count > 0;
+count
+-----
+1    
+(1 row)
+
+-- session1: the query ends
+1<:  <... completed>
+count|pg_sleep
+-----+--------
+2    |        
+(1 row)
+
+-- session2: query the view to make sure there is an idle process there
+2: select count(*) from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE%' and qe_count > 0;
+count
+-----
+1    
+(1 row)
+
+2&: select pg_sleep(30);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+
+-- session2: make sure the idle process is gone
+2: select count(*) from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE%';
+count
+-----
+0    
+(1 row)
+
+2&: select pg_sleep(5);  <waiting ...>
+2<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_pincount_fatal.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_pincount_fatal.ans
@@ -1,0 +1,72 @@
+-- @Description Ensures that pinCount is released on SessionState when a QE calls elog(FATAL)
+-- @author George Caragea
+-- @vlimMB 1100
+-- @slimMB 0
+-- @redzone 80
+
+-- Check that only one session is running
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+count
+-----
+1    
+(1 row)
+
+-- Start another session; set gp_debug_linger to 0 so we clean up immediately on FATAL
+2: set gp_debug_linger = 0;
+SET
+
+-- Set the timeout to keep idle QEs around to 60 seconds so they don't get cleaned up
+2: set gp_vmem_idle_resource_timeout = 60000;
+SET
+
+-- content/segment = 0; size = 120MB; sleep = 1 sec
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 120 * 1024 * 1024, 1);
+gp_allocate_top_memory_ctxt_test_all_segs
+-----------------------------------------
+0                                        
+0                                        
+125829120                                
+(3 rows)
+
+1&: select pg_sleep(2);  <waiting ...>
+1<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+
+-- Check that now we have two sessions active
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+count
+-----
+2    
+(1 row)
+
+-- Have session 2 call a elog(FATAL) on segment 0
+--  content/segment = 0; FAULT_TYPE_FATAL = 2; sleep = 0
+2: select gp_inject_fault_test_all_segs(0, 2, 0);
+ERROR:  User fault injection raised fatal (runaway_test.c:250)  (seg0 slice2 gcaragea-mbp.local:40090 pid=83018) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_inject_fault_test_all_segs" statement 1
+ERROR:  could not temporarily connect to one or more segments (cdbgang.c:2433)
+
+-- make sure session 2 is still around and accepting queries
+2: select 1;
+?column?
+--------
+1       
+(1 row)
+
+1&: select pg_sleep(5);  <waiting ...>
+1<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+
+-- only one active session on segment 0 should be left
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+count
+-----
+1    
+(1 row)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_vmem_fatal.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_vmem_fatal.ans
@@ -1,0 +1,100 @@
+-- @Description Ensures that all vmem is released when a QE calls elog(FATAL)
+-- @author George Caragea
+-- @vlimMB 1000
+-- @slimMB 0
+-- @redzone 80
+
+-- Check that only one session is running
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+count
+-----
+1    
+(1 row)
+
+-- Check the vmem tracked for only one session running
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+?column?
+--------
+t       
+(1 row)
+
+-- Start another session; set gp_debug_linger to 0 so we clean up immediately on FATAL
+2: set gp_debug_linger = 0;
+SET
+
+-- Set the timeout to keep idle QEs around to 60 seconds so they don't get cleaned up
+2: set gp_vmem_idle_resource_timeout = 60000;
+SET
+
+-- Check the vmem tracked for when two sessions are running, second one still idle
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+?column?
+--------
+t       
+(1 row)
+
+-- content/segment = 0; size = 250MB; sleep = 1 sec
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 250 * 1024 * 1024, 1);
+gp_allocate_top_memory_ctxt_test_all_segs
+-----------------------------------------
+0                                        
+0                                        
+262144000                                
+(3 rows)
+
+1&: select pg_sleep(2);  <waiting ...>
+1<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+
+-- Check that now we have two sessions active
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+count
+-----
+2    
+(1 row)
+
+-- Check the vmem tracked for when two sessions are running, one using some memory
+1: select (vmem_mb > 745 AND vmem_mb < 751) from gp_available_vmem_mb_test_all_segs where segid = 0;
+?column?
+--------
+t       
+(1 row)
+
+
+-- Have session 2 call a elog(FATAL) on segment 0
+--  content/segment = 0; FAULT_TYPE_FATAL = 2; sleep = 0
+2: select gp_inject_fault_test_all_segs(0, 2, 0);
+ERROR:  User fault injection raised fatal (runaway_test.c:250)  (seg0 slice2 gcaragea-mbp.local:40090 pid=26904) (cdbdisp.c:1526)
+CONTEXT:  SQL function "gp_inject_fault_test_all_segs" statement 1
+ERROR:  could not temporarily connect to one or more segments (cdbgang.c:2433)
+
+-- make sure session 2 is still around and accepting queries
+2: select 1;
+?column?
+--------
+1       
+(1 row)
+
+1&: select pg_sleep(5);  <waiting ...>
+1<:  <... completed>
+pg_sleep
+--------
+        
+(1 row)
+
+-- only one active session on segment 0 should be left
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+count
+-----
+1    
+(1 row)
+
+-- Check that now vmem tracked is back to normal
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+?column?
+--------
+t       
+(1 row)

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/delete_while_vacuum.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/delete_while_vacuum.sql
@@ -1,0 +1,11 @@
+-- @Description Ensures that a delete before a vacuum operation is ok
+-- @author Dirk Meister
+
+DELETE FROM ao WHERE a < 12;
+1: BEGIN;
+1: SELECT COUNT(*) FROM ao;
+1>: DELETE FROM ao WHERE a < 90;COMMIT;
+2: VACUUM ao;
+1<:
+1: SELECT COUNT(*) FROM ao;
+3: INSERT INTO ao VALUES (0);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/delete_while_vacuum_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/delete_while_vacuum_setup.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS ao;
+
+CREATE TABLE ao (a INT, b INT) WITH (appendonly=true);
+INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100) AS i;
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_all_in_transaction_idle_qe.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_all_in_transaction_idle_qe.sql
@@ -1,0 +1,33 @@
+-- @Description Testing TRQ: A query within a transaction block, some idle QEs, terminates correctly after being detected as Run-away
+-- @author Zhongxian Gu
+-- @vlimMB 400 
+-- @slimMB 0
+-- @redzone 80
+
+-- session1: issue the query that has only one active QE; 
+-- content/segment = 0; size = 100MB; sleep = 15 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 100*1024*1024, 15);
+
+-- session2: Check the active QE, make sure there is only one.
+2&: select pg_sleep(2);
+2<:
+2: select qe_count < 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike 'select gp_allocate_palloc_gradual_test_all_segs%';
+
+-- session1: the query should finish properly
+1<:
+
+-- session1: issue a query that has more than one active QEs
+1: begin;
+1: select count(*) from rqt_it_iq a, rqt_it_iq b where a.c1 < b.c2 and a.c2 > (select count(*) from rqt_it_iq c where c.c2 >= a.c1);
+
+-- session2: Make sure there are more than one idle QEs
+2&: select pg_sleep(5);
+2<:
+2: select qe_count > 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+
+-- session1: issue the query that has only one active QE and memory-intensive in a transaction
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20); commit;
+
+-- session1: the query should be terminated after being detected as Run-away
+1<:

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_all_in_transaction_idle_qe_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_all_in_transaction_idle_qe_setup.sql
@@ -1,0 +1,7 @@
+drop table if exists rqt_it_iq;
+
+create table rqt_it_iq(c1 int, c2 int);
+
+insert into rqt_it_iq select i, i+1 from generate_series(1,1000)i;
+
+analyze rqt_it_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_all_in_transaction_idle_qe_teardown.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_all_in_transaction_idle_qe_teardown.sql
@@ -1,0 +1,1 @@
+drop table if exists rqt_it_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_in_transaction_idle_qe.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_in_transaction_idle_qe.sql
@@ -1,0 +1,32 @@
+-- @Description Testing TRQ: A query within a transaction block, some idle QEs, terminates correctly after being detected as Run-away
+-- @author Zhongxian Gu
+-- @vlimMB 400 
+-- @slimMB 0
+-- @redzone 80
+
+-- session1: issue the query that has only one active QE; 
+-- content/segment = 0; size = 100MB; sleep = 15 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 100*1024*1024, 15);
+
+-- session2: Check the active QE, make sure there is only one.
+2&: select pg_sleep(2);
+2<:
+2: select qe_count < 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike 'select gp_allocate_palloc_gradual_test_all_segs%';
+
+-- session1: the query should finish properly
+1<:
+
+-- session1: issue a query that has more than one active QEs
+1: select count(*) from rqt_it_iq a, rqt_it_iq b where a.c1 < b.c2 and a.c2 > (select count(*) from rqt_it_iq c where c.c2 >= a.c1);
+
+-- session2: Make sure there are more than one idle QEs
+2&: select pg_sleep(5);
+2<:
+2: select qe_count > 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+
+-- session1: issue the query that has only one active QE and memory-intensive in a transaction
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+1&: begin; select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20); commit;
+
+-- session1: the query should be terminated after being detected as Run-away
+1<:

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_in_transaction_idle_qe_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_in_transaction_idle_qe_setup.sql
@@ -1,0 +1,7 @@
+drop table if exists rqt_it_iq;
+
+create table rqt_it_iq(c1 int, c2 int);
+
+insert into rqt_it_iq select i, i+1 from generate_series(1,1000)i;
+
+analyze rqt_it_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_in_transaction_idle_qe_teardown.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_in_transaction_idle_qe_teardown.sql
@@ -1,0 +1,1 @@
+drop table if exists rqt_it_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_no_transaction_idle_qe.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_no_transaction_idle_qe.sql
@@ -1,0 +1,32 @@
+-- @Description Testing TRQ: A query outside of a transaction, some QEs idle, terminates correctly after being detected as Run-away
+-- @author Zhongxian Gu
+-- @vlimMB 400 
+-- @slimMB 0
+-- @redzone 80
+
+-- session1: issue the query that has only one active QE; 
+-- content/segment = 0; size = 100MB; sleep = 15 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 100*1024*1024, 15);
+
+-- session2: Check the active QE, make sure there is only one.
+2&: select pg_sleep(2);
+2<:
+2: select qe_count < 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike 'select gp_allocate_palloc_gradual_test_all_segs%';
+
+-- session1: the query should finish properly
+1<:
+
+-- session1: issue a query that has more than one active QEs
+1: select count(*) from rqt_nt_iq a, rqt_nt_iq b where a.c1 < b.c2 and a.c2 > (select count(*) from rqt_nt_iq c where c.c2 >= a.c1);
+
+-- session2: Make sure there are more than one idle QEs
+2&: select pg_sleep(5);
+2<:
+2: select qe_count > 3 from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+
+-- session1: issue the query that has only one active QE and memory-intensive;
+-- content/segment = 0; size = 450MB; sleep = 20 sec
+1&: select gp_allocate_palloc_gradual_test_all_segs(0, 450*1024*1024, 20);
+
+-- session1: the query should be terminated after being detected as Run-away
+1<:

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_no_transaction_idle_qe_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_no_transaction_idle_qe_setup.sql
@@ -1,0 +1,7 @@
+drop table if exists rqt_nt_iq;
+
+create table rqt_nt_iq(c1 int, c2 int);
+
+insert into rqt_nt_iq select i, i+1 from generate_series(1,1000)i;
+
+analyze rqt_nt_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_no_transaction_idle_qe_teardown.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/enable_rqt_no_transaction_idle_qe_teardown.sql
@@ -1,0 +1,1 @@
+drop table if exists rqt_nt_iq;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/hit_vlim_2sessions.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/hit_vlim_2sessions.sql
@@ -1,0 +1,17 @@
+-- @Description Ensures that two sessions together allocate more than VLIM and one of them errors out
+-- @author George Caragea
+-- @vlimMB 900 
+-- @slimMB 600
+
+-- content/segment = 0; size = 455MB; sleep = 20 sec; crit_section = false
+1&: select gp_allocate_palloc_test_all_segs(0, 455 * 1024 * 1024, 20, false);
+
+-- give session 1 enough time to do the allocation
+2&: select pg_sleep(10);
+2<:
+
+-- content/segment = 0; size = 450MB; sleep = 20 sec; crit_section = false
+2&: select gp_allocate_palloc_test_all_segs(0, 450 * 1024 * 1024, 20, false);
+
+1<:
+2<:

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone.sql
@@ -1,0 +1,32 @@
+-- @Description Testing TRQ: After cleaning up an RSS, system is still in red-zone, and the same session is the top consumer, check the system is stable.
+-- @author Zhongxian Gu
+-- @vlimMB 1100 
+-- @slimMB 0
+-- @redzone 10
+
+-- session1: issue a query that consumes large memory and will be terminated as a runaway query
+-- content/segment = 0; size = 120MB; sleep = 1 sec
+1: select gp_allocate_top_memory_ctxt_test_all_segs(0, 120 * 1024 * 1024, 1);
+
+-- session2: query the view to make sure it's idle yet still consumes memory
+2&: select pg_sleep(2);
+2<:
+
+2: select vmem_mb > 110, is_runaway from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+
+-- session2: issue queries with small usage of memory but processing many tuples to check system stability
+-- these queries should run and finish without error
+2&: select count(*) from test as a where a.c2 >= (select sum(b.c1) from test as b where a.c1 > b.c2);
+
+2<:
+
+2&: select count(*) from test as a where a.c2 >= (select sum(b.c1) from test as b where a.c1 > b.c2);
+
+2<:
+
+2&: select count(*) from test as a where a.c2 >= (select sum(b.c1) from test as b where a.c1 > b.c2);
+
+2<:
+
+-- session2: issue a query that consumes larger memory than the idle process and it should be terminated as primary-runaway query
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 125 * 1024 * 1024, 1);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_non_superuser.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_non_superuser.sql
@@ -1,0 +1,22 @@
+-- @Description Testing TRQ: After cleaning up an RSS, system is still in red-zone, and the same session is the top consumer
+-- @author Zhongxian Gu
+-- @vlimMB 1100 
+-- @slimMB 0
+-- @redzone 10
+
+-- session1: log in as non-super use and wait to issue a query
+1: set role rqt_temp_role;
+
+-- session2: issue a query that consumes large memory and will be terminated as a runaway query
+-- content/segment = 0; size = 120MB; sleep = 1 sec
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 120 * 1024 * 1024, 1);
+
+-- session3: query the view to make sure it's idle yet still consumes memory
+3&: select pg_sleep(2);
+3<:
+
+3: select vmem_mb > 110, is_runaway from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE>%';
+
+-- session1: A non-super user issues a query. This query should be terminated.
+1: select count(*) from test as a where a.c2 >= (select sum(b.c1) from test as b where a.c1 > b.c2);
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_non_superuser_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_non_superuser_setup.sql
@@ -1,0 +1,14 @@
+drop table if exists test;
+
+create table test(c1 int, c2 int);
+
+insert into test select i, i+1 from generate_series(1,5000)i;
+
+analyze test;
+
+drop role if exists rqt_temp_role;
+
+create role rqt_temp_role;
+
+grant all on test to rqt_temp_role;
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_non_superuser_teardown.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_non_superuser_teardown.sql
@@ -1,0 +1,3 @@
+drop table if exists test;
+
+drop role if exists rqt_temp_role;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_setup.sql
@@ -1,0 +1,7 @@
+drop table if exists test;
+
+create table test(c1 int, c2 int);
+
+insert into test select i, i+1 from generate_series(1,5000)i;
+
+analyze test;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_teardown.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/idle_rss_red_zone_teardown.sql
@@ -1,0 +1,1 @@
+drop table if exists test;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/init_file
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/init_file
@@ -1,0 +1,15 @@
+-- start_matchsubs
+m/DETAIL:  Per-query VM protect limit reached/
+s/DETAIL:  Per-query VM protect limit reached.*/DETAIL:  Per-query VM protect limit reached/g
+
+
+m/DETAIL:  VM Protect failed to allocate/
+s/DETAIL:  VM Protect failed to allocate.*/DETAIL:  VM Protect failed to allocate/g
+
+m/ERROR:  Canceling query because of high VMEM usage/
+s/ERROR:  Canceling query because of high VMEM usage.*/ERROR:  Canceling query because of high VMEM usage/g
+
+m/ERROR:  Error on receive from/
+s/ERROR:  Error on receive from.*/ERROR:  Error on receive from/g
+
+-- end_matchsubs

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/recover_from_segv.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/recover_from_segv.sql
@@ -1,0 +1,45 @@
+-- @Description Testing TRQ: after a PM reset, correct reinitialization of VMEM and SessionState
+-- @author Zhongxian Gu
+-- @vlimMB 1000 
+-- @slimMB 0
+-- @skip FATAL handling from UDFs has changed since older version. Renable after fixing that.
+-- @redzone 80
+
+-- Check that only one session is running
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+
+-- Check the vmem tracked for only one session running
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+
+-- Start another session; set gp_debug_linger to 0 so we clean up immediately on FATAL
+2: set gp_debug_linger = 0;
+
+-- Set the timeout to keep idle QEs around to 60 seconds so they don't get cleaned up 
+2: set gp_vmem_idle_resource_timeout = 60000;
+
+-- Check the vmem tracked for when two sessions are running, second one still idle
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+
+-- content/segment = 0; size = 250MB; sleep = 1 sec
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 250 * 1024 * 1024, 1);
+
+1&: select pg_sleep(2);
+1<:
+
+-- Check that now we have two sessions active
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+
+-- Check the vmem tracked for when two sessions are running, one using some memory
+1: select (vmem_mb > 745 AND vmem_mb < 751) from gp_available_vmem_mb_test_all_segs where segid = 0;
+
+
+-- Have session 2 to trigger a PM reset
+--  content/segment = 0; FAULT_TYPE_FATAL = 4 (SEGV); sleep = 0
+2: select gp_inject_fault_test_all_segs(0, 4, 0);
+
+-- only one active session on segment 0 should be left
+3: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+
+-- Check that now vmem tracked is back to normal
+3: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount.sql
@@ -1,0 +1,26 @@
+-- @Description Ensures that pinCount is released on SessionState after QE cleaned up by idle gang
+-- @author Zhongxian
+
+-- session1: issue the testing query
+1: set gp_vmem_idle_resource_timeout=20000;
+1&: select count(*), pg_sleep(5) from rp a where a.c1 > (select sum(c1) from rp b where b.c2 < a.c1);
+
+-- session2: query the view to see query in session1 is running
+2&: select pg_sleep(2);
+2<:
+2: select count(*) from session_state.session_level_memory_consumption where segid= 0 and current_query ilike 'select count(*), pg_sleep(5) from rp%' and qe_count > 0;
+
+-- session1: the query ends
+1<:
+
+-- session2: query the view to make sure there is an idle process there
+2: select count(*) from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE%' and qe_count > 0;
+
+2&: select pg_sleep(30);
+2<:
+
+-- session2: make sure the idle process is gone
+2: select count(*) from session_state.session_level_memory_consumption where segid= 0 and current_query ilike '<IDLE%';
+
+2&: select pg_sleep(5);
+2<:

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount_fatal.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount_fatal.sql
@@ -1,0 +1,38 @@
+-- @Description Ensures that pinCount is released on SessionState when a QE calls elog(FATAL)
+-- @author George Caragea
+-- @vlimMB 1100 
+-- @slimMB 0
+-- @skip FATAL handling from UDFs has changed since older version. Renable after fixing that.
+-- @redzone 80
+
+-- Check that only one session is running
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+
+-- Start another session; set gp_debug_linger to 0 so we clean up immediately on FATAL
+2: set gp_debug_linger = 0;
+
+-- Set the timeout to keep idle QEs around to 60 seconds so they don't get cleaned up 
+2: set gp_vmem_idle_resource_timeout = 60000;
+
+-- content/segment = 0; size = 120MB; sleep = 1 sec
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 120 * 1024 * 1024, 1);
+
+1&: select pg_sleep(2);
+1<:
+
+-- Check that now we have two sessions active
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+
+-- Have session 2 call a elog(FATAL) on segment 0
+--  content/segment = 0; FAULT_TYPE_FATAL = 2; sleep = 0
+2: select gp_inject_fault_test_all_segs(0, 2, 0);
+
+-- make sure session 2 is still around and accepting queries
+2: select 1;
+
+1&: select pg_sleep(5);
+1<:
+
+-- only one active session on segment 0 should be left
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount_setup.sql
@@ -1,0 +1,7 @@
+drop table if exists rp;
+
+create table rp(c1 int, c2 int);
+
+insert into rp select i, i+1 from generate_series(1,1000)i;
+
+analyze rp;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount_teardown.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount_teardown.sql
@@ -1,0 +1,1 @@
+drop table if exists rp;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_vmem_fatal.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_vmem_fatal.sql
@@ -1,0 +1,50 @@
+-- @Description Ensures that all vmem is released when a QE calls elog(FATAL)
+-- @author George Caragea
+-- @vlimMB 1000 
+-- @slimMB 0
+-- @skip FATAL handling from UDFs has changed since older version. Renable after fixing that.
+-- @redzone 80
+
+-- Check that only one session is running
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+
+-- Check the vmem tracked for only one session running
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+
+-- Start another session; set gp_debug_linger to 0 so we clean up immediately on FATAL
+2: set gp_debug_linger = 0;
+
+-- Set the timeout to keep idle QEs around to 60 seconds so they don't get cleaned up 
+2: set gp_vmem_idle_resource_timeout = 60000;
+
+-- Check the vmem tracked for when two sessions are running, second one still idle
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;
+
+-- content/segment = 0; size = 250MB; sleep = 1 sec
+2: select gp_allocate_top_memory_ctxt_test_all_segs(0, 250 * 1024 * 1024, 1);
+
+1&: select pg_sleep(2);
+1<:
+
+-- Check that now we have two sessions active
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+
+-- Check the vmem tracked for when two sessions are running, one using some memory
+1: select (vmem_mb > 745 AND vmem_mb < 751) from gp_available_vmem_mb_test_all_segs where segid = 0;
+
+
+-- Have session 2 call a elog(FATAL) on segment 0
+--  content/segment = 0; FAULT_TYPE_FATAL = 2; sleep = 0
+2: select gp_inject_fault_test_all_segs(0, 2, 0);
+
+-- make sure session 2 is still around and accepting queries
+2: select 1;
+
+1&: select pg_sleep(5);
+1<:
+
+-- only one active session on segment 0 should be left
+1: select count(*) from session_state.session_level_memory_consumption where segid = 0;
+
+-- Check that now vmem tracked is back to normal
+1: select vmem_mb > 995 from gp_available_vmem_mb_test_all_segs where segid = 0;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/test_runaway_multisession.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/test_runaway_multisession.py
@@ -1,0 +1,77 @@
+import tinctest
+
+from mpp.gpdb.tests.storage.lib.sql_isolation_testcase import SQLIsolationTestCase
+from gppylib.commands.base import Command
+from resource_management.runaway_query.runaway_udf import *
+from mpp.lib.PSQL import PSQL
+
+def _set_VLIM_SLIM_REDZONEPERCENT(vlimMB, slimMB, activationPercent):
+
+    # Set up GUCs for VLIM (gp_vmem_protect_limit), SLIM (gp_vmem_limit_per_query) and RQT activation percent (runaway_detector_activation_percent)
+    tinctest.logger.info('Setting GUCs for VLIM gp_vmem_protect_limit=%dMB, SLIM gp_vmem_limit_per_query=%dMB and RQT activation percent runaway_detector_activation_percent=%s'%(vlimMB, slimMB, activationPercent))
+    Command('Run gpconfig to set GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v %d' % vlimMB).run(validateAfter=True)
+    Command('Run gpconfig to set GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_limit_per_query -v %d --skipvalidation' % (slimMB * 1024)).run(validateAfter=True)
+    Command('Run gpconfig to set GUC runaway_detector_activation_percent',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c runaway_detector_activation_percent -v %d --skipvalidation' % activationPercent).run(validateAfter=True)
+
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+def _reset_VLIM_SLIM_REDZONEPERCENT():
+
+    # Reset GUCs for VLIM (gp_vmem_protect_limit), SLIM (gp_vmem_limit_per_query) and RQT activation percent (runaway_detector_activation_percent)
+    tinctest.logger.info('Resetting GUCs for VLIM gp_vmem_protect_limit, SLIM gp_vmem_limit_per_query, and RQT activation percent runaway_detector_activation_percent')
+    Command('Run gpconfig to reset GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v 8192').run(validateAfter=True)
+    Command('Run gpconfig to reset GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -r gp_vmem_limit_per_query --skipvalidation').run(validateAfter=True)
+    Command('Run gpconfig to reset GUC runaway_detector_activation_percent',
+            'source $GPHOME/greenplum_path.sh;gpconfig -r runaway_detector_activation_percent --skipvalidation').run(validateAfter=True)
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+
+class RunawayMultiSessionTestCase(SQLIsolationTestCase):
+    """
+    @tags runaway_query_termination
+    """
+
+    '''
+    Test for Runaway Query Termination that require concurrent sessions
+    '''
+
+    def _infer_metadata(self):
+        super(RunawayMultiSessionTestCase, self)._infer_metadata()
+        try:
+            self.vlimMB = int(self._metadata.get('vlimMB', '8192')) # Default is 8192
+            self.slimMB = int(self._metadata.get('slimMB', '0')) # Default is 0
+            self.activationPercent = int(self._metadata.get('redzone', '80')) # Default is 80
+        except Exception:
+            tinctest.logger.info("Error getting the testcase related metadata")
+            raise
+    
+    def setUp(self):
+        _set_VLIM_SLIM_REDZONEPERCENT(self.vlimMB, self.slimMB, self.activationPercent)
+        return super(RunawayMultiSessionTestCase, self).setUp()
+
+    @classmethod
+    def setUpClass(cls):
+        super(RunawayMultiSessionTestCase, cls).setUpClass()
+        create_runaway_udf()
+        create_session_state_view()
+        
+    @classmethod
+    def tearDownClass(cls):
+        drop_session_state_view()
+        drop_runaway_udf()
+        _reset_VLIM_SLIM_REDZONEPERCENT()
+ 
+    
+    sql_dir = 'sql/'
+    ans_dir = 'expected'
+    out_dir = 'output/'
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/__init__.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/__init__.py
@@ -1,0 +1,220 @@
+from mpp.models.sql_tc import SQLTestCase
+from tinctest.models.scenario import ScenarioTestCase
+from gppylib.commands.base import Command
+import datetime, os, random, shutil, tinctest
+
+def _set_VLIM_SLIM_REDZONEPERCENT(vlimMB, slimMB, activationPercent):
+
+    # Set up GUCs for VLIM (gp_vmem_protect_limit), SLIM (gp_vmem_limit_per_query) and RQT activation percent (runaway_detector_activation_percent)
+    tinctest.logger.info('Setting GUCs for VLIM gp_vmem_protect_limit=%dMB, SLIM gp_vmem_limit_per_query=%dMB and RQT activation percent runaway_detector_activation_percent=%s'%(vlimMB, slimMB, activationPercent))
+    Command('Run gpconfig to set GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v %d' % vlimMB).run(validateAfter=True)
+    Command('Run gpconfig to set GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_limit_per_query -v %d --skipvalidation' % (slimMB * 1024)).run(validateAfter=True)
+    Command('Run gpconfig to set GUC runaway_detector_activation_percent',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c runaway_detector_activation_percent -v %d --skipvalidation' % activationPercent).run(validateAfter=True)
+
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+def _reset_VLIM_SLIM_REDZONEPERCENT():
+
+    # Reset GUCs for VLIM (gp_vmem_protect_limit), SLIM (gp_vmem_limit_per_query) and RQT activation percent (runaway_detector_activation_percent)
+    tinctest.logger.info('Resetting GUCs for VLIM gp_vmem_protect_limit, SLIM gp_vmem_limit_per_query, and RQT activation percent runaway_detector_activation_percent')
+    Command('Run gpconfig to reset GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v 8192').run(validateAfter=True)
+    Command('Run gpconfig to reset GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -r gp_vmem_limit_per_query --skipvalidation').run(validateAfter=True)
+    Command('Run gpconfig to reset GUC runaway_detector_activation_percent',
+            'source $GPHOME/greenplum_path.sh;gpconfig -r runaway_detector_activation_percent --skipvalidation').run(validateAfter=True)
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+class RQTBaseScenarioTestCase(ScenarioTestCase):
+    
+    def _infer_metadata(self):
+        """
+        Adding two new metadata 
+        1. concurrency specify the number of concurrent sessions
+        2. rqt_sql_test_case specify the class path of SQLTestCase that will be used for this scenario testcase
+        """
+        super(RQTBaseScenarioTestCase, self)._infer_metadata()
+        try:
+            self.concurrency = int(self._metadata.get('concurrency', '10'))
+            self.rqt_sql_test_case = self._metadata.get('rqt_sql_test_case', 'resource_management.runaway_query.runaway_query_scenario.RQTBaseSQLTestCase')
+        except:
+            raise
+    
+    def test_run(self):
+        # setup
+        test_case_setup = []
+        test_case_setup.append('%s.test_setup'%(self.rqt_sql_test_case))
+        self.test_case_scenario.append(test_case_setup)
+        
+        # run testcase
+        test_case_run = []
+        for count in range(self.concurrency):
+            test_case_run.append('%s.test_run'%(self.rqt_sql_test_case))
+        self.test_case_scenario.append(test_case_run)
+        
+        # teardown
+        test_case_teardown = []
+        test_case_teardown.append('%s.test_teardown'%(self.rqt_sql_test_case))
+        self.test_case_scenario.append(test_case_teardown)
+
+class RQTBaseSQLTestCase(SQLTestCase):
+    """
+    RQTBaseSQLTestCase is used in RQTBaseScenarioTestCase for specifying how we iteratively
+    run sql files for one session
+    """
+
+    sql_dir = 'sql/'
+    out_dir = 'output/'
+    
+    def _infer_metadata(self):
+        """
+        We introduce four new metadata 
+        1. vlimMB specify vmem protect limit
+        2. slimMB specify vmem limit per query
+        3. redzone specify red zone detection percentage range from 0 ~ 100
+        4. iterations specify how many iterations we will run 
+        """
+        super(RQTBaseSQLTestCase, self)._infer_metadata()
+        try:
+            self.vlimMB = int(self._metadata.get('vlimMB', '8192')) # Default is 8192
+            self.slimMB = int(self._metadata.get('slimMB', '0')) # Default is 0
+            self.redzone_percent = int(self._metadata.get('redzone', '80')) # Default is 80
+            self.iterations = int(self._metadata.get('iterations', '10')) # Default is 10
+        except:
+            raise
+    
+    def test_setup(self):
+        """
+        global setup function for the testcase 
+        The default one will setup the vlimMB, slimMB and runaway_detector_activation_percent
+        Overwirte it if you need to add more setup such as creating new tables and loading new data
+        """
+        _set_VLIM_SLIM_REDZONEPERCENT(self.vlimMB, self.slimMB, self.redzone_percent)
+        self.__cleanup_out_dir()
+        
+    def get_next_sql(self, sql_files, iteration_count):
+        """
+        Pick the next sql file to run in this session
+        By default we use random algorithm
+        Rewrite this function to support others
+        @arg sql_files list of sql files detected in the sql_dir
+        @arg iteration_count count of the current iteration 
+        """
+        return sql_files[random.randint(0, len(sql_files) - 1)]
+    
+    def test_run(self):
+        """
+        For each iteration, pick a sql file and run. 
+        """
+        sql_files = os.listdir(self.get_sql_dir())
+        for iter in range(1, self.iterations+1):
+            sql_file = self.get_next_sql(sql_files, iter)
+            current_timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
+            run_sql_file = os.path.join(self.get_out_dir(), '%s-iter%s-%s'%(current_timestamp, iter, sql_file))
+            shutil.copyfile(os.path.join(self.get_sql_dir(),sql_file), run_sql_file)
+            run_out_file = run_sql_file.replace('.sql','.out')
+            run_sql_cmd = 'psql -d %s -a -f %s &> %s'%(self.db_name, run_sql_file, run_out_file)
+            Command('Run Sql File', run_sql_cmd).run(validateAfter=True)     
+            end_timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
+            with open(run_out_file, 'a') as o:
+                o.write('\nFINISH_TIME:%s'%end_timestamp)
+                
+    def __cleanup_out_dir(self):
+        """
+        Remove existing ans and sql files in out dir to avoid wrong results
+        """
+        for ff in os.listdir(self.get_out_dir()):
+            if ff.endswith('.sql') or ff.endswith('.out') or ff.endswith('.txt'):
+                os.remove(os.path.join(self.get_out_dir(), ff))
+                
+    def __summary_result(self):
+        """
+        Summarize the concurrency test into runtime.txt file 
+        """
+        
+        test_fail = False
+        timeline = {}
+        for ff in os.listdir(self.get_out_dir()):
+            if ff.endswith('.out'):
+                query_name = ff[ff.index('iter'):ff.index('.')]
+                temp_line = ff[:ff.index('-iter')]
+                start_time = temp_line[:temp_line.rindex('-')]
+                self.__update_result(timeline, start_time, query_name, 0)
+        
+                lines = [line.strip() for line in open(os.path.join(self.get_out_dir(), ff))]
+                b_error = False
+                error_reason = ''
+                finish_time = ''
+                for line in lines:
+                    if line.find('ERROR') != -1:
+                        b_error = True
+                        if line.find('Out of memory') != -1:
+                            error_reason = 'OOM'
+                            test_fail = True
+                        elif line.find('red zone') != -1:
+                            error_reason = 'Hit red zone'
+                        elif line.find('current transaction is aborted') != -1:
+                            continue
+                        else:
+                            error_reason = 'Unexpected'
+                            test_fail = True
+                    elif line.find('FINISH_TIME') != -1:
+                        finish_time = line[line.index(':')+1:line.rindex('-')]
+                if b_error:
+                    self.__update_result(timeline, finish_time, '%s (%s)'%(query_name, error_reason), 2)
+                else:
+                    self.__update_result(timeline, finish_time, query_name, 1)
+        result = ''
+        
+        arr_timeline = []
+        arr_timeline.extend(timeline.keys())
+        arr_timeline.sort()
+        
+        result += self.__print_timeline(arr_timeline[0], timeline[arr_timeline[0]])
+        for i in range(1, len(arr_timeline)):
+            cur_time = arr_timeline[i]
+            result +='|\n|\n'
+            result += self.__print_timeline(cur_time, timeline[cur_time])
+            
+        with open(os.path.join(self.get_out_dir(),'runtime.txt'), 'w') as o:
+            o.write(result)
+        if test_fail:
+            raise Exception("Test failed: error reason %s" % error_reason)
+        
+        
+    def __print_timeline(self, timestamp, bullet):
+        result = 'Time:%s\n'%timestamp
+        if len(bullet['query_start']) != 0:
+            result+= 'Query started (%s):%s\n'%(len(bullet['query_start']), ','.join(bullet['query_start']))
+        if len(bullet['query_finish']) != 0:
+            result+= 'Query finished (%s):%s\n'%(len(bullet['query_finish']), ','.join(bullet['query_finish']))
+        if len(bullet['query_error']) != 0:
+            result+= 'Query errored (%s):%s\n'%(len(bullet['query_error']), ','.join(bullet['query_error']))
+        return result
+
+    def test_teardown(self):
+        self.__summary_result()
+        _reset_VLIM_SLIM_REDZONEPERCENT()
+        
+    def __update_result(self, dict_timeline, timestamp, query_name, update_type):
+        if timestamp not in dict_timeline.keys():
+            dict_timeline[timestamp] = {}
+            dict_timeline[timestamp]['query_start'] = []
+            dict_timeline[timestamp]['query_finish'] = []
+            dict_timeline[timestamp]['query_error'] = []
+            
+        if update_type == 0:
+            dict_timeline[timestamp]['query_start'].append(query_name)
+        elif update_type == 1:
+            dict_timeline[timestamp]['query_finish'].append(query_name)
+        elif update_type == 2:
+            dict_timeline[timestamp]['query_error'].append(query_name)
+        else:
+            raise Exception("Invalid update type: %d" % update_type)

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query01.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query01.sql
@@ -1,0 +1,27 @@
+-- @author balasr3
+-- @description TPC-H query01
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+      l_returnflag,
+      l_linestatus,
+      sum(l_quantity) as sum_qty,
+      sum(l_extendedprice) as sum_base_price,
+      sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+      sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+      avg(l_quantity) as avg_qty,
+      avg(l_extendedprice) as avg_price,
+      avg(l_discount) as avg_disc,
+      count(*) as count_order
+from
+      lineitem
+where
+      l_shipdate <= date '1998-12-01' - interval '114 day'
+group by
+      l_returnflag,
+      l_linestatus
+order by
+      l_returnflag,
+      l_linestatus;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query01_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query01_subtransaction.sql
@@ -1,0 +1,35 @@
+-- @author balasr3
+-- @description TPC-H query01
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+      l_returnflag,
+      l_linestatus,
+      sum(l_quantity) as sum_qty,
+      sum(l_extendedprice) as sum_base_price,
+      sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+      sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+      avg(l_quantity) as avg_qty,
+      avg(l_extendedprice) as avg_price,
+      avg(l_discount) as avg_disc,
+      count(*) as count_order
+from
+      lineitem
+where
+      l_shipdate <= date '1998-12-01' - interval '114 day'
+group by
+      l_returnflag,
+      l_linestatus
+order by
+      l_returnflag,
+      l_linestatus;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query02.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query02.sql
@@ -1,0 +1,48 @@
+-- @author balasr3
+-- @description TPC-H query02
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+	s_acctbal,
+	s_name,
+	n_name,
+	p_partkey,
+	p_mfgr,
+	s_address,
+	s_phone,
+	s_comment
+from
+	part,
+	supplier,
+	partsupp,
+	nation,
+	region
+where
+	p_partkey = ps_partkey
+	and s_suppkey = ps_suppkey
+	and p_size = 42
+	and p_type like '%NICKEL'
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'MIDDLE EAST'
+	and ps_supplycost = (
+		select
+			min(ps_supplycost)
+		from
+			partsupp, supplier,
+			nation, region
+		where
+			p_partkey = ps_partkey
+			and s_suppkey = ps_suppkey
+			and s_nationkey = n_nationkey
+			and n_regionkey = r_regionkey
+			and r_name = 'MIDDLE EAST'
+	)
+order by
+	s_acctbal desc,
+	n_name,
+	s_name,
+	p_partkey
+LIMIT 100;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query02_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query02_subtransaction.sql
@@ -1,0 +1,56 @@
+-- @author balasr3
+-- @description TPC-H query02
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+	s_acctbal,
+	s_name,
+	n_name,
+	p_partkey,
+	p_mfgr,
+	s_address,
+	s_phone,
+	s_comment
+from
+	part,
+	supplier,
+	partsupp,
+	nation,
+	region
+where
+	p_partkey = ps_partkey
+	and s_suppkey = ps_suppkey
+	and p_size = 42
+	and p_type like '%NICKEL'
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'MIDDLE EAST'
+	and ps_supplycost = (
+		select
+			min(ps_supplycost)
+		from
+			partsupp, supplier,
+			nation, region
+		where
+			p_partkey = ps_partkey
+			and s_suppkey = ps_suppkey
+			and s_nationkey = n_nationkey
+			and n_regionkey = r_regionkey
+			and r_name = 'MIDDLE EAST'
+	)
+order by
+	s_acctbal desc,
+	n_name,
+	s_name,
+	p_partkey
+LIMIT 100;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query03.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query03.sql
@@ -1,0 +1,29 @@
+-- @author balasr3
+-- @description TPC-H query03
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                l_orderkey,
+                sum(l_extendedprice * (1 - l_discount)) as revenue,
+                o_orderdate,
+                o_shippriority
+from
+                customer,
+                orders,
+                lineitem
+where
+                c_mktsegment = 'BUILDING'
+                and c_custkey = o_custkey
+                and l_orderkey = o_orderkey
+                and o_orderdate < date '1995-03-26'
+                and l_shipdate > date '1995-03-26'
+group by
+                l_orderkey,
+                o_orderdate,
+                o_shippriority
+order by
+                revenue desc,
+                o_orderdate
+LIMIT 10;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query03_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query03_subtransaction.sql
@@ -1,0 +1,37 @@
+-- @author balasr3
+-- @description TPC-H query03
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                l_orderkey,
+                sum(l_extendedprice * (1 - l_discount)) as revenue,
+                o_orderdate,
+                o_shippriority
+from
+                customer,
+                orders,
+                lineitem
+where
+                c_mktsegment = 'BUILDING'
+                and c_custkey = o_custkey
+                and l_orderkey = o_orderkey
+                and o_orderdate < date '1995-03-26'
+                and l_shipdate > date '1995-03-26'
+group by
+                l_orderkey,
+                o_orderdate,
+                o_shippriority
+order by
+                revenue desc,
+                o_orderdate
+LIMIT 10;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query04.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query04.sql
@@ -1,0 +1,27 @@
+-- @author balasr3
+-- @description TPC-H query04
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                o_orderpriority,
+                count(*) as order_count
+from
+                orders
+where
+                o_orderdate >= date '1996-03-01'
+                and o_orderdate < date '1996-03-01' + interval '3 month'
+                and exists (
+                        select
+                                *
+                        from
+                                lineitem
+                        where
+                                l_orderkey = o_orderkey
+                                and l_commitdate < l_receiptdate
+                )
+group by
+                o_orderpriority
+order by
+                o_orderpriority;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query04_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query04_subtransaction.sql
@@ -1,0 +1,35 @@
+-- @author balasr3
+-- @description TPC-H query04
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                o_orderpriority,
+                count(*) as order_count
+from
+                orders
+where
+                o_orderdate >= date '1996-03-01'
+                and o_orderdate < date '1996-03-01' + interval '3 month'
+                and exists (
+                        select
+                                *
+                        from
+                                lineitem
+                        where
+                                l_orderkey = o_orderkey
+                                and l_commitdate < l_receiptdate
+                )
+group by
+                o_orderpriority
+order by
+                o_orderpriority;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query05.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query05.sql
@@ -1,0 +1,29 @@
+-- @author balasr3
+-- @description TPC-H query05
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select  n_name,
+       		sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+                customer,
+                orders,
+                lineitem,
+                supplier,
+                nation,
+                region
+where
+                c_custkey = o_custkey
+                and l_orderkey = o_orderkey
+                and l_suppkey = s_suppkey
+                and c_nationkey = s_nationkey
+                and s_nationkey = n_nationkey
+                and n_regionkey = r_regionkey
+                and r_name = 'ASIA'
+                and o_orderdate >= date '1994-01-01'
+                and o_orderdate < date '1994-01-01' + interval '1 year'
+group by 
+	        n_name
+order by
+	        revenue desc;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query05_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query05_subtransaction.sql
@@ -1,0 +1,37 @@
+-- @author balasr3
+-- @description TPC-H query05
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select  n_name,
+       		sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+                customer,
+                orders,
+                lineitem,
+                supplier,
+                nation,
+                region
+where
+                c_custkey = o_custkey
+                and l_orderkey = o_orderkey
+                and l_suppkey = s_suppkey
+                and c_nationkey = s_nationkey
+                and s_nationkey = n_nationkey
+                and n_regionkey = r_regionkey
+                and r_name = 'ASIA'
+                and o_orderdate >= date '1994-01-01'
+                and o_orderdate < date '1994-01-01' + interval '1 year'
+group by 
+	        n_name
+order by
+	        revenue desc;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query06.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query06.sql
@@ -1,0 +1,15 @@
+-- @author balasr3
+-- @description TPC-H query06
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                sum(l_extendedprice * l_discount) as revenue
+from
+                lineitem
+where
+                l_shipdate >= date '1993-01-01'
+                and l_shipdate < date '1993-01-01' + interval '1 year'
+                and l_discount between 0.03 - 0.01 and 0.03 + 0.01
+                and l_quantity < 24;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query06_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query06_subtransaction.sql
@@ -1,0 +1,23 @@
+-- @author balasr3
+-- @description TPC-H query06
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                sum(l_extendedprice * l_discount) as revenue
+from
+                lineitem
+where
+                l_shipdate >= date '1993-01-01'
+                and l_shipdate < date '1993-01-01' + interval '1 year'
+                and l_discount between 0.03 - 0.01 and 0.03 + 0.01
+                and l_quantity < 24;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query07.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query07.sql
@@ -1,0 +1,45 @@
+-- @author balasr3
+-- @description TPC-H query07
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                supp_nation,
+                cust_nation,
+                l_year,
+                sum(volume) as revenue
+        from
+                (
+                        select
+                                n1.n_name as supp_nation,
+                                n2.n_name as cust_nation,
+                                extract(year from l_shipdate) as l_year,
+                                l_extendedprice * (1 - l_discount) as volume
+                        from
+                                supplier,
+                                lineitem,
+                                orders,
+                                customer,
+                                nation n1,
+                                nation n2
+                        where
+                                s_suppkey = l_suppkey
+                                and o_orderkey = l_orderkey
+                                and c_custkey = o_custkey
+                                and s_nationkey = n1.n_nationkey
+                                and c_nationkey = n2.n_nationkey
+                                and (
+                                        (n1.n_name = 'JORDAN' and n2.n_name = 'INDIA')
+                                        or (n1.n_name = 'INDIA' and n2.n_name = 'JORDAN')
+                                )
+                                and l_shipdate between date '1995-01-01' and date '1996-12-31'
+                ) as shipping
+        group by
+                supp_nation,
+                cust_nation,
+                l_year
+        order by
+                supp_nation,
+                cust_nation,
+                l_year;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query07_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query07_subtransaction.sql
@@ -1,0 +1,53 @@
+-- @author balasr3
+-- @description TPC-H query07
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                supp_nation,
+                cust_nation,
+                l_year,
+                sum(volume) as revenue
+        from
+                (
+                        select
+                                n1.n_name as supp_nation,
+                                n2.n_name as cust_nation,
+                                extract(year from l_shipdate) as l_year,
+                                l_extendedprice * (1 - l_discount) as volume
+                        from
+                                supplier,
+                                lineitem,
+                                orders,
+                                customer,
+                                nation n1,
+                                nation n2
+                        where
+                                s_suppkey = l_suppkey
+                                and o_orderkey = l_orderkey
+                                and c_custkey = o_custkey
+                                and s_nationkey = n1.n_nationkey
+                                and c_nationkey = n2.n_nationkey
+                                and (
+                                        (n1.n_name = 'JORDAN' and n2.n_name = 'INDIA')
+                                        or (n1.n_name = 'INDIA' and n2.n_name = 'JORDAN')
+                                )
+                                and l_shipdate between date '1995-01-01' and date '1996-12-31'
+                ) as shipping
+        group by
+                supp_nation,
+                cust_nation,
+                l_year
+        order by
+                supp_nation,
+                cust_nation,
+                l_year;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query08.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query08.sql
@@ -1,0 +1,43 @@
+-- @author balasr3
+-- @description TPC-H query08
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                o_year,
+                sum(case
+                        when nation = 'RUSSIA' then volume
+                        else 0
+                end) / sum(volume) as mkt_share
+        from
+                (
+                        select
+                                extract(year from o_orderdate) as o_year,
+                                l_extendedprice * (1 - l_discount) as volume,
+                                n2.n_name as nation
+                        from
+                                part,
+                                supplier,
+                                lineitem,
+                                orders,
+                                customer,
+                                nation n1,
+                                nation n2,
+                                region
+                        where
+                                p_partkey = l_partkey
+                                and s_suppkey = l_suppkey
+                                and l_orderkey = o_orderkey
+                                and o_custkey = c_custkey
+                                and c_nationkey = n1.n_nationkey
+                                and n1.n_regionkey = r_regionkey
+                                and r_name = 'EUROPE'
+                                and s_nationkey = n2.n_nationkey
+                                and o_orderdate between date '1995-01-01' and date '1996-12-31'
+                                and p_type = 'LARGE BRUSHED STEEL'
+                ) as all_nations
+        group by
+                o_year
+        order by
+                o_year;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query08_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query08_subtransaction.sql
@@ -1,0 +1,51 @@
+-- @author balasr3
+-- @description TPC-H query08
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                o_year,
+                sum(case
+                        when nation = 'RUSSIA' then volume
+                        else 0
+                end) / sum(volume) as mkt_share
+        from
+                (
+                        select
+                                extract(year from o_orderdate) as o_year,
+                                l_extendedprice * (1 - l_discount) as volume,
+                                n2.n_name as nation
+                        from
+                                part,
+                                supplier,
+                                lineitem,
+                                orders,
+                                customer,
+                                nation n1,
+                                nation n2,
+                                region
+                        where
+                                p_partkey = l_partkey
+                                and s_suppkey = l_suppkey
+                                and l_orderkey = o_orderkey
+                                and o_custkey = c_custkey
+                                and c_nationkey = n1.n_nationkey
+                                and n1.n_regionkey = r_regionkey
+                                and r_name = 'EUROPE'
+                                and s_nationkey = n2.n_nationkey
+                                and o_orderdate between date '1995-01-01' and date '1996-12-31'
+                                and p_type = 'LARGE BRUSHED STEEL'
+                ) as all_nations
+        group by
+                o_year
+        order by
+                o_year;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query09.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query09.sql
@@ -1,0 +1,38 @@
+-- @author balasr3
+-- @description TPC-H query09
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                nation,
+                o_year,
+                sum(amount) as sum_profit
+        from
+                (
+                        select
+                                n_name as nation,
+                                extract(year from o_orderdate) as o_year,
+                                l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+                        from
+                                part,
+                                supplier,
+                                lineitem,
+                                partsupp,
+                                orders,
+                                nation
+                        where
+                                s_suppkey = l_suppkey
+                                and ps_suppkey = l_suppkey
+                                and ps_partkey = l_partkey
+                                and p_partkey = l_partkey
+                                and o_orderkey = l_orderkey
+                                and s_nationkey = n_nationkey
+                                and p_name like '%light%'
+                ) as profit
+        group by
+                nation,
+                o_year
+        order by
+                nation,
+                o_year desc;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query09_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query09_subtransaction.sql
@@ -1,0 +1,46 @@
+-- @author balasr3
+-- @description TPC-H query09
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                nation,
+                o_year,
+                sum(amount) as sum_profit
+        from
+                (
+                        select
+                                n_name as nation,
+                                extract(year from o_orderdate) as o_year,
+                                l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+                        from
+                                part,
+                                supplier,
+                                lineitem,
+                                partsupp,
+                                orders,
+                                nation
+                        where
+                                s_suppkey = l_suppkey
+                                and ps_suppkey = l_suppkey
+                                and ps_partkey = l_partkey
+                                and p_partkey = l_partkey
+                                and o_orderkey = l_orderkey
+                                and s_nationkey = n_nationkey
+                                and p_name like '%light%'
+                ) as profit
+        group by
+                nation,
+                o_year
+        order by
+                nation,
+                o_year desc;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query10.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query10.sql
@@ -1,0 +1,38 @@
+-- @author balasr3
+-- @description TPC-H query10
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                c_custkey,
+                c_name,
+                sum(l_extendedprice * (1 - l_discount)) as revenue,
+                c_acctbal,
+                n_name,
+                c_address,
+                c_phone,
+                c_comment
+        from
+                customer,
+                orders,
+                lineitem,
+                nation
+        where
+                c_custkey = o_custkey
+                and l_orderkey = o_orderkey
+                and o_orderdate >= date '1993-07-01'
+                and o_orderdate < date '1993-07-01' + interval '3 month'
+                and l_returnflag = 'R'
+                and c_nationkey = n_nationkey
+        group by
+                c_custkey,
+                c_name,
+                c_acctbal,
+                c_phone,
+                n_name,
+                c_address,
+                c_comment
+        order by
+                revenue desc
+        LIMIT 20;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query10_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query10_subtransaction.sql
@@ -1,0 +1,46 @@
+-- @author balasr3
+-- @description TPC-H query10
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                c_custkey,
+                c_name,
+                sum(l_extendedprice * (1 - l_discount)) as revenue,
+                c_acctbal,
+                n_name,
+                c_address,
+                c_phone,
+                c_comment
+        from
+                customer,
+                orders,
+                lineitem,
+                nation
+        where
+                c_custkey = o_custkey
+                and l_orderkey = o_orderkey
+                and o_orderdate >= date '1993-07-01'
+                and o_orderdate < date '1993-07-01' + interval '3 month'
+                and l_returnflag = 'R'
+                and c_nationkey = n_nationkey
+        group by
+                c_custkey,
+                c_name,
+                c_acctbal,
+                c_phone,
+                n_name,
+                c_address,
+                c_comment
+        order by
+                revenue desc
+        LIMIT 20;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query11.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query11.sql
@@ -1,0 +1,33 @@
+-- @author balasr3
+-- @description TPC-H query11
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                ps_partkey,
+                sum(ps_supplycost * ps_availqty) as value
+        from
+                partsupp,
+                supplier,
+                nation
+        where
+                ps_suppkey = s_suppkey
+                and s_nationkey = n_nationkey
+                and n_name = 'BRAZIL'
+        group by
+                ps_partkey having
+                        sum(ps_supplycost * ps_availqty) > (
+                                select
+                                        sum(ps_supplycost * ps_availqty) * 0.0000015625
+                                from
+                                        partsupp,
+                                        supplier,
+                                        nation
+                                where
+                                        ps_suppkey = s_suppkey
+                                        and s_nationkey = n_nationkey
+                                        and n_name = 'BRAZIL'
+                        )
+        order by
+                value desc;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query11_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query11_subtransaction.sql
@@ -1,0 +1,41 @@
+-- @author balasr3
+-- @description TPC-H query11
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                ps_partkey,
+                sum(ps_supplycost * ps_availqty) as value
+        from
+                partsupp,
+                supplier,
+                nation
+        where
+                ps_suppkey = s_suppkey
+                and s_nationkey = n_nationkey
+                and n_name = 'BRAZIL'
+        group by
+                ps_partkey having
+                        sum(ps_supplycost * ps_availqty) > (
+                                select
+                                        sum(ps_supplycost * ps_availqty) * 0.0000015625
+                                from
+                                        partsupp,
+                                        supplier,
+                                        nation
+                                where
+                                        ps_suppkey = s_suppkey
+                                        and s_nationkey = n_nationkey
+                                        and n_name = 'BRAZIL'
+                        )
+        order by
+                value desc;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query12.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query12.sql
@@ -1,0 +1,34 @@
+-- @author balasr3
+-- @description TPC-H query12
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                l_shipmode,
+                sum(case
+                        when o_orderpriority = '1-URGENT'
+                                or o_orderpriority = '2-HIGH'
+                                then 1
+                        else 0
+                end) as high_line_count,
+                sum(case
+                        when o_orderpriority <> '1-URGENT'
+                                and o_orderpriority <> '2-HIGH'
+                                then 1
+                        else 0
+                end) as low_line_count
+        from
+                orders,
+                lineitem
+        where
+                o_orderkey = l_orderkey
+                and l_shipmode in ('AIR', 'RAIL')
+                and l_commitdate < l_receiptdate
+                and l_shipdate < l_commitdate
+                and l_receiptdate >= date '1997-01-01'
+                and l_receiptdate < date '1997-01-01' + interval '1 year'
+        group by
+                l_shipmode
+        order by
+                l_shipmode;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query12_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query12_subtransaction.sql
@@ -1,0 +1,42 @@
+-- @author balasr3
+-- @description TPC-H query12
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                l_shipmode,
+                sum(case
+                        when o_orderpriority = '1-URGENT'
+                                or o_orderpriority = '2-HIGH'
+                                then 1
+                        else 0
+                end) as high_line_count,
+                sum(case
+                        when o_orderpriority <> '1-URGENT'
+                                and o_orderpriority <> '2-HIGH'
+                                then 1
+                        else 0
+                end) as low_line_count
+        from
+                orders,
+                lineitem
+        where
+                o_orderkey = l_orderkey
+                and l_shipmode in ('AIR', 'RAIL')
+                and l_commitdate < l_receiptdate
+                and l_shipdate < l_commitdate
+                and l_receiptdate >= date '1997-01-01'
+                and l_receiptdate < date '1997-01-01' + interval '1 year'
+        group by
+                l_shipmode
+        order by
+                l_shipmode;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query13.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query13.sql
@@ -1,0 +1,26 @@
+-- @author balasr3
+-- @description TPC-H query13
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                c_count,
+                count(*) as custdist
+        from
+                (
+                        select
+                                c_custkey,
+                                count(o_orderkey)
+                        from
+                                customer left outer join orders on
+                                        c_custkey = o_custkey
+                                        and o_comment not like '%express%accounts%'
+                        group by
+                                c_custkey
+                ) as c_orders (c_custkey, c_count)
+        group by
+                c_count
+        order by
+                custdist desc,
+                c_count desc;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query13_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query13_subtransaction.sql
@@ -1,0 +1,34 @@
+-- @author balasr3
+-- @description TPC-H query13
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                c_count,
+                count(*) as custdist
+        from
+                (
+                        select
+                                c_custkey,
+                                count(o_orderkey)
+                        from
+                                customer left outer join orders on
+                                        c_custkey = o_custkey
+                                        and o_comment not like '%express%accounts%'
+                        group by
+                                c_custkey
+                ) as c_orders (c_custkey, c_count)
+        group by
+                c_count
+        order by
+                custdist desc,
+                c_count desc;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query14.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query14.sql
@@ -1,0 +1,19 @@
+-- @author balasr3
+-- @description TPC-H query14
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                100.00 * sum(case
+                        when p_type like 'PROMO%'
+                                then l_extendedprice * (1 - l_discount)
+                        else 0
+                end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+        from
+                lineitem,
+                part
+        where
+                l_partkey = p_partkey
+                and l_shipdate >= date '1997-01-01'
+                and l_shipdate < date '1997-01-01' + interval '1 month';

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query14_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query14_subtransaction.sql
@@ -1,0 +1,27 @@
+-- @author balasr3
+-- @description TPC-H query14
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                100.00 * sum(case
+                        when p_type like 'PROMO%'
+                                then l_extendedprice * (1 - l_discount)
+                        else 0
+                end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+        from
+                lineitem,
+                part
+        where
+                l_partkey = p_partkey
+                and l_shipdate >= date '1997-01-01'
+                and l_shipdate < date '1997-01-01' + interval '1 month';
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query16.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query16.sql
@@ -1,0 +1,36 @@
+-- @author balasr3
+-- @description TPC-H query16
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select 
+                p_brand, 
+                p_type, 
+                p_size, 
+                count(distinct ps_suppkey) as supplier_cnt 
+        from 
+                partsupp, 
+                part 
+        where 
+                p_partkey = ps_partkey 
+                and p_brand <> 'Brand#55' 
+                and p_type not like 'SMALL POLISHED%' 
+                and p_size in (14, 36, 50, 23, 2, 19, 18, 43)
+                and ps_suppkey not in (
+                    select
+                        s_suppkey
+                    from
+                        supplier
+                    where
+                        s_comment like '%Customer%Complaints%'
+                ) 
+        group by 
+                p_brand, 
+                p_type, 
+                p_size 
+        order by 
+                supplier_cnt desc, 
+                p_brand, 
+                p_type, 
+                p_size;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query16_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query16_subtransaction.sql
@@ -1,0 +1,44 @@
+-- @author balasr3
+-- @description TPC-H query16
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select 
+                p_brand, 
+                p_type, 
+                p_size, 
+                count(distinct ps_suppkey) as supplier_cnt 
+        from 
+                partsupp, 
+                part 
+        where 
+                p_partkey = ps_partkey 
+                and p_brand <> 'Brand#55' 
+                and p_type not like 'SMALL POLISHED%' 
+                and p_size in (14, 36, 50, 23, 2, 19, 18, 43)
+                and ps_suppkey not in (
+                    select
+                        s_suppkey
+                    from
+                        supplier
+                    where
+                        s_comment like '%Customer%Complaints%'
+                ) 
+        group by 
+                p_brand, 
+                p_type, 
+                p_size 
+        order by 
+                supplier_cnt desc, 
+                p_brand, 
+                p_type, 
+                p_size;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query17.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query17.sql
@@ -1,0 +1,23 @@
+-- @author balasr3
+-- @description TPC-H query17
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+              sum(l_extendedprice) / 7.0 as avg_yearly
+        from
+              lineitem,
+              part
+        where
+              p_partkey = l_partkey
+              and p_brand = 'Brand#52'
+              and p_container = 'SM DRUM'
+              and l_quantity < (
+		select
+			0.2 * avg(l_quantity)
+		from
+			lineitem
+		where
+			l_partkey = p_partkey
+              );

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query17_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query17_subtransaction.sql
@@ -1,0 +1,31 @@
+-- @author balasr3
+-- @description TPC-H query17
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+              sum(l_extendedprice) / 7.0 as avg_yearly
+        from
+              lineitem,
+              part
+        where
+              p_partkey = l_partkey
+              and p_brand = 'Brand#52'
+              and p_container = 'SM DRUM'
+              and l_quantity < (
+		select
+			0.2 * avg(l_quantity)
+		from
+			lineitem
+		where
+			l_partkey = p_partkey
+              );
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query18.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query18.sql
@@ -1,0 +1,39 @@
+-- @author balasr3
+-- @description TPC-H query18
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                c_name,
+                c_custkey,
+                o_orderkey,
+                o_orderdate,
+                o_totalprice,
+                sum(l_quantity)
+        from
+                customer,
+                orders,
+                lineitem
+        where
+                o_orderkey in (
+                        select
+                                l_orderkey
+                        from
+                                lineitem
+                        group by
+                                l_orderkey having
+                                        sum(l_quantity) > 312
+                )
+                and c_custkey = o_custkey
+                and o_orderkey = l_orderkey
+        group by
+                c_name,
+                c_custkey,
+                o_orderkey,
+                o_orderdate,
+                o_totalprice
+        order by
+                o_totalprice desc,
+                o_orderdate
+        LIMIT 100;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query18_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query18_subtransaction.sql
@@ -1,0 +1,47 @@
+-- @author balasr3
+-- @description TPC-H query18
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                c_name,
+                c_custkey,
+                o_orderkey,
+                o_orderdate,
+                o_totalprice,
+                sum(l_quantity)
+        from
+                customer,
+                orders,
+                lineitem
+        where
+                o_orderkey in (
+                        select
+                                l_orderkey
+                        from
+                                lineitem
+                        group by
+                                l_orderkey having
+                                        sum(l_quantity) > 312
+                )
+                and c_custkey = o_custkey
+                and o_orderkey = l_orderkey
+        group by
+                c_name,
+                c_custkey,
+                o_orderkey,
+                o_orderdate,
+                o_totalprice
+        order by
+                o_totalprice desc,
+                o_orderdate
+        LIMIT 100;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query19.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query19.sql
@@ -1,0 +1,41 @@
+-- @author balasr3
+-- @description TPC-H query19
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+                sum(l_extendedprice* (1 - l_discount)) as revenue
+        from
+                lineitem,
+                part
+        where
+                (
+                        p_partkey = l_partkey
+                        and p_brand = 'Brand#12'
+                        and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+                        and l_quantity >= 3 and l_quantity <= 3 + 10
+                        and p_size between 1 and 5
+                        and l_shipmode in ('AIR', 'AIR REG')
+                        and l_shipinstruct = 'DELIVER IN PERSON'
+                )
+                or
+                (
+                        p_partkey = l_partkey
+                        and p_brand = 'Brand#31'
+                        and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+                        and l_quantity >= 11 and l_quantity <= 11 + 10
+                        and p_size between 1 and 10
+                        and l_shipmode in ('AIR', 'AIR REG')
+                        and l_shipinstruct = 'DELIVER IN PERSON'
+                )
+                or
+                (
+                        p_partkey = l_partkey
+                        and p_brand = 'Brand#14'
+                        and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+                        and l_quantity >= 30 and l_quantity <= 30 + 10
+                        and p_size between 1 and 15
+                        and l_shipmode in ('AIR', 'AIR REG')
+                        and l_shipinstruct = 'DELIVER IN PERSON'
+                );

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query19_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query19_subtransaction.sql
@@ -1,0 +1,49 @@
+-- @author balasr3
+-- @description TPC-H query19
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+                sum(l_extendedprice* (1 - l_discount)) as revenue
+        from
+                lineitem,
+                part
+        where
+                (
+                        p_partkey = l_partkey
+                        and p_brand = 'Brand#12'
+                        and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+                        and l_quantity >= 3 and l_quantity <= 3 + 10
+                        and p_size between 1 and 5
+                        and l_shipmode in ('AIR', 'AIR REG')
+                        and l_shipinstruct = 'DELIVER IN PERSON'
+                )
+                or
+                (
+                        p_partkey = l_partkey
+                        and p_brand = 'Brand#31'
+                        and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+                        and l_quantity >= 11 and l_quantity <= 11 + 10
+                        and p_size between 1 and 10
+                        and l_shipmode in ('AIR', 'AIR REG')
+                        and l_shipinstruct = 'DELIVER IN PERSON'
+                )
+                or
+                (
+                        p_partkey = l_partkey
+                        and p_brand = 'Brand#14'
+                        and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+                        and l_quantity >= 30 and l_quantity <= 30 + 10
+                        and p_size between 1 and 15
+                        and l_shipmode in ('AIR', 'AIR REG')
+                        and l_shipinstruct = 'DELIVER IN PERSON'
+                );
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query20.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query20.sql
@@ -1,0 +1,43 @@
+-- @author balasr3
+-- @description TPC-H query20
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select 
+                s_name,
+                s_address 
+        from 
+                supplier, 
+                nation 
+        where 
+                s_suppkey in( 
+                        select 
+                                ps_suppkey 
+                        from 
+                                partsupp
+                        where 
+				ps_partkey in (
+					select
+						p_partkey
+					from
+						part
+					where
+						p_name like 'antique%'
+				)
+			and ps_availqty > (
+				select
+					0.5 * sum(l_quantity)
+				from
+					lineitem
+				where
+					l_partkey = ps_partkey
+					and l_suppkey = ps_suppkey
+					and l_shipdate >= date '1994-01-01'
+					and l_shipdate < date '1994-01-01' + interval '1 year'
+			)
+		)
+                and s_nationkey = n_nationkey 
+                and n_name = 'GERMANY'
+        order by 
+                s_name;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query20_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query20_subtransaction.sql
@@ -1,0 +1,51 @@
+-- @author balasr3
+-- @description TPC-H query20
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select 
+                s_name,
+                s_address 
+        from 
+                supplier, 
+                nation 
+        where 
+                s_suppkey in( 
+                        select 
+                                ps_suppkey 
+                        from 
+                                partsupp
+                        where 
+				ps_partkey in (
+					select
+						p_partkey
+					from
+						part
+					where
+						p_name like 'antique%'
+				)
+			and ps_availqty > (
+				select
+					0.5 * sum(l_quantity)
+				from
+					lineitem
+				where
+					l_partkey = ps_partkey
+					and l_suppkey = ps_suppkey
+					and l_shipdate >= date '1994-01-01'
+					and l_shipdate < date '1994-01-01' + interval '1 year'
+			)
+		)
+                and s_nationkey = n_nationkey 
+                and n_name = 'GERMANY'
+        order by 
+                s_name;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query21.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query21.sql
@@ -1,0 +1,46 @@
+-- @author balasr3
+-- @description TPC-H query21
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select
+	s_name,
+	count(*) as numwait
+from
+	supplier,
+	lineitem l1,
+	orders,
+	nation
+where
+	s_suppkey = l1.l_suppkey
+	and o_orderkey = l1.l_orderkey
+	and o_orderstatus = 'F'
+	and l1.l_receiptdate > l1.l_commitdate
+	and exists (
+		select
+			*
+		from
+			lineitem l2
+		where
+			l2.l_orderkey = l1.l_orderkey
+			and l2.l_suppkey <> l1.l_suppkey
+	)
+	and not exists (
+		select
+			*
+		from
+			lineitem l3
+		where
+			l3.l_orderkey = l1.l_orderkey
+			and l3.l_suppkey <> l1.l_suppkey
+			and l3.l_receiptdate > l3.l_commitdate
+	)
+	and s_nationkey = n_nationkey
+	and n_name = 'ALGERIA'
+group by
+	s_name
+order by
+	numwait desc,
+	s_name
+        LIMIT 100;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query21_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query21_subtransaction.sql
@@ -1,0 +1,54 @@
+-- @author balasr3
+-- @description TPC-H query21
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select
+	s_name,
+	count(*) as numwait
+from
+	supplier,
+	lineitem l1,
+	orders,
+	nation
+where
+	s_suppkey = l1.l_suppkey
+	and o_orderkey = l1.l_orderkey
+	and o_orderstatus = 'F'
+	and l1.l_receiptdate > l1.l_commitdate
+	and exists (
+		select
+			*
+		from
+			lineitem l2
+		where
+			l2.l_orderkey = l1.l_orderkey
+			and l2.l_suppkey <> l1.l_suppkey
+	)
+	and not exists (
+		select
+			*
+		from
+			lineitem l3
+		where
+			l3.l_orderkey = l1.l_orderkey
+			and l3.l_suppkey <> l1.l_suppkey
+			and l3.l_receiptdate > l3.l_commitdate
+	)
+	and s_nationkey = n_nationkey
+	and n_name = 'ALGERIA'
+group by
+	s_name
+order by
+	numwait desc,
+	s_name
+        LIMIT 100;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query22.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query22.sql
@@ -1,0 +1,43 @@
+-- @author balasr3
+-- @description TPC-H query22
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+select 
+                cntrycode, 
+                count(*) as numcust, 
+                sum(c_acctbal) as totacctbal 
+        from 
+                ( 
+                        select 
+                                substring(c_phone from 1 for 2) as cntrycode, 
+                                c_acctbal 
+                        from 
+                                customer 
+                        where 
+                                substring(c_phone from 1 for 2) in 
+                                        ('11', '24', '25', '19', '30', '26', '16')
+                                and c_acctbal > ( 
+                                        select 
+                                                avg(c_acctbal) 
+                                        from 
+                                                customer 
+                                        where 
+                                                c_acctbal > 0.00 
+                                                and substring(c_phone from 1 for 2) in 
+                                                        ('11', '24', '25', '19', '30', '26', '16')
+                                ) 
+                                and not exists (
+					select
+						*
+					from
+						orders
+					where
+						o_custkey = c_custkey
+                                )
+                ) as custsale 
+        group by 
+                cntrycode 
+        order by 
+                cntrycode;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query22_subtransaction.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/sql/query22_subtransaction.sql
@@ -1,0 +1,51 @@
+-- @author balasr3
+-- @description TPC-H query22
+-- @created 2012-07-26 22:04:56
+-- @modified 2012-07-26 22:04:56
+-- @tags orca
+
+BEGIN;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'SAVEPOINT_NAME');
+SAVEPOINT sp_SAVEPOINT_NAME;
+INSERT INTO region (r_name, r_comment) values ('QUERY EXECUTION', 'inner_SAVEPOINT_NAME');
+
+select 
+                cntrycode, 
+                count(*) as numcust, 
+                sum(c_acctbal) as totacctbal 
+        from 
+                ( 
+                        select 
+                                substring(c_phone from 1 for 2) as cntrycode, 
+                                c_acctbal 
+                        from 
+                                customer 
+                        where 
+                                substring(c_phone from 1 for 2) in 
+                                        ('11', '24', '25', '19', '30', '26', '16')
+                                and c_acctbal > ( 
+                                        select 
+                                                avg(c_acctbal) 
+                                        from 
+                                                customer 
+                                        where 
+                                                c_acctbal > 0.00 
+                                                and substring(c_phone from 1 for 2) in 
+                                                        ('11', '24', '25', '19', '30', '26', '16')
+                                ) 
+                                and not exists (
+					select
+						*
+					from
+						orders
+					where
+						o_custkey = c_custkey
+                                )
+                ) as custsale 
+        group by 
+                cntrycode 
+        order by 
+                cntrycode;
+
+RELEASE SAVEPOINT sp_SAVEPOINT_NAME;
+COMMIT;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/test_runaway_query_scenario.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_scenario/test_runaway_query_scenario.py
@@ -1,0 +1,43 @@
+from resource_management.runaway_query.runaway_query_scenario import \
+    RQTBaseScenarioTestCase, RQTBaseSQLTestCase
+from gppylib.commands.base import Command
+import datetime, os, random, shutil, tinctest
+
+class RQTScenarioTestCase(RQTBaseScenarioTestCase):
+    """
+    @concurrency 20
+    @tags runaway_query_termination
+    @rqt_sql_test_case resource_management.runaway_query.runaway_query_scenario.test_runaway_query_scenario.RQTSQLTestCase
+    """
+
+class RQTSQLTestCase(RQTBaseSQLTestCase):
+    """
+    @db_name runaway_query
+    @vlimMB 1024
+    @redzone 10
+    @iterations 20
+    """
+    sql_dir = 'sql/'
+    out_dir = 'output/'
+    
+    def test_run(self):
+        """
+        For each iteration, pick a sql file and run. 
+        """
+        sql_files = os.listdir(self.get_sql_dir())
+        for iter in range(1, self.iterations+1):
+            sql_file = self.get_next_sql(sql_files, iter)
+            current_timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
+            savepoint_name = current_timestamp.replace('-','')
+            run_sql_file = os.path.join(self.get_out_dir(), '%s-iter%s-%s'%(current_timestamp, iter, sql_file))
+            # need to replace SAVEPOINT_NAME with timestamp
+            with open(run_sql_file, 'w') as o:
+                f = open(os.path.join(self.get_sql_dir(),sql_file), 'r')
+                text = f.read()
+                o.write(text.replace('SAVEPOINT_NAME', savepoint_name))  
+            run_out_file = run_sql_file.replace('.sql','.out')
+            run_sql_cmd = 'psql -d %s -a -f %s &> %s'%(self.db_name, run_sql_file, run_out_file)
+            Command('Run Sql File', run_sql_cmd).run(validateAfter=True)     
+            end_timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
+            with open(run_out_file, 'a') as o:
+                o.write('\nFINISH_TIME:%s'%end_timestamp)

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress1.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress1.ans
@@ -1,0 +1,52 @@
+-- @Description Test concurrency for runaway query termination
+-- @author Zhongxian Gu
+-- @concurrency 10
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 2, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 4, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 6, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 8, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 10, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress2.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress2.ans
@@ -1,0 +1,52 @@
+-- @Description Test concurrency for runaway query termination
+-- @author Zhongxian Gu
+-- @concurrency 20
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 2, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 4, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 6, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 8, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 10, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress3.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress3.ans
@@ -1,0 +1,52 @@
+-- @Description Test concurrency for runaway query termination
+-- @author Zhongxian Gu
+-- @concurrency 30
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 2, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 4, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 6, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 8, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 10, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress4.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress4.ans
@@ -1,0 +1,1003 @@
+-- @Description Test concurrency for runaway query termination
+-- @author Zhongxian Gu
+-- @concurrency 30
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                                0
+                                0
+(3 rows)
+
+\c gptest
+You are now connected to database "gptest" as user "guz4".
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                                0
+                          1048576
+                                0
+(3 rows)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress_iterations.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/expected/stress_iterations.ans
@@ -1,0 +1,35 @@
+-- start_ignore
+-- end_ignore
+-- @Description Test releasing session state when running very many sessions one after the other
+-- @author George Caragea
+-- @concurrency 1
+-- We want at least max_connections + 1 iterations here. max_connections is typically set for 250
+-- @iterations 550
+select gp_allocate_palloc_test_all_segs(-2, 1 * 1024 * 1024, 0, false);
+ gp_allocate_palloc_test_all_segs 
+----------------------------------
+                          1048576
+                          1048576
+                          1048576
+(3 rows)
+
+begin;
+BEGIN
+DECLARE f CURSOR WITH HOLD FOR
+select * from stress_iterations_table
+ORDER BY num, letter;
+DECLARE CURSOR
+commit;
+COMMIT
+FETCH FROM f;
+ num | letter 
+-----+--------
+   1 | a
+(1 row)
+
+FETCH FROM f;
+ num | letter 
+-----+--------
+   2 | b
+(1 row)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/init_file
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/init_file
@@ -1,0 +1,12 @@
+-- start_matchsubs
+m/DETAIL:  Per-query VM protect limit reached/
+s/DETAIL:  Per-query VM protect limit reached.*/DETAIL:  Per-query VM protect limit reached/g
+
+
+m/DETAIL:  VM Protect failed to allocate/
+s/DETAIL:  VM Protect failed to allocate.*/DETAIL:  VM Protect failed to allocate/g
+
+m/ERROR:  Canceling query because of high VMEM usage/
+s/ERROR:  Canceling query because of high VMEM usage.*/ERROR:  Canceling query because of high VMEM usage/g
+
+-- end_matchsubs

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress1.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress1.sql
@@ -1,0 +1,24 @@
+-- @Description Test concurrency for runaway query termination
+-- @author Zhongxian Gu
+-- @concurrency 10
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 2, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 4, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 6, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 8, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 10, false);
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress2.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress2.sql
@@ -1,0 +1,23 @@
+-- @Description Test concurrency for runaway query termination
+-- @author Zhongxian Gu
+-- @concurrency 20
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 2, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 4, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 6, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 8, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 10, false);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress3.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress3.sql
@@ -1,0 +1,23 @@
+-- @Description Test concurrency for runaway query termination
+-- @author Zhongxian Gu
+-- @concurrency 30
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 2, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 4, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 6, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 8, false);
+
+\c gptest
+
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 10, false);

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress4.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress4.sql
@@ -1,0 +1,304 @@
+-- @Description Test concurrency for runaway query termination
+-- @author Zhongxian Gu
+-- @concurrency 30
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+
+\c gptest
+select gp_allocate_palloc_test_all_segs(0, 1 * 1024 * 1024, 0, false);
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress_iterations.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress_iterations.sql
@@ -1,0 +1,18 @@
+-- @Description Test releasing session state when running very many sessions one after the other
+-- @author George Caragea
+-- @concurrency 1
+-- We want at least max_connections + 1 iterations here. max_connections is typically set for 250
+-- @iterations 550
+
+select gp_allocate_palloc_test_all_segs(-2, 1 * 1024 * 1024, 0, false);
+
+begin;
+DECLARE f CURSOR WITH HOLD FOR
+select * from stress_iterations_table
+ORDER BY num, letter;
+commit;
+
+FETCH FROM f;
+
+FETCH FROM f;
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress_iterations_setup.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress_iterations_setup.sql
@@ -1,0 +1,9 @@
+CREATE TABLE stress_iterations_table(num int, letter text) distributed randomly;
+
+insert into stress_iterations_table values('1', 'a');
+insert into stress_iterations_table values('2', 'b');
+insert into stress_iterations_table values('3', 'c');
+insert into stress_iterations_table values('4', 'd');
+insert into stress_iterations_table values('5', 'e');
+insert into stress_iterations_table values('6', 'f');
+insert into stress_iterations_table values('7', 'g');

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress_iterations_teardown.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/sql/stress_iterations_teardown.sql
@@ -1,0 +1,1 @@
+drop table stress_iterations_table; 

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/test_runaway_query_stress.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_stress/test_runaway_query_stress.py
@@ -1,0 +1,21 @@
+from mpp.models.sql_concurrency_tc import SQLConcurrencyTestCase
+from resource_management.runaway_query.runaway_udf import create_runaway_udf, drop_runaway_udf
+
+class RunawayQueryStressTestCase(SQLConcurrencyTestCase):
+    """
+    @db_name gptest
+    @tags runaway_query_termination
+    @gpdiff True
+    """
+    sql_dir = 'sql/'
+    ans_dir = 'expected'
+    out_dir = 'output/'
+
+    @classmethod
+    def setUpClass(cls):
+        super(RunawayQueryStressTestCase, cls).setUpClass()
+        create_runaway_udf(cls.db_name)
+        
+    @classmethod
+    def tearDownClass(cls):
+        drop_runaway_udf(cls.db_name)

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/expected/query1.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/expected/query1.ans
@@ -1,0 +1,1 @@
+NOT_USED

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/sql/init_file
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/sql/init_file
@@ -1,0 +1,12 @@
+-- start_matchsubs
+m/DETAIL:  Per-query VM protect limit reached/
+s/DETAIL:  Per-query VM protect limit reached.*/DETAIL:  Per-query VM protect limit reached/g
+
+
+m/DETAIL:  VM Protect failed to allocate/
+s/DETAIL:  VM Protect failed to allocate.*/DETAIL:  VM Protect failed to allocate/g
+
+m/ERROR:  Canceling query because of high VMEM usage/
+s/ERROR:  Canceling query because of high VMEM usage.*/ERROR:  Canceling query because of high VMEM usage/g
+
+-- end_matchsubs

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/sql/query1.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/sql/query1.sql
@@ -1,0 +1,17 @@
+-- @Description Test vmem shown in the live view matches the amount in memory accounting
+-- @skip Memory accounting failed to capture the memory allocation in UDF. Enable this test once the bug is fixed.
+-- @author Zhongxian Gu
+
+-- session1: issue the testing query
+1: set explain_memory_verbosity = 'summary';
+-- content/segment = 0; size = 100MB; sleep = 20 sec, critical section = false
+1&: explain analyze select gp_allocate_palloc_test_all_segs(0, 100 * 1024 * 1024, 20, false);
+
+-- session2: query the live view
+2&: select pg_sleep(5);
+2<:
+
+2: select vmem_mb from session_state.session_state_memory_entries where segid = 0 and current_query ilike 'explain analyze select gp_allocate_palloc_test_all_segs%' and qe_count > 0;
+
+-- session1: testing query finish
+1<:

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/test_runaway_query_vmem_memoryaccounting.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_vmem_memoryaccounting/test_runaway_query_vmem_memoryaccounting.py
@@ -1,0 +1,105 @@
+from gppylib.commands.base import Command
+from mpp.gpdb.tests.storage.lib.sql_isolation_testcase import \
+    SQLIsolationTestCase
+from mpp.lib.PSQL import PSQL
+from resource_management.runaway_query.runaway_udf import *
+import tinctest
+
+
+def _set_VLIM_SLIM(vlimMB, slimMB):
+
+    # Set up GUCs for VLIM (gp_vmem_protect_limit) and SLIM (gp_vmem_limit_per_query)
+    tinctest.logger.info('Setting GUCs for VLIM gp_vmem_protect_limit=%dMB and SLIM gp_vmem_limit_per_query=%dMB' % (vlimMB, slimMB))
+    Command('Run gpconfig to set GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v %d' % vlimMB).run(validateAfter=True)
+    Command('Run gpconfig to set GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_limit_per_query -v %d --skipvalidation' % (slimMB * 1024)).run(validateAfter=True)
+
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+def _reset_VLIM_SLIM():
+
+    # Reset GUCs for VLIM (gp_vmem_protect_limit) and SLIM (gp_vmem_limit_per_query)
+    tinctest.logger.info('Resetting GUCs for VLIM gp_vmem_protect_limit and SLIM gp_vmem_limit_per_query')
+    Command('Run gpconfig to reset GUC gp_vmem_protect_limit',
+            'source $GPHOME/greenplum_path.sh;gpconfig -c gp_vmem_protect_limit -v 8192').run(validateAfter=True)
+    Command('Run gpconfig to reset GUC gp_vmem_limit_per_query',
+            'source $GPHOME/greenplum_path.sh;gpconfig -r gp_vmem_limit_per_query --skipvalidation').run(validateAfter=True)
+    
+    # Restart DB
+    Command('Restart database for GUCs to take effect', 
+            'source $GPHOME/greenplum_path.sh && gpstop -ar').run(validateAfter=True)
+
+
+class RQTMemoryAccountingTestCase(SQLIsolationTestCase):
+    """
+    @tags runaway_query_termination
+    """
+
+    sql_dir = 'sql/'
+    ans_dir = 'expected'
+    out_dir = 'output/'
+
+    def _infer_metadata(self):
+        super(RQTMemoryAccountingTestCase, self)._infer_metadata()
+        try:
+            self.vlimMB = int(self._metadata.get('vlimMB', '8192')) # Default is 8192
+            self.slimMB = int(self._metadata.get('slimMB', '0')) # Default is 0
+        except Exception:
+            tinctest.logger.info("Error getting the testcase related metadata")
+            raise
+    
+    def setUp(self):
+        _set_VLIM_SLIM(self.vlimMB, self.slimMB)
+        return super(RQTMemoryAccountingTestCase, self).setUp()
+
+    @classmethod
+    def setUpClass(cls):
+        super(RQTMemoryAccountingTestCase, cls).setUpClass()
+        create_runaway_udf()
+        create_session_state_view()
+        
+    @classmethod
+    def tearDownClass(cls):
+        drop_session_state_view()
+        drop_runaway_udf()
+        _reset_VLIM_SLIM()
+ 
+    def verify_out_file(self, out_file, ans_file):
+        """
+        Override SQLTestCase, verify vmem shown in the live view matched the memory accounting output in explain analyze
+        """
+        lines = [line.strip() for line in open(out_file)]
+        vmem_mb = 0
+        mem_memory_accounting = 0.0
+        for num in range(len(lines)):
+            cur_line = lines[num]
+            if cur_line.startswith('vmem_mb'):
+                try:
+                    vmem_mb = int(lines[num+2])
+                except:
+                    raise
+            elif cur_line.startswith('(slice') and line.find('workers,') != -1:
+                # slices that happen in segments
+                temp_line = cur_line[cur_line.index('Peak memory:'):]
+                try:
+                    # the line looks like: Peak memory: 1585K bytes.
+                    peak_mem_str = temp_line.split(' ')[2]
+                    peak_mem_max = int(peak_mem_str[:-1])
+                    print peak_mem_max
+                except:
+                    raise
+                mem_memory_accounting += peak_mem_max
+        
+        # Comparing vmem_mb with the memory recorded in memory accounting
+        # TODO 2014-10-01 Zhongxian.Gu
+        # Calibrate difference MARGIN
+        MARGIN = 1
+        mem_memory_accounting /= 1024.0 
+        if vmem_mb - MARGIN <= mem_memory_accounting and mem_memory_accounting <= vmem_mb + MARGIN:
+            return True
+        
+        return False
+    

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_udf.py
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_udf.py
@@ -1,0 +1,44 @@
+import sys
+import os
+import tinctest
+from mpp.lib.PSQL import PSQL
+from tinctest.lib import local_path
+from gppylib.commands.base import Command, ExecutionError
+from mpp.gpdb.lib.models.sql.template import SQLTemplateTestCase
+
+gphome = os.environ["GPHOME"]
+
+def build_udf():
+    tinctest.logger.info('Building UDF library runaway_test.so in the %s directory' % local_path('./udfs'))
+    Command('re-build runaway_test.so',
+            'make -C %s/udfs runaway_test.so' % local_path('.')).run(validateAfter=True)
+
+def create_runaway_udf(dbname = None):
+    build_udf()
+
+    SQLTemplateTestCase.perform_transformation_on_sqlfile(local_path('./udfs/runaway_test.sql.in'),
+        local_path('./udfs/runaway_test.sql'),
+        {'@source@' : local_path('./udfs/runaway_test.so')})
+
+    tinctest.logger.info('Creating Runaway Query Termination testing UDFs by running sql file %s' % local_path('./udfs/runaway_test.sql'))
+
+    PSQL.run_sql_file(sql_file=local_path('./udfs/runaway_test.sql'),
+        out_file=local_path('./udfs/runaway_test.out'), dbname=dbname)
+
+
+def drop_runaway_udf(dbname = None):
+    tinctest.logger.info('Removing Runaway Query Termination testing UDFs by running sql file %s' % local_path('./udfs/uninstall_runaway_test.sql'))
+
+    PSQL.run_sql_file(sql_file=local_path('./udfs/uninstall_runaway_test.sql'),
+                      out_file=local_path('./udfs/uninstall_runaway_test.out'), dbname=dbname)
+
+    
+def create_session_state_view(dbname = None):
+    cmd = os.path.join(gphome, "share/postgresql/contrib/gp_session_state.sql")
+    tinctest.logger.info('Creating Session State View by running sql file %s' % cmd)
+    PSQL.run_sql_file(cmd, dbname=dbname)
+
+def drop_session_state_view(dbname = None):
+    cmd = os.path.join(gphome, "share/postgresql/contrib/uninstall_gp_session_state.sql")
+    tinctest.logger.info('Removing Session State View by running sql file %s' % cmd)
+    PSQL.run_sql_file(cmd, dbname=dbname)

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/Makefile
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/Makefile
@@ -1,0 +1,6 @@
+MODULES=runaway_test
+PG_CONFIG=pg_config
+
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/runaway_test.c
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/runaway_test.c
@@ -1,0 +1,311 @@
+
+/*
+ * runaway_test.c
+ *   Auxiliary functionality to test Runaway Query Termination
+ *
+ * ---------------------------------------------------------------------
+ *
+ * The dynamically linked library created from this source can be reference by
+ * creating a SQL function that references it. For example,
+ *
+ * CREATE OR REPLACE FUNCTION gp_workfile_cache_test()
+ *   RETURNS bool
+ *   AS '$libdir/runaway_termination.so', 'gp_allocate_palloc_test' LANGUAGE C STRICT;
+ *
+ */
+
+#include "postgres.h"
+#include "utils/builtins.h"
+#include "fmgr.h"
+#include "funcapi.h"
+#include "miscadmin.h"
+#include "utils/vmem_tracker.h"
+#include <unistd.h>
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
+/* The types of faults supported by the gp_inject_fault_test UDF */
+#define FAULT_TYPE_ERROR 1
+#define FAULT_TYPE_FATAL 2
+#define FAULT_TYPE_PANIC 3
+#define FAULT_TYPE_SEGV 4
+#define FAULT_USER_SEGV_CRITICAL 5
+#define FAULT_USER_SEGV_LWLOCK 6
+#define FAULT_USER_PROCEXIT 7
+#define FAULT_USER_ABORT 8
+
+/* GPDB variable needed */ 
+extern int Gp_segment;
+
+static char *ptrAllocation = NULL;
+
+Datum gp_allocate_palloc_test(PG_FUNCTION_ARGS);
+Datum gp_allocate_palloc_gradual_test(PG_FUNCTION_ARGS);
+Datum gp_inject_fault_test(PG_FUNCTION_ARGS);
+Datum gp_allocate_top_memory_ctxt_test(PG_FUNCTION_ARGS);
+Datum gp_available_vmem_mb_test(PG_FUNCTION_ARGS);
+
+
+PG_FUNCTION_INFO_V1(gp_allocate_palloc_test);
+PG_FUNCTION_INFO_V1(gp_inject_fault_test);
+PG_FUNCTION_INFO_V1(gp_allocate_palloc_gradual_test);
+PG_FUNCTION_INFO_V1(gp_allocate_top_memory_ctxt_test);
+PG_FUNCTION_INFO_V1(gp_available_vmem_mb_test);
+
+
+/*
+ * gp_allocate_palloc_test
+ *    Allocates a specified amount of memory using a single palloc call on
+ *    the specified segment
+ *
+ *   content: segid this is applicable to. segid <= -2 means all segments
+ *   size: amount of memory to palloc
+ *   sleep: number of seconds to sleep after the allocation (0 = disable)
+ *   crit_section: allocate in critical section if true
+ */
+Datum
+gp_allocate_palloc_test(PG_FUNCTION_ARGS)
+{
+	int segno = PG_GETARG_INT32(0);
+	int size = PG_GETARG_INT32(1);
+	int sleep_sec = PG_GETARG_INT32(2);
+	bool crit_section = PG_GETARG_BOOL(3);
+
+	int size_alloc = 0;
+
+	if (segno < -1 || segno == Gp_segment)
+	{
+		elog(LOG, "Allocating %d bytes %s", size,
+				crit_section ? " in critical section" : "");
+
+		if (crit_section)
+		{
+			START_CRIT_SECTION();
+		}
+
+		ptrAllocation = (char *) palloc(size);
+		size_alloc = size;
+
+		if (crit_section)
+		{
+			/*
+			 * For critical section allocation, we want to free it right away,
+			 * so that we don't trigger the runaway detector.
+			 */
+			pfree(ptrAllocation);
+
+			END_CRIT_SECTION();
+		}
+
+		/*
+		 * This doesn't check for interrupts during sleep.
+		 * Alternatively, we can use a loop with CHECK_FOR_INTERRUPTS
+		 * if we want to check for interrupts (see debug_break_timed)
+		 */
+		if (sleep_sec > 0)
+		{
+			elog(LOG, "Sleeping for %d seconds", sleep_sec);
+			sleep(sleep_sec);
+		}
+
+	}
+
+	PG_RETURN_INT32(size_alloc);
+
+}
+
+/*
+ * gp_allocate_top_memory_ctxt_test
+ *    Allocates a specified amount of memory using a single palloc call on
+ *    the specified segment in the TopMemoryContext
+ *
+ *   content: segid this is applicable to. segid <= -2 means all segments
+ *   size: amount of memory to palloc
+ *   sleep: number of seconds to sleep after the allocation (0 = disable)
+ */
+Datum
+gp_allocate_top_memory_ctxt_test(PG_FUNCTION_ARGS)
+{
+	int segno = PG_GETARG_INT32(0);
+	int size = PG_GETARG_INT32(1);
+	int sleep_sec = PG_GETARG_INT32(2);
+
+	int size_alloc = 0;
+
+	if (segno < -1 || segno == Gp_segment)
+	{
+		elog(LOG, "Allocating %d bytes in TopMemoryContext", size);
+
+		ptrAllocation = (char *) MemoryContextAlloc(TopMemoryContext, size);
+		size_alloc = size;
+
+		/*
+		 * This doesn't check for interrupts during sleep.
+		 * Alternatively, we can use a loop with CHECK_FOR_INTERRUPTS
+		 * if we want to check for interrupts (see debug_break_timed)
+		 */
+		if (sleep_sec > 0)
+		{
+			elog(LOG, "Sleeping for %d seconds", sleep_sec);
+			sleep(sleep_sec);
+		}
+
+	}
+
+	PG_RETURN_INT32(size_alloc);
+
+}
+
+/*
+ * gp_allocate_palloc_gradual_test
+ *    Allocates a specified amount of memory using many palloc calls of 10MB
+ *    on the specified segment
+ *
+ *
+ *   content: segid this is applicable to. segid <= -2 means all segments
+ *   size: amount of memory to palloc
+ *   sleep: number of seconds to sleep after the allocation (0 = disable)
+ */
+Datum
+gp_allocate_palloc_gradual_test(PG_FUNCTION_ARGS)
+{
+	int segno = PG_GETARG_INT32(0);
+	int size = PG_GETARG_INT32(1);
+	int sleep_sec = PG_GETARG_INT32(2);
+
+	int size_alloc = 0;
+
+	/* Allocate in chunks of 10MB */
+	int quanta = 10 * 1024 * 1024;
+
+	if (segno < -1 || segno == Gp_segment)
+	{
+		elog(LOG, "Gradually allocating %d bytes in chunks of %dMB",
+				size, (quanta / 2^20));
+
+		int size_done = 0;
+		while (size_done + quanta < size)
+		{
+			ptrAllocation = (char *) palloc(quanta);
+			size_done += quanta;
+			elog(LOG, "Done allocating %dMB", size_done / (1024 * 1024));
+		}
+
+		/* Allocate the last chunk if needed */
+		if (size - size_done > 0)
+		{
+			ptrAllocation = (char *) palloc(size - size_done);
+		}
+
+		/*
+		 * This doesn't check for interrupts during sleep.
+		 * Alternatively, we can use a loop with CHECK_FOR_INTERRUPTS
+		 * if we want to check for interrupts (see debug_break_timed)
+		 */
+		if (sleep_sec > 0)
+		{
+			elog(LOG, "Sleeping for %d seconds", sleep_sec);
+			sleep(sleep_sec);
+		}
+
+		size_alloc = size;
+
+	}
+
+	PG_RETURN_INT32(size_alloc);
+}
+
+/*
+ * gp_inject_fault_test
+ *    Allocates a specified amount of memory using many palloc calls of 10MB
+ *    on the specified segment
+ *
+ *
+ *   content: segid this is applicable to. segid <= -2 means all segments
+ *   fault_type: type of fault to inject
+ *   arg: optional argument to the fault type
+ */
+Datum
+gp_inject_fault_test(PG_FUNCTION_ARGS)
+{
+	int segno = PG_GETARG_INT32(0);
+	int fault_type = PG_GETARG_INT32(1);
+	int arg = PG_GETARG_INT32(2);
+
+
+	if (segno >= -1 && segno != Gp_segment)
+	{
+		PG_RETURN_BOOL(false);
+	}
+
+	switch(fault_type)
+	{
+	case FAULT_TYPE_ERROR:
+		elog(ERROR, "User fault injection raised error");
+		break;
+
+	case FAULT_TYPE_FATAL:
+		elog(FATAL, "User fault injection raised fatal");
+		break;
+
+	case FAULT_TYPE_PANIC:
+		elog(PANIC, "User fault injection raised panic");
+		break;
+
+	case FAULT_TYPE_SEGV:
+		*(int *) 0 = 1234;
+		break;
+
+	case FAULT_USER_SEGV_CRITICAL:
+		START_CRIT_SECTION();
+		*(int *) 0 = 1234;
+		END_CRIT_SECTION();
+		break;
+
+	case FAULT_USER_SEGV_LWLOCK:
+		LWLockAcquire(WALInsertLock, LW_EXCLUSIVE);
+		*(int *) 0 = 1234;
+		break;
+
+	case FAULT_USER_PROCEXIT:
+		{
+			extern void proc_exit(int);
+			proc_exit((int) arg);
+		}
+
+	case FAULT_USER_ABORT:
+		abort();
+
+	default:
+		elog(ERROR, "Invalid user fault injection code");
+
+	}
+
+
+	PG_RETURN_BOOL(true);
+}
+
+/*
+ * gp_available_vmem_mb_test
+ *    Returns the available Vmem for the segment (in MB)
+ *    The format of the returned text is the following:
+ *       "segid=N,vmem_mb=X"
+ *     where N and X are integer values.
+ *
+ */
+Datum
+gp_available_vmem_mb_test(PG_FUNCTION_ARGS)
+{
+
+	StringInfo resultStr = makeStringInfo();
+	appendStringInfo(resultStr, "segid=%d,vmem_mb=%d",
+			Gp_segment, VmemTracker_GetAvailableVmemMB());
+
+	text *resultTxt = cstring_to_text(resultStr->data);
+	pfree(resultStr->data);
+
+	PG_RETURN_TEXT_P(resultTxt);
+
+}

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/runaway_test.sql.in
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/runaway_test.sql.in
@@ -1,0 +1,239 @@
+BEGIN;
+
+-- Register the functions.
+     
+     
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_allocate_palloc_test_f
+-- @in:
+--		content - segment on which to allocate. -1 is master. -2 is all.
+--		size - amount of memory to allocate (in bytes)
+--		sleep - sleep for a number of seconds after allocation. 0 is disable
+--		crit_section - allocate in critical section if true
+-- @out:
+--		int - amount allocated
+--
+-- @doc:
+--		Wrapper to the C UDF to allocate a specified amount of memory 
+--		using a single palloc call on the specified segment
+--        
+--------------------------------------------------------------------------------  
+CREATE OR REPLACE FUNCTION gp_allocate_palloc_test_f(content int, size int, sleep int, crit_section bool)
+RETURNS int
+AS '@source@', 'gp_allocate_palloc_test'
+LANGUAGE C VOLATILE;
+
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_allocate_palloc_test_all_segs
+-- @in:
+--		content - segment on which to allocate. -1 is master. -2 is all.
+--		size - amount of memory to allocate (in bytes)
+--		sleep - sleep for a number of seconds after allocation. 0 is disable
+--		crit_section - allocate in critical section if true
+-- @out:
+-- 		int - amount allocated
+--
+-- @doc:
+--		Allocates a specified amount of memory using a single palloc call on
+--		the specified segment(s). This function executes the UDF on master 
+--		and all segments. Only the segments identified by content perform
+--		the allocation
+--        
+--------------------------------------------------------------------------------
+CREATE FUNCTION gp_allocate_palloc_test_all_segs(content int, size int, sleep int, crit_section bool)
+RETURNS SETOF int
+AS
+$$
+ SELECT gp_allocate_palloc_test_f($1, $2, $3, $4) from gp_dist_random('gp_id')
+ UNION ALL
+ SELECT gp_allocate_palloc_test_f($1, $2, $3, $4);
+$$
+LANGUAGE SQL;
+
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_allocate_top_memory_ctxt_test_f
+-- @in:
+--		content - segment on which to allocate. -1 is master. -2 is all.
+--		size - amount of memory to allocate (in bytes)
+--		sleep - sleep for a number of seconds after allocation. 0 is disable
+-- @out:
+--		int - amount allocated
+--
+-- @doc:
+--		Wrapper to the C UDF to allocate a specified amount of memory 
+--		using a single palloc call in the TopMemoryContext on the specified segment
+--        
+--------------------------------------------------------------------------------  
+CREATE OR REPLACE FUNCTION gp_allocate_top_memory_ctxt_test_f(content int, size int, sleep int)
+RETURNS int
+AS '@source@', 'gp_allocate_top_memory_ctxt_test'
+LANGUAGE C VOLATILE;
+
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_allocate_top_memory_ctxt_test_all_segs
+-- @in:
+--		content - segment on which to allocate. -1 is master. -2 is all.
+--		size - amount of memory to allocate (in bytes)
+--		sleep - sleep for a number of seconds after allocation. 0 is disable
+-- @out:
+-- 		int - amount allocated
+--
+-- @doc:
+--		Allocates a specified amount of memory using a single palloc call on
+--		the specified segment(s) in the TopMemoryContext. 
+--		This function executes the UDF on master 
+--		and all segments. Only the segments identified by content perform
+--		the allocation
+--        
+--------------------------------------------------------------------------------
+CREATE FUNCTION gp_allocate_top_memory_ctxt_test_all_segs(content int, size int, sleep int)
+RETURNS SETOF int
+AS
+$$
+ SELECT gp_allocate_top_memory_ctxt_test_f($1, $2, $3) from gp_dist_random('gp_id')
+ UNION ALL
+ SELECT gp_allocate_top_memory_ctxt_test_f($1, $2, $3);
+$$
+LANGUAGE SQL;
+
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_allocate_palloc_gradual_test_f
+-- @in:
+--		content - segment on which to allocate. -1 is master. -2 is all.
+--		size - amount of memory to allocate (in bytes)
+--		sleep - sleep for a number of seconds after allocation. 0 is disable
+-- @out:
+--		int - amount allocated
+--
+-- @doc:
+--		Wrapper to the C UDF to gradually allocate a specified amount of memory 
+--		using a many 10MB palloc calls on the specified segment
+--        
+--------------------------------------------------------------------------------  
+CREATE OR REPLACE FUNCTION gp_allocate_palloc_gradual_test_f(content int, size int, sleep int)
+RETURNS int
+AS '@source@', 'gp_allocate_palloc_gradual_test'
+LANGUAGE C VOLATILE;
+
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_allocate_palloc_gradual_test_all_segs
+-- @in:
+--		content - segment on which to allocate. -1 is master. -2 is all.
+--		size - amount of memory to allocate (in bytes)
+--		sleep - sleep for a number of seconds after allocation. 0 is disable
+-- @out:
+-- 		int - amount allocated
+--
+-- @doc:
+--		Gradually allocates a specified amount of memory using 
+--		several 10MB palloc call on the specified segment(s). This function 
+--		executes the UDF on master and all segments. Only the segments 
+--		identified by content perform the allocation
+--        
+--------------------------------------------------------------------------------
+CREATE FUNCTION gp_allocate_palloc_gradual_test_all_segs(content int, size int, sleep int)
+RETURNS SETOF int
+AS
+$$
+ SELECT gp_allocate_palloc_gradual_test_f($1, $2, $3) from gp_dist_random('gp_id')
+ UNION ALL
+ SELECT gp_allocate_palloc_gradual_test_f($1, $2, $3);
+$$
+LANGUAGE SQL;
+
+
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_inject_fault_test_f
+-- @in:
+--		content: segid this is applicable to. segid <= -2 means all segments
+--		fault_type: type of fault to inject
+--		arg: optional argument to the fault type
+-- @out:
+--		bool - true if fault injector was triggered on segment
+--
+-- @doc:
+--		Wrapper to the C UDF to inject a fault on a specified segment
+--        
+--------------------------------------------------------------------------------  
+CREATE OR REPLACE FUNCTION gp_inject_fault_test_f(content int, fault_type int, arg int)
+RETURNS bool
+AS '@source@', 'gp_inject_fault_test'
+LANGUAGE C VOLATILE;
+
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_inject_fault_test_all_segs
+-- @in:
+--		content: segid this is applicable to. segid <= -2 means all segments
+--		fault_type: type of fault to inject
+--		arg: optional argument to the fault type
+-- @out:
+--		bool - true if fault injector was triggered on segment
+--
+-- @doc:
+--		Inject the specified type of fault. Only the segments 
+--		identified by content execute the fault injector
+--        
+--------------------------------------------------------------------------------
+CREATE FUNCTION gp_inject_fault_test_all_segs(content int, fault_type int, arg int)
+RETURNS SETOF bool
+AS
+$$
+ SELECT gp_inject_fault_test_f($1, $2, $3) from gp_dist_random('gp_id')
+ UNION ALL
+ SELECT gp_inject_fault_test_f($1, $2, $3);
+$$
+LANGUAGE SQL;
+
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_available_vmem_mb_test_f
+-- @in:
+--
+-- @out:
+--		text - format: "segid=N,vmem_mb=X"
+--
+-- @doc:
+--		Wrapper to the C UDF to read the vmem mb available
+--        
+--------------------------------------------------------------------------------  
+CREATE OR REPLACE FUNCTION gp_available_vmem_mb_test_f()
+RETURNS text
+AS '@source@', 'gp_available_vmem_mb_test'
+LANGUAGE C VOLATILE;
+
+--------------------------------------------------------------------------------
+-- @function: 
+--        gp_available_vmem_mb_test_all_segs
+-- @in:
+--
+-- @out:
+--		text - format: "segid=N,vmem_mb=X"
+--
+-- @doc:
+--		Read the number of megabytes available from vmem tracker
+--        
+--------------------------------------------------------------------------------
+CREATE VIEW gp_available_vmem_mb_test_all_segs AS
+	SELECT
+		substring(val from 'segid=(.*),')::integer as segid,
+		substring(val from 'vmem_mb=(.*)$')::integer as vmem_mb
+	FROM 
+		(SELECT gp_available_vmem_mb_test_f() as val from gp_dist_random('gp_id')) foo
+	UNION ALL
+	SELECT
+		substring(val from 'segid=(.*),')::integer as segid,
+		substring(val from 'vmem_mb=(.*)$')::integer as vmem_mb
+	FROM 
+		(SELECT gp_available_vmem_mb_test_f() as val) foo;
+
+
+COMMIT;
+

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/uninstall_runaway_test.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/udfs/uninstall_runaway_test.sql
@@ -1,0 +1,18 @@
+BEGIN; 
+
+DROP FUNCTION gp_allocate_palloc_test_all_segs(content int, size int, sleep int, crit_section bool);
+DROP FUNCTION gp_allocate_palloc_test_f(content int, size int, sleep int, crit_section bool);
+
+DROP FUNCTION gp_allocate_top_memory_ctxt_test_all_segs(content int, size int, sleep int);
+DROP FUNCTION gp_allocate_top_memory_ctxt_test_f(content int, size int, sleep int);
+
+DROP FUNCTION gp_allocate_palloc_gradual_test_all_segs(content int, size int, sleep int);
+DROP FUNCTION gp_allocate_palloc_gradual_test_f(content int, size int, sleep int);
+
+DROP FUNCTION gp_inject_fault_test_all_segs(content int, fault_type int, arg int);
+DROP FUNCTION gp_inject_fault_test_f(content int, fault_type int, arg int); 
+
+DROP VIEW gp_available_vmem_mb_test_all_segs;
+DROP FUNCTION gp_available_vmem_mb_test_f(); 
+
+COMMIT;


### PR DESCRIPTION
Runs in a concourse container for 24 mins

Output from the pipeline :

```
tinc.py \
		resource_management.runaway_query.runaway_query_scenario.test_runaway_query_scenario.RQTScenarioTestCase \
		resource_management.runaway_query.runaway_detector.test_runaway_detector.RunawayDetectorTestCase \
		resource_management.runaway_query.runaway_query_limits.test_runaway_query.RunawayQueryTestCase \
		resource_management.runaway_query.runaway_query_multisession.test_runaway_multisession.RunawayMultiSessionTestCase \
		resource_management.runaway_query.runaway_query_vmem_memoryaccounting.test_runaway_query_vmem_memoryaccounting.RQTMemoryAccountingTestCase \
		resource_management.runaway_query.runaway_query_stress.test_runaway_query_stress.RunawayQueryStressTestCase
RQTScenarioTestCase.test_run ... 74690.77 ms ... ok
RunawayDetectorTestCase.test_runaway_detected_by_other ... 58738.25 ms ... ok
RunawayDetectorTestCase.test_runaway_detects_itself ... 48960.00 ms ... ok
RunawayQueryTestCase.test_disable_rqt ... 28912.93 ms ... ok
RunawayQueryTestCase.test_enable_rqt ... 28314.44 ms ... ok
RunawayQueryTestCase.test_enable_rqt_in_transaction ... 28564.95 ms ... ok
RunawayQueryTestCase.test_hit_slim ... 28495.95 ms ... ok
RunawayQueryTestCase.test_hit_slim_crit_section ... 28185.11 ms ... ok
RunawayQueryTestCase.test_hit_vlim_crit_section ... 28168.62 ms ... ok
RunawayQueryTestCase.test_hit_vlim_one_session ... 28260.29 ms ... ok
RunawayQueryTestCase.test_rqt_in_subtransaction_cursor ... 29485.88 ms ... ok
RunawayQueryTestCase.test_rqt_in_subtransaction_no_idle ... 29103.67 ms ... ok
RunawayMultiSessionTestCase.test_delete_while_vacuum ... 28772.87 ms ... ok
RunawayMultiSessionTestCase.test_enable_rqt_all_in_transaction_idle_qe ... 49147.23 ms ... ok
RunawayMultiSessionTestCase.test_enable_rqt_in_transaction_idle_qe ... 49124.02 ms ... ok
RunawayMultiSessionTestCase.test_enable_rqt_no_transaction_idle_qe ... 49030.71 ms ... ok
RunawayMultiSessionTestCase.test_hit_vlim_2sessions ... 48340.26 ms ... ok
RunawayMultiSessionTestCase.test_idle_rss_red_zone ... 52195.58 ms ... ok
RunawayMultiSessionTestCase.test_idle_rss_red_zone_non_superuser ... 31398.76 ms ... ok
RunawayMultiSessionTestCase.test_recover_from_segv ... 28014.46 ms ... skipped 'FATAL handling from UDFs has changed since older version. Renable after fixing that.'
RunawayMultiSessionTestCase.test_release_pincount ... 68963.36 ms ... ok
RunawayMultiSessionTestCase.test_release_pincount_fatal ... 28300.62 ms ... skipped 'FATAL handling from UDFs has changed since older version. Renable after fixing that.'
RunawayMultiSessionTestCase.test_release_vmem_fatal ... 28699.78 ms ... skipped 'FATAL handling from UDFs has changed since older version. Renable after fixing that.'
RQTMemoryAccountingTestCase.test_query1 ... 27948.28 ms ... skipped 'Memory accounting failed to capture the memory allocation in UDF. Enable this test once the bug is fixed.'
RunawayQueryStressTestCase.test_stress1 ... 30454.10 ms ... ok
RunawayQueryStressTestCase.test_stress2 ... 30614.56 ms ... ok
RunawayQueryStressTestCase.test_stress3 ... 30822.12 ms ... ok
RunawayQueryStressTestCase.test_stress4 ... 15800.01 ms ... ok
RunawayQueryStressTestCase.test_stress_iterations ... 122097.62 ms ... ok
```
