### PR TITLE
gpcloud: use resource owner mechanism for cleanup

### DIFF
--- a/gpAux/extensions/gpcloud/regress/output/2_02_invalid_region.source
+++ b/gpAux/extensions/gpcloud/regress/output/2_02_invalid_region.source
@@ -1,6 +1,6 @@
 CREATE READABLE EXTERNAL TABLE s3regress_invalid_region (date text, time text, open float, high float,
 	low float, volume int) LOCATION('s3://neverland.amazonaws.com/wherever/whatever/ config=@config_file@') format 'csv';
 SELECT count(*) FROM s3regress_invalid_region;
-ERROR:  Failed to init S3 extension (segid = 5, segnum = 6), please check your configurations and net connection: Failed to list bucket for URL: s3://neverland.amazonaws.com/wherever/whatever/, Function: open, File: src/s3bucket_reader.cpp(55). (gpcloud.cpp:88)  (seg5 slice1 ip-172-31-2-195.us-west-2.compute.internal:40001 pid=2338) (cdbdisp.c:1326)
+ERROR:  Failed to init gpcloud extension (segid = 5, segnum = 6), please check your configurations and net connection: Failed to list bucket for URL: s3://neverland.amazonaws.com/wherever/whatever/, Function: open, File: src/s3bucket_reader.cpp(55). (gpcloud.cpp:88)  (seg5 slice1 ip-172-31-2-195.us-west-2.compute.internal:40001 pid=2338) (cdbdisp.c:1326)
 DETAIL:  External table s3regress_invalid_region, file s3://neverland.amazonaws.com/wherever/whatever/ config=@config_file@
 DROP EXTERNAL TABLE s3regress_invalid_region;

--- a/gpAux/extensions/gpcloud/regress/output/2_03_invalid_config.source
+++ b/gpAux/extensions/gpcloud/regress/output/2_03_invalid_config.source
@@ -1,6 +1,6 @@
 CREATE READABLE EXTERNAL TABLE s3regress_invalid_config (date text, time text, open float, high float,
 	low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@read_prefix@/normal/') format 'csv';
 SELECT count(*) FROM s3regress_invalid_config;
-ERROR:  Failed to init S3 extension (segid = -1, segnum = -1), please check your configurations and network connection: reader_init caught a S3RuntimeError exception: Unexpected error: Failed to parse config file "s3/s3.conf", or it doesn't exist, Function: InitConfig, File: src/s3conf.cpp(28). (gpcloud.cpp:95)  (seg1 slice1 88daf7ed-1555-4d4c-5fca-62b98eea93ce:40001 pid=13622) (cdbdisp.c:1326)
+ERROR:  Failed to init gpcloud extension (segid = -1, segnum = -1), please check your configurations and network connection: reader_init caught a S3RuntimeError exception: Unexpected error: Failed to parse config file "s3/s3.conf", or it doesn't exist, Function: InitConfig, File: src/s3conf.cpp(28). (gpcloud.cpp:95)  (seg1 slice1 88daf7ed-1555-4d4c-5fca-62b98eea93ce:40001 pid=13622) (cdbdisp.c:1326)
 DETAIL:  External table s3regress_invalid_config, file s3://s3-us-west-2.amazonaws.com/@read_prefix@/normal/
 DROP EXTERNAL TABLE s3regress_invalid_config;

--- a/gpAux/extensions/gpcloud/src/gpcloud.cpp
+++ b/gpAux/extensions/gpcloud/src/gpcloud.cpp
@@ -215,15 +215,13 @@ static void destroyGpcloudResHandle(gpcloudResHandle *resHandle) {
 
     if (resHandle->gpreader != NULL) {
         if (!reader_cleanup(&resHandle->gpreader)) {
-            ereport(ERROR, (0, errmsg("Failed to cleanup gpcloud extension: %s",
-                                      s3extErrorMessage.c_str())));
+            elog(WARNING, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
         }
     }
 
     if (resHandle->gpwriter != NULL) {
         if (!writer_cleanup(&resHandle->gpwriter)) {
-            ereport(ERROR, (0, errmsg("Failed to cleanup gpcloud extension: %s",
-                                      s3extErrorMessage.c_str())));
+            elog(WARNING, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
         }
     }
 

--- a/gpAux/extensions/gpcloud/src/gpcloud.cpp
+++ b/gpAux/extensions/gpcloud/src/gpcloud.cpp
@@ -164,6 +164,97 @@ static void parseFormatOpts(FunctionCallInfo fcinfo) {
     }
 }
 
+typedef struct gpcloudResHandle {
+    GPReader *gpreader;
+    GPWriter *gpwriter;
+
+    ResourceOwner owner; /* owner of this handle */
+
+    struct gpcloudResHandle *next;
+    struct gpcloudResHandle *prev;
+} gpcloudResHandle;
+
+// Linked list of opened "handles", which are allocated in TopMemoryContext, and tracked by resource
+// owners.
+static gpcloudResHandle *openedResHandles;
+
+static bool isGpcloudResReleaseCallbackRegistered;
+
+static gpcloudResHandle *createGpcloudResHandle(void) {
+    gpcloudResHandle *resHandle;
+
+    resHandle = (gpcloudResHandle *)MemoryContextAlloc(TopMemoryContext, sizeof(gpcloudResHandle));
+    resHandle->gpreader = NULL;
+    resHandle->gpwriter = NULL;
+
+    resHandle->owner = CurrentResourceOwner;
+    resHandle->next = openedResHandles;
+    resHandle->prev = NULL;
+
+    if (openedResHandles) {
+        openedResHandles->prev = resHandle;
+    }
+
+    openedResHandles = resHandle;
+
+    return resHandle;
+}
+
+static void destroyGpcloudResHandle(gpcloudResHandle *resHandle) {
+    if (resHandle == NULL) return;
+
+    /* unlink from linked list first */
+    if (resHandle->prev)
+        resHandle->prev->next = resHandle->next;
+    else
+        openedResHandles = resHandle->next;
+
+    if (resHandle->next) {
+        resHandle->next->prev = resHandle->prev;
+    }
+
+    if (resHandle->gpreader != NULL) {
+        if (!reader_cleanup(&resHandle->gpreader)) {
+            ereport(ERROR, (0, errmsg("Failed to cleanup gpcloud extension: %s",
+                                      s3extErrorMessage.c_str())));
+        }
+    }
+
+    if (resHandle->gpwriter != NULL) {
+        if (!writer_cleanup(&resHandle->gpwriter)) {
+            ereport(ERROR, (0, errmsg("Failed to cleanup gpcloud extension: %s",
+                                      s3extErrorMessage.c_str())));
+        }
+    }
+
+    thread_cleanup();
+    pfree(resHandle);
+}
+
+/*
+ * Close any open handles on abort.
+ */
+static void gpcloudAbortCallback(ResourceReleasePhase phase, bool isCommit, bool isTopLevel,
+                                 void *arg) {
+    gpcloudResHandle *curr;
+    gpcloudResHandle *next;
+
+    if (phase != RESOURCE_RELEASE_AFTER_LOCKS) return;
+
+    next = openedResHandles;
+    while (next) {
+        curr = next;
+        next = curr->next;
+
+        if (curr->owner == CurrentResourceOwner) {
+            if (isCommit)
+                elog(WARNING, "gpcloud external table reference leak: %p still referenced", curr);
+
+            destroyGpcloudResHandle(curr);
+        }
+    }
+}
+
 /*
  * Import data into GPDB.
  * invoked by GPDB, be careful with C++ exceptions.
@@ -174,23 +265,24 @@ Datum s3_import(PG_FUNCTION_ARGS) {
         elog(ERROR, "extprotocol_import: not called by external protocol manager");
 
     /* Get our internal description of the protocol */
-    GPReader *gpreader = (GPReader *)EXTPROTOCOL_GET_USER_CTX(fcinfo);
+    gpcloudResHandle *resHandle = (gpcloudResHandle *)EXTPROTOCOL_GET_USER_CTX(fcinfo);
 
     /* last call. destroy reader */
     if (EXTPROTOCOL_IS_LAST_CALL(fcinfo)) {
-        if (!reader_cleanup(&gpreader)) {
-            ereport(ERROR,
-                    (0, errmsg("Failed to cleanup S3 extension: %s", s3extErrorMessage.c_str())));
-        }
-
-        thread_cleanup();
+        destroyGpcloudResHandle(resHandle);
 
         EXTPROTOCOL_SET_USER_CTX(fcinfo, NULL);
         PG_RETURN_INT32(0);
     }
 
     /* first call. do any desired init */
-    if (gpreader == NULL) {
+    if (resHandle == NULL) {
+        if (!isGpcloudResReleaseCallbackRegistered) {
+            RegisterResourceReleaseCallback(gpcloudAbortCallback, NULL);
+            isGpcloudResReleaseCallbackRegistered = true;
+        }
+        resHandle = createGpcloudResHandle();
+
         queryCancelFlag = false;
         const char *url_with_options = EXTPROTOCOL_GET_URL(fcinfo);
 
@@ -199,21 +291,21 @@ Datum s3_import(PG_FUNCTION_ARGS) {
 
         thread_setup();
 
-        gpreader = reader_init(url_with_options);
-        if (!gpreader) {
-            ereport(ERROR, (0, errmsg("Failed to init S3 extension (segid = %d, "
+        resHandle->gpreader = reader_init(url_with_options);
+        if (!resHandle->gpreader) {
+            ereport(ERROR, (0, errmsg("Failed to init gpcloud extension (segid = %d, "
                                       "segnum = %d), please check your "
                                       "configurations and network connection: %s",
                                       s3ext_segid, s3ext_segnum, s3extErrorMessage.c_str())));
         }
 
-        EXTPROTOCOL_SET_USER_CTX(fcinfo, gpreader);
+        EXTPROTOCOL_SET_USER_CTX(fcinfo, resHandle);
     }
 
     char *data_buf = EXTPROTOCOL_GET_DATABUF(fcinfo);
     int32 data_len = EXTPROTOCOL_GET_DATALEN(fcinfo);
 
-    if (!reader_transfer_data(gpreader, data_buf, data_len)) {
+    if (!reader_transfer_data(resHandle->gpreader, data_buf, data_len)) {
         ereport(ERROR,
                 (0, errmsg("s3_import: could not read data: %s", s3extErrorMessage.c_str())));
     }
@@ -230,44 +322,45 @@ Datum s3_export(PG_FUNCTION_ARGS) {
         elog(ERROR, "extprotocol_import: not called by external protocol manager");
 
     /* Get our internal description of the protocol */
-    GPWriter *gpwriter = (GPWriter *)EXTPROTOCOL_GET_USER_CTX(fcinfo);
+    gpcloudResHandle *resHandle = (gpcloudResHandle *)EXTPROTOCOL_GET_USER_CTX(fcinfo);
 
     /* last call. destroy writer */
     if (EXTPROTOCOL_IS_LAST_CALL(fcinfo)) {
-        if (!writer_cleanup(&gpwriter)) {
-            ereport(ERROR,
-                    (0, errmsg("Failed to cleanup S3 extension: %s", s3extErrorMessage.c_str())));
-        }
-
-        thread_cleanup();
+        destroyGpcloudResHandle(resHandle);
 
         EXTPROTOCOL_SET_USER_CTX(fcinfo, NULL);
         PG_RETURN_INT32(0);
     }
 
     /* first call. do any desired init */
-    if (gpwriter == NULL) {
+    if (resHandle == NULL) {
+        if (!isGpcloudResReleaseCallbackRegistered) {
+            RegisterResourceReleaseCallback(gpcloudAbortCallback, NULL);
+            isGpcloudResReleaseCallbackRegistered = true;
+        }
+        resHandle = createGpcloudResHandle();
+
         queryCancelFlag = false;
         const char *url_with_options = EXTPROTOCOL_GET_URL(fcinfo);
         const char *format = getFormatStr(fcinfo);
 
         thread_setup();
 
-        gpwriter = writer_init(url_with_options, format);
-        if (!gpwriter) {
-            ereport(ERROR, (0, errmsg("Failed to init S3 extension (segid = %d, "
+        resHandle->gpwriter = writer_init(url_with_options, format);
+        if (!resHandle->gpwriter) {
+            ereport(ERROR, (0, errmsg("Failed to init gpcloud extension (segid = %d, "
                                       "segnum = %d), please check your "
                                       "configurations and network connection: %s",
                                       s3ext_segid, s3ext_segnum, s3extErrorMessage.c_str())));
         }
 
-        EXTPROTOCOL_SET_USER_CTX(fcinfo, gpwriter);
+        EXTPROTOCOL_SET_USER_CTX(fcinfo, resHandle);
     }
 
     char *data_buf = EXTPROTOCOL_GET_DATABUF(fcinfo);
     int32 data_len = EXTPROTOCOL_GET_DATALEN(fcinfo);
 
-    if (!writer_transfer_data(gpwriter, data_buf, data_len)) {
+    if (!writer_transfer_data(resHandle->gpwriter, data_buf, data_len)) {
         ereport(ERROR,
                 (0, errmsg("s3_export: could not write data: %s", s3extErrorMessage.c_str())));
     }


### PR DESCRIPTION
Last call is never guaranteed for aborting transaction,
register resource owner callback to ensure proper cleanup.

Signed-off-by: Haozhou Wang <hawang@pivotal.io>