### PR TITLE
Fix QX coverity issues

### DIFF
--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -3456,6 +3456,7 @@ tupsort_prepare_char(MKEntry *a, bool isCHAR)
 
 	kstr.ref = 1;
 	kstr.xfrm_pos = lenToStore + 1;
+	kstr.isPrefixOnly = storePrefixOnly ? 1 : 0;
 	memcpy(kstr.data, p, lenToStore);
 	kstr.data[lenToStore] = '\0';
 
@@ -3557,7 +3558,6 @@ tupsort_prepare_char(MKEntry *a, bool isCHAR)
 	/*
 	 * finalize result
 	 */
-	ret->isPrefixOnly = storePrefixOnly ? 1 : 0;
 	a->d = PointerGetDatum(ret);
 	mke_set_refc(a);
 }

--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -277,7 +277,7 @@ create_workset_directory(NodeTag node_type, int slice_id)
 	char *final_path = (char *) palloc0(MAXPGPATH);
 
 	/* Initialize result path. Strip prefix from path since bfz/fd add the getCurrentTempFilePath to it */
-	strncpy(final_path,
+	strlcpy(final_path,
 			workset_path_unmasked + strlen(getCurrentTempFilePath) + 1,
 			MAXPGPATH);
 
@@ -324,7 +324,7 @@ workfile_mgr_populate_set(const void *resource, const void *param)
 	work_set->session_start_time = set_info->session_start_time;
 
 	Assert(strlen(set_info->dir_path) < MAXPGPATH);
-	strncpy(work_set->path, set_info->dir_path, MAXPGPATH);
+	strlcpy(work_set->path, set_info->dir_path, MAXPGPATH);
 }
 
 /*

--- a/src/backend/utils/workfile_manager/workfile_mgr_test.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr_test.c
@@ -229,7 +229,7 @@ cache_test_create()
 	cacheCtl.keyOffset = GPDB_OFFSET(TestCacheElt, key);
 
 	cacheCtl.hash = string_hash;
-	cacheCtl.keyCopy = (HashCopyFunc) strncpy;
+	cacheCtl.keyCopy = (HashCopyFunc) strlcpy;
 	cacheCtl.match = (HashCompareFunc) strncmp;
 
 	cacheCtl.cleanupEntry = cacheEltCleanup;
@@ -1993,7 +1993,7 @@ syncrefhastable_test_create(void)
 	syncHTCtl.keySize = TEST_NAME_LENGTH;
 
 	syncHTCtl.hash = string_hash;
-	syncHTCtl.keyCopy = (HashCopyFunc) strncpy;
+	syncHTCtl.keyCopy = (HashCopyFunc) strlcpy;
 	syncHTCtl.match = (HashCompareFunc) strncmp;
 
 	syncHTCtl.numElements = TEST_HT_NUM_ELEMENTS;

--- a/src/bin/gp_workfile_mgr/gp_workfile_cache_stats.c
+++ b/src/bin/gp_workfile_mgr/gp_workfile_cache_stats.c
@@ -200,7 +200,7 @@ gp_workfile_mgr_cache_entries(PG_FUNCTION_ARGS)
 		}
 
 		values[0] = Int32GetDatum(Gp_segment);
-		strncpy(work_set_path, work_set->path, MAXPGPATH);
+		strlcpy(work_set_path, work_set->path, MAXPGPATH);
 
 		values[2] = UInt32GetDatum(crtEntry->hashvalue);
 


### PR DESCRIPTION
See the individual commit messages for details on the fix.

Regarding converting strncpy to strlcpy, the original issue identified on gp_workfile_cache_stats.c. I made similar changes in workfile_mgr.c & workfile_mgr_test.c since I noticed possible issues there as well.