### PR TITLE
Add check to refuse upgrades of external partitions

### DIFF
--- a/contrib/pg_upgrade/README.gpdb
+++ b/contrib/pg_upgrade/README.gpdb
@@ -52,3 +52,7 @@ synchronization.
   - AO table segment files will be rewritten when a segment containing numeric
     attributes are written to from database operations.
 
+* External partitions are not supported since management of external partitions
+  is not allowed in utility mode. All external partitions must be either moved
+  out of the partition hierarchy with ALTER TABLE EXCHANGE, or dropped, prior
+  to the upgrade.

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -38,6 +38,9 @@
 #define DB_DUMP_FILE		"pg_upgrade_dump_db.sql"
 #define ARRAY_DUMP_FILE		"pg_upgrade_dump_arraytypes.sql"
 
+/* needs to be kept in sync with pg_class.h */
+#define RELSTORAGE_EXTERNAL	'x'
+
 #ifndef WIN32
 #define pg_copy_file		copy_file
 #define pg_mv_file			rename


### PR DESCRIPTION
Partitioned tables with external tables in the partition hierarchy cannot be upgraded since external partition management is prohibited in utility mode (the partitioning system catalogs are not replicated to the segments). Add a check for external partitions and abort the upgrade if found.

This PR replaces #1940 which implemented support for external partitions but at a too high cost, the added complexity in the upgrade process is simply not worth it.