### PR TITLE
Fix more QP coverity issues.

### DIFF
--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -1330,6 +1330,8 @@ do_text_output_multiline(TupOutputState *tstate, char *text)
 		else
 			eol = text +strlen(text);
 
+		/* &text yields a singleton pointer - make sure only one is read */
+		Assert(1 == tstate->metadata->tupdesc->natts);
 		do_tup_output(tstate, &text);
 		text = eol;
 	}

--- a/src/backend/executor/nodeTableFunction.c
+++ b/src/backend/executor/nodeTableFunction.c
@@ -225,6 +225,8 @@ TableFunctionNext(TableFunctionState *node)
 		 * to get away with fewer pallocs.
 		 */
 		oldcontext = MemoryContextSwitchTo(econtext->ecxt_per_tuple_memory);
+		/* &user_result yields a singleton pointer - make sure only one is read */
+		Assert(1 == resultdesc->natts);
 		tuple = heap_form_tuple(resultdesc, 
 								&user_result, 
 								&node->fcinfo.isnull);


### PR DESCRIPTION
* &user_result yields a singleton pointer that is used as an array.
* &text yields a singleton pointer that is used as an array.