### PR TITLE
Fix planning of NOT IN (<empty set>).

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -76,7 +76,6 @@ static void RemoveInnerJoinQuals(Query *subselect);
 static bool find_nonnullable_vars_walker(Node *node, NonNullableVarsContext *context);
 static bool is_attribute_nonnullable(Oid relationOid, AttrNumber attrNumber);
 static bool is_targetlist_nullable(Query *subq);
-static Node *make_outer_nonnull_clause(SubLink *sublink);
 
 #define DUMMY_COLUMN_NAME "zero"
 
@@ -1750,93 +1749,6 @@ is_targetlist_nullable(Query *subq)
 	return result;
 }
 
-/**
- * This method looks at a sublink expression and generates a not-null
- * clause for the outer-side expression.
- * For e.g. (foo(a),bar(b)) not in (...)
- * results in foo(a) is not null OR bar(b) is not null
- */
-static Node *
-make_outer_nonnull_clause(SubLink *sublink)
-{
-	Node	   *outerNonNullClause = NULL;
-
-	Assert(nodeTag(sublink->testexpr) == T_BoolExpr || nodeTag(sublink->testexpr) == T_OpExpr);
-
-	switch (nodeTag(sublink->testexpr))
-	{
-		case T_BoolExpr:
-			{
-				/*
-				 * This is the case when the testexpr involves multiple
-				 * columns such as (foo(a), bar(b)). This is represent as an
-				 * OR expression.
-				 */
-				List	   *exprList = NIL;
-				BoolExpr   *boolExpr = (BoolExpr *) sublink->testexpr;
-
-				Assert(boolExpr->boolop == OR_EXPR);
-				ListCell   *lc = NULL;
-
-				foreach(lc, boolExpr->args)
-				{
-					Node	   *singleColumnExpr = (Node *) lfirst(lc);
-
-					Assert(nodeTag(singleColumnExpr) == T_OpExpr);
-					OpExpr	   *opExpr = (OpExpr *) singleColumnExpr;	/* opExpr represents
-																		 * foo(a) <> param */
-
-					Assert(list_length(opExpr->args) == 2);		/* i.e. foo(a), param */
-					Expr	   *outerExpr = (Expr *) lfirst(list_head(opExpr->args));	/* outerExpr represents
-																						 * foo(a) */
-
-					NullTest   *nullTest = makeNode(NullTest);
-
-					nullTest->arg = outerExpr;
-					nullTest->nulltesttype = IS_NOT_NULL;		/* nullTest represents
-																 * foo(a) is not null */
-
-					exprList = lappend(exprList, nullTest);
-				}
-				outerNonNullClause = (Node *) make_orclause(exprList);	/* represents foo(a) is
-																		 * not null OR bar(b) is
-																		 * not null */
-				break;
-			}
-		case T_OpExpr:
-			{
-				/*
-				 * This represents the single column testexpr. Does not
-				 * contain the top OR clause.
-				 */
-				OpExpr	   *opExpr = (OpExpr *) sublink->testexpr;		/* opExpr represents
-																		 * foo(a) <> param */
-
-				Assert(list_length(opExpr->args) == 2); /* i.e. foo(a), param */
-				Expr	   *outerExpr = (Expr *) lfirst(list_head(opExpr->args));		/* outerExpr represents
-																						 * foo(a) */
-
-				NullTest   *nullTest = makeNode(NullTest);
-
-				nullTest->arg = outerExpr;
-				nullTest->nulltesttype = IS_NOT_NULL;	/* nullTest represents
-														 * foo(a) is not null */
-
-				outerNonNullClause = (Node *) nullTest; /* represents foo(a) is
-														 * not null OR bar(b) is
-														 * not null */
-				break;
-			}
-		default:
-			Assert(false && "Unsupported sublink expression");
-
-	}
-
-	Assert(outerNonNullClause);
-
-	return outerNonNullClause;
-}
-
 /*
  * convert_IN_to_antijoin: can we convert an ALL SubLink to join style?
  * If not appropriate to process this SubLink, return it as it is.
@@ -1857,8 +1769,8 @@ make_outer_nonnull_clause(SubLink *sublink)
  * in a top-level where clause (or through a series of inner joins).
  */
 static Node *
-			convert_IN_to_antijoin(PlannerInfo *root, List **rtrlist_inout __attribute__((unused)),
-											   SubLink *sublink)
+convert_IN_to_antijoin(PlannerInfo *root, List **rtrlist_inout __attribute__((unused)),
+					   SubLink *sublink)
 {
 	Query	   *parse = root->parse;
 	Query	   *subselect = (Query *) sublink->subselect;
@@ -1884,18 +1796,10 @@ static Node *
 			join_expr->quals = add_null_match_clause(join_expr->quals);
 		}
 
-		/*
-		 * What clause needs to be added to ensure that the outer side does
-		 * not contain nulls. This is because nulls in the outer side are
-		 * filtered out in a NOT IN clause.
-		 */
-		Node	   *notNullConstraints = make_outer_nonnull_clause(sublink);
-
 		parse->jointree->fromlist = list_make1(join_expr);		/* Replace the join-tree
 																 * with the new one */
 
-		/** Add not null constraints for the outer side to the top-level clause*/
-		return notNullConstraints;
+		return NULL;
 	}
 	else
 	{

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -1146,6 +1146,12 @@ select * from Tbl04 where (x,y) not in (select 1,y from Tbl10);
  3 | 4
 (1 row)
 
+select * from tbl10 where y not in (select 1 where false);
+ x | y 
+---+---
+ 1 |  
+(1 row)
+
 -- start_ignore
 alter table Tbl10 alter column x set not null;
 ALTER TABLE

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1147,6 +1147,12 @@ select * from Tbl04 where (x,y) not in (select 1,y from Tbl10);
  3 | 4
 (1 row)
 
+select * from tbl10 where y not in (select 1 where false);
+ x | y 
+---+---
+ 1 |  
+(1 row)
+
 -- start_ignore
 alter table Tbl10 alter column x set not null;
 ALTER TABLE

--- a/src/test/regress/sql/qp_subquery.sql
+++ b/src/test/regress/sql/qp_subquery.sql
@@ -535,6 +535,8 @@ select * from Tbl04 where (x,y) not in (select x,y from Tbl10);
 
 select * from Tbl04 where (x,y) not in (select 1,y from Tbl10);
 
+select * from tbl10 where y not in (select 1 where false);
+
 -- start_ignore
 alter table Tbl10 alter column x set not null;
 -- end_ignore
@@ -609,4 +611,3 @@ select * from TblUp2;
 -- start_ignore
 drop schema qp_subquery cascade;
 -- end_ignore
-

--- a/src/test/tinc/tincrepo/query/joins/lasj/expected/lasj_hash_notin_multiple_3.ans
+++ b/src/test/tinc/tincrepo/query/joins/lasj/expected/lasj_hash_notin_multiple_3.ans
@@ -22,4 +22,5 @@ SELECT * FROM foo WHERE (a, b) NOT IN (SELECT x, y FROM bar WHERE y = -1);
  1  |  12
  1  | 102
     |   2
-(6 rows)
+    |    
+(7 rows)

--- a/src/test/tinc/tincrepo/query/joins/lasj/expected/lasj_notin_multiple_3.ans
+++ b/src/test/tinc/tincrepo/query/joins/lasj/expected/lasj_notin_multiple_3.ans
@@ -22,4 +22,5 @@ SELECT * FROM foo WHERE (a, b) NOT IN (SELECT x, y FROM bar WHERE y = -1);
  1  |   2
  1  |  12
  1  | 102
-(6 rows)
+    |    
+(7 rows)


### PR DESCRIPTION
The transformation of "NOT IN" or "= ALL" incorrectly added a condition
that the outer side of the join must not be NULL. But that's not true,
when the other side is an empty set.

Discovered while moving old TINC tests to the main test suite.

Fixes github issue #1907.