### PR TITLE
Not to compile gpfdist/ext in OSes other than Windows

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -255,7 +255,7 @@ BLD_CONFIG_SHELL=$($(BLD_ARCH)_CONFIG_SHELL)
 $(GPPGDIR)/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	rm -rf $(INSTLOC)
 	mkdir -p $(GPPGDIR) 
-	$(MAKE) -C $(GPPGDIR)/src/bin/gpfdist/ext BLD_TOP=$(BLD_TOP)
+	-[ "$(BLD_ARCH)" = "win32" ] && $(MAKE) -C $(GPPGDIR)/src/bin/gpfdist/ext BLD_TOP=$(BLD_TOP)
 	cd $(GPPGDIR) && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"    \
                      CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL) \
                      ./configure $(CONFIGFLAGS)               \


### PR DESCRIPTION
> src/bin/gpfdist/ext is a submodule, from
> https://github.com/greenplum-db/gpfdist-ext. It contains tarballs of libapr,
> libevent, openssl and zlib, and a bunch of patches. Why do we build gpfdist
> like that? On my laptop, I never use those ancient, patched, versions, I
> link with the normal libraries that come with my distribution, and it works
> fine.
>
> I think that has something to do with Windows, because I also found this in
> src/interfaces/libpq/Makefile:
>
> ifeq ($(PORTNAME), win32)
> SHLIB_LINK += -L../../../../gpAux/ext/win32/kfw-3-2-2/lib
> -L../../../src/bin/gpfdist/ext/lib -lgssapi32 -lshfolder -lwsock32 -lws2_32
> -lsecur32 $(filter -leay32 -lssleay32 -lcomerr32 -lkrb5_32, $(LIBS))
> endif
>
> But if that's only for Windows builds, why do we try to build it on Linux?
>
> - Heikki

Thanks Heikki for bringing this up, we created a story to review the gpfdist/ext submodule,
this commit is to remove it from other OSes first.