### PR TITLE
Skip pg_index.indcheckxmin column in gpcheckcat.

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3047,7 +3047,16 @@ def checkTableInconsistentEntry(cat):
     pkey = cat.getPrimaryKey()
     master = cat.isMasterOnly()
     isShared = cat.isShared()
-    columns = cat.getTableColumns(with_acl=False)
+
+    # Skip the indcheckxmin column in pg_index for now as that can be
+    # different between master and segment due to HOT feature.
+
+    if catname == 'pg_index':
+        columnsToBeExcluded = ['indcheckxmin']
+    else:
+        columnsToBeExcluded = None
+
+    columns = cat.getTableColumns(with_acl=False, excluding=columnsToBeExcluded)
     coltypes = cat.getTableColtypes()
 
     # Skip master only tables


### PR DESCRIPTION
The gpcheckcat 'inconsistent' check should skip the pg_index.indcheckxmin column
for now as due to the HOT feature, the value of this column can be different
between the master and the segments.

A more long term fix will resolve the underlying issue that makes the
indcheckxmin column value to be different between the master and the segments.