### PR TITLE
Fix gppersistentrebuild and its behave tests

### DIFF
--- a/gpMgmt/bin/gppylib/operations/persistent_rebuild.py
+++ b/gpMgmt/bin/gppylib/operations/persistent_rebuild.py
@@ -207,7 +207,7 @@ class GetDbIdInfo:
         '''
         fs_to_ts_map = {}
         fs_oids = segdb.getSegmentFilespaces().keys()
-        FILESPACE_TO_TABLESPACE_MAP_QUERY = """SELECT spcfsoid, string_agg(oid, ' ')
+        FILESPACE_TO_TABLESPACE_MAP_QUERY = """SELECT spcfsoid, string_agg(oid::text, ' ')
                                                FROM pg_tablespace
                                                WHERE spcfsoid IN (%s) GROUP BY spcfsoid""" % ', '.join(map(str, fs_oids))
         with dbconn.connect(dbconn.DbURL(dbname=DEFAULT_DATABASE)) as conn:
@@ -223,7 +223,7 @@ class GetDbIdInfo:
         The value is a list of oids which represent the oids of databases
         '''
         ts_to_dboid_map = {}
-        TABLESPACE_TO_DBOID_MAP_QUERY = """SELECT dattablespace, string_agg(oid, ' ')
+        TABLESPACE_TO_DBOID_MAP_QUERY = """SELECT dattablespace, string_agg(oid::text, ' ')
                                            FROM pg_database
                                            WHERE dattablespace IN (%s) GROUP BY dattablespace""" % ', '.join(map(str, ts_oids))
         with dbconn.connect(dbconn.DbURL(dbname=DEFAULT_DATABASE)) as conn:

--- a/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
@@ -14,6 +14,7 @@
     And user returns the data directory to the default location of the killed mirror
     And the user runs command "gprecoverseg -a"
     And gprecoverseg should return a return code of 0
+    And the segments are synchronized
 
   Scenario: persistent_rebuild on mirrored systems should correctly rebuild persistent tables with mirrors
     Given the database is running


### PR DESCRIPTION
The gppersistentrebuild tool was trying to use string_agg without
casting the oid to text. This used to work before but not anymore. The
behave tests only have two scenarios but the second scenario would
always fail because it would run when a primary/mirror segment pair
were still in resync mode.