### PR TITLE
Remove unnecessary DROP + CREATE DATABASE from tests.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/sub_transaction_limit_removal/sub_transaction_limit_scenario/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/sub_transaction_limit_removal/sub_transaction_limit_scenario/__init__.py
@@ -31,10 +31,6 @@ from mpp.lib.gpstart import GpStart
 from mpp.lib.gpstop import GpStop
 
 from mpp.gpdb.tests.storage.lib.dbstate import DbStateClass
-from mpp.gpdb.tests.storage.lib import Database
-
-from mpp.lib.gpfilespace import Gpfilespace
-
 
 class SubTransactionLimitRemovalTestCase(MPPTestCase):
 
@@ -398,12 +394,3 @@ class SubTransactionLimitRemovalTestCase(MPPTestCase):
         if not ok1:
             raise Exception("[STLRTest]Fault injection failed")
         tinctest.logger.info("[STLRTest]Done skipping the checkpoint fault")
-
-    def method_setup(self):
-        tinctest.logger.info("Performing setup tasks")
-        gpfs=Gpfilespace()
-        gpfs.create_filespace('subt_filespace_a')
-
-    def cleandb(self):
-        db = Database()
-        db.setupDatabase('gptest')

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/sub_transaction_limit_removal/sub_transaction_limit_scenario/test_func_sanity_sub_transaction_limit_removal.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/sub_transaction_limit_removal/sub_transaction_limit_scenario/test_func_sanity_sub_transaction_limit_removal.py
@@ -46,10 +46,6 @@ class SubTransactionLimitRemovalScenarioTestCase(ScenarioTestCase):
         
         path_to_init="mpp.gpdb.tests.storage.sub_transaction_limit_removal.sub_transaction_limit_scenario.SubTransactionLimitRemovalTestCase."
 
-        cleandb = []
-        cleandb.append(path_to_init+"cleandb")
-        self.test_case_scenario.append(cleandb)
-
         check_system = []
         check_system.append(path_to_init+"check_system")
         self.test_case_scenario.append(check_system)

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/sub_transaction_limit_removal/sub_transaction_limit_scenario/test_func_sub_transaction_limit_removal.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/sub_transaction_limit_removal/sub_transaction_limit_scenario/test_func_sub_transaction_limit_removal.py
@@ -97,10 +97,6 @@ class SubTransactionLimitRemovalScenarioTestCase(ScenarioTestCase):
 
         path_to_init="mpp.gpdb.tests.storage.sub_transaction_limit_removal.sub_transaction_limit_scenario.SubTransactionLimitRemovalTestCase."
 
-        cleandb = []
-        cleandb.append(path_to_init+"cleandb")
-        self.test_case_scenario.append(cleandb) 
-        
         check_system = []
         check_system.append(path_to_init+"check_system")
         self.test_case_scenario.append(check_system)


### PR DESCRIPTION
The 'gptest' database was actually used by the tests. CREATE DATABASE is
a fairly expensive operation, so let's avoid doing it without a good
reason.