### PR TITLE
Remove unnecessary unlink in checkpoint process

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -962,9 +962,16 @@ mdunlink(
 		}
 	}
 
+	/*
+	 * In PostgreSQL, register_unlink is called to let the checkpoint process to clean up the files.
+	 * In GPDB, the cleanup is handled by persistent table. Hence, we don't need to register the
+	 * unlink request.
+	 */
+#if 0 /* Upstream code not applicable to GPDB */
 	/* Register request to unlink first segment later */
 	if (!isRedo)
 		register_unlink(rnode);
+#endif
 }
 
 static void mdsetupdropobjmirroraccess(	


### PR DESCRIPTION
In PostgreSQL, the unlink is deferred and handled by checkpoint.

In GPDB, the unlink is always handled by persistent tables and hence it's
protected of duplicated relfilenode deletion during recovery. Functionally,
there is no harm to send unlink to checkpoint process, and checkpoint process
cannot even find the relfilenode to be deleted. However, this will be a
performance impact under scenario like deleting a table with large number of
partitions, where the fsync request queue is unnecessarily filled.

The detailed discussions are at:
https://groups.google.com/a/greenplum.org/forum/#!searchin/gpdb-dev/mdunlink%7Csort:relevance/gpdb-dev/PHKuQPNwWs0/1kIwDk-CEgAJ