### PR TITLE
Partitioning cleanup

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1927,8 +1927,6 @@ RelationRemoveInheritance(Oid relid)
 	heap_close(catalogRelation, RowExclusiveLock);
 }
 
-/* del_part_entry_by_key is superfluous - removed */
-
 static void
 RemovePartitioning(Oid relid)
 {

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -4983,18 +4983,11 @@ get_part_rule(Relation rel,
 		ListCell				*lc;
 		AlterPartitionId		*pid2	= NULL;
 		PgPartRule*				 prule2 = NULL;
-		StringInfoData			 sid1, sid2;
-
-		initStringInfo(&sid1);
-		initStringInfo(&sid2);
 
 		lc = list_head(l1);
 		prule2 = (PgPartRule*) lfirst(lc);
 		if (prule2 && prule2->topRule && prule2->topRule->children)
 			pNode = prule2->topRule->children;
-
-		truncateStringInfo(&sid1, 0);
-		appendStringInfo(&sid1, "%s", prule2->relname);
 
 		lc = lnext(lc);
 
@@ -5003,7 +4996,7 @@ get_part_rule(Relation rel,
 		prule2 = get_part_rule1(rel,
 								pid2,
 								bExistError, bMustExist,
-								pSearch, pNode, sid1.data, &pNode2);
+								pSearch, pNode, pstrdup(prule2->relname), &pNode2);
 
 		pNode = pNode2;
 

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -868,7 +868,8 @@ cdb_exchange_part_constraints(Relation table,
 	int delta_checks = 0;
 
 
-	/* Setup an empty hash table mapping constraint definition
+	/*
+	 * Setup an empty hash table mapping constraint definition
 	 * strings to ConstraintEntry structures.
 	 */
 	context = AllocSetContextCreate(CurrentMemoryContext,
@@ -1597,8 +1598,6 @@ del_part_template(Oid rootrelid, int16 parlevel, Oid parent)
 /*
  * add_part_to_catalog() - add a partition to the catalog
  *
- *
-
  * NOTE: If bTemplate_Only = false, add both actual partitions and the
  * template definitions (if specified).  However, if bTemplate_Only =
  * true, then only treat the partition spec as a template.

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -722,7 +722,7 @@ DefineRelation(CreateStmt *stmt, char relkind, char relstorage, bool dispatch)
 *		DefinePartitionedRelation
 *				Create the rewrite rule for a partitioned table
 *
-* parse/analyze.c/transformPartitionBy does the bulk of the work for
+* parse_partition.c/transformPartitionBy does the bulk of the work for
 * partitioned tables, converting a single CREATE TABLE into a series
 * of statements to create the child tables for each partition.  Each
 * child table has a check constraint and a rewrite rule to ensure that

--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -49,7 +49,7 @@ typedef struct
 } part_col_cxt;
 
 
-/* state structures for validing parsed partition specifications */
+/* state structures for validating parsed partition specifications */
 typedef struct
 {
 	ParseState *pstate;
@@ -417,7 +417,7 @@ transformPartitionBy(ParseState *pstate, CreateStmtContext *cxt,
 							 "partition key",
 							 what),
 						 errhint("Include column \"%s\" in the %s constraint or create "
-				"a part-wise UNIQUE index after creating the table instead.",
+								 "a part-wise UNIQUE index after creating the table instead.",
 								 strVal(partkeyname), what)));
 			}
 		}
@@ -1085,7 +1085,7 @@ make_child_node(ParseState *pstate, CreateStmt *stmt, CreateStmtContext *cxt, ch
 	 * so we can usually pick up tablespace from the parent relation.  If the
 	 * child is a top-level branch, though, we take the tablespace from the
 	 * root. Ultimately, we take the tablespace as specified in the command,
-	 * or, if none was specified, the one from the root paritioned table.
+	 * or, if none was specified, the one from the root partitioned table.
 	 */
 	if (!child_tab_stmt->tablespacename)
 	{
@@ -1724,9 +1724,11 @@ make_partition_rules(ParseState *pstate,
 				if ((everyOffset + 1) < maxEveryOffset)
 					expr_op = "<";
 				else
+				{
 					/* only be inclusive if set that way */
-				if (pRI && (PART_EDGE_INCLUSIVE == pRI->partedge))
-					expr_op = "<=";
+					if (pRI && (PART_EDGE_INCLUSIVE == pRI->partedge))
+						expr_op = "<=";
+				}
 
 				/* If have EVERY, and not the very first START or last END */
 				if ((0 != everyOffset) && (everyOffset + 1 <= maxEveryOffset))
@@ -2318,9 +2320,7 @@ make_prule_rulestmt(ParseState *pstate,
 		pIns->selectStmt = (Node *) makeNode(SelectStmt);
 		((SelectStmt *) pIns->selectStmt)->valuesLists =
 			list_make1(vl1);
-
 	}
-
 
 	return (pResult);
 }	/* end make_prule_rulestmt */
@@ -3846,7 +3846,6 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 											   ((A_Const *) n2)->location)));
 						}
 					}
-
 				}
 
 				curval = lappend(curval, newend);
@@ -3865,8 +3864,6 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 
 					outputstr = OutputFunctionCall(&finfo, res);
 				}
-
-
 
 				/* the comparison */
 				restypid = InvalidOid;
@@ -4033,7 +4030,10 @@ validate_range_partition(partValidationState *vstate)
 		vstate->prevStartEnd = currStartEnd;
 	}
 
-	vstate->prevHadName = !!(vstate->pElem->partName);	/* bool t/f */
+	if (vstate->pElem->partName != NULL)
+		vstate->prevHadName = true;
+	else
+		vstate->prevHadName = false;
 
 	if (spec->partStart)
 		PartitionRangeItemIsValid(vstate->pstate, (PartitionRangeItem *) spec->partStart);

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -6797,7 +6797,6 @@ check_next_every_name(char *parname1, char *nextname, int parrank)
 
 	initStringInfo(&sid1);
 
-	truncateStringInfo(&sid1, 0);
 	appendStringInfo(&sid1, "%s_%d", parname1, parrank);
 
 	bstat = nextname && (0 == strcmp(sid1.data, nextname));
@@ -6908,8 +6907,6 @@ partition_rule_def_worker(PartitionRule *rule, Node *start,
 
 		initStringInfo(&sid2);
 
-		truncateStringInfo(&sid2, 0);
-
 		/*
 		 * If it's in a nondefault tablespace, say so
 		 * (append after the reloptions)
@@ -6937,8 +6934,6 @@ partition_rule_def_worker(PartitionRule *rule, Node *start,
 			PQExpBuffer      	 pqbuf = createPQExpBuffer();
 
 			initStringInfo(&sid1);
-
-			truncateStringInfo(&sid1, 0);
 
 			/* always quote to make WITH (tablename=...) work correctly */
 			/* MPP-12243: but don't use quote_identifier if already quoted! */
@@ -7008,8 +7003,6 @@ partition_rule_def_worker(PartitionRule *rule, Node *start,
 
 		initStringInfo(&buf);
 		initStringInfo(&sid3);
-
-		truncateStringInfo(&sid3, 0);
 
 		/* NOTE: only the template case */
 		Assert(part->paristemplate);

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1686,7 +1686,7 @@ typedef struct PartitionBy			/* the Partition By clause */
 	PartitionByType		partType;
 	List			   *keys;		/* key columns (Partition By ...) */
 	List			   *keyopclass;	/* opclass for each key */
-	Node			   *partNum;	/* partitionS (constant number)*/
+	Node			   *partNum;	/* partitions (constant number)*/
 	Node			   *subPart;	/* optional subpartn (PartitionBy ptr) */
 	Node			   *partSpec;	/* specification or template */
 	Node			   *partDefault;/* DEFAULT partition (if exists) */


### PR DESCRIPTION
When reading through the partitioning code, found some minor cleanups that seemed worthwhile. Removes some dead code, cleans up some style and removes superflous string truncation calls. See individual commit messages for more information.