### PR TITLE
Add extra ignored output in extern_tables suite

### DIFF
--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -431,6 +431,10 @@ WHERE e1.i = e2.i ORDER BY e1.i
 SELECT * FROM cte1 ORDER BY cte1.i;
 select count(*) from gp_read_error_log('exttab_cte_2');
 select count(*) from gp_read_error_log('exttab_cte_1');
+-- start_ignore
+select gp_read_error_log('exttab_cte_1');
+select gp_read_error_log('exttab_cte_2');
+-- end_ignore
 
 -- CTE without segment reject limit exceeded
 select gp_truncate_error_log('exttab_cte_1');


### PR DESCRIPTION
The count(*) on exttab_cte_1 errorlog has failed without explanation, and without being reproducible, both locally (I've seen it at least) and on the CI pipeline. Since the errorlog might hold insights into what went wrong, print it in an ignored block to preserve it for debugging before it's lost. This will include the errorlog output prefixed with GP_IGNORE in the regression.diffs file.

Adding the output before the count(*) operation doesn't work since diff is smart enough to skip it from the context.

Faking an error by altering the output source, I get the following regression.diffs with this applied:
```diff
*** ./expected/external_table.out	Tue Mar  7 10:16:48 2017
--- ./results/external_table.out	Tue Mar  7 10:16:48 2017
***************
*** 805,813 ****
  select count(*) from gp_read_error_log('exttab_cte_1');
   count 
  -------
!      1
  (1 row)
  
  -- CTE without segment reject limit exceeded
  select gp_truncate_error_log('exttab_cte_1');
   gp_truncate_error_log 
--- 797,820 ----
  select count(*) from gp_read_error_log('exttab_cte_1');
   count 
  -------
!      2
  (1 row)
  
+ GP_IGNORE:-- start_ignore
+ GP_IGNORE:select gp_read_error_log('exttab_cte_1');
+ GP_IGNORE:                                                                                                                                                gp_read_error_log                                                                                                                                                 
+ GP_IGNORE:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GP_IGNORE: ("Tue Mar 07 01:15:48.891586 2017 PST",exttab_cte_1,"file://computer.local/greenplum/src/test/regress/data/exttab_few_errors.data [/greenplum/src/test/regress/data/exttab_few_errors.data]",3,,"missing data for column ""j""",error_0,)
+ GP_IGNORE: ("Tue Mar 07 01:15:48.891586 2017 PST",exttab_cte_1,"file://computer.local/greenplum/src/test/regress/data/exttab_few_errors.data [/greenplum/src/test/regress/data/exttab_few_errors.data]",5,,"missing data for column ""j""",error_1,)
+ GP_IGNORE:(2 rows)
+ GP_IGNORE:
+ GP_IGNORE:select gp_read_error_log('exttab_cte_2');
+ GP_IGNORE:                                                                                                                                                 gp_read_error_log                                                                                                                                                  
+ GP_IGNORE:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GP_IGNORE: ("Tue Mar 07 01:15:48.892084 2017 PST",exttab_cte_2,"file://computer.local/greenplum/src/test/regress/data/exttab_more_errors.data [/greenplum/src/test/regress/data/exttab_more_errors.data]",5,,"missing data for column ""j""",error_1,)
+ GP_IGNORE:(1 row)
+ GP_IGNORE:
+ GP_IGNORE:-- end_ignore
  -- CTE without segment reject limit exceeded
  select gp_truncate_error_log('exttab_cte_1');
   gp_truncate_error_log 
```
Hopefully, when the intermittent error hits again we'll have enough insights from the errorlog to figure out what's going on.