### PR TITLE
regression.diffs printing in gpAux/extensions under CI

### DIFF
--- a/gpAux/extensions/gphdfs/regression/run_gphdfs_regression.sh
+++ b/gpAux/extensions/gphdfs/regression/run_gphdfs_regression.sh
@@ -88,9 +88,6 @@ _main() {
 	$HADOOPCMD fs -rm -f -r /mapreduce/*
 	$HADOOPCMD fs -rm -f -r /mapred/*
 
-	# limited_schedule
-	#${PGREGRESS} --psqldir=$GPHOME/bin/ --init-file=$CURDIR/gphdfs_init_file --schedule=$CURDIR/limited_schedule --srcdir=$CURDIR/source_replaced --inputdir=$CURDIR/source_replaced --outputdir=.
-
 	# gphdfs_regress_schedule
 	PGOPTIONS="-c optimizer=off -c codegen=off -c gp_hadoop_home=${HADOOP_HOME} -c gp_hadoop_target_version=${GP_HADOOP_TARGET_VERSION}" ${PGREGRESS} --psqldir=$GPHOME/bin/ --init-file=$CURDIR/gphdfs_init_file --schedule=$CURDIR/gphdfs_regress_schedule  --srcdir=$CURDIR/source_replaced --inputdir=$CURDIR/source_replaced --outputdir=.
 }


### PR DESCRIPTION
The generated bash scripts for running the regression tests are executing with "set -exo pipefail" where "-o pipefail" makes the script exit on the first error. Since pg_regress will exit with returncode 1 on a run with a failed suite, the script will exit before reaching the check for regression.diffs. Fix by adding a trap function instead like the other CI scripts.

This use the same construction as other CI scripts of using find rather than hardcoding the path, which can be seen as overkill since there will only be a single file. This is a cheap operation though and will ensure that we don't miss a future regression.diffs added somewhere, or a changed outputdir parameter.

Also purges som dead gphdfs code.