### PR TITLE
Make 'gpstart' parameters '-a' effect in use '-m'

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -112,19 +112,6 @@ class GpStart:
                 if self.interactive:
                     if not userinput.ask_yesno(None, "\nContinue with master-only startup", 'N'):
                         raise UserAbortedException()
-                try:
-                    # Disable Ctrl-C
-                    signal.signal(signal.SIGINT,signal.SIG_IGN)
-
-                    self._startMaster()
-                    logger.info("Master Started...")
-
-                    if self.masteronly:
-                        return 0
-                finally:
-                    # Reenable Ctrl-C
-                    self.cleanup()
-                    signal.signal(signal.SIGINT,signal.default_int_handler)
 
         try:
             # Disable Ctrl-C

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -109,8 +109,22 @@ class GpStart:
                     logger.warning("****************************************************************************")
                 else:
                     logger.info('Master-only start requested in configuration without a standby master.')
-                if not userinput.ask_yesno(None, "\nContinue with master-only startup", 'N'):
-                    raise UserAbortedException()
+                if self.interactive:
+                    if not userinput.ask_yesno(None, "\nContinue with master-only startup", 'N'):
+                        raise UserAbortedException()
+                try:
+                    # Disable Ctrl-C
+                    signal.signal(signal.SIGINT,signal.SIG_IGN)
+
+                    self._startMaster()
+                    logger.info("Master Started...")
+
+                    if self.masteronly:
+                        return 0
+                finally:
+                    # Reenable Ctrl-C
+                    self.cleanup()
+                    signal.signal(signal.SIGINT,signal.default_int_handler)
 
         try:
             # Disable Ctrl-C


### PR DESCRIPTION
When I use gpstart whith parameters '-m', '-a' is not effective.

`gpstart` and `gpstop` phenomenon is a bit different
https://github.com/greenplum-db/gpdb/pull/1988

[gp@node ~]$ gpstart --help
...
-a (do not prompt)

  Do not prompt the user for confirmation.
...
-m (master only)

  Optional. Starts the master instance only, which may be necessary 
  for maintenance tasks. This mode only allows connections to the master 
  in utility mode. For example:

  PGOPTIONS='-c gp_session_role=utility' psql

  Note that starting the system in master-only mode is only advisable
  under supervision of Bcmpp support.  Improper use of this option
  may lead to a split-brain condition and possible data loss.
...

**The status quo:**
[gp@node gpdb]$ gpstart -m
20170308:17:15:42:011435 gpstart:node:gp-[INFO]:-Starting gpstart with args: **-m**
20170308:17:15:42:011435 gpstart:node:gp-[INFO]:-Gathering information and validating the environment...
20170308:17:15:43:011435 gpstart:node:gp-[INFO]:-Greenplum Binary Version: 'postgres (Greenplum Database) 5.0.0 build dev'
20170308:17:15:43:011435 gpstart:node:gp-[INFO]:-Greenplum Catalog Version: '301702171'
20170308:17:15:43:011435 gpstart:node:gp-[INFO]:-Master-only start requested in configuration without a standby master.

Continue with master-only startup Yy|Nn (default=N):
> y
20170308:17:15:44:011435 gpstart:node:gp-[INFO]:-Starting Master instance in admin mode
20170308:17:15:46:011435 gpstart:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170308:17:15:46:011435 gpstart:node:gp-[INFO]:-Obtaining Segment details from master...
20170308:17:15:47:011435 gpstart:node:gp-[INFO]:-Setting new master era
20170308:17:15:47:011435 gpstart:node:gp-[INFO]:-Master Started...
[gp@node gpdb]$ gpstart -m -a
20170308:17:15:56:011481 gpstart:node:gp-[INFO]:-Starting gpstart with args: **-m -a**
20170308:17:15:56:011481 gpstart:node:gp-[INFO]:-Gathering information and validating the environment...
20170308:17:15:56:011481 gpstart:node:gp-[INFO]:-Greenplum Binary Version: 'postgres (Greenplum Database) 5.0.0 build dev'
20170308:17:15:56:011481 gpstart:node:gp-[INFO]:-Greenplum Catalog Version: '301702171'
20170308:17:15:56:011481 gpstart:node:gp-[INFO]:-Master-only start requested in configuration without a standby master.

Continue with master-only startup Yy|Nn (default=N):
> y
20170308:17:15:58:011481 gpstart:node:gp-[INFO]:-Starting Master instance in admin mode
20170308:17:15:59:011481 gpstart:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170308:17:15:59:011481 gpstart:node:gp-[INFO]:-Obtaining Segment details from master...
20170308:17:15:59:011481 gpstart:node:gp-[INFO]:-Setting new master era
20170308:17:15:59:011481 gpstart:node:gp-[INFO]:-Master Started...


**Modified results:**
[gp@node gpdb]$ gpstart -m
20170308:17:25:55:011629 gpstart:node:gp-[INFO]:-Starting gpstart with args: -m
20170308:17:25:55:011629 gpstart:node:gp-[INFO]:-Gathering information and validating the environment...
20170308:17:25:55:011629 gpstart:node:gp-[INFO]:-Greenplum Binary Version: 'postgres (Greenplum Database) 5.0.0 build dev'
20170308:17:25:55:011629 gpstart:node:gp-[INFO]:-Greenplum Catalog Version: '301702171'
20170308:17:25:55:011629 gpstart:node:gp-[INFO]:-Master-only start requested in configuration without a standby master.

Continue with master-only startup Yy|Nn (default=N):
> y
20170308:17:25:57:011629 gpstart:node:gp-[INFO]:-Starting Master instance in admin mode
20170308:17:25:58:011629 gpstart:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170308:17:25:58:011629 gpstart:node:gp-[INFO]:-Obtaining Segment details from master...
20170308:17:25:58:011629 gpstart:node:gp-[INFO]:-Setting new master era
20170308:17:25:58:011629 gpstart:node:gp-[INFO]:-Master Started...
[gp@node gpdb]$ gpstart -m -a
20170308:17:26:04:011674 gpstart:node:gp-[INFO]:-Starting gpstart with args: -m -a
20170308:17:26:04:011674 gpstart:node:gp-[INFO]:-Gathering information and validating the environment...
20170308:17:26:04:011674 gpstart:node:gp-[INFO]:-Greenplum Binary Version: 'postgres (Greenplum Database) 5.0.0 build dev'
20170308:17:26:04:011674 gpstart:node:gp-[INFO]:-Greenplum Catalog Version: '301702171'
20170308:17:26:04:011674 gpstart:node:gp-[INFO]:-Master-only start requested in configuration without a standby master.
20170308:17:26:04:011674 gpstart:node:gp-[INFO]:-Starting Master instance in admin mode
20170308:17:26:05:011674 gpstart:node:gp-[INFO]:-Obtaining Greenplum Master catalog information
20170308:17:26:05:011674 gpstart:node:gp-[INFO]:-Obtaining Segment details from master...
20170308:17:26:05:011674 gpstart:node:gp-[INFO]:-Setting new master era
20170308:17:26:05:011674 gpstart:node:gp-[INFO]:-Master Started...