### PR TITLE
Fix ON COMMIT DELETE ROWS action for append optimized tables

### DIFF
--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -76,6 +76,8 @@ extern void AlterRelationNamespaceInternal(Relation classRel, Oid relOid,
 
 extern void CheckTableNotInUse(Relation rel, const char *stmt);
 
+extern void TruncateRelfiles(Relation rel);
+
 extern void ExecuteTruncate(TruncateStmt *stmt);
 
 extern void renameatt(Oid myrelid,
@@ -126,4 +128,5 @@ extern List *make_dist_clause(Relation rel);
 extern Oid transformFkeyCheckAttrs(Relation pkrel,
 								   int numattrs, int16 *attnums,
 								   Oid *opclasses);
+
 #endif   /* TABLECMDS_H */

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -154,7 +154,7 @@ test: uaocs_compaction/index
 test: uaocs_compaction/drop_column
 
 test: uao_ddl/cursor_row uao_ddl/cursor_column uao_ddl/alter_ao_table_statistics_row uao_ddl/analyze_ao_table_every_dml_row uao_ddl/analyze_ao_table_every_dml_column uao_ddl/alter_ao_table_statistics_column uao_ddl/alter_ao_table_setdefault_row uao_ddl/alter_ao_table_index_row uao_ddl/alter_ao_table_owner_column
-test: uao_ddl/alter_ao_table_owner_row uao_ddl/alter_ao_table_setstorage_row uao_ddl/alter_ao_table_constraint_row uao_ddl/alter_ao_table_constraint_column uao_ddl/alter_ao_table_index_column uao_ddl/blocksize_row uao_ddl/compresstype_column uao_ddl/alter_ao_table_setdefault_column uao_ddl/blocksize_column
+test: uao_ddl/alter_ao_table_owner_row uao_ddl/alter_ao_table_setstorage_row uao_ddl/alter_ao_table_constraint_row uao_ddl/alter_ao_table_constraint_column uao_ddl/alter_ao_table_index_column uao_ddl/blocksize_row uao_ddl/compresstype_column uao_ddl/alter_ao_table_setdefault_column uao_ddl/blocksize_column uao_ddl/temp_on_commit_delete_rows_row uao_ddl/temp_on_commit_delete_rows_column
 # Do not add the two uao*_catalog_tables tests to a group that runs
 # serializable transactions.  They run VACUUM FULL on append-optimized
 # tables and assume that no AWAITING_DROP segfiles exist at the end of

--- a/src/test/regress/input/uao_ddl/temp_on_commit_delete_rows.source
+++ b/src/test/regress/input/uao_ddl/temp_on_commit_delete_rows.source
@@ -1,0 +1,68 @@
+create schema temp_on_commit_delete_rows_@orientation@;
+set search_path="$user",temp_on_commit_delete_rows_@orientation@,public;
+SET gp_default_storage_options='orientation=@orientation@';
+--
+-- Test ON COMMIT DELETE ROWS action against AO/AOCS tables.
+--
+
+create function nonempty_segno(oid) returns setof int as 
+$$
+-- Input to this function must be oid and not table name.  A distinct
+-- query fails to find the temp table in the right namespace
+-- otherwise.
+select segno from gp_toolkit.__gp_@aoseg@_name($1::regclass::text)
+ where tupcount > 0;
+$$ language sql;
+
+begin;
+create temp table temp_delrows(a int, b int)
+ with (appendonly=true) on commit delete rows distributed by(a);
+insert into temp_delrows select i, i from generate_series(1,20)i;
+create index idelrows on temp_delrows using bitmap(a);
+update temp_delrows set b = -a;
+-- Aoseg table should report at least one non-empty segfile.
+select distinct nonempty_segno('temp_delrows'::regclass);
+select distinct nonempty_segno('temp_delrows'::regclass)
+ from gp_dist_random('gp_id');
+commit;
+
+select count(*) = 0 as passed from temp_delrows;
+
+-- All segfiles must be empty after commit.
+select nonempty_segno('temp_delrows'::regclass);
+select nonempty_segno('temp_delrows'::regclass)
+ from gp_dist_random('gp_id');
+
+-- PT should contain entry for segno = 0 only, segno = 1 files
+-- have been deleted by "ON COMMIT DELETE ROWS" action.
+select pt.segment_file_num from gp_relation_node pt inner join pg_class c
+ on c.relfilenode = pt.relfilenode_oid where c.relname = 'temp_delrows'
+ and c.relnamespace = pg_my_temp_schema();
+select distinct pt.segment_file_num from
+ gp_dist_random('gp_relation_node') pt inner join
+ gp_dist_random('pg_class') c on c.gp_segment_id = pt.gp_segment_id and
+ c.relfilenode = pt.relfilenode_oid where c.relname = 'temp_delrows' and
+ c.relnamespace = pg_my_temp_schema();
+
+-- DML after delete rows action.
+begin;
+insert into temp_delrows select i, i from generate_series(1,50)i;
+delete from temp_delrows where a > 25;
+select count(*) = 25 as passed from temp_delrows;
+
+-- Abort should leave no tuples in the table.
+abort;
+
+select count(*) = 0 as passed from temp_delrows;
+
+-- No begin/end block, each insert is a separate transaction
+insert into temp_delrows values (1,1), (2,2), (3,3);
+select count(*) = 0 as passed from temp_delrows;
+insert into temp_delrows select i,i from generate_series(1,10)i;
+select count(*) = 0 as passed from temp_delrows;
+
+-- All segfiles must be empty after commit.
+select nonempty_segno('temp_delrows'::regclass);
+select nonempty_segno('temp_delrows'::regclass)
+ from gp_dist_random('gp_id');
+

--- a/src/test/regress/output/uao_ddl/temp_on_commit_delete_rows.source
+++ b/src/test/regress/output/uao_ddl/temp_on_commit_delete_rows.source
@@ -1,0 +1,118 @@
+create schema temp_on_commit_delete_rows_@orientation@;
+set search_path="$user",temp_on_commit_delete_rows_@orientation@,public;
+SET gp_default_storage_options='orientation=@orientation@';
+--
+-- Test ON COMMIT DELETE ROWS action against AO/AOCS tables.
+--
+create function nonempty_segno(oid) returns setof int as 
+$$
+-- Input to this function must be oid and not table name.  A distinct
+-- query fails to find the temp table in the right namespace
+-- otherwise.
+select segno from gp_toolkit.__gp_@aoseg@_name($1::regclass::text)
+ where tupcount > 0;
+$$ language sql;
+begin;
+create temp table temp_delrows(a int, b int)
+ with (appendonly=true) on commit delete rows distributed by(a);
+insert into temp_delrows select i, i from generate_series(1,20)i;
+create index idelrows on temp_delrows using bitmap(a);
+update temp_delrows set b = -a;
+-- Aoseg table should report at least one non-empty segfile.
+select distinct nonempty_segno('temp_delrows'::regclass);
+ nonempty_segno 
+----------------
+              1
+(1 row)
+
+select distinct nonempty_segno('temp_delrows'::regclass)
+ from gp_dist_random('gp_id');
+ nonempty_segno 
+----------------
+              1
+(1 row)
+
+commit;
+select count(*) = 0 as passed from temp_delrows;
+ passed 
+--------
+ t
+(1 row)
+
+-- All segfiles must be empty after commit.
+select nonempty_segno('temp_delrows'::regclass);
+ nonempty_segno 
+----------------
+(0 rows)
+
+select nonempty_segno('temp_delrows'::regclass)
+ from gp_dist_random('gp_id');
+ nonempty_segno 
+----------------
+(0 rows)
+
+-- PT should contain entry for segno = 0 only, segno = 1 files
+-- have been deleted by "ON COMMIT DELETE ROWS" action.
+select pt.segment_file_num from gp_relation_node pt inner join pg_class c
+ on c.relfilenode = pt.relfilenode_oid where c.relname = 'temp_delrows'
+ and c.relnamespace = pg_my_temp_schema();
+ segment_file_num 
+------------------
+                0
+(1 row)
+
+select distinct pt.segment_file_num from
+ gp_dist_random('gp_relation_node') pt inner join
+ gp_dist_random('pg_class') c on c.gp_segment_id = pt.gp_segment_id and
+ c.relfilenode = pt.relfilenode_oid where c.relname = 'temp_delrows' and
+ c.relnamespace = pg_my_temp_schema();
+ segment_file_num 
+------------------
+                0
+(1 row)
+
+-- DML after delete rows action.
+begin;
+insert into temp_delrows select i, i from generate_series(1,50)i;
+delete from temp_delrows where a > 25;
+select count(*) = 25 as passed from temp_delrows;
+ passed 
+--------
+ t
+(1 row)
+
+-- Abort should leave no tuples in the table.
+abort;
+select count(*) = 0 as passed from temp_delrows;
+ passed 
+--------
+ t
+(1 row)
+
+-- No begin/end block, each insert is a separate transaction
+insert into temp_delrows values (1,1), (2,2), (3,3);
+select count(*) = 0 as passed from temp_delrows;
+ passed 
+--------
+ t
+(1 row)
+
+insert into temp_delrows select i,i from generate_series(1,10)i;
+select count(*) = 0 as passed from temp_delrows;
+ passed 
+--------
+ t
+(1 row)
+
+-- All segfiles must be empty after commit.
+select nonempty_segno('temp_delrows'::regclass);
+ nonempty_segno 
+----------------
+(0 rows)
+
+select nonempty_segno('temp_delrows'::regclass)
+ from gp_dist_random('gp_id');
+ nonempty_segno 
+----------------
+(0 rows)
+

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -428,7 +428,13 @@ convert_line(char *line, replacements *repls)
 	replace_string(line, "@DLSUFFIX@", repls->dlsuffix);
 	replace_string(line, "@bindir@", repls->bindir);
 	if (repls->orientation)
+	{
 		replace_string(line, "@orientation@", repls->orientation);
+		if (strcmp(repls->orientation, "row") == 0)
+			replace_string(line, "@aoseg@", "aoseg");
+		else
+			replace_string(line, "@aoseg@", "aocsseg");
+	}
 }
 
 /*


### PR DESCRIPTION
The fix is to perform the same steps as a TRUNCATE command - set new relfiles
and drop existing ones for parent AO table as well as all its auxiliary tables.

This fixes issue #913.  Thank you, Tao-Ma for reporting the issue and
proposing a fix as PR #960.  This commit implements Tao-Ma's idea but
implementation differs from the original proposal.
