### PR TITLE
Use tablespace oid as part of the dbInfoRel hash table key

### DIFF
--- a/src/backend/catalog/gp_persistent.c
+++ b/src/backend/catalog/gp_persistent.c
@@ -638,13 +638,15 @@ void GpPersistent_GetCommonValues(
 
 void GpRelationNode_GetValues(
 	Datum							*values,
-
+	Oid 							*tablespaceOid,
 	Oid 							*relfilenodeOid,
 	int32							*segmentFileNum,
 	int64							*createMirrorDataLossTrackingSessionNum,
 	ItemPointer		 				persistentTid,
 	int64							*persistentSerialNum)
 {
+	*tablespaceOid = DatumGetObjectId(values[Anum_gp_relation_node_tablespace_oid - 1]);
+
 	*relfilenodeOid = DatumGetObjectId(values[Anum_gp_relation_node_relfilenode_oid - 1]);
 
 	*segmentFileNum = DatumGetInt32(values[Anum_gp_relation_node_segment_file_num - 1]);

--- a/src/backend/cdb/cdbpersistentbuild.c
+++ b/src/backend/cdb/cdbpersistentbuild.c
@@ -218,15 +218,15 @@ static void PersistentBuild_PopulateGpRelationNode(
 		ItemPointerData persistentTid;
 		int64 persistentSerialNum;
 
-		if (dbInfoRel->reltablespace == GLOBALTABLESPACE_OID &&
+		if (dbInfoRel->dbInfoRelKey.reltablespace == GLOBALTABLESPACE_OID &&
 			info->database != TemplateDbOid)
 			continue;
 
-		relFileNode.spcNode = dbInfoRel->reltablespace;
+		relFileNode.spcNode = dbInfoRel->dbInfoRelKey.reltablespace;
 		relFileNode.dbNode = 
-				(dbInfoRel->reltablespace == GLOBALTABLESPACE_OID ?
+				(dbInfoRel->dbInfoRelKey.reltablespace == GLOBALTABLESPACE_OID ?
 														0 : info->database);
-		relFileNode.relNode = dbInfoRel->relfilenodeOid;
+		relFileNode.relNode = dbInfoRel->dbInfoRelKey.relfilenode;
 
 		if (dbInfoRel->relationOid == GpRelationNodeOidIndexId)
 		{
@@ -280,7 +280,7 @@ static void PersistentBuild_PopulateGpRelationNode(
 							gp_relation_node,
 							dbInfoRel->relationOid,	// pg_class OID
 							dbInfoRel->relname,
-							(dbInfoRel->reltablespace == MyDatabaseTableSpace) ? 0:dbInfoRel->reltablespace,
+							(dbInfoRel->dbInfoRelKey.reltablespace == MyDatabaseTableSpace) ? 0:dbInfoRel->dbInfoRelKey.reltablespace,
 							relFileNode.relNode,	// pg_class relfilenode
 							/* segmentFileNum */ 0,
 							/* updateIndex */ false,
@@ -400,7 +400,7 @@ static void PersistentBuild_PopulateGpRelationNode(
 								gp_relation_node,
 								dbInfoRel->relationOid, // pg_class OID
 								dbInfoRel->relname,
-								(dbInfoRel->reltablespace == MyDatabaseTableSpace) ? 0:dbInfoRel->reltablespace,
+								(dbInfoRel->dbInfoRelKey.reltablespace == MyDatabaseTableSpace) ? 0:dbInfoRel->dbInfoRelKey.reltablespace,
 								relFileNode.relNode,	// pg_class relfilenode
 								physicalSegmentFileNum,
 								/* updateIndex */ false,

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -1140,13 +1140,13 @@ createdb(CreatedbStmt *stmt)
 
 			PersistentFileSysRelStorageMgr relStorageMgr;
 
-			tablespace = dbInfoRel->reltablespace;
+			tablespace = dbInfoRel->dbInfoRelKey.reltablespace;
 			if (tablespace == GLOBALTABLESPACE_OID)
 				continue;
 
 			CHECK_FOR_INTERRUPTS();
 
-			relfilenode = dbInfoRel->relfilenodeOid;
+			relfilenode = dbInfoRel->dbInfoRelKey.relfilenode;
 			
 			srcRelFileNode.spcNode = tablespace;
 			srcRelFileNode.dbNode = info->database;
@@ -1290,7 +1290,7 @@ createdb(CreatedbStmt *stmt)
 							dst_deftablespace,
 							dboid,
 							&dbInfoGpRelationNode->gpRelationNodeTid,
-							dbInfoRel->relfilenodeOid,
+							dbInfoRel->dbInfoRelKey.relfilenode,
 							dbInfoGpRelationNode->segmentFileNum,
 							&dbInfoGpRelationNode->persistentTid,		// INPUT
 							dbInfoGpRelationNode->persistentSerialNum);	// INPUT
@@ -1560,12 +1560,12 @@ dropdb(const char *dbname, bool missing_ok)
 			PersistentFileSysRelStorageMgr relStorageMgr;
 
 			int g;
-			if (dbInfoRel->reltablespace == GLOBALTABLESPACE_OID)
+			if (dbInfoRel->dbInfoRelKey.reltablespace == GLOBALTABLESPACE_OID)
 				continue;
 			
-			relFileNode.spcNode = dbInfoRel->reltablespace;
+			relFileNode.spcNode = dbInfoRel->dbInfoRelKey.reltablespace;
 			relFileNode.dbNode = db_id;
-			relFileNode.relNode = dbInfoRel->relfilenodeOid;
+			relFileNode.relNode = dbInfoRel->dbInfoRelKey.relfilenode;
 
 			CHECK_FOR_INTERRUPTS();
 

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -361,12 +361,13 @@ GpRelationNodeGetNext(
 	int64				*persistentSerialNum)
 {
 	HeapTuple tuple;
-	
+
 	bool			nulls[Natts_gp_relation_node];
 	Datum			values[Natts_gp_relation_node];
-	
+
+	Oid tablespace;
 	Oid actualRelationNode;
-	
+
 	int64 createMirrorDataLossTrackingSessionNum;
 
 	tuple = systable_getnext((SysScanDesc)gpRelationNodeScan->scan);
@@ -385,6 +386,7 @@ GpRelationNodeGetNext(
 		
 	GpRelationNode_GetValues(
 						values,
+						&tablespace,
 						&actualRelationNode,
 						segmentFileNum,
 						&createMirrorDataLossTrackingSessionNum,
@@ -478,7 +480,8 @@ FetchGpRelationNodeTuple(
 	
 	bool			nulls[Natts_gp_relation_node];
 	Datum			values[Natts_gp_relation_node];
-	
+
+	Oid tablespace;
 	Oid actualRelationNode;
 	int32 actualSegmentFileNum;
 
@@ -511,6 +514,7 @@ FetchGpRelationNodeTuple(
 		
 	GpRelationNode_GetValues(
 						values,
+						&tablespace,
 						&actualRelationNode,
 						&actualSegmentFileNum,
 						&createMirrorDataLossTrackingSessionNum,

--- a/src/include/catalog/gp_persistent.h
+++ b/src/include/catalog/gp_persistent.h
@@ -605,7 +605,7 @@ extern void GpPersistent_GetCommonValues(
 
 extern void GpRelationNode_GetValues(
 	Datum							*values,
-
+	Oid 							*tablespaceOid,
 	Oid 							*relfilenodeOid,
 	int32							*segmentFileNum,
 	int64							*createMirrorDataLossTrackingSessionNum,

--- a/src/include/cdb/cdbdatabaseinfo.h
+++ b/src/include/cdb/cdbdatabaseinfo.h
@@ -80,6 +80,27 @@ typedef struct DbInfoAppendOnlyCatalogSegmentInfo
 	int64		logicalEof;
 } DbInfoAppendOnlyCatalogSegmentInfo;
 
+/*
+ * struct DbInfoRelKeyPair -
+ *   Describes a hash table key leading to a DbInfoRel element.
+ *
+ *   The DbInfoRel struct holds this hash table key.  The key is used
+ *   to do a lookup in the HTAB dbInfoRelHashTable initialised in
+ *   DatabaseInfo_Collect.  A constructed DbInfoRelKeyPair can be used
+ *   to create a hash value from the HTAB->hash function.  This hash
+ *   value will be converted into a bucket number which will lead to
+ *   the HASHBUCKET that should contain the DbInfoRel element.
+ *
+ *   We use reltablespace and relfilenode in the key because there can
+ *   be the same relfilenode in different tablespaces.  We cannot use
+ *   relation OID because gp_relation_node does not keep that
+ *   information.
+ */
+typedef struct DbInfoRelKeyPair
+{
+	Oid	reltablespace;
+	Oid	relfilenode;
+} DbInfoRelKeyPair;
 
 /*
  * struct DbInfoRel - 
@@ -98,16 +119,15 @@ typedef struct DbInfoAppendOnlyCatalogSegmentInfo
 typedef struct DbInfoRel
 {
 	/* Key */
-	Oid									 relfilenodeOid;
+	DbInfoRelKeyPair					 dbInfoRelKey;
 
 	/* Catalog */
 	bool								 inPgClass;    /* Can we find it in pg_class ? */
 	ItemPointerData						 pgClassTid;   /* At what row id? */
 
 	/* A couple key fields from pg_class */
-	Oid									 relationOid; 
-	char								*relname;     
-	Oid									 reltablespace;
+	Oid									 relationOid;
+	char								*relname;
 	char								 relkind;
 	char								 relstorage;
 	Oid									 relam;

--- a/src/test/regress/input/filespace.source
+++ b/src/test/regress/input/filespace.source
@@ -1376,6 +1376,33 @@ SET ROLE fsts_up_user1;
 SELECT * FROM fsts_up_table2;
 RESET ROLE;
 
+-- create new database which we'll try to drop at the end
+create database dropdb_same_relfilenode;
+\c dropdb_same_relfilenode
+
+-- create two heap tables where one is on a different tablespace
+create table same_relfilenode (a int, b int) distributed by (a);
+create table same_relfilenode2 (a int, b int) tablespace regression_ts_a1 distributed by (a);
+
+-- change the relfilenode of one heap table to be the same as the other heap table
+set allow_system_table_mods = 'DML';
+set gp_permit_relation_node_change = true;
+update gp_relation_node set relfilenode_oid=(select relfilenode from pg_class where relname='same_relfilenode' limit 1)
+    where relfilenode_oid=(select relfilenode from pg_class where relname='same_relfilenode2' limit 1);
+update pg_class set relfilenode=(select relfilenode from pg_class where relname='same_relfilenode' limit 1)
+    where relname='same_relfilenode2';
+reset allow_system_table_mods;
+reset gp_permit_relation_node_change;
+select relname from pg_class where relfilenode='same_relfilenode'::regclass;
+
+-- try to drop the database which should work (previously failed due to unique check on relfilenode)
+-- a warning will be given since we haven't renamed the actual segment file on all postgres
+-- instances... so suppress the warning by changing session message level to ERROR
+\c fsts_db_name1
+set client_min_messages=ERROR;
+drop database dropdb_same_relfilenode;
+reset client_min_messages;
+
 DROP TABLE fsts_up_table1;
 DROP TABLE fsts_up_table2;
 DROP TABLE fsts_alter_table1;

--- a/src/test/regress/output/filespace.source
+++ b/src/test/regress/output/filespace.source
@@ -2689,6 +2689,35 @@ SELECT * FROM fsts_up_table2;
 (5 rows)
 
 RESET ROLE;
+-- create new database which we'll try to drop at the end
+create database dropdb_same_relfilenode;
+\c dropdb_same_relfilenode
+-- create two heap tables where one is on a different tablespace
+create table same_relfilenode (a int, b int) distributed by (a);
+create table same_relfilenode2 (a int, b int) tablespace regression_ts_a1 distributed by (a);
+-- change the relfilenode of one heap table to be the same as the other heap table
+set allow_system_table_mods = 'DML';
+set gp_permit_relation_node_change = true;
+update gp_relation_node set relfilenode_oid=(select relfilenode from pg_class where relname='same_relfilenode' limit 1)
+    where relfilenode_oid=(select relfilenode from pg_class where relname='same_relfilenode2' limit 1);
+update pg_class set relfilenode=(select relfilenode from pg_class where relname='same_relfilenode' limit 1)
+    where relname='same_relfilenode2';
+reset allow_system_table_mods;
+reset gp_permit_relation_node_change;
+select relname from pg_class where relfilenode='same_relfilenode'::regclass;
+      relname      
+-------------------
+ same_relfilenode
+ same_relfilenode2
+(2 rows)
+
+-- try to drop the database which should work (previously failed due to unique check on relfilenode)
+-- a warning will be given since we haven't renamed the actual segment file on all postgres
+-- instances... so suppress the warning by changing session message level to ERROR
+\c fsts_db_name1
+set client_min_messages=ERROR;
+drop database dropdb_same_relfilenode;
+reset client_min_messages;
 DROP TABLE fsts_up_table1;
 DROP TABLE fsts_up_table2;
 DROP TABLE fsts_alter_table1;


### PR DESCRIPTION
The current dbInfoRel hash table key only contains the relfilenode
oid. However, relfilenode oids can be duplicated over different
tablespaces which can cause dropdb (and possibly persistent rebuild)
to fail. This commit adds the tablespace oid as part of the dbInfoRel
hash table key for more uniqueness.

One thing to note is that a constructed tablespace/relfilenode key is
compared with other keys using memcmp. Supposedly... this should be
fine since the struct just contains two OID variables and the keys are
always palloc0'd. The alignment should be fine during comparison.

Without this fix, you could get something like this:
```
  drop database dropdb_same_relfilenode;
  ERROR:  More than one pg_class entry ('same_relfilenode' 22867 and 'same_relfilenode2' 22870) references the same relfilenode 22867 (cdbdatabaseinfo.c:538)
```