### PR TITLE
gpfdist: Free session after all segment requests are finished

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -1382,6 +1382,7 @@ static void session_detach(request_t* r)
 		if (session->is_get && session->nrequest == 0)
 		{
 			gprintln(r, "session has finished all segment requests");
+			session_free(session);
 		}
 
 		/* for auto-tid sessions, we can free it now */


### PR DESCRIPTION
gpfdist doesn't free session data immediately.

Most importantly, if gpfdist is used with transformations, it will
execute a script for every request. For normal requests, gpfdist
will read all data from the script output and the script can exit.
If any data error, like incorrect format and insufficient/extra
columns, occurs while processing, gpdb will shutdown connection and
gpfdist will stop read from script but won't kill it since session
isn't properly freed. The script will hang after its stdout buffer
is used up. As more erroneous requests come in and the 'zombie'
proceesses pile up, the system will be stuck.

Signed-off-by: Jianxia Chen <jchen@pivotal.io>