### PR TITLE
Enable dblink in GPDB

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -19,6 +19,7 @@ all:
 	$(MAKE) -C contrib/formatter_fixedwidth all
 	$(MAKE) -C contrib/fuzzystrmatch all
 	$(MAKE) -C contrib/extprotocol all	
+	$(MAKE) -C contrib/dblink all
 	$(MAKE) -C contrib/gp_sparse_vector all
 	$(MAKE) -C contrib/gp_distribution_policy all
 	$(MAKE) -C contrib/gp_internal_tools all
@@ -39,6 +40,7 @@ install:
 	$(MAKE) -C contrib/formatter_fixedwidth $@
 	$(MAKE) -C contrib/fuzzystrmatch $@
 	$(MAKE) -C contrib/extprotocol $@
+	$(MAKE) -C contrib/dblink $@
 	$(MAKE) -C contrib/gp_sparse_vector $@
 	$(MAKE) -C contrib/gp_distribution_policy $@
 	$(MAKE) -C contrib/gp_internal_tools $@
@@ -61,6 +63,7 @@ installdirs uninstall:
 	$(MAKE) -C contrib/formatter_fixedwidth $@
 	$(MAKE) -C contrib/fuzzystrmatch $@
 	$(MAKE) -C contrib/extprotocol $@
+	$(MAKE) -C contrib/dblink $@
 	$(MAKE) -C contrib/gp_sparse_vector $@
 	$(MAKE) -C contrib/gp_distribution_policy $@
 	$(MAKE) -C contrib/gp_internal_tools $@
@@ -88,6 +91,7 @@ clean:
 	$(MAKE) -C contrib/formatter_fixedwidth $@
 	$(MAKE) -C contrib/fuzzystrmatch $@
 	$(MAKE) -C contrib/extprotocol $@
+	$(MAKE) -C contrib/dblink $@
 	$(MAKE) -C contrib/gp_sparse_vector $@
 	$(MAKE) -C contrib/gp_distribution_policy $@
 	$(MAKE) -C contrib/gp_internal_tools $@
@@ -123,6 +127,7 @@ installcheck-world:
 	#$(MAKE) -C src/interfaces/ecpg installcheck
 	#$(MAKE) -C contrib installcheck
 	$(MAKE) -C contrib/extprotocol installcheck
+	$(MAKE) -C contrib/dblink installcheck
 	$(MAKE) -C contrib/indexscan installcheck
 	$(MAKE) -C gpAux/extensions installcheck
 	$(MAKE) -C src/bin/gpfdist installcheck

--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -8,7 +8,7 @@ SHLIB_LINK = $(libpq)
 DATA_built = dblink.sql 
 DATA = uninstall_dblink.sql 
 REGRESS = dblink
-
+REGRESS_OPTS = --init-file=$(top_builddir)/src/test/regress/init_file --dbname=contrib_regression
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config
@@ -21,8 +21,9 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
+installcheck: prepare_dblink_sql
 
-installcheck:
-	-$(top_builddir)/src/test/regress/pg_regress --psqldir=$$GPHOME/bin/ --init-file=$(top_builddir)/src/test/regress/init_file --dbname=contrib_regression dblink
+prepare_dblink_sql:
+	cp $(GPHOME)/share/postgresql/contrib/dblink.sql ./dblink.sql
 
-.PHONY: installcheck
+.PHONY: prepare_dblink_sql

--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -20,3 +20,9 @@ top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
+
+
+installcheck:
+	-$(top_builddir)/src/test/regress/pg_regress --psqldir=$$GPHOME/bin/ --init-file=$(top_builddir)/src/test/regress/init_file --dbname=contrib_regression dblink
+
+.PHONY: installcheck

--- a/contrib/dblink/dblink.sql.in
+++ b/contrib/dblink/dblink.sql.in
@@ -168,25 +168,26 @@ RETURNS text
 AS 'SELECT pg_catalog.current_query()'
 LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION dblink_send_query(text, text)
-RETURNS int4
-AS 'MODULE_PATHNAME', 'dblink_send_query'
-LANGUAGE C STRICT;
+-- GPDB does not support these functions correctly
+-- CREATE OR REPLACE FUNCTION dblink_send_query(text, text)
+-- RETURNS int4
+-- AS 'MODULE_PATHNAME', 'dblink_send_query'
+-- LANGUAGE C STRICT;
 
-CREATE OR REPLACE FUNCTION dblink_is_busy(text)
-RETURNS int4
-AS 'MODULE_PATHNAME', 'dblink_is_busy'
-LANGUAGE C STRICT;
+-- CREATE OR REPLACE FUNCTION dblink_is_busy(text)
+-- RETURNS int4
+-- AS 'MODULE_PATHNAME', 'dblink_is_busy'
+-- LANGUAGE C STRICT;
 
-CREATE OR REPLACE FUNCTION dblink_get_result(text)
-RETURNS SETOF record
-AS 'MODULE_PATHNAME', 'dblink_get_result'
-LANGUAGE C STRICT;
+-- CREATE OR REPLACE FUNCTION dblink_get_result(text)
+-- RETURNS SETOF record
+-- AS 'MODULE_PATHNAME', 'dblink_get_result'
+-- LANGUAGE C STRICT;
 
-CREATE OR REPLACE FUNCTION dblink_get_result(text, bool)
-RETURNS SETOF record
-AS 'MODULE_PATHNAME', 'dblink_get_result'
-LANGUAGE C STRICT;
+-- CREATE OR REPLACE FUNCTION dblink_get_result(text, bool)
+-- RETURNS SETOF record
+-- AS 'MODULE_PATHNAME', 'dblink_get_result'
+-- LANGUAGE C STRICT;
 
 CREATE OR REPLACE FUNCTION dblink_get_connections()
 RETURNS text[]

--- a/contrib/dblink/expected/dblink.out
+++ b/contrib/dblink/expected/dblink.out
@@ -22,13 +22,6 @@ INSERT INTO foo VALUES (7,'h','{"a7","b7","c7"}');
 INSERT INTO foo VALUES (8,'i','{"a8","b8","c8"}');
 INSERT INTO foo VALUES (9,'j','{"a9","b9","c9"}');
 -- misc utilities
--- show the currently executing query
-SELECT 'hello' AS hello, dblink_current_query() AS query;
- hello |                           query                           
--------+-----------------------------------------------------------
- hello | SELECT 'hello' AS hello, dblink_current_query() AS query;
-(1 row)
-
 -- list the primary key fields
 SELECT *
 FROM dblink_get_pkey('foo');
@@ -143,7 +136,8 @@ WHERE t.a > 7;
 SELECT dblink_open('rmt_foo_cursor','SELECT * FROM foobar',false);
 NOTICE:  sql error
 DETAIL:  ERROR:  relation "foobar" does not exist
-
+LINE 1: DECLARE rmt_foo_cursor CURSOR FOR SELECT * FROM foobar
+                                                        ^
  dblink_open 
 -------------
  ERROR
@@ -171,7 +165,7 @@ SELECT dblink_close('rmt_foo_cursor',false);
 (1 row)
 
 -- open the cursor again
-SELECT dblink_open('rmt_foo_cursor','SELECT * FROM foo');
+SELECT dblink_open('rmt_foo_cursor','SELECT * FROM foo ORDER BY f1');
  dblink_open 
 -------------
  OK
@@ -212,7 +206,6 @@ SELECT *
 FROM dblink_fetch('rmt_foobar_cursor',4,false) AS t(a int, b text, c text[]);
 NOTICE:  sql error
 DETAIL:  ERROR:  cursor "rmt_foobar_cursor" does not exist
-
  a | b | c 
 ---+---+---
 (0 rows)
@@ -228,7 +221,6 @@ SELECT dblink_exec('ABORT');
 SELECT dblink_close('rmt_foobar_cursor',false);
 NOTICE:  sql error
 DETAIL:  ERROR:  cursor "rmt_foobar_cursor" does not exist
-
  dblink_close 
 --------------
  ERROR
@@ -239,13 +231,11 @@ SELECT *
 FROM dblink_fetch('rmt_foo_cursor',4) AS t(a int, b text, c text[]);
 ERROR:  sql error
 DETAIL:  ERROR:  cursor "rmt_foo_cursor" does not exist
-
 -- this time, 'cursor "rmt_foo_cursor" not found' as a notice
 SELECT *
 FROM dblink_fetch('rmt_foo_cursor',4,false) AS t(a int, b text, c text[]);
 NOTICE:  sql error
 DETAIL:  ERROR:  cursor "rmt_foo_cursor" does not exist
-
  a | b | c 
 ---+---+---
 (0 rows)
@@ -307,9 +297,8 @@ FROM dblink('SELECT * FROM foo') AS t(a int, b text, c text[]);
 -- bad remote select
 SELECT *
 FROM dblink('SELECT * FROM foobar',false) AS t(a int, b text, c text[]);
-NOTICE:  sql error
-DETAIL:  ERROR:  relation "foobar" does not exist
-
+NOTICE:  relation "foobar" does not exist
+CONTEXT:  Error occurred on dblink connection named "unnamed": could not execute query.
  a | b | c 
 ---+---+---
 (0 rows)
@@ -334,7 +323,8 @@ WHERE a = 11;
 SELECT dblink_exec('UPDATE foobar SET f3[2] = ''b99'' WHERE f1 = 11',false);
 NOTICE:  sql error
 DETAIL:  ERROR:  relation "foobar" does not exist
-
+LINE 1: UPDATE foobar SET f3[2] = 'b99' WHERE f1 = 11
+               ^
  dblink_exec 
 -------------
  ERROR
@@ -371,7 +361,6 @@ FROM dblink('myconn','SELECT * FROM foo') AS t(a int, b text, c text[])
 WHERE t.a > 7;
 ERROR:  could not establish connection
 DETAIL:  missing "=" after "myconn" in connection info string
-
 -- create a named persistent connection
 SELECT dblink_connect('myconn','dbname=contrib_regression');
  dblink_connect 
@@ -394,9 +383,8 @@ WHERE t.a > 7;
 SELECT *
 FROM dblink('myconn','SELECT * FROM foobar',false) AS t(a int, b text, c text[])
 WHERE t.a > 7;
-NOTICE:  sql error
-DETAIL:  ERROR:  relation "foobar" does not exist
-
+NOTICE:  relation "foobar" does not exist
+CONTEXT:  Error occurred on dblink connection named "unnamed": could not execute query.
  a | b | c 
 ---+---+---
 (0 rows)
@@ -434,7 +422,8 @@ SELECT dblink_disconnect('myconn2');
 SELECT dblink_open('myconn','rmt_foo_cursor','SELECT * FROM foobar',false);
 NOTICE:  sql error
 DETAIL:  ERROR:  relation "foobar" does not exist
-
+LINE 1: DECLARE rmt_foo_cursor CURSOR FOR SELECT * FROM foobar
+                                                        ^
  dblink_open 
 -------------
  ERROR
@@ -521,7 +510,6 @@ SELECT dblink_close('myconn','rmt_foo_cursor');
 SELECT dblink_exec('myconn','DECLARE xact_test CURSOR FOR SELECT * FROM foo');
 ERROR:  sql error
 DETAIL:  ERROR:  DECLARE CURSOR can only be used in transaction blocks
-
 -- reset remote transaction state
 SELECT dblink_exec('myconn','ABORT');
  dblink_exec 
@@ -530,7 +518,7 @@ SELECT dblink_exec('myconn','ABORT');
 (1 row)
 
 -- open a cursor
-SELECT dblink_open('myconn','rmt_foo_cursor','SELECT * FROM foo');
+SELECT dblink_open('myconn','rmt_foo_cursor','SELECT * FROM foo ORDER BY f1');
  dblink_open 
 -------------
  OK
@@ -572,7 +560,6 @@ SELECT *
 FROM dblink_fetch('myconn','rmt_foobar_cursor',4,false) AS t(a int, b text, c text[]);
 NOTICE:  sql error
 DETAIL:  ERROR:  cursor "rmt_foobar_cursor" does not exist
-
  a | b | c 
 ---+---+---
 (0 rows)
@@ -589,7 +576,6 @@ SELECT *
 FROM dblink_fetch('myconn','rmt_foo_cursor',4) AS t(a int, b text, c text[]);
 ERROR:  sql error
 DETAIL:  ERROR:  cursor "rmt_foo_cursor" does not exist
-
 -- close the named persistent connection
 SELECT dblink_disconnect('myconn');
  dblink_disconnect 
@@ -603,7 +589,6 @@ FROM dblink('myconn','SELECT * FROM foo') AS t(a int, b text, c text[])
 WHERE t.a > 7;
 ERROR:  could not establish connection
 DETAIL:  missing "=" after "myconn" in connection info string
-
 -- create a named persistent connection
 SELECT dblink_connect('myconn','dbname=contrib_regression');
  dblink_connect 
@@ -680,130 +665,6 @@ SELECT dblink_disconnect('myconn');
 -- should get 'connection "myconn" not available' error
 SELECT dblink_disconnect('myconn');
 ERROR:  connection "myconn" not available
--- test asynchronous queries
-SELECT dblink_connect('dtest1', 'dbname=contrib_regression');
- dblink_connect 
-----------------
- OK
-(1 row)
-
-SELECT * from 
- dblink_send_query('dtest1', 'select * from foo where f1 < 3') as t1;
- t1 
-----
-  1
-(1 row)
-
-SELECT dblink_connect('dtest2', 'dbname=contrib_regression');
- dblink_connect 
-----------------
- OK
-(1 row)
-
-SELECT * from 
- dblink_send_query('dtest2', 'select * from foo where f1 > 2 and f1 < 7') as t1;
- t1 
-----
-  1
-(1 row)
-
-SELECT dblink_connect('dtest3', 'dbname=contrib_regression');
- dblink_connect 
-----------------
- OK
-(1 row)
-
-SELECT * from 
- dblink_send_query('dtest3', 'select * from foo where f1 > 6') as t1;
- t1 
-----
-  1
-(1 row)
-
-CREATE TEMPORARY TABLE result AS
-(SELECT * from dblink_get_result('dtest1') as t1(f1 int, f2 text, f3 text[]))
-UNION
-(SELECT * from dblink_get_result('dtest2') as t2(f1 int, f2 text, f3 text[]))
-UNION
-(SELECT * from dblink_get_result('dtest3') as t3(f1 int, f2 text, f3 text[]))
-ORDER by f1;
-SELECT dblink_get_connections();
- dblink_get_connections 
-------------------------
- {dtest1,dtest2,dtest3}
-(1 row)
-
-SELECT dblink_is_busy('dtest1');
- dblink_is_busy 
-----------------
-              0
-(1 row)
-
-SELECT dblink_disconnect('dtest1');
- dblink_disconnect 
--------------------
- OK
-(1 row)
-
-SELECT dblink_disconnect('dtest2');
- dblink_disconnect 
--------------------
- OK
-(1 row)
-
-SELECT dblink_disconnect('dtest3');
- dblink_disconnect 
--------------------
- OK
-(1 row)
-
-SELECT * from result;
- f1 | f2 |      f3       
-----+----+---------------
-  0 | a  | {a0,b0,c0}
-  1 | b  | {a1,b1,c1}
-  2 | c  | {a2,b2,c2}
-  3 | d  | {a3,b3,c3}
-  4 | e  | {a4,b4,c4}
-  5 | f  | {a5,b5,c5}
-  6 | g  | {a6,b6,c6}
-  7 | h  | {a7,b7,c7}
-  8 | i  | {a8,b8,c8}
-  9 | j  | {a9,b9,c9}
- 10 | k  | {a10,b10,c10}
-(11 rows)
-
-SELECT dblink_connect('dtest1', 'dbname=contrib_regression');
- dblink_connect 
-----------------
- OK
-(1 row)
-
-SELECT * from 
- dblink_send_query('dtest1', 'select * from foo where f1 < 3') as t1;
- t1 
-----
-  1
-(1 row)
-
-SELECT dblink_cancel_query('dtest1');
- dblink_cancel_query 
----------------------
- OK
-(1 row)
-
-SELECT dblink_error_message('dtest1');
- dblink_error_message 
-----------------------
- OK
-(1 row)
-
-SELECT dblink_disconnect('dtest1');
- dblink_disconnect 
--------------------
- OK
-(1 row)
-
 -- test dropped columns in dblink_build_sql_insert, dblink_build_sql_update
 CREATE TEMP TABLE test_dropped
 (
@@ -840,4 +701,59 @@ SELECT dblink_build_sql_delete('test_dropped', '2', 1,
 -----------------------------------------
  DELETE FROM test_dropped WHERE id = '2'
 (1 row)
+
+ -- test nested query for GPDB
+ CREATE TEMPORARY TABLE result AS
+ (SELECT * from dblink('dbname=contrib_regression','select * from foo where f1 > 2 and f1 < 7') as t1(f1 int, f2 text, f3 text[]))
+ UNION
+ (SELECT * from dblink('dbname=contrib_regression','select * from foo where f1 < 3') as t2(f1 int, f2 text, f3 text[]))
+ UNION
+ (SELECT * from dblink('dbname=contrib_regression','select * from foo where f1 > 2 and f1 < 7') as t3(f1 int, f2 text, f3 text[]))
+ ORDER by f1;
+ SELECT * FROM result;
+  f1 | f2 |     f3
+ ----+----+------------
+   0 | a  | {a0,b0,c0}
+   1 | b  | {a1,b1,c1}
+   2 | c  | {a2,b2,c2}
+   3 | d  | {a3,b3,c3}
+   4 | e  | {a4,b4,c4}
+   5 | f  | {a5,b5,c5}
+   6 | g  | {a6,b6,c6}
+ (7 rows)
+
+ DROP TABLE result;
+ CREATE TEMPORARY TABLE result (f1 int, f2 text, f3 text[]);
+ INSERT INTO result SELECT * FROM dblink ('dbname=contrib_regression','select * from foo') AS t(f1 int, f2 text, f3 text[]);
+ SELECT * FROM result;
+  f1 | f2 |      f3
+ ----+----+---------------
+   0 | a  | {a0,b0,c0}
+   1 | b  | {a1,b1,c1}
+   2 | c  | {a2,b2,c2}
+   3 | d  | {a3,b3,c3}
+   4 | e  | {a4,b4,c4}
+   5 | f  | {a5,b5,c5}
+   6 | g  | {a6,b6,c6}
+   7 | h  | {a7,b7,c7}
+   8 | i  | {a8,b8,c8}
+   9 | j  | {a9,b9,c9}
+  10 | k  | {a10,b10,c10}
+ (11 rows)
+
+ SELECT * FROM (SELECT * FROM dblink('dbname=contrib_regression','select * from foo') AS t(f1 int, f2 text, f3 text[])) AS t1;
+  f1 | f2 |      f3
+ ----+----+---------------
+   0 | a  | {a0,b0,c0}
+   1 | b  | {a1,b1,c1}
+   2 | c  | {a2,b2,c2}
+   3 | d  | {a3,b3,c3}
+   4 | e  | {a4,b4,c4}
+   5 | f  | {a5,b5,c5}
+   6 | g  | {a6,b6,c6}
+   7 | h  | {a7,b7,c7}
+   8 | i  | {a8,b8,c8}
+   9 | j  | {a9,b9,c9}
+  10 | k  | {a10,b10,c10}
+ (11 rows)
 

--- a/contrib/dblink/uninstall_dblink.sql
+++ b/contrib/dblink/uninstall_dblink.sql
@@ -73,10 +73,10 @@ DROP FUNCTION dblink_error_message(text);
 
 DROP FUNCTION dblink_get_connections();
 
-DROP FUNCTION dblink_get_result(text);
+-- DROP FUNCTION dblink_get_result(text);
 
-DROP FUNCTION dblink_get_result(text, boolean);
+-- DROP FUNCTION dblink_get_result(text, boolean);
 
-DROP FUNCTION dblink_is_busy(text);
+-- DROP FUNCTION dblink_is_busy(text);
 
-DROP FUNCTION dblink_send_query(text, text);
+-- DROP FUNCTION dblink_send_query(text, text);


### PR DESCRIPTION
dblink is a bulit-in module of postgresql, this patch enable it in GPDB.

1. Enable compiling dblink with GPDB
2. Update and enable dblink test cases

Known issue:

1. The following functions are not supported by GPDB and disabled temporarily
   due to GPDB behavior changed.
   dblink_send_query()
   dblink_is_busy()
   dblink_get_result()

2. Anonymous connection and connection by name are not supported in a nested statement with
   both write and read. E.g.
   INSERT INTO tblname SELECT * FROM dblink(['connName'],'SELECT * FROM otherdb.tblname') as tbl;
   Currently, only connection with connection string is supported in such statements.

Signed-off-by: Peifeng Qiu <pqiu@pivotal.io>
Signed-off-by: Yuan Zhao <yuzhao@pivotal.io>
Signed-off-by: Jianxia Chen <jchen@pivotal.io>