### PR TITLE
Fix resource leaks in backup code

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_ddboost_util.c
+++ b/src/bin/pg_dump/cdb/cdb_ddboost_util.c
@@ -2480,6 +2480,8 @@ copyFilesFromDir(const char *fromDir, char *toDir, ddp_conn_desc_t ddp_conn, cha
 
 			/* File full_path is closed in the callee */
 			err = readFromDDFile(fp, full_path, ddboost_storage_unit);
+			fclose(fp);
+			fp = NULL;
 		}
 	}
 
@@ -3019,6 +3021,8 @@ syncFilesFromDDBoostTimestamp(struct ddboost_options *dd_options, ddp_conn_desc_
 
 			/* Close both files in the called function */
 			err = readFromDDFile(fp, ddboostPath, dd_options->ddboost_storage_unit);
+			fclose(fp);
+			fp = NULL;
 			if (err)
 			{
 				mpp_err_msg(logError, progname, "Copy failed from DDboost file %s to GPDB file %s\n", ddboostPath, gpdbPath);


### PR DESCRIPTION
Fixes some of the resource leaks in backup and DDBoost code. 

Fixes memory leaks.

We also make sure to close a file pointer that is overwritten in a loop and may cause the open file limit to be reached. 