### PR TITLE
Fix checkpoint wait for CommitTransaction.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -726,7 +726,7 @@ doInsertForgetCommitted(void)
 	 * master readers (e.g. those using  SnapshotNow for reading) the same as for
 	 * distributed transactions.
 	 */
-	ClearTransactionFromPgProc_UnderLock(MyProc);
+	ClearTransactionFromPgProc_UnderLock(MyProc, true);
 	releaseGxact_UnderLocks();
 
 	elog(DTM_DEBUG5, "doInsertForgetCommitted called releaseGxact");

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -1074,15 +1074,6 @@ FaultInjector_NewHashEntry(
 		case FileRepTransitionToChangeTracking:
 		case FileRepIsOperationCompleted:
 		case FileRepImmediateShutdownRequested:
-		case TransactionCommitPass1FromCreatePendingToCreated:
-		case TransactionCommitPass1FromDropInMemoryToDropPending:
-		case TransactionCommitPass1FromAbortingCreateNeededToAbortingCreate:
-		case TransactionAbortPass1FromCreatePendingToAbortingCreate:
-		case TransactionAbortPass1FromAbortingCreateNeededToAbortingCreate:
-		case TransactionCommitPass2FromDropInMemoryToDropPending:
-		case TransactionCommitPass2FromAbortingCreateNeededToAbortingCreate:
-		case TransactionAbortPass2FromCreatePendingToAbortingCreate:
-		case TransactionAbortPass2FromAbortingCreateNeededToAbortingCreate:
 			
 		case FinishPreparedTransactionCommitPass1FromCreatePendingToCreated:
 		case FinishPreparedTransactionCommitPass2FromCreatePendingToCreated:

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -70,6 +70,9 @@ typedef struct
 #define VirtualTransactionIdIsValid(vxid) \
 	(((vxid).backendId != InvalidBackendId) && \
 	 LocalTransactionIdIsValid((vxid).localTransactionId))
+#define VirtualTransactionIdEquals(vxid1, vxid2) \
+	((vxid1).backendId == (vxid2).backendId && \
+	 (vxid1).localTransactionId == (vxid2).localTransactionId)
 #define GET_VXID_FROM_PGPROC(vxid, proc) \
 	((vxid).backendId = (proc).backendId, \
 	 (vxid).localTransactionId = (proc).lxid)

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -35,8 +35,8 @@ extern bool TransactionIdIsInProgress(TransactionId xid);
 extern bool TransactionIdIsActive(TransactionId xid);
 extern TransactionId GetOldestXmin(bool allDbs, bool ignoreVacuum);
 
-extern int	GetTransactionsInCommit(TransactionId **xids_p);
-extern bool HaveTransactionsInCommit(TransactionId *xids, int nxids);
+extern VirtualTransactionId *GetVirtualXIDsDelayingChkpt(int *nvxids);
+extern bool HaveVirtualXIDsDelayingChkpt(VirtualTransactionId *vxids, int nvxids);
 
 extern PGPROC *BackendPidGetProc(int pid);
 extern int	BackendXidGetPid(TransactionId xid);

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -28,8 +28,8 @@ extern void ProcArrayRemove(PGPROC *proc, TransactionId latestXid);
 extern void ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid, bool isCommit,
 						bool *needStateChangeFromDistributed,
 						bool *needNotifyCommittedDtxTransaction);
-extern void ProcArrayClearTransaction(PGPROC *proc);
-extern void ClearTransactionFromPgProc_UnderLock(PGPROC *proc);
+extern void ProcArrayClearTransaction(PGPROC *proc, bool commit);
+extern void ClearTransactionFromPgProc_UnderLock(PGPROC *proc, bool commit);
 
 extern bool TransactionIdIsInProgress(TransactionId xid);
 extern bool TransactionIdIsActive(TransactionId xid);

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -44,4 +44,4 @@ clean distclean:
 	rm -rf $(pg_regress_clean_files)
 
 installcheck: all gpdiff.pl gpstringsubs.pl
-	./pg_isolation2_regress --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --ao-dir=uao --schedule=$(srcdir)/isolation2_schedule
+	./pg_isolation2_regress --init-file=$(top_builddir)/src/test/regress/init_file --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --ao-dir=uao --schedule=$(srcdir)/isolation2_schedule

--- a/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
+++ b/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
@@ -1,0 +1,69 @@
+-- TEST 1: block checkpoint on segments
+
+-- pause the 2PC after setting inCommit flag
+! gpfaultinjector -f twophase_transaction_commit_prepared -m async -y suspend -o 0 -H ALL -r primary;
+20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-Starting gpfaultinjector with args: -f twophase_transaction_commit_prepared -m async -y suspend -o 0 -H ALL -r primary
+20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-Injecting fault on content=1:dbid=3:mode=s:status=u
+20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-Injecting fault on content=2:dbid=4:mode=s:status=u
+20170303:00:02:12:067930 gpfaultinjector:-[INFO]:-DONE
+
+
+-- trigger a 2PC, and it will block at commit;
+2: checkpoint;
+CHECKPOINT
+2: begin;
+BEGIN
+2: create table t_commit_transaction_block_checkpoint (c int) distributed by (c);
+CREATE
+2&: commit;  <waiting ...>
+
+-- do checkpoint on dbid 3 (segment 1) in utility mode, and it should block
+3U&: checkpoint;  <waiting ...>
+
+-- resume the 2PC after setting inCommit flag
+! gpfaultinjector -f twophase_transaction_commit_prepared -m async -y reset -o 0 -H ALL -r primary;
+20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-Starting gpfaultinjector with args: -f twophase_transaction_commit_prepared -m async -y reset -o 0 -H ALL -r primary
+20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-Injecting fault on content=0:dbid=2:mode=s:status=u
+20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-Injecting fault on content=1:dbid=3:mode=s:status=u
+20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-Injecting fault on content=2:dbid=4:mode=s:status=u
+20170303:00:02:14:067954 gpfaultinjector:-[INFO]:-DONE
+
+2<:  <... completed>
+COMMIT
+3U<:  <... completed>
+CHECKPOINT
+
+-- TEST 2: block checkpoint on master
+
+-- pause the CommitTransaction right before persistent table cleanup after
+-- notifyCommittedDtxTransaction()
+! gpfaultinjector -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y suspend -o 0 -s 1;
+20170303:00:02:15:067973 gpfaultinjector:-[INFO]:-Starting gpfaultinjector with args: -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y suspend -o 0 -s 1
+20170303:00:02:15:067973 gpfaultinjector:-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170303:00:02:15:067973 gpfaultinjector:-[INFO]:-DONE
+
+
+-- trigger a 2PC, and it will block at commit;
+2: checkpoint;
+CHECKPOINT
+2: begin;
+BEGIN
+2: drop table t_commit_transaction_block_checkpoint;
+DROP
+2&: commit;  <waiting ...>
+
+-- do checkpoint on dbid 1 (master) in utility mode, and it should block
+1U&: checkpoint;  <waiting ...>
+
+-- resume the 2PC
+! gpfaultinjector -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y reset -o 0 -s 1;
+20170303:00:02:16:067988 gpfaultinjector:-[INFO]:-Starting gpfaultinjector with args: -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y reset -o 0 -s 1
+20170303:00:02:16:067988 gpfaultinjector:-[INFO]:-Injecting fault on content=-1:dbid=1:mode=s:status=u
+20170303:00:02:16:067988 gpfaultinjector:-[INFO]:-DONE
+
+2<:  <... completed>
+COMMIT
+1U<:  <... completed>
+CHECKPOINT
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,5 +1,6 @@
-test: setup
+test: commit_transaction_block_checkpoint
 
+test: setup
 # Tests on Append-Optimized tables (row-oriented).
 test: uao/alter_while_vacuum_row
 test: uao/alter_while_vacuum2_row

--- a/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
+++ b/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
@@ -1,0 +1,39 @@
+-- TEST 1: block checkpoint on segments
+
+-- pause the 2PC after setting inCommit flag
+! gpfaultinjector -f twophase_transaction_commit_prepared -m async -y suspend -o 0 -H ALL -r primary;
+
+-- trigger a 2PC, and it will block at commit;
+2: checkpoint;
+2: begin;
+2: create table t_commit_transaction_block_checkpoint (c int) distributed by (c);
+2&: commit;
+
+-- do checkpoint on dbid 3 (segment 1) in utility mode, and it should block
+3U&: checkpoint;
+
+-- resume the 2PC after setting inCommit flag
+! gpfaultinjector -f twophase_transaction_commit_prepared -m async -y reset -o 0 -H ALL -r primary;
+2<:
+3U<:
+
+-- TEST 2: block checkpoint on master
+
+-- pause the CommitTransaction right before persistent table cleanup after
+-- notifyCommittedDtxTransaction()
+! gpfaultinjector -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y suspend -o 0 -s 1;
+
+-- trigger a 2PC, and it will block at commit;
+2: checkpoint;
+2: begin;
+2: drop table t_commit_transaction_block_checkpoint;
+2&: commit;
+
+-- do checkpoint on dbid 1 (master) in utility mode, and it should block
+1U&: checkpoint;
+
+-- resume the 2PC
+! gpfaultinjector -f transaction_commit_pass1_from_drop_in_memory_to_drop_pending -m async -y reset -o 0 -s 1;
+2<:
+1U<:
+


### PR DESCRIPTION
Change 1: Use VXIDs instead of xid for checkpoint delay.

Originally checkpoint is checking for xid, however, xid is used to control the
transaction visibility and it's crucial to clean this xid if process is done
with commit and before release locks.

However, checkpoint need to wait for the `AtExat_smgr()` to cleanup persistent
table information, which happened after release locks, where `xid` is already
cleaned.

Hence, we use VXID, which doesn't have visibility impact.

NOTE: Upstream PostgreSQL commit f21bb9c for the similar fix.

Change 2: Fix checkpoint wait for CommitTransaction.

`MyProc->inCommit` is to protect checkpoint running during inCommit
transactions.

However, `MyProc->lxid` has to be valid because `GetVirtualXIDsDelayingChkpt()`
and `HaveVirtualXIDsDelayingChkpt()` require `VirtualTransactionIdIsValid()` in
addition to `inCommit` to block the checkpoint process.

In this fix, we defer clearing `inCommit` and `lxid` to `CommitTransaction()`.

Change 3: Extend isolation2 test framework for new test to ensure proper blocking 
behavior of checkpoint.
