### PR TITLE
Release locks when exiting from FileRepPrimary_IsMirroringRequired()

### DIFF
--- a/src/backend/cdb/cdbfilerepprimary.c
+++ b/src/backend/cdb/cdbfilerepprimary.c
@@ -269,8 +269,15 @@ FileRepPrimary_IsMirroringRequired(
 						primaryMirrorSetIOSuspended(TRUE);
 					}
 
-					if (!PostmasterIsAlive(true))
+					/*
+					 * This code path can be reached from backends which are
+					 * not directly spawned from PostMaster.  For e.g the
+					 * FileRepResyncWorker process is spawned by FileRepMain.
+					 * Hence PostmasterIsAlive() needs to be called with false.
+					 */
+					if (!PostmasterIsAlive(false))
 					{
+						LockReleaseAll(DEFAULT_LOCKMETHOD, false);
 						LWLockReleaseAll();
 						proc_exit(0);
 					}


### PR DESCRIPTION
Commit d09cf2e6424470c3651365df133fcf4177a48871 introduced proc_exit(0) based
on the check that postmaster is not alive and the segment is at fault. The
check for postmaster being alive is incorrect when passed true for
`PostmasterIsAlive()` in case of resync worker as resync workers are not direct
children on postmaster. Because of the incorrect check proc_exit(0) is called
always for resync worker when segment is in fault. Also, the locks are not
released while exiting which might cause other backends `StartTransaction()` to
hang due to virtual xact lock.

Fixes #1791