### PR TITLE
Remove bogus checks that REINDEX chooses same relfilenode on all segm…

### DIFF
--- a/src/test/regress/expected/gp_owner_permission.out
+++ b/src/test/regress/expected/gp_owner_permission.out
@@ -51,21 +51,3 @@ select usename as user_for_reindex_aoco from pg_stat_operations where objname = 
  test2
 (1 row)
 
-SELECT 1 AS relfilenode_same_on_all_segs_heap from gp_dist_random('pg_class')   WHERE relname = 'idx_mytab1_heap' GROUP BY relfilenode having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);
- relfilenode_same_on_all_segs_heap 
------------------------------------
-                                 1
-(1 row)
-
-SELECT 1 AS relfilenode_same_on_all_segs_ao from gp_dist_random('pg_class')   WHERE relname = 'idx_mytab1_ao' GROUP BY relfilenode having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);
- relfilenode_same_on_all_segs_ao 
----------------------------------
-                               1
-(1 row)
-
-SELECT 1 AS relfilenode_same_on_all_segs_aoco from gp_dist_random('pg_class')   WHERE relname = 'idx_mytab1_aoco' GROUP BY relfilenode having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);
- relfilenode_same_on_all_segs_aoco 
------------------------------------
-                                 1
-(1 row)
-

--- a/src/test/regress/sql/gp_owner_permission.sql
+++ b/src/test/regress/sql/gp_owner_permission.sql
@@ -33,9 +33,7 @@ COMMIT;
 SET role = test2;
 SET client_min_messages=WARNING;
 REINDEX DATABASE  reindexdb2;
+
 select usename as user_for_reindex_heap from pg_stat_operations where objname = 'idx_mytab1_heap' and subtype = 'REINDEX' ;
 select usename as user_for_reindex_ao from pg_stat_operations where objname = 'idx_mytab1_ao' and subtype = 'REINDEX' ;
 select usename as user_for_reindex_aoco from pg_stat_operations where objname = 'idx_mytab1_aoco' and subtype = 'REINDEX' ;
-SELECT 1 AS relfilenode_same_on_all_segs_heap from gp_dist_random('pg_class')   WHERE relname = 'idx_mytab1_heap' GROUP BY relfilenode having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);
-SELECT 1 AS relfilenode_same_on_all_segs_ao from gp_dist_random('pg_class')   WHERE relname = 'idx_mytab1_ao' GROUP BY relfilenode having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);
-SELECT 1 AS relfilenode_same_on_all_segs_aoco from gp_dist_random('pg_class')   WHERE relname = 'idx_mytab1_aoco' GROUP BY relfilenode having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);


### PR DESCRIPTION
…ents.

REINDEX chooses the new relfilenode for an index independently in each
segment (see also 88f0623ea1). Therefore, it is not safe to assume, that
after REINDEX, the relfilenode would be the same in all segments, if there
is concurrent activity. These tests failed a few times in the concourse
pipeline. The purpose of this test, per the @description, is to test
permissions, so I'm not sure why these relfilenode checks were tacked on to
it in the first place.