### PR TITLE
Make bfv_temp test more robust.

### DIFF
--- a/src/test/regress/expected/bfv_temp.out
+++ b/src/test/regress/expected/bfv_temp.out
@@ -29,12 +29,19 @@ select count(*) from pg_tables where schemaname like 'pg_temp%';
 
 -- Disconnect and reconnect.
 \c regression
--- Check that the temporary table was dropped at disconnect.
-select count(*) from pg_tables where schemaname like 'pg_temp%';
- count 
--------
-     0
+-- It can take a while for the old backend to finish cleaning up the
+-- temp tables.
+select pg_sleep(2);
+ pg_sleep 
+----------
+ 
 (1 row)
+
+-- Check that the temporary table was dropped at disconnect.
+select * from pg_tables where schemaname like 'pg_temp%';
+ schemaname | tablename | tableowner | tablespace | hasindexes | hasrules | hastriggers 
+------------+-----------+------------+------------+------------+----------+-------------
+(0 rows)
 
 -- Clean up
 reset role;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -108,11 +108,10 @@ test: aggregate_with_groupingsets
 
 test: nested_case_null sort
 
-test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy
-
-# This test gets confused if there are other connections, with temp tables,
-# active at the same time.
-test: bfv_temp
+# NOTE: The bfv_temp test assumes that there are no temporary tables in
+# other sessions. Therefore the other tests in this group mustn't create
+# temp tables
+test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy bfv_temp
 
 test: qp_olap_mdqa qp_misc
 

--- a/src/test/regress/sql/bfv_temp.sql
+++ b/src/test/regress/sql/bfv_temp.sql
@@ -24,8 +24,12 @@ select count(*) from pg_tables where schemaname like 'pg_temp%';
 -- Disconnect and reconnect.
 \c regression
 
+-- It can take a while for the old backend to finish cleaning up the
+-- temp tables.
+select pg_sleep(2);
+
 -- Check that the temporary table was dropped at disconnect.
-select count(*) from pg_tables where schemaname like 'pg_temp%';
+select * from pg_tables where schemaname like 'pg_temp%';
 
 -- Clean up
 reset role;


### PR DESCRIPTION
The test disconnects, and immediately reconnects and checks that temp
table from the previous session has been removed. However, the old backend
removes the tables only after the disconnection, so there's a race
condition here: the new session might query pg_tables and still see the
table, if the old session was not fast enough to remove it first.

Add a two-second sleep, to make the race condition less likely to happen.
This is not guaranteed to avoid the race altogether, but I don't see an
easy way to wait for the specific event that the old backend has exited.

A sleep in a test that doesn't run in parallel with other tests is a bit
annoying, as it directly makes the whole regression suite slower. To
compensate for that, move the test to run in parallel with the other
nearby bfv_* tests. Those other tests don't use temp tables, so it still
works.

Also, modify the validation query in the test that checks that there are
no temp tables, to return whole rows, not just COUNT(*). That'll make
analyzing easier, if this test fails.