### PR TITLE
gpconfig: change error message to reflect 'hidden' guc

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -273,53 +273,25 @@ def do_change(options):
         enable_verbose_logging()
 
     try:
-        dburl = dbconn.DbURL()
-
-        gparray = GpArray.initFromCatalog(dburl, utility=True)
+        gp_array = GpArray.initFromCatalog(dbconn.DbURL(), utility=True)
 
         if not options.skipvalidation:
+            validate_options(options)
 
-            conn = dbconn.connect(dburl, True)
-
-            rows = dbconn.execSQL(conn, GucQuery(options.entry).query)
-
-            guc = None
-
-            for row in rows:
-                if guc:
-                    logger.fatal("more than 1 GUC matches: " + options.entry)
-                    sys.exit(1)
-
-                guc = Guc(row)
-
-            if not guc:
-                logger.fatal("not a valid GUC: " + options.entry)
-                sys.exit(1)
-
-            conn.close()
-
-            if options.entry in prohibitedGucs:
-                logger.fatal("The parameter '%s' is not modifiable with this tool" % options.entry)
-                sys.exit(1)
-
-            if options.value:
-                msg = guc.validate(options.value, options.mastervalue, options)
-                if msg != "ok":
-                    logger.fatal("new GUC value failed validation: " + msg)
-                    sys.exit(1)
-    except DatabaseError, ex:
+    except DatabaseError as ex:
         logger.error(ex.__str__())
-        logger.error(
-            'Failed to connect to database, exiting without action. This script can only be run when the database is up.')
-        sys.exit(1)
+        msg = 'Failed to connect to database, exiting without action. ' \
+              'This script can only be run when the database is up.'
+        logger.error(msg)
+        raise Exception(msg)
 
     pool = WorkerPool()
 
-    hostCache = GpHostCache(gparray, pool)
-    failedPings = hostCache.ping_hosts(pool)
+    host_cache = GpHostCache(gp_array, pool)
+    failed_pings = host_cache.ping_hosts(pool)
 
-    if len(failedPings):
-        for i in failedPings:
+    if len(failed_pings):
+        for i in failed_pings:
             logger.warning('unreachable host: ' + i.hostname)
         confirm_user()
 
@@ -327,7 +299,7 @@ def do_change(options):
     try:
         # do the segments
         if not options.masteronly:
-            for h in hostCache.get_hosts():
+            for h in host_cache.get_hosts():
 
                 if options.primaryvalue:
                     do_add_config_script(pool, h.hostname, [seg for seg in h.dbs if seg.isSegmentPrimary()],
@@ -342,18 +314,18 @@ def do_change(options):
 
         # do the master
         if options.mastervalue or options.remove:
-            print_verbosely(options, gparray.master.hostname, gparray.master.hostname, gparray.master.datadir)
-            cmd = GpAddConfigScript("master", gparray.master.datadir, options.entry, options.mastervalue,
-                                    options.remove, ctxt=REMOTE, remoteHost=gparray.master.hostname)
+            print_verbosely(options, gp_array.master.hostname, gp_array.master.hostname, gp_array.master.datadir)
+            cmd = GpAddConfigScript("master", gp_array.master.datadir, options.entry, options.mastervalue,
+                                    options.remove, ctxt=REMOTE, remoteHost=gp_array.master.hostname)
             pool.addCommand(cmd)
 
             # do the standby master
-            if gparray.standbyMaster:
-                print_verbosely(options, gparray.standbyMaster.hostname, gparray.standbyMaster.hostname,
-                                gparray.standbyMaster.datadir)
-                cmd = GpAddConfigScript("standbymaster", gparray.standbyMaster.datadir, options.entry,
+            if gp_array.standbyMaster:
+                print_verbosely(options, gp_array.standbyMaster.hostname, gp_array.standbyMaster.hostname,
+                                gp_array.standbyMaster.datadir)
+                cmd = GpAddConfigScript("standbymaster", gp_array.standbyMaster.datadir, options.entry,
                                         options.mastervalue, options.remove, ctxt=REMOTE,
-                                        remoteHost=gparray.standbyMaster.hostname)
+                                        remoteHost=gp_array.standbyMaster.hostname)
                 pool.addCommand(cmd)
 
         pool.join()
@@ -365,6 +337,7 @@ def do_change(options):
 
         pool.check_results()
     except Exception, e:
+        failure = True
         logger.error('errors in job:')
         logger.error(e.__str__())
         logger.error('exiting early')
@@ -376,6 +349,50 @@ def do_change(options):
         logger.error('finished with errors')
     else:
         logger.info("completed successfully")
+
+
+def validate_options(options):
+    conn = dbconn.connect(dbconn.DbURL(), True)
+    guc = get_normal_guc(conn, options)
+    if not guc:
+        # Hidden gucs: a guc is considered hidden if both:
+        #     1. It is not present with normal gucs in pg_settings
+        #     2. It has a valid return from SHOW <guc_name>;
+        try:
+            dbconn.execSQLForSingleton(conn, "SHOW %s" % options.entry)
+        except DatabaseError:
+            msg = "not a valid GUC: " + options.entry
+            logger.fatal(msg)
+            raise Exception(msg)
+
+        msg = "GUC Validation Failed: %s cannot be changed under normal conditions. " \
+              "Please refer to gpconfig documentation." % options.entry
+        logger.fatal(msg)
+        raise Exception(msg)
+    conn.close()
+    if options.entry in prohibitedGucs:
+        msg = "The parameter '%s' is not modifiable with this tool" % options.entry
+        logger.fatal(msg)
+        raise Exception(msg)
+    if options.value:
+        msg = guc.validate(options.value, options.mastervalue, options)
+        if msg != "ok":
+            msg = "new GUC value failed validation: " + msg
+            logger.fatal(msg)
+            raise Exception(msg)
+
+
+def get_normal_guc(conn, options):
+    cursor = dbconn.execSQL(conn, GucQuery(options.entry).query)
+    rows = cursor.fetchall()
+    guc = None
+    if len(rows) > 1:
+        msg = "more than 1 GUC matches: " + options.entry
+        logger.fatal(msg)
+        raise Exception(msg)
+    elif len(rows) == 1:
+        guc = Guc(rows[0])
+    return guc
 
 
 def log_and_raise(err_str):

--- a/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
+++ b/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
@@ -49,8 +49,30 @@ def add_setup(setup=None, teardown=None):
         return wrapper
     return decorate_function
 
+
 # hide unittest dependencies here
 def run_tests():
     unittest.main(verbosity=2, buffer=True)
 
 skip = unittest.skip
+
+
+class FakeCursor:
+    def __init__(self, my_list=None):
+        self.list = []
+        self.rowcount = 0
+        if my_list:
+            self.set_result_for_testing(my_list)
+
+    def __iter__(self):
+        return iter(self.list)
+
+    def close(self):
+        pass
+
+    def fetchall(self):
+        return self.list
+
+    def set_result_for_testing(self, result_list):
+        self.list = result_list
+        self.rowcount = len(result_list)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gptransfer.py
@@ -1119,21 +1119,6 @@ class CursorSideEffect:
         self.second_values[key] = value
         self.counters[key] = 0
 
-class FakeCursor:
-    def __init__(self, my_list):
-        self.list = []
-        if my_list:
-            self.list = my_list
-        self.rowcount = len(self.list)
-
-    def __iter__(self):
-        return iter(self.list)
-
-    def close(self):
-        pass
-
-    def fetchall(self):
-        return self.list
 
 class SingletonSideEffect:
     """

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -1,15 +1,16 @@
 @gpconfig
 Feature: gpconfig integration tests
 
-    Scenario: gpconfig -s option with --file option
-        Given the user runs "gpconfig -s shared_buffers --file"
-        Then gpconfig should return a return code of 0
-        Then gpconfig should print Master[\s]*value: 125MB to stdout
-
-    Scenario: gpconfig -s option with --file option with inconsistency
+    Scenario: gpconfig -s option with --file option with difference between db and conf file
+        # it requires 2 change (-c) operations to prove that we have changed a file,
+        # because any existing postgresql.conf file could already have the first value in it a priori
         Given the user runs "gpconfig -c statement_mem -v 130MB"
         Then gpconfig should return a return code of 0
+        Given the user runs "gpconfig -c statement_mem -v 129MB"
+        Then gpconfig should return a return code of 0
+        Then verify that the last line of the master postgres configuration file contains the string "129MB"
         Given the user runs "gpconfig -s statement_mem --file"
         Then gpconfig should return a return code of 0
-        Then gpconfig should print Master[\s]*value: 130MB to stdout
-        #TODO: Remove statement_mem change from postgresql.conf
+        Then gpconfig should print Master[\s]*value: 129MB to stdout
+        # TODO verify all segments also have this string
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3731,6 +3731,18 @@ def impl(context, filename, output):
     print contents
     check_stdout_msg(context, output)
 
+@then('verify that the last line of the master postgres configuration file contains the string "{output}"')
+def impl(context, output):
+    contents = ''
+    filename = master_data_dir + "/postgresql.conf"
+    with open(filename) as fr:
+        for line in fr:
+            contents = line.strip()
+    pat = re.compile(output)
+    if not pat.search(contents):
+        err_str = "Expected stdout string '%s' and found: '%s'" % (msg, contents)
+        raise Exception(err_str)
+
 @then('the user waits for "{process_name}" to finish running')
 def impl(context, process_name):
      run_command(context, "ps ux | grep `which %s` | grep -v grep | awk '{print $2}' | xargs" % process_name)


### PR DESCRIPTION
gpconfig: for "hidden" guc's that are read-only when not accompanied by --skipvalidation, instead of saying that a "hidden" guc doesn't exist, say that it is not changeable and refer user to documentation. 

-- Expand both unit and behave tests

Signed-off-by: Chumki Roy <croy@pivotal.io>