### PR TITLE
Check statement_mem up limit at runtime.

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -1354,25 +1354,6 @@ gpvars_show_gp_resgroup_memory_policy(void)
 }
 
 /*
- * gpvars_assign_statement_mem
- */
-bool
-gpvars_assign_statement_mem(int newval, bool doit, GucSource source __attribute__((unused)))
-{
-	if (doit)
-	{
-		if (newval >= max_statement_mem)
-		{
-			elog(ERROR, "Invalid input for statement_mem. Must be less than max_statement_mem (%d kB).", max_statement_mem);
-		}
-
-		statement_mem = newval;
-	}
-
-	return true;
-}
-
-/*
  * increment_command_count
  *	  Increment gp_command_count. If the new command count is 0 or a negative number, reset it to 1.
  */
@@ -1392,4 +1373,14 @@ increment_command_count()
 	{
 		gp_command_count = 1;
 	}
+}
+
+uint64
+GetStatementMem() {
+	if (statement_mem > max_statement_mem)
+	{
+		elog(WARNING, "statement_mem must be <= max_statement_mem (%d kB). Throttled to %d kB", max_statement_mem, max_statement_mem);
+		return (uint64) max_statement_mem;
+	}
+	return (uint64) statement_mem;
 }

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2561,7 +2561,7 @@ void SPI_InitMemoryReservation(void)
 	}
 	else
 	{
-		SPIMemReserved = (uint64) statement_mem * 1024L;;
+		SPIMemReserved = GetStatementMem() * 1024L;;
 	}
 }
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3529,9 +3529,9 @@ struct config_int ConfigureNamesInt_gp[] =
 		&statement_mem,
 #ifdef USE_ASSERT_CHECKING
 		/** Allow lower values for testing */
-		128000, 50, INT_MAX, gpvars_assign_statement_mem, NULL
+		128000, 50, INT_MAX, NULL, NULL
 #else
-		128000, 1000, INT_MAX, gpvars_assign_statement_mem, NULL
+		128000, 1000, INT_MAX, NULL, NULL
 #endif
 	},
 

--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -477,9 +477,9 @@ MemoryAccounting_SaveToFile(int currentSliceId)
 	initStringInfo(&memBuf);
 
 	/* run_id, dataset_id, query_id, scale_factor, gp_session_id, current_statement_timestamp, slice_id, segment_idx, */
-	appendStringInfo(&prefix, "%s,%s,%s,%u,%u,%d," UINT64_FORMAT ",%d,%d",
+	appendStringInfo(&prefix, "%s,%s,%s,%u," UINT64_FORMAT ",%d," UINT64_FORMAT ",%d,%d",
 			memory_profiler_run_id, memory_profiler_dataset_id, memory_profiler_query_id,
-			memory_profiler_dataset_size, statement_mem, gp_session_id, GetCurrentStatementStartTimestamp(),
+			memory_profiler_dataset_size, GetStatementMem(), gp_session_id, GetCurrentStatementStartTimestamp(),
 			currentSliceId, GpIdentity.segindex);
 
 	MemoryAccountTree *tree = ConvertMemoryAccountArrayToTree(&longLivingMemoryAccountArray[MEMORY_OWNER_TYPE_Undefined],

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -2173,9 +2173,9 @@ uint64 ResourceQueueGetQueryMemoryLimit(PlannedStmt *stmt, Oid queueId)
 	/**
 	 * If user requests more using statement_mem, grant that.
 	 */
-	if (queryMem < statement_mem * 1024L)
+	if (queryMem < GetStatementMem() * 1024L)
 	{
-		queryMem = (uint64) statement_mem * 1024L;
+		queryMem = GetStatementMem() * 1024L;
 	}
 
 	return queryMem;
@@ -2187,5 +2187,5 @@ uint64 ResourceQueueGetQueryMemoryLimit(PlannedStmt *stmt, Oid queueId)
 static uint64 ResourceQueueGetSuperuserQueryMemoryLimit(void)
 {
 	Assert(superuser());
-	return (uint64) statement_mem * 1024L;
+	return GetStatementMem() * 1024L;
 }

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1056,8 +1056,6 @@ extern const char *gpvars_assign_gp_resgroup_memory_policy(const char *newval, b
 
 extern const char *gpvars_show_gp_resgroup_memory_policy(void);
 
-extern bool gpvars_assign_statement_mem(int newval, bool doit, GucSource source __attribute__((unused)) );
-
 extern void increment_command_count(void);
 
 /*

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -317,6 +317,7 @@ extern PGDLLIMPORT int planner_work_mem;
 extern PGDLLIMPORT int work_mem;
 extern PGDLLIMPORT int maintenance_work_mem;
 extern PGDLLIMPORT int statement_mem;
+extern uint64 GetStatementMem(void);
 extern PGDLLIMPORT int max_statement_mem;
 extern PGDLLIMPORT int gp_vmem_limit_per_query;
 


### PR DESCRIPTION
GUC doesn't support correlated variables in static check functions, which is
applied to statement_mem currently. This patch moves the check to runtime.