### PR TITLE
Fix gpcrondump of external tables.

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_dump_include.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_include.c
@@ -3423,7 +3423,8 @@ getTableAttrs(TableInfo *tblinfo, int numTables)
 bool
 shouldPrintColumn(TableInfo *tbinfo, int colno)
 {
-	return (tbinfo->attislocal[colno] && !tbinfo->attisdropped[colno]);
+	return ((tbinfo->attislocal[colno] || tbinfo->relstorage == RELSTORAGE_EXTERNAL) &&
+			(!tbinfo->attisdropped[colno] /* || binary_upgrade */));
 }
 
 /*


### PR DESCRIPTION
Commit 821b8e10af changed pg_dump's shouldPrintColumn() function to return
true for all columns in an external table, and changed dumpExternal() to use
the shouldPrintColumn() function. However, that change was not made to the
copy of shouldPrintColumn() in cdb_dump_include.c.

That oversight didn't cause any ill effects, until commit 58b8668397 came
along and refreshed cdb_dump_agent.c's copy of the dumpExternal() function,
to match that in pg_dump.c. With that change cdb_dump_agent's dumpExternal()
started to call shouldPrintColumn() for external tables, but its version of
shouldPrintColumn() didn't have the change to always return true for
external tables yet. As a result, external tables didn't have any of their
columns included.

To fix, update cdb_dump's copy of shouldPrintColumn() to match that in
pg_dump.c.