### PR TITLE
Reorganize Concourse Pipeline: isolate pulse jobs by team

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -585,7 +585,34 @@ jobs:
     - put: gpdb_src_behave_tarball
       params:
         file: packaged_gpdb_src_behave/greenplum-db-4.3.99.0-behave.tar.gz
-# Stage 3: Trigger and monitor pulse project
+
+# Stage 4: "Gatekeep" and organize longer-running or resource-intensive tests, typically in pulse
+
+- name: cs-gatekeeper
+  plan:
+  - aggregate: &pulse_gatekeeper_resources
+    - get: gpdb_src
+      params: {submodules: none}
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+      trigger: true
+    - get: gpdb_src_tinc_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: installer_rhel6_gpdb_rc
+      tags: ["gpdb5-pulse-worker"]
+      resource: installer_rhel6_gpdb_rc
+      passed: [gpdb_rc_packaging_centos]
+    - get: qautils_rhel6_tarball
+      tags: ["gpdb5-pulse-worker"]
+      resource: qautils_rhel6_tarball
+      passed: [gpdb_rc_packaging_centos]
+    - get: gpdb_src_behave_tarball
+      tags: ["gpdb5-pulse-worker"]
+      resource: gpdb_src_behave_tarball
+      passed: [gpdb_rc_packaging_centos]
+
+# Stage 5: Trigger and monitor pulse project
 
 - name: MU_netbackup76
   plan:
@@ -750,7 +777,27 @@ jobs:
 
 - name: cs-pg-two-phase
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: &pulse_trigger_cs_resources
+    - get: gpdb_src
+      params: {submodules: none}
+      tags: ["gpdb5-pulse-worker"]
+      passed: [cs-gatekeeper]
+      trigger: true
+    - get: gpdb_src_tinc_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [cs-gatekeeper]
+    - get: installer_rhel6_gpdb_rc
+      tags: ["gpdb5-pulse-worker"]
+      resource: installer_rhel6_gpdb_rc
+      passed: [cs-gatekeeper]
+    - get: qautils_rhel6_tarball
+      tags: ["gpdb5-pulse-worker"]
+      resource: qautils_rhel6_tarball
+      passed: [cs-gatekeeper]
+    - get: gpdb_src_behave_tarball
+      tags: ["gpdb5-pulse-worker"]
+      resource: gpdb_src_behave_tarball
+      passed: [cs-gatekeeper]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -767,7 +814,7 @@ jobs:
 
 - name: cs-walrepl-multinode
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_cs_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -784,7 +831,7 @@ jobs:
 
 - name: cs-fts
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_cs_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -801,7 +848,7 @@ jobs:
 
 - name: cs-storage
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_cs_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -824,22 +871,22 @@ jobs:
     - get: gpdb_src
       params: {submodules: none}
       tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
+      passed: [cs-gatekeeper]
     - get: gpdb_src_tinc_tarball
       tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
+      passed: [cs-gatekeeper]
     - get: installer_rhel6_gpdb_rc
       tags: ["gpdb5-pulse-worker"]
       resource: installer_rhel6_gpdb_rc
-      passed: [gpdb_rc_packaging_centos]
+      passed: [cs-gatekeeper]
     - get: qautils_rhel6_tarball
       tags: ["gpdb5-pulse-worker"]
       resource: qautils_rhel6_tarball
-      passed: [gpdb_rc_packaging_centos]
+      passed: [cs-gatekeeper]
     - get: gpdb_src_behave_tarball
       tags: ["gpdb5-pulse-worker"]
       resource: gpdb_src_behave_tarball
-      passed: [gpdb_rc_packaging_centos]
+      passed: [cs-gatekeeper]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -616,6 +616,18 @@ jobs:
   plan:
   - aggregate: *pulse_gatekeeper_resources
 
+- name: unite-gatekeeper
+  plan:
+  - aggregate: *pulse_gatekeeper_resources
+
+- name: qp-gatekeeper
+  plan:
+  - aggregate: *pulse_gatekeeper_resources
+
+- name: mpp-gatekeeper
+  plan:
+  - aggregate: *pulse_gatekeeper_resources
+
 # Stage 5: Trigger and monitor pulse project
 
 - name: MU_netbackup76
@@ -907,27 +919,24 @@ jobs:
 
 - name: mpp_interconnect
   plan:
-  - aggregate: &pulse_trigger_resource
+  - aggregate:
     - get: gpdb_src
       params: {submodules: none}
       tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mpp-gatekeeper]
       trigger: true
     - get: gpdb_src_tinc_tarball
       tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mpp-gatekeeper]
     - get: installer_rhel6_gpdb_rc
       tags: ["gpdb5-pulse-worker"]
-      resource: installer_rhel6_gpdb_rc
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mpp-gatekeeper]
     - get: qautils_rhel6_tarball
       tags: ["gpdb5-pulse-worker"]
-      resource: qautils_rhel6_tarball
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mpp-gatekeeper]
     - get: gpdb_src_behave_tarball
       tags: ["gpdb5-pulse-worker"]
-      resource: gpdb_src_behave_tarball
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mpp-gatekeeper]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -944,7 +953,24 @@ jobs:
 
 - name: unite_ccle_gpdb5
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate:
+    - get: gpdb_src
+      params: {submodules: none}
+      tags: ["gpdb5-pulse-worker"]
+      passed: [unite-gatekeeper]
+      trigger: true
+    - get: gpdb_src_tinc_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [unite-gatekeeper]
+    - get: installer_rhel6_gpdb_rc
+      tags: ["gpdb5-pulse-worker"]
+      passed: [unite-gatekeeper]
+    - get: qautils_rhel6_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [unite-gatekeeper]
+    - get: gpdb_src_behave_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [unite-gatekeeper]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -961,7 +987,24 @@ jobs:
 
 - name: QP_memory-accounting
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate:
+    - get: gpdb_src
+      params: {submodules: none}
+      tags: ["gpdb5-pulse-worker"]
+      passed: [qp-gatekeeper]
+      trigger: true
+    - get: gpdb_src_tinc_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [qp-gatekeeper]
+    - get: installer_rhel6_gpdb_rc
+      tags: ["gpdb5-pulse-worker"]
+      passed: [qp-gatekeeper]
+    - get: qautils_rhel6_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [qp-gatekeeper]
+    - get: gpdb_src_behave_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [qp-gatekeeper]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -980,7 +1023,7 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: [gpdb_rc_packaging_centos]
+      passed: [qp-gatekeeper]
       trigger: true
     - get: bin_gpdb
       passed: [gpdb_rc_packaging_centos]
@@ -999,7 +1042,7 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: [gpdb_rc_packaging_centos]
+      passed: [unite-gatekeeper]
       trigger: true
     - get: bin_gpdb
       passed: [gpdb_rc_packaging_centos]

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -612,31 +612,35 @@ jobs:
       resource: gpdb_src_behave_tarball
       passed: [gpdb_rc_packaging_centos]
 
+- name: mu-gatekeeper
+  plan:
+  - aggregate: *pulse_gatekeeper_resources
+
 # Stage 5: Trigger and monitor pulse project
 
 - name: MU_netbackup76
   plan:
-  - aggregate: &pulse_trigger_resource
+  - aggregate: &pulse_trigger_mu_resources
     - get: gpdb_src
       params: {submodules: none}
       tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mu-gatekeeper]
       trigger: true
     - get: gpdb_src_tinc_tarball
       tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mu-gatekeeper]
     - get: installer_rhel6_gpdb_rc
       tags: ["gpdb5-pulse-worker"]
       resource: installer_rhel6_gpdb_rc
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mu-gatekeeper]
     - get: qautils_rhel6_tarball
       tags: ["gpdb5-pulse-worker"]
       resource: qautils_rhel6_tarball
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mu-gatekeeper]
     - get: gpdb_src_behave_tarball
       tags: ["gpdb5-pulse-worker"]
       resource: gpdb_src_behave_tarball
-      passed: [gpdb_rc_packaging_centos]
+      passed: [mu-gatekeeper]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -657,7 +661,7 @@ jobs:
 
 - name: MU_backup-restore
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_mu_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -674,7 +678,7 @@ jobs:
 
 - name: MU_gpcheckcat
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_mu_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -691,7 +695,7 @@ jobs:
 
 - name: MU_gprecoverseg
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_mu_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -708,7 +712,7 @@ jobs:
 
 - name: MU_kerberos-smoke
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_mu_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -725,7 +729,7 @@ jobs:
 
 - name: MU_gpexpand
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_mu_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -742,7 +746,7 @@ jobs:
 
 - name: MU_gptransfer-43x-to-5x
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_mu_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -759,7 +763,7 @@ jobs:
 
 - name: MU_gptransfer-5x-to-5x
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *pulse_trigger_mu_resources
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -903,7 +907,27 @@ jobs:
 
 - name: mpp_interconnect
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: &pulse_trigger_resource
+    - get: gpdb_src
+      params: {submodules: none}
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+      trigger: true
+    - get: gpdb_src_tinc_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: installer_rhel6_gpdb_rc
+      tags: ["gpdb5-pulse-worker"]
+      resource: installer_rhel6_gpdb_rc
+      passed: [gpdb_rc_packaging_centos]
+    - get: qautils_rhel6_tarball
+      tags: ["gpdb5-pulse-worker"]
+      resource: qautils_rhel6_tarball
+      passed: [gpdb_rc_packaging_centos]
+    - get: gpdb_src_behave_tarball
+      tags: ["gpdb5-pulse-worker"]
+      resource: gpdb_src_behave_tarball
+      passed: [gpdb_rc_packaging_centos]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml


### PR DESCRIPTION
This helps when forking the pipeline to demonstrate a particular pulse job's green-ness before merging; you only have to pause the gatekeeper jobs, not every single one.

Pipeline to demonstrate the visual effect of the change: http://gpdb.ci.pivotalci.info/teams/dev/pipelines/pipeline_reorganization_pulse_team_isolation_1795

The paused jobs in the pipeline are highlighting the gatekeepers we added.