### PR TITLE
Error help available for "ALTER PROTOCOL". 

### DIFF
--- a/doc/src/sgml/ref/alter_protocol.sgml
+++ b/doc/src/sgml/ref/alter_protocol.sgml
@@ -10,7 +10,7 @@ PostgreSQL documentation
 
  <refnamediv>
   <refname>ALTER PROTOCOL</refname>
-  <refpurpose>create a custom data access protocol</refpurpose>
+  <refpurpose>change the definition of a custom data access protocol</refpurpose>
  </refnamediv>
 
  <indexterm zone="sql-alterprotocol">


### PR DESCRIPTION
**Error help available for "ALTER PROTOCOL"**
PostgreSQL 8.3.23 (Greenplum Database 5.0.0 build dev) on x86_64-pc-linux-gnu, compiled by GCC gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-17) compiled on Feb 19 2017 06:53:25
(1 row)
postgres=# \h **ALTER** PROTOCOL
Command: ALTER PROTOCOL
Description: **create** a custom data access protocol
Syntax:
ALTER PROTOCOL name RENAME TO newname

ALTER PROTOCOL name OWNER TO newowner

postgres=# \h **CREATE** PROTOCOL
Command: CREATE PROTOCOL
Description: **create** a custom data access protocol
Syntax:
CREATE [TRUSTED] PROTOCOL name (
[readfunc='read_call_handler'] [, writefunc='write_call_handler']
[, validatorfunc='validate_handler' ])

**The right example**
postgres=# \h ALTER SCHEMA
Command: ALTER SCHEMA
Description: change the definition of a schema
Syntax:
ALTER SCHEMA name RENAME TO newname
ALTER SCHEMA name OWNER TO newowner