### PR TITLE
Remove extended ALTER TABLE INHERIT <column list> syntax

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -263,9 +263,6 @@ int			gp_motion_slice_noop = 0;
 int			gp_ltrace_flag = 0;
 #endif
 
-/* Internal Features */
-bool		gp_enable_alter_table_inherit_cols = false;
-
 /* During insertion in a table with parquet partitions, require tuples to be sorted by partition key */
 bool		gp_parquet_insert_sort = true;
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -10466,21 +10466,12 @@ ATExecAddInherit(Relation child_rel, Node *node)
 
 	if (IsA(node, InheritPartitionCmd))
 	{
-		parent = ((InheritPartitionCmd *)node)->parent;
+		parent = ((InheritPartitionCmd *) node)->parent;
 		is_partition = true;
 	}
 	else
 	{
-		List *inhParms;
-		Assert(IsA(node, List));
-		inhParms = (List *)node;
-
-		Insist(list_length(inhParms) == 2);
-		Assert(IsA(linitial(inhParms), RangeVar));
-		Assert(lsecond(inhParms) == NIL || IsA(lsecond(inhParms), List));
-
-		parent = (RangeVar *)linitial(inhParms);
-		inhAttrNameList = (List *)lsecond(inhParms);
+		parent = (RangeVar *) node;
 		is_partition = false;
 	}
 

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -288,7 +288,6 @@ static Node *makeIsNotDistinctFromNode(Node *expr, int position);
 				cdb_string_list
 				opt_column_list columnList opt_name_list
 				exttab_auth_list keyvalue_list
-				opt_inherited_column_list
 				sort_clause opt_sort_clause sortby_list index_params
 				name_list from_clause from_list opt_array_bounds
 				qualified_name_list any_name any_name_list
@@ -2347,12 +2346,12 @@ alter_table_cmd:
 					n->name = $3;
 					$$ = (Node *)n;
 				}
-			/* ALTER TABLE <name> INHERIT <parent> [( column_list )] */
-			| INHERIT qualified_name opt_inherited_column_list
+			/* ALTER TABLE <name> INHERIT <parent> */
+			| INHERIT qualified_name
 				{
 					AlterTableCmd *n = makeNode(AlterTableCmd);
 					n->subtype = AT_AddInherit;
-					n->def = (Node *)list_make2($2, $3);
+					n->def = (Node *) $2;
 					$$ = (Node *)n;
 				}
 			/* ALTER TABLE <name> NO INHERIT <parent> */
@@ -3791,21 +3790,6 @@ opt_column_list:
 			| /*EMPTY*/								{ $$ = NIL; }
 		;
 		
-opt_inherited_column_list:
-			'('
-				{
-					/* Allowed only when
-					 * gp_enable_alter_table_inherit_cols is true 
-					 */
-					if (!gp_enable_alter_table_inherit_cols)
-					{
-						yyerror("syntax error");
-					}
-				}
-				columnList ')'						{ $$ = $3; }
-			| /*EMPTY*/								{ $$ = NIL; }
-		;
-
 columnList:
 			columnElem								{ $$ = list_make1($1); }
 			| columnList ',' columnElem				{ $$ = lappend($1, $3); }

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2063,17 +2063,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_enable_alter_table_inherit_cols", PGC_USERSET, UNGROUPED,
-			gettext_noop("Enable extended 'ALTER TABLE child INHERIT parent' syntax."),
-			gettext_noop("The extended syntax adds an optional '( column_list )' identifying columns "
-						 "to be marked as fully-inherited from parent."),
-			GUC_NO_SHOW_ALL | GUC_NO_RESET_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
-		},
-		&gp_enable_alter_table_inherit_cols,
-		false, NULL, NULL
-	},
-
-	{
 		{"gp_mapreduce_define", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prepare mapreduce object creation"),	/* turn off statement
 																 * logging */

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -92,7 +92,6 @@ main(int argc, char *argv[])
 	bool		globals_only = false;
 	bool		tablespaces_only = false;
 	bool		schema_only = false;
-	static int	gp_migrator = 0;
 	bool		gp_syntax = false;
 	bool		no_gp_syntax = false;
 	PGconn	   *conn;
@@ -139,7 +138,6 @@ main(int argc, char *argv[])
 		/* START MPP ADDITION */
 		{"gp-syntax", no_argument, NULL, 1},
 		{"no-gp-syntax", no_argument, NULL, 2},
-		{"gp-migrator", no_argument, &gp_migrator, 1},
 		/* END MPP ADDITION */
 
 		{NULL, 0, NULL, 0}

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -661,19 +661,6 @@ extern double gp_selectivity_damping_factor;
 extern bool gp_selectivity_damping_sigsort;
 
 
-/* ----- Internal Features ----- */
-
-/*
- * gp_enable_alter_table_inherit_cols
- *
- * Allows the use of the ALTER TABLE client INHERIT parent [( column_list )]
- * optional column_list.  If this variable is false (the default), use of
- * the optional column_list.  This variable is used by pg_dump --gp-migrator
- * to enable use of the extended syntax.
- */
-extern bool gp_enable_alter_table_inherit_cols;
-
-
 /* ----- Experimental Features ----- */
 
 /*


### PR DESCRIPTION
The gp_enable_alter_table_inherit_cols GUC was used to allow a list of columns to override the attribute discovery for inheritance in ALTER TABLE INHERIT. According to code comments the only consumer of this was gpmigrator, but no callsite remains and no support in pg_dumpall remains either. Remove the leftovers of this to avoid a potential footgun and get us closer to upstream code.