### PR TITLE
Reuse sending port of Interconnect across different queries

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -183,13 +183,6 @@ bool		gp_enable_slow_cursor_testmode = false;
  */
 bool		gp_eager_hashtable_release = true;
 
-/*
- * TCP port the Interconnect listens on for incoming connections from other
- * backends.  Assigned by initMotionLayerIPC() at process startup.  This port
- * is used for the duration of this process and should never change.
- */
-int			Gp_listener_port;
-
 int			Gp_max_packet_size; /* max Interconnect packet size */
 
 int			Gp_interconnect_queue_depth = 4;	/* max number of messages

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -37,6 +37,7 @@
 #include "cdb/cdbtm.h"			/* discardDtxTransaction() */
 #include "cdb/cdbutil.h"		/* CdbComponentDatabaseInfo */
 #include "cdb/cdbvars.h"		/* Gp_role, etc. */
+#include "cdb/ml_ipc.h"
 #include "storage/bfz.h"
 #include "gp-libpq-fe.h"
 #include "gp-libpq-int.h"
@@ -1048,7 +1049,7 @@ getCdbProcessesForQD(int isPrimary)
 	 * interconnect connection.
 	 */
 	proc->listenerAddr = NULL;
-	proc->listenerPort = Gp_listener_port;
+	proc->listenerPort = ICListenerPort;
 
 	proc->pid = MyProcPid;
 	proc->contentid = -1;

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -59,8 +59,19 @@
  * GLOBAL STATE VARIABLES
  */
 
-/* Socket file descriptor for the listener. */
-int		UDP_listenerFd;
+/* Socket file descriptor for the listener and sender. */
+int		ICListenerSocket;
+int 	ICSenderSocket;
+
+/*
+ * Ports of Interconnect, assigned by initMotionLayerIPC() at process startup.
+ * These ports are used for the duration of this process and should never change.
+ */
+uint16	ICListenerPort;
+uint16 	ICSenderPort;
+
+int 	ICSenderFamily;
+
 
 /* Socket file descriptor for the sequence server. */
 int		savedSeqServerFd = -1;
@@ -202,11 +213,9 @@ InitMotionLayerIPC(void)
 	savedSeqServerFd = -1;
 
 	/* use a local uint16 to remove warning of 'incompatible type' */
-	uint16 port;
-	InitMotionUDPIFC(&UDP_listenerFd, &port);
-	Gp_listener_port = port;
+	InitMotionUDPIFC();
 
-	elog(DEBUG1, "Interconnect listening on udp port %d", Gp_listener_port);
+	elog(DEBUG1, "Interconnect listener port %d, sender port %d", ICListenerPort, ICSenderPort);
 }
 
 /* See ml_ipc.h */
@@ -220,12 +229,12 @@ CleanUpMotionLayerIPC(void)
 
 	/* close down the Interconnect listener socket. */
 
-	if (UDP_listenerFd >= 0)
-		closesocket(UDP_listenerFd);
+	if (ICListenerSocket >= 0)
+		closesocket(ICListenerSocket);
 
 	/* be safe and reset global state variables. */
-	Gp_listener_port = 0;
-	UDP_listenerFd = -1;
+	ICListenerPort = 0;
+	ICListenerSocket = -1;
 }
 
 /* See ml_ipc.h */

--- a/src/backend/tcop/dest.c
+++ b/src/backend/tcop/dest.c
@@ -38,6 +38,7 @@
 #include "utils/portal.h"
 
 #include "cdb/cdbvars.h"
+#include "cdb/ml_ipc.h"
 #include "utils/vmem_tracker.h"
 
 /* ----------------
@@ -266,7 +267,7 @@ sendQEDetails(void)
 	StringInfoData buf;
 
 	pq_beginmessage(&buf, 'w');
-	pq_sendint(&buf, (int32) Gp_listener_port, sizeof(int32));			
+	pq_sendint(&buf, (int32) ICListenerPort, sizeof(int32));
 	pq_sendint(&buf, sizeof(PG_VERSION_STR), sizeof(int32));
 	pq_sendbytes(&buf, PG_VERSION_STR, sizeof(PG_VERSION_STR));
 	pq_endmessage(&buf);

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1032,14 +1032,6 @@ extern GpId GpIdentity;
 #define UNINITIALIZED_GP_IDENTITY_VALUE (-10000)
 extern int GpStandbyDbid;
 
-
-/* Stores the listener port that this process uses to listen for incoming
- * Interconnect connections from other Motion nodes.
- */
-extern int	Gp_listener_port;
-
-
-
 /* SequenceServer information to be shared with everyone */
 typedef struct SeqServerControlBlock
 {

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -17,8 +17,21 @@
 struct SliceTable;                          /* #include "nodes/execnodes.h" */
 struct EState;                              /* #include "nodes/execnodes.h" */
 
-/* listener filedescriptors */
-extern int		UDP_listenerFd;
+/* Socket file descriptor for the listener and sender. */
+extern int	ICListenerSocket;
+extern int	ICSenderSocket;
+
+/*
+ * Ports of Interconnect, assigned by initMotionLayerIPC() at process startup.
+ * These ports are used for the duration of this process and should never change.
+ */
+extern uint16	ICListenerPort;
+extern uint16	ICSenderPort;
+
+extern int	ICSenderFamily;
+
+
+
 
 /* 2 bytes to store the size of the entire packet.	a packet is composed of
  * of one or more serialized TupleChunks (each of which has a TupleChunk
@@ -276,7 +289,7 @@ extern ChunkTransportStateEntry *removeChunkTransportState(ChunkTransportState *
 
 extern TupleChunkListItem RecvTupleChunk(MotionConn *conn, bool inTeardown);
 
-extern void InitMotionUDPIFC(int *listenerSocketFd, uint16 *listenerPort);
+extern void InitMotionUDPIFC(void);
 extern void markUDPConnInactiveIFC(MotionConn *conn);
 extern void CleanupMotionUDPIFC(void);
 extern void WaitInterconnectQuitUDPIFC(void);


### PR DESCRIPTION
Azure has restriction on distinct <src_port, dst_port> pairs: 500k per 5 minutes. Currently, GPDB backend process reuses IC listener port for its lifetime, while setting up a new IC sending port for each query, which makes it easy to hit this limit for commands like `analyzedb`.