### PR TITLE
GUC and spelling spring cleaning

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
@@ -340,7 +340,7 @@ GRANT SELECT ON sales TO guest;
           optimizer. For information about uniform multi-level partitioned tables, see <xref
             href="../query/topics/query-piv-uniform-part-tbl.xml#topic1"/>.</p>
         <p>Exchanging a leaf child partition with an external table is not supported if the
-          partitioned table is created with the <codeph>SUBPARITION</codeph> clause or if a
+          partitioned table is created with the <codeph>SUBPARTITION</codeph> clause or if a
           partition has a subpartition. For information about exchanging a leaf child partition with
           an external table, see <xref href="#topic_yhz_gpn_qs" format="dita"/>.</p>
         <p>These are limitations for partitioned tables when a leaf child partition of the table is
@@ -807,7 +807,7 @@ INTO (PARTITION jan09, default partition);
           partition elimination to prevent scanning the older, unneeded partitions.</p>
         <p>Exchanging a leaf child partition with an external table is not supported in these
             cases:<ul id="ul_ijp_pqx_bt">
-            <li>The partitioned table is created with the <codeph>SUBPARITION</codeph> clause or if
+            <li>The partitioned table is created with the <codeph>SUBPARTITION</codeph> clause or if
               a partition has a subpartition.</li>
             <li>The partitioned table contains a column with a check constraint or a <codeph>NOT
                 NULL</codeph> constraint.</li>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -595,7 +595,7 @@ ALTER TABLE <varname>name</varname>
                                                 is not supported in these cases:<ul
                                                   id="ul_xfz_ckw_yt">
                                                   <li>The partitioned table is created with the
-                                                  <codeph>SUBPARITION</codeph> clause or if a
+                                                  <codeph>SUBPARTITION</codeph> clause or if a
                                                   partition has a subpartition.</li>
                                                   <li>The partitioned table contains a column with a
                                                   check constraint or a <codeph>NOT NULL</codeph>

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -1844,7 +1844,7 @@ bool RecordCrashTransactionAbortRecord(
 	bool           validStatus;
 
 	/* Fix for MPP-12614. The call to TransactionIdGetStatus() has been removed since    */
-	/* The clog many not have the the referenced transation as of crash recovery         */
+	/* The clog many not have the the referenced transaction as of crash recovery        */
 	/* pass 2. The clog will be fully built in pass 3 of crash recovery.                 */
 	/* The new call "InRecoveryTansactionIdGetStatus will return TRUE or FALSE in the    */
 	/* validStatus parameter, which indicates whether or not the returned value is good. */

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7463,7 +7463,7 @@ StartupXLOG_Pass2(void)
 		if (Debug_persistent_recovery_print)
 			elog(PersistentRecovery_DebugPrintLevel(),
 				"Read the checkpoint record location saved from pass1, "
-				"and setup the prepared transation hash list.");
+				"and setup the prepared transaction hash list.");
 		record = XLogReadRecord(&XLogCtl->pass1LastCheckpointLoc, false, PANIC);
 		SetupCheckpointPreparedTransactionList(record);
 	}

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -3238,7 +3238,7 @@ void
 DropTempTableNamespaceForResetSession(Oid namespaceOid)
 {
 	if (IsTransactionOrTransactionBlock())
-		elog(ERROR, "Called within a transation");
+		elog(ERROR, "Called within a transaction");
 	
 	StartTransactionCommand();
 

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1521,10 +1521,10 @@ analyzeEstimateReltuplesRelpages(Oid relationOid, float4 *relTuples, float4 *rel
 	List *allRelOids = NIL;
 
 	/* if GUC optimizer_analyze_root_partition is off, we do not analyze root partitions, unless
-	 * using the 'ANALYZE ROOTPARITION tablename' command.
+	 * using the 'ANALYZE ROOTPARTITION tablename' command.
 	 * This is done by estimating the reltuples to be 0 and thus bypass the actual analyze.
 	 * See MPP-21427.
-	 * For mid-level parititions, we aggregate the reltuples and relpages from all leaf children beneath.
+	 * For mid-level partitions, we aggregate the reltuples and relpages from all leaf children beneath.
 	 */
 	if (rel_part_status(relationOid) == PART_STATUS_INTERIOR ||
 			(rel_is_partitioned(relationOid) && (optimizer_analyze_root_partition || rootonly)))

--- a/src/backend/optimizer/plan/planwindow.c
+++ b/src/backend/optimizer/plan/planwindow.c
@@ -1509,7 +1509,7 @@ set_window_keys(WindowContext *context, int wind_index)
 		}
 	}
 	
-	/* Careful.  Within sort key, parition key may overlap order keys. */
+	/* Careful.  Within sort key, partition key may overlap order keys. */
 	nextsk = skoffset = winfo->orderkeys_offset;
 	
 	/* Make a WindowKey per SpecInfo. */

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -740,36 +740,12 @@ RelationFetchGpRelationNodeForXLog_Index(
 
 	if (deep >= 2)
 	{
-		int saveDeep;
-
-		if (Debug_gp_relation_node_fetch_wait_for_debugging)
-		{
-			/* Code for investigating MPP-16395, will be removed as part of the fix */
-			elog(WARNING, "RelationFetchGpRelationNodeForXLog_Index [%d] for non-heap %u/%u/%u (deep %d) -- waiting for debug attach...",
-				 countInThisBackend,
-				 relation->rd_node.spcNode,
-				 relation->rd_node.dbNode,
-				 relation->rd_node.relNode,
-				 deep);
-
-			for (int i=0; i < 24 * 60; i++)
-			{
-				pg_usleep(60000000L); /* 60 sec */
-			}
-		}
-
-		/*
-		 * Reset counter in case the user continues to use the session.
-		 */
-		saveDeep = deep;
-		deep = 0;
-
 		elog(ERROR, "RelationFetchGpRelationNodeForXLog_Index [%d] for non-heap %u/%u/%u (deep %d)",
 			 countInThisBackend,
 			 relation->rd_node.spcNode,
 			 relation->rd_node.dbNode,
 			 relation->rd_node.relNode,
-			 saveDeep);
+			 deep);
 	}
 
 	RelationFetchSegFile0GpRelationNode(relation);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -168,7 +168,6 @@ int			Debug_appendonly_bad_header_print_level = ERROR;
 bool		Debug_appendonly_print_datumstream = false;
 bool		Debug_appendonly_print_visimap = false;
 bool		Debug_appendonly_print_compaction = false;
-bool		Debug_gp_relation_node_fetch_wait_for_debugging = false;
 bool		gp_crash_recovery_abort_suppress_fatal = false;
 bool		gp_persistent_statechange_suppress_error = false;
 bool		Debug_bitmap_print_insert = false;
@@ -1621,16 +1620,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Debug_appendonly_print_datumstream,
-		false, NULL, NULL
-	},
-
-	{
-		{"debug_gp_relation_node_fetch_wait_for_debugging", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Wait for debugger attach for MPP-16395 RelationFetchGpRelationNodeForXLog issue."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_gp_relation_node_fetch_wait_for_debugging,
 		false, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -63,9 +63,6 @@
 #define S_PER_D (60 * 60 * 24)
 #define MS_PER_D (1000 * 60 * 60 * 24)
 
-static bool defunct_bool = false;
-static double defunct_double = 0;
-
 /*
  * Assign/Show hook functions defined in this module
  */
@@ -141,12 +138,10 @@ char	   *Debug_dtm_action_protocol_str;
 bool		Debug_print_full_dtm = false;
 bool		Debug_print_snapshot_dtm = false;
 bool		Debug_print_qd_mirroring = false;
-bool		Debug_permit_same_host_standby = false;
 bool		Debug_print_semaphore_detail = false;
 bool		Debug_disable_distributed_snapshot = false;
 bool		Debug_abort_after_distributed_prepared = false;
 bool		Debug_abort_after_segment_prepared = false;
-bool		Debug_print_tablespace = false;
 bool		Debug_print_server_processes = false;
 bool		Debug_print_control_checkpoints = false;
 bool		Debug_appendonly_print_insert = false;
@@ -154,8 +149,6 @@ bool		Debug_appendonly_print_insert_tuple = false;
 bool		Debug_appendonly_print_scan = false;
 bool		Debug_appendonly_print_scan_tuple = false;
 bool		Debug_appendonly_print_delete = false;
-bool		Debug_appendonly_print_update = false;
-bool		Debug_appendonly_print_update_tuple = false;
 bool		Debug_appendonly_print_storage_headers = false;
 bool		Debug_appendonly_print_verify_write_block = false;
 bool		Debug_appendonly_use_no_toast = false;
@@ -202,7 +195,6 @@ bool		Debug_persistent_store_print = false;
 int			Debug_persistent_store_print_level = LOG;
 bool		Debug_persistent_bootstrap_print = false;
 bool		persistent_integrity_checks = true;
-bool		disable_persistent_diagnostic_dump = false;
 bool		debug_persistent_ptcat_verification = false;
 bool		debug_print_persistent_checks = false;
 bool		Debug_bulk_load_bypass_wal = true;
@@ -235,7 +227,6 @@ bool		gp_dump_memory_usage = FALSE;
 int			verify_checkpoint_interval =
 VERIFY_CHECKPOINT_INTERVAL_DEFAULT;
 
-bool		Debug_rle_type_compression = false;
 bool		rle_type_compression_stats = false;
 
 bool		Debug_database_command_print = false;
@@ -261,7 +252,6 @@ bool		Debug_filerep_crc_on = true;
 bool		Debug_filerep_print = false;
 bool		Debug_filerep_gcov = false;
 bool		Debug_filerep_config_print = false;
-bool		Debug_filerep_verify_performance_print = false;
 bool		Debug_filerep_memory_log_flush = false;
 bool		filerep_mirrorvalidation_during_resync = false;
 bool		log_filerep_to_syslogger = false;
@@ -299,11 +289,9 @@ int			Debug_dtm_action_target = DEBUG_DTM_ACTION_TARGET_DEFAULT;
 
 int			Debug_dtm_action_protocol = DEBUG_DTM_ACTION_PROTOCOL_DEFAULT;
 
-#define DEBUG_DTM_ACTION_DELAY_MS_DEFAULT 5000
 #define DEBUG_DTM_ACTION_SEGMENT_DEFAULT 1
 #define DEBUG_DTM_ACTION_NESTINGLEVEL_DEFAULT 0
 
-int			Debug_dtm_action_delay_ms = DEBUG_DTM_ACTION_DELAY_MS_DEFAULT;
 int			Debug_dtm_action_segment = DEBUG_DTM_ACTION_SEGMENT_DEFAULT;
 int			Debug_dtm_action_nestinglevel = DEBUG_DTM_ACTION_NESTINGLEVEL_DEFAULT;
 
@@ -746,16 +734,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&log_dispatch_stats,
 		false, assign_dispatch_log_stats, NULL
-	},
-
-	{
-		{"enable_agg_restructure", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Deprecated: use gp_enable_multiphase_agg."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&defunct_bool,
-		true, NULL, NULL
 	},
 
 	{
@@ -1384,16 +1362,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"debug_permit_same_host_standby", PGC_SUSET, LOGGING_WHAT,
-			gettext_noop("Permits QD mirroring standby to exist on same host as primary."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_permit_same_host_standby,
-		false, NULL, NULL
-	},
-
-	{
 		{"Debug_print_semaphore_detail", PGC_SUSET, LOGGING_WHAT,
 			gettext_noop("Print semaphore detailed information."),
 			NULL,
@@ -1430,16 +1398,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Debug_abort_after_segment_prepared,
-		false, NULL, NULL
-	},
-
-	{
-		{"debug_print_tablespace", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Print TABLESPACE debugging information."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_print_tablespace,
 		false, NULL, NULL
 	},
 
@@ -1540,26 +1498,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Debug_appendonly_print_delete,
-		false, NULL, NULL
-	},
-
-	{
-		{"debug_appendonly_print_update", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Print log messages for append-only update."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_appendonly_print_update,
-		false, NULL, NULL
-	},
-
-	{
-		{"debug_appendonly_print_update_tuple", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Print log messages for append-only update tuples (caution -- generates a lot of log!)."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_appendonly_print_update_tuple,
 		false, NULL, NULL
 	},
 
@@ -1701,16 +1639,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&persistent_integrity_checks,
 		false, NULL, NULL
-	},
-
-	{
-		{"disable_persistent_diagnostic_dump", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("When set disables printing full PT on erros."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&disable_persistent_diagnostic_dump,
-		true, NULL, NULL
 	},
 
 	{
@@ -2143,15 +2071,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&Debug_filerep_crc_on,
 		false, NULL, NULL
 	},
-	{
-		{"debug_rle_type_compression", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("enable extensive debugging information for rle_type compression"),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_rle_type_compression,
-		false, NULL, NULL
-	},
 
 	{
 		{"rle_type_compression_stats", PGC_SUSET, DEVELOPER_OPTIONS,
@@ -2201,16 +2120,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&Debug_filerep_config_print,
 		true, NULL, NULL
-	},
-
-	{
-		{"debug_filerep_verify_performance_print", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("enable filerep verify performance tracing"),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&Debug_filerep_verify_performance_print,
-		false, NULL, NULL
 	},
 
 	{
@@ -3401,16 +3310,6 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_max_filespaces,
 		GP_MAX_FILESPACES_DEFAULT, 8, 256, NULL, NULL
-	},
-
-	{
-		{"debug_dtm_action_delay_ms", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Sets the debug DTM action delay in milliseconds."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_UNIT_MS
-		},
-		&Debug_dtm_action_delay_ms,
-		DEBUG_DTM_ACTION_DELAY_MS_DEFAULT, 0, INT_MAX / 1000, NULL, NULL
 	},
 
 	{
@@ -4766,17 +4665,6 @@ struct config_real ConfigureNamesReal_gp[] =
 		},
 		&gp_motion_cost_per_row,
 		0, 0, DBL_MAX, NULL, NULL
-	},
-
-	{
-		{"gp_hashagg_rewrite_limit", PGC_USERSET, QUERY_TUNING_OTHER,
-			gettext_noop("(Obsolete) Planner will not choose hashed aggregation if "
-						 "expected number of extra passes exceeds limit."),
-			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&defunct_double,
-		2.0, 1.0, 100.0, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4209,7 +4209,7 @@ struct config_int ConfigureNamesInt_gp[] =
 	{
 		{"gp_motion_slice_noop", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Make motion nodes in certain slices noop"),
-			gettext_noop("Make motion nodes noop, to help analyze performace"),
+			gettext_noop("Make motion nodes noop, to help analyze performance"),
 			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_GPDB_ADDOPT
 		},
 		&gp_motion_slice_noop,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2590,16 +2590,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&optimizer_print_optimization_context,
 		false, NULL, NULL
 	},
-	{
-		{"gp_reject_internal_tcp_connection", PGC_POSTMASTER,
-			DEVELOPER_OPTIONS,
-			gettext_noop("Permit internal TCP connections to the master."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_reject_internal_tcp_conn,
-		true, NULL, NULL
-	},
 
 	{
 		{"optimizer_print_optimization_stats", PGC_USERSET, LOGGING_WHAT,

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -52,7 +52,7 @@ typedef struct DistributedSnapshotHeader
 	DistributedTransactionId 	xmin;	/* XID < xmin are visible to me */
 	DistributedTransactionId 	xmax;	/* XID >= xmax are invisible to me */
 	int32						count;	/* 
-										 * Count of distributed transations
+										 * Count of distributed transactions
 										 * in inProgress*Array. 
 										 */
 	int32						maxCount;

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -285,7 +285,7 @@ namespace gpdb {
 	// parts of a partitioned table
 	bool FLeafPartition(Oid oid);
 
-	// partition table has an external parition
+	// partition table has an external partition
 	bool FHasExternalPartition(Oid oid);
 
 	// find the oid of the root partition given partition oid belongs to

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -144,7 +144,6 @@ extern bool Explain_pretty_print;
 extern bool	Debug_print_full_dtm;
 extern bool	Debug_print_snapshot_dtm;
 extern bool	Debug_print_qd_mirroring;
-extern bool Debug_permit_same_host_standby;
 extern bool Debug_print_semaphore_detail;
 extern bool Debug_disable_distributed_snapshot;
 extern bool Debug_abort_after_distributed_prepared;
@@ -154,8 +153,6 @@ extern bool Debug_appendonly_print_insert_tuple;
 extern bool Debug_appendonly_print_scan;
 extern bool Debug_appendonly_print_scan_tuple;
 extern bool Debug_appendonly_print_delete;
-extern bool Debug_appendonly_print_update;
-extern bool Debug_appendonly_print_update_tuple;
 extern bool Debug_appendonly_print_storage_headers;
 extern bool Debug_appendonly_print_verify_write_block;
 extern bool Debug_appendonly_use_no_toast;
@@ -211,7 +208,6 @@ extern bool Disable_persistent_recovery_logging;
 extern bool	Debug_persistent_store_print;
 extern bool Debug_persistent_bootstrap_print;
 extern bool persistent_integrity_checks;
-extern bool disable_persistent_diagnostic_dump;
 extern bool debug_persistent_ptcat_verification;
 extern bool debug_print_persistent_checks;
 extern bool Debug_bulk_load_bypass_wal;
@@ -244,7 +240,6 @@ extern bool Debug_filerep_crc_on;
 extern bool Debug_filerep_print;
 extern bool Debug_filerep_gcov;
 extern bool Debug_filerep_config_print;
-extern bool Debug_filerep_verify_performance_print;
 extern bool Debug_filerep_memory_log_flush;
 extern bool filerep_mirrorvalidation_during_resync;
 extern bool log_filerep_to_syslogger;
@@ -273,10 +268,8 @@ extern bool gp_ignore_window_exclude;
 
 extern int verify_checkpoint_interval;
 
-extern bool Debug_rle_type_compression;
 extern bool rle_type_compression_stats;
 
-extern bool Debug_print_tablespace;
 extern bool	Debug_print_server_processes;
 extern bool Debug_print_control_checkpoints;
 extern bool	Debug_dtm_action_primary;
@@ -341,7 +334,6 @@ typedef enum
 extern int Debug_dtm_action;
 extern int Debug_dtm_action_target;
 extern int Debug_dtm_action_protocol;
-extern int Debug_dtm_action_delay_ms;
 extern int Debug_dtm_action_segment;
 extern int Debug_dtm_action_nestinglevel;
 

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -1,5 +1,5 @@
 set optimizer_disable_missing_stats_collection = on;
--- MPP-23647 Create a paritioned appendonly table, let its age
+-- MPP-23647 Create a partitioned appendonly table, let its age
 -- increase during the test.  We will vacuum it at the end of the
 -- test.
 create table ao_age_test (i int, b bool, c char, d date)
@@ -130,7 +130,7 @@ insert into vactst select i, (i%123 > 50), (i/11) || '', '2008/10/12'::date + (i
 from generate_series(0, 99) i;
 vacuum analyze vactst;
 drop table vactst;
--- MPP-23647 Vacuum appendonly paritioned table ao_age_test, check
+-- MPP-23647 Vacuum appendonly partitioned table ao_age_test, check
 -- that its age is correctly updated along with its partitions.
 set vacuum_freeze_min_age=20;
 show vacuum_freeze_min_age;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -41,7 +41,7 @@ m/^NOTICE:.*resource queue required -- using default resource queue ".*"/
 
 # The following NOTICE is generated when a user creates an index on the parent
 # partition table. For each child partition, it informs the user that the
-# database will create an index for that parition. The messages might appear in
+# database will create an index for that partition. The messages might appear in
 # different order for the child partitions.
 m/^NOTICE:.*building index for child partition ".*"/
 

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -1,6 +1,6 @@
 set optimizer_disable_missing_stats_collection = on;
 
--- MPP-23647 Create a paritioned appendonly table, let its age
+-- MPP-23647 Create a partitioned appendonly table, let its age
 -- increase during the test.  We will vacuum it at the end of the
 -- test.
 create table ao_age_test (i int, b bool, c char, d date)
@@ -107,7 +107,7 @@ from generate_series(0, 99) i;
 vacuum analyze vactst;
 drop table vactst;
 
--- MPP-23647 Vacuum appendonly paritioned table ao_age_test, check
+-- MPP-23647 Vacuum appendonly partitioned table ao_age_test, check
 -- that its age is correctly updated along with its partitions.
 set vacuum_freeze_min_age=20;
 show vacuum_freeze_min_age;


### PR DESCRIPTION
Random things that had piled up in various git stashes: Fixes spelling in code and user facing documentation, removes unused dead GUCs, a duplicated GUC and an IMO pointless debugging GUC.