### PR TITLE
Remove unnecessary 1 MB blocksize tests

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/test_func_aococompression_large_01.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/test_func_aococompression_large_01.py
@@ -54,30 +54,17 @@ class AOCOCompressionTestCase(ScenarioTestCase):
 
 @tinctest.dataProvider('test_types_large')
 def test_data_provider():
-    data = {'test_01_1_co_create_storage_directive_large':['co_create_storage_directive_large_1G_zlib'],
-            'test_01_2_co_create_storage_directive_large':['co_create_storage_directive_large_1G_quick_rle'],
-            'test_01_3_co_create_storage_directive_large':['co_create_storage_directive_large_2G_zlib'],
+    data = {'test_01_3_co_create_storage_directive_large':['co_create_storage_directive_large_2G_zlib'],
             'test_01_4_co_create_storage_directive_large':['co_create_storage_directive_large_2G_quick_rle'],
-            'test_01_5_co_create_storage_directive_large':['co_create_storage_directive_large_1G_zlib_2'],
             'test_01_6_co_create_storage_directive_large':['co_create_storage_directive_large_2G_zlib_2'],
-            'test_02_1_co_create_column_reference_default_large':['co_create_column_reference_default_large_1G_zlib'],
-            'test_02_2_co_create_column_reference_default_large':['co_create_column_reference_default_large_1G_quick_rle'],
             'test_02_3_co_create_column_reference_default_large':['co_create_column_reference_default_large_2G_zlib'],
             'test_02_4_co_create_column_reference_default_large':['co_create_column_reference_default_large_2G_quick_rle'],
-            'test_02_5_co_create_column_reference_default_large':['co_create_column_reference_default_large_1G_zlib_2'],
             'test_02_6_co_create_column_reference_default_large':['co_create_column_reference_default_large_2G_zlib_2'],
-            'test_03_1_co_create_column_reference_column_large':['co_create_column_reference_column_large_1G_zlib'],
-            'test_03_2_co_create_column_reference_column_large':['co_create_column_reference_column_large_1G_quick_rle'],
             'test_03_3_co_create_column_reference_column_large':['co_create_column_reference_column_large_2G_zlib'],
             'test_03_4_co_create_column_reference_column_large':['co_create_column_reference_column_large_2G_quick_rle'],
-            'test_03_5_co_create_column_reference_column_large':['co_create_column_reference_column_large_1G_zlib_2'],
             'test_03_6_co_create_column_reference_column_large':['co_create_column_reference_column_large_2G_zlib_2'],
-            'test_04_1_ao_create_with_row_large':['ao_create_with_row_large_1G_zlib'],
-            'test_04_2_ao_create_with_row_large':['ao_create_with_row_large_1G_quick_rle'],
             'test_04_3_ao_create_with_row_large':['ao_create_with_row_large_2G_zlib'],
             'test_04_4_ao_create_with_row_large':['ao_create_with_row_large_2G_quick_rle'],
-            'test_04_5_ao_create_with_row_large':['ao_create_with_row_large_1G_zlib_2'],
-            'test_04_6_ao_create_with_row_large':['ao_create_with_row_large_2G_zlib_2'],
            }
     return data
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/test_func_aococompression_large_02.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/aoco_compression/test_func_aococompression_large_02.py
@@ -53,11 +53,8 @@ class AOCOCompressionTestCase(ScenarioTestCase):
 
 @tinctest.dataProvider('test_types_large')
 def test_data_provider():
-    data = {'test_05_1_co_create_with_column_large':['co_create_with_column_large_1G_zlib'],
-            'test_05_2_co_create_with_column_large':['co_create_with_column_large_1G_quick_rle'],
-            'test_05_3_co_create_with_column_large':['co_create_with_column_large_2G_zlib'],
+    data = {'test_05_3_co_create_with_column_large':['co_create_with_column_large_2G_zlib'],
             'test_05_4_co_create_with_column_large':['co_create_with_column_large_2G_quick_rle'],
-            'test_05_5_co_create_with_column_large':['co_create_with_column_large_1G_zlib_2'],
             'test_05_6_co_create_with_column_large':['co_create_with_column_large_2G_zlib_2'],
             'test_06_1_ao_create_with_row_part_large':['ao_create_with_row_part_large_1G_zlib'],
             'test_06_2_ao_create_with_row_part_large':['ao_create_with_row_part_large_1G_quick_rle'],


### PR DESCRIPTION
Some tests in the AOCO compression TINC test suite were run with 1MB and
2MB block sizes. That seems excessive. There is no magic boundary, like
e.g. when going from 1 GB to 2 GB, between 1 MB and 2 MB, so it's hard to
see how anything would behave differently in any interesting way between
those two values. This test suite runs for a very long time, so remove
the 1 MB permutations from those cases, to reduce the runtime.

(The test files have 1G and 2G in the names, but that is misleading; these
tests vary the blocksize option to CREATE TABLE command, between 1MB and
2MB. That's megabytes, not gigabytes. That ought to be fixed, but not in
this patch)

@asimrp, @ashwinstar, would you agree that running all these tests with both 1MB and 2MB block sizes is overkill?