### PR TITLE
Fix typos when using gpinitsystem

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -913,7 +913,8 @@ CREATE_GROUP_MIRROR_ARRAY () {
 }
 
 GET_REPLY () {
-	$ECHO "$1 Yy/Nn>"
+	$ECHO -e "\n$1 Yy|Nn (default=N):"
+	$ECHO -n ">"
 	read REPLY
 	if [ -z $REPLY ]; then
 		LOG_MSG "[WARN]:-User abort requested, Script Exits!" 1

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -914,7 +914,7 @@ CREATE_GROUP_MIRROR_ARRAY () {
 
 GET_REPLY () {
 	$ECHO -e "\n$1 Yy|Nn (default=N):"
-	$ECHO -n ">"
+	$ECHO -n "> "
 	read REPLY
 	if [ -z $REPLY ]; then
 		LOG_MSG "[WARN]:-User abort requested, Script Exits!" 1


### PR DESCRIPTION
$ gpinitsystem -c gpinitsystem_config 
...show too much omitted ...
20170303:10:19:41:125712 gpinitsystem:node:gp-[INFO]:----------------------------------------
20170303:10:19:41:125712 gpinitsystem:node:gp-[INFO]:-node   /data/gp/primary/gpseg0   40000  2  0
Continue with Greenplum creation **Yy/Nn>**
n
20170303:10:09:08:122134 gpinitsystem:node:gp-[WARN]:-User abort requested, Script Exits!

**The right example**
$ gpstart
20170303:10:23:03:005007 gpstart:node:gp-[INFO]:-Starting gpstart with args: 
...show too much omitted ...
20170303:10:23:05:005007 gpstart:node:gp-[INFO]:---------------------------------------
20170303:10:23:05:005007 gpstart:node:gp-[INFO]:-   Host   Datadir                   Port
20170303:10:23:05:005007 gpstart:node:gp-[INFO]:-   node   /data/gp/primary/gpseg0   40000

Continue with Greenplum instance startup **Yy|Nn (default=N):**
**>** n
20170303:10:23:08:005007 gpstart:node:gp-[INFO]:-User abort requested, Exiting...

$ gpstop
20170303:10:24:14:005176 gpstop:node:gp-[INFO]:-Starting gpstop with args: 
...show too much omitted ...
20170303:10:24:14:005176 gpstop:node:gp-[INFO]:---------------------------------------------
20170303:10:24:14:005176 gpstop:node:gp-[INFO]:-   Host   Datadir                   Port    Status
20170303:10:24:14:005176 gpstop:node:gp-[INFO]:-   node   /data/gp/primary/gpseg0   40000   u

Continue with Greenplum instance shutdown **Yy|Nn (default=N):**
**>** n
20170303:10:24:16:005176 gpstop:node:gp-[INFO]:-User abort requested, Exiting...