### PR TITLE
Avoid string duplication in cdb_bsa agents

### DIFF
--- a/src/bin/pg_dump/cdb/cdb_bsa_delete_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_bsa_delete_agent.c
@@ -11,8 +11,6 @@
 
 #include "cdb_bsa_util.h"
 
-char					*NetBackupServiceHost = NULL;
-char					*NetBackupDeleteObject = NULL;
 char					*progname = NULL;
 char					*netbackupServiceHost = NULL;
 char					*netbackupDeleteObject = NULL;
@@ -84,36 +82,17 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
-	NetBackupServiceHost = (char *)malloc(sizeof(char) *(1 + strlen(netbackupServiceHost)));
-	if(NetBackupServiceHost == NULL){
-		mpp_err_msg("ERROR", "gp_bsa_delete_agent", "Failed to allocate memory for NetBackup Service Hostname\n");
-		exit(1);
-	}
-	strncpy(NetBackupServiceHost, netbackupServiceHost, (1 + strlen(netbackupServiceHost)));
-
-	if (netbackupDeleteObject)
-	{
-		NetBackupDeleteObject = (char *)malloc(sizeof(char) *(1 + strlen(netbackupDeleteObject)));
-		if (NetBackupDeleteObject == NULL) {
-			mpp_err_msg("ERROR", "gp_bsa_delete_agent", "Failed to allocate memory for NetBackup Delete Object\n");
-			exit(1);
-		}
-		strncpy(NetBackupDeleteObject, netbackupDeleteObject, (1 + strlen(netbackupDeleteObject)));
-	}
-
-	if(initBSARestoreSession(NetBackupServiceHost) != 0){
+	if (initBSARestoreSession(netbackupServiceHost) != 0) {
 		mpp_err_msg("ERROR", "gp_bsa_delete_agent", "Failed to initialize the NetBackup BSA session to query BSA object\n");
 		exit(1);
 	}
 
-	if (NetBackupDeleteObject) {
-		if (deleteBSAObjects(NetBackupDeleteObject) != 0) {
-			mpp_err_msg("INFO", "gp_bsa_delete_agent", "No objects of the format '%s' found on the NetBackup server or could not delete objecs of the format '%s'\n", NetBackupDeleteObject, NetBackupDeleteObject);
-		}
+	if (deleteBSAObjects(netbackupDeleteObject) != 0) {
+		mpp_err_msg("INFO", "gp_bsa_delete_agent", "No objects of the format '%s' found on the NetBackup server or could not delete objecs of the format '%s'\n", netbackupDeleteObject, netbackupDeleteObject);
+		exit(1);
 	}
 
 	exit(0);
-
 }
 
 static void

--- a/src/bin/pg_dump/cdb/cdb_bsa_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_bsa_dump_agent.c
@@ -12,12 +12,6 @@
 
 #include "cdb_bsa_util.h"
 
-char                    *BackupFilePathName;
-int						BackupFilePathLength = 0;
-char                    *NetBackupPolicy = NULL;
-char                    *NetBackupServiceHost = NULL;
-char                    *NetBackupSchedule = NULL;
-char                    *NetBackupKeyword = NULL;
 char					*progname;
 char					*netbackupDumpFilename = NULL;
 char					*netbackupServiceHost = NULL;
@@ -121,56 +115,12 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
-	BackupFilePathLength = strlen(netbackupDumpFilename);
-	BackupFilePathName = (char *)malloc(sizeof(char) *(1 + BackupFilePathLength));
-	if(BackupFilePathName == NULL){
-		mpp_err_msg("ERROR", "gp_bsa_dump_agent", "Failed to allocate memory for Backup Filename\n");
-		exit(1);
-	}
-	memset(BackupFilePathName, 0x00, (1 + BackupFilePathLength));
-	strncpy(BackupFilePathName, netbackupDumpFilename, (1 + BackupFilePathLength));
-
-	NetBackupServiceHost = (char *)malloc(sizeof(char) *(1 + strlen(netbackupServiceHost)));
-	if(NetBackupServiceHost == NULL){
-		mpp_err_msg("ERROR", "gp_bsa_dump_agent", "Failed to allocate memory for NetBackup Service Hostname\n");
-		exit(1);
-	}
-	memset(NetBackupServiceHost, 0x00, (1 + strlen(netbackupServiceHost)));
-	strncpy(NetBackupServiceHost, netbackupServiceHost, (1 + strlen(netbackupServiceHost)));
-
-	NetBackupPolicy = (char *)malloc(sizeof(char) *(1 + strlen(netbackupPolicy)));
-	if(NetBackupPolicy == NULL){
-		mpp_err_msg("ERROR", "gp_bsa_dump_agent", "Failed to allocate memory for NetBackup Policy name\n");
-		exit(1);
-	}
-	memset(NetBackupPolicy, 0x00, (1 + strlen(netbackupPolicy)));
-	strncpy(NetBackupPolicy, netbackupPolicy, (1 + strlen(netbackupPolicy)));
-
-	NetBackupSchedule = (char *)malloc(sizeof(char) *(1 + strlen(netbackupSchedule)));
-	if(NetBackupSchedule == NULL){
-		mpp_err_msg("ERROR", "gp_bsa_dump_agent", "Failed to allocate memory for NetBackup Schedule name\n");
-		exit(1);
-	}
-	memset(NetBackupSchedule, 0x00, (1 + strlen(netbackupSchedule)));
-	strncpy(NetBackupSchedule, netbackupSchedule, (1 + strlen(netbackupSchedule)));
-
-	if (netbackupKeyword)
-	{
-		NetBackupKeyword = (char *)malloc(sizeof(char) *(1 + strlen(netbackupKeyword)));
-		if(NetBackupKeyword == NULL){
-			mpp_err_msg("ERROR", "gp_bsa_dump_agent", "Failed to allocate memory for NetBackup Keyword\n");
-			exit(1);
-		}
-		memset(NetBackupKeyword, 0x00, (1 + strlen(netbackupKeyword)));
-		strncpy(NetBackupKeyword, netbackupKeyword, (1 + strlen(netbackupKeyword)));
-	}
-
-	if(initBSADumpSession(NetBackupServiceHost, NetBackupPolicy, NetBackupSchedule, NetBackupKeyword) != 0){
+	if(initBSADumpSession(netbackupServiceHost, netbackupPolicy, netbackupSchedule, netbackupKeyword) != 0){
 		mpp_err_msg("ERROR", "gp_bsa_dump_agent", "Failed to initialize NetBackup BSA session for Backup\n");
 		exit(1);
 	}
 
-	if(createBSADumpObject(BackupFilePathName) != 0){
+	if(createBSADumpObject(netbackupDumpFilename) != 0){
 		mpp_err_msg("ERROR", "gp_bsa_dump_agent", "Failed to create NetBackup BSA object to perform Backup\n");
 		exit(1);
 	}
@@ -185,16 +135,6 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
-	free(netbackupDumpFilename);
-	free(netbackupSchedule);
-	free(netbackupPolicy);
-	free(netbackupServiceHost);
-	free(netbackupKeyword);
-	free(BackupFilePathName);
-	free(NetBackupServiceHost);
-	free(NetBackupPolicy);
-	free(NetBackupSchedule);
-	free(NetBackupKeyword);
 	exit(0);
 }
 

--- a/src/bin/pg_dump/cdb/cdb_bsa_query_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_bsa_query_agent.c
@@ -11,10 +11,6 @@
 
 #include "cdb_bsa_util.h"
 
-char                    *BackupFilePathName;
-int						BackupFilePathLength = 0;
-char					*NetBackupServiceHost;
-char					*NetBackupQueryObject;
 char					*progname;
 char					*netbackupRestoreFilename = NULL;
 char					*netbackupServiceHost = NULL;
@@ -96,61 +92,38 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
-	if (netbackupRestoreFilename)
+	if (initBSARestoreSession(netbackupServiceHost) != 0)
 	{
-		BackupFilePathLength = strlen(netbackupRestoreFilename);
-		BackupFilePathName = (char *)malloc(sizeof(char) *(1 + BackupFilePathLength));
-		if(BackupFilePathName == NULL){
-			mpp_err_msg("ERROR", "gp_bsa_query_agent", "Failed to allocate memory for Restore Filename\n");
-			exit(1);
-		}
-		strncpy(BackupFilePathName, netbackupRestoreFilename, (1 + BackupFilePathLength));
-	}
-
-	NetBackupServiceHost = (char *)malloc(sizeof(char) *(1 + strlen(netbackupServiceHost)));
-	if(NetBackupServiceHost == NULL){
-		mpp_err_msg("ERROR", "gp_bsa_query_agent", "Failed to allocate memory for NetBackup Service Hostname\n");
-		exit(1);
-	}
-	strncpy(NetBackupServiceHost, netbackupServiceHost, (1 + strlen(netbackupServiceHost)));
-
-	if (netbackupQueryObject)
-	{
-		NetBackupQueryObject = (char *)malloc(sizeof(char) *(1 + strlen(netbackupQueryObject)));
-		if (NetBackupQueryObject == NULL) {
-			mpp_err_msg("ERROR", "gp_bsa_query_agent", "Failed to allocate memory for NetBackup Query Object\n");
-			exit(1);
-		}
-		strncpy(NetBackupQueryObject, netbackupQueryObject, (1 + strlen(netbackupQueryObject)));
-	}
-
-	if(initBSARestoreSession(NetBackupServiceHost) != 0){
 		mpp_err_msg("ERROR", "gp_bsa_query_agent", "Failed to initialize the NetBackup BSA session to query BSA object\n");
 		exit(1);
 	}
 
-	if (BackupFilePathName) {
-		if(queryBSAObject(BackupFilePathName) == NULL){
-			mpp_err_msg("INFO", "gp_bsa_query_agent", "Query to NetBackup server failed for object: %s\n", BackupFilePathName);
+	if (netbackupRestoreFilename)
+	{
+		if (queryBSAObject(netbackupRestoreFilename) == NULL)
+		{
+			mpp_err_msg("INFO", "gp_bsa_query_agent", "Query to NetBackup server failed for object: %s\n", netbackupRestoreFilename);
 		}
-		else {
-			printf("%s\n", (char *)BackupFilePathName);
+		else
+		{
+			printf("%s\n", netbackupRestoreFilename);
 		}
 	}
-	else if (NetBackupQueryObject) {
-		if (searchBSAObject(NetBackupQueryObject) != 0) {
-			mpp_err_msg("INFO", "gp_bsa_query_agent", "No objects of the format '%s' found on the NetBackup server\n", NetBackupQueryObject);
+	else if (netbackupQueryObject)
+	{
+		if (searchBSAObject(netbackupQueryObject) != 0)
+		{
+			mpp_err_msg("INFO", "gp_bsa_query_agent", "No objects of the format '%s' found on the NetBackup server\n", netbackupQueryObject);
 		}
 	}
 
 	exit(0);
-
 }
 
 static void
 help(const char *progname)
 {
-	printf(_("\n%s queries the given object to NetBackup server to determine if it has been backup up using NetBackup\n\n"), progname);
+	printf(_("\n%s queries the given object to NetBackup server to determine if it has been backed up using NetBackup\n\n"), progname);
 	printf(_("Usage:\n"));
 	printf(_("	%s [OPTION]... [FILENAME]"), progname);
 

--- a/src/bin/pg_dump/cdb/cdb_bsa_restore_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_bsa_restore_agent.c
@@ -12,9 +12,6 @@
 
 #include "cdb_bsa_util.h"
 
-char                    *BackupFilePathName;
-int						BackupFilePathLength = 0;
-char					*NetBackupServiceHost;
 char					*progname;
 char					*netbackupRestoreFilename = NULL;
 char					*netbackupServiceHost = NULL;
@@ -91,29 +88,12 @@ main(int argc, char *argv[]){
 		exit(1);
 	}
 
-	BackupFilePathLength = strlen(netbackupRestoreFilename);
-	BackupFilePathName = (char *)malloc(sizeof(char) *(1 + BackupFilePathLength));
-	if(BackupFilePathName == NULL){
-		mpp_err_msg("ERROR", "gp_bsa_restore_agent", "Failed to allocate memory for Restore Filename\n");
-		exit(1);
-	}
-	memset(BackupFilePathName, 0x00, (1 + BackupFilePathLength));
-	strncpy(BackupFilePathName, netbackupRestoreFilename, (1 + BackupFilePathLength));
-
-	NetBackupServiceHost = (char *)malloc(sizeof(char) *(1 + strlen(netbackupServiceHost)));
-	if(NetBackupServiceHost == NULL){
-		mpp_err_msg("ERROR", "gp_bsa_dump_agent", "Failed to allocate memory for NetBackup Service Hostname\n");
-		exit(1);
-	}
-	memset(NetBackupServiceHost, 0x00, (1 + strlen(netbackupServiceHost)));
-	strncpy(NetBackupServiceHost, netbackupServiceHost, (1 + strlen(netbackupServiceHost)));
-
-	if(initBSARestoreSession(NetBackupServiceHost) != 0){
+	if(initBSARestoreSession(netbackupServiceHost) != 0){
 		mpp_err_msg("ERROR", "gp_bsa_restore_agent", "Failed to initialize the NetBackup BSA session to perform Restore\n");
 		exit(1);
 	}
 
-	if(getBSARestoreObject(BackupFilePathName) != 0){
+	if(getBSARestoreObject(netbackupRestoreFilename) != 0){
 		mpp_err_msg("ERROR", "gp_bsa_restore_agent", "Failed to get the NetBackup BSA restore object to perform Restore\n");
 		exit(1);
 	}
@@ -128,10 +108,6 @@ main(int argc, char *argv[]){
 		exit(1);
 	}
 
-	free(BackupFilePathName);
-	free(NetBackupServiceHost);
-	free(netbackupRestoreFilename);
-	free(netbackupServiceHost);
 	exit(0);
 }
 


### PR DESCRIPTION
The cdb_bsa agents were all following a similar pattern, strduping the optarg and then strncpy()'ing the already allocated string into a second allocated string which was used for processing. Remove the extra malloc() + strncpy() since we already have perfectly good strings to operate on from the optarg processing. Also remove calls to free() just before exit since thats unnecessary.