### PR TITLE
Remove SOMEFILE matchsub leftover

### DIFF
--- a/src/test/regress/expected/errors.out
+++ b/src/test/regress/expected/errors.out
@@ -65,13 +65,6 @@ delete from;
 ERROR:  syntax error at or near ";"
 LINE 1: delete from;
                    ^
--- start_matchsubs
---
--- # SPARC diff:
--- m/ERROR\:.*does not exist.* \(SOMEFILE\:SOMEFUNC\)/
--- s/\(SOMEFILE\:SOMEFUNC\)//
---
--- end_matchsubs
 -- no such relation 
 delete from nonesuch;
 ERROR:  relation "nonesuch" does not exist

--- a/src/test/regress/sql/errors.sql
+++ b/src/test/regress/sql/errors.sql
@@ -48,14 +48,6 @@ select distinct on (foobar) * from pg_database;
 delete from;
 
 
--- start_matchsubs
---
--- # SPARC diff:
--- m/ERROR\:.*does not exist.* \(SOMEFILE\:SOMEFUNC\)/
--- s/\(SOMEFILE\:SOMEFUNC\)//
---
--- end_matchsubs
-
 -- no such relation 
 delete from nonesuch;
 


### PR DESCRIPTION
The SOMEFILE:SOMEFUNC construction was removed from atmsort with
commit 0bf31cd66217c213bc796fa9abfd1c9e77641ec6, remove leftover
rules relying on it still in the error suite (obviously not needed
either since the suite still works).