### PR TITLE
Removes uninitialized variable compiler warning

### DIFF
--- a/src/backend/access/gist/gistproc.c
+++ b/src/backend/access/gist/gistproc.c
@@ -219,8 +219,8 @@ chooseLR(GIST_SPLITVEC *v,
 		}
 		else
 		{
-			float		p1,
-						p2;
+			float		p1 = 0.0;
+			float		p2 = 0.0;
 			GISTENTRY	oldUnion,
 						addon;
 

--- a/src/backend/access/gist/gistutil.c
+++ b/src/backend/access/gist/gistutil.c
@@ -292,7 +292,7 @@ gistMakeUnionKey(GISTSTATE *giststate, int attno,
 bool
 gistKeyIsEQ(GISTSTATE *giststate, int attno, Datum a, Datum b)
 {
-	bool		result;
+	bool		result = false;
 
 	FunctionCall3(&giststate->equalFn[attno],
 				  a, b,

--- a/src/backend/tsearch/ts_parse.c
+++ b/src/backend/tsearch/ts_parse.c
@@ -350,8 +350,8 @@ LexizeExec(LexizeData *ld, ParsedLex **correspondLexem)
 void
 parsetext(Oid cfgId, ParsedText *prs, char *buf, int buflen)
 {
-	int			type,
-				lenlemm;
+	int			type;
+	int			lenlemm = 0;
 	char	   *lemm = NULL;
 	LexizeData	ldata;
 	TSLexeme   *norms;


### PR DESCRIPTION
 warning: variable 'XXXXX' is uninitialized when used here [-Wuninitialized]