### PR TITLE
Run behave tests in concourse; add pt rebuild to concourse pipeline

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -414,6 +414,28 @@ jobs:
       MAKE_TEST_COMMAND: sub_transaction_limit_removal
       TEST_OS: centos
 
+- name: pt-rebuild
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      params:
+        submodules:
+        - gpMgmt/bin/pythonSrc/ext
+      passed: [compile_gpdb_centos6]
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      passed: [compile_gpdb_centos6]
+      trigger: true
+    - get: centos-gpdb-dev-6
+  - aggregate:
+    - task: pt_rebuild
+      file: gpdb_src/concourse/tasks/behave_gpdb.yml
+      image: centos-gpdb-dev-6
+      params:
+        BEHAVE_TAGS: persistent_rebuild
+        BLDWRAP_POSTGRES_CONF_ADDONS: ""
+        TEST_OS: centos
+
 - name: fts
   plan:
   - aggregate:

--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -427,14 +427,12 @@ jobs:
       passed: [compile_gpdb_centos6]
       trigger: true
     - get: centos-gpdb-dev-6
-  - aggregate:
-    - task: pt_rebuild
-      file: gpdb_src/concourse/tasks/behave_gpdb.yml
-      image: centos-gpdb-dev-6
-      params:
-        BEHAVE_TAGS: persistent_rebuild
-        BLDWRAP_POSTGRES_CONF_ADDONS: ""
-        TEST_OS: centos
+  - task: persistent_table_rebuild
+    file: gpdb_src/concourse/tasks/behave_gpdb.yml
+    image: centos-gpdb-dev-6
+    params:
+      BEHAVE_TAGS: persistent_rebuild
+      BLDWRAP_POSTGRES_CONF_ADDONS: ""
 
 - name: fts
   plan:

--- a/concourse/scripts/behave_gpdb.bash
+++ b/concourse/scripts/behave_gpdb.bash
@@ -1,0 +1,49 @@
+#!/bin/bash -l
+
+set -eox pipefail
+
+CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${CWDIR}/common.bash"
+
+function gen_env(){
+  cat > /opt/run_test.sh <<-EOF
+
+		source /usr/local/greenplum-db-devel/greenplum_path.sh
+		cd "\${1}/gpdb_src/gpAux"
+		source gpdemo/gpdemo-env.sh
+		cd "\${1}/gpdb_src/gpMgmt/"
+		# Does this report failures?
+		make -f Makefile.behave behave tags=${BEHAVE_TAGS}
+	EOF
+
+	chmod a+x /opt/run_test.sh
+}
+
+function _main() {
+
+    if [ -z "${BEHAVE_TAGS}" ]; then
+        echo "FATAL: BEHAVE_TAGS is not set"
+        exit 1
+    fi
+
+    if [ -z "$TEST_OS" ]; then
+        echo "FATAL: TEST_OS is not set"
+        exit 1
+    fi
+
+    if [ "$TEST_OS" != "centos" -a "$TEST_OS" != "sles" ]; then
+        echo "FATAL: TEST_OS is set to an invalid value: $TEST_OS"
+        echo "Configure TEST_OS to be centos or sles"
+        exit 1
+    fi
+
+    time install_gpdb
+    time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash "$TEST_OS"
+
+    time make_cluster
+
+    time gen_env
+    time run_test
+}
+
+_main "$@"

--- a/concourse/scripts/behave_gpdb.bash
+++ b/concourse/scripts/behave_gpdb.bash
@@ -26,17 +26,6 @@ function _main() {
         exit 1
     fi
 
-    if [ -z "$TEST_OS" ]; then
-        echo "FATAL: TEST_OS is not set"
-        exit 1
-    fi
-
-    if [ "$TEST_OS" != "centos" -a "$TEST_OS" != "sles" ]; then
-        echo "FATAL: TEST_OS is set to an invalid value: $TEST_OS"
-        echo "Configure TEST_OS to be centos or sles"
-        exit 1
-    fi
-
     time install_gpdb
     time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 

--- a/concourse/scripts/behave_gpdb.bash
+++ b/concourse/scripts/behave_gpdb.bash
@@ -38,7 +38,7 @@ function _main() {
     fi
 
     time install_gpdb
-    time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash "$TEST_OS"
+    time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 
     time make_cluster
 

--- a/concourse/tasks/behave_gpdb.yml
+++ b/concourse/tasks/behave_gpdb.yml
@@ -8,6 +8,5 @@ outputs:
 params:
   BEHAVE_TAGS: ""
   BLDWRAP_POSTGRES_CONF_ADDONS: ""
-  TEST_OS: ""
 run:
   path: gpdb_src/concourse/scripts/behave_gpdb.bash

--- a/concourse/tasks/behave_gpdb.yml
+++ b/concourse/tasks/behave_gpdb.yml
@@ -1,0 +1,13 @@
+platform: linux
+image_resource:
+  type: docker-image
+inputs:
+  - name: gpdb_src
+  - name: bin_gpdb
+outputs:
+params:
+  BEHAVE_TAGS: ""
+  BLDWRAP_POSTGRES_CONF_ADDONS: ""
+  TEST_OS: ""
+run:
+  path: gpdb_src/concourse/scripts/behave_gpdb.bash

--- a/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gppersistent_rebuild.feature
@@ -1,4 +1,4 @@
-@gppersistent_rebuid
+@persistent_rebuild
   Feature: persistent rebuild tests
 
   Scenario: Persistent rebuild tools should not error out when mirror is marked down and files are missing in the data directory for single node


### PR DESCRIPTION
* Add pt rebuild into concourse pipeline.
* Initial steps to enable us to run behave tests in concourse.
  This will only work for single node behave tests.

Signed-off-by: Chumki Roy <croy@pivotal.io>


https://gpdb.ci.pivotalci.info/teams/gpdb/pipelines/gpdb-master-pt-rebuild