### PR TITLE
Reinstate explain logic to use varnoold [#130852085]

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -3149,6 +3149,20 @@ get_variable(Var *var, int levelsup, bool istoplevel, deparse_context *context)
 		rte = rt_fetch(var->varno, dpns->rtable);
 		attnum = var->varattno;
 	}
+	/*
+	 * This following logic was deemed unnecessary in ce5b24ab , but the
+	 * printable predicates in PartitionSelectors currently breaks the
+	 * assumption that a VAR with OUTER or INNER varno can only point to an
+	 * immediate child or (in the case of the right child of a nested loop)
+	 * an outer sibling. Granted we abused the old explain logic in
+	 * Postgres 8.2, but it's much more involved and difficult to overhaul
+	 * that overnight.
+	*/
+	else if (var->varnoold >= 1 && var->varnoold <= list_length(dpns->rtable))
+	{
+		rte = rt_fetch(var->varnoold, dpns->rtable);
+		attnum = var->varoattno;
+	}
 	else if (var->varno == OUTER && dpns->outer_plan)
 	{
 		TargetEntry *tle;


### PR DESCRIPTION
This logic was deemed unnecessary in ce5b24ab , but the
printable predicates in PartitionSelectors currently breaks the
assumption that a VAR with OUTER or INNER varno can only point to an
immediate child or (in the case of the right child of a nested loop) an
outer sibling. Granted we abused the old explain logic in Postgres 8.2,
but it's much more involved and difficult to overhaul that overnight.

An example query that gets the wrong explain output is:

Without this patch we got
```
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=4 width=24)
   ->  Hash Join  (cost=0.00..1293.00 rows=2 width=24)
         Hash Cond: bar.c = another_partition_table.x AND bar.d = another_partition_table.another_pk AND partition_table.a = another_partition_table.x AND partition_table.pk = another_partition_table.another_pk
         ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
               Hash Cond: partition_table.a = bar.c AND partition_table.pk = bar.d
               ->  Dynamic Table Scan on partition_table (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
               ->  Hash  (cost=100.00..100.00 rows=34 width=4)
                     ->  Partition Selector for partition_table (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                           Filter: partition_table.pk = bar.d
                           ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
               ->  Partition Selector for partition_table (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                     Filter: another_partition_table.another_pk = another_partition_table.another_pk
                     ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
                           ->  Partition Selector for another_partition_table (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
                                 Partitions selected: 2 (out of 2)
                           ->  Dynamic Table Scan on another_partition_table (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
 Settings:  optimizer=on
 Optimizer status: PQO version 2.10.0
(19 rows)
```
Notice how the second partition selector is incorrectly rendered. We
expect something like this:

```
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=4 width=24)
   ->  Hash Join  (cost=0.00..1293.00 rows=2 width=24)
         Hash Cond: bar.c = another_partition_table.x AND bar.d = another_partition_table.another_pk AND partition_table.a = another_partition_table.x AND partition_table.pk = another_partition_table.another_pk
         ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
               Hash Cond: partition_table.a = bar.c AND partition_table.pk = bar.d
               ->  Dynamic Table Scan on partition_table (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
               ->  Hash  (cost=100.00..100.00 rows=34 width=4)
                     ->  Partition Selector for partition_table (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                           Filter: partition_table.pk = bar.d
                           ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
               ->  Partition Selector for partition_table (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                     Filter: partition_table.pk = another_partition_table.another_pk
                     ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
                           ->  Partition Selector for another_partition_table (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
                                 Partitions selected: 2 (out of 2)
                           ->  Dynamic Table Scan on another_partition_table (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
 Settings:  optimizer=on
 Optimizer status: PQO version 2.10.0
(19 rows)
```

This commit fixes that.

Joint work between Bhuvnesh, Jemish, and Jesse.