### PR TITLE
Correctly report PR as pending while waiting for CI to complete.

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -41,6 +41,11 @@ jobs:
       - get: centos-gpdb-dev-6
       - get: gpaddon_src
 
+    - put: gpdb_pr
+      params:
+        path: gpdb_pr
+        status: pending
+
     - aggregate:
       - task: compile_gpdb_open_source_centos6
         file: gpdb_pr/concourse/tasks/compile_gpdb_open_source.yml


### PR DESCRIPTION
PR github page currently doesn't show PR pipeline is running and incorrectly
shows passed if its a rebase. This fixes it so that correctly reflects it has
started running the job.