### PR TITLE
Fix ps display logic to correctly print process status.

### DIFF
--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -80,7 +80,7 @@ bool		update_process_title = true;
 
 
 /* Different systems want the buffer padded differently */
-#if defined(_AIX) || defined(__linux__) || defined(__svr4__)
+#if defined(_AIX) || defined(__linux__) || defined(__darwin__)
 #define PS_PADDING '\0'
 #else
 #define PS_PADDING ' '
@@ -105,8 +105,6 @@ static size_t ps_buffer_fixed_size;		/* size of the constant prefix */
 static size_t ps_argument_size; /* size for the first argument */
 #endif
 
-static size_t   ps_host_info_size;		/*CDB*/
-static char     ps_host_info[64];       /*CDB*/
 static char     ps_username[64];        /*CDB*/
 
 /* save the original argv[] location here */
@@ -329,25 +327,6 @@ init_ps_display(const char *username, const char *dbname,
 			 PostPortNumber, username, dbname, host_info);
 #endif /* not PS_USE_SETPROCTITLE */
 
-	ps_buffer_fixed_size = strlen(ps_buffer);
-
-	real_act_prefix_size = ps_buffer_fixed_size;
-
-	set_ps_display(initial_str, true);
-
-	/* CDB */
-	StrNCpy(ps_host_info, host_info, sizeof(ps_host_info));
-	ps_host_info_size = snprintf(ps_buffer + ps_buffer_fixed_size,
-								 ps_buffer_size - ps_buffer_fixed_size,
-								 "%s ", host_info);
-
-	/*
-	 * MPP-14501, don't let a NUL from snprintf mess up our padding
-	 */
-#if defined(__darwin__)
-	ps_buffer[ps_buffer_fixed_size + ps_host_info_size] = PS_PADDING;
-#endif
-
 	ps_buffer_cur_len = ps_buffer_fixed_size = strlen(ps_buffer);
 	real_act_prefix_size = ps_buffer_fixed_size;
 
@@ -382,23 +361,10 @@ set_ps_display(const char *activity, bool force)
 		return;
 #endif
 
-	/* Drop the remote host and port from the fixed prefix. */
-	if (ps_host_info_size > 0)
-	{
-		ps_buffer_fixed_size -= ps_host_info_size;
-		cp -= ps_host_info_size;
-		ps_host_info_size = 0;
-	}
-
 	Assert(cp >= ps_buffer);
 	/* Add client session's global id. */
 	if (gp_session_id > 0 && ep - cp > 0)
 		cp += snprintf(cp, ep - cp, "con%d ", gp_session_id);
-
-	/* Add host and port.  (Not very useful for qExecs, so skip.) */
-	if (Gp_role != GP_ROLE_EXECUTE &&
-		ps_host_info[0] != '\0' && ep - cp > 0)
-		cp += snprintf(cp, ep - cp, "%s ", ps_host_info);
 
 	/* Which segment is accessed by this qExec? */
 	if (Gp_role == GP_ROLE_EXECUTE &&
@@ -420,11 +386,12 @@ set_ps_display(const char *activity, bool force)
 	 * effectively becomes ps_buffer_size.
 	 */
 	real_act_prefix_size = Min(cp, ep) - ps_buffer;
-	ps_buffer_cur_len = real_act_prefix_size;
 
 	/* Append caller's activity string. */
 	if (ep - cp > 0)
 		StrNCpy(cp, activity, ep - cp);
+
+	ps_buffer_cur_len = strlen(ps_buffer) + 1;
 
     /* Transmit new setting to kernel, if necessary */
 #ifdef PS_USE_SETPROCTITLE
@@ -492,7 +459,7 @@ get_ps_display_from_position(size_t pos, int *displen)
 	}
 #endif
 
-	*displen = (int) (ps_buffer_cur_len - ps_buffer_fixed_size);
+	*displen = (int) (ps_buffer_cur_len - real_act_prefix_size);
 
 	return ps_buffer + pos;
 }

--- a/src/backend/utils/misc/test/ps_status_test.c
+++ b/src/backend/utils/misc/test/ps_status_test.c
@@ -37,15 +37,13 @@ test__set_ps_display__real_act_prefix_size(void **state)
 {
 	int		len;
 
-	ps_buffer = (char *) malloc(127 * sizeof(char));
-	ps_buffer_fixed_size = 79;
+	ps_buffer_size = 10;
+	ps_buffer = (char *) malloc(ps_buffer_size * sizeof(char));
+	ps_buffer_fixed_size = 7;
 	memset(ps_buffer, 'x', ps_buffer_fixed_size * sizeof(char));
-	ps_buffer_size = 127;
+
 	IsUnderPostmaster = true;
 
-	StrNCpy(ps_host_info, "msa4000125.europe.corp.microsoft.com(57193)",
-			sizeof(ps_host_info));
-	ps_host_info_size = 0;
 	gp_session_id = 26351;
 	Gp_role = GP_ROLE_DISPATCH;
 	Gp_segment = -1;
@@ -56,7 +54,7 @@ test__set_ps_display__real_act_prefix_size(void **state)
 	assert_true(real_act_prefix_size <= ps_buffer_size);
 
 	get_real_act_ps_display(&len);
-	assert_true(len >= 0);
+	assert_true(len == 0);
 }
 
 int


### PR DESCRIPTION
Seems 8.3 merge messed up the ps display logic, ends up missing to print useful
information for process like what command its running, waiting for lock,
etc. Also introduces newline causing the output to not look tidy. It seem was
broken much more for MAC than other platforms, this commit fixes to correctly
report the useful process information.

Missing this proved very difficult to debug some of the recent issues.

Before fix
```
  501 64306 64305   0  4:42PM ??         0:00.02 postgres: port 15432, master logger process

  501 64309 64305   0  4:42PM ??         0:00.01 postgres: port 15432, stats collector process

  501 64310 64305   0  4:42PM ??         0:00.07 postgres: port 15432, writer process

  501 64311 64305   0  4:42PM ??         0:00.02 postgres: port 15432, checkpointer process

  501 64312 64305   0  4:42PM ??         0:00.01 postgres: port 15432, seqserver process

  501 64313 64305   0  4:42PM ??         0:00.05 postgres: port 15432, ftsprobe process

  501 64314 64305   0  4:42PM ??         0:00.03 postgres: port 15432, sweeper process

  501 64315 64305   0  4:42PM ??         0:00.06 postgres: port 15432, wal writer process

  501 65107 64305   0  4:46PM ??         0:00.03 postgres: port 15432, aagrawal postgres 127.0.0.1(60396) 127.0.0.1(60396)
                                                     con6 127.0.0.1(
  501 65120 64201   0  4:46PM ??         0:00.03 postgres: port 25432, aagrawal postgres 127.0.0.1(60397) 127.0.0.1(60397)
                                                   con6 seg0
  501 65121 64199   0  4:46PM ??         0:00.03 postgres: port 25433, aagrawal postgres 127.0.0.1(60398) 127.0.0.1(60398)
                                                   con6 seg1
  501 65122 64200   0  4:46PM ??         0:00.03 postgres: port 25434, aagrawal postgres 127.0.0.1(60399) 127.0.0.1(60399)
                                                   con6 seg2
  501 65148 64305   0  4:46PM ??         0:00.02 postgres: port 15432, aagrawal postgres 127.0.0.1(60400) 127.0.0.1(60400)
                                                     con7 127.0.0.1(

```

With the fix

```
  501 68901 68896   0  4:51PM ??         0:00.00 postgres: port 15432, master logger process
  501 68904 68896   0  4:51PM ??         0:00.00 postgres: port 15432, stats collector process
  501 68905 68896   0  4:51PM ??         0:00.00 postgres: port 15432, writer process
  501 68906 68896   0  4:51PM ??         0:00.00 postgres: port 15432, checkpointer process
  501 68907 68896   0  4:51PM ??         0:00.01 postgres: port 15432, seqserver process
  501 68908 68896   0  4:51PM ??         0:00.01 postgres: port 15432, ftsprobe process
  501 68909 68896   0  4:51PM ??         0:00.00 postgres: port 15432, sweeper process
  501 68910 68896   0  4:51PM ??         0:00.00 postgres: port 15432, wal writer process
  501 53665 53662   0  4:18PM ??         0:00.01 postgres: port 25432, primary consumer ack process
  501 53817 53704   0  4:18PM ??         0:00.08 postgres: port 15432, aagrawal postgres 127.0.0.1(59986) con7 cmd3 DROP TABLE waiting
  501 69746 69783   0  4:55PM ??         0:00.02 postgres: port 15432, aagrawal postgres 127.0.0.1(60553) con6 cmd2 COMMIT
  501 69754 70002   0  4:55PM ??         0:00.03 postgres: port 25432, aagrawal postgres 127.0.0.1(60557) con6 seg0 Distributed Commit Prepared
  501 69755 68794   0  4:55PM ??         0:00.03 postgres: port 25433, aagrawal postgres 127.0.0.1(60558) con6 seg1 idle
  501 69756 68793   0  4:55PM ??         0:00.03 postgres: port 25434, aagrawal postgres 127.0.0.1(60559) con6 seg2 idle
  501 70425 68896   0  4:59PM ??         0:00.01 postgres: port 15432, aagrawal postgres 127.0.0.1(60614) con8 cmd1 idle in transaction
  501 70439 68795   0  4:59PM ??         0:00.01 postgres: port 25432, aagrawal postgres 127.0.0.1(60615) con8 seg0 idle in transaction
  501 70440 68794   0  4:59PM ??         0:00.01 postgres: port 25433, aagrawal postgres 127.0.0.1(60616) con8 seg1 idle in transaction
  501 70441 68793   0  4:59PM ??         0:00.01 postgres: port 25434, aagrawal postgres 127.0.0.1(60617) con8 seg2 idle in transaction
```