### PR TITLE
Avoid initialization of relcache during recovery

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -431,21 +431,21 @@ jobs:
       image: centos-gpdb-dev-6
       params:
         MAKE_TEST_COMMAND: fts_transitions_part01
-        BLDWRAP_POSTGRES_CONF_ADDONS: gp_segment_connect_timeout=10 gp_fts_probe_interval=20
+        BLDWRAP_POSTGRES_CONF_ADDONS: gp_segment_connect_timeout=20 gp_fts_probe_interval=20
         TEST_OS: centos
     - task: fts_transitions_part02
       file: gpdb_src/concourse/tasks/tinc_gpdb.yml
       image: centos-gpdb-dev-6
       params:
         MAKE_TEST_COMMAND: fts_transitions_part02
-        BLDWRAP_POSTGRES_CONF_ADDONS: gp_segment_connect_timeout=10 gp_fts_probe_interval=20
+        BLDWRAP_POSTGRES_CONF_ADDONS: gp_segment_connect_timeout=20 gp_fts_probe_interval=20
         TEST_OS: centos
     - task: fts_transitions_part03
       file: gpdb_src/concourse/tasks/tinc_gpdb.yml
       image: centos-gpdb-dev-6
       params:
         MAKE_TEST_COMMAND: fts_transitions_part03
-        BLDWRAP_POSTGRES_CONF_ADDONS: gp_segment_connect_timeout=10 gp_fts_probe_interval=20
+        BLDWRAP_POSTGRES_CONF_ADDONS: gp_segment_connect_timeout=20 gp_fts_probe_interval=20
         TEST_OS: centos
 
 - name: storage

--- a/src/backend/cdb/cdbfilerepprimaryrecovery.c
+++ b/src/backend/cdb/cdbfilerepprimaryrecovery.c
@@ -326,6 +326,12 @@ FileRepPrimary_RunChangeTrackingCompacting(void)
 		pg_usleep(50000L); /* 50 ms */	
 	}		
 
+	/*
+	 * It is safe to initialize relcache and use heap access methods
+	 * now, after crash recovery passes have finished applying xlog.
+	 */
+	FileRepSubProcess_InitHeapAccess();
+
 	ChangeTracking_DoFullCompactingRoundIfNeeded();
 
 	

--- a/src/backend/cdb/cdbfilerepresyncmanager.c
+++ b/src/backend/cdb/cdbfilerepresyncmanager.c
@@ -761,6 +761,8 @@ FileRepPrimary_StartResyncManager(void)
 		Insist(segmentState == SegmentStateInResyncTransition ||
 			   segmentState == SegmentStateReady);
 
+		FileRepSubProcess_InitHeapAccess();
+
 		if (isLastLocTracked == FALSE)
 		{
 			status = FileRepResyncManager_InResyncTransition();

--- a/src/backend/cdb/cdbfilerepservice.c
+++ b/src/backend/cdb/cdbfilerepservice.c
@@ -79,8 +79,6 @@ static void FileRepSubProcess_HandleCrash(SIGNAL_ARGS);
 
 static void FileRepSubProcess_ConfigureSignals(void);
 
-extern bool FindMyDatabase(const char *name, Oid *db_id, Oid *db_tablespace);
-
 /*
  *  SIGHUP signal from main file rep process
  *  It re-loads configuration file at next convenient time.
@@ -572,11 +570,8 @@ FileRepSubProcess_SetState(FileRepState_e fileRepStateLocal)
 }
 	
 static void
-FileRepSubProcess_InitializeResyncManagerProcess(void)
+FileRepSubProcess_InitProcess(void)
 {
-	char	*fullpath;
-	char	*knownDatabase = "postgres";
-	
 	SetProcessingMode(InitProcessing);
 	
 	/*
@@ -620,11 +615,22 @@ FileRepSubProcess_InitializeResyncManagerProcess(void)
 	 * bufmgr needs another initialization call too
 	 */
 	InitBufferPoolBackend();
-	
+}
+
+void
+FileRepSubProcess_InitHeapAccess(void)
+{
+	char	*fullpath;
+	static bool heapAccessInitialized = false;
+
+	if (heapAccessInitialized)
+		return;
+
+
 	/* heap access requires the rel-cache */
 	RelationCacheInitialize();
 	InitCatalogCache();
-	
+
 	/*
 	 * It's now possible to do real access to the system catalogs.
 	 *
@@ -638,10 +644,8 @@ FileRepSubProcess_InitializeResyncManagerProcess(void)
 	 * tablespace; our access to the heap is going to be slightly
 	 * limited, so we'll just use some defaults.
 	 */
-	if (!FindMyDatabase(knownDatabase, &MyDatabaseId, &MyDatabaseTableSpace))
-		ereport(FATAL,
-				(errcode(ERRCODE_UNDEFINED_DATABASE),
-				 errmsg("database \"%s\" does not exit", knownDatabase)));
+	MyDatabaseId = TemplateDbOid;
+	MyDatabaseTableSpace = DEFAULTTABLESPACE_OID;
 
 	/* Now we can mark our PGPROC entry with the database ID */
 	/* (We assume this is an atomic store so no lock is needed) */
@@ -653,7 +657,7 @@ FileRepSubProcess_InitializeResyncManagerProcess(void)
 
 	RelationCacheInitializePhase3();
 
-	/* No need to StartupXLOG_Pass2(); since we're not writing any data to disk */
+	heapAccessInitialized = true;
 }
 
 static void
@@ -828,7 +832,22 @@ FileRepSubProcess_Main()
 			break;
 			
 		case FileRepProcessTypePrimaryRecovery:
-			FileRepSubProcess_InitializeResyncManagerProcess();
+			FileRepSubProcess_InitProcess();
+			/*
+			 * At this point, database is starting up and xlog is not
+			 * yet replayed.  Initializing relcache now is dangerous,
+			 * a sequential scan of catalog tables may end up with
+			 * incorrect hint bits.  E.g. a committed transaction's
+			 * dirty heap pages made it to disk but pg_clog update was
+			 * still in memory and we crashed.  If a tuple inserted by
+			 * this transaction is read during relcache
+			 * initialization, status of the tuple's xmin will be
+			 * incorrectly determined as "not commited" from pg_clog.
+			 * And HEAP_XMIN_INVALID hint bit will be set, rendering
+			 * the tuple perpetually invisible.  Relcache
+			 * initialization must be deferred to only after all of
+			 * xlog has been replayed.
+			 */
 			FileRepPrimary_StartRecovery();
 			
 			ResourceOwnerRelease(CurrentResourceOwner,
@@ -837,7 +856,7 @@ FileRepSubProcess_Main()
 			break;
 
 		case FileRepProcessTypeResyncManager:
-			FileRepSubProcess_InitializeResyncManagerProcess();
+			FileRepSubProcess_InitProcess();
 			FileRepPrimary_StartResyncManager();
 			
 			ResourceOwnerRelease(CurrentResourceOwner,
@@ -849,8 +868,7 @@ FileRepSubProcess_Main()
 		case FileRepProcessTypeResyncWorker2:
 		case FileRepProcessTypeResyncWorker3:
 		case FileRepProcessTypeResyncWorker4:
-
-			FileRepSubProcess_InitializeResyncManagerProcess();
+			FileRepSubProcess_InitProcess();
 			FileRepPrimary_StartResyncWorker();
 			
 			ResourceOwnerRelease(CurrentResourceOwner,

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2396,7 +2396,7 @@ ServerLoop(void)
 
 		/*
 		 * GPDB Change:  Reaper just sets a flag, and we call the real reaper code here.
-		 * I assume this was done because we wanted to excecute some code that wasn't safe in a
+		 * I assume this was done because we wanted to execute some code that wasn't safe in a
 		 * signal handler context (debugging code, most likely).
 		 * But the real reason is lost in antiquity.
 		 */

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3370,6 +3370,13 @@ RelationCacheInitializePhase3(void)
 	bool		needNewCacheFile = !criticalSharedRelcachesBuilt;
 
 	/*
+	 * Relation cache initialization or any sort of heap access is
+	 * dangerous before recovery is finished.
+	 */
+	if (!IsBootstrapProcessingMode() && RecoveryInProgress())
+		elog(ERROR, "relation cache initialization during recovery or non-bootstrap processes.");
+
+	/*
 	 * switch to cache memory context
 	 */
 	oldcxt = MemoryContextSwitchTo(CacheMemoryContext);

--- a/src/include/cdb/cdbfilerepservice.h
+++ b/src/include/cdb/cdbfilerepservice.h
@@ -39,5 +39,6 @@ extern bool FileRepSubProcess_ProcessSignals(void);
 
 extern bool FileRepSubProcess_IsStateTransitionRequested(void);
 
+extern void FileRepSubProcess_InitHeapAccess(void);
 #endif   /* CDBFILEREPSERVICE_H */
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_reindex_pg_class.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/crashrecovery/test_reindex_pg_class.py
@@ -72,9 +72,6 @@ class ReindexPgClass(TINCTestCase):
     def test_reindex_pg_class_template1(self):
         """Test that relcache does not contain stale refilenodes after
         crash recovery.
-
-        This used to happen before we started deleting relcache init
-        file at the end of crash recovery pass 2.
         """
         self.dbname = "template1"
         self.test_reindex_pg_class()


### PR DESCRIPTION
This patch set defers relcache initialization in crash recovery as well as filerep processes until after xlog replay. If relcache is initialized before xlog replay, this leads to inconsistencies such as results of a committed transaction lost after recovery.

A error message put in place to expose this issue. This will prevent any future regression.

The previous PR #1786 didn't cover resync manager and worker processes, which caught by FTS tests.