### PR TITLE
Rename make variables to PYTHON and PYTHONHOME

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -584,8 +584,6 @@ define tmpLOADERS_FILESET_BINEXT
 endef
 LOADERS_FILESET_BINEXT = $(strip $(tmpLOADERS_FILESET_BINEXT))
 
-# moved BLD_PYTHON definition and inclusion in path and library path to Makefile.global
-
 # define python file subset to ship by platform, as desired
 BLD_PYTHON_FILESET=.
 aix5_ppc_32_PYTHON_FILESET=bin/python* lib/python* include/python*
@@ -780,9 +778,9 @@ ifeq "$(findstring win,$(BLD_ARCH))" "win"
 	# ---- copy pygresql from ext/win32 ----
 	(cd $(BLD_THIRDPARTY)/win32 && $(TAR) cf - pygresql) | (cd $(LOADERSINSTLOC_BINEXT)/ && $(TAR) xpf -)$(check_pipe_for_errors)
 endif
-ifneq "$($(BLD_ARCH)_PYTHON)" ""
+ifneq "$(PYTHONHOME)" ""
 	mkdir -p $(LOADERSINSTLOC_EXT)/python
-	(cd $($(BLD_ARCH)_PYTHON) && $(TAR) cf - $(BLD_PYTHON_FILESET)) | (cd $(LOADERSINSTLOC_EXT)/python/ && $(TAR) xpf -)$(check_pipe_for_errors)
+	(cd $(PYTHONHOME) && $(TAR) cf - $(BLD_PYTHON_FILESET)) | (cd $(LOADERSINSTLOC_EXT)/python/ && $(TAR) xpf -)$(check_pipe_for_errors)
 endif
 	mkdir -p $(LOADERSINSTLOC_LIB)
 ifneq "$(LOADERS_FILESET_LIB)" ""
@@ -799,7 +797,7 @@ endif
 ifneq "$(LOADERS_FILESET_LIB_PWARE)" ""
 	# include libraries from pware needed by the pware Python-2.6.1 build
 	mkdir -p $(LOADERSINSTLOC_LIB_PWARE)
-	($(TAR) cf - -C $($(BLD_ARCH)_PYTHON)/lib $(LOADERS_FILESET_LIB_PWARE)) | ($(TAR) xpf - -C $(LOADERSINSTLOC_LIB_PWARE))$(check_pipe_for_errors)
+	($(TAR) cf - -C $(PYTHONHOME)/lib $(LOADERS_FILESET_LIB_PWARE)) | ($(TAR) xpf - -C $(LOADERSINSTLOC_LIB_PWARE))$(check_pipe_for_errors)
 endif
 ifneq "$(findstring $(BLD_ARCH),sol10_sparc_32)" ""
 	(cd /usr/local/lib/ && $(TAR) cf - libiconv.so* libexpat.so*) | (cd $(LOADERSINSTLOC_LIB)/ && $(TAR) xpf -)$(check_pipe_for_errors)
@@ -1113,9 +1111,9 @@ copylibs : thirdparty-dist copy-nbu-libs
 	fi
 	# Create the python directory to flag to build scripts that python has been handled
 	mkdir -p $(INSTLOC)/ext/python
-	@if [ ! -z "$(BLD_PYTHON)" ]; then \
-	    echo "Copying python, $(BLD_PYTHON_FILESET), from $(BLD_PYTHON) into $(INSTLOC)/ext/python..."; \
-	    (cd $(BLD_PYTHON) && $(TAR) cf - $(BLD_PYTHON_FILESET)) | (cd $(INSTLOC)/ext/python/ && $(TAR) xpf -); \
+	@if [ ! -z "$(PYTHONHOME)" ]; then \
+	    echo "Copying python, $(BLD_PYTHON_FILESET), from $(PYTHONHOME) into $(INSTLOC)/ext/python..."; \
+	    (cd $(PYTHONHOME) && $(TAR) cf - $(BLD_PYTHON_FILESET)) | (cd $(INSTLOC)/ext/python/ && $(TAR) xpf -); \
 		echo "...DONE"; \
 	else \
 	    echo "INFO: Python not found on this platform, $(BLD_ARCH), not copying it into the GPDB package."; \

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -79,47 +79,36 @@ endif
 export BLD_LD_LIBRARY_PATH_FIXED=true
 
 # specify python version to use for build-time and run-time
-aix5_ppc_32_PYTHON=/opt/pware
-aix5_ppc_64_PYTHON=/opt/pware64
-hpux_ia64_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.5.6
-osx106_x86_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-rhel5_x86_32_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-rhel5_x86_64_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-rhel6_x86_64_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-rhel7_x86_64_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-sol10_x86_64_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-sol10_x86_32_PYTHON=/opt/python32-2.5.1
-sol10_sparc_64_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-sol10_sparc_32_PYTHON=/opt/python32-2.5.1
-suse10_x86_64_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-suse11_x86_64_PYTHON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-BLD_PYTHON=$($(BLD_ARCH)_PYTHON)
+aix5_ppc_32_PYTHONHOME=/opt/pware
+aix5_ppc_64_PYTHONHOME=/opt/pware64
+hpux_ia64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.5.6
+osx106_x86_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.6.2
+rhel5_x86_32_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.6.2
+rhel5_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.6.2
+rhel6_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.6.2
+rhel7_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.6.2
+sol10_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.6.2
+sol10_x86_32_PYTHONHOME=/opt/python32-2.5.1
+sol10_sparc_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.6.2
+sol10_sparc_32_PYTHONHOME=/opt/python32-2.5.1
+suse10_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.6.2
+suse11_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.6.2
+export PYTHONHOME=$($(BLD_ARCH)_PYTHONHOME)
 
-# perfmon version of python since at some point
-# it may diverge from the GPDB version
-aix5_ppc_32_PYTHON_PERFMON=/opt/pware
-aix5_ppc_64_PYTHON_PERFMON=/opt/pware64
-osx106_x86_PYTHON_PERFMON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-rhel5_x86_32_PYTHON_PERFMON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-rhel5_x86_64_PYTHON_PERFMON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-rhel6_x86_64_PYTHON_PERFMON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-rhel7_x86_64_PYTHON_PERFMON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-sol10_x86_64_PYTHON_PERFMON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-sol10_x86_32_PYTHON_PERFMON=/opt/python32-2.5.1
-sol10_sparc_64_PYTHON_PERFMON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-sol10_sparc_32_PYTHON_PERFMON=/opt/python32-2.5.1
-suse10_x86_64_PYTHON_PERFMON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-suse11_x86_64_PYTHON_PERFMON=$(BLD_THIRDPARTY_DIR)/python-2.6.2
-BLD_PYTHON_PERFMON=$($(BLD_ARCH)_PYTHON_PERFMON)
+PYTHON=$(PYTHONHOME)/bin/python
+aix5_ppc_32_PYTHON=$(PYTHONHOME)/bin/python2.7
+aix5_ppc_64_PYTHON=$(PYTHONHOME)/bin/python2.7_64
+ifneq "$($(BLD_ARCH)_PYTHON)" ""
+export PYTHON=$($(BLD_ARCH)_PYTHON)
+endif
 
-# if PYTHON was specified above, use it for the build
-ifneq "$(BLD_PYTHON)" ""
+# if PYTHONHOME was specified above, use it for the build
+ifneq "$(PYTHONHOME)" ""
 ifeq "$(findstring $(BLD_ARCH),aix5_ppc_32 aix5_ppc_64)" ""
-tmpPATH=$(BLD_PYTHON)/bin:$(PATH)
+tmpPATH=$(PYTHONHOME)/bin:$(PATH)
 export PATH:=$(tmpPATH)
-tmpLD_LIBRARY_PATH=$(BLD_PYTHON)/lib:$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))
+tmpLD_LIBRARY_PATH=$(PYTHONHOME)/lib:$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))
 export $(BLD_WHERE_THE_LIBRARY_THINGS_ARE):=$(tmpLD_LIBRARY_PATH)
-export PYTHONHOME=$(BLD_PYTHON)
 endif
 endif
 


### PR DESCRIPTION
- BLD_PYTHON -> PYTHONHOME.
- New variable PYTHON is the python binary.
- Export both PYTHON and PYTHONHOME.
- Remove unused BLD_PYTHON_PERFMON variables.

Signed-off-by: David Sharp <dsharp@pivotal.io>