### PR TITLE
Merge "uao" concourse job into "storage".

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -395,24 +395,6 @@ jobs:
       TARGET_OS: centos
       TARGET_OS_VERSION: 6
 
-- name: uao
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      params: {submodules: none}
-      passed: [compile_gpdb_centos6]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-      passed: [compile_gpdb_centos6]
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: uao_orca_both_regression
-    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
-    image: centos-gpdb-dev-6
-    params:
-      MAKE_TEST_COMMAND: uao_orca_both_regression
-      TEST_OS: centos
-
 - name: subtransaction
   plan:
   - aggregate:

--- a/concourse/pipelines/pipeline_tinc.yml
+++ b/concourse/pipelines/pipeline_tinc.yml
@@ -70,27 +70,6 @@ jobs:
         file: sync_tools_gpdb/sync_tools_gpdb.tar.gz
 
 # Stage 2: CS Tests
-- name: cs-uao
-  plan:
-  - aggregate:
-    - get: gpdb_src
-      params: {submodules: none}
-      passed: [compile_gpdb_centos6]
-    - get: sync_tools_gpdb
-      resource: sync_tools_gpdb_centos
-      passed: [compile_gpdb_centos6]
-    - get: bin_gpdb
-      resource: bin_gpdb_centos
-      passed: [compile_gpdb_centos6]
-      trigger: true
-    - get: centos-gpdb-dev-6
-  - task: uao_orca_both_regression
-    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
-    image: centos-gpdb-dev-6
-    params:
-      MAKE_TEST_COMMAND: uao_orca_both_regression
-      TEST_OS: centos
-
 - name: cs-subtransaction
   plan:
   - aggregate:

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -51,7 +51,7 @@ DISCOVER=discover
 storage_targets: discover_targets non_discover_targets
 
 discover_targets: storage walrep_multinode \
-	uao_orca_both_regression upgrade pgtwophase \
+	upgrade pgtwophase \
 	sub_transaction_limit_removal filerep_schematopology_crashrecov
 
 non_discover_targets: aoco_compression filerep_end_to_end fts
@@ -90,6 +90,7 @@ storage_queryfinish_and_transactionmanagement:
 	-s dispatch/queryfinish \
 	-s storage/transaction_management \
 	-s storage/basic
+	-s storage/uao
 
 storage_persistent_filerep_accessmethods_and_vacuum:
 	$(TESTER) $(DISCOVER) -t tincrepo/mpp/gpdb/tests/storage \
@@ -138,16 +139,6 @@ walrep_2:
 	-s xact \
 	-q "class!=DDLTestCase" \
 	-q "class!=DMLTestCase"
-
-# cs-uao-regression
-# The following targets are pulled from:
-# http://pulse-cloud.gopivotal.com/admin/projects/cs-uao-regression
-#
-# Refer to the properties of the pulse project and individual build
-# stages for configuration requirements.
-
-uao_orca_both_regression:
-	$(TESTER) $(DISCOVER) -s tincrepo/mpp/gpdb/tests/storage/uao
 
 
 # cs-aoco-compression


### PR DESCRIPTION
There are only a few tests left in "uao", most have now been moved to
installcheck-world. The "uao" job now runs in about 4 minutes, of which
2 minutes is spent on setting up the test cluster. That seems like
overkill, so simplify things by merging the remaining uao fault injection
tests into the larger "storage" job.