### PR TITLE
moved SET_LOCKTAG_RESOURCE_QUEUE macro definition to lock.h

### DIFF
--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -312,6 +312,13 @@ typedef struct LOCKTAG
 	 (locktag).locktag_type = LOCKTAG_ADVISORY, \
 	 (locktag).locktag_lockmethodid = USER_LOCKMETHOD)
 
+#define SET_LOCKTAG_RESOURCE_QUEUE(locktag, queueid) \
+	((locktag).locktag_field1 = (queueid), \
+	 (locktag).locktag_field2 = 0, \
+	 (locktag).locktag_field3 = 0, \
+	 (locktag).locktag_field4 = 0, \
+	 (locktag).locktag_type = LOCKTAG_RESOURCE_QUEUE,		\
+	 (locktag).locktag_lockmethodid = RESOURCE_LOCKMETHOD)
 
 /*
  * Per-locked-object lock information:

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -103,17 +103,6 @@ typedef struct ResPortalTag
 } ResPortalTag;
 
 
-/*
- * Lock/Queue macros (maybe first one should be in lock.h)?
- */
-#define SET_LOCKTAG_RESOURCE_QUEUE(locktag, queueid) \
-	((locktag).locktag_field1 = (queueid), \
-	 (locktag).locktag_field2 = 0, \
-	 (locktag).locktag_field3 = 0, \
-	 (locktag).locktag_field4 = 0, \
-	 (locktag).locktag_type = LOCKTAG_RESOURCE_QUEUE,		\
-	 (locktag).locktag_lockmethodid = RESOURCE_LOCKMETHOD)
-
 #define GET_RESOURCE_QUEUEID_FOR_LOCK(lock) \
 	((lock->tag).locktag_field1)
 


### PR DESCRIPTION
First of all, the PR is not about bug fix. It is about improving code quality by putting related codes in the same header file.

Here is my story. Due to the requirement of my own project, I need to add extra fields in the struct LOCKTAG to provide more fine-grained lock control. So, I updated the definition of the struct LOCKTAG, and then I updated all the macros named SET_LOCKTAG_XXXX in the same file lock.h. At that point, I assumed all macros related to SET LOCKTAG had been updated. Everything worked fine until I ran some tests and encountered some weird issues. As we all know, in a database system, if the allocation and release of locks go wrong, the behave of the database tells you very little about the real root cause. It took me about three hours to debug the issues and figure out I missed the macro SET_LOCKTAG_RESOURCE_QUEUE. And the reason I missed it is because its definition is not in the lock.h, but resscheduler.h. As the original comment said, IT SHOULD BE IN lock.h.  It would have saved me three hours if SET_LOCKTAG_RESOURCE_QUEUE was defined in lock.h at the first beginning.

In my opinion, maybe someday in the future, GPDB would need to update the struct LOCKTAG too. So, I opened this PR to prevent other guys from making the same mistake.