### PR TITLE
Fix planning of a table function with an aggregate.

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -3996,7 +3996,13 @@ add_second_stage_agg(PlannerInfo *root,
 			}
 		}
 	}
-	
+
+	/*
+	 * Ensure that the plan we're going to attach to the subquery scan has
+	 * all the parameter fields figured out.
+	 */
+	SS_finalize_plan(root, result_plan, false);
+
 	/* Construct a range table entry referring to it. */
 	newrte = addRangeTableEntryForSubquery(NULL,
 										   subquery,
@@ -4027,12 +4033,6 @@ add_second_stage_agg(PlannerInfo *root,
 		}
 		parse->targetList = copyObject(upper_tlist); /* Match range. */
 	}
-
-	/*
-	 * Ensure that the plan we're going to attach to the subquery scan has all the
-	 * parameter fields figured out.
-	 */
-	SS_finalize_plan(root, result_plan, false);
 
 	result_plan = add_subqueryscan(root, p_current_pathkeys, 
 								   1, subquery, result_plan);

--- a/src/test/regress/input/table_functions.source
+++ b/src/test/regress/input/table_functions.source
@@ -462,6 +462,9 @@ explain SELECT x.* FROM multiset_5( TABLE ( SELECT 1 ) ) x right join (SELECT 1)
 -- Do an explain analyze while we are at it:
 explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hello'::text from example_r scatter randomly) );
 
+-- Test for an old bug in aggregate planning - this used to crash.
+select count(*) from multiset_5(table(select * from example)) s ;
+
 -- ===========================================
 -- Test invalid use of table value expressions
 -- ===========================================

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -2034,6 +2034,13 @@ explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hell
  Total runtime: 5.296 ms
 (23 rows)
 
+-- Test for an old bug in aggregate planning - this used to crash.
+select count(*) from multiset_5(table(select * from example)) s ;
+ count 
+-------
+    10
+(1 row)
+
 -- ===========================================
 -- Test invalid use of table value expressions
 -- ===========================================

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -2035,6 +2035,13 @@ explain analyze SELECT * FROM multiset_5( TABLE( SELECT count(*)::integer, 'hell
  Total runtime: 5.296 ms
 (23 rows)
 
+-- Test for an old bug in aggregate planning - this used to crash.
+select count(*) from multiset_5(table(select * from example)) s ;
+ count 
+-------
+    10
+(1 row)
+
 -- ===========================================
 -- Test invalid use of table value expressions
 -- ===========================================


### PR DESCRIPTION
add_second_stage_agg() builds a SubQueryScan, and moves the "current" plan
underneath it. The SS_finalize_plan() call was misplaced, it needs to be
called before constructing the new upper-level range table, because any
references to the range table in the subplan refer to the original range
table, not the new dummy one that only contains an entry for the
SubQueryScan. It looks like the only thing in SS_finalize_plan() processing
that accesses the range table is processing a TableFunctionScan. That lead
to an assertion failure or crash, if a table function was used in a query
with an aggregate.

Fixes github issue #2033.