### PR TITLE
Make 'gpstop' parameters '-a' effect in use '-m'

### DIFF
--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -100,7 +100,18 @@ class GpStop:
         self._prepare()
         
         if self.masteronly:
-            self._stop_master()                                 
+            if self.interactive:
+                if not userinput.ask_yesno(None, "\nContinue with master-only shutdown", 'N'):
+                    raise UserAbortedException()
+            try:
+                # Disable Ctrl-C
+                signal.signal(signal.SIGINT,signal.SIG_IGN)
+
+                self._stop_master()    
+            finally:
+                # Reenable Ctrl-C
+                self.cleanup()
+                signal.signal(signal.SIGINT,signal.default_int_handler)
         else:
             if self.sighup:
                 return self._sighup_cluster()


### PR DESCRIPTION
When I use `gpstop` whith parameters '-m', '-a' is not effective.

[gp@node ~]$ gpstop --help
...
-a (do not prompt)

 Do not prompt the user for confirmation.
...
-m (master only)

 Optional. Shuts down a Greenplum master instance that was 
 started in maintenance mode.
...


**The status quo:**
[gp@node ~]$ gpstop -m
20170308:04:26:13:007535 gpstop:node:gp-[INFO]:-Starting gpstop with args: -m
20170308:04:26:13:007535 gpstop:node:gp-[INFO]:-Gathering information and validating the environment...
20170308:04:26:13:007535 gpstop:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170308:04:26:13:007535 gpstop:node:gp-[INFO]:-Obtaining Segment details from master...
20170308:04:26:14:007535 gpstop:node:gp-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0 build dev'
20170308:04:26:14:007535 gpstop:node:gp-[INFO]:-There are 0 connections to the database
20170308:04:26:14:007535 gpstop:node:gp-[INFO]:-Commencing Master instance shutdown with mode='smart'
20170308:04:26:14:007535 gpstop:node:gp-[INFO]:-Master host=node
20170308:04:26:14:007535 gpstop:node:gp-[INFO]:-Commencing Master instance shutdown with mode=smart
20170308:04:26:14:007535 gpstop:node:gp-[INFO]:-Master segment instance directory=/data/gp/master/gpseg-1
20170308:04:26:15:007535 gpstop:node:gp-[INFO]:-Attempting forceful termination of any leftover master process
20170308:04:26:15:007535 gpstop:node:gp-[INFO]:-Terminating processes for segment /data/gp/master/gpseg-1
[gp@node ~]$ gpstop -m -a
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-Starting gpstop with args: -m -a
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-Gathering information and validating the environment...
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-Obtaining Segment details from master...
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0 build dev'
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-There are 0 connections to the database
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-Commencing Master instance shutdown with mode='smart'
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-Master host=node
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-Commencing Master instance shutdown with mode=smart
20170308:04:28:05:007631 gpstop:node:gp-[INFO]:-Master segment instance directory=/data/gp/master/gpseg-1
20170308:04:28:06:007631 gpstop:node:gp-[INFO]:-Attempting forceful termination of any leftover master process
20170308:04:28:06:007631 gpstop:node:gp-[INFO]:-Terminating processes for segment /data/gp/master/gpseg-1


**Ther ringht expale:**
[gp@node ~]$ gpstart -m
20170307:20:39:57:004862 gpstart:node:gp-[INFO]:-Starting gpstart with args: -m
20170307:20:39:57:004862 gpstart:node:gp-[INFO]:-Gathering information and validating the environment...
20170307:20:39:57:004862 gpstart:node:gp-[INFO]:-Greenplum Binary Version: 'postgres (Greenplum Database) 5.0.0 build dev'
20170307:20:39:57:004862 gpstart:node:gp-[INFO]:-Greenplum Catalog Version: '301702171'
20170307:20:39:57:004862 gpstart:node:gp-[INFO]:-Master-only start requested in configuration without a standby master.

Continue with master-only startup Yy|Nn (default=N):
> y
20170307:20:39:58:004862 gpstart:node:gp-[INFO]:-Starting Master instance in admin mode
20170307:20:39:59:004862 gpstart:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170307:20:39:59:004862 gpstart:node:gp-[INFO]:-Obtaining Segment details from master...
20170307:20:39:59:004862 gpstart:node:gp-[INFO]:-Setting new master era
20170307:20:39:59:004862 gpstart:node:gp-[INFO]:-Master Started...


**I modified results:**
[gp@node ~]$ gpstop -m
20170308:05:13:00:008049 gpstop:node:gp-[INFO]:-Starting gpstop with args: -m
20170308:05:13:00:008049 gpstop:node:gp-[INFO]:-Gathering information and validating the environment...
20170308:05:13:00:008049 gpstop:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170308:05:13:00:008049 gpstop:node:gp-[INFO]:-Obtaining Segment details from master...
20170308:05:13:00:008049 gpstop:node:gp-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0 build dev'

Continue with master-only shutdown Yy|Nn (default=N):
> y
20170308:05:13:01:008049 gpstop:node:gp-[INFO]:-There are 0 connections to the database
20170308:05:13:01:008049 gpstop:node:gp-[INFO]:-Commencing Master instance shutdown with mode='smart'
20170308:05:13:01:008049 gpstop:node:gp-[INFO]:-Master host=node
20170308:05:13:01:008049 gpstop:node:gp-[INFO]:-Commencing Master instance shutdown with mode=smart
20170308:05:13:01:008049 gpstop:node:gp-[INFO]:-Master segment instance directory=/data/gp/master/gpseg-1
20170308:05:13:02:008049 gpstop:node:gp-[INFO]:-Attempting forceful termination of any leftover master process
20170308:05:13:02:008049 gpstop:node:gp-[INFO]:-Terminating processes for segment /data/gp/master/gpseg-1
[gp@node ~]$ gpstop -m -a
20170308:05:13:11:008094 gpstop:node:gp-[INFO]:-Starting gpstop with args: -m -a
20170308:05:13:11:008094 gpstop:node:gp-[INFO]:-Gathering information and validating the environment...
20170308:05:13:11:008094 gpstop:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170308:05:13:11:008094 gpstop:node:gp-[INFO]:-Obtaining Segment details from master...
20170308:05:13:12:008094 gpstop:node:gp-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 5.0.0 build dev'
20170308:05:13:12:008094 gpstop:node:gp-[INFO]:-There are 0 connections to the database
20170308:05:13:12:008094 gpstop:node:gp-[INFO]:-Commencing Master instance shutdown with mode='smart'
20170308:05:13:12:008094 gpstop:node:gp-[INFO]:-Master host=node
20170308:05:13:12:008094 gpstop:node:gp-[INFO]:-Commencing Master instance shutdown with mode=smart
20170308:05:13:12:008094 gpstop:node:gp-[INFO]:-Master segment instance directory=/data/gp/master/gpseg-1
20170308:05:13:13:008094 gpstop:node:gp-[INFO]:-Attempting forceful termination of any leftover master process
20170308:05:13:13:008094 gpstop:node:gp-[INFO]:-Terminating processes for segment /data/gp/master/gpseg-1