### PR TITLE
Reorganize Concourse Pipeline: re-assign responsibilities of packaging job

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -174,7 +174,7 @@ resources:
     start: 4:00 AM
     stop: 5:00 AM
 
-- name: nightly-trigger-pulse
+- name: nightly-trigger
   type: time
   source:
     location: America/Los_Angeles
@@ -538,9 +538,9 @@ jobs:
   - aggregate:
     - get: gpdb_src
       passed: [compile_gpdb_centos6]
-      trigger: true
     - get: bin_gpdb
       passed: [compile_gpdb_centos6]
+      trigger: true
       resource: bin_gpdb_centos6
     - get: centos-gpdb-dev-6
   - task: regression_tests_gphdfs
@@ -700,12 +700,13 @@ jobs:
 
 - name: MU_netbackup76
   plan:
-  - aggregate: &post_packaging_gets_trigger_true
+  - get: nightly-trigger
+    trigger: true
+  - aggregate: &post_packaging_gets_trigger_false
     - get: gpdb_src
       params: {submodules: none}
       tags: ["gpdb5-pulse-worker"]
       passed: [gpdb_rc_packaging_centos]
-      trigger: true
     - get: gpdb_src_tinc_tarball
       tags: ["gpdb5-pulse-worker"]
       passed: [gpdb_rc_packaging_centos]
@@ -738,7 +739,24 @@ jobs:
 
 - name: MU_backup-restore
   plan:
-  - aggregate: *post_packaging_gets_trigger_true
+  - aggregate: &post_packaging_gets_trigger_true
+    - get: gpdb_src
+      params: {submodules: none}
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+      trigger: true
+    - get: gpdb_src_tinc_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: installer_rhel6_gpdb_rc
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: qautils_rhel6_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
+    - get: gpdb_src_behave_tarball
+      tags: ["gpdb5-pulse-worker"]
+      passed: [gpdb_rc_packaging_centos]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -806,7 +824,9 @@ jobs:
 
 - name: MU_gpexpand
   plan:
-  - aggregate: *post_packaging_gets_trigger_true
+  - get: nightly-trigger
+    trigger: true
+  - aggregate: *post_packaging_gets_trigger_false
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -823,7 +843,9 @@ jobs:
 
 - name: MU_gptransfer-43x-to-5x
   plan:
-  - aggregate: *post_packaging_gets_trigger_true
+  - get: nightly-trigger
+    trigger: true
+  - aggregate: *post_packaging_gets_trigger_false
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -892,28 +914,9 @@ jobs:
 
 - name: cs-aoco-compression
   plan:
-  - get: nightly-trigger-pulse
+  - get: nightly-trigger
     trigger: true
-  - aggregate:
-    - get: gpdb_src
-      params: {submodules: none}
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
-    - get: gpdb_src_tinc_tarball
-      tags: ["gpdb5-pulse-worker"]
-      passed: [gpdb_rc_packaging_centos]
-    - get: installer_rhel6_gpdb_rc
-      tags: ["gpdb5-pulse-worker"]
-      resource: installer_rhel6_gpdb_rc
-      passed: [gpdb_rc_packaging_centos]
-    - get: qautils_rhel6_tarball
-      tags: ["gpdb5-pulse-worker"]
-      resource: qautils_rhel6_tarball
-      passed: [gpdb_rc_packaging_centos]
-    - get: gpdb_src_behave_tarball
-      tags: ["gpdb5-pulse-worker"]
-      resource: gpdb_src_behave_tarball
-      passed: [gpdb_rc_packaging_centos]
+  - aggregate: *post_packaging_gets_trigger_false
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -947,7 +950,9 @@ jobs:
 
 - name: unite_ccle_gpdb5
   plan:
-  - aggregate: *post_packaging_gets_trigger_true
+  - get: nightly-trigger
+    trigger: true
+  - aggregate: *post_packaging_gets_trigger_false
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -269,7 +269,8 @@ jobs:
       COVERITY_TOKEN: {{coverity_token}}
       COVERITY_EMAIL: {{coverity_email}}
 
-# Stage 2: Run regression tests (make installcheck-world)
+# Stage 2a: Run regression tests against binaries (make installcheck-world and similar)
+
 - name: icw_planner_centos6
   plan:
   - aggregate:
@@ -494,31 +495,77 @@ jobs:
       image: centos-gpdb-dev-6
       timeout: 3h
 
-# Stage 3: Packaging
+- name: QP_memory-accounting
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: bin_gpdb
+      passed: [compile_gpdb_centos6]
+      resource: bin_gpdb_centos6
+    - get: centos-gpdb-dev-6
+  - task: memory-accounting
+    timeout: 3h
+    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      MAKE_TEST_COMMAND: memory_accounting
+      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      TEST_OS: "centos"
+
+- name: QP_runaway-query
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: bin_gpdb
+      passed: [compile_gpdb_centos6]
+      resource: bin_gpdb_centos6
+    - get: centos-gpdb-dev-6
+  - task: runaway-query
+    timeout: 3h
+    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      MAKE_TEST_COMMAND: runaway_query
+      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      TEST_OS: "centos"
+
+- name: regression_tests_gphdfs_centos
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: bin_gpdb
+      passed: [compile_gpdb_centos6]
+      resource: bin_gpdb_centos6
+    - get: centos-gpdb-dev-6
+  - task: regression_tests_gphdfs
+    file: gpdb_src/concourse/tasks/regression_tests_gphdfs.yml
+    image: centos-gpdb-dev-6
+    params:
+      TARGET_OS: centos
+      TARGET_OS_VERSION: 6
+
+# Stage 2b: Packaging
 
 - name: gpdb_rc_packaging_centos
   plan:
   - aggregate:
     - get: gpdb_src
       passed:
-      - icw_planner_centos6
-      - icw_gporca_centos6
-      - icw_gporca_centos7
-      - icw_planner_codegen_centos6
-      - icw_gporca_codegen_centos6
-      - MU_check_centos
+      - compile_gpdb_centos6
+      - compile_gpdb_centos7
     - get: gpaddon_src
+      passed: [compile_gpdb_centos6]
     - get: bin_gpdb_centos6
-      passed:
-      - icw_planner_centos6
-      - icw_gporca_centos6
-      - icw_planner_codegen_centos6
-      - icw_gporca_codegen_centos6
-      - MU_check_centos
+      passed: [compile_gpdb_centos6]
       trigger: true
     - get: bin_gpdb_centos7
-      passed:
-      - icw_gporca_centos7
+      passed: [compile_gpdb_centos7]
       trigger: true
     - get: centos-gpdb-dev-6
     - get: centos-gpdb-dev-7
@@ -649,11 +696,11 @@ jobs:
       params:
         file: packaged_gpdb_src_behave/greenplum-db-4.3.99.0-behave.tar.gz
 
-# Stage 4: Trigger and monitor pulse project
+# Stage 3: Trigger jobs that rely on packaging
 
 - name: MU_netbackup76
   plan:
-  - aggregate: &pulse_trigger_resource
+  - aggregate: &post_packaging_gets_trigger_true
     - get: gpdb_src
       params: {submodules: none}
       tags: ["gpdb5-pulse-worker"]
@@ -691,7 +738,7 @@ jobs:
 
 - name: MU_backup-restore
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -708,7 +755,7 @@ jobs:
 
 - name: MU_gpcheckcat
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -725,7 +772,7 @@ jobs:
 
 - name: MU_gprecoverseg
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -742,7 +789,7 @@ jobs:
 
 - name: MU_kerberos-smoke
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -759,7 +806,7 @@ jobs:
 
 - name: MU_gpexpand
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -776,7 +823,7 @@ jobs:
 
 - name: MU_gptransfer-43x-to-5x
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -793,7 +840,7 @@ jobs:
 
 - name: MU_gptransfer-5x-to-5x
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -811,7 +858,7 @@ jobs:
 
 - name: cs-pg-two-phase
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -828,7 +875,7 @@ jobs:
 
 - name: cs-walrepl-multinode
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -883,7 +930,7 @@ jobs:
 
 - name: mpp_interconnect
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -900,7 +947,7 @@ jobs:
 
 - name: unite_ccle_gpdb5
   plan:
-  - aggregate: *pulse_trigger_resource
+  - aggregate: *post_packaging_gets_trigger_true
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]
     file: gpdb_src/ci/pulse/api/trigger_pulse.yml
@@ -914,58 +961,3 @@ jobs:
     params:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "GPDB-5-CCLE"
-
-- name: QP_memory-accounting
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [compile_gpdb_centos6]
-      trigger: true
-    - get: bin_gpdb
-      passed: [compile_gpdb_centos6]
-      resource: bin_gpdb_centos6
-    - get: centos-gpdb-dev-6
-  - task: memory-accounting
-    timeout: 3h
-    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
-    image: centos-gpdb-dev-6
-    params:
-      MAKE_TEST_COMMAND: memory_accounting
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
-      TEST_OS: "centos"
-
-- name: QP_runaway-query
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [compile_gpdb_centos6]
-      trigger: true
-    - get: bin_gpdb
-      passed: [compile_gpdb_centos6]
-      resource: bin_gpdb_centos6
-    - get: centos-gpdb-dev-6
-  - task: runaway-query
-    timeout: 3h
-    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
-    image: centos-gpdb-dev-6
-    params:
-      MAKE_TEST_COMMAND: runaway_query
-      BLDWRAP_POSTGRES_CONF_ADDONS: ""
-      TEST_OS: "centos"
-
-- name: regression_tests_gphdfs_centos
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      passed: [gpdb_rc_packaging_centos]
-      trigger: true
-    - get: bin_gpdb
-      passed: [gpdb_rc_packaging_centos]
-      resource: bin_gpdb_centos6
-    - get: centos-gpdb-dev-6
-  - task: regression_tests_gphdfs
-    file: gpdb_src/concourse/tasks/regression_tests_gphdfs.yml
-    image: centos-gpdb-dev-6
-    params:
-      TARGET_OS: centos
-      TARGET_OS_VERSION: 6

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -648,7 +648,8 @@ jobs:
     - put: gpdb_src_behave_tarball
       params:
         file: packaged_gpdb_src_behave/greenplum-db-4.3.99.0-behave.tar.gz
-# Stage 3: Trigger and monitor pulse project
+
+# Stage 4: Trigger and monitor pulse project
 
 - name: MU_netbackup76
   plan:
@@ -663,15 +664,12 @@ jobs:
       passed: [gpdb_rc_packaging_centos]
     - get: installer_rhel6_gpdb_rc
       tags: ["gpdb5-pulse-worker"]
-      resource: installer_rhel6_gpdb_rc
       passed: [gpdb_rc_packaging_centos]
     - get: qautils_rhel6_tarball
       tags: ["gpdb5-pulse-worker"]
-      resource: qautils_rhel6_tarball
       passed: [gpdb_rc_packaging_centos]
     - get: gpdb_src_behave_tarball
       tags: ["gpdb5-pulse-worker"]
-      resource: gpdb_src_behave_tarball
       passed: [gpdb_rc_packaging_centos]
   - task: trigger_pulse
     tags: ["gpdb5-pulse-worker"]


### PR DESCRIPTION
Until now, the packaging job has served three purposes:
    - consolidating the fact that a binary passed all ICW testing (or tests at similar levels)
    - being a gatekeeper for long-running & resource-intensive jobs, often those on Pulse
    - producing a wide variety of packages

The packaging job happened to serve the role as gatekeeper because the pulse jobs run against packaged installers. This is still often true, but we want to emphasize instead how shorter running jobs come earlier in the pipeline whereas longer running jobs come later.

This also moves the responsibility, "consolidate the verification that various ICW and similar tests pass", onto the long-running-tests gatekeeper, as it fits better with that job's purpose.

Note that most long running tests use the packages, but a few use the binaries. This is a good thing and affirms our decision to move the responsibility. This change also highlights that many artifacts do not depend on long-running tests!

Because of this change, the installer files in S3 will not necessarily correspond to binaries which passed ICW. If this is concerning, we could implement a promotion mechanism for these artifacts.

Pipeline demonstrating this change: http://gpdb.ci.pivotalci.info/teams/dev/pipelines/pipeline_reorganization_packaging_reorder_1797