### PR TITLE
Remove -Winline from the default set of CFLAGS

### DIFF
--- a/configure
+++ b/configure
@@ -4819,7 +4819,7 @@ fi
 # ICC pretends to be GCC but it's lying; it doesn't support these options.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="$CFLAGS -Wall -Wmissing-prototypes -Wpointer-arith -Winline"
+  CFLAGS="$CFLAGS -Wall -Wmissing-prototypes -Wpointer-arith"
   # These work in some but not all gcc versions
   # GPDB code is full of declarations after statement.
   #PGAC_PROG_CC_CFLAGS_OPT([-Wdeclaration-after-statement])

--- a/configure.in
+++ b/configure.in
@@ -445,7 +445,7 @@ AC_SUBST(PG_CRC32C_OBJS)
 # ICC pretends to be GCC but it's lying; it doesn't support these options.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="$CFLAGS -Wall -Wmissing-prototypes -Wpointer-arith -Winline"
+  CFLAGS="$CFLAGS -Wall -Wmissing-prototypes -Wpointer-arith"
   # These work in some but not all gcc versions
   # GPDB code is full of declarations after statement.
   #PGAC_PROG_CC_CFLAGS_OPT([-Wdeclaration-after-statement])


### PR DESCRIPTION
	commit 3cab8bdf4384d3353bec1b5655256d19d75c181d
	Author: Tom Lane <tgl@sss.pgh.pa.us>
	Date:   Tue Aug 19 19:17:40 2008 +0000

	    Remove -Winline from the default set of CFLAGS for gcc.  It's gotten much
	    too noisy to be useful as of gcc 4.3, and we were never really doing
	    anything about inlining warnings anyway.