### PR TITLE
Fix broken free_readfile()

### DIFF
--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -508,7 +508,6 @@ test_postmaster_connection(bool do_checkpoint __attribute__((unused)))
 	static const char *backend_options = "'-c gp_session_role=utility'";
 
 	*portstr = '\0';
-	
 
 	/*
 	 * Look in post_opts for a -p switch.
@@ -585,13 +584,6 @@ test_postmaster_connection(bool do_checkpoint __attribute__((unused)))
 				strlcpy(portstr, p, Min((q - p) + 1, sizeof(portstr)));
 				/* keep looking, maybe there is another */
 			}
-
-			/*
-			 * Free the results of readfile.
-			 *
-			 * This is safe to call even if optlines is NULL.
-			 */
-			free_readfile(optlines);
 		}
 	}
 


### PR DESCRIPTION
Commit 5a2d9a5aad cherry-picked some code to plug a memory leak from
test_postmaster_connection(), but the surrounding code looks quite
different in the upstream version where it was cherry-picked from. In our
8.3-based version of the function, 'optlines' is modified in the loop, and
doesn't point to the original allocated array anymore, so we passed a bogus
pointer to free().

This made e.g. "pg_ctl restart -w" throw GLIBC warnings.

Remove the offending call to free_readfile(), reverting that back to the
way it was before commit 5a2d9a5aad. Yes, that re-introduces the memory
leak, but that's not a big deal. pg_ctl is not a server program, it will
exit as soon as it gets its job done, so the leak is very short-lived.
It was plugged only to silence Coverity warnings in the first place.