### PR TITLE
Fix QP_memory-accounting tests 

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -919,20 +919,22 @@ jobs:
 
 - name: QP_memory-accounting
   plan:
-  - aggregate: *pulse_trigger_resource
-  - task: trigger_pulse
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/trigger_pulse.yml
-    input_mapping: *input_mappings
+  - aggregate:
+    - get: gpdb_src
+      passed: [gpdb_rc_packaging_centos]
+      trigger: true
+    - get: bin_gpdb
+      passed: [gpdb_rc_packaging_centos]
+      resource: bin_gpdb_centos6
+    - get: centos-gpdb-dev-6
+  - task: memory-accounting
+    timeout: 3h
+    file: gpdb_src/concourse/tasks/tinc_gpdb.yml
+    image: centos-gpdb-dev-6
     params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "QP_memory-accounting"
-  - task: monitor_pulse
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/monitor_pulse.yml
-    params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "QP_memory-accounting"
+      MAKE_TEST_COMMAND: memory_accounting
+      BLDWRAP_POSTGRES_CONF_ADDONS: ""
+      TEST_OS: "centos"
 
 - name: QP_runaway-query
   plan:

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -921,10 +921,10 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: [gpdb_rc_packaging_centos]
+      passed: [compile_gpdb_centos6]
       trigger: true
     - get: bin_gpdb
-      passed: [gpdb_rc_packaging_centos]
+      passed: [compile_gpdb_centos6]
       resource: bin_gpdb_centos6
     - get: centos-gpdb-dev-6
   - task: memory-accounting
@@ -940,10 +940,10 @@ jobs:
   plan:
   - aggregate:
     - get: gpdb_src
-      passed: [gpdb_rc_packaging_centos]
+      passed: [compile_gpdb_centos6]
       trigger: true
     - get: bin_gpdb
-      passed: [gpdb_rc_packaging_centos]
+      passed: [compile_gpdb_centos6]
       resource: bin_gpdb_centos6
     - get: centos-gpdb-dev-6
   - task: runaway-query

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -339,3 +339,8 @@ runaway_query:
 		resource_management.runaway_query.runaway_query_multisession.test_runaway_multisession.RunawayMultiSessionTestCase \
 		resource_management.runaway_query.runaway_query_vmem_memoryaccounting.test_runaway_query_vmem_memoryaccounting.RQTMemoryAccountingTestCase \
 		resource_management.runaway_query.runaway_query_stress.test_runaway_query_stress.RunawayQueryStressTestCase
+
+memory_accounting:
+	$(TESTER) \
+		resource_management.memory_accounting.test_oom.OOMTestCase \
+		resource_management.memory_accounting.too_many_exec_accounts.test_exec_accounts

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/oom.ans
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/oom.ans
@@ -16,24 +16,24 @@ select 2 as oom_test;
         2
 (1 row)
 
-select count(*) from 
-    (select o0.o_orderkey from 
-    (orders o0 
-        left outer join orders o1 on o0.o_orderkey = o1.o_orderkey 
-	left outer join orders o2 on o1.o_orderkey = o2.o_orderkey 
-	left outer join orders o3 on o2.o_orderkey = o3.o_orderkey 
-	left outer join orders o4 on o3.o_orderkey = o4.o_orderkey 
-	left outer join orders o5 on o4.o_orderkey = o5.o_orderkey 
-	left outer join orders o6 on o5.o_orderkey = o6.o_orderkey 
-	left outer join orders o7 on o6.o_orderkey = o7.o_orderkey 
-	left outer join orders o8 on o7.o_orderkey = o8.o_orderkey 
-	left outer join orders o9 on o8.o_orderkey = o9.o_orderkey 
-	left outer join orders o10 on o9.o_orderkey = o10.o_orderkey 
-	left outer join orders o11 on o10.o_orderkey = o11.o_orderkey 
-	left outer join orders o12 on o11.o_orderkey = o12.o_orderkey 
-	left outer join orders o13 on o12.o_orderkey = o13.o_orderkey 
-	left outer join orders o14 on o13.o_orderkey = o14.o_orderkey 
-	left outer join orders o15 on o14.o_orderkey = o15.o_orderkey) 
-    order by o0.o_orderkey) as foo;
+select count(*) from
+  (select l0.l_orderkey from
+    (lineitem l0
+     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
+     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
+     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
+     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
+     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
+     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
+     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
+     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
+     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
+     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
+     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
+     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
+     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
+     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
+     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
+    order by l0.l_orderkey) as foo;
 psql:/data/suchitra/workspace/tincrepo/main/memory_accounting/scenario/oom_test/output/oom.sql:31: ERROR:  Out of memory  (seg0 slice12 rh55-qavm67:9655 pid=17870)
 DETAIL:  VM Protect failed to allocate 16384 bytes, 0 MB available

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/oom_dumpusage.ans
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/oom_dumpusage.ans
@@ -10,15 +10,27 @@ SET
 show gp_vmem_protect_limit;
  gp_vmem_protect_limit 
 -----------------------
- 4
+ 20
 (1 row)
 
-select count(*) from 
-    (select o0.o_orderkey from 
-    (orders o0 
-        left outer join orders o1 on o0.o_orderkey = o1.o_orderkey 
-	left outer join orders o2 on o1.o_orderkey = o2.o_orderkey 
-	left outer join orders o3 on o2.o_orderkey = o3.o_orderkey)
-    order by o0.o_orderkey) as foo;
+select count(*) from
+  (select l0.l_orderkey from
+    (lineitem l0
+     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
+     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
+     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
+     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
+     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
+     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
+     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
+     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
+     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
+     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
+     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
+     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
+     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
+     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
+     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
+    order by l0.l_orderkey) as foo;
 psql:/data/home/gpadmin/suchitra/tincrepo/main/resource_management/memory_accounting/scenario/oom_test/output/oom_dumpusage.sql:20: ERROR:  Out of memory  (seg0 slice2 mdw:40000 pid=1116)
 DETAIL:  VM Protect failed to allocate 8388608 bytes, 4 MB available

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/singlequery_oom.ans
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/singlequery_oom.ans
@@ -16,24 +16,24 @@ select 1 as oom_test;
         1
 (1 row)
 
-select count(*) from 
-    (select o0.o_orderkey from 
-    (orders o0 
-        left outer join orders o1 on o0.o_orderkey = o1.o_orderkey 
-	left outer join orders o2 on o1.o_orderkey = o2.o_orderkey 
-	left outer join orders o3 on o2.o_orderkey = o3.o_orderkey 
-	left outer join orders o4 on o3.o_orderkey = o4.o_orderkey 
-	left outer join orders o5 on o4.o_orderkey = o5.o_orderkey 
-	left outer join orders o6 on o5.o_orderkey = o6.o_orderkey 
-	left outer join orders o7 on o6.o_orderkey = o7.o_orderkey 
-	left outer join orders o8 on o7.o_orderkey = o8.o_orderkey 
-	left outer join orders o9 on o8.o_orderkey = o9.o_orderkey 
-	left outer join orders o10 on o9.o_orderkey = o10.o_orderkey 
-	left outer join orders o11 on o10.o_orderkey = o11.o_orderkey 
-	left outer join orders o12 on o11.o_orderkey = o12.o_orderkey 
-	left outer join orders o13 on o12.o_orderkey = o13.o_orderkey 
-	left outer join orders o14 on o13.o_orderkey = o14.o_orderkey 
-	left outer join orders o15 on o14.o_orderkey = o15.o_orderkey) 
-    order by o0.o_orderkey) as foo;
+select count(*) from
+  (select l0.l_orderkey from
+    (lineitem l0
+     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
+     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
+     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
+     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
+     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
+     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
+     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
+     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
+     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
+     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
+     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
+     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
+     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
+     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
+     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
+    order by l0.l_orderkey) as foo;
 psql:/data/suchitra/workspace/tincrepo/main/memory_accounting/scenario/oom_test/output/singlequery_oom.sql:31: ERROR:  Out of memory  (seg0 slice14 rh55-qavm67:9655 pid=30792)
 DETAIL:  VM Protect failed to allocate 524392 bytes, 0 MB available

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/verify_oom_abort_query.ans
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/answer/verify_oom_abort_query.ans
@@ -4,4 +4,4 @@
 -- end_matchsubs
 select count(1) from lineitem as a, lineitem as b where a.l_orderkey = b.l_orderkey;
 psql:/data/soedoj/tincrepo/main/resource_management/memory_accounting/scenario/oom_test/output/verify_oom_abort_query.sql:5: ERROR:  Out of memory  (seg0 slice1 gpdb5.sto.dh.greenplum.com:48506 pid=8015)
-DETAIL:  Per-query VM protect limit reached: current limit is 102400 kB, requested 8388608 bytes, available 2 MB
+DETAIL:  Per-query VM protect limit reached: current limit is 2048 kB, requested 4194384 bytes, available 1 MB

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/oom.sql
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/oom.sql
@@ -6,22 +6,22 @@
 show gp_vmem_protect_limit;
 
 select 2 as oom_test;
-select count(*) from 
-    (select o0.o_orderkey from 
-    (orders o0 
-        left outer join orders o1 on o0.o_orderkey = o1.o_orderkey 
-	left outer join orders o2 on o1.o_orderkey = o2.o_orderkey 
-	left outer join orders o3 on o2.o_orderkey = o3.o_orderkey 
-	left outer join orders o4 on o3.o_orderkey = o4.o_orderkey 
-	left outer join orders o5 on o4.o_orderkey = o5.o_orderkey 
-	left outer join orders o6 on o5.o_orderkey = o6.o_orderkey 
-	left outer join orders o7 on o6.o_orderkey = o7.o_orderkey 
-	left outer join orders o8 on o7.o_orderkey = o8.o_orderkey 
-	left outer join orders o9 on o8.o_orderkey = o9.o_orderkey 
-	left outer join orders o10 on o9.o_orderkey = o10.o_orderkey 
-	left outer join orders o11 on o10.o_orderkey = o11.o_orderkey 
-	left outer join orders o12 on o11.o_orderkey = o12.o_orderkey 
-	left outer join orders o13 on o12.o_orderkey = o13.o_orderkey 
-	left outer join orders o14 on o13.o_orderkey = o14.o_orderkey 
-	left outer join orders o15 on o14.o_orderkey = o15.o_orderkey) 
-    order by o0.o_orderkey) as foo;
+select count(*) from
+  (select l0.l_orderkey from
+    (lineitem l0
+     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
+     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
+     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
+     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
+     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
+     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
+     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
+     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
+     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
+     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
+     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
+     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
+     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
+     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
+     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
+    order by l0.l_orderkey) as foo;

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/oom_dumpusage.sql
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/oom_dumpusage.sql
@@ -6,10 +6,22 @@
 
 show gp_vmem_protect_limit;
 
-select count(*) from 
-    (select o0.o_orderkey from 
-    (orders o0 
-        left outer join orders o1 on o0.o_orderkey = o1.o_orderkey 
-	left outer join orders o2 on o1.o_orderkey = o2.o_orderkey 
-	left outer join orders o3 on o2.o_orderkey = o3.o_orderkey)
-    order by o0.o_orderkey) as foo;
+select count(*) from
+  (select l0.l_orderkey from
+    (lineitem l0
+     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
+     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
+     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
+     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
+     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
+     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
+     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
+     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
+     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
+     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
+     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
+     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
+     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
+     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
+     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
+    order by l0.l_orderkey) as foo;

--- a/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/singlequery_oom.sql
+++ b/src/test/tinc/tincrepo/resource_management/memory_accounting/scenario/oom_test/sql/singlequery_oom.sql
@@ -6,22 +6,22 @@
 show gp_vmem_protect_limit;
 
 select 1 as oom_test;
-select count(*) from 
-    (select o0.o_orderkey from 
-    (orders o0 
-        left outer join orders o1 on o0.o_orderkey = o1.o_orderkey 
-	left outer join orders o2 on o1.o_orderkey = o2.o_orderkey 
-	left outer join orders o3 on o2.o_orderkey = o3.o_orderkey 
-	left outer join orders o4 on o3.o_orderkey = o4.o_orderkey 
-	left outer join orders o5 on o4.o_orderkey = o5.o_orderkey 
-	left outer join orders o6 on o5.o_orderkey = o6.o_orderkey 
-	left outer join orders o7 on o6.o_orderkey = o7.o_orderkey 
-	left outer join orders o8 on o7.o_orderkey = o8.o_orderkey 
-	left outer join orders o9 on o8.o_orderkey = o9.o_orderkey 
-	left outer join orders o10 on o9.o_orderkey = o10.o_orderkey 
-	left outer join orders o11 on o10.o_orderkey = o11.o_orderkey 
-	left outer join orders o12 on o11.o_orderkey = o12.o_orderkey 
-	left outer join orders o13 on o12.o_orderkey = o13.o_orderkey 
-	left outer join orders o14 on o13.o_orderkey = o14.o_orderkey 
-	left outer join orders o15 on o14.o_orderkey = o15.o_orderkey) 
-    order by o0.o_orderkey) as foo;
+select count(*) from
+  (select l0.l_orderkey from
+    (lineitem l0
+     left outer join lineitem l1 on l0.l_orderkey = l1.l_orderkey
+     left outer join lineitem l2 on l1.l_orderkey = l2.l_orderkey
+     left outer join lineitem l3 on l2.l_orderkey = l3.l_orderkey
+     left outer join lineitem l4 on l3.l_orderkey = l4.l_orderkey
+     left outer join lineitem l5 on l4.l_orderkey = l5.l_orderkey
+     left outer join lineitem l6 on l5.l_orderkey = l6.l_orderkey
+     left outer join lineitem l7 on l6.l_orderkey = l7.l_orderkey
+     left outer join lineitem l8 on l7.l_orderkey = l8.l_orderkey
+     left outer join lineitem l9 on l8.l_orderkey = l9.l_orderkey
+     left outer join lineitem l10 on l9.l_orderkey = l10.l_orderkey
+     left outer join lineitem l11 on l10.l_orderkey = l11.l_orderkey
+     left outer join lineitem l12 on l11.l_orderkey = l12.l_orderkey
+     left outer join lineitem l13 on l12.l_orderkey = l13.l_orderkey
+     left outer join lineitem l14 on l13.l_orderkey = l14.l_orderkey
+     left outer join lineitem l15 on l14.l_orderkey = l15.l_orderkey)
+    order by l0.l_orderkey) as foo;


### PR DESCRIPTION
* Run them earlier in the pipeline.
* Run QP_memory-accounting in concourse instead of Pulse
* Some tests are modified slightly so that they need less data overall to go OOM.