### PR TITLE
Fix representation of CONST in explain plan

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -3165,14 +3165,30 @@ get_variable(Var *var, int levelsup, bool istoplevel, deparse_context *context)
 		push_plan(dpns, dpns->outer_plan);
 
 		/*
-		 * Force parentheses because our caller probably assumed a Var is a
-		 * simple expression.
+		 * In cases where the INNER VAR subtree (left/right) contains a CONST
+		 * in Target Entry use outer for refname and resname for attname.
 		 */
-		if (!IsA(tle->expr, Var))
-			appendStringInfoChar(buf, '(');
-		get_rule_expr((Node *) tle->expr, context, true);
-		if (!IsA(tle->expr, Var))
-			appendStringInfoChar(buf, ')');
+		if (IsA(tle->expr, Const) && tle->resname)
+		{
+			if (context->varprefix)
+			{
+				appendStringInfoString(buf, quote_identifier("outer"));
+				appendStringInfoChar(buf, '.');
+			}
+			appendStringInfoString(buf, tle->resname);
+		}
+		else
+		{
+			/*
+			 * Force parentheses because our caller probably assumed a Var is a
+			 * simple expression.
+			 */
+			if (!IsA(tle->expr, Var))
+				appendStringInfoChar(buf, '(');
+			get_rule_expr((Node *) tle->expr, context, true);
+			if (!IsA(tle->expr, Var))
+				appendStringInfoChar(buf, ')');
+		}
 
 		dpns->outer_plan = save_outer;
 		dpns->inner_plan = save_inner;
@@ -3194,14 +3210,30 @@ get_variable(Var *var, int levelsup, bool istoplevel, deparse_context *context)
 		push_plan(dpns, dpns->inner_plan);
 
 		/*
-		 * Force parentheses because our caller probably assumed a Var is a
-		 * simple expression.
+		 * In cases where the INNER VAR subtree (left/right) contains a CONST
+		 * in Target Entry use inner for refname and resname for attname.
 		 */
-		if (!IsA(tle->expr, Var))
-			appendStringInfoChar(buf, '(');
-		get_rule_expr((Node *) tle->expr, context, true);
-		if (!IsA(tle->expr, Var))
-			appendStringInfoChar(buf, ')');
+		if (IsA(tle->expr, Const) && tle->resname)
+		{
+			if (context->varprefix)
+			{
+				appendStringInfoString(buf, quote_identifier("inner"));
+				appendStringInfoChar(buf, '.');
+			}
+			appendStringInfoString(buf, tle->resname);
+		}
+		else
+		{
+			/*
+			 * Force parentheses because our caller probably assumed a Var is a
+			 * simple expression.
+			 */
+			if (!IsA(tle->expr, Var))
+				appendStringInfoChar(buf, '(');
+			get_rule_expr((Node *) tle->expr, context, true);
+			if (!IsA(tle->expr, Var))
+				appendStringInfoChar(buf, ')');
+		}
 
 		dpns->outer_plan = save_outer;
 		dpns->inner_plan = save_inner;

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -1,3 +1,5 @@
+create schema gpexplain;
+set search_path = gpexplain;
 -- Helper function, to return the EXPLAIN output of a query as a normal
 -- result set, so that you can manipulate it further.
 create or replace function get_explain_output(explain_query text) returns setof text as
@@ -108,4 +110,28 @@ WHERE et like '%Filter: %';
  et 
 ----
 (0 rows)
+
+--
+-- Join condition in explain plan should represent constants with proper
+-- variable name
+--
+create table foo (a int) distributed randomly;
+-- "outer", "inner" prefix must also be prefixed to variable name as length of rtable > 1
+SELECT * from
+get_explain_output($$ 
+	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b join foo on true join foo as foo2 on true $$) as et
+WHERE et like '%Hash Cond:%';
+                                   et                                   
+------------------------------------------------------------------------
+                     Hash Cond: "*VALUES*".column1 = "*VALUES*".column1
+(1 row)
+
+SELECT * from
+get_explain_output($$
+	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b$$) as et
+WHERE et like '%Hash Cond:%';
+                          et                          
+------------------------------------------------------
+   Hash Cond: "*VALUES*".column1 = "*VALUES*".column1
+(1 row)
 

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -1,3 +1,5 @@
+create schema gpexplain;
+set search_path = gpexplain;
 -- Helper function, to return the EXPLAIN output of a query as a normal
 -- result set, so that you can manipulate it further.
 create or replace function get_explain_output(explain_query text) returns setof text as
@@ -98,8 +100,8 @@ WHERE mpp22263.unique1 = v.i and mpp22263.stringu1 = v.j;
                ->  Result  (cost=0.00..0.00 rows=1 width=12)
                      ->  Result  (cost=0.00..0.00 rows=1 width=12)
          ->  Index Scan using mpp22263_idx1 on mpp22263  (cost=0.00..2.00 rows=1 width=244)
-               Index Cond: mpp22263.unique1 = (147)
-               Filter: mpp22263.stringu1::text = ('RFAAAA'::text)
+               Index Cond: mpp22263.unique1 = "outer".column1
+               Filter: mpp22263.stringu1::text = "outer".column2
  Settings:  optimizer=on
  Optimizer status: PQO version 2.7.0
 (13 rows)
@@ -113,9 +115,33 @@ select * from mpp22263, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
 WHERE mpp22263.unique1 = v.i and mpp22263.stringu1 = v.j;
   $$) as et
 WHERE et like '%Filter: %';
-                                et                                
-------------------------------------------------------------------
+                               et                                
+-----------------------------------------------------------------
          Join Filter: true
-               Filter: mpp22263.stringu1::text = ('RFAAAA'::text)
+               Filter: mpp22263.stringu1::text = "outer".column2
 (2 rows)
+
+--
+-- Join condition in explain plan should represent constants with proper
+-- variable name
+--
+create table foo (a int) distributed randomly;
+-- "outer", "inner" prefix must also be prefixed to variable name as length of rtable > 1
+SELECT * from
+get_explain_output($$ 
+	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b join foo on true join foo as foo2 on true $$) as et
+WHERE et like '%Hash Cond:%';
+                          et                          
+------------------------------------------------------
+         Hash Cond: "inner".column1 = "outer".column1
+(1 row)
+
+SELECT * from
+get_explain_output($$
+	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b$$) as et
+WHERE et like '%Hash Cond:%';
+               et               
+--------------------------------
+   Hash Cond: column1 = column1
+(1 row)
 


### PR DESCRIPTION
When `explain` traces a VAR to a CONST, it assumes (rightly so) that
it's most likely the only constant being projected at that operator,
e.g.

```
EXPLAIN SELECT a AS c FROM (SELECT 1 AS a) AS bar ORDER BY 1;
                   QUERY PLAN
------------------------------------------------
 Sort  (cost=0.03..0.04 rows=1 width=4)
   Sort Key: (1)
   ->  Result  (cost=0.00..0.01 rows=1 width=0)
 Optimizer status: legacy query optimizer
(4 rows)

```

For a query containing the `VALUES` construct, planner would generate
VALUESSCAN, whereas ORCA will generate an `APPEND` with each constant
as a `RESULT` node underneath. Notice how the ORCA plan shape breaks the
assumption of the `EXPLAIN` rendering logic, resulting somehow confusing
output like this:

```
explain select * from foo, (values (1), (2)) f(i) where foo.a=f.i;
                                  QUERY PLAN
------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
   ->  Hash Join  (cost=0.00..431.00 rows=1 width=8)
         Hash Cond: (1) = a
         ->  Append  (cost=0.00..0.00 rows=1 width=4)
               ->  Result  (cost=0.00..0.00 rows=1 width=4)
                     ->  Result  (cost=0.00..0.00 rows=1 width=4)
               ->  Result  (cost=0.00..0.00 rows=1 width=4)
                     ->  Result  (cost=0.00..0.00 rows=1 width=4)
         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
               ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=4)
 Settings:  optimizer=on
 Optimizer status: PQO version 2.7.0
(12 rows)
```
In the above case, `(1)` is less than helpful because that is not the
only constant in the relation.

This commit renders a `VAR` node that trace back to a `CONST` that has a
non empty `resname` with the `resname` instead of the constant value.

An unintended (but good) consequence of this change is that some
constants are now rendered as their projected column instead of the
constant value, e.g.:

```
EXPLAIN SELECT a AS c FROM (SELECT 1 AS a) AS bar ORDER BY 1;
                   QUERY PLAN
------------------------------------------------
 Sort  (cost=0.03..0.04 rows=1 width=4)
   Sort Key: c
   ->  Result  (cost=0.00..0.01 rows=1 width=0)
 Optimizer status: legacy query optimizer
(4 rows)
```
