### PR TITLE
Reorder validate check for gpconfig & Add gpconfig unit test coverage

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -45,8 +45,9 @@ def parseargs():
     parser.add_option('-f', '--file', action='store_true')
     (options, args) = parser.parse_args()
 
-    validate_mutual_options(options)
+    options.entry = None
     validate_four_verbs(options)
+    validate_mutual_options(options)
     return options
 
 


### PR DESCRIPTION
* Reorder validate check for gpconfig
    - We were accessing a non-existent variable as it's being generated by
      the later function. Swapping the two methods.

* Make sure we step through our code within the unit test.

Was reporting the following:
```
gpconfig -c wal_buffers -v 512 -m 512
Values instance has no attribute 'entry'
```