### PR TITLE
Change order of test scenarios to avoid test pollution

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
@@ -1,5 +1,13 @@
-@gppersistent_rebuid
+@persistent_rebuild
   Feature: persistent rebuild tests
+
+  Scenario: persistent_rebuild on mirrored systems should correctly rebuild persistent tables with mirrors
+    Given the database is running
+    And there is a "ao" table "public.ao_table" in "bkdb" with data
+    And the information of a "mirror" segment on any host is saved
+    Then run gppersistent_rebuild with the saved content id
+    And gppersistent_rebuild should return a return code of 0
+    And verify that mirror_existence_state of segment "0" is "3"
 
   Scenario: Persistent rebuild tools should not error out when mirror is marked down and files are missing in the data directory for single node
     Given the database is running
@@ -16,10 +24,3 @@
     And gprecoverseg should return a return code of 0
     And the segments are synchronized
 
-  Scenario: persistent_rebuild on mirrored systems should correctly rebuild persistent tables with mirrors
-    Given the database is running
-    And there is a "ao" table "public.ao_table" in "bkdb" with data
-    And the information of a "mirror" segment on any host is saved
-    Then run gppersistent_rebuild with the saved content id
-    And gppersistent_rebuild should return a return code of 0
-    And verify that mirror_existence_state of segment "0" is "3"


### PR DESCRIPTION
-- the scenario that calls gprecoverseg can leave a segment rebuilding,
which can trip up a scenario after it.