### PR TITLE
Use backend quoting functions instead of libpq

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -6963,31 +6963,12 @@ partition_rule_def_worker(PartitionRule *rule, Node *start,
 		if (bLeafTablename) /* MPP-6297: dump by tablename */	
 		{
 			StringInfoData      	 sid1;
-			PQExpBuffer      	 pqbuf = createPQExpBuffer();
 
 			initStringInfo(&sid1);
 
-			/* always quote to make WITH (tablename=...) work correctly */
-			/* MPP-12243: but don't use quote_identifier if already quoted! */
-
+			/* Always quote to make WITH (tablename=...) work correctly */
 			char *relname = get_rel_name(rule->parchildrelid);
-			int len = strlen(relname);
-
-			if(strchr(relname, '\\') != NULL)
-				appendPQExpBufferChar(pqbuf, ESCAPE_STRING_SYNTAX);
-
-			appendPQExpBufferChar(pqbuf, '\'');
-
-			if(!enlargePQExpBuffer(pqbuf, 2 * len + 2))
-				elog(ERROR, "failed to increase buffer size for escaping relname %s", relname);
-
-			pqbuf->len += PQescapeString(pqbuf->data + pqbuf->len, relname, len);
-
-			appendPQExpBufferChar(pqbuf, '\'');
-
-			appendStringInfo(&sid1, "tablename=%s", pqbuf->data);
-
-			destroyPQExpBuffer(pqbuf);
+			appendStringInfo(&sid1, "tablename=%s", quote_literal_internal(relname));
 
 			/* MPP-7191, MPP-7193: fully-qualify storage type if not
 			 * specified (and not a template)
@@ -7041,36 +7022,16 @@ partition_rule_def_worker(PartitionRule *rule, Node *start,
 
 		if (bLeafTablename && part->paristemplate)
 		{
-			/* hackery! */
-			/* MPP-6297: Make a fake tablename for template entries to
-			 * invoke special dump/restore magic for EVERY in
-			 * analyze.c:partition_range_every().  Note that the
-			 * tablename is ignored during SET SUBPARTITION TEMPLATE
-			 * because the template rules do not have corresponding
-			 * relations
-			 *
-			 * MPP-10480: use tablename
+			/*
+			 * Make a fake tablename for template entries to invoke special
+			 * dump/restore magic in parse_partition.c:partition_range_every()
+			 * for EVERY.  Note that the tablename is ignored during SET
+			 * SUBPARTITION TEMPLATE because the template rules do not have
+			 * corresponding relations (MPP-6297)
 			 */
 
-			PQExpBuffer pqbuf = createPQExpBuffer();
 			char *relname = get_rel_name(part->parrelid);
-			int len = strlen(relname);
-
-			if(strchr(relname, '\\') != NULL)
-				 appendPQExpBufferChar(pqbuf, ESCAPE_STRING_SYNTAX);
-
-			appendPQExpBufferChar(pqbuf, '\'');
-
-			if(!enlargePQExpBuffer(pqbuf, 2 * len + 2))
-				elog(ERROR, "failed to increase buffer size for escaping relname %s", relname);
-
-			pqbuf->len += PQescapeString(pqbuf->data + pqbuf->len, relname, len);
-
-			appendPQExpBufferChar(pqbuf, '\'');
-
-			appendStringInfo(&buf, "tablename=%s", pqbuf->data);
-
-			destroyPQExpBuffer(pqbuf);
+			appendStringInfo(&buf, "tablename=%s", quote_literal_internal(relname));
 		}
 
 		opts = rule->parreloptions;


### PR DESCRIPTION
libpq is front-end code and shouldn't be used in backend processes. The requirement here is to correctly quote the relation name in partitioning such that pg_dump/gp_dump can create working DDL for the partition hierarchy. For this purpose, quote_literal_internal() does the same thing as PQescapeString().. or am I missing a case where it would behave differently?

The following relation definitions were hitting the previous bug fixed by applying proper quoting:

```SQL
CREATE TABLE part_test (id int, id2 int)
  PARTITION BY LIST (id2) (
    PARTITION "A1" VALUES (1)
  );

CREATE TABLE sales (trans_id int, date date)
  DISTRIBUTED BY (trans_id)
  PARTITION BY RANGE (date) (
    START (date '2008-01-01') INCLUSIVE
    END (date '2009-01-01') EXCLUSIVE
    EVERY (INTERVAL '1 month')
  );

ALTER TABLE sales
  SPLIT PARTITION FOR ('2008-01-01')
  AT ('2008-01-16')
  INTO (PARTITION jan081to15, PARTITION jan0816to31);
ALTER TABLE sales
  ADD DEFAULT PARTITION other;
ALTER TABLE sales
  SPLIT DEFAULT PARTITION
  START ('2009-01-01') INCLUSIVE
  END ('2009-02-01') EXCLUSIVE
  INTO (PARTITION jan09, PARTITION other);
```
The partition test suite has ample coverage of the issue.

Also rewords, fixes comments and removes uninteresting Jira ticket numbers.

From a comment by @hlinnaka in #1808.