### PR TITLE
Add note about updatable cursor restriction

### DIFF
--- a/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
@@ -46,12 +46,11 @@
         <ul>
           <li id="pt219857">Triggers are not supported.</li>
           <li id="pt222490">Cursors are forward moving only (not scrollable).</li>
-          <li>When updating or deleting rows with a cursor in Greenplum Database, the
-              <codeph>UPDATE/DELETE...WHERE CURRENT OF</codeph> cursor statement must be executed by
+          <li>When updating or deleting a row with a cursor in Greenplum Database, the
+              <codeph>UPDATE/DELETE...WHERE CURRENT OF</codeph> statement must be executed by
             Greenplum Server. In PL/pgSQL, for example, the <codeph>UPDATE</codeph> or
               <codeph>DELETE</codeph> statement must be wrapped in an <codeph>EXECUTE</codeph>
-              statement.<image href="https://ssl.gstatic.com/ui/v1/icons/mail/images/cleardot.gif"
-              id="image_rpk_kj1_2z"/></li>
+            statement.</li>
         </ul>
         <p>For information about Greenplum Database SQL conformance, see <xref
             href="../feature_summary.xml#topic1"/> in the <cite>Greenplum Database Reference

--- a/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
@@ -44,13 +44,10 @@
       <body>
         <p>When using Greenplum Database PL/pgSQL, limitations include</p>
         <ul>
-          <li id="pt219857">Triggers are not supported.</li>
-          <li id="pt222490">Cursors are forward moving only (not scrollable).</li>
-          <li>When updating or deleting a row with a cursor in Greenplum Database, the
-              <codeph>UPDATE/DELETE...WHERE CURRENT OF</codeph> statement must be executed by
-            Greenplum Server. In PL/pgSQL, for example, the <codeph>UPDATE</codeph> or
-              <codeph>DELETE</codeph> statement must be wrapped in an <codeph>EXECUTE</codeph>
-            statement.</li>
+          <li id="pt219857">Triggers are not supported</li>
+          <li id="pt222490">Cursors are forward moving only (not scrollable)</li>
+          <li>Updatable cursors (<codeph>UPDATE...WHERE CURRENT OF</codeph> and
+              <codeph>DELETE...WHERE CURRENT OF</codeph>) are not supported.</li>
         </ul>
         <p>For information about Greenplum Database SQL conformance, see <xref
             href="../feature_summary.xml#topic1"/> in the <cite>Greenplum Database Reference

--- a/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
+++ b/gpdb-doc/dita/ref_guide/extensions/pl_sql.xml
@@ -8,7 +8,7 @@
     <ul>
       <li id="pt222286">
         <xref href="#topic2" type="topic" format="dita"/>
-       </li>
+      </li>
       <li id="pt222315">
         <xref href="#topic6" type="topic" format="dita"/>
       </li>
@@ -44,8 +44,14 @@
       <body>
         <p>When using Greenplum Database PL/pgSQL, limitations include</p>
         <ul>
-          <li id="pt219857">Triggers are not supported</li>
-          <li id="pt222490">Cursors are forward moving only (not scrollable) </li>
+          <li id="pt219857">Triggers are not supported.</li>
+          <li id="pt222490">Cursors are forward moving only (not scrollable).</li>
+          <li>When updating or deleting rows with a cursor in Greenplum Database, the
+              <codeph>UPDATE/DELETE...WHERE CURRENT OF</codeph> cursor statement must be executed by
+            Greenplum Server. In PL/pgSQL, for example, the <codeph>UPDATE</codeph> or
+              <codeph>DELETE</codeph> statement must be wrapped in an <codeph>EXECUTE</codeph>
+              statement.<image href="https://ssl.gstatic.com/ui/v1/icons/mail/images/cleardot.gif"
+              id="image_rpk_kj1_2z"/></li>
         </ul>
         <p>For information about Greenplum Database SQL conformance, see <xref
             href="../feature_summary.xml#topic1"/> in the <cite>Greenplum Database Reference

--- a/gpdb-doc/dita/ref_guide/sql_commands/DECLARE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DECLARE.xml
@@ -40,10 +40,10 @@
       <p>A cursor can be specified in the <codeph>WHERE CURRENT OF</codeph> clause of the
             <codeph><xref href="./UPDATE.xml#topic1" type="topic" format="dita"/></codeph> or
             <codeph><xref href="./DELETE.xml#topic1" type="topic" format="dita"/></codeph> statement
-        to update or delete table data. The <codeph>UPDATE/DELETE...WHERE CURRENT OF</codeph> cursor
-        statement must be executed by Greenplum Database. For example, the statement must be
-        executed from an interactive psql session or a script, or wrapped in a PL/pgSQL EXECUTE
-        statement.</p>
+        to update or delete table data. The <codeph>UPDATE</codeph> or <codeph>DELETE</codeph>
+        statement can only be executed on the server, for example in an interactive psql session or
+        a script. Language extensions such as PL/pgSQL do not have support for updatable cursors.
+      </p>
     </section>
     <section id="section4">
       <title>Parameters</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DECLARE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DECLARE.xml
@@ -39,8 +39,11 @@
       </note>
       <p>A cursor can be specified in the <codeph>WHERE CURRENT OF</codeph> clause of the
             <codeph><xref href="./UPDATE.xml#topic1" type="topic" format="dita"/></codeph> or
-            <codeph><xref href="./DELETE.xml#topic1" type="topic" format="dita"/></codeph> command
-        to update or delete table data.</p>
+            <codeph><xref href="./DELETE.xml#topic1" type="topic" format="dita"/></codeph> statement
+        to update or delete table data. The <codeph>UPDATE/DELETE...WHERE CURRENT OF</codeph> cursor
+        statement must be executed by Greenplum Database. For example, the statement must be
+        executed from an interactive psql session or a script, or wrapped in a PL/pgSQL EXECUTE
+        statement.</p>
     </section>
     <section id="section4">
       <title>Parameters</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
@@ -88,11 +88,10 @@
                             <codeph>DELETE</codeph> target table. </pd>
                     <pd><codeph>WHERE CURRENT OF</codeph> cannot be specified together with a
                         Boolean condition.</pd>
-                    <pd>When deleting a row with a cursor in Greenplum Database, the
-                            <codeph>DELETE...WHERE CURRENT OF</codeph> cursor statement must be
-                        executed by Greenplum Database. For example, the statement must be executed
-                        from an interactive psql session or a script, or wrapped in a PL/pgSQL
-                        EXECUTE statement.</pd>
+                    <pd>The <codeph>DELETE...WHERE CURRENT OF</codeph> cursor statement can only be
+                        executed on the server, for example in an interactive psql session or a
+                        script. Language extensions such as PL/pgSQL do not have support for
+                        updatable cursors. </pd>
                     <pd>See <codeph><xref href="DECLARE.xml#topic1" type="topic" format="dita"
                             /></codeph> for more information about creating cursors.</pd>
                 </plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DELETE.xml
@@ -85,11 +85,14 @@
                     <pd>The name of the cursor to use in a <codeph>WHERE CURRENT OF</codeph>
                         condition. The row to be deleted is the one most recently fetched from this
                         cursor. The cursor must be a simple (non-join, non-aggregate) query on the
-                            <codeph>DELETE</codeph> target table. See <codeph><xref
-                                href="DECLARE.xml#topic1" type="topic" format="dita"/></codeph> for
-                        more information about creating cursors.</pd>
+                            <codeph>DELETE</codeph> target table. </pd>
                     <pd><codeph>WHERE CURRENT OF</codeph> cannot be specified together with a
                         Boolean condition.</pd>
+                    <pd>When deleting a row with a cursor in Greenplum Database, the
+                            <codeph>DELETE...WHERE CURRENT OF</codeph> cursor statement must be
+                        executed by Greenplum Database. For example, the statement must be executed
+                        from an interactive psql session or a script, or wrapped in a PL/pgSQL
+                        EXECUTE statement.</pd>
                     <pd>See <codeph><xref href="DECLARE.xml#topic1" type="topic" format="dita"
                             /></codeph> for more information about creating cursors.</pd>
                 </plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
@@ -146,10 +146,10 @@
         will be used is not readily predictable.</p>
       <p>Because of this indeterminacy, referencing other tables only within sub-selects is safer,
         though often harder to read and slower than using a join.</p>
-      <p>Execution of <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> commands directly on a
-        specific partition (child table) of a partitioned table is not supported. Instead, these
-        commands must be executed on the root partitioned table, the table created with the
-          <codeph>CREATE TABLE</codeph> command.</p>
+      <p>Executing <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> commands directly on a
+        specific partition (child table) of a partitioned table is not supported. Instead, execute
+        these commands on the root partitioned table, the table created with the <codeph>CREATE
+          TABLE</codeph> command.</p>
     </section>
     <section id="section7">
       <title>Examples</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
@@ -111,10 +111,9 @@
             for more information about creating cursors. </pd>
           <pd><codeph>WHERE CURRENT OF</codeph> cannot be specified together with a Boolean
             condition. </pd>
-          <pd>When updating a row with a cursor in Greenplum Database, the <codeph>UPDATE...WHERE
-              CURRENT OF</codeph> cursor statement must be executed by Greenplum Database. For
-            example, the statement must be executed from an interactive psql session or a script, or
-            wrapped in a PL/pgSQL EXECUTE statement.</pd>
+          <pd>The <codeph>UPDATE...WHERE CURRENT OF</codeph> statement can only be executed on the
+            server, for example in an interactive psql session or a script. Language extensions such
+            as PL/pgSQL do not have support for updatable cursors.</pd>
           <pd>See <codeph><xref href="DECLARE.xml#topic1" type="topic" format="dita"/></codeph> for
             more information about creating cursors.</pd>
         </plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/UPDATE.xml
@@ -111,6 +111,12 @@
             for more information about creating cursors. </pd>
           <pd><codeph>WHERE CURRENT OF</codeph> cannot be specified together with a Boolean
             condition. </pd>
+          <pd>When updating a row with a cursor in Greenplum Database, the <codeph>UPDATE...WHERE
+              CURRENT OF</codeph> cursor statement must be executed by Greenplum Database. For
+            example, the statement must be executed from an interactive psql session or a script, or
+            wrapped in a PL/pgSQL EXECUTE statement.</pd>
+          <pd>See <codeph><xref href="DECLARE.xml#topic1" type="topic" format="dita"/></codeph> for
+            more information about creating cursors.</pd>
         </plentry>
         <plentry>
           <pt>
@@ -141,7 +147,7 @@
         will be used is not readily predictable.</p>
       <p>Because of this indeterminacy, referencing other tables only within sub-selects is safer,
         though often harder to read and slower than using a join.</p>
-      <p>Execution of  <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> commands directly on a
+      <p>Execution of <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> commands directly on a
         specific partition (child table) of a partitioned table is not supported. Instead, these
         commands must be executed on the root partitioned table, the table created with the
           <codeph>CREATE TABLE</codeph> command.</p>


### PR DESCRIPTION
[ci-skip]

The updatable cursor restriction is currently only mentioned in the release notes. This adds notes  to cursor command refs and PL/pgSQL doc. 