### PR TITLE
Pass NULL instead of InvalidOid for pointer argument

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -747,7 +747,7 @@ void MetaTrackAddObject(Oid		classid,
 
 	MetaTrackAddUpdInternal(classid, objoid, relowner,
 							actionname, subtype,
-							rel, InvalidOid);
+							rel, NULL);
 
 	heap_close(rel, RowExclusiveLock);
 


### PR DESCRIPTION
MetaTrackAddUpdInternal() takes a HeapTuple as argument, which in turn is defined as a pointer to a HeapTupleData structure. Pass NULL rather than InvalidOid as that gets treated as a null pointer
constant causing a compiler warning:
```
heap.c:750:13: warning: expression which evaluates to zero treated
               as a null pointer constant of type 'HeapTuple'
               (aka 'struct HeapTupleData *')
      [-Wnon-literal-null-conversion]
```