### PR TITLE
gpcloud: retry when S3 has internal errors

### DIFF
--- a/gpAux/extensions/gpcloud/include/restful_service.h
+++ b/gpAux/extensions/gpcloud/include/restful_service.h
@@ -11,7 +11,6 @@ enum ResponseStatus {
 };
 
 typedef long ResponseCode;
-#define HeadResponseFail -1
 
 // 2XX are successful response.
 // Here we deal with 200 (OK), 204 (no content) and 206 (partial content) currently,
@@ -46,6 +45,8 @@ class Response {
     }
 
     void FillResponse(ResponseCode responseCode) {
+        this->setResponseCode(responseCode);
+
         if (isSuccessfulResponse(responseCode)) {
             this->setStatus(RESPONSE_OK);
             this->setMessage("Success");
@@ -71,11 +72,6 @@ class Response {
         headersBuffer.insert(headersBuffer.end(), ptr, ptr + size);
     }
 
-    void clearHeadersBuffer() {
-        vector<uint8_t> emptyHeaders;
-        headersBuffer.swap(emptyHeaders);
-    }
-
     S3VectorUInt8& getRawData() {
         return dataBuffer;
     }
@@ -96,6 +92,14 @@ class Response {
         headersBuffer.swap(emptyHeaders);
     }
 
+    ResponseCode getResponseCode() const {
+        return responseCode;
+    }
+
+    void setResponseCode(ResponseCode responseCode) {
+        this->responseCode = responseCode;
+    }
+
     const string& getMessage() const {
         return message;
     }
@@ -113,9 +117,12 @@ class Response {
     }
 
    private:
+    ResponseCode responseCode;
+
     // status is OK when get full HTTP response even response body may means request failure.
     ResponseStatus status;
     string message;
+
     vector<uint8_t> headersBuffer;
     S3VectorUInt8 dataBuffer;
 };

--- a/gpAux/extensions/gpcloud/include/s3restful_service.h
+++ b/gpAux/extensions/gpcloud/include/s3restful_service.h
@@ -29,10 +29,14 @@ class S3RESTfulService : public RESTfulService {
    private:
     uint64_t lowSpeedLimit;
     uint64_t lowSpeedTime;
+
     bool debugCurl;
     bool verifyCert;
+
     uint64_t chunkBufferSize;
     S3MemoryContext s3MemContext;
+
+    void performCurl(CURL* curl, Response& response);
 };
 
 #endif /* INCLUDE_S3RESTFUL_SERVICE_H_ */

--- a/gpAux/extensions/gpcloud/include/s3utils.h
+++ b/gpAux/extensions/gpcloud/include/s3utils.h
@@ -17,7 +17,8 @@ bool sha1hmac_hex(const char* str, char out_hash_hex[SHA_DIGEST_STRING_LENGTH], 
 
 bool sha256(const char* string, unsigned char out_hash[SHA256_DIGEST_LENGTH]);
 
-bool sha256_hex(const char* string, uint64_t length, char out_hash_hex[SHA256_DIGEST_STRING_LENGTH]);
+bool sha256_hex(const char* string, uint64_t length,
+                char out_hash_hex[SHA256_DIGEST_STRING_LENGTH]);
 
 bool sha256_hex(const char* string, char out_hash_hex[SHA256_DIGEST_STRING_LENGTH]);
 

--- a/gpAux/extensions/gpcloud/src/s3interface.cpp
+++ b/gpAux/extensions/gpcloud/src/s3interface.cpp
@@ -104,7 +104,7 @@ ResponseCode S3InterfaceService::headResponseWithRetries(const string &url, HTTP
                 S3_DIE(S3QueryAbort, "Uploading is interrupted");
             }
 
-            S3WARN("Failed to get a good response in PUT from '%s', retrying ...", url.c_str());
+            S3WARN("Failed to get a good response in HEAD from '%s', retrying ...", url.c_str());
         }
     };
 
@@ -122,7 +122,7 @@ Response S3InterfaceService::deleteRequestWithRetries(const string &url, HTTPHea
             if (S3QueryIsAbortInProgress()) {
                 S3_DIE(S3QueryAbort, "Uploading is interrupted");
             }
-            S3WARN("Failed to get a good response in PUT from '%s', retrying ...", url.c_str());
+            S3WARN("Failed to get a good response in DELETE from '%s', retrying ...", url.c_str());
         }
     };
 

--- a/gpAux/extensions/gpcloud/src/s3restful_service.cpp
+++ b/gpAux/extensions/gpcloud/src/s3restful_service.cpp
@@ -133,6 +133,10 @@ Response S3RESTfulService::get(const string &url, HTTPHeaders &headers) {
         // Get the HTTP response status code from HTTP header
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
 
+        if (responseCode == 500) {
+            S3_DIE(S3ConnectionError, "Server temporary unavailable");
+        }
+
         response.FillResponse(responseCode);
     }
 
@@ -168,6 +172,10 @@ Response S3RESTfulService::put(const string &url, HTTPHeaders &headers, const S3
         // Get the HTTP response status code from HTTP header
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
 
+        if (responseCode == 500) {
+            S3_DIE(S3ConnectionError, "Server temporary unavailable");
+        }
+
         response.FillResponse(responseCode);
     }
 
@@ -202,6 +210,10 @@ Response S3RESTfulService::post(const string &url, HTTPHeaders &headers,
         // Get the HTTP response status code from HTTP header
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
 
+        if (responseCode == 500) {
+            S3_DIE(S3ConnectionError, "Server temporary unavailable");
+        }
+
         response.FillResponse(responseCode);
     }
 
@@ -235,6 +247,10 @@ ResponseCode S3RESTfulService::head(const string &url, HTTPHeaders &headers) {
     } else {
         // Get the HTTP response status code from HTTP header
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
+
+        if (responseCode == 500) {
+            S3_DIE(S3ConnectionError, "Server temporary unavailable");
+        }
     }
 
     return responseCode;
@@ -266,6 +282,11 @@ Response S3RESTfulService::deleteRequest(const string &url, HTTPHeaders &headers
         long responseCode;
         // Get the HTTP response status code from HTTP header
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
+
+        if (responseCode == 500) {
+            S3_DIE(S3ConnectionError, "Server temporary unavailable");
+        }
+
         response.FillResponse(responseCode);
     }
 

--- a/gpAux/extensions/gpcloud/src/s3utils.cpp
+++ b/gpAux/extensions/gpcloud/src/s3utils.cpp
@@ -34,7 +34,8 @@ bool sha1hmac_hex(const char *str, char out_hash_hex[SHA_DIGEST_STRING_LENGTH], 
     return true;
 }
 
-bool sha256_hex(const char *string, uint64_t length, char out_hash_hex[SHA256_DIGEST_STRING_LENGTH]) {
+bool sha256_hex(const char *string, uint64_t length,
+                char out_hash_hex[SHA256_DIGEST_STRING_LENGTH]) {
     if (!string) return false;
 
     unsigned char hash[SHA256_DIGEST_LENGTH];  // 32


### PR DESCRIPTION
AWS S3 returns internal errors (HTTP response code 500) serveral times,
unusual but better not to ignore, this commit re-sends requests when it
happens.

Signed-off-by: Haozhou Wang <hawang@pivotal.io>