### PR TITLE
Add gpconfig flag --file

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -169,10 +169,12 @@ SETUP_TOOLS_DIR=setuptools-$(SETUP_TOOLS_VERSION)
 PARSE_DIR=parse-$(PARSE_VERSION)
 ARG_PARSE_DIR=argparse-$(ARG_PARSE_VERSION)
 PYTHONSRC_INSTALL=$(PYLIB_SRC_EXT)/install
-PYTHONSRC_INSTALL_SITE=$(PYLIB_SRC_EXT)/install/lib/python2.6/site-packages
+PYTHON_VERSION=$(shell python -c "import sys; print '%s.%s' % (sys.version_info[0:2])")
+PYTHONSRC_INSTALL_SITE=$(PYLIB_SRC_EXT)/install/lib/python$(PYTHON_VERSION)/site-packages
 PYTHONSRC_INSTALL_PYTHON_PATH=$(PYTHONPATH):$(PYTHONSRC_INSTALL_SITE)
 BEHAVE_BIN=$(PYTHONSRC_INSTALL)/bin/behave
-MOCK_BIN=$(PYTHONSRC_INSTALL)/lib/python2.6/site-packages/mock-1.0.1-py2.6.egg
+# TODO: mock-1.0.1-py2.6.egg package should be updated.
+MOCK_BIN=$(PYTHONSRC_INSTALL)/lib/python$(PYTHON_VERSION)/site-packages/mock-1.0.1-py2.6.egg
 
 pylint:
 	@echo "--- pylint"

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -253,23 +253,6 @@ solarisTest:
 		echo "SOLARIS" ; \
 	fi
 
-#
-#EPYDOC
-#
-
-EPYDOC_VERSION=3.0.1
-EPYDOC_DIR=epydoc-$(EPYDOC_VERSION)
-EPYDOC_PYTHONPATH=$(PYLIB_DIR):$(PYLIB_SRC_EXT)/$(EPYDOC_DIR)/build/lib/
-
-epydoc:
-	@echo "--- epydoc"
-	@cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(EPYDOC_DIR).tar.gz
-	@cd $(PYLIB_SRC_EXT)/$(EPYDOC_DIR)/ && python setup.py build 1> /dev/null
-
-docs: epydoc
-	@echo "Running epydoc on management scripts..."
-	@PYTHONPATH=$(PYTHONPATH):$(EPYDOC_PYTHONPATH) $(PYLIB_SRC_EXT)/$(EPYDOC_DIR)/build/scripts-2.6/epydoc --config=.epydoc.config
-
 .PHONY: clean
 clean :
 	@rm -rf $(PYLIB_SRC_EXT)/$(LOCKFILE_DIR)

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 #
-# Copyright (c) Greenplum Inc 2009. All Rights Reserved. 
+# Copyright (c) Greenplum Inc 2009. All Rights Reserved.
 
 import os, sys, re
 
 try:
-    from optparse import Option, OptionParser 
+    from optparse import Option, OptionParser
     from gppylib.gpparseopts import OptParser, OptChecker
     from gppylib.gparray import GpArray
     from gppylib.gphostcache import *
@@ -15,8 +15,7 @@ try:
     from gppylib.db import dbconn
     from gppylib.userinput import *
     from pygresql.pg import DatabaseError
-    from gppylib.gpcoverage import GpCoverage
-except ImportError, e:    
+except ImportError, e:
     sys.exit('Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
 EXECNAME = os.path.split(__file__)[-1]
@@ -24,9 +23,10 @@ EXECNAME = os.path.split(__file__)[-1]
 prohibitedGucs = set(["port", "listen_addresses"])
 sameValueGucs = set(["gp_default_storage_options"])
 longShow = set(["port"])
+logger = get_default_logger()
+setup_tool_logging(EXECNAME, getLocalHostname(), getUserName())
 
 def parseargs():
-
     parser = OptParser(option_class=OptChecker)
     parser.remove_option('-h')
     parser.add_option('-h', '-?', '--help', action='help')
@@ -42,79 +42,65 @@ def parseargs():
     parser.add_option('-l', '--list', action='store_true')
     parser.add_option('-P', '--primaryvalue', type='string')
     parser.add_option('-M', '--mirrorvalue', type='string')
+    parser.add_option('-f', '--file', action='store_true')
     (options, args) = parser.parse_args()
 
-    USER=os.getenv('USER')
-    if USER is None or USER is ' ':
-        logger.error('USER environment variable must be set.')
-        parser.exit(status=1)
+    validate_mutual_options(options)
+    validate_four_verbs(options)
+    return options
 
-    if options.list:
-        doList(options.skipvalidation)
-        parser.exit()
 
-    if options.show:
-
-        if options.skipvalidation:
-            logger.error('--skipvalidation can not be combined with --show')
-            parser.exit(status=1)
-        elif options.show in longShow:
-            doShow(options.show, longform=True)
-        else:
-            doShow(options.show, longform=False)
-
-        parser.exit()
-
-    if options.change and options.remove:
-        logger.error("Multiple actions specified.  See the --help info.")
-        parser.exit(status=1)
-
+def validate_four_verbs(options):
     if options.change:
         options.entry = options.change
+
     elif options.remove:
         options.entry = options.remove
         options.remove = True
-    else:
-        logger.error("No action specified.  See the --help info.")
-        parser.exit(status=1)
+    elif not options.list and not options.show:
+        log_and_raise("No action specified.  See the --help info.")
 
+
+def validate_mutual_options(options):
+    user = os.getenv('USER')
+    if user is None or user is ' ':
+        log_and_raise("USER environment variable must be set.")
+
+    if options.change and options.remove:
+        log_and_raise("Multiple actions specified.  See the --help info.")
+    if options.file and not options.show:
+        log_and_raise("'--file' option must accompany '--show' option")
     if options.remove and (options.value or options.primaryvalue or options.mirrorvalue or options.mastervalue):
-        logger.error("remove action does not take a value, primary value, mirror value or master value parameter")
-        parser.exit(status=1)
-
+        log_and_raise("remove action does not take a value, primary value, mirror value or master value parameter")
     if options.change and (not options.value and (not options.mirrorvalue and not options.primaryvalue)):
-        logger.error("change requested but value not specified")
-        parser.exit(status=1)
-
+        log_and_raise("change requested but value not specified")
     if options.change and options.mastervalue and options.masteronly:
-        logger.error("when changing a parameter on the master only specify the --value not --mastervalue")
-        parser.exit(status=1)
-
+        log_and_raise("when changing a parameter on the master only specify the --value not --mastervalue")
     if options.change and (options.value and (options.primaryvalue or options.mirrorvalue)):
-        logger.error("cannot use both value option and primaryvalue/mirrorvalue option")
-        parser.exit(status=1)
-
+        log_and_raise("cannot use both value option and primaryvalue/mirrorvalue option")
     if (options.masteronly or options.mastervalue) and options.entry in sameValueGucs:
-        logger.error("%s value cannot be different on master and segments", options.entry)
-        parser.exit(status=1)
-
+        log_and_raise("%s value cannot be different on master and segments" % options.entry)
     if options.value and (not options.mastervalue):
         options.mastervalue = options.value
+    if "MASTER_DATA_DIRECTORY" not in os.environ:
+        log_and_raise("--file option requires that MASTER_DATA_DIRECTORY be set")
 
-    return options
+
 
 class JetPackQuery:
     def __init__(self, name):
         self.query = "select * from gp_toolkit.gp_param_setting('%s')" % name
 
+
 class JetPackGuc:
-    def __init__(self,row): 
+    def __init__(self, row):
         self.context = row[0]
         self.name = row[1]
         self.value = row[2]
 
-    def Print(self):
+    def print_info(self):
         print "[context: %s] [name: %s] [value: %s]" % (self.context, self.name, self.value)
+
 
 class GucQuery:
     def __init__(self, name=None):
@@ -122,8 +108,9 @@ class GucQuery:
         if name:
             self.query = self.query + " where name = '" + name + "'"
 
+
 class Guc:
-    def __init__(self,row): 
+    def __init__(self, row):
         self.name = row[0]
         self.setting = row[1]
         self.unit = row[2]
@@ -133,7 +120,7 @@ class Guc:
         self.min_val = row[6]
         self.max_val = row[7]
 
-    def validate(self, newval, newmasterval):
+    def validate(self, newval, newmasterval, options):
         # todo add code here...
         # be careful 128KB in postgresql.conf is translated into 32KB units
 
@@ -148,7 +135,9 @@ class Guc:
 
         elif self.name == 'unix_socket_permissions':
             if newval[0] != '0':
-                logger.warn('Permission not entered in octal format.It was interpreted as Decimal.  %s in Octal = 0%s' % (newval, int(newval, 8)))
+                logger.warn(
+                    'Permission not entered in octal format.It was interpreted as Decimal.  %s in Octal = 0%s' % (
+                    newval, int(newval, 8)))
         elif self.name == "gp_default_storage_options":
             newval = newval.strip()
             # Value must be enclosed in single quotes else postgres
@@ -171,20 +160,24 @@ class Guc:
                     return ("Valid values are of the form 'name=value,...'.")
         return "ok"
 
-    def Print(self):
-        print "[name: %s] [unit: %s] [context: %s] [vartype: %s] [min_val: %s] [max_val: %s]" % (self.name, self.unit, self.context, self.vartype, self.min_val, self.max_val)
+    def print_info(self):
+        print "[name: %s] [unit: %s] [context: %s] [vartype: %s] [min_val: %s] [max_val: %s]" % (
+        self.name, self.unit, self.context, self.vartype, self.min_val, self.max_val)
 
-def userConfirm():
-    if not ask_yesno('', "Are you sure you want to ignore unreachable hosts?",'N'):                            
+
+def confirm_user():
+    if not ask_yesno('', "Are you sure you want to ignore unreachable hosts?", 'N'):
         logger.info("User Aborted. Exiting...")
         sys.exit(0)
 
-def verbosePrint(options, normalized_hostname, hostname, directory):
+
+def print_verbosely(options, normalized_hostname, hostname, directory):
     if options.verbose:
         msg = "normalized_host=%s host=%s dir=%s" % (normalized_hostname, hostname, directory)
         logger.info(msg)
 
-def doList(skipvalidation):
+
+def do_list(skipvalidation):
     try:
         dburl = dbconn.DbURL()
         conn = dbconn.connect(dburl, True)
@@ -193,200 +186,267 @@ def doList(skipvalidation):
         for row in rows:
             guc = Guc(row)
             if skipvalidation or (guc.name not in prohibitedGucs):
-                guc.Print()
-    
+                guc.print_info()
+
         conn.close()
 
     except DatabaseError, ex:
         logger.error('Failed to connect to database, this script can only be run when the database is up.')
 
-def doShow(gucname, longform):
+
+def do_show_from_psql(gucname, longform):
     try:
         dburl = dbconn.DbURL()
         conn = dbconn.connect(dburl, False)
         query = JetPackQuery(gucname).query
         rows = dbconn.execSQL(conn, query)
-
-        mastervalue = None
-        value = None
-        valid = True
-    
-        if longform:
-
-            print "GUC                 : %s" % gucname
-            for row in rows:
-                guc = JetPackGuc(row)
-                print "Context: %5s Value: %s" % (guc.context, guc.value)
-
-        else:
-            for row in rows:
-                guc = JetPackGuc(row)
-    
-                if guc.context == -1:
-                    mastervalue = guc.value
-    
-                elif not value:
-                    value = guc.value
-    
-                elif value == guc.value:
-                    pass
-            
-                else:
-                    valid = False
-                    break
-    
-            if valid:
-                print "Values on all segments are consistent"
-                print "GUC          : %s" % gucname
-                print "Master  value: %s" % mastervalue
-                print "Segment value: %s" % value
-            
-            else:
-                print "WARNING: GUCS ARE OUT OF SYNC: "
-    
-                rows = dbconn.execSQL(conn, query)
-                for row in rows:
-                    guc = JetPackGuc(row)
-                    guc.Print()
-    
+        gucs = [JetPackGuc(r) for r in rows]
+        _print_gucs(gucname, gucs, longform)
         conn.close()
 
-    except DatabaseError, ex:
+    except DatabaseError as ex:
 
         if re.search("unrecognized configuration parameter", ex.__str__()):
             logger.error('Failed to retrieve GUC information, guc does not exist: ' + gucname)
         elif re.search("could not connect to server", ex.__str__()):
-            logger.error('Failed to retrieve GUC information, the database is not accesible')
+            logger.error('Failed to retrieve GUC information, the database is not accessible')
         else:
             logger.error('Failed to retrieve GUC information: ' + ex.__str__())
 
 
-def doAddConfigScript(pool, hostname, segs, value):
+def _print_gucs(gucname, gucs, longform):
+    mastervalue = None
+    value = None
+    valid = True
+    if longform:
+        print "GUC                 : %s" % gucname
+        for guc in gucs:
+            print "Context: %5s Value: %s" % (guc.context, guc.value)
+    else:
+        for guc in gucs:
+
+            if guc.context == -1:
+                mastervalue = guc.value
+
+            elif not value:
+                value = guc.value
+
+            elif value == guc.value:
+                pass
+
+            else:
+                valid = False
+                break
+
+        if valid:
+            print "Values on all segments are consistent"
+            print "GUC          : %s" % gucname
+            print "Master  value: %s" % mastervalue
+            print "Segment value: %s" % value
+
+        else:
+            print "WARNING: GUCS ARE OUT OF SYNC: "
+            for guc in gucs:
+                guc.print_info()
+
+
+def do_add_config_script(pool, hostname, segs, value, options):
     directory_string = None
-    
+
     for seg in segs:
-   
+
         if directory_string:
             directory_string = directory_string + "\n" + seg.datadir
         else:
             directory_string = seg.datadir
-    
-        verbosePrint(options, hostname, seg.hostname, seg.datadir)
-    
-    cmd = GpAddConfigScript(hostname, directory_string, options.entry, value, options.remove, ctxt=REMOTE, remoteHost=hostname)
+
+        print_verbosely(options, hostname, seg.hostname, seg.datadir)
+
+    cmd = GpAddConfigScript(hostname, directory_string, options.entry, value, options.remove, ctxt=REMOTE,
+                            remoteHost=hostname)
     pool.addCommand(cmd)
 
-#------------------------------- Mainline --------------------------------
 
-coverage = GpCoverage()
-coverage.start()
+def do_change(options):
+    if options.debug:
+        enable_verbose_logging()
 
-logger = get_default_logger()
-setup_tool_logging(EXECNAME,getLocalHostname(),getUserName())
+    try:
+        dburl = dbconn.DbURL()
 
-options = parseargs()
+        gparray = GpArray.initFromCatalog(dburl, utility=True)
 
-if options.debug:
-    enable_verbose_logging()
+        if not options.skipvalidation:
 
-try:
-    dburl = dbconn.DbURL()
+            conn = dbconn.connect(dburl, True)
 
-    gparray = GpArray.initFromCatalog(dburl,utility=True)
+            rows = dbconn.execSQL(conn, GucQuery(options.entry).query)
 
-    if not options.skipvalidation:
+            guc = None
 
-        conn = dbconn.connect(dburl, True)
-    
-        rows = dbconn.execSQL(conn, GucQuery(options.entry).query)
+            for row in rows:
+                if guc:
+                    logger.fatal("more than 1 GUC matches: " + options.entry)
+                    sys.exit(1)
 
-        guc = None
+                guc = Guc(row)
 
-        for row in rows:
-            if guc:
-                logger.fatal("more than 1 GUC matches: " + options.entry)
+            if not guc:
+                logger.fatal("not a valid GUC: " + options.entry)
                 sys.exit(1)
 
-            guc = Guc(row)
-    
-        if not guc:
-            logger.fatal("not a valid GUC: " + options.entry)
-            sys.exit(1)
-    
-        conn.close()
+            conn.close()
 
-        if options.entry in prohibitedGucs:
-            logger.fatal("The parameter '%s' is not modifiable with this tool" % options.entry)
-            sys.exit(1)
-    
-        if options.value:
-            msg = guc.validate(options.value, options.mastervalue)
-            if msg != "ok":
-                logger.fatal("new GUC value failed validation: " + msg )
+            if options.entry in prohibitedGucs:
+                logger.fatal("The parameter '%s' is not modifiable with this tool" % options.entry)
                 sys.exit(1)
-except DatabaseError, ex:
-    logger.error(ex.__str__())
-    logger.error('Failed to connect to database, exiting without action. This script can only be run when the database is up.')
-    sys.exit(1)
 
-pool = WorkerPool()
+            if options.value:
+                msg = guc.validate(options.value, options.mastervalue, options)
+                if msg != "ok":
+                    logger.fatal("new GUC value failed validation: " + msg)
+                    sys.exit(1)
+    except DatabaseError, ex:
+        logger.error(ex.__str__())
+        logger.error(
+            'Failed to connect to database, exiting without action. This script can only be run when the database is up.')
+        sys.exit(1)
 
-hostCache = GpHostCache(gparray, pool)
-failedPings = hostCache.ping_hosts(pool)
+    pool = WorkerPool()
 
-if len(failedPings):
-    for i in failedPings:
-        logger.warning('unreachable host: ' + i.hostname)
-    userConfirm()
+    hostCache = GpHostCache(gparray, pool)
+    failedPings = hostCache.ping_hosts(pool)
 
-try:
-    # do the segments
-    if not options.masteronly:
-        for h in hostCache.get_hosts():
-            directory_string = None
-            
-            if options.primaryvalue:
-                doAddConfigScript(pool, h.hostname, [seg for seg in h.dbs if seg.isSegmentPrimary()], options.primaryvalue)
+    if len(failedPings):
+        for i in failedPings:
+            logger.warning('unreachable host: ' + i.hostname)
+        confirm_user()
 
-            if options.mirrorvalue:
-                doAddConfigScript(pool, h.hostname, [seg for seg in h.dbs if seg.isSegmentMirror()], options.mirrorvalue)
-                
-            if not options.primaryvalue and not options.mirrorvalue:
-                doAddConfigScript(pool, h.hostname, h.dbs, options.value)
-    
-    # do the master
-    if options.mastervalue or options.remove:
-        verbosePrint(options, gparray.master.hostname, gparray.master.hostname, gparray.master.datadir)
-        cmd = GpAddConfigScript("master", gparray.master.datadir, options.entry, options.mastervalue, options.remove, ctxt=REMOTE, remoteHost=gparray.master.hostname)
-        pool.addCommand(cmd)
-    
-        # do the standby master
-        if gparray.standbyMaster:
-            verbosePrint(options, gparray.standbyMaster.hostname, gparray.standbyMaster.hostname, gparray.standbyMaster.datadir)
-            cmd = GpAddConfigScript("standbymaster", gparray.standbyMaster.datadir, options.entry, options.mastervalue, options.remove, ctxt=REMOTE, remoteHost=gparray.standbyMaster.hostname)
+    failure = False
+    try:
+        # do the segments
+        if not options.masteronly:
+            for h in hostCache.get_hosts():
+
+                if options.primaryvalue:
+                    do_add_config_script(pool, h.hostname, [seg for seg in h.dbs if seg.isSegmentPrimary()],
+                                         options.primaryvalue, options)
+
+                if options.mirrorvalue:
+                    do_add_config_script(pool, h.hostname, [seg for seg in h.dbs if seg.isSegmentMirror()],
+                                         options.mirrorvalue, options)
+
+                if not options.primaryvalue and not options.mirrorvalue:
+                    do_add_config_script(pool, h.hostname, h.dbs, options.value, options)
+
+        # do the master
+        if options.mastervalue or options.remove:
+            print_verbosely(options, gparray.master.hostname, gparray.master.hostname, gparray.master.datadir)
+            cmd = GpAddConfigScript("master", gparray.master.datadir, options.entry, options.mastervalue,
+                                    options.remove, ctxt=REMOTE, remoteHost=gparray.master.hostname)
             pool.addCommand(cmd)
 
+            # do the standby master
+            if gparray.standbyMaster:
+                print_verbosely(options, gparray.standbyMaster.hostname, gparray.standbyMaster.hostname,
+                                gparray.standbyMaster.datadir)
+                cmd = GpAddConfigScript("standbymaster", gparray.standbyMaster.datadir, options.entry,
+                                        options.mastervalue, options.remove, ctxt=REMOTE,
+                                        remoteHost=gparray.standbyMaster.hostname)
+                pool.addCommand(cmd)
+
+        pool.join()
+        items = pool.getCompletedItems()
+        for i in items:
+            if not i.was_successful():
+                logger.error('failed updating the postgresql.conf files on host: ' + i.remoteHost)
+                failure = True
+
+        pool.check_results()
+    except Exception, e:
+        logger.error('errors in job:')
+        logger.error(e.__str__())
+        logger.error('exiting early')
+
+    pool.haltWork()
+    pool.joinWorkers()
+
+    if failure:
+        logger.error('finished with errors')
+    else:
+        logger.info("completed successfully")
+
+
+def log_and_raise(err_str):
+    logger.error(err_str)
+    raise Exception(err_str)
+
+
+def do_show_from_file(gucname, long_format):
+
+    dburl = dbconn.DbURL()
+    gparray = GpArray.initFromCatalog(dburl, utility=True)
+
+    pool = WorkerPool()
+    host_cache = GpHostCache(gparray, pool, withMasters=True)
+    failed_pings = host_cache.ping_hosts(pool)
+
+    if len(failed_pings):
+        for i in failed_pings:
+            logger.warning('unreachable host: ' + i.hostname)
+        confirm_user()
+
+    commands = []
+    for h in host_cache.get_hosts():
+        for seg in h.dbs:
+            command = GpReadConfig("readConfig", h, seg, gucname)
+            commands.append(command)
+            pool.addCommand(command)
+
     pool.join()
-    items = pool.getCompletedItems()
-    failure = False
-    for i in items:
-        if not i.was_successful():
-            logger.error('failed updating the postgresql.conf files on host: ' + i.remoteHost)
-            failure = True
-        
+
+    gucs = []
+    for cmd in pool.getCompletedItems():
+        value = cmd.get_guc_value()
+        if not value:
+            value = "not set in postgresql.conf"
+        gucs.append(JetPackGuc([cmd.get_seg_content_id(), gucname, value]))
+    _print_gucs(gucname, gucs, long_format)
+
     pool.check_results()
-except Exception, e:
-    logger.error('errors in job:')
-    logger.error(e.__str__())
-    logger.error('exiting early')
+    pool.haltWork()
+    pool.joinWorkers()
 
-pool.haltWork()
-pool.joinWorkers()
 
-if failure:
-    logger.error('finished with errors')
-else:
-    logger.info("completed successfully")
+def do_main():
+    options = parseargs()
+    if options.list:
+        do_list(options.skipvalidation)
 
-coverage.stop()
-coverage.generate_report()
+    elif options.show:
+        # TODO looks like the following line is supposed to be ... options.value in longShow
+        # therefore, this long format has NEVER been used and can be removed.
+        long_format = options.show in longShow
+        if options.skipvalidation:
+            log_and_raise('--skipvalidation can not be combined with --show')
+        elif options.file:
+            do_show_from_file(options.show, long_format)
+        else:
+            do_show_from_psql(options.show, long_format)
+
+    elif options.remove or options.change:
+        do_change(options)
+
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+if __name__ == '__main__':
+    """
+    Avoid stack trace; just print exception message and return error code
+    """
+    try:
+        do_main()
+    except Exception as e:
+        print (e.message)
+        sys.exit(1)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -85,8 +85,8 @@ class PySync(Command):
 
 class CmdArgs(list):
     """
-    Conceptually this is a list of an executable path and executable options 
-    built in a structured manner with a canonical string representation suitable 
+    Conceptually this is a list of an executable path and executable options
+    built in a structured manner with a canonical string representation suitable
     for execution via a shell.
 
     Examples
@@ -128,18 +128,18 @@ class CmdArgs(list):
         @param wait: true if should wait until operation completes
         @param timeout: number of seconds to wait before giving up
         """
-        if wait: 
+        if wait:
             self.append("-w")
-        if timeout: 
+        if timeout:
             self.append("-t")
             self.append(str(timeout))
         return self
 
     def set_segments(self, segments):
         """
-        The reduces the command line length of the gpsegstart.py and other 
-        commands. There are shell limitations to the length and if there are a 
-        large number of segments and filespaces this limit can be exceeded. 
+        The reduces the command line length of the gpsegstart.py and other
+        commands. There are shell limitations to the length and if there are a
+        large number of segments and filespaces this limit can be exceeded.
         Since filespaces are not used by our callers, we remove all but one of them.
 
         @param segments - segments (from GpArray.getSegmentsByHostName)
@@ -154,7 +154,7 @@ class CmdArgs(list):
 class PgCtlBackendOptions(CmdArgs):
     """
     List of options suitable for use with the -o option of pg_ctl.
-    Used by MasterStart, SegmentStart to format the backend options 
+    Used by MasterStart, SegmentStart to format the backend options
     string passed via pg_ctl -o
 
     Examples
@@ -178,14 +178,14 @@ class PgCtlBackendOptions(CmdArgs):
     '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_restricted(True,1))
     '-p 5432 --gp_dbid=1 --gp_num_contents_in_cluster=2 --silent-mode=true -c superuser_reserved_connections=1'
-    >>> 
+    >>>
 
     """
 
     def __init__(self, port, dbid, numcids):
         """
         @param port: backend port
-        @param dbid: backed dbid 
+        @param dbid: backed dbid
         @param numcids: total number of content ids in cluster
         """
         CmdArgs.__init__(self, [
@@ -256,8 +256,8 @@ class PgCtlStartArgs(CmdArgs):
 
     >>> a = PgCtlStartArgs("/data1/master/gpseg-1", str(PgCtlBackendOptions(5432, 1, 2)), 123, None, None, True, 600)
     >>> str(a).split(' ') #doctest: +NORMALIZE_WHITESPACE
-    ['env', GPERA=123', '$GPHOME/bin/pg_ctl', '-D', '/data1/master/gpseg-1', '-l', 
-     '/data1/master/gpseg-1/pg_log/startup.log', '-w', '-t', '600', 
+    ['env', GPERA=123', '$GPHOME/bin/pg_ctl', '-D', '/data1/master/gpseg-1', '-l',
+     '/data1/master/gpseg-1/pg_log/startup.log', '-w', '-t', '600',
      '-o', '"', '-p', '5432', '--gp_dbid=1', '--gp_num_contents_in_cluster=2', '--silent-mode=true', '"', 'start']
     """
 
@@ -502,9 +502,9 @@ class SendFilerepTransitionStatusMessage(Command):
 class SendFilerepVerifyMessage(Command):
 
     DEFAULT_IGNORE_FILES = [
-        'pg_internal.init', 'pgstat.stat', 'pga_hba.conf', 
-        'pg_ident.conf', 'pg_fsm.cache', 'gp_dbid', 'gp_pmtransitions_args', 
-        'gp_dump', 'postgresql.conf', 'postmaster.log', 'postmaster.opts', 
+        'pg_internal.init', 'pgstat.stat', 'pga_hba.conf',
+        'pg_ident.conf', 'pg_fsm.cache', 'gp_dbid', 'gp_pmtransitions_args',
+        'gp_dump', 'postgresql.conf', 'postmaster.log', 'postmaster.opts',
         'postmaser.pids', 'postgresql.conf.bak', 'core',  'wet_execute.tbl',
         'recovery.done', 'gp_temporary_files_filespace', 'gp_transaction_files_filespace']
 
@@ -516,18 +516,18 @@ class SendFilerepVerifyMessage(Command):
                  abort=None, suspend=None, resume=None, ignore_dir=None, ignore_file=None,
                  results=None, results_level=None, ctxt=LOCAL, remoteHost=None):
         """
-        Sends gp_verify message to backend to either start or get results of a 
+        Sends gp_verify message to backend to either start or get results of a
         mirror verification.
         """
-        
+
         self.host = host
         self.port = port
-        
+
         msg_contents = ['gp_verify']
-        
+
         ## The ordering of the following appends is critical.  Do not rearrange without
         ## an associated change in gp_primarymirror
-        
+
         # full
         msg_contents.append('true') if full else msg_contents.append('')
         # verify_file
@@ -535,7 +535,7 @@ class SendFilerepVerifyMessage(Command):
         # verify_dir
         msg_contents.append(verify_dir) if verify_dir else msg_contents.append('')
         # token
-        msg_contents.append(token) 
+        msg_contents.append(token)
         # abort
         msg_contents.append('true') if abort else msg_contents.append('')
         # suspend
@@ -550,16 +550,16 @@ class SendFilerepVerifyMessage(Command):
         msg_contents.append(','.join(ignore_file_list))
         # resultslevel
         msg_contents.append(str(results_level)) if results_level else msg_contents.append('')
-        
+
         logger.debug("gp_verify message sent to %s:%s:\n%s" % (host, port, "\n".join(msg_contents)))
-        
+
         self.cmdStr='$GPHOME/bin/gp_primarymirror -h %s -p %s' % (host, port)
         Command.__init__(self, name, self.cmdStr, ctxt, remoteHost, stdin="\n".join(msg_contents))
-        
-    
+
+
 #-----------------------------------------------
 class SegmentStop(Command):
-    def __init__(self, name, dataDir,mode='smart', nowait=False, ctxt=LOCAL, 
+    def __init__(self, name, dataDir,mode='smart', nowait=False, ctxt=LOCAL,
                  remoteHost=None, timeout=SEGMENT_STOP_TIMEOUT_DEFAULT):
 
         self.cmdStr = str( PgCtlStopArgs(dataDir, mode, not nowait, timeout) )
@@ -686,7 +686,7 @@ class GpGetSegmentStatusValues(Command):
 
     def decodeResults(self):
         """
-        return (warning,outputFromCmd) tuple, where if warning is None then 
+        return (warning,outputFromCmd) tuple, where if warning is None then
            results were returned and outputFromCmd should be read.  Otherwise, the warning should
            be logged and outputFromCmd ignored
         """
@@ -717,7 +717,7 @@ SEGSTART_ERROR_PG_CTL_FAILED = 8
 SEGSTART_ERROR_CHECKING_CONNECTION_AND_LOCALE_FAILED = 9
 SEGSTART_ERROR_PING_FAILED = 10 # not actually done inside GpSegStartCmd, done instead by caller
 SEGSTART_ERROR_OTHER = 1000
-    
+
 
 class GpSegStartArgs(CmdArgs):
     """
@@ -752,7 +752,7 @@ class GpSegStartArgs(CmdArgs):
         @param special - special mode
         """
         assert(special in [None, 'upgrade', 'maintenance'])
-        if special: 
+        if special:
             self.append("-U")
             self.append(special)
         return self
@@ -771,7 +771,7 @@ class GpSegStartArgs(CmdArgs):
 class GpSegStartCmd(Command):
     def __init__(self, name, gphome, segments, localeData, gpversion,
                  mirrormode, numContentsInCluster, era,
-                 timeout=SEGMENT_TIMEOUT_DEFAULT, verbose=False, 
+                 timeout=SEGMENT_TIMEOUT_DEFAULT, verbose=False,
                  ctxt=LOCAL, remoteHost=None, pickledTransitionData=None,
                  specialMode=None, wrapper=None, wrapper_args=None,
                  logfileDirectory=False):
@@ -1020,7 +1020,7 @@ class Psql(Command):
         elif filename is not None:
             cmdStr += '-f %s ' % filename
         else:
-            raise Exception('Psql must be passed a query or a filename.')    
+            raise Exception('Psql must be passed a query or a filename.')
 
         # shell escape and force double quote of database in case of any funny chars
         cmdStr += '"%s" ' % shellEscape(database)
@@ -1065,7 +1065,7 @@ class GpDumpDirsExist(Command):
     def __init__(self, name, baseDir, ctxt=LOCAL, remoteHost=None):
         cmdStr = "find %s -name '*dump*' -print" % baseDir
         Command.__init__(self, name, cmdStr, ctxt, remoteHost)
-        
+
     @staticmethod
     def local(name, baseDir):
         cmd = GpDumpDirsExist(name, baseDir)
@@ -1113,10 +1113,10 @@ class ConfigureNewSegment(Command):
                                       and we should have lighter restrictions on how to check it for emptiness
                                       Passing None is the same as passing an array of all False values
 
-        @param primaryMirror Process 'primary' or 'mirror' or 'both' 
-                                      
+        @param primaryMirror Process 'primary' or 'mirror' or 'both'
+
         @return A dictionary with the following format:
-        
+
                 Name  =   <host name>
                 Value =   <system data directory>
                         : <port>
@@ -1149,7 +1149,7 @@ class ConfigureNewSegment(Command):
                         "true" if seg.isSegmentPrimary(current_role=True) else "false",
                         "true" if isTargetReusedLocation else "false",
                         seg.getSegmentDbId(),
-                        "" if len(filespaces) == 0 else (":" + ":".join(filespaces))  
+                        "" if len(filespaces) == 0 else (":" + ":".join(filespaces))
             )
         return result
 
@@ -1236,23 +1236,23 @@ class GpAddConfigScript(Command):
 
         Command.__init__(self,name,cmdStr,ctxt,remoteHost)
 
-#-----------------------------------------------        
+#-----------------------------------------------
 class GpAppendGucToFile(Command):
 
     # guc value will come in pickled and base64 encoded
 
-    def __init__(self,name,file,guc,value,ctxt=LOCAL,remoteHost=None):    
+    def __init__(self,name,file,guc,value,ctxt=LOCAL,remoteHost=None):
         unpickledText = pickle.loads(base64.urlsafe_b64decode(value))
         finalText = unpickledText.replace('"', '\\\"')
         cmdStr = 'echo "%s=%s" >> %s' %  (guc, finalText, file)
         Command.__init__(self,name,cmdStr,ctxt,remoteHost)
 
 
-#-----------------------------------------------        
+#-----------------------------------------------
 class GpLogFilter(Command):
-    def __init__(self, name, filename, start=None, end=None, duration=None, 
+    def __init__(self, name, filename, start=None, end=None, duration=None,
                  case=None, count=None, search_string=None,
-                 exclude_string=None, search_regex=None, exclude_regex=None, 
+                 exclude_string=None, search_regex=None, exclude_regex=None,
                  trouble=None, ctxt=LOCAL,remoteHost=None):
         cmdfrags = []
         if start:
@@ -1276,14 +1276,14 @@ class GpLogFilter(Command):
         if trouble:
             cmdfrags.append('-t')
         cmdfrags.append(filename)
-        
+
         self.cmdStr = "$GPHOME/bin/gplogfilter %s" % ' '.join(cmdfrags)
         Command.__init__(self, name, self.cmdStr, ctxt,remoteHost)
 
     @staticmethod
-    def local(name, filename, start=None, end=None, duration=None, 
+    def local(name, filename, start=None, end=None, duration=None,
                case=None, count=None, search_string=None,
-               exclude_string=None, search_regex=None, exclude_regex=None, 
+               exclude_string=None, search_regex=None, exclude_regex=None,
                trouble=None):
         cmd = GpLogFilter(name, filename, start, end, duration, case, count, search_string,
                           exclude_string, search_regex, exclude_regex, trouble)
@@ -1412,10 +1412,10 @@ def start_standbymaster(host, datadir, port, dbid, ncontents, era=None,
 
 def get_pid_from_remotehost(host, datadir):
     cmd = Command(name = 'get the pid from postmaster file',
-                  cmdStr = 'head -1 %s/postmaster.pid' % datadir, 
-                  ctxt=REMOTE, remoteHost = host)  
+                  cmdStr = 'head -1 %s/postmaster.pid' % datadir,
+                  ctxt=REMOTE, remoteHost = host)
     cmd.run()
-    pid = None 
+    pid = None
     if cmd.get_results().rc == 0 and cmd.get_results().stdout.strip():
         pid = int(cmd.get_results().stdout.strip())
     return pid
@@ -1440,7 +1440,7 @@ def is_pid_postmaster(datadir, pid, remoteHost=None):
         ctxt = REMOTE
     else:
         ctxt = LOCAL
-    
+
     is_postmaster = True
     if (validate_command ('pgrep', datadir, ctxt, remoteHost) and
             validate_command ('pwdx', datadir, ctxt, remoteHost)):
@@ -1453,7 +1453,7 @@ def is_pid_postmaster(datadir, pid, remoteHost=None):
             if not res.stdout.strip():
                 is_postmaster = False
             else:
-                logger.info(res.stdout.strip())                
+                logger.info(res.stdout.strip())
         except Exception as e:
             if not remoteHost is None:
                 logger.warning('failed to get the status of postmaster %s on %s. assuming that postmaster is running' % (datadir, remoteHost))
@@ -1645,12 +1645,12 @@ def pausePg(db):
             pass
 
     decsendentProcessPids = getDescendentProcesses(postmasterPID)
-        
+
     for killpid in decsendentProcessPids:
 
         Kill.local(name="pausep "+str(killpid), pid=killpid, signal="STOP")
 
-    
+
 def resumePg(db):
     """
     1) resume the processes descendent from the postmaster process
@@ -1664,7 +1664,7 @@ def resumePg(db):
         raise Exception, 'print "could not locate postmasterPID during resume'
 
     decsendentProcessPids = getDescendentProcesses(postmasterPID)
-        
+
     for killpid in decsendentProcessPids:
 
         Kill.local(name="pausep "+str(killpid), pid=killpid, signal="CONT")
@@ -1682,7 +1682,7 @@ def createTempDirectoryName(masterDataDirectory, tempDirPrefix):
 
 #-------------------------------------------------------------------------
 # gp_dbid methods moved to gp_dbid.py, but this class was left here
-# to avoid changing gpmigrator and gpmigrator_mirror (which is the only caller).  
+# to avoid changing gpmigrator and gpmigrator_mirror (which is the only caller).
 #
 
 class GpCreateDBIdFile(Command):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gp.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gp.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import tempfile
+
+from StringIO import StringIO
+
+from commands.base import CommandResult
+from commands.gp import GpReadConfig
+from gparray import GpDB, GpArray, Segment
+import shutil
+from mock import *
+from gp_unittest import *
+
+from gphostcache import GpHost
+
+class GpConfig(GpTestCase):
+    def setUp(self):
+
+        self.gparray = self.createGpArrayWith2Primary2Mirrors()
+        self.host_cache = Mock()
+
+    def createGpArrayWith2Primary2Mirrors(self):
+        master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        mirror1 = GpDB.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        return GpArray([master, primary0, primary1, mirror0, mirror1])
+
+    def test_GpReadConfig_creates_command_string(self):
+        seg = self.gparray.master
+        seg = self.gparray.master
+        args = dict(name="my_command",
+                    host="host",
+                    seg=seg,
+                    guc_name="statement_mem",)
+        subject = GpReadConfig(**args)
+
+        self.assertEquals(subject.cmdStr, "/bin/cat /data/master/postgresql.conf")
+
+    @patch("gppylib.commands.base.Command.__init__", create=False)
+    @patch("gppylib.commands.base.Command.get_results", return_value=CommandResult(0, "#statement_mem = 100\nstatement_mem = 200", "", True, False))
+    @patch("gppylib.commands.base.Command.run")
+    def test_GpReadConfig_returns_selected_guc(self, mock_run, mock_results, mock_init):
+        seg = self.gparray.master
+        args = dict(name="my_command",
+                    host="host",
+                    seg=seg,
+                    guc_name="statement_mem",
+        )
+
+        subject = GpReadConfig(**args)
+
+        subject.run(validateAfter=True)
+        self.assertEquals('200', subject.get_guc_value())
+
+    @patch("gppylib.commands.base.Command.__init__", create=False)
+    @patch("gppylib.commands.base.Command.get_results", return_value=CommandResult(0, "statement_mem=100\n statement_mem=200 #blah", "", True, False))
+    @patch("gppylib.commands.base.Command.run")
+    def test_GpReadConfig_returns_selected_guc_with_whitespace_before_key(self, mock_run, mock_results, mock_init):
+        seg = self.gparray.master
+        args = dict(name="my_command",
+                    host="host",
+                    seg=seg,
+                    guc_name="statement_mem",
+        )
+
+        subject = GpReadConfig(**args)
+
+        subject.run(validateAfter=True)
+        self.assertEquals('200', subject.get_guc_value())
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -1,0 +1,167 @@
+import imp
+import os
+import sys
+import tempfile
+
+from StringIO import StringIO
+
+from gparray import GpDB, GpArray, Segment
+import shutil
+from mock import *
+from gp_unittest import *
+from gphostcache import GpHost
+
+
+class GpConfig(GpTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.postgressql_conf = self.temp_dir + "/postgresql.conf"
+        with open(self.postgressql_conf, "w") as postgresql:
+            postgresql.close()
+
+        # because gpconfig does not have a .py extension,
+        # we have to use imp to import it
+        # if we had a gpconfig.py, this is equivalent to:
+        #   import gpconfig
+        #   self.subject = gpconfig
+        gpconfig_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpconfig")
+        self.subject = imp.load_source('gpconfig', gpconfig_file)
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning'])
+
+        self.conn = Mock()
+        self.rows = []
+        self.conn.execSql.return_value = self.rows
+
+        self.os_env = dict(USER="my_user")
+        self.os_env["MASTER_DATA_DIRECTORY"] = self.temp_dir
+        self.gparray = self.createGpArrayWith2Primary2Mirrors()
+        self.host_cache = Mock()
+
+        host = GpHost('localhost')
+        seg = Segment()
+        db = self.gparray.master
+        seg.addPrimary(db)
+        host.addDB(seg)
+        self.host_cache.get_hosts.return_value = [host]
+        self.host_cache.ping_hosts.return_value = []
+
+        self.master_read_config = Mock()
+        self.master_read_config.get_guc_value.return_value = "foo"
+        self.master_read_config.get_seg_id.return_value = -1
+        self.segment_read_config = Mock()
+        self.segment_read_config.get_guc_value.return_value = "foo"
+        self.segment_read_config.get_seg_id.return_value = 0
+
+        self.pool = Mock()
+        self.pool.getCompletedItems.return_value = [self.master_read_config, self.segment_read_config]
+
+        self.apply_patches([
+            patch('os.environ', new=self.os_env),
+            patch('gpconfig.dbconn.connect', return_value=self.conn),
+            patch('gpconfig.dbconn.execSQL', return_value=self.rows),
+            patch('gpconfig.GpHostCache', return_value=self.host_cache),
+            patch('gpconfig.GpArray.initFromCatalog', return_value=self.gparray),
+            patch('gpconfig.GpReadConfig', return_value=self.master_read_config),
+            patch('gpconfig.WorkerPool', return_value=self.pool)
+        ])
+        sys.argv = ["gpconfig"] # reset to relatively empty args list
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def createGpArrayWith2Primary2Mirrors(self):
+        master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        mirror1 = GpDB.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        return GpArray([master, primary0, primary1, mirror0, mirror1])
+
+    def test_option_f_parses(self):
+        sys.argv = ["gpconfig", "--file", "--show", "statement_mem"]
+        options = self.subject.parseargs()
+
+        self.assertEquals(options.show, "statement_mem")
+        self.assertEquals(options.file, True)
+
+    def test_option_list_parses(self):
+        sys.argv = ["gpconfig", "--list"]
+        options = self.subject.parseargs()
+
+        self.assertEquals(options.list, True)
+
+    def test_when_no_options_prints_and_throws(self):
+        with self.assertRaisesRegexp(Exception, "No action specified.  See the --help info."):
+            self.subject.do_main()
+        self.subject.logger.error.assert_called_once_with("No action specified.  See the --help info.")
+
+    def test_option_value_must_accompany_option_change(self):
+        sys.argv = ["gpconfig", "--change", "statement_mem"]
+        with self.assertRaisesRegexp(Exception, "change requested but value not specified"):
+            self.subject.parseargs()
+        self.subject.logger.error.assert_called_once_with("change requested but value not specified")
+
+    def test_option_file_with_option_change_will_raise(self):
+        sys.argv = ["gpconfig", "--file", "--change", "statement_mem"]
+        with self.assertRaisesRegexp(Exception, "'--file' option must accompany '--show' option"):
+            self.subject.parseargs()
+        self.subject.logger.error.assert_called_once_with("'--file' option must accompany '--show' option")
+
+    def test_option_file_with_option_list_will_raise(self):
+        sys.argv = ["gpconfig", "--file", "--list", "statement_mem"]
+        with self.assertRaisesRegexp(Exception, "'--file' option must accompany '--show' option"):
+            self.subject.parseargs()
+        self.subject.logger.error.assert_called_once_with("'--file' option must accompany '--show' option")
+
+    def test_option_file_without_MASTER_DATA_DIR_will_raise(self):
+        sys.argv = ["gpconfig", "--file", "--show", "statement_mem"]
+        del self.os_env["MASTER_DATA_DIRECTORY"]
+        with self.assertRaisesRegexp(Exception, "--file option requires that MASTER_DATA_DIRECTORY be set"):
+            self.subject.parseargs()
+        self.subject.logger.error.assert_called_once_with("--file option requires that MASTER_DATA_DIRECTORY be set")
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_option_f_will_report_presence_of_setting(self, mock_stdout):
+        sys.argv = ["gpconfig", "--show", "my_property_name", "--file"]
+
+        self.subject.do_main()
+
+        self.assertEqual(self.subject.logger.error.call_count, 0)
+        self.assertIn("foo", mock_stdout.getvalue())
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_option_f_will_report_absence_of_setting(self, mock_stdout):
+        sys.argv = ["gpconfig", "--show", "my_property_name", "--file"]
+        self.master_read_config.get_guc_value.return_value = None
+        self.segment_read_config.get_guc_value.return_value = None
+
+        self.subject.do_main()
+
+        self.assertEqual(self.subject.logger.error.call_count, 0)
+        self.assertIn("not set in postgresql.conf", mock_stdout.getvalue())
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_option_f_will_report_difference_segments_out_of_sync(self, mock_stdout):
+        sys.argv = ["gpconfig", "--show", "my_property_name", "--file"]
+        self.master_read_config.get_guc_value.return_value = 'foo'
+        self.segment_read_config.get_guc_value.return_value = 'bar'
+        another_segment_read_config = Mock()
+        another_segment_read_config.get_guc_value.return_value = "baz"
+        another_segment_read_config.get_seg_id.return_value = 1
+        self.pool.getCompletedItems.return_value.append(another_segment_read_config)
+
+        self.subject.do_main()
+
+        self.assertEqual(self.subject.logger.error.call_count, 0)
+        self.assertIn("WARNING: GUCS ARE OUT OF SYNC", mock_stdout.getvalue())
+        self.assertIn("bar", mock_stdout.getvalue())
+        self.assertIn("baz", mock_stdout.getvalue())
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -68,6 +68,7 @@ class GpConfig(GpTestCase):
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
+        super(GpConfig, self).tearDown()
 
     def createGpArrayWith2Primary2Mirrors(self):
         master = GpDB.initFromString(

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -153,6 +153,8 @@ class GpTransfer(GpTestCase):
 
     def tearDown(self):
         shutil.rmtree(self.TEMP_DIR)
+        super(GpTransfer, self).tearDown()
+
 
     @patch('gptransfer.TableValidatorFactory', return_value=Mock())
     def test__get_distributed_by_quotes_column_name(self, mock1):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
@@ -104,6 +104,7 @@ class RepairTestCase(GpTestCase):
 
     def tearDown(self):
         shutil.rmtree(self.repair_dir_path)
+        super(RepairTestCase, self).tearDown()
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/doc/gpconfig_help
+++ b/gpMgmt/doc/gpconfig_help
@@ -12,7 +12,7 @@ gpconfig -c <param_name> -v <value> [-m <master_value> | --masteronly]
        | -l 
    [--skipvalidation] [--verbose] [--debug]
 
-gpconfig -s <param_name> [--verbose] [--debug]
+gpconfig -s <param_name> [--flag] [--verbose] [--debug]
 
 gpconfig --help
 
@@ -119,6 +119,21 @@ then running gpconfig -s to verify the changes, you might still
 see the previous (old) values. You must reload the configuration 
 files (gpstop -u) or restart the system (gpstop -r) for changes 
 to take effect.
+
+
+--file
+
+For a configuration parameter, shows the value from the postgresql.conf
+file on all instances (master and segments) in the Greenplum Database
+system. If there is a discrepancy in a parameter value between segment
+instances, the gpconfig utility displays a warning message. Must be
+specified with the -s option.
+
+For example, a configuration parameter statement_mem is set to
+64MB for a user with the ALTER ROLE command, and the value in the
+postgresql.conf file is 128MB. Running the command
+gpconfig -s statement_mem --file displays 128MB. The command
+gpconfig -s statement_mem run by the user displays 64MB.
 
 
 --skipvalidation

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -1,0 +1,15 @@
+@gpconfig
+Feature: gpconfig integration tests
+
+    Scenario: gpconfig -s option with --file option
+        Given the user runs "gpconfig -s shared_buffers --file"
+        Then gpconfig should return a return code of 0
+        Then gpconfig should print Master[\s]*value: 125MB to stdout
+
+    Scenario: gpconfig -s option with --file option with inconsistency
+        Given the user runs "gpconfig -c statement_mem -v 130MB"
+        Then gpconfig should return a return code of 0
+        Given the user runs "gpconfig -s statement_mem --file"
+        Then gpconfig should return a return code of 0
+        Then gpconfig should print Master[\s]*value: 130MB to stdout
+        #TODO: Remove statement_mem change from postgresql.conf

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/package/mapreduce/test_mapreduce.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/package/mapreduce/test_mapreduce.py
@@ -72,7 +72,7 @@ class MapreduceMPPTestCase(MPPTestCase):
             scp_cmd = 'gpscp  -h ' +' -h '.join(map(str,hosts)) +' '+ sharedObj + ' =:%s' % so_dir
             run_shell_command(scp_cmd)
             if res['rc']:
-                raise Excpetion('Could not copy shared object to primary segment')
+                raise Exception('Could not copy shared object to primary segment')
 
     def check_orca(self):
         cmd = 'gpconfig -s optimizer'
@@ -80,7 +80,7 @@ class MapreduceMPPTestCase(MPPTestCase):
         run_shell_command(cmd, 'check if orca enabled', res)        
         for line in res['stdout']:
             if 'Master  value: off' in line or 'Segment value: off' in line:
-                return false
+                return False
         return True
 
     def doTest(self, fileName):
@@ -349,7 +349,7 @@ class MapreduceMPPTestCase(MPPTestCase):
         cmd = "gpmapreduce -f mpp5551.yml;echo $?"
         self.run_gpmapreduce_cmd(gpmaprcmd=cmd, expected_ret = 1)
 
-    def test_Neg_InvalidTable(self):
+    def test_Neg_InvalidTable2(self):
         "Invalid Table"
         cmd = "gpmapreduce -f mpp5550.yml"
         self.run_gpmapreduce_cmd(gpmaprcmd=cmd, expected_ret = 1)
@@ -371,7 +371,7 @@ class MapreduceMPPTestCase(MPPTestCase):
         cmd = "gpmapreduce -f neg_missingYMLversion.yml"
         self.run_gpmapreduce_cmd(gpmaprcmd=cmd, expected_ret = 1)
 
-    def test_Neg_MissingYMLversion(self):
+    def test_Neg_MissingYMLversion2(self):
         "missing YML version"
         cmd = "gpmapreduce -f neg_invalidYMLversion.yml"
         self.run_gpmapreduce_cmd(gpmaprcmd=cmd, expected_ret = 1)
@@ -603,7 +603,7 @@ class MapreduceMPPTestCase(MPPTestCase):
         """
         self.runFunctionTest("scalar_consolidation","1outParam_unnamedInYml_unnamed")
 
-    def test_scalar_consolidation_1outParam_unnamedInYml_namedInDB(self):
+    def test_scalar_consolidation_1outParam_unnamedInYml_namedInDB2(self):
         """
         scalar  Consolidation use 1 named out parameter, not specified in yaml 
         """


### PR DESCRIPTION
By default, -s flag will show the user GUC setting on the database.
Use --file with -s flag to show the file GUC setting instead of the user GUC setting from the database. --file will also report discrepancy between postgresql.conf files on all the segments.

* Introduced unit test for gpconfig.
   - Refactored gpconfig to enable unit testing.
* Added gpconfig behave tests to ensure that we are not missing anything
  in the unit test tests. As we are mocking the pool, we need to make sure
  that we are not doing anything silly, so adding minimal behave tests.
  Single node is probably enough.


MISC:
* Ensure that we use the current python instead of hardcoded value
 -  Fixing a hardcoded python library path that may not be valid for other
     python version.
* Remove unused makefile flag 