### PR TITLE
gpcloud: fix issues reported by Coverity

### DIFF
--- a/gpAux/extensions/gpcloud/include/restful_service.h
+++ b/gpAux/extensions/gpcloud/include/restful_service.h
@@ -30,18 +30,18 @@ struct UploadData {
 
 class Response {
    public:
-    explicit Response(ResponseStatus status) : status(status) {
+    explicit Response(ResponseStatus status) : responseCode(-1), status(status) {
     }
     explicit Response(ResponseStatus status, S3MemoryContext& context)
-        : status(status), dataBuffer(context) {
+        : responseCode(-1), status(status), dataBuffer(context) {
     }
 
     explicit Response(ResponseStatus status, const vector<uint8_t>& dataBuffer)
-        : status(status), dataBuffer(dataBuffer) {
+        : responseCode(-1), status(status), dataBuffer(dataBuffer) {
     }
     explicit Response(ResponseStatus status, const vector<uint8_t>& headersBuffer,
                       const S3VectorUInt8& dataBuffer)
-        : status(status), headersBuffer(headersBuffer), dataBuffer(dataBuffer) {
+        : responseCode(-1), status(status), headersBuffer(headersBuffer), dataBuffer(dataBuffer) {
     }
 
     void FillResponse(ResponseCode responseCode) {

--- a/gpAux/extensions/gpcloud/include/s3interface.h
+++ b/gpAux/extensions/gpcloud/include/s3interface.h
@@ -72,7 +72,7 @@ class S3Interface {
     virtual ~S3Interface() {
     }
 
-    virtual ListBucketResult listBucket(S3Url s3Url) = 0;
+    virtual ListBucketResult listBucket(S3Url &s3Url) = 0;
 
     virtual uint64_t fetchData(uint64_t offset, S3VectorUInt8 &data, uint64_t len,
                                const S3Url &s3Url) = 0;
@@ -98,7 +98,7 @@ class S3InterfaceService : public S3Interface {
     S3InterfaceService(const S3Params &);
     virtual ~S3InterfaceService();
 
-    ListBucketResult listBucket(S3Url s3Url);
+    ListBucketResult listBucket(S3Url &s3Url);
 
     uint64_t fetchData(uint64_t offset, S3VectorUInt8 &data, uint64_t len, const S3Url &s3Url);
 

--- a/gpAux/extensions/gpcloud/include/s3key_writer.h
+++ b/gpAux/extensions/gpcloud/include/s3key_writer.h
@@ -16,7 +16,10 @@ class S3KeyWriter : public Writer {
         pthread_mutex_init(&this->exceptionMutex, NULL);
     }
     virtual ~S3KeyWriter() {
-        this->close();
+        try {
+            this->close();
+        } catch (...) {
+        }
         pthread_mutex_destroy(&this->mutex);
         pthread_cond_destroy(&this->cv);
         pthread_mutex_destroy(&this->exceptionMutex);

--- a/gpAux/extensions/gpcloud/include/s3params.h
+++ b/gpAux/extensions/gpcloud/include/s3params.h
@@ -9,7 +9,15 @@ class S3Params {
    public:
     S3Params(const string& sourceUrl = "", bool useHttps = true, const string& version = "",
              const string& region = "")
-        : s3Url(sourceUrl, useHttps, version, region), keySize(0), chunkSize(0), numOfChunks(0) {
+        : s3Url(sourceUrl, useHttps, version, region),
+          keySize(0),
+          chunkSize(0),
+          numOfChunks(0),
+          lowSpeedLimit(0),
+          lowSpeedTime(0),
+          debugCurl(false),
+          autoCompress(false),
+          verifyCert(false) {
     }
 
     virtual ~S3Params() {

--- a/gpAux/extensions/gpcloud/src/compress_writer.cpp
+++ b/gpAux/extensions/gpcloud/src/compress_writer.cpp
@@ -7,7 +7,10 @@ CompressWriter::CompressWriter() : writer(NULL), isClosed(true) {
 }
 
 CompressWriter::~CompressWriter() {
-    this->close();
+    try {
+        this->close();
+    } catch (...) {
+    }
     delete this->out;
 }
 

--- a/gpAux/extensions/gpcloud/src/gpwriter.cpp
+++ b/gpAux/extensions/gpcloud/src/gpwriter.cpp
@@ -45,6 +45,8 @@ string GPWriter::constructRandomStr() {
     char randomData[32];
     size_t randomDataLen = 0;
 
+    S3_CHECK_OR_DIE(randomDevice >= 0, S3RuntimeError, "failed to generate random number");
+
     while (randomDataLen < sizeof(randomData)) {
         ssize_t result =
             ::read(randomDevice, randomData + randomDataLen, sizeof(randomData) - randomDataLen);
@@ -57,7 +59,7 @@ string GPWriter::constructRandomStr() {
 
     char out_hash_hex[SHA256_DIGEST_STRING_LENGTH];
 
-    sha256_hex(randomData, out_hash_hex);
+    sha256_hex(randomData, 32, out_hash_hex);
 
     return out_hash_hex + SHA256_DIGEST_STRING_LENGTH - 8 - 1;
 }

--- a/gpAux/extensions/gpcloud/src/s3bucket_reader.cpp
+++ b/gpAux/extensions/gpcloud/src/s3bucket_reader.cpp
@@ -21,7 +21,7 @@ void S3BucketReader::open(const S3Params& params) {
 
     S3_CHECK_OR_DIE(this->s3Interface != NULL, S3RuntimeError, "s3Interface is NULL");
 
-    const S3Url& s3Url = this->params.getS3Url();
+    S3Url& s3Url = this->params.getS3Url();
 
     S3_CHECK_OR_DIE(s3Url.isValidUrl(), S3ConfigError, s3Url.getFullUrlForCurl() + " is not valid",
                     s3Url.getFullUrlForCurl());

--- a/gpAux/extensions/gpcloud/src/s3interface.cpp
+++ b/gpAux/extensions/gpcloud/src/s3interface.cpp
@@ -262,7 +262,7 @@ bool S3InterfaceService::parseBucketXML(ListBucketResult *result, xmlParserCtxtP
 // service unstable, so that caller could retry.
 //
 // Caller should delete returned object.
-ListBucketResult S3InterfaceService::listBucket(S3Url s3Url) {
+ListBucketResult S3InterfaceService::listBucket(S3Url &s3Url) {
     ListBucketResult result;
 
     string marker = "";
@@ -547,7 +547,7 @@ bool S3InterfaceService::abortUpload(const S3Url &s3Url, const string &uploadId)
     }
 }
 
-S3MessageParser::S3MessageParser(const Response &resp) {
+S3MessageParser::S3MessageParser(const Response &resp) : xmlptr(NULL) {
     // Compatible S3 services don't always return XML
     if (resp.getRawData().data() == NULL) {
         message = "Unknown error";

--- a/gpAux/extensions/gpcloud/test/mock_classes.h
+++ b/gpAux/extensions/gpcloud/test/mock_classes.h
@@ -10,7 +10,7 @@
 class MockS3Interface : public S3Interface {
    public:
     MOCK_METHOD1(listBucket,
-                 ListBucketResult(S3Url));
+                 ListBucketResult(S3Url &));
 
     MOCK_METHOD4(fetchData,
                  uint64_t(uint64_t , S3VectorUInt8& , uint64_t len, const S3Url &));

--- a/gpAux/extensions/gpcloud/test/s3interface_test.cpp
+++ b/gpAux/extensions/gpcloud/test/s3interface_test.cpp
@@ -188,15 +188,11 @@ TEST_F(S3InterfaceServiceTest, PostResponseWithRetriesAndSuccess) {
     EXPECT_EQ(RESPONSE_OK, this->postResponseWithRetries(url, headers, data).getStatus());
 }
 
-TEST_F(S3InterfaceServiceTest, ListBucketThrowExceptionWithInvalidUrl) {
-    EXPECT_THROW(result = this->listBucket(S3Url("s3://")), S3RuntimeError);
-}
-
 TEST_F(S3InterfaceServiceTest, ListBucketWithWrongRegion) {
     EXPECT_CALL(mockRESTfulService, get(_, _)).WillRepeatedly(Throw(S3ConnectionError("")));
 
-    EXPECT_THROW(this->listBucket(S3Url("s3://s3-noexist.amazonaws.com/bucket/prefix")),
-                 S3FailedAfterRetry);
+    S3Url s3Url("s3://s3-noexist.amazonaws.com/bucket/prefix");
+    EXPECT_THROW(this->listBucket(s3Url), S3FailedAfterRetry);
 }
 
 TEST_F(S3InterfaceServiceTest, ListBucketWithWrongBucketName) {


### PR DESCRIPTION
________________________________________________________________________________________________________
*** CID 163038:  Uninitialized members  (UNINIT_CTOR)
/extensions/gpcloud/src/s3interface.cpp: 556 in S3MessageParser::S3MessageParser(const Response &)()
550     S3MessageParser::S3MessageParser(const Response &resp) {
551         // Compatible S3 services don't always return XML
552         if (resp.getRawData().data() == NULL) {
553             message = "Unknown error";
554             code = "Unknown error code";
555
>>>     CID 163038:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "xmlptr" is not initialized in this constructor nor in any functions that it calls.
556             return;
557         }

________________________________________________________________________________________________________
*** CID 163037:  Uninitialized members  (UNINIT_CTOR)
/extensions/gpcloud/include/restful_service.h: 37 in Response::Response(ResponseStatus, PGAllocator<unsigned char> &)()
31     class Response {
32        public:
33         explicit Response(ResponseStatus status) : status(status) {
34         }
35         explicit Response(ResponseStatus status, S3MemoryContext& context)
36             : status(status), dataBuffer(context) {
>>>     CID 163037:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "responseCode" is not initialized in this constructor nor in any functions that it calls.
37         }

________________________________________________________________________________________________________
*** CID 163033:  Uninitialized members  (UNINIT_CTOR)
/extensions/gpcloud/include/s3params.h: 13 in S3Params::S3Params(const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &, bool, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &, const
+std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &)()
7
8     class S3Params {
9        public:
10         S3Params(const string& sourceUrl = "", bool useHttps = true, const string& version = "",
11                  const string& region = "")
12             : s3Url(sourceUrl, useHttps, version, region), keySize(0), chunkSize(0), numOfChunks(0) {
>>>     CID 163033:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "verifyCert" is not initialized in this constructor nor in any functions that it calls.
13         }

________________________________________________________________________________________________________
*** CID 163032:  Error handling issues  (UNCAUGHT_EXCEPT)
/extensions/gpcloud/src/compress_writer.cpp: 9 in CompressWriter::~CompressWriter()()
3     uint64_t S3_ZIP_COMPRESS_CHUNKSIZE = S3_ZIP_DEFAULT_CHUNKSIZE;
4
5     CompressWriter::CompressWriter() : writer(NULL), isClosed(true) {
6         this->out = new char[S3_ZIP_COMPRESS_CHUNKSIZE];
7     }
8
>>>     CID 163032:  Error handling issues  (UNCAUGHT_EXCEPT)
>>>     An exception of type "S3RuntimeError" is thrown but the throw list "throw()" doesn't allow it to be thrown. This will cause a call to unexpected() which usually calls terminate().
9     CompressWriter::~CompressWriter() {
10         this->close();
11         delete this->out;
12     }

________________________________________________________________________________________________________
*** CID 163029:  Memory - illegal accesses  (STRING_NULL)
/extensions/gpcloud/src/gpwriter.cpp: 49 in _ZN8GPWriter18constructRandomStrB5cxx11Ev()
43     string GPWriter::constructRandomStr() {
44         int randomDevice = ::open("/dev/urandom", O_RDONLY);
45         char randomData[32];
46         size_t randomDataLen = 0;
47
48         while (randomDataLen < sizeof(randomData)) {
>>>     CID 163029:  Memory - illegal accesses  (STRING_NULL)
>>>     Function "read" does not terminate string "randomData[randomDataLen]".

________________________________________________________________________________________________________
*** CID 163028:  Performance inefficiencies  (PASS_BY_VALUE)
/extensions/gpcloud/src/s3interface.cpp: 265 in S3InterfaceService::listBucket(S3Url)()
259     // ListBucket lists all keys in given bucket with given prefix.
260     //
261     // Return NULL when there is failure due to network instability or
262     // service unstable, so that caller could retry.
263     //
264     // Caller should delete returned object.
>>>     CID 163028:  Performance inefficiencies  (PASS_BY_VALUE)
>>>     Passing parameter s3Url of type "S3Url" (size 256 bytes) by value.

Signed-off-by: Haozhou Wang <hawang@pivotal.io>
Signed-off-by: Yuan Zhao <yuzhao@pivotal.io>
Signed-off-by: Adam Lee <ali@pivotal.io>