### PR TITLE
Random fixes for pg_upgrade (pg_dump)

### DIFF
--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -949,7 +949,6 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 		char		name[NAMEDATALEN];
 		Oid			part_oid;
 		Oid			conns_oid;
-		Oid			conrel_oid;
 		Oid			contyp_oid;
 		Oid			con_oid;
 		Oid			prev_oid = InvalidOid;
@@ -960,7 +959,6 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 						  "       co.oid AS conoid, "
 						  "       co.conname, "
 						  "       co.connamespace, "
-						  "       co.conrelid, "
 						  "       co.contypid "
 						  "FROM pg_partitions p "
 						  "JOIN pg_catalog.pg_class c ON "
@@ -996,10 +994,9 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 					strlcpy(name, PQgetvalue(par_res, i, PQfnumber(par_res, "conname")), sizeof(name));
 					con_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "conoid")));
 					conns_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "connamespace")));
-					conrel_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "conrelid")));
 					contyp_oid = atooid(PQgetvalue(par_res, i, PQfnumber(par_res, "contypid")));
 
-					preassign_constraint_oid(AH, con_oid, conns_oid, name, conrel_oid, contyp_oid);
+					preassign_constraint_oid(AH, con_oid, conns_oid, name, part_oid, contyp_oid);
 				}
 
 				prev_oid = part_oid;

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -870,10 +870,6 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 	Oid			pg_type_oid;
 	bool		columnstore;
 
-	/* we only support old >= 8.3 for binary upgrades */
-	if (fout->remoteVersion >= 80300)
-		return;
-
 	upgrade_query = createPQExpBuffer();
 	upgrade_buffer = createPQExpBuffer();
 

--- a/src/bin/pg_dump/binary_upgrade.c
+++ b/src/bin/pg_dump/binary_upgrade.c
@@ -1054,12 +1054,21 @@ preassign_type_oids_by_rel_oid(PGconn *conn, Archive *fout, Archive *AH, Oid pg_
 
 	PQclear(upgrade_res);
 
-	ArchiveEntry(AH, nilCatalogId, createDumpId(),
-				 objname,
-				 NULL, NULL, "",
-				 false, "BINARY UPGRADE", upgrade_buffer->data, "", NULL,
-				 NULL, 0,
-				 NULL, NULL);
+	/*
+	 * It's not unlikely that neither check resulted in more Oids preassigned
+	 * here since the type Oid is handled in the call to preassign_type_oid
+	 * leaving this function to deal with toast and AO auxiliary tables etc.
+	 * Skip adding an archive entry if nothing was added.
+	 */
+	if (upgrade_buffer->len > 0)
+	{
+		ArchiveEntry(AH, nilCatalogId, createDumpId(),
+					 objname,
+					 NULL, NULL, "",
+					 false, "BINARY UPGRADE", upgrade_buffer->data, "", NULL,
+					 NULL, 0,
+					 NULL, NULL);
+	}
 
 	destroyPQExpBuffer(upgrade_query);
 	destroyPQExpBuffer(upgrade_buffer);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -5407,6 +5407,17 @@ dumpBinaryUpgrade(Archive *fout, DumpableObject **dobjs, int numObjs)
 	if (!binary_upgrade || dataOnly)
 		return;
 
+	/*
+	 * We only support binary upgrades from GPDB versions based on
+	 * PostgreSQL 8.2 and higher. This is different from PostgreSQL
+	 * where the lower limit is at 8.3 since the on-disk format
+	 * changes introduced in 8.3 aren't supported in the upstream
+	 * version of pg_upgrade. The GPDB version of pg_upgrade does
+	 * however handle these changes.
+	 */
+	if (fout->remoteVersion < 80200)
+		return;
+
 	for (i = 0; i < numObjs; i++)
 	{
 		DumpableObject *dobj = dobjs[i];


### PR DESCRIPTION
A few random small things stumbled over while working on another patch in pg_upgrade. While related to pg_upgrade, all fixes are in the binary-upgrade code in pg_dump.

* Remove pointless duplicate Oid projection
* Avoid creating an empty Archive which leads to a header comment without content in the dump
* Remove version check for >= 8.3 in dumping