### PR TITLE
Modified gprestore_filter.py to include CASTs

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
@@ -2411,6 +2411,14 @@ CREATE SCHEMA user_schema_e;
 ALTER SCHEMA user_schema_e OWNER TO user_role_a;
 
 --
+-- Name: plpgsql; Type: PROCEDURAL LANGUAGE; Schema: -; Owner: dcddev
+--
+
+CREATE PROCEDURAL LANGUAGE plpgsql;
+ALTER FUNCTION plpgsql_call_handler() OWNER TO dcddev;
+ALTER FUNCTION plpgsql_validator(oid) OWNER TO dcddev;
+
+
 SET search_path = user_schema_a, pg_catalog;
 
 SET default_tablespace = '';
@@ -2548,7 +2556,7 @@ SET default_tablespace = '';
         self.assertEquals(results, expected_out)
 
 
-    def test_process_schema_with_priviledges(self):
+    def test_process_schema_with_privileges(self):
         test_case_buf = """--
 -- Greenplum Database database dump
 --
@@ -2719,6 +2727,14 @@ CREATE SCHEMA user_schema_a;
 ALTER SCHEMA user_schema_a OWNER TO user_role_a;
 
 --
+-- Name: plpgsql; Type: PROCEDURAL LANGUAGE; Schema: -; Owner: dcddev
+--
+
+CREATE PROCEDURAL LANGUAGE plpgsql;
+ALTER FUNCTION plpgsql_call_handler() OWNER TO dcddev;
+ALTER FUNCTION plpgsql_validator(oid) OWNER TO dcddev;
+
+
 SET search_path = user_schema_a, pg_catalog;
 
 SET default_tablespace = '';
@@ -2884,6 +2900,13 @@ CREATE SCHEMA "测试_schema";
 ALTER SCHEMA "测试_schema" OWNER TO user_role_a;
 
 --
+-- Name: plpgsql; Type: PROCEDURAL LANGUAGE; Schema: -; Owner: dcddev
+--
+
+CREATE PROCEDURAL LANGUAGE plpgsql;
+ALTER FUNCTION plpgsql_call_handler() OWNER TO dcddev;
+ALTER FUNCTION plpgsql_validator(oid) OWNER TO dcddev;
+
 SET search_path = "测试_schema", pg_catalog;
 
 --
@@ -3047,6 +3070,13 @@ CREATE SCHEMA "Áá_schema";
 ALTER SCHEMA "Áá_schema" OWNER TO user_role_a;
 
 --
+-- Name: plpgsql; Type: PROCEDURAL LANGUAGE; Schema: -; Owner: dcddev
+--
+
+CREATE PROCEDURAL LANGUAGE plpgsql;
+ALTER FUNCTION plpgsql_call_handler() OWNER TO dcddev;
+ALTER FUNCTION plpgsql_validator(oid) OWNER TO dcddev;
+
 SET search_path = "Áá_schema", pg_catalog;
 
 --
@@ -3210,6 +3240,13 @@ CREATE SCHEMA "Ж_schema";
 ALTER SCHEMA "Ж_schema" OWNER TO user_role_a;
 
 --
+-- Name: plpgsql; Type: PROCEDURAL LANGUAGE; Schema: -; Owner: dcddev
+--
+
+CREATE PROCEDURAL LANGUAGE plpgsql;
+ALTER FUNCTION plpgsql_call_handler() OWNER TO dcddev;
+ALTER FUNCTION plpgsql_validator(oid) OWNER TO dcddev;
+
 SET search_path = "Ж_schema", pg_catalog;
 
 --

--- a/gpMgmt/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup.feature
@@ -3943,6 +3943,60 @@ Feature: Validate command line arguments
         Then verify the metadata dump file does contain "SESSION AUTHORIZATION"
         Then verify the metadata dump file does not contain "ALTER TABLE * OWNER TO"
 
+    Scenario: Backup and restore CAST, with associated function in restored schema 
+        Given the test is initialized
+        And there is a "heap" table "public.heap_table" in "bkdb" with data
+        And there is schema "testschema" exists in "bkdb"
+        And there is a "heap" table "testschema.heap_table" in "bkdb" with data
+        And a cast is created in "bkdb"
+        Then verify that a cast exists in "bkdb" in schema "public"
+        When the user runs "gpcrondump -a -x bkdb"
+        And gpcrondump should return a return code of 0
+        And the timestamp from gpcrondump is stored
+        # No filter
+        And the user runs gpdbrestore with the stored timestamp
+        And gpdbrestore should return a return code of 0
+        Then verify that a cast exists in "bkdb" in schema "public"
+        # Table filter
+        And the user runs gpdbrestore with the stored timestamp and options "-T public.heap_table"
+        And gpdbrestore should return a return code of 0
+        Then verify that a cast exists in "bkdb" in schema "public"
+        # Schema filter
+        And the user runs gpdbrestore with the stored timestamp and options "-S public"
+        And gpdbrestore should return a return code of 0
+        Then verify that a cast exists in "bkdb" in schema "public"
+        # Change schema filter
+        And database "bkdb" is dropped and recreated
+        And there is schema "newschema" exists in "bkdb"
+        When the user runs gpdbrestore with the stored timestamp and options "-T public.heap_table --change-schema newschema" without -e option
+        And gpdbrestore should return a return code of 0
+        Then verify that a cast exists in "bkdb" in schema "newschema"
+
+    Scenario: Backup and restore CAST, with associated function in non-restored schema 
+        Given the test is initialized
+        And there is a "heap" table "public.heap_table" in "bkdb" with data
+        And there is schema "testschema" exists in "bkdb"
+        And there is a "heap" table "testschema.heap_table" in "bkdb" with data
+        And a cast is created in "bkdb"
+        Then verify that a cast exists in "bkdb" in schema "public"
+        When the user runs "gpcrondump -a -x bkdb"
+        And gpcrondump should return a return code of 0
+        And the timestamp from gpcrondump is stored
+        # Table filter
+        And the user runs gpdbrestore with the stored timestamp and options "-T testschema.heap_table"
+        And gpdbrestore should return a return code of 0
+        Then verify that a cast does not exist in "bkdb" in schema "testschema"
+        # Schema filter
+        And the user runs gpdbrestore with the stored timestamp and options "-S testschema"
+        And gpdbrestore should return a return code of 0
+        Then verify that a cast does not exist in "bkdb" in schema "testschema"
+        # Change schema filter
+        And database "bkdb" is dropped and recreated
+        Given there is schema "newschema" exists in "bkdb"
+        When the user runs gpdbrestore with the stored timestamp and options "-T testschema.heap_table --change-schema newschema" without -e option
+        And gpdbrestore should return a return code of 0
+        Then verify that a cast does not exist in "bkdb" in schema "newschema"
+
     # THIS SHOULD BE THE LAST TEST
     @backupfire
     Scenario: cleanup for backup feature


### PR DESCRIPTION
Previously, any restore that filtered based on table or
schema name did not restore user-created CASTs because
they were not included in the filter.  This commit adds
support for restoring casts with table and schema filters
and the --change-schema flag.