### PR TITLE
Add new fault injector to make the transaction management test more s…

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsInjectFault.py
+++ b/gpMgmt/bin/gppylib/programs/clsInjectFault.py
@@ -424,6 +424,7 @@ class GpInjectFaultProgram:
                   "cursor_qe_reader_after_snapshot (inject fault after QE READER has populated snashot for cursor)" \
 			      "fsync_counter (inject fault to count buffers fsync'ed by checkpoint process), " \
 			      "bg_buffer_sync_default_logic (inject fault to 'skip' in order to flush all buffers in BgBufferSync()), " \
+                  "finish_prepared_after_record_commit_prepared (inject fault in FinishPreparedTransaction() after recording the commit prepared record), " \
 			      "all (affects all faults injected, used for 'status' and 'reset'), ") 
         addTo.add_option("-c", "--ddl_statement", dest="ddlStatement", type="string",
                          metavar="ddlStatement",

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1646,6 +1646,8 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
 
 	END_CRIT_SECTION();
 
+	SIMPLE_FAULT_INJECTOR(FinishPreparedAfterRecordCommitPrepared);
+
 	/* Need to figure out the memory allocation and deallocationfor "buffer". For now, just let it leak. */
 
 	return true;

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -331,6 +331,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault to 'skip' in order to flush all buffers in BgBufferSync() */
 	_("bg_buffer_sync_default_logic"),
 		/* inject fault to count buffers fsync'ed by checkpoint process */
+	_("finish_prepared_after_record_commit_prepared"),
+		/* inject fault in FinishPreparedTransaction() after recording the commit prepared record */
 	_("not recognized"),
 };
 

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -221,6 +221,7 @@ typedef enum FaultInjectorIdentifier_e {
 	FsyncCounter,
 	BgBufferSyncDefaultLogic,
 
+	FinishPreparedAfterRecordCommitPrepared,
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -64,11 +64,6 @@ non_discover_targets: aoco_compression filerep_end_to_end fts
 # Refer to the properties of the pulse project and individual build
 # stages for configuration requirements.
 
-storage: storage_vacuum_xidlimits aocoalter_catalog_loaders \
-	storage_uao_and_transactionmanagement \
-	storage_persistent_accessmethods_and_vacuum \
-	storage_filerep
-
 storage_vacuum_xidlimits:
 	$(TESTER) $(DISCOVER) \
 	-s tincrepo/mpp/gpdb/tests/storage/vacuum \
@@ -110,8 +105,6 @@ storage_filerep:
 # Refer to the properties of the pulse project and individual build
 # stages for configuration requirements.
 
-walrep_multinode: walrep_1 walrep_2
-
 walrep_1:
 	$(TESTER) $(DISCOVER) -t tincrepo/mpp/gpdb/tests/storage/walrepl \
 	-s gpactivatestandby \
@@ -145,10 +138,6 @@ walrep_2:
 # Refer to the properties of the pulse project and individual build
 # stages for configuration requirements.
 
-aoco_compression: aoco_compression_large_01 aoco_compression_large_02 \
-	aoco_compression_large_03 aoco_compression_large_04 \
-	aoco_compression_small aoco_compression_small_serial
-
 aoco_compression_large_01:
 	$(TESTER) mpp.gpdb.tests.storage.aoco_compression.test_func_aococompression_large_01
 
@@ -174,9 +163,6 @@ aoco_compression_small_serial:
 # Refer to the properties of the pulse project and individual build
 # stages for configuration requirements.
 
-filerep_end_to_end: filerep_end_to_end_full_primary filerep_end_to_end_incr_primary \
-	filerep_end_to_end_full_mirror filerep_end_to_end_incr_mirror
-
 filerep_end_to_end_full_primary:
 	$(TESTER) mpp.gpdb.tests.storage.filerep_end_to_end.test_filerep_e2e.FilerepE2EScenarioTestCase.test_full_primary
 
@@ -196,10 +182,6 @@ filerep_end_to_end_incr_mirror:
 #
 # Refer to the properties of the pulse project and individual build
 # stages for configuration requirements.
-
-pgtwophase: test_pg_twophase_01_10 test_pg_twophase_11_20 \
-	test_pg_twophase_21_30 test_pg_twophase_31_40 test_pg_twophase_41_49 \
-	test_switch_01_12 test_switch_13_24 test_switch_25_33
 
 test_pg_twophase_01_10:
 	$(TESTER) $(DISCOVER) \
@@ -249,8 +231,6 @@ test_switch_25_33:
 # Refer to the properties of the pulse project and individual build
 # stages for configuration requirements.
 
-fts: fts_transitions_part01 fts_transitions_part02 fts_transitions_part03
-
 fts_transitions_part01:
 	$(TESTER) mpp.gpdb.tests.storage.fts.fts_transitions.test_fts_transitions_01
 
@@ -280,10 +260,6 @@ sub_transaction_limit_removal:
 #
 # Refer to the properties of the pulse project and individual build
 # stages for configuration requirements.
-
-filerep_schematopology_crashrecov: crash_recovery_04_10 crash_recovery_11_20 \
-	crash_recovery_21_30 crash_recovery_31_42 \
-	crash_recovery_filerep_end_to_end crash_recovery_schema_topology
 
 crash_recovery_04_10:
 	$(TESTER) $(DISCOVER) \

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -65,7 +65,7 @@ non_discover_targets: aoco_compression filerep_end_to_end fts
 # stages for configuration requirements.
 
 storage: storage_vacuum_xidlimits aocoalter_catalog_loaders \
-	storage_queryfinish_and_transactionmanagement \
+	storage_uao_and_transactionmanagement \
 	storage_persistent_accessmethods_and_vacuum \
 	storage_filerep
 

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/transaction_management/mpp23395/test_mpp23395.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/transaction_management/mpp23395/test_mpp23395.py
@@ -181,19 +181,17 @@ class mpp23395(MPPTestCase):
         SET debug_dtm_action = "fail_begin_command";
         CREATE TABLE mpp23395(a int);
         '''
-        self.run_sequence(sql, 'twophase_transaction_commit_prepared', 'error', 2, False);
+        self.run_sequence(sql, 'finish_prepared_after_record_commit_prepared', 'error', 2, False);
 
-        # QE panics after writing prepare xlog record.  This should cause
-        # master to broadcast abort but QEs handle the abort in
+        # Scenario 8: QE panics after writing prepare xlog record.  This should
+        # cause master to broadcast abort but QEs handle the abort in
         # DTX_CONTEXT_LOCAL_ONLY context.
         sql = '''
         DROP TABLE IF EXISTS mpp23395;
         CREATE TABLE mpp23395(a int);
         INSERT INTO mpp23395 VALUES(1), (2), (3);
-        BEGIN;
         SET debug_abort_after_segment_prepared = true;
         DELETE FROM mpp23395;
-        COMMIT;
         '''
 
         # No prepared transactions should remain lingering


### PR DESCRIPTION
…table.

The fault `twophase_transaction_commit_prepared` would cause the segment to
PANIC while writing a `COMMIT PREPARED` record on the segment. The master would
then retry the `COMMIT PREPARED` while the postmaster was still resetting on the
segment causing the master itself to `PANIC`. This patch introduces a new fault
injector `finish_prepared_before_commit`  which will not cause a `PANIC`, but
just error out since the intent of the test is to ensure that the retry works
correctly.