### PR TITLE
Re-enable 3 runaway query tests.

### DIFF
--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/recover_from_segv.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/recover_from_segv.ans
@@ -72,7 +72,6 @@ DETAIL:
 	This probably means the server terminated abnormally
 	before or while processing the request.
 CONTEXT:  SQL function "gp_inject_fault_test_all_segs" statement 1
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:2433)
 
 -- only one active session on segment 0 should be left
 3: select count(*) from session_state.session_level_memory_consumption where segid = 0;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_pincount_fatal.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_pincount_fatal.ans
@@ -47,7 +47,6 @@ count
 2: select gp_inject_fault_test_all_segs(0, 2, 0);
 ERROR:  User fault injection raised fatal (runaway_test.c:250)  (seg0 slice2 gcaragea-mbp.local:40090 pid=83018) (cdbdisp.c:1526)
 CONTEXT:  SQL function "gp_inject_fault_test_all_segs" statement 1
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:2433)
 
 -- make sure session 2 is still around and accepting queries
 2: select 1;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_vmem_fatal.ans
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/expected/release_vmem_fatal.ans
@@ -69,7 +69,6 @@ t
 2: select gp_inject_fault_test_all_segs(0, 2, 0);
 ERROR:  User fault injection raised fatal (runaway_test.c:250)  (seg0 slice2 gcaragea-mbp.local:40090 pid=26904) (cdbdisp.c:1526)
 CONTEXT:  SQL function "gp_inject_fault_test_all_segs" statement 1
-ERROR:  could not temporarily connect to one or more segments (cdbgang.c:2433)
 
 -- make sure session 2 is still around and accepting queries
 2: select 1;

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/recover_from_segv.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/recover_from_segv.sql
@@ -2,7 +2,6 @@
 -- @author Zhongxian Gu
 -- @vlimMB 1000 
 -- @slimMB 0
--- @skip FATAL handling from UDFs has changed since older version. Renable after fixing that.
 -- @redzone 80
 
 -- Check that only one session is running

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount_fatal.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_pincount_fatal.sql
@@ -2,7 +2,6 @@
 -- @author George Caragea
 -- @vlimMB 1100 
 -- @slimMB 0
--- @skip FATAL handling from UDFs has changed since older version. Renable after fixing that.
 -- @redzone 80
 
 -- Check that only one session is running

--- a/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_vmem_fatal.sql
+++ b/src/test/tinc/tincrepo/resource_management/runaway_query/runaway_query_multisession/sql/release_vmem_fatal.sql
@@ -2,7 +2,6 @@
 -- @author George Caragea
 -- @vlimMB 1000 
 -- @slimMB 0
--- @skip FATAL handling from UDFs has changed since older version. Renable after fixing that.
 -- @redzone 80
 
 -- Check that only one session is running


### PR DESCRIPTION
There was a difference in the output of GPDB4 and GPDB5 for these when porting them to GPDB5. They were skipped when porting. After further investigation the change is benign. So re-enabling them now.

See commit : eb40e073c5c62ab2870bf3f2a4a791bb966a6f6b