### PR TITLE
Backport to fix dblink_connect() password verification

### DIFF
--- a/contrib/dblink/dblink.c
+++ b/contrib/dblink/dblink.c
@@ -252,7 +252,7 @@ dblink_connect(PG_FUNCTION_ARGS)
 		connstr = GET_STR(PG_GETARG_TEXT_P(1));
 		connname = GET_STR(PG_GETARG_TEXT_P(0));
 	}
-	else if (PG_NARGS() == 1)
+	else
 		connstr = GET_STR(PG_GETARG_TEXT_P(0));
 
 	if (connname)

--- a/contrib/dblink/dblink.c
+++ b/contrib/dblink/dblink.c
@@ -195,6 +195,7 @@ typedef struct remoteConnHashEnt
 			else \
 			{ \
 				connstr = conname_or_str; \
+				dblink_connstr_check(connstr); \
 				conn = PQconnectdb(connstr); \
 				if (PQstatus(conn) == CONNECTION_BAD) \
 				{ \
@@ -258,6 +259,8 @@ dblink_connect(PG_FUNCTION_ARGS)
 		rconn = (remoteConn *) MemoryContextAlloc(TopMemoryContext,
 												  sizeof(remoteConn));
 
+	/* check password in connection string if not superuser */
+	dblink_connstr_check(connstr);
 	conn = PQconnectdb(connstr);
 
 	if (PQstatus(conn) == CONNECTION_BAD)
@@ -273,7 +276,7 @@ dblink_connect(PG_FUNCTION_ARGS)
 				 errdetail("%s", msg)));
 	}
 
-	/* check password used if not superuser */
+	/* check password actually used if not superuser */
 	dblink_security_check(conn, rconn);
 
 	if (connname)


### PR DESCRIPTION
        commit cae7ad906a0337120afe856b0a76b03b8ffc7440
        Author: Tom Lane <tgl@sss.pgh.pa.us>
        Date:   Mon Sep 22 13:55:14 2008 +0000

            Fix dblink_connect() so that it verifies that a password is supplied in the
            conninfo string *before* trying to connect to the remote server, not after.
            As pointed out by Marko Kreen, in certain not-very-plausible situations
            this could result in sending a password from the postgres user's .pgpass file,
            or other places that non-superusers shouldn't have access to, to an
            untrustworthy remote server.  The cleanest fix seems to be to expose libpq's
            conninfo-string-parsing code so that dblink can check for a password option
            without duplicating the parsing logic.

            Joe Conway, with a little cleanup by Tom Lane