### PR TITLE
137544393 analyze large records

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -50,8 +50,6 @@
 #include "utils/syscache.h"
 #include "utils/tuplesort.h"
 
-#define COLUMN_WIDTH_THRESHOLD  1024
-
 /* Data structure for Algorithm S from Knuth 3.4.2 */
 typedef struct
 {
@@ -808,7 +806,7 @@ analyzeComputeAverageWidth(Relation onerel, int attr_cnt, bool **excludeAttr)
 
 		width = DatumGetFloat4(heap_getattr(SPI_tuptable->vals[0], i + 1, SPI_tuptable->tupdesc, &isNull));
 
-		if (width > COLUMN_WIDTH_THRESHOLD)
+		if (width > analyze_column_width_threshold)
 			*flag = true;
 
 		excludeAttr[i] = flag;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -552,6 +552,11 @@ bool		optimizer_prefer_scalar_dqa_multistage_agg;
 bool 		optimizer_parallel_union;
 bool		optimizer_array_constraints;
 
+/** 
+ * GUCs related to analyze and vacuum
+ **/
+int		analyze_column_width_threshold;
+
 /**
  * GUCs related to code generation.
  **/
@@ -4617,6 +4622,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_server_version_num,
 		GP_VERSION_NUM, GP_VERSION_NUM, GP_VERSION_NUM, NULL, NULL
+	},
+
+	{
+		{"analyze_column_width_threshold", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Maximum column width threshold for analyze and vacuum to process a column."),
+			NULL,
+			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
+		},
+		(int *) &analyze_column_width_threshold,
+		100000000, 4, INT_MAX, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -473,6 +473,11 @@ extern bool optimizer_prefer_scalar_dqa_multistage_agg;
 extern bool optimizer_parallel_union;
 extern bool optimizer_array_constraints;
 
+/** 
+ * GUCs related to analyze and vacuum
+ **/
+extern int analyze_column_width_threshold;
+
 /**
  * GUCs related to code generation.
  **/

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -794,3 +794,47 @@ select * from pg_stats where tablename like 'p3_sales%' order by tablename, attn
 -- start_ignore
 DROP TABLE IF EXISTS p3_sales;
 -- end_ignore
+-- Case 16: Analyzing a table with a large column that exceeds the analyze_column_width_threshold
+-- start_ignore
+set analyze_column_width_threshold=4;
+DROP TABLE if exists p3_sales;
+-- end_ignore
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'North America');
+analyze p3_sales;
+select count(*) from pg_statistic where starelid = 'p3_sales'::regclass::oid;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) from pg_statistic where starelid = 'p3_sales_1_prt_2_2_prt_2_3_prt_other_regions'::regclass::oid;
+ count 
+-------
+     4
+(1 row)
+
+select count(*) from pg_statistic where starelid = 'p3_sales_1_prt_2_2_prt_2_3_prt_usa'::regclass::oid;
+ count 
+-------
+     5
+(1 row)
+
+-- start_ignore
+reset analyze_column_width_threshold;
+DROP TABLE if exists p3_sales;
+-- end_ignore

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -22,7 +22,9 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_1;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=546252"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4 from public.dd_singlecol_1 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471625"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b from public.dd_singlecol_1 as Ta  limit 7500 "
 -- ctas tests
@@ -98,18 +100,18 @@ select * from dd_singlecol_1 where a in (1,3,5);
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
- 1 | 1
  3 | 3
  5 | 5
+ 1 | 1
 (3 rows)
 
 select * from dd_singlecol_1 where a=1 or a=3 or a=5;
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
+ 1 | 1
  3 | 3
  5 | 5
- 1 | 1
 (3 rows)
 
 select * from dd_singlecol_1 where a is null or a=1;
@@ -150,8 +152,8 @@ select * from dd_singlecol_1 where a is null or a=2;
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
-   |  
  2 | 2
+   |  
 (2 rows)
 
 select * from dd_singlecol_1 where (a,b) in ((1,2),(3,4)); 
@@ -202,17 +204,17 @@ select * from dd_part_singlecol where a=1 or a=3 or a=5;
 INFO:  Dispatch command to ALL contents
  a | b  | c  
 ---+----+----
- 1 |  2 |  3
  3 |  6 |  9
  5 | 10 | 15
+ 1 |  2 |  3
 (3 rows)
 
 select * from dd_part_singlecol where a is null or a=1;
 INFO:  Dispatch command to ALL contents
  a | b | c 
 ---+---+---
- 1 | 2 | 3
    |   |  
+ 1 | 2 | 3
 (2 rows)
 
 -- simple predicates
@@ -335,20 +337,24 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547102"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_idx as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471755"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547129"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471769"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547148"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471782"
 analyze dd_singlecol_idx2;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547167"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_idx2 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471783"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_idx2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547194"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471797"
 -- disjunction with index scans
 select * from dd_singlecol_idx where (a=1 or a=3) and b<3;
 INFO:  Dispatch command to ALL contents
@@ -399,13 +405,15 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_bitmap_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547213"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_bitmap_idx as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471798"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_bitmap_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547240"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471812"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547261"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471828"
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=3) and b<3;
 INFO:  Dispatch command to ALL contents
@@ -496,41 +504,55 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_part_bitmap_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547336"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_2 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471851"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_bitmap_idx_1_prt_2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547591"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471974"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547364"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_3 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547392"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471867"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547420"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_4 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547448"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471883"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547309"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_5 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471899"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_6 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471915"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_extra as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471835"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_bitmap_idx_1_prt_extra as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547570"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471958"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547336"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547364"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471851"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547392"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471867"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547420"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471883"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547448"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471899"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547309"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471915"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471835"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_bitmap_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547549"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2471942"
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
 INFO:  Dispatch command to SINGLE content
@@ -578,11 +600,13 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_multicol_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547696"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_multicol_idx as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472042"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_multicol_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547723"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472056"
 select count(*) from dd_multicol_idx;
 INFO:  Dispatch command to ALL contents
  count 
@@ -734,78 +758,106 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_part_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547796"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_2 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472076"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx_1_prt_2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548047"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472193"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547824"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_3 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547852"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472092"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547880"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_4 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547908"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472108"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547769"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_5 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472124"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_6 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472140"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_extra as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472060"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx_1_prt_extra as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548028"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472180"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547796"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547824"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472076"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547852"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472092"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547880"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472108"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547908"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472124"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=547769"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472140"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472060"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548009"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472167"
 analyze dd_singlecol_part_idx2;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548196"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_2 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472265"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx2_1_prt_2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548447"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472382"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548224"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_3 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548252"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472281"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548280"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_4 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548308"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472297"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548169"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_5 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472313"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_6 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472329"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_extra as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472249"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx2_1_prt_extra as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548428"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472369"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548196"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548224"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472265"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548252"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472281"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548280"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472297"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548308"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472313"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548169"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472329"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472249"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=548409"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472356"
 -- indexes on partitioned tables
 select * from dd_singlecol_part_idx where a=1 and b>0;
 INFO:  Dispatch command to SINGLE content
@@ -1108,14 +1160,14 @@ select * from dd_singlecol_1 where a=1 or b=5;
 INFO:  Dispatch command to ALL contents
  a  | b 
 ----+---
- 65 | 5
- 80 | 5
- 95 | 5
   1 | 1
  35 | 5
  50 | 5
   5 | 5
  20 | 5
+ 65 | 5
+ 80 | 5
+ 95 | 5
 (8 rows)
 
 -- group by and sort

--- a/src/test/regress/expected/bfv_dd_multicolumn.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn.out
@@ -32,7 +32,9 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_multicol_1;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=29535"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4 from public.dd_multicol_1 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472456"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b from public.dd_multicol_1 as Ta  limit 7500 "
 insert into dd_multicol_2 select g, g%2 from generate_series(1, 100) g;
@@ -57,8 +59,8 @@ select * from dd_multicol_1 where a in (1,3) and b in (1,3);
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
- 3 | 1
  1 | 1
+ 3 | 1
 (2 rows)
 
 select * from dd_multicol_1 where a = 1 and b in (1,3);
@@ -255,6 +257,9 @@ select * from dd_multicol_1 where a>80 and b=1;
 INFO:  Dispatch command to ALL contents
  a  | b 
 ----+---
+ 85 | 1
+ 89 | 1
+ 99 | 1
  83 | 1
  93 | 1
  97 | 1
@@ -262,9 +267,6 @@ INFO:  Dispatch command to ALL contents
  87 | 1
  91 | 1
  95 | 1
- 85 | 1
- 89 | 1
- 99 | 1
 (10 rows)
 
 select * from dd_multicol_1 where a<=5 and b>0;

--- a/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
@@ -32,7 +32,9 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 analyze dd_multicol_1;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=44360"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4 from public.dd_multicol_1 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=2472463"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b from public.dd_multicol_1 as Ta  limit 7500 "
 insert into dd_multicol_2 select g, g%2 from generate_series(1, 100) g;
@@ -57,8 +59,8 @@ select * from dd_multicol_1 where a in (1,3) and b in (1,3);
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
- 1 | 1
  3 | 1
+ 1 | 1
 (2 rows)
 
 select * from dd_multicol_1 where a = 1 and b in (1,3);
@@ -87,10 +89,10 @@ select * from dd_multicol_1 where a is null or a=1;
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
-   |  
-   | 1
  1 | 1
  1 |  
+   |  
+   | 1
 (4 rows)
 
 select * from dd_multicol_1 where (a is null or a=1) and b=2;
@@ -257,9 +259,6 @@ select * from dd_multicol_1 where a>80 and b=1;
 INFO:  Dispatch command to ALL contents
  a  | b 
 ----+---
- 83 | 1
- 93 | 1
- 97 | 1
  81 | 1
  87 | 1
  91 | 1
@@ -267,6 +266,9 @@ INFO:  Dispatch command to ALL contents
  85 | 1
  89 | 1
  99 | 1
+ 83 | 1
+ 93 | 1
+ 97 | 1
 (10 rows)
 
 select * from dd_multicol_1 where a<=5 and b>0;

--- a/src/test/regress/expected/bfv_dd_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_optimizer.out
@@ -22,7 +22,9 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_1;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48152"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4 from public.dd_singlecol_1 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25662"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b from public.dd_singlecol_1 as Ta  limit 7500 "
 -- ctas tests
@@ -97,26 +99,26 @@ select * from dd_singlecol_1 where a in (1,3,5);
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
+ 1 | 1
  3 | 3
  5 | 5
- 1 | 1
 (3 rows)
 
 select * from dd_singlecol_1 where a=1 or a=3 or a=5;
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
+ 1 | 1
  3 | 3
  5 | 5
- 1 | 1
 (3 rows)
 
 select * from dd_singlecol_1 where a is null or a=1;
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
- 1 | 1
    |  
+ 1 | 1
 (2 rows)
 
 -- projections and disjunction
@@ -149,8 +151,8 @@ select * from dd_singlecol_1 where a is null or a=2;
 INFO:  Dispatch command to ALL contents
  a | b 
 ---+---
- 2 | 2
    |  
+ 2 | 2
 (2 rows)
 
 select * from dd_singlecol_1 where (a,b) in ((1,2),(3,4)); 
@@ -332,20 +334,24 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48490"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_idx as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25792"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48516"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25806"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48535"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25819"
 analyze dd_singlecol_idx2;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48554"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_idx2 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25820"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_idx2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48580"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25834"
 -- disjunction with index scans
 select * from dd_singlecol_idx where (a=1 or a=3) and b<3;
 INFO:  Dispatch command to ALL contents
@@ -396,13 +402,15 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_bitmap_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48599"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_bitmap_idx as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25835"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_bitmap_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48625"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25849"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48646"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25865"
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=3) and b<3;
 INFO:  Dispatch command to ALL contents
@@ -493,41 +501,55 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_part_bitmap_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48719"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_2 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25888"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_bitmap_idx_1_prt_2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48969"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26011"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48746"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_3 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48773"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25904"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48800"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_4 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48827"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25920"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48693"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_5 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25936"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_6 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25952"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx_1_prt_extra as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25872"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_bitmap_idx_1_prt_extra as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48948"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25995"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48719"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_bitmap_idx as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48746"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25888"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48773"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25904"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48800"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25920"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48827"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25936"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48693"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25952"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25872"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_bitmap_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=48927"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=25979"
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
 INFO:  Dispatch command to SINGLE content
@@ -575,11 +597,13 @@ INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
 analyze dd_multicol_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49074"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_multicol_idx as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26079"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_multicol_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49100"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26093"
 select count(*) from dd_multicol_idx;
 INFO:  Dispatch command to ALL contents
  count 
@@ -730,78 +754,106 @@ INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 analyze dd_singlecol_part_idx;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49171"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_2 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26113"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx_1_prt_2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49417"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26230"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49198"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_3 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49225"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26129"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49252"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_4 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49279"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26145"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49145"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_5 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26161"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_6 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26177"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx_1_prt_extra as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26097"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx_1_prt_extra as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49398"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26217"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49171"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49198"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26113"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49225"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26129"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49252"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26145"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49279"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26161"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49145"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26177"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26097"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49379"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26204"
 analyze dd_singlecol_part_idx2;
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49564"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_2 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26302"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx2_1_prt_2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49810"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26419"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49591"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_3 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49618"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26318"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49645"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_4 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49672"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26334"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49538"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_5 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26350"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_6 as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26366"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2_1_prt_extra as Ta"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26286"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx2_1_prt_extra as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49791"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26406"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49564"
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.a))::float4, avg(pg_column_size(Ta.b))::float4, avg(pg_column_size(Ta.c))::float4 from public.dd_singlecol_part_idx2 as Ta"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49591"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26302"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49618"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26318"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49645"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26334"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49672"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26350"
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49538"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26366"
+INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26286"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.a, Ta.b, Ta.c from public.dd_singlecol_part_idx2 as Ta  limit 7500 "
 INFO:  Dispatch command to ALL contents
-CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=49772"
+CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=26393"
 -- indexes on partitioned tables
 select * from dd_singlecol_part_idx where a=1 and b>0;
 INFO:  Dispatch command to SINGLE content
@@ -1103,14 +1155,14 @@ select * from dd_singlecol_1 where a=1 or b=5;
 INFO:  Dispatch command to ALL contents
  a  | b 
 ----+---
+  5 | 5
+ 20 | 5
  65 | 5
  80 | 5
  95 | 5
   1 | 1
  35 | 5
  50 | 5
-  5 | 5
- 20 | 5
 (8 rows)
 
 -- group by and sort

--- a/src/test/regress/expected/qp_targeted_dispatch.out
+++ b/src/test/regress/expected/qp_targeted_dispatch.out
@@ -936,6 +936,8 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'ke
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.key))::float4, avg(pg_column_size(Ta.value))::float4 from public.zoompp7620 as Ta"
+INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1237045"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.key, Ta.value from public.zoompp7620 as Ta  limit 7500 "

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -921,6 +921,8 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
 INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to ALL contents
 INFO:  Dispatch command to ALL contents
+CONTEXT:  SQL statement "select avg(pg_column_size(Ta.key))::float4, avg(pg_column_size(Ta.value))::float4 from public.zoompp7620 as Ta"
+INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select sum(gp_statistics_estimate_reltuples_relpages_oid(c.oid))::float4[] from gp_dist_random('pg_class') c where c.oid=1232388"
 INFO:  Dispatch command to ALL contents
 CONTEXT:  SQL statement "select Ta.key, Ta.value from public.zoompp7620 as Ta  limit 7500 "

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -367,3 +367,37 @@ select * from pg_stats where tablename like 'p3_sales%' order by tablename, attn
 -- start_ignore
 DROP TABLE IF EXISTS p3_sales;
 -- end_ignore
+
+-- Case 16: Analyzing a table with a large column that exceeds the analyze_column_width_threshold
+-- start_ignore
+set analyze_column_width_threshold=4;
+DROP TABLE if exists p3_sales;
+-- end_ignore
+CREATE TABLE p3_sales (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+    SUBPARTITION BY RANGE (month)
+       SUBPARTITION TEMPLATE (
+        START (1) END (2) EVERY (1),
+        DEFAULT SUBPARTITION other_months )
+           SUBPARTITION BY LIST (region)
+             SUBPARTITION TEMPLATE (
+               SUBPARTITION usa VALUES ('usa'),
+               DEFAULT SUBPARTITION other_regions )
+( START (2002) END (2003) EVERY (1),
+  DEFAULT PARTITION outlying_years );
+insert into p3_sales values (1, 2002, 1, 20, 'usa');
+insert into p3_sales values (1, 2002, 1, 20, 'North America');
+analyze p3_sales;
+
+select count(*) from pg_statistic where starelid = 'p3_sales'::regclass::oid;
+select count(*) from pg_statistic where starelid = 'p3_sales_1_prt_2_2_prt_2_3_prt_other_regions'::regclass::oid;
+select count(*) from pg_statistic where starelid = 'p3_sales_1_prt_2_2_prt_2_3_prt_usa'::regclass::oid;
+
+-- start_ignore
+reset analyze_column_width_threshold;
+DROP TABLE if exists p3_sales;
+-- end_ignore
+
+


### PR DESCRIPTION
This pull request excludes large columns from being analyzed or vacuumed if the column width is above a threshold.

When we insert one record that have 100 - 500MB it may cause gpdb to report below. 

`ERROR:  Canceling query because of high VMEM usage. Used: 7378MB, available 792MB, red zone: 7372MB (runaway_cleaner.c:129)
CONTEXT:  SQL statement "select Ta.btyeacolumn from public.byteatable as Ta where random() < 0.13841724395751953125000000000000000000 limit 7500 "`

The reason for that is insert is triggering an `analyze` on all columns that leads to out of memory condition.

We introduced a GUC `analyze_column_width_threshold` to set the column width threshold in order to exclude a column from being analyzed. 

We also added tests to exercise the effect of the new GUC and updated the tests to handle the extra SQL output. 