### PR TITLE
Move filerep TINC tests from one Concourse task to another.

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -466,17 +466,17 @@ jobs:
         MAKE_TEST_COMMAND: aocoalter_catalog_loaders
         TEST_OS: centos
       image: centos-gpdb-dev-6
-    - task: storage_persistent_filerep_accessmethods_and_vacuum
+    - task: storage_persistent_accessmethods_and_vacuum
       file: gpdb_src/concourse/tasks/tinc_gpdb.yml
       params:
-        MAKE_TEST_COMMAND: storage_persistent_filerep_accessmethods_and_vacuum
+        MAKE_TEST_COMMAND: storage_persistent_accessmethods_and_vacuum
         TEST_OS: centos
       image: centos-gpdb-dev-6
       timeout: 3h
-    - task: filerep_end_to_end_xlog_ctlog_cons
+    - task: storage_filerep
       file: gpdb_src/concourse/tasks/tinc_gpdb.yml
       params:
-        MAKE_TEST_COMMAND: filerep_end_to_end_xlog_ctlog_cons
+        MAKE_TEST_COMMAND: storage_filerep
         TEST_OS: centos
       image: centos-gpdb-dev-6
       timeout: 3h

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -66,8 +66,8 @@ non_discover_targets: aoco_compression filerep_end_to_end fts
 
 storage: storage_vacuum_xidlimits aocoalter_catalog_loaders \
 	storage_queryfinish_and_transactionmanagement \
-	storage_persistent_filerep_accessmethods_and_vacuum \
-	filerep_end_to_end_xlog_ctlog_cons
+	storage_persistent_accessmethods_and_vacuum \
+	storage_filerep
 
 storage_vacuum_xidlimits:
 	$(TESTER) $(DISCOVER) \
@@ -96,15 +96,13 @@ storage_persistent_filerep_accessmethods_and_vacuum:
 	$(TESTER) $(DISCOVER) -t tincrepo/mpp/gpdb/tests/storage \
 	-s persistent \
 	-s access_methods \
-	-s filerep \
 	-s vacuum \
-	-q "class!=XidlimitsTests" \
-	-q "class!=Mpp18816" \
-	-q "class!=FilerepMiscTestCase"
+	-q "class!=XidlimitsTests"
 
-filerep_end_to_end_xlog_ctlog_cons:
+storage_filerep:
 	$(TESTER) $(DISCOVER) \
-	-s tincrepo/mpp/gpdb/tests/storage/filerep/mpp23631
+	-q "class!=Mpp18816" \
+	-s tincrepo/mpp/gpdb/tests/storage/filerep
 
 # cs-walrepl-multinode
 # The following targets are pulled from:

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -92,7 +92,7 @@ storage_queryfinish_and_transactionmanagement:
 	-s storage/basic \
 	-s storage/uao
 
-storage_persistent_filerep_accessmethods_and_vacuum:
+storage_persistent_accessmethods_and_vacuum:
 	$(TESTER) $(DISCOVER) -t tincrepo/mpp/gpdb/tests/storage \
 	-s persistent \
 	-s access_methods \


### PR DESCRIPTION
The storage_persistent_filerep_accessmethods_and_vacuum task contained
two filerep tests:

FilerepResync.test_filerep_resysnc ... 585576.51 ms ... ok
FilerepProcArrayRemoveTestCase.test_verify_ct_after_procarray_removal ... 136553.63 ms ... ok

Move them together with the filerep_end_to_end_xlog_ctlog_cons task, so that
all the filerep tests are in the same task. To reflect that, rename the
'filerep_end_to_end_xlog_ctlog_cons task' to just 'filerep'.

The 'storage_persistent_filerep_accessmethods_and_vacuum' task was the
slowest task among the parallel tasks in the job, so moving the two filerep
tests elsewhere should reduce overall runtime of the storage job.