### PR TITLE
Use available Makefile variables for src/bin

### DIFF
--- a/src/bin/Makefile
+++ b/src/bin/Makefile
@@ -11,10 +11,10 @@
 
 subdir = src/bin
 top_builddir = ../..
-nbu_libdir = $(shell cd ../../gpAux/ext/$(BLD_ARCH)/Netbackup/nbu75/lib; pwd)
+nbu_libdir = $(shell cd $(top_builddir)/gpAux/ext/$(BLD_ARCH)/Netbackup/nbu75/lib; pwd)
 include $(top_builddir)/src/Makefile.global
 
-ifeq "$(findstring -ftest-coverage,$(CFLAGS))" ""
+ifneq ($(enable_coverage), yes)
 unittest-check:
 	$(MAKE) -e LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(nbu_libdir) -C pg_dump/cdb/test check
 	$(MAKE) -C pg_dump/test check


### PR DESCRIPTION
Since we have a boolean yes/no switch for coverage enabled builds
in Makefile.global from autoconf, use that rather than inspecting
the CFLAGS for ease of reading the code. Also use the top_builddir
variable in setting the libdir, while unlikely to move in the
hierarchy it's the right thing to do.