### PR TITLE
Ignore "Execute on" syntax when comparing gptransfer diffs between 43 and 5.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/data/global_init_file
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/global_init_file
@@ -72,4 +72,7 @@ s/Checksum: \w+//
 m/External options: {}\n/
 s/External options: {}\n//
 
+m/Execute on: all segments\n/
+s/Execute on: all segments\n//
+
 -- end_matchsubs


### PR DESCRIPTION
The "Execute on" syntax was added when performing a "\d" on external tables in gpdb5 but is not present in gpdb4.
When transferring between these clusters, we will ignore these differences.