### PR TITLE
Backup Coverity fixes

### DIFF
--- a/src/backend/cdb/cdbbackup.c
+++ b/src/backend/cdb/cdbbackup.c
@@ -456,6 +456,9 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
 		}
 		free(temp);
 
+		if (pszDDBoostFileName == NULL)
+			elog(ERROR, "\nDDboost filename is NULL\n");
+
 		/* Create the gpddboost parameter string */
 		len = strlen(pszDDBoostDirName)
 			+ strlen(pszDDBoostFileName)
@@ -471,9 +474,6 @@ gp_backup_launch__(PG_FUNCTION_ARGS)
 			+ 20;
 
 		gpDDBoostCmdLine = (char *) palloc(len);
-
-		if (pszDDBoostFileName == NULL)
-			elog(ERROR, "\nDDboost filename is NULL\n");
 
 		sprintf(gpDDBoostCmdLine,
 			"%s --write-file-from-stdin --to-file=%s/%s --dd_boost_buf_size=%s ",

--- a/src/bin/pg_dump/cdb/cdb_ddboost_util.c
+++ b/src/bin/pg_dump/cdb/cdb_ddboost_util.c
@@ -2553,7 +2553,7 @@ writeToDDFileFromInput(struct ddboost_options *dd_options)
 	char	   *buf = NULL;
 	ddp_uint64_t rw_size = dd_boost_buf_size;
 	ddp_uint64_t total_bytes = 0;
-	ddp_uint64_t read_bytes = 0;
+	ddp_int64_t read_bytes = 0;
 	ddp_path_t	path1 = {0};
 	char	   *full_path = NULL;
 	char	   *buf_iogroup = NULL;

--- a/src/bin/pg_dump/cdb/cdb_ddboost_util.c
+++ b/src/bin/pg_dump/cdb/cdb_ddboost_util.c
@@ -1396,7 +1396,7 @@ writeToDDFile(FILE *fp, char *ddBoostFileName, char *ddboost_storage_unit)
 		{
 			mpp_err_msg(logError, progname, "ddboost write failed on %s with err %d\n", path1.path_name, err);
 			err = -1;
-			break;
+			goto cleanup;
 		}
 
 		total_bytes += ret_count;

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -1465,12 +1465,13 @@ exit_nicely(void)
 
 	pszErrorMsg = MakeString("*** aborted because of error: %s\n", lastMsg);
 
-	mpp_err_msg(logError, progname, pszErrorMsg);
-
 	makeSureMonitorThreadEnds(TASK_RC_FAILURE, pszErrorMsg);
 
-	if (pszErrorMsg)
+	if (pszErrorMsg != NULL)
+	{
+		mpp_err_msg(logError, progname, pszErrorMsg);
 		free(pszErrorMsg);
+	}
 
 	PQfinish(g_conn);
 	g_conn = NULL;


### PR DESCRIPTION
Various coverity fixes in the backup C code.

* Remove unnecessary NULL checks
* Use correct datatypes
* Change a break to a "goto cleanup"

Authors: Chris Hajas and Jamie McAtamney 