### PR TITLE
Set timezone to PST in gptransfer tests.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_ao_tables.ans
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_ao_tables.ans
@@ -1,4 +1,5 @@
 You are now connected to database "gptest" as user "tangp3".
+SET
  text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
 ----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
  0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_ao_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_ao_tables.sql
@@ -1,5 +1,7 @@
 \c gptest;
 
+set time zone PST8PDT;
+
 select * from sto_alt_ao1 order by bigint_col;
 -- Alter table add column
 Alter Table sto_alt_ao1  ADD COLUMN added_col character varying(30) default 'default';

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_co_tables.ans
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_co_tables.ans
@@ -1,4 +1,5 @@
 You are now connected to database "gptest" as user "tangp3".
+SET
  text_col | bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col |    a_ts_without     |       b_ts_with        | date_column | col_set_default 
 ----------+------------+---------------+-------------+---------+-----------+---------------+-------------------+---------------------+---------------------+------------------------+-------------+-----------------
  0_zero   |          0 | 0_zero        |           0 |       0 |         0 | {0}           |                 0 |                   0 | 2004-10-19 10:23:54 | 2004-10-19 01:23:54-07 | 2000-01-01  |               0

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_co_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_co_tables.sql
@@ -1,5 +1,7 @@
 \c gptest;
 
+set time zone PST8PDT;
+
 select * from sto_alt_co1 order by bigint_col;
 
 -- Alter table add column

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_heap_tables.ans
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_heap_tables.ans
@@ -1,4 +1,5 @@
 You are now connected to database "gptest" as user "tangp3".
+SET
 ALTER TABLE
 INSERT 0 1
 ALTER TABLE

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_heap_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/ddl/alter_heap_tables.sql
@@ -1,5 +1,7 @@
 \c gptest;
 
+set time zone PST8PDT;
+
 -- Alter table add column
 Alter Table sto_alt_heap1  ADD COLUMN added_col character varying(30) default 'default';
 insert into sto_alt_heap1 values ('3_zero', 3, '3_zero', 3, 3, 3, '{3}', 3, 3, '2004-10-19 10:23:54', '2004-10-19 10:23:54+02', '1-1-2000',3, 'newcol');

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/dml/insert_select_ao.ans
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/dml/insert_select_ao.ans
@@ -1,4 +1,5 @@
 You are now connected to database "gptest" as user "tangp3".
+SET
                                      Append-Only Table "public.ao_table"
  Column |            Type             |                  Modifiers                   | Storage  | Description 
 --------+-----------------------------+----------------------------------------------+----------+-------------

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/dml/insert_select_ao.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/post/dml/insert_select_ao.sql
@@ -1,5 +1,7 @@
 \c gptest;
 
+set time zone PST8PDT;
+
 \d+ ao_table
 
 select * from ao_table  order by a; -- order 1

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/alter_ao_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/alter_ao_tables.sql
@@ -2,6 +2,7 @@
 
 -- start_ignore
 DROP TABLE if exists sto_alt_ao1;
+set time zone PST8PDT;
 -- end_ignore
 
 CREATE TABLE sto_alt_ao1(

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/alter_co_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/alter_co_tables.sql
@@ -2,6 +2,7 @@
 
 -- start_ignore
 DROP TABLE if exists sto_alt_co1;
+set time zone PST8PDT;
 -- end_ignore
 
 CREATE TABLE sto_alt_co1(

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/alter_heap_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/alter_heap_tables.sql
@@ -2,6 +2,7 @@
 
 -- start_ignore
 DROP TABLE if exists sto_alt_heap1;
+set time zone PST8PDT;
 -- end_ignore
 CREATE TABLE sto_alt_heap1(
           text_col text default 'remove it',

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/create_ao_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/create_ao_tables.sql
@@ -6,6 +6,7 @@
 -- Create heap tables 
 --start_ignore
 DROP TABLE if exists sto_ao1;
+set time zone PST8PDT;
 --end_ignore
 CREATE TABLE sto_ao1(
           col_text text,

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/create_heap_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gptransfer/pre/ddl/create_heap_tables.sql
@@ -6,6 +6,7 @@
 -- Create heap tables 
 --start_ignore
 DROP TABLE if exists sto_heap1;
+set time zone PST8PDT;
 --end_ignore
 CREATE TABLE sto_heap1(
           col_text text,


### PR DESCRIPTION
- Update sql/answer files to set timezone to PST.
- This prevents test failures if the tests are run on a
  machine that has a different timezone

Authors: Chris Hajas and Karen Huddleston