### PR TITLE
Initialize resource_manager GUC to avoid macOS linker error

### DIFF
--- a/src/backend/utils/resource_manager/resource_manager.c
+++ b/src/backend/utils/resource_manager/resource_manager.c
@@ -17,5 +17,5 @@
 /*
  * GUC variables.
  */
-bool	ResourceScheduler;						/* Is scheduling enabled? */
+bool	ResourceScheduler = false;						/* Is scheduling enabled? */
 ResourceManagerPolicy Gp_resource_manager_policy;


### PR DESCRIPTION
The macOS ld64 linker has an assertion on empty DATA segments within linker Atoms. This assertion trips on the resource_manager since it only contains uninitialized variables placed for the BSS segment. This fails linking the backend on the resource_manager SUBSYS object. Without anything initialized, an no exported function symbols, the sections are:
```
$ nm -mgU src/backend/utils/resource_manager/SUBSYS.o
0000000000000004 (common) (alignment 2^2) external _Gp_resource_manager_policy
0000000000000001 (common) external _ResourceScheduler
```
With the initialization of the ResourceScheduler GUC variable:
```
$ nm -mgU src/backend/utils/resource_manager/SUBSYS.o
0000000000000004 (common) (alignment 2^2) external _Gp_resource_manager_policy
0000000000000004 (__DATA,__common) external _ResourceScheduler
```
Since the resource_manager in its current state is off anyways it seems harmless to initialize to the correct value.

Those of you working on macOS, does compiling and linking master work without this? I'm hitting this on ld64-264.3.101 under macOS 10.11.6.