### PR TITLE
Use packages's gpcloud to test in the main pipeline

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -393,6 +393,7 @@ jobs:
     image: centos-gpdb-dev-6
     params:
       s3conf: {{s3_configuration_file}}
+      overwrite_gpcloud: false
       TARGET_OS: centos
       TARGET_OS_VERSION: 6
 

--- a/concourse/pipelines/pipeline_gpcloud.yml
+++ b/concourse/pipelines/pipeline_gpcloud.yml
@@ -63,6 +63,7 @@ jobs:
     image: centos-gpdb-dev-6
     params:
       s3conf: {{s3_configuration_file}}
+      overwrite_gpcloud: true
       TARGET_OS: centos
       TARGET_OS_VERSION: 6
 
@@ -82,6 +83,7 @@ jobs:
     image: centos-gpdb-dev-6
     params:
       s3conf: {{s3_configuration_file}}
+      overwrite_gpcloud: true
       TARGET_OS: centos
       TARGET_OS_VERSION: 6
 

--- a/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
+++ b/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
@@ -12,8 +12,11 @@ function gen_env(){
 	source /opt/gcc_env.sh
 	source /usr/local/greenplum-db-devel/greenplum_path.sh
 
-	cd "\${1}/gpdb_src/gpAux/extensions/gpcloud"
-	make -B gpcheckcloud
+	if [ "$overwrite_gpcloud" = "true" ]
+	then
+		cd "\${1}/gpdb_src/gpAux/extensions/gpcloud"
+		make install -C bin/gpcheckcloud
+	fi
 
 	cd "\${1}/gpdb_src/gpAux/extensions/gpcloud/regress"
 	bash gpcheckcloud_regress.sh

--- a/concourse/scripts/regression_tests_gpcloud.bash
+++ b/concourse/scripts/regression_tests_gpcloud.bash
@@ -15,8 +15,11 @@ function gen_env(){
 	cd "\${1}/gpdb_src/gpAux"
 	source gpdemo/gpdemo-env.sh
 
-	cd "\${1}/gpdb_src/gpAux/extensions/gpcloud"
-	make -B install
+	if [ "$overwrite_gpcloud" = "true" ]
+	then
+		cd "\${1}/gpdb_src/gpAux/extensions/gpcloud"
+		make -B install
+	fi
 
 	cd "\${1}/gpdb_src/gpAux/extensions/gpcloud/regress"
 	make installcheck pgxs_dir=/usr/local/greenplum-db-devel/lib/postgresql/pgxs

--- a/concourse/tasks/gpcheckcloud_tests_gpcloud.yml
+++ b/concourse/tasks/gpcheckcloud_tests_gpcloud.yml
@@ -11,5 +11,6 @@ inputs:
   - name: bin_gpdb
 params:
   s3conf:
+  overwrite_gpcloud:
 run:
   path: gpdb_src/concourse/scripts/gpcheckcloud_tests_gpcloud.bash

--- a/concourse/tasks/regression_tests_gpcloud.yml
+++ b/concourse/tasks/regression_tests_gpcloud.yml
@@ -11,5 +11,6 @@ inputs:
   - name: bin_gpdb
 params:
   s3conf:
+  overwrite_gpcloud:
 run:
   path: gpdb_src/concourse/scripts/regression_tests_gpcloud.bash

--- a/gpAux/extensions/gpcloud/regress/gpcheckcloud_regress.sh
+++ b/gpAux/extensions/gpcloud/regress/gpcheckcloud_regress.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 EXIT_CODE=0
-GPCHECKCLOUD=../bin/gpcheckcloud/gpcheckcloud
+[ -n "`command -v gpcheckcloud`" ] && GPCHECKCLOUD=gpcheckcloud || GPCHECKCLOUD=../bin/gpcheckcloud/gpcheckcloud
 RANDOM_PREFIX=gpcheckcloud-$(date +%Y%m%d)-$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 
 echo "Preparing data to upload..."


### PR DESCRIPTION
Without this commit, test scripts will re-compile gpcloud anyway, better
to use the one from package instead in the main pipeline.