### PR TITLE
Analyzedb should analyze root partitions [#140458013]

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -142,7 +142,7 @@ INNER JOIN (VALUES %s) o(orig_name) ON c.oid = o.orig_name::regclass
 """
 
 GET_LEAF_ROOT_MAPPING_SQL = """
-SELECT n.nspname || '.' || c2.relname, n.nspname || '.' || c.relname from pg_class c, pg_class c2, pg_namespace n, pg_partition pp, pg_partition_rule ppr
+SELECT n.nspname, c2.relname, n.nspname, c.relname from pg_class c, pg_class c2, pg_namespace n, pg_partition pp, pg_partition_rule ppr
 WHERE ppr.parchildrelid in (%s) AND ppr.paroid = pp.oid AND pp.parrelid = c.oid AND c.relnamespace = n.oid AND ppr.parchildrelid = c2.oid;
 """
 
@@ -724,7 +724,7 @@ class AnalyzeDb(Operation):
         oid_str = get_oid_str(candidates)
         qresult = run_sql(self.conn, GET_LEAF_ROOT_MAPPING_SQL % oid_str)
         for mapping in qresult:
-            leaf_root_dict[mapping[0]] = mapping[1]
+            leaf_root_dict[(mapping[0], mapping[1])] = (mapping[2], mapping[3])
 
         for can in candidates:
             if can in leaf_root_dict: # this is a leaf partition

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1684,6 +1684,16 @@ Feature: Incrementally analyze the database
       And "public.sales_1_prt_2" should appear in the latest state files
       And "public.sales_1_prt_3" should appear in the latest state files
 
+      @analyzedb_core @analyzedb_root_and_partition_tables @refresh_root_stats
+    Scenario: Partition tables, (entries for all parts, no change, some parts, root parts), request root stats
+      Given no state files exist for database "incr_analyze"
+      And the user runs "analyzedb -a -d incr_analyze -t public.sales"
+      When the user runs "analyzedb -a -d incr_analyze -t public.sales"
+      Then analyzedb should print There are no tables or partitions to be analyzed to stdout
+      And "public.sales_1_prt_2" should appear in the latest state files
+      And "public.sales_1_prt_3" should appear in the latest state files
+      And "public.sales" should appear in the latest report file
+
     # request mid-level
      @analyzedb_core @analyzedb_partition_tables
     Scenario: Multi-level partition and request mid-level


### PR DESCRIPTION
When analyzedb is run without --skip_root_partition flag like below,
it should also analyze the root partitions.

`analyzedb -d <dbname> -s <schema> -a`

The expected key format for `leaf_root_dict` used for the check
is a tuple form and the result returned from the SQL was a string
concatenated with ".". Because of this, candidates could not be matched
in the dictionary and we never got the root partition details.

Made the appropriate changes in analyzedb so that it will
identify and analyze on the root partitions.

Signed-off-by: Jemish Patel <jpatel-pivotal@pivotal.io>