### PR TITLE
GPDB DOCS Port 4.3.12.0 updates and other changes to 5.0.0

### DIFF
--- a/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-partition.xml
@@ -5,9 +5,9 @@
   <body>
     <p>Table partitioning enables supporting very large tables, such as fact tables, by logically
       dividing them into smaller, more manageable pieces. Partitioned tables can improve query
-      performance by allowing the Greenplum Database query optimizer to scan only the
-      data needed to satisfy a given query instead of scanning all the contents of a large table.
-        <ul id="ul_szj_5sz_bt">
+      performance by allowing the Greenplum Database query optimizer to scan only the data needed to
+      satisfy a given query instead of scanning all the contents of a large table. <ul
+        id="ul_szj_5sz_bt">
         <li><xref href="#topic_tvx_nsz_bt" format="dita"/></li>
         <li><xref href="#topic65" format="dita"/></li>
         <li><xref href="#topic66" format="dita"/></li>
@@ -21,11 +21,11 @@
     <title>About Table Partitioning</title>
     <body>
       <p>Partitioning does not change the physical distribution of table data across the segments.
-        Table distribution is physical: Greenplum Database physically divides
-        partitioned tables and non-partitioned tables across segments to enable parallel query
-        processing. Table <i>partitioning</i> is logical: Greenplum Database logically
-        divides big tables to improve query performance and facilitate data warehouse maintenance
-        tasks, such as rolling old data out of the data warehouse. </p>
+        Table distribution is physical: Greenplum Database physically divides partitioned tables and
+        non-partitioned tables across segments to enable parallel query processing. Table
+          <i>partitioning</i> is logical: Greenplum Database logically divides big tables to improve
+        query performance and facilitate data warehouse maintenance tasks, such as rolling old data
+        out of the data warehouse. </p>
       <p>Greenplum Database supports:</p>
       <ul id="ul_ohc_2wy_sp">
         <li id="im204035"><i>range partitioning</i>: division of data based on a numerical range,
@@ -44,22 +44,21 @@
   <topic id="topic64" xml:lang="en">
     <title>Table Partitioning in Greenplum Database</title>
     <body>
-      <p>Greenplum Database divides tables into parts (also known as partitions) to
-        enable massively parallel processing. Tables are partitioned during <codeph>CREATE
-          TABLE</codeph> using the <codeph>PARTITION BY</codeph> (and optionally the
-          <codeph>SUBPARTITION BY</codeph>) clause. Partitioning creates a top-level (or parent)
-        table with one or more levels of sub-tables (or child tables). Internally, Greenplum Database creates an inheritance relationship between the top-level table
-        and its underlying partitions, similar to the functionality of the <codeph>INHERITS</codeph>
-        clause of PostgreSQL.</p>
-      <p>Greenplum uses the partition criteria defined during table
-        creation to create each partition with a distinct <codeph>CHECK</codeph> constraint, which
-        limits the data that table can contain. The query optimizer uses <codeph>CHECK</codeph>
-        constraints to determine which table partitions to scan to satisfy a given query
-        predicate.</p>
-      <p>The Greenplum system catalog stores partition hierarchy
-        information so that rows inserted into the top-level parent table propagate correctly to the
-        child table partitions. To change the partition design or table structure, alter the parent
-        table using <codeph>ALTER TABLE</codeph> with the <codeph>PARTITION</codeph> clause.</p>
+      <p>Greenplum Database divides tables into parts (also known as partitions) to enable massively
+        parallel processing. Tables are partitioned during <codeph>CREATE TABLE</codeph> using the
+          <codeph>PARTITION BY</codeph> (and optionally the <codeph>SUBPARTITION BY</codeph>)
+        clause. Partitioning creates a top-level (or parent) table with one or more levels of
+        sub-tables (or child tables). Internally, Greenplum Database creates an inheritance
+        relationship between the top-level table and its underlying partitions, similar to the
+        functionality of the <codeph>INHERITS</codeph> clause of PostgreSQL.</p>
+      <p>Greenplum uses the partition criteria defined during table creation to create each
+        partition with a distinct <codeph>CHECK</codeph> constraint, which limits the data that
+        table can contain. The query optimizer uses <codeph>CHECK</codeph> constraints to determine
+        which table partitions to scan to satisfy a given query predicate.</p>
+      <p>The Greenplum system catalog stores partition hierarchy information so that rows inserted
+        into the top-level parent table propagate correctly to the child table partitions. To change
+        the partition design or table structure, alter the parent table using <codeph>ALTER
+          TABLE</codeph> with the <codeph>PARTITION</codeph> clause.</p>
       <p>To insert data into a partitioned table, you specify the root partitioned table, the table
         created with the <codeph>CREATE TABLE</codeph> command. You also can specify a leaf child
         table of the partitioned table in an <codeph>INSERT</codeph> command. An error is returned
@@ -166,8 +165,8 @@
           partitions, rather than partition by year then subpartition by month then subpartition by
           day. A multi-level design can reduce query planning time, but a flat partition design runs
           faster.</p>
-        <p>You can have Greenplum Database automatically generate partitions by giving
-          a <codeph>START</codeph> value, an <codeph>END</codeph> value, and an
+        <p>You can have Greenplum Database automatically generate partitions by giving a
+            <codeph>START</codeph> value, an <codeph>END</codeph> value, and an
             <codeph>EVERY</codeph> clause that defines the partition increment value. By default,
             <codeph>START</codeph> values are always inclusive and <codeph>END</codeph> values are
           always exclusive. For example:</p>
@@ -241,10 +240,10 @@ PARTITION BY LIST (gender)
   DEFAULT PARTITION other );
 </codeblock>
         </p>
-        <note>The current Greenplum Database legacy optimizer allows list partitions
-          with multi-column (composite) partition keys. A range partition only allows a single
-          column as the partition key. The Greenplum Query Optimizer does not support composite keys,
-          so you should not use composite partition keys.</note>
+        <note>The current Greenplum Database legacy optimizer allows list partitions with
+          multi-column (composite) partition keys. A range partition only allows a single column as
+          the partition key. The Greenplum Query Optimizer does not support composite keys, so you
+          should not use composite partition keys.</note>
         <p>For more information about default partitions, see <xref href="#topic80" type="topic"
             format="dita"/>.</p>
       </body>
@@ -336,7 +335,9 @@ GRANT SELECT ON sales TO guest;
           partitioning columns. A unique index can omit the partitioning columns; however, it is
           enforced only on the parts of the partitioned table, not on the partitioned table as a
           whole.</p>
-        <p>GPORCA, the Greenplum next generation query optimizer, supports uniform multi-level partitioned tables. If GPORCA is enabled and the multi-level partitioned table is not uniform, Greenplum Database executes queries against the table with the legacy query
+        <p>GPORCA, the Greenplum next generation query optimizer, supports uniform multi-level
+          partitioned tables. If GPORCA is enabled and the multi-level partitioned table is not
+          uniform, Greenplum Database executes queries against the table with the legacy query
           optimizer. For information about uniform multi-level partitioned tables, see <xref
             href="../query/topics/query-piv-uniform-part-tbl.xml#topic1"/>.</p>
         <p>Exchanging a leaf child partition with an external table is not supported if the
@@ -494,8 +495,8 @@ WHERE tablename='sales';
         <li id="im156103"><i>pg_partition_columns</i> - Shows the partition key columns used in a
           partition design.</li>
       </ul>
-      <p>For information about Greenplum Database system catalog tables and views,
-        see the <i>Greenplum Database Reference Guide</i>. </p>
+      <p>For information about Greenplum Database system catalog tables and views, see the
+          <i>Greenplum Database Reference Guide</i>. </p>
     </body>
   </topic>
   <topic id="topic77" xml:lang="en">
@@ -634,8 +635,8 @@ WHERE tablename='sales';
           <codeblock>ALTER TABLE sales ADD DEFAULT PARTITION other;
 </codeblock>
         </p>
-        <p>If your partition design is multi-level, each level in the hierarchy
-          must have a default partition. For example:</p>
+        <p>If your partition design is multi-level, each level in the hierarchy must have a default
+          partition. For example:</p>
         <p>
           <codeblock>ALTER TABLE sales ALTER PARTITION FOR (RANK(1)) ADD DEFAULT 
 PARTITION other;
@@ -705,17 +706,16 @@ WITH TABLE jan12;
         <p>The Greenplum Database server configuration parameter
             <codeph>gp_enable_exchange_default_partition</codeph> controls availability of the
             <codeph>EXCHANGE DEFAULT PARTITION</codeph> clause. The default value for the parameter
-          is <codeph>off</codeph>, the clause is not available and Greenplum Database
-          returns an error if the clause is specified in an <codeph>ALTER TABLE</codeph>
-          command.</p>
+          is <codeph>off</codeph>, the clause is not available and Greenplum Database returns an
+          error if the clause is specified in an <codeph>ALTER TABLE</codeph> command.</p>
         <p>For information about the parameter, see "Server Configuration Parameters" in the
-              <cite>Greenplum Database Reference Guide</cite>.<note type="warning"
-            >Before you exchange the default partition, you must ensure the data in the table to be
-            exchanged, the new default partition, is valid for the default partition. For example,
-            the data in the new default partition must not contain data that would be valid in other
-            leaf child partitions of the partitioned table. Otherwise, queries against the
-            partitioned table with the exchanged default partition that are executed by the Pivotal
-            Query Optimizer might return incorrect results.</note></p>
+            <cite>Greenplum Database Reference Guide</cite>.<note type="warning">Before you exchange
+            the default partition, you must ensure the data in the table to be exchanged, the new
+            default partition, is valid for the default partition. For example, the data in the new
+            default partition must not contain data that would be valid in other leaf child
+            partitions of the partitioned table. Otherwise, queries against the partitioned table
+            with the exchanged default partition that are executed by the Pivotal Query Optimizer
+            might return incorrect results.</note></p>
       </body>
     </topic>
     <topic id="topic84" xml:lang="en">
@@ -813,8 +813,8 @@ INTO (PARTITION jan09, default partition);
                 NULL</codeph> constraint.</li>
           </ul></p>
         <p>For information about exchanging and altering a leaf child partition, see the
-            <codeph>ALTER TABLE</codeph> command in the<cite>
-            Greenplum Database Command Reference</cite>.</p>
+            <codeph>ALTER TABLE</codeph> command in the<cite> Greenplum Database Command
+            Reference</cite>.</p>
         <p>For information about limitations of partitioned tables that contain a external table
           partition, see <xref href="#topic72" format="dita"/>.</p>
       </body>

--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -302,9 +302,10 @@
           both the <codeph>optimizer</codeph> and <codeph>optimizer_analyze_root_partition</codeph>
           system configuration parameters to on. The root level statistics are then updated when you
           run <codeph>ANALYZE</codeph> or <codeph>ANALYZE ROOTPARTITION</codeph>. The time to run
-            <codeph>ANALYZE ROOTPARTITION</codeph> is similar to the time to analyze a single
-          partition since <codeph>ANALYZE ROOTPARTITION</codeph>. The <codeph>analyzedb</codeph>
-          utility updates root partition statistics by default but you can add the the
+            <codeph>ANALYZE ROOTPARTITION</codeph> is similar to the time to analyze a non-partitioned table with
+          the same data since <codeph>ANALYZE ROOTPARTITION</codeph> does not collect statistics on
+          the leaf partitions, the data is only sampled. The <codeph>analyzedb</codeph> utility
+          updates root partition statistics by default but you can add the
             <codeph>--skip_root_stats</codeph> option to leave root partition statistics empty if
           you do not use GPORCA.</p>
       </section>

--- a/gpdb-doc/dita/admin_guide/kerberos-win-client.xml
+++ b/gpdb-doc/dita/admin_guide/kerberos-win-client.xml
@@ -46,13 +46,13 @@
         <p>The automatic start up of the Kerberos service is not enabled. The service cannot be used
           to authenticate with Greenplum Database.</p>
         <p>Create a copy of the Kerberos configuration file <codeph>/etc/krb5.conf</codeph> from the
-          Greenplum Database master and place it in default Kerberos location on the Windows system
-            <codeph>C:\ProgramData\MIT\Kerberos5\krb5.ini</codeph>. In the file section
-            <codeph>[libdefaults]</codeph>, remove the Location of the Kerberos kicket cache
+          Greenplum Database master and place it in the default Kerberos location on the Windows
+          system <codeph>C:\ProgramData\MIT\Kerberos5\krb5.ini</codeph>. In the file section
+            <codeph>[libdefaults]</codeph>, remove the location of the Kerberos ticket cache
             <codeph>default_ccache_name</codeph>.</p>
         <p>On the Windows system, use the environment variable <codeph>KRB5CCNAME</codeph> to
-          specify the location of the Kerberos ticket. The value for environment variable is a file,
-          not a directory and should be unique to each login on the server. </p>
+          specify the location of the Kerberos ticket. The value for the environment variable is a
+          file, not a directory and should be unique to each login on the server. </p>
         <p>This is an example configuration file with <codeph>default_ccache_name</codeph> removed.
           Also, the section <codeph>[logging]</codeph> is removed. </p>
         <codeblock>[libdefaults]
@@ -76,8 +76,8 @@
  example.local = EXAMPLE.LOCAL</codeblock>
         <p>When specifying a Kerberos ticket with <codeph>KRB5CCNAME</codeph>, you can specify the
           value in either a local user environment or within a session. These commands set
-            <codeph>KRB5CCNAME</codeph>, runs kinit, and runs the batch file to set the environment
-          variables for the Greenplum Database clients.</p>
+            <codeph>KRB5CCNAME</codeph>, runs <codeph>kinit</codeph>, and runs the batch file to set
+          the environment variables for the Greenplum Database clients.</p>
         <codeblock>set KRB5CCNAME=%USERPROFILE%\krb5cache
 kinit
 
@@ -114,17 +114,17 @@ Type "help" for help.</codeblock>
             id="ul_q5z_js4_cw">
             <li>Windows Kerberos utility <codeph>ktpass</codeph></li>
             <li>Java JRE keytab utility <codeph>ktab</codeph><p>If you use AES256-CTS-HMAC-SHA1-96
-                encryption, you need download and install the Java extension <cite>Java Cryptography
-                  Extension (JCE) Unlimited Strength Jurisdiction Policy Files for JDK/JRE</cite>
-                from Oracle. This command creates the keyab file
+                encryption, you need to download and install the Java extension <cite>Java
+                  Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files for
+                  JDK/JRE</cite> from Oracle. This command creates the keyab file
                   <codeph>svcPostgresProd1.keytab</codeph>.</p></li>
           </ul></p>
-        <p>You run the <codeph>ktpass</codeph> utility an AD Domain Administrator. The utility
+        <p>You run the <codeph>ktpass</codeph> utility as an AD Domain Administrator. The utility
           expects a user account to have a Service Principal Name (SPN) defined as an AD user
           attribute, however, it does not appear to be required. You can specify it as a parameter
           to <codeph>ktpass</codeph> and ignore the warning that it cannot be set. </p>
-        <p>The Java JRE <codeph>ktab</codeph> utiltiy does not require an AD Domain Administrator
-          does not require an SPN.</p>
+        <p>The Java JRE <codeph>ktab</codeph> utility does not require an AD Domain Administrator
+          and does not require an SPN.</p>
         <note>When you enter the password to create the keytab file, the password is visible on
           screen.</note>
         <p>This example runs the <codeph>ktpass</codeph> utility to create the ketyab
@@ -203,8 +203,8 @@ gpload.py -f test.yaml
 (Kerberos error 193)
 krb5_cc_default() failed</codeblock><p>To
               ensure that Kerberos can find the file set the environment variable
-                <codeph>KRB5CCNAME</codeph> and run <codeph>kinit</codeph>.</p>Kerberos cannot find
-            your cache file.<codeblock>set KRB5CCNAME=%USERPROFILE%\krb5cache
+                <codeph>KRB5CCNAME</codeph> and run
+            <codeph>kinit</codeph>.</p><codeblock>set KRB5CCNAME=%USERPROFILE%\krb5cache
 kinit</codeblock></li>
           <li>This <codeph>kinit</codeph> message indicates that the <codeph>kinit -k -t</codeph>
             command could not find the
@@ -224,11 +224,11 @@ kinit</codeblock></li>
         client application to log into a Greenplum Database system. For example, a Windows user can
         use Active Directory credentials with PGadmin III to access a Greenplum Database system.
         Also, for Windows applications that use ODBC, the ODBC driver can use Active Directory
-        credentials to connect to a Greenplum Databases system.</p>
+        credentials to connect to a Greenplum Database system.</p>
       <note>Greenplum Database clients that run on Windows, like <codeph>gpload</codeph>, connect
-        with Greenplum Database directly and do not use Active Directrory. For information about
+        with Greenplum Database directly and do not use Active Directory. For information about
         connecting Greenplum Database clients on Windows to a Greenplum Database system with
-        Kerberos authentication. See <xref href="#topic_vjg_d5m_sv" format="dita"/>.</note>
+        Kerberos authentication, see <xref href="#topic_vjg_d5m_sv" format="dita"/>.</note>
       <p>This section contains the following information.<ul id="ul_o1g_1qs_bz">
           <li><xref href="#topic_uzb_t5m_sv/ad_prereq" format="dita"/></li>
           <li><xref href="#topic_uzb_t5m_sv/ad_setup" format="dita"/></li>
@@ -238,11 +238,11 @@ kinit</codeblock></li>
         </ul></p>
       <section id="ad_prereq">
         <title>Prerequisites</title>
-        <p>These are items are required enable AD single sign-on to a Greenplum Database system.</p>
+        <p>These items are required enable AD single sign-on to a Greenplum Database system.</p>
         <ul id="ul_v2b_5n2_pw">
-          <li>The Greenplum Database system must be configured to support for Kerberos
-            authentication. For information about configuring Greenplum Database with Kerberos
-            authentication, see <xref href="#topic1" format="dita"/>. </li>
+          <li>The Greenplum Database system must be configured to support Kerberos authentication.
+            For information about configuring Greenplum Database with Kerberos authentication, see
+              <xref href="#topic1" format="dita"/>. </li>
           <li>You must know the fully-qualified domain name (FQDN) of the Greenplum Database master
             host. Also, the Greenplum Database master host name must have a domain portion. If the
             system does do not have a domain, you must configure the system to use a domain.<p>This
@@ -253,11 +253,11 @@ kinit</codeblock></li>
             time source to be an AD Domain Controller, or configure the master host to use the same
             external time source as the AD Domain Controller.</li>
           <li>To support single sign-on, you configure an AD user account as a Managed Service
-            Account in AD. These are requirements for Kerboros authentication.<ul id="ul_yw3_4nx_tv">
+            Account in AD. These are requirements for Kerberos authentication.<ul id="ul_yw3_4nx_tv">
               <li>You need to add the Service Principal Name (SPN) attribute to the user account
                 information because the Kerberos utilities require the information during Kerberos
                 authentication. </li>
-              <li>Also, as Greenplum database have unattended startups, you must also provide the
+              <li>Also, as Greenplum database has unattended startups, you must also provide the
                 account login details in a Kerberos keytab file.</li>
             </ul><note>Setting the SPN and creating the keytab requires AD administrative
               permissions.</note></li>
@@ -292,7 +292,7 @@ kinit</codeblock></li>
         <codeblock>setspn -A postgres/prod1.example.local svcPostgresProd1</codeblock>
         <p>You can see the SPN if Advanced Features are set in the Active Directory Users and
           Computers view. Find <codeph>servicePrincipalName</codeph> in the Attribute Editor tab and
-          edit it if you need to make changes.</p>
+          edit it if necessary.</p>
         <p>
           <image href="graphics/kerb-ms-ad-attribute-editor.png" placement="break" width="447px"
             height="398px" id="image_pbt_hfx_tv"/>
@@ -305,7 +305,8 @@ kinit</codeblock></li>
           controller supports with this <codeph>ktpass</codeph> command:</p>
         <codeblock>ktpass /? </codeblock>
         <p>As an AD Domain Administrator, you can run the <codeph>ktpass</codeph> command to create
-          a keytab file. This example command creates a svcPostgresProd1.keytab with this information:<sl>
+          a keytab file. This example command creates the file
+            <codeph>svcPostgresProd1.keytab</codeph> with this information:<sl>
             <sli>ServicePrincipalName (SPN):
                 <codeph>postgres/prod1.example.local@EXAMPLE.LOCAL</codeph></sli>
             <sli>AD user: <codeph>svcPostgresProd1</codeph></sli>
@@ -327,7 +328,7 @@ kinit</codeblock></li>
 Password for svcPostgresprod1@EXAMPLE.LOCAL:<varname>your_password</varname>
 Done!
 Service key for svcPostgresprod1 is saved in svcPostgresProd1.keytab</codeblock><note>If
-            you use AES256-CTS-HMAC-SHA1-96 encryption, requires download and install the Java
+            you use AES256-CTS-HMAC-SHA1-96 encryption, you must download and install the Java
             extension <cite>Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy
               Files for JDK/JRE</cite> from Oracle. </note></p>
       </section>
@@ -361,29 +362,29 @@ Service key for svcPostgresprod1 is saved in svcPostgresProd1.keytab</codeblock>
  .example.local = EXAMPLE.LOCAL
  example.com = EXAMPLE.LOCAL</codeblock>
         <p>Copy the Kerberos keytab file that contains the AD user information to the Greenplum
-          Database master directory. This example copies <codeph>svcPostgresProd1.keytab</codeph>
-          that was created in <xref href="#topic_uzb_t5m_sv/ad_setup" format="dita">Active Directory
-            Setup</xref>.</p>
+          Database master directory. This example copies the
+            <codeph>svcPostgresProd1.keytab</codeph> that was created in <xref
+            href="#topic_uzb_t5m_sv/ad_setup" format="dita">Active Directory Setup</xref>.</p>
         <codeblock>mv svcPostgresProd1.keytab $MASTER_DATA_DIRECTORY
 chown gpadmin:gpadmin $MASTER_DATA_DIRECTORY/svcPostgresProd1.keytab
 chmod 600 $MASTER_DATA_DIRECTORY/svcPostgresProd1.keytab</codeblock>
         <p>Add this line as the last line in the Greenplum Database <codeph>pg_hba.conf</codeph>
           file. This line configures Greenplum Database authentication to use Active Directory for
-          authentication for connection attempt that is not matched by a previous line attempts.</p>
+          authentication for connection any attempt that is not matched by a previous line.</p>
         <codeblock>host all all 0.0.0.0/0 gss include_realm=0</codeblock>
         <p>Update the Greenplum Database <codeph>postgresql.conf</codeph> file with the location
-          details for the keytab file and the principal name to use. The fully qualified hostname
+          details for the keytab file and the principal name to use. The fully qualified host name
           and the default realm from <codeph>/etc/krb5.conf</codeph> forms the full service
           principal name.</p>
         <codeblock>krb_server_keyfile = '/data/master/gpseg-1/svcPostgresProd1.keytab'
 krb_srvname = 'postgres'</codeblock>
-        <p>Create a database role for the AD user. This example logs into default database and runs
-          the <codeph>CREATE ROLE</codeph> command. The user <codeph>dev1</codeph> was the user
+        <p>Create a database role for the AD user. This example logs into the default database and
+          runs the <codeph>CREATE ROLE</codeph> command. The user <codeph>dev1</codeph> was the user
           specified when creating the keytab file in <xref href="#topic_uzb_t5m_sv/ad_setup"
             format="dita">Active Directory Setup</xref>.</p>
         <codeblock>psql
 create role dev1 with login superuser;</codeblock>
-        <p>Restart the database to use the updated the authentication information:</p>
+        <p>Restart the database to use the updated authentication information:</p>
         <codeblock>gpstop -a
 gpstart  </codeblock>
         <note>The Greenplum Database libraries might conflict with the Kerberos workstation
@@ -409,7 +410,7 @@ psql -h prod1.example.local -U dev1</codeblock>
           <image href="graphics/kerb-pgadmin-config.png" placement="break" width="319px"
             height="327px" id="image_rb2_jfx_tv"/>
         </p>
-        <p>Also,when you reconnect to the database, pgAdmin III prompts for a password. When
+        <p>Also, when you reconnect to the database, pgAdmin III prompts for a password. When
           prompted, leave the field blank and click OK. </p>
         <p>This example configures Aginity Workbench for Pivotal Greenplum. When using single
           sign-on, you enable Use Integrated Security.</p>
@@ -443,8 +444,8 @@ print(my_data)</codeblock>
               Administrator:</p><codeblock>kvno postgres/prod1.example.local@EXAMPLE.LOCAL</codeblock></li>
         </ul>
         <ul id="ul_azk_1bs_wv">
-          <li>This login error can occur when there is a mismatch between the Widows ID and the
-            Greenplum database user role ID. This log file entry shows the login error. A user
+          <li>This login error can occur when there is a mismatch between the Windows ID and the
+            Greenplum Database user role ID. This log file entry shows the login error. A user
               <codeph>dev22</codeph> is attempting to login from a Windows desktop where the user is
             logged in as a different Windows
               user.<codeblock>2016-03-29 14:30:54.041151 PDT,"dev22","gpadmin",p15370,th2040321824,
@@ -452,7 +453,7 @@ print(my_data)</codeblock>
   "FATAL","28000","authentication failed for user ""dev22"": valid 
   until timestamp expired",,,,,,,0,,"auth.c",628,</codeblock><p>The
               error can also occur when the user can be authenticated, but does not have a Greenplum
-              database user role. </p><p>Ensure that the user is using the correct Windows ID and
+              Database user role. </p><p>Ensure that the user is using the correct Windows ID and
               that a Greenplum Database user role is configured for the user ID.</p></li>
           <li>
             <p>This error can occur when the Kerberos keytab does not contain a matching

--- a/gpdb-doc/dita/admin_guide/load/topics/g-one-time-hdfs-protocol-installation.xml
+++ b/gpdb-doc/dita/admin_guide/load/topics/g-one-time-hdfs-protocol-installation.xml
@@ -69,7 +69,7 @@
                            </row>
                            <row>
                               <entry>Hortonworks Data Platform</entry>
-                              <entry>HDP 2.1, 2.2, 2.3</entry>
+                              <entry>HDP 2.1, 2.2, 2.3, 2.4, 2.5</entry>
                               <entry>
                                  <codeph>hdp2</codeph>
                               </entry>

--- a/gpdb-doc/dita/admin_guide/load/topics/g-s3-protocol.xml
+++ b/gpdb-doc/dita/admin_guide/load/topics/g-s3-protocol.xml
@@ -15,6 +15,9 @@
          to select one or more files for a read-only table, or to define the location and filename
          format to use when uploading S3 files for <codeph>INSERT</codeph> operations to writable
          tables.</p>
+      <p>The <codeph>s3</codeph> protocol also supports <xref
+            href="https://www.emc.com/en-us/storage/ecs/index.htm" format="html" scope="external"
+            >Dell EMC Elastic Cloud Storage</xref> (ECS), an Amazon S3 compatible service. </p>
       <p>This topic contains the sections:<ul id="ul_o15_22r_kx">
             <li><xref href="#amazon-emr/s3_prereq" format="dita"/></li>
             <li><xref href="#amazon-emr/section_stk_c2r_kx" format="dita"/></li>
@@ -88,14 +91,14 @@
                   location and prefix used to select existing data files that comprise the S3 table.
                   For example:
                      <codeblock>CREATE READABLE EXTERNAL TABLE S3TBL (date text, time text, amt int)
-   location('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/
+   LOCATION('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/
       config=/home/gpadmin/aws_s3/s3.conf')
    FORMAT 'csv';</codeblock><p>For
                      writable S3 tables, the protocol URL defines the S3 location in which Greenplum
                      database stores data files for the table, as well as a prefix to use when
                      creating files for table <codeph>INSERT</codeph> operations. For
                      example:<codeblock>CREATE WRITABLE EXTERNAL TABLE S3WRIT (LIKE S3TBL)
-   location('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/
+   LOCATION('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/
       config=/home/gpadmin/aws_s3/s3.conf')
    FORMAT 'csv';</codeblock></p><p>See
                         <xref href="#amazon-emr/section_stk_c2r_kx" format="dita"/> for more
@@ -107,11 +110,19 @@
          <p>For the <codeph>s3</codeph> protocol, you specify a location for files and an optional
             configuration file location in the <codeph>LOCATION</codeph> clause of the
                <codeph>CREATE EXTERNAL TABLE</codeph> command. This is the syntax:</p>
-         <codeblock>'s3://<varname>S3_endpoint</varname>/<varname>bucket_name</varname>/[<varname>S3_prefix</varname>] [config=<varname>config_file_location</varname>]'</codeblock>
-         <p>The <codeph>s3</codeph> protocol URL must the AWS S3 endpoint and S3 bucket name. Each
-            Greenplum Database segment instance must have access to the S3 location. The optional
-               <varname>S3_prefix</varname> value is used to select files for read-only S3 tables,
-            or as a filename prefix to use when uploading files for S3 writable tables.</p>
+         <codeblock>'s3://<varname>S3_endpoint</varname>[:<varname>port</varname>]/<varname>bucket_name</varname>/[<varname>S3_prefix</varname>] [region=<varname>S3_region</varname>] [config=<varname>config_file_location</varname>]'</codeblock>
+         <p>For the <codeph>s3</codeph> protocol you must specify the S3 endpoint and S3 bucket
+            name. Each Greenplum Database segment instance must have access to the S3 location. The
+            optional <varname>S3_prefix</varname> value is used to select files for read-only S3
+            tables, or as a filename prefix to use when uploading files for S3 writable tables.</p>
+         <p>To specify an ECS endpoint (an Amazon S3 compatible service) in the
+               <codeph>LOCATION</codeph> clause, you must set the <codeph>s3</codeph> configuration
+            file parameter <codeph>version</codeph> to 2. The <codeph>version</codeph> parameter
+            controls whether the <codeph>region</codeph> parameter is used in the
+               <codeph>LOCATION</codeph> clause. You can also specify an Amazon S3 location when the
+               <codeph>version</codeph> parameter is 2. For information about
+               <codeph>version</codeph> parameter, see <xref href="#amazon-emr/s3_config_file"
+               format="dita"/>.</p>
          <!--conref in CREATE EXTERNAL TABLE-->
          <note id="s3-prefix-note">Although the <varname>S3_prefix</varname> is an optional part of
             the syntax, you should always include an S3 prefix for both writable and read-only S3
@@ -158,7 +169,7 @@ s3://domain/test1/abcdefff</codeblock>
             file must also contain complete data rows. A data row cannot be split between files. The
             S3 file permissions must be <codeph>Open/Download</codeph> and <codeph>View</codeph> for
             the S3 user ID that is accessing the files. </p>
-         <p>For information about the AWS S3 endpoints see <xref
+         <p>For information about the Amazon S3 endpoints see <xref
                href="http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region"
                format="html" scope="external"
                >http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region</xref>. For
@@ -222,9 +233,9 @@ s3://domain/test1/abcdefff</codeblock>
          <title>About the S3 Protocol config Parameter</title>
          <!--conref in CREATE EXTERNAL TABLE-->
          <p>The optional <codeph>config</codeph> parameter specifies the location of the required
-               <codeph>s3</codeph> protocol configuration file. The file contains AWS connection
-            credentials and communication parameters. For information about the file, see <xref
-               href="#amazon-emr/s3_config_file" format="dita"/>.</p>
+               <codeph>s3</codeph> protocol configuration file. The file contains Amazon Web
+            Services (AWS) connection credentials and communication parameters. For information
+            about the file, see <xref href="#amazon-emr/s3_config_file" format="dita"/>.</p>
          <p>The configuration file is required on all Greenplum Database segment hosts. This is
             default location is a location in the data directory of each Greenplum Database segment
             instance.<codeblock><varname>gpseg_data_dir</varname>/<varname>gpseg_prefix</varname><varname>N</varname>/s3/s3.conf</codeblock></p>
@@ -312,18 +323,18 @@ chunksize = 67108864</codeblock></p>
                         documentation for more information about uploads to S3.</p></pd>
                </plentry>
                <plentry>
-                  <pt>threadnum</pt>
-                  <pd>The maximum number of concurrent threads a segment can create when uploading
-                     data to or downloading data from the S3 bucket. The default is 4. The minimum
-                     is 1 and the maximum is 8.</pd>
-               </plentry>
-               <plentry>
                   <pt>encryption</pt>
                   <pd>Use connections that are secured with Secure Sockets Layer (SSL). Default
                      value is <codeph>true</codeph>. The values <codeph>true</codeph>,
                         <codeph>t</codeph>, <codeph>on</codeph>, <codeph>yes</codeph>, and
                         <codeph>y</codeph> (case insensitive) are treated as <codeph>true</codeph>.
-                     Any other value is treated as <codeph>false</codeph>.</pd>
+                     Any other value is treated as <codeph>false</codeph>.<p>If the port is not
+                        specified in the URL in the <codeph>LOCATION</codeph> clause of the
+                           <codeph>CREATE EXTERNAL TABLE</codeph> command, the configuration file
+                           <codeph>encryption</codeph> parameter affects the port used by the
+                           <codeph>s3</codeph> protocol (port 80 for HTTP or port 443 for HTTPS). If
+                        the port is specified, that port is used regardless of the encryption
+                        setting.</p></pd>
                </plentry>
                <plentry>
                   <pt>low_speed_limit</pt>
@@ -340,14 +351,69 @@ chunksize = 67108864</codeblock></p>
                      upload to or a download from the S3 bucket. The default is 60 seconds. A value
                      of 0 specifies no time limit.</pd>
                </plentry>
+               <plentry>
+                  <pt>threadnum</pt>
+                  <pd>The maximum number of concurrent threads a segment can create when uploading
+                     data to or downloading data from the S3 bucket. The default is 4. The minimum
+                     is 1 and the maximum is 8.</pd>
+               </plentry>
+               <plentry>
+                  <pt>verifycert</pt>
+                  <pd>Controls how the <codeph>s3</codeph> protocol handles authentication when
+                     establishing encrypted communication between a client and an S3 data source
+                     over HTTPS. The value is either <codeph>true</codeph> or
+                     <codeph>false</codeph>. The default value is <codeph>true</codeph>.<ul
+                        id="ul_hxt_gkl_wy">
+                        <li><codeph>verifycert=false</codeph> - Ignores authentication errors and
+                           allows encrypted communication over HTTPS.</li>
+                        <li><codeph>verifycert=true</codeph> - Requires valid authentication (a
+                           proper certificate) for encrypted communication over HTTPS.</li>
+                     </ul></pd>
+                  <pd>Setting the value to <codeph>false</codeph> can be useful in testing and
+                     development environments to allow communication without changing
+                        certificates.<note type="warning">Setting the value to
+                           <codeph>false</codeph> exposes a security risk by ignoring invalid
+                        credentials when establishing communication between a client and a S3 data
+                        store. </note></pd>
+               </plentry>
+               <plentry>
+                  <pt>version</pt>
+                  <pd>Specifies the version of the information in specified in the
+                        <codeph>LOCATION</codeph> clause of the <codeph>CREATE EXTERNAL
+                        TABLE</codeph> command. The value is either <codeph>1</codeph> or
+                        <codeph>2</codeph>. The default value is <codeph>1</codeph>.</pd>
+                  <pd>If the value is <codeph>1</codeph>, the <codeph>LOCATION</codeph> clause
+                     supports an Amazon S3 URL, and does not contain the <codeph>region</codeph>
+                     parameter. If the value is <codeph>2</codeph>, the <codeph>LOCATION</codeph>
+                     clause supports S3 compatible services and must include the
+                        <codeph>region</codeph> parameter. The <codeph>region</codeph> parameter
+                     specifies the S3 data source region. For this S3 URL
+                        <codeph>s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/</codeph>,
+                     the AWS S3 region is <codeph>us-west-2</codeph>. </pd>
+                  <pd>If <codeph>version</codeph> is 1 or is not specified, this is an example of
+                     the <codeph>LOCATION</codeph> clause of the <codeph>CREATE EXTERNAL
+                        TABLE</codeph> command that specifies an Amazon S3
+                     endpoint.<codeblock>LOCATION ('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/
+      config=/home/gpadmin/aws_s3/s3.conf')</codeblock></pd>
+                  <pd> If <codeph>version</codeph> is 2, this is an example
+                        <codeph>LOCATION</codeph> clause with the <codeph>region</codeph> parameter
+                     for an AWS S3 compatible
+                     service.<codeblock>LOCATION ('s3://test.company.com/s3test.company/test1/normal/ region=local-test
+      config=/home/gpadmin/aws_s3/s3.conf') </codeblock></pd>
+                  <pd>If <codeph>version</codeph> is 2, the <codeph>LOCATION</codeph> clause can
+                     also specify an Amazon S3 endpoint. This example specifies an Amazon S3
+                     endpoint that uses the <codeph>region</codeph>
+                     parameter.<codeblock>LOCATION ('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/ region=us-west-2
+      config=/home/gpadmin/aws_s3/s3.conf') </codeblock></pd>
+               </plentry>
             </parml>
             <!--conref in 43100 RelNotes-->
             <note><ph id="memory-phrase">Greenplum Database can require up to <codeph>threadnum *
                      chunksize</codeph> memory on each segment host when uploading or downloading S3
                   files. Consider this <codeph>s3</codeph> protocol memory requirement when you
                   configure overall Greenplum Database memory, and increase the value of <xref
-                     href="../../../ref_guide/config_params/guc_category-list.xml#gp_vmem_protect_limit"
-                  /> as necessary.</ph>
+                     href="../../../ref_guide/config_params/guc-list.xml#gp_vmem_protect_limit"
+                     >gp_vmem_protect_limit</xref> as necessary.</ph>
             </note>
          </sectiondiv>
       </section>

--- a/gpdb-doc/dita/admin_guide/managing/backup-gpcrondump.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-gpcrondump.xml
@@ -42,6 +42,12 @@
       backup in the format <i>YYYYMMDDHHMMSS</i>, for example
         <codeph>gp_dump_0_2_20151012195916.gz</codeph>. The <codeph>gpdbrestore</codeph> command
       uses the most recent backup by default but you can specify an earlier backup to restore. </p>
+    <p>The utility creates backup files with this file name format.</p>
+    <p><codeblock><varname>prefix_</varname>gp_dump_<varname>content</varname>_<varname>dbid</varname>_<varname>timestamp</varname></codeblock>The
+        <codeph>content</codeph> and <codeph>dbid</codeph> are identifiers for the Greenplum
+      Database segment instances that are assigned by Greenplum Database. For information about the
+      identifiers, see the Greenplum Database system catalog table <i>gp_id</i> in the
+        <cite>Greenplum Database Reference Guide</cite>. </p>
     <p>If you include the <codeph>-g</codeph> option, <codeph>gpcrondump</codeph> saves the
       configuration files with the backup. These configuration files are dumped in the master or
       segment data directory to
@@ -50,7 +56,7 @@
       in the directory specified by <codeph>--ddboost-backupdir</codeph> when the Data Domain Boost
       credentials were set. The <codeph>-G</codeph> option backs up global objects such as roles and
       tablespaces to a file in the master backup directory named
-          <codeph>gp_global_1_1_<varname>timestamp</varname></codeph>. </p>
+          <codeph>gp_global_-1_1_<varname>timestamp</varname></codeph>. </p>
     <p>If <codeph>--ddboost</codeph> is specified, the backup is located on the default storage unit
       in the directory specified by <codeph>--ddboost-backupdir</codeph> when the Data Domain Boost
       credentials were set.</p>

--- a/gpdb-doc/dita/admin_guide/managing/backup-named-pipes.xml
+++ b/gpdb-doc/dita/admin_guide/managing/backup-named-pipes.xml
@@ -78,9 +78,9 @@ total 8
         <li>View the contents of the <filepath>_pipes</filepath> file.
           <codeblock>$ cat /backups/db_dumps/20150519/gp_dump_20150519160000_pipes 
 sdw1:/backups/db_dumps/20150519/gp_dump_0_2_20150519160000.gz
-sdw2:/backups/db_dumps/20150519/gp_dump_0_3_20150519160000.gz
-mdw:/backups/db_dumps/20150519/gp_dump_1_1_20150519160000.gz
-mdw:/backups/db_dumps/20150519/gp_dump_1_1_20150519160000_post_data.gz
+sdw2:/backups/db_dumps/20150519/gp_dump_1_3_20150519160000.gz
+mdw:/backups/db_dumps/20150519/gp_dump_-1_1_20150519160000.gz
+mdw:/backups/db_dumps/20150519/gp_dump_-1_1_20150519160000_post_data.gz
 </codeblock></li>
         <li>Create the specified named pipes on the Greenplum Database segments. Also set up a
           reader for the named pipe.

--- a/gpdb-doc/dita/admin_guide/managing/restore-diff-system.xml
+++ b/gpdb-doc/dita/admin_guide/managing/restore-diff-system.xml
@@ -25,11 +25,11 @@
       <title>To restore a database to a different system configuration</title>
       <ol>
         <li id="kk159159">Ensure that you have a complete backup set, including dump files of the
-          master (<codeph>gp_dump_1_1_<varname>timestamp</varname></codeph>,
-              <codeph>gp_dump_1_1_<varname>timestamp</varname>_post_data</codeph>) and one for each
-          segment instance (<codeph>gp_dump_0_2_<varname>timestamp</varname></codeph>,
-              <codeph>gp_dump_0_3_<varname>timestamp</varname></codeph>,
-              <codeph>gp_dump_0_4_<varname>timestamp</varname></codeph>, and so on). Each dump file
+          master (<codeph>gp_dump_-1_1_<varname>timestamp</varname></codeph>,
+              <codeph>gp_dump_-1_1_<varname>timestamp</varname>_post_data</codeph>) and one for each
+          segment instance (for example, <codeph>gp_dump_0_2_<varname>timestamp</varname></codeph>,
+              <codeph>gp_dump_1_3_<varname>timestamp</varname></codeph>,
+              <codeph>gp_dump_2_4_<varname>timestamp</varname></codeph>, and so on). Each dump file
           must have the same timestamp key. <codeph>gpcrondump</codeph> creates the dump files in
           each segment instance's data directory. You must collect all the dump files and move them
           to one location on the master host. You can copy each segment dump file to the master,
@@ -37,12 +37,12 @@
         <li id="kk158088">Ensure that the database you are restoring to is created in the system.
           For example:<codeblock>$ createdb <varname>database_name</varname></codeblock></li>
         <li id="kk158025">Load the master dump file to restore the database objects. For
-          example:<codeblock>$ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_1_1_20120714</codeblock></li>
+          example:<codeblock>$ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_-1_1_20120714</codeblock></li>
         <li id="kk158097">Load each segment dump file to restore the data. For
           example:<codeblock>$ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_0_2_20120714
-$ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_0_3_20120714
-$ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_0_4_20120714
-$ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_0_5_20120714
+$ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_1_3_20120714
+$ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_2_4_20120714
+$ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_3_5_20120714
 ...</codeblock></li>
         <li id="kk159206">Load the post data file to restore database objects such as indexes,
           triggers, primary key constraints,
@@ -50,14 +50,14 @@ $ psql <varname>database_name</varname> -f /gpdb/backups/gp_dump_0_5_20120714
         <li>Update the database sequences based on the values from the original database. <p>You can
             use the system utilities <codeph>gunzip</codeph> and <codeph>egrep</codeph> to extract
             the sequence value information from the original Greenplum Database master dump file
-                <codeph>gp_dump_1_1_<varname>timestamp</varname>.gz</codeph> into a text file. This
+                <codeph>gp_dump_-1_1_<varname>timestamp</varname>.gz</codeph> into a text file. This
             command extracts the information into the file
               <codeph>schema_path_and_seq_next_val</codeph>.
-            <codeblock>gunzip -c <varname>path_to_master_dump_directory</varname>/gp_dump_1_1_<varname>timestamp</varname>.gz | egrep "SET search_path|SELECT pg_catalog.setval"  
+            <codeblock>gunzip -c <varname>path_to_master_dump_directory</varname>/gp_dump_-1_1_<varname>timestamp</varname>.gz | egrep "SET search_path|SELECT pg_catalog.setval"  
    > schema_path_and_seq_next_val</codeblock></p><p>This
             example command assumes the original Greenplum Database master dump file is in
               <codeph>/data/gpdb/master/gpseg-1/db_dumps/20150112</codeph>.
-            </p><codeblock>gunzip -c /data/gpdb/master/gpseg-1/db_dumps/20150112/gp_dump_1_1_20150112140316.gz 
+            </p><codeblock>gunzip -c /data/gpdb/master/gpseg-1/db_dumps/20150112/gp_dump_-1_1_20150112140316.gz 
   | egrep "SET search_path|SELECT pg_catalog.setval" > schema_path_and_seq_next_val</codeblock><p>After
             extracting the information, use the Greenplum Database <codeph>psql</codeph> utility to
             update the sequences in the database. This example command updates the sequence

--- a/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/functions-operators.xml
@@ -578,7 +578,7 @@ SELECT foo();
                                 each row.</entry>
                         </row>
                         <row>
-                            <entry colname="col1"><codeph>percent_rank(</codeph>)</entry>
+                            <entry colname="col1"><codeph>percent_rank()</codeph></entry>
                             <entry colname="col2">
                                 <codeph>double precision</codeph>
                             </entry>
@@ -606,7 +606,7 @@ SELECT foo();
                                 numbers in this case.</entry>
                         </row>
                         <row>
-                            <entry colname="col1"><codeph>row_number(</codeph>)</entry>
+                            <entry colname="col1"><codeph>row_number()</codeph></entry>
                             <entry colname="col2">
                                 <codeph>bigint</codeph>
                             </entry>
@@ -697,7 +697,7 @@ FROM employees GROUP BY department_id;</codeblock>
                         </row>
                         <row>
                             <entry colname="col1"><codeph>PERCENTILE_DISC (<i>expr</i>) WITHIN GROUP
-                                    (ORDER BY <i>expr</i> [DESC/ASC]</codeph>)</entry>
+                                    (ORDER BY <i>expr</i> [DESC/ASC])</codeph></entry>
                             <entry colname="col2">
                                 <codeph>timestamp, timestampz, interval, float</codeph>
                             </entry>

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-enable.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-enable.xml
@@ -27,16 +27,16 @@
       Query Optimizer enabled, you must collect statistics on the partitioned table root partition
       with the <cmdname>ANALYZE ROOTPARTITION</cmdname> command. The command <codeph>ANALYZE
         ROOTPARTITION</codeph> collects statistics on the root partition of a partitioned table
-      without collecting statistics on the leaf partitions. If you specify a list of column names
-      for a partitioned table, the statistics for the columns and the root partition are collected.
-      For information on the <cmdname>ANALYZE</cmdname> command, see the <cite>Greenplum Database Reference Guide</cite>.<p>You can also use the Greenplum Database utility <codeph>analyzedb</codeph> to update table statistics. The
+      based on the data in the table. Statistics are not collected on the leaf partitions, leaf
+      partition data is only sampled. If you specify a list of column names for a partitioned table,
+      the statistics for the columns and the root partition are collected. For information on the
+        <cmdname>ANALYZE</cmdname> command, see the <cite>Greenplum Database Reference Guide</cite>.<p>You can also use the Greenplum Database utility <codeph>analyzedb</codeph> to update table statistics. The
           Greenplum Database utility <codeph>analyzedb</codeph> can update statistics
         for multiple tables in parallel. The utility can also check table statistics and update
         statistics only if the statistics are not current or do not exist. For information about the
           <codeph>analyzedb</codeph> utility, see the <cite>Greenplum Database Utility
-          Guide</cite>.</p><p>As part of routine database maintenance, Refresh
-        statistics on the root partition when there are significant changes to child leaf partition
-        data.</p></note>
+          Guide</cite>.</p><p>As part of routine database maintenance, Refresh statistics on
+        the root partition when there are significant changes to leaf partition data.</p></note>
   </body>
   <topic id="topic_r5d_hv1_kr">
     <title>Setting the optimizer_analyze_root_partition Parameter</title>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -6,6 +6,7 @@
   <abstract>Descriptions of the Greenplum Database server configuration parameters listed
     alphabetically.</abstract>
   <body>
+    <!--Table is HTML only op-help-->
     <simpletable frame="all" relcolwidth="1.0* 1.09* 1.13*" id="simpletable_c53_rlx_wp"
       otherprops="op-help">
       <strow>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -100,22 +100,27 @@
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#tcp_keepalives_count" type="section">tcp_keepalives_count</xref>
+                <xref href="guc-list.xml#tcp_keepalives_count" type="section"
+                  >tcp_keepalives_count</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#tcp_keepalives_idle" type="section">tcp_keepalives_idle</xref>
+                <xref href="guc-list.xml#tcp_keepalives_idle" type="section"
+                  >tcp_keepalives_idle</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#tcp_keepalives_interval" type="section">tcp_keepalives_interval</xref>
+                <xref href="guc-list.xml#tcp_keepalives_interval" type="section"
+                  >tcp_keepalives_interval</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#unix_socket_directory" type="section">unix_socket_directory</xref>
+                <xref href="guc-list.xml#unix_socket_directory" type="section"
+                  >unix_socket_directory</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#unix_socket_group" type="section">unix_socket_group</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#unix_socket_permissions" type="section">unix_socket_permissions</xref>
+                <xref href="guc-list.xml#unix_socket_permissions" type="section"
+                  >unix_socket_permissions</xref>
               </p>
             </stentry>
           </strow>
@@ -129,7 +134,8 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#authentication_timeout" type="section">authentication_timeout</xref>
+                <xref href="guc-list.xml#authentication_timeout" type="section"
+                  >authentication_timeout</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#db_user_namespace" type="section">db_user_namespace</xref>
@@ -138,7 +144,8 @@
                 <xref href="guc-list.xml#krb_caseins_users" type="section">krb_caseins_users</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#krb_server_keyfile" type="section">krb_server_keyfile</xref>
+                <xref href="guc-list.xml#krb_server_keyfile" type="section"
+                  >krb_server_keyfile</xref>
               </p>
             </stentry>
             <stentry>
@@ -146,10 +153,12 @@
                 <xref href="guc-list.xml#krb_srvname" type="section">krb_srvname</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#password_encryption" type="section">password_encryption</xref>
+                <xref href="guc-list.xml#password_encryption" type="section"
+                  >password_encryption</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#password_hash_algorithm" type="section">password_hash_algorithm</xref>
+                <xref href="guc-list.xml#password_hash_algorithm" type="section"
+                  >password_hash_algorithm</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#ssl" type="section">ssl</xref>
@@ -181,7 +190,8 @@
                   >gp_vmem_idle_resource_timeout</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_vmem_protect_limit" type="section">gp_vmem_protect_limit</xref>
+                <xref href="guc-list.xml#gp_vmem_protect_limit" type="section"
+                  >gp_vmem_protect_limit</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_vmem_protect_segworker_cache_limit" type="section"
@@ -230,7 +240,6 @@
                 <xref href="guc-list.xml#max_fsm_relations" type="section">max_fsm_relations</xref>
               </p>
             </stentry>
-            <stentry/>
           </strow>
         </simpletable>
       </body>
@@ -242,14 +251,14 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#max_files_per_process" type="section">max_files_per_process</xref>
+                <xref href="guc-list.xml#max_files_per_process" type="section"
+                  >max_files_per_process</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#shared_preload_libraries" type="section"
                   >shared_preload_libraries</xref>
               </p>
             </stentry>
-            <stentry/>
           </strow>
         </simpletable>
       </body>
@@ -276,15 +285,18 @@
                 <xref href="guc-list.xml#vacuum_cost_limit" type="section">vacuum_cost_limit</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#vacuum_cost_page_dirty" type="section">vacuum_cost_page_dirty</xref>
+                <xref href="guc-list.xml#vacuum_cost_page_dirty" type="section"
+                  >vacuum_cost_page_dirty</xref>
               </p>
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#vacuum_cost_page_hit" type="section">vacuum_cost_page_hit</xref>
+                <xref href="guc-list.xml#vacuum_cost_page_hit" type="section"
+                  >vacuum_cost_page_hit</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#vacuum_cost_page_miss" type="section">vacuum_cost_page_miss</xref>
+                <xref href="guc-list.xml#vacuum_cost_page_miss" type="section"
+                  >vacuum_cost_page_miss</xref>
               </p>
             </stentry>
           </strow>
@@ -304,7 +316,6 @@
                 <xref href="guc-list.xml#xid_warn_limit" type="section">xid_warn_limit</xref>
               </p>
             </stentry>
-            <stentry/>
           </strow>
         </simpletable>
       </body>
@@ -338,8 +349,9 @@
             <p><xref href="guc-list.xml#optimizer_join_order_threshold" format="dita"
                 >optimizer_join_order_threshold</xref></p>
             <p><xref href="guc-list.xml#optimizer_parallel_union" type="section"
-              >optimizer_parallel_union</xref></p>
-            <p><xref href="guc-list.xml#optimizer_sort_factor" format="dita">optimizer_sort_factor</xref></p>
+                >optimizer_parallel_union</xref></p>
+            <p><xref href="guc-list.xml#optimizer_sort_factor" format="dita"
+                >optimizer_sort_factor</xref></p>
           </stentry>
         </strow>
       </simpletable>
@@ -394,7 +406,8 @@
                   >gp_enable_adaptive_nestloop</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_enable_agg_distinct" type="section">gp_enable_agg_distinct</xref>
+                <xref href="guc-list.xml#gp_enable_agg_distinct" type="section"
+                  >gp_enable_agg_distinct</xref>
               </p>
             </stentry>
             <stentry>
@@ -407,10 +420,12 @@
                   >gp_enable_direct_dispatch</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_enable_fallback_plan" type="section">gp_enable_fallback_plan</xref>
+                <xref href="guc-list.xml#gp_enable_fallback_plan" type="section"
+                  >gp_enable_fallback_plan</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_enable_fast_sri" type="section">gp_enable_fast_sri</xref>
+                <xref href="guc-list.xml#gp_enable_fast_sri" type="section"
+                  >gp_enable_fast_sri</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_enable_groupext_distinct_gather" type="section"
@@ -429,7 +444,8 @@
                   >gp_enable_predicate_propagation</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_enable_preunique" type="section">gp_enable_preunique</xref></p>
+                <xref href="guc-list.xml#gp_enable_preunique" type="section"
+                  >gp_enable_preunique</xref></p>
               <p>
                 <xref href="guc-list.xml#gp_enable_relsize_collection" format="dita"
                   >gp_enable_relsize_collection</xref></p>
@@ -438,10 +454,12 @@
                   >gp_enable_sequential_window_plans</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_enable_sort_distinct" type="section">gp_enable_sort_distinct</xref>
+                <xref href="guc-list.xml#gp_enable_sort_distinct" type="section"
+                  >gp_enable_sort_distinct</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_enable_sort_limit" type="section">gp_enable_sort_limit</xref>
+                <xref href="guc-list.xml#gp_enable_sort_limit" type="section"
+                  >gp_enable_sort_limit</xref>
               </p>
             </stentry>
           </strow>
@@ -459,7 +477,8 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#cpu_index_tuple_cost" type="section">cpu_index_tuple_cost</xref>
+                <xref href="guc-list.xml#cpu_index_tuple_cost" type="section"
+                  >cpu_index_tuple_cost</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#cpu_operator_cost" type="section">cpu_operator_cost</xref>
@@ -468,18 +487,22 @@
                 <xref href="guc-list.xml#cpu_tuple_cost" type="section">cpu_tuple_cost</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#cursor_tuple_fraction" type="section">cursor_tuple_fraction</xref>
+                <xref href="guc-list.xml#cursor_tuple_fraction" type="section"
+                  >cursor_tuple_fraction</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#effective_cache_size" type="section">effective_cache_size</xref>
+                <xref href="guc-list.xml#effective_cache_size" type="section"
+                  >effective_cache_size</xref>
               </p>
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#gp_motion_cost_per_row" type="section">gp_motion_cost_per_row</xref>
+                <xref href="guc-list.xml#gp_motion_cost_per_row" type="section"
+                  >gp_motion_cost_per_row</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_segments_for_planner" type="section">gp_segments_for_planner</xref>
+                <xref href="guc-list.xml#gp_segments_for_planner" type="section"
+                  >gp_segments_for_planner</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#random_page_cost" type="section">random_page_cost</xref>
@@ -503,15 +526,14 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#default_statistics_target" type="section">default_statistics_target
-                </xref>
+                <xref href="guc-list.xml#default_statistics_target" type="section"
+                  >default_statistics_target </xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_analyze_relative_error" type="section"
                   >gp_analyze_relative_error</xref>
               </p>
             </stentry>
-            <stentry/>
           </strow>
         </simpletable>
       </body>
@@ -523,13 +545,14 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#gp_enable_sort_distinct" type="section">gp_enable_sort_distinct</xref>
+                <xref href="guc-list.xml#gp_enable_sort_distinct" type="section"
+                  >gp_enable_sort_distinct</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_enable_sort_limit" type="section">gp_enable_sort_limit</xref>
+                <xref href="guc-list.xml#gp_enable_sort_limit" type="section"
+                  >gp_enable_sort_limit</xref>
               </p>
             </stentry>
-            <stentry/>
           </strow>
         </simpletable>
       </body>
@@ -541,7 +564,8 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#gp_enable_agg_distinct" type="section">gp_enable_agg_distinct</xref>
+                <xref href="guc-list.xml#gp_enable_agg_distinct" type="section"
+                  >gp_enable_agg_distinct</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_enable_agg_distinct_pruning" type="section"
@@ -552,7 +576,8 @@
                   >gp_enable_multiphase_agg</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_enable_preunique" type="section">gp_enable_preunique</xref>
+                <xref href="guc-list.xml#gp_enable_preunique" type="section"
+                  >gp_enable_preunique</xref>
               </p>
             </stentry>
             <stentry>
@@ -580,7 +605,8 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#join_collapse_limit" type="section">join_collapse_limit</xref>
+                <xref href="guc-list.xml#join_collapse_limit" type="section"
+                  >join_collapse_limit</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_adjust_selectivity_for_outerjoins" type="section"
@@ -593,7 +619,8 @@
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#gp_statistics_use_fkeys" type="section">gp_statistics_use_fkeys</xref>
+                <xref href="guc-list.xml#gp_statistics_use_fkeys" type="section"
+                  >gp_statistics_use_fkeys</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_workfile_compress_algorithm" type="section"
@@ -611,7 +638,8 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#from_collapse_limit" type="section">from_collapse_limit</xref>
+                <xref href="guc-list.xml#from_collapse_limit" type="section"
+                  >from_collapse_limit</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_enable_predicate_propagation" type="section"
@@ -625,7 +653,6 @@
                   >gp_statistics_pullup_from_child_partition</xref>
               </p>
             </stentry>
-            <stentry/>
           </strow>
         </simpletable>
       </body>
@@ -664,10 +691,12 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#client_min_messages" type="section">client_min_messages</xref>
+                <xref href="guc-list.xml#client_min_messages" type="section"
+                  >client_min_messages</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#log_error_verbosity" type="section">log_error_verbosity</xref>
+                <xref href="guc-list.xml#log_error_verbosity" type="section"
+                  >log_error_verbosity</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#log_min_duration_statement" type="section"
@@ -676,13 +705,15 @@
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#log_min_error_statement" type="section">log_min_error_statement</xref>
+                <xref href="guc-list.xml#log_min_error_statement" type="section"
+                  >log_min_error_statement</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#log_min_messages" type="section">log_min_messages</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#optimizer_minidump" type="section">optimizer_minidump</xref>
+                <xref href="guc-list.xml#optimizer_minidump" type="section"
+                  >optimizer_minidump</xref>
               </p>
             </stentry>
           </strow>
@@ -696,7 +727,8 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#debug_pretty_print" type="section">debug_pretty_print</xref>
+                <xref href="guc-list.xml#debug_pretty_print" type="section"
+                  >debug_pretty_print</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#debug_print_parse" type="section">debug_print_parse</xref>
@@ -705,13 +737,16 @@
                 <xref href="guc-list.xml#debug_print_plan" type="section">debug_print_plan</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#debug_print_prelim_plan" type="section">debug_print_prelim_plan</xref>
+                <xref href="guc-list.xml#debug_print_prelim_plan" type="section"
+                  >debug_print_prelim_plan</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#debug_print_rewritten" type="section">debug_print_rewritten</xref>
+                <xref href="guc-list.xml#debug_print_rewritten" type="section"
+                  >debug_print_rewritten</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#debug_print_slice_table" type="section">debug_print_slice_table</xref>
+                <xref href="guc-list.xml#debug_print_slice_table" type="section"
+                  >debug_print_slice_table</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#log_autostats" type="section">log_autostats</xref>
@@ -720,10 +755,12 @@
                 <xref href="guc-list.xml#log_connections" type="section">log_connections</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#log_disconnections" type="section">log_disconnections</xref>
+                <xref href="guc-list.xml#log_disconnections" type="section"
+                  >log_disconnections</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#log_dispatch_stats" type="section">log_dispatch_stats</xref>
+                <xref href="guc-list.xml#log_dispatch_stats" type="section"
+                  >log_dispatch_stats</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#log_duration" type="section">log_duration</xref>
@@ -731,7 +768,8 @@
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#log_executor_stats" type="section">log_executor_stats</xref>
+                <xref href="guc-list.xml#log_executor_stats" type="section"
+                  >log_executor_stats</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#log_hostname" type="section">log_hostname</xref>
@@ -746,7 +784,8 @@
                 <xref href="guc-list.xml#log_statement" type="section">log_statement</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#log_statement_stats" type="section">log_statement_stats</xref>
+                <xref href="guc-list.xml#log_statement_stats" type="section"
+                  >log_statement_stats</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#log_timezone" type="section">log_timezone</xref>
@@ -758,7 +797,8 @@
                 <xref href="guc-list.xml#gp_log_format" type="section">gp_log_format</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_max_csv_line_length" type="section">gp_max_csv_line_length</xref>
+                <xref href="guc-list.xml#gp_max_csv_line_length" type="section"
+                  >gp_max_csv_line_length</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_reraise_signal" type="section">gp_reraise_signal</xref>
@@ -784,7 +824,8 @@
                 <xref href="guc-list.xml#gp_snmp_community" type="section">gp_snmp_community</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_snmp_monitor_address" type="section">gp_snmp_monitor_address</xref>
+                <xref href="guc-list.xml#gp_snmp_monitor_address" type="section"
+                  >gp_snmp_monitor_address</xref>
               </p>
             </stentry>
             <stentry>
@@ -809,15 +850,18 @@
                 <xref href="guc-list.xml#gp_email_from" type="section">gp_email_from</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_email_smtp_password" type="section">gp_email_smtp_password</xref>
+                <xref href="guc-list.xml#gp_email_smtp_password" type="section"
+                  >gp_email_smtp_password</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_email_smtp_server" type="section">gp_email_smtp_server</xref>
+                <xref href="guc-list.xml#gp_email_smtp_server" type="section"
+                  >gp_email_smtp_server</xref>
               </p>
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#gp_email_smtp_userid" type="section">gp_email_smtp_userid</xref>
+                <xref href="guc-list.xml#gp_email_smtp_userid" type="section"
+                  >gp_email_smtp_userid</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_email_to" type="section">gp_email_to</xref>
@@ -836,7 +880,8 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#gp_enable_gpperfmon" type="section">gp_enable_gpperfmon</xref>
+                <xref href="guc-list.xml#gp_enable_gpperfmon" type="section"
+                  >gp_enable_gpperfmon</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_gpperfmon_send_interval" type="section"
@@ -878,7 +923,8 @@
               <xref href="guc-list.xml#track_counts" type="section">track_counts</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#update_process_title" type="section">update_process_title</xref>
+              <xref href="guc-list.xml#update_process_title" type="section"
+                >update_process_title</xref>
             </p>
           </stentry>
         </strow>
@@ -914,7 +960,6 @@
               <xref href="guc-list.xml#log_autostats" type="section">log_autostats</xref>
             </p>
           </stentry>
-          <stentry/>
         </strow>
       </simpletable>
       <note type="warning">Depending on the specific nature of your database operations, automatic
@@ -933,10 +978,12 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#check_function_bodies" type="section">check_function_bodies</xref>
+                <xref href="guc-list.xml#check_function_bodies" type="section"
+                  >check_function_bodies</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#default_tablespace" type="section">default_tablespace</xref>
+                <xref href="guc-list.xml#default_tablespace" type="section"
+                  >default_tablespace</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#default_transaction_isolation" type="section"
@@ -955,7 +1002,8 @@
                 <xref href="guc-list.xml#statement_timeout" type="section">statement_timeout</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#vacuum_freeze_min_age" type="section">vacuum_freeze_min_age</xref>
+                <xref href="guc-list.xml#vacuum_freeze_min_age" type="section"
+                  >vacuum_freeze_min_age</xref>
               </p>
             </stentry>
           </strow>
@@ -975,7 +1023,8 @@
                 <xref href="guc-list.xml#DateStyle" type="section">DateStyle</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#extra_float_digits" type="section">extra_float_digits</xref>
+                <xref href="guc-list.xml#extra_float_digits" type="section"
+                  >extra_float_digits</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#IntervalStyle" type="section">IntervalStyle</xref>
@@ -1015,15 +1064,18 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#dynamic_library_path" type="section">dynamic_library_path</xref>
+                <xref href="guc-list.xml#dynamic_library_path" type="section"
+                  >dynamic_library_path</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#explain_pretty_print" type="section">explain_pretty_print</xref>
+                <xref href="guc-list.xml#explain_pretty_print" type="section"
+                  >explain_pretty_print</xref>
               </p>
             </stentry>
             <stentry>
               <p>
-                <xref href="guc-list.xml#local_preload_libraries" type="section">local_preload_libraries</xref>
+                <xref href="guc-list.xml#local_preload_libraries" type="section"
+                  >local_preload_libraries</xref>
               </p>
             </stentry>
           </strow>
@@ -1046,7 +1098,6 @@
                 >max_locks_per_transaction</xref>
             </p>
           </stentry>
-          <stentry/>
         </strow>
       </simpletable>
     </body>
@@ -1060,7 +1111,8 @@
         <strow>
           <stentry>
             <p>
-              <xref href="guc-list.xml#gp_resqueue_priority" type="section">gp_resqueue_priority</xref>
+              <xref href="guc-list.xml#gp_resqueue_priority" type="section"
+                >gp_resqueue_priority</xref>
             </p>
             <p>
               <xref href="guc-list.xml#gp_resqueue_priority_cpucores_per_segment" type="section"
@@ -1075,7 +1127,8 @@
                 >gp_vmem_idle_resource_timeout</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#gp_vmem_protect_limit" type="section">gp_vmem_protect_limit</xref>
+              <xref href="guc-list.xml#gp_vmem_protect_limit" type="section"
+                >gp_vmem_protect_limit</xref>
             </p>
             <p>
               <xref href="guc-list.xml#gp_vmem_protect_segworker_cache_limit" type="section"
@@ -1084,7 +1137,8 @@
           </stentry>
           <stentry>
             <p>
-              <xref href="guc-list.xml#max_resource_queues" type="section">max_resource_queues</xref>
+              <xref href="guc-list.xml#max_resource_queues" type="section"
+                >max_resource_queues</xref>
             </p>
             <p>
               <xref href="guc-list.xml#max_resource_portals_per_transaction" type="section"
@@ -1095,7 +1149,8 @@
                 >resource_cleanup_gangs_on_wait</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#resource_select_only" type="section">resource_select_only</xref>
+              <xref href="guc-list.xml#resource_select_only" type="section"
+                >resource_select_only</xref>
             </p>
             <p>
               <xref href="guc-list.xml#runaway_detector_activation_percent" type="section"
@@ -1104,7 +1159,8 @@
             <p>
               <xref href="guc-list.xml#stats_queue_level" type="section">stats_queue_level</xref>
             </p>
-            <p><xref href="guc-list.xml#vmem_process_interrupt" type="section">vmem_process_interrupt</xref></p>
+            <p><xref href="guc-list.xml#vmem_process_interrupt" type="section"
+                >vmem_process_interrupt</xref></p>
           </stentry>
         </strow>
       </simpletable>
@@ -1118,15 +1174,18 @@
         <strow>
           <stentry>
             <p>
-              <xref href="guc-list.xml#gp_external_enable_exec" type="section">gp_external_enable_exec</xref>
+              <xref href="guc-list.xml#gp_external_enable_exec" type="section"
+                >gp_external_enable_exec</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#gp_external_max_segs" type="section">gp_external_max_segs</xref>
+              <xref href="guc-list.xml#gp_external_max_segs" type="section"
+                >gp_external_max_segs</xref>
             </p>
           </stentry>
           <stentry>
             <p>
-              <xref href="guc-list.xml#topic_lvm_ttc_3p" type="section">gp_initial_bad_row_limit</xref>
+              <xref href="guc-list.xml#topic_lvm_ttc_3p" type="section"
+                >gp_initial_bad_row_limit</xref>
             </p>
             <p>
               <xref href="guc-list.xml#gp_reject_percent_threshold" type="section"
@@ -1164,7 +1223,6 @@
                 >gp_enable_exchange_default_partition</xref>
             </p>
           </stentry>
-          <stentry/>
         </strow>
       </simpletable>
     </body>
@@ -1177,7 +1235,8 @@
           <strow>
             <stentry>
               <p>
-                <xref href="guc-list.xml#max_appendonly_tables" type="section">max_appendonly_tables</xref>
+                <xref href="guc-list.xml#max_appendonly_tables" type="section"
+                  >max_appendonly_tables</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_appendonly_compaction" type="section"
@@ -1188,7 +1247,6 @@
               <p><xref href="guc-list.xml#validate_previous_free_tid"/>
               </p>
             </stentry>
-            <stentry/>
           </strow>
         </simpletable>
       </body>
@@ -1212,7 +1270,6 @@
               <xref href="guc-list.xml#gp_max_databases" type="section">gp_max_databases</xref>
             </p>
           </stentry>
-          <stentry/>
         </strow>
       </simpletable>
     </body>
@@ -1235,7 +1292,8 @@
               <xref href="guc-list.xml#backslash_quote" type="section">backslash_quote</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#escape_string_warning" type="section">escape_string_warning</xref>
+              <xref href="guc-list.xml#escape_string_warning" type="section"
+                >escape_string_warning</xref>
             </p>
           </stentry>
           <stentry>
@@ -1247,7 +1305,8 @@
                 >standard_conforming_strings</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#transform_null_equals" type="section">transform_null_equals</xref>
+              <xref href="guc-list.xml#transform_null_equals" type="section"
+                >transform_null_equals</xref>
             </p>
           </stentry>
         </strow>
@@ -1290,18 +1349,20 @@
                   >gp_interconnect_snd_queue_depth</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_interconnect_type" type="section">gp_interconnect_type</xref>
+                <xref href="guc-list.xml#gp_interconnect_type" type="section"
+                  >gp_interconnect_type</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_max_packet_size" type="section">gp_max_packet_size</xref>
+                <xref href="guc-list.xml#gp_max_packet_size" type="section"
+                  >gp_max_packet_size</xref>
               </p>
             </stentry>
           </strow>
         </simpletable>
         <note>The Greenplum Database interconnect types TCP and UDP are deprecated. In the next
           major release, only the UDPIFC interconnect type will be supported by Greenplum Database.
-          The server configuration parameter <xref href="guc-list.xml#gp_interconnect_type" type="section"
-            >gp_interconnect_type</xref> controls the interconnect type.</note>
+          The server configuration parameter <xref href="guc-list.xml#gp_interconnect_type"
+            type="section">gp_interconnect_type</xref> controls the interconnect type.</note>
       </body>
     </topic>
     <topic id="topic51" xml:lang="en">
@@ -1329,7 +1390,8 @@
                   >gp_segment_connect_timeout</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_set_proc_affinity" type="section">gp_set_proc_affinity</xref>
+                <xref href="guc-list.xml#gp_set_proc_affinity" type="section"
+                  >gp_set_proc_affinity</xref>
               </p>
             </stentry>
           </strow>
@@ -1346,10 +1408,12 @@
                 <xref href="guc-list.xml#gp_set_read_only" type="section">gp_set_read_only</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_fts_probe_interval" type="section">gp_fts_probe_interval</xref>
+                <xref href="guc-list.xml#gp_fts_probe_interval" type="section"
+                  >gp_fts_probe_interval</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_fts_probe_retries" type="section">gp_fts_probe_retries</xref>
+                <xref href="guc-list.xml#gp_fts_probe_retries" type="section"
+                  >gp_fts_probe_retries</xref>
               </p>
             </stentry>
             <stentry>
@@ -1379,7 +1443,6 @@
                   >gp_max_local_distributed_cache</xref>
               </p>
             </stentry>
-            <stentry/>
           </strow>
         </simpletable>
       </body>
@@ -1415,7 +1478,8 @@
                 <xref href="guc-list.xml#gp_server_version" type="section">gp_server_version</xref>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_server_version_num" type="section">gp_server_version_num</xref>
+                <xref href="guc-list.xml#gp_server_version_num" type="section"
+                  >gp_server_version_num</xref>
               </p>
             </stentry>
           </strow>
@@ -1439,7 +1503,8 @@
                 >repl_catchup_within_range</xref>
             </p>
             <p>
-              <xref href="guc-list.xml#replication_timeout" type="section">replication_timeout</xref>
+              <xref href="guc-list.xml#replication_timeout" type="section"
+                >replication_timeout</xref>
             </p>
             <p>
               <xref href="guc-list.xml#wal_receiver_status_interval" type="section"
@@ -1458,7 +1523,6 @@
                 >filerep_mirrorvalidation_during_resync</xref>
             </p>
           </stentry>
-          <stentry/>
         </strow>
       </simpletable>
     </body>
@@ -1487,7 +1551,6 @@
               <xref href="guc-list.xml#pljava_vmoptions"/>
             </p>
           </stentry>
-          <stentry/>
         </strow>
       </simpletable>
     </body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map title="Server Configuration Parameters">
-    <!--  msk - added chunk attribute to fix error in Oxygen HTML transform -->
-    <topicref href="guc_config.xml" navtitle="Server Configuration Parameters">
+    <!--  msk - added no linking -->
+    <topicref href="guc_config.xml" navtitle="Server Configuration Parameters" linking="none">
+        <topicref href="guc_config.xml#topic_vsn_22l_z4"/>
+        <topicref href="guc_config.xml#topic_cyz_p2l_z4"/>
         <topicref href="guc_category-list.xml"/>
         <topicref href="guc-list.xml">
             <topicref href="guc-list.xml#add_missing_from"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.xml
@@ -4,19 +4,18 @@
 <topic id="topic1" xml:lang="en">
   <title id="ih135496">Server Configuration Parameters</title>
   <body>
-    <p>There are many Greenplum server configuration parameters that
-      affect the behavior of the Greenplum Database system. Many of these
-      configuration parameters have the same names, settings, and behaviors as in a regular
-      PostgreSQL database system. </p>
+    <p>There are many Greenplum server configuration parameters that affect the behavior of the
+      Greenplum Database system. Many of these configuration parameters have the same names,
+      settings, and behaviors as in a regular PostgreSQL database system. </p>
     <ul id="ul_nss_zzh_3p">
       <li><xref href="#topic_vsn_22l_z4" format="dita"/> describes the parameter data types and
         values.</li>
       <li><xref href="#topic_cyz_p2l_z4" format="dita"/> describes limitations on who can change
         them and where or when they can be set.</li>
-      <li><xref href="guc_category-list.xml#topic11">Parameter Categories</xref> organizes
+      <li><xref href="guc_category-list.xml#guc-cat-list">Parameter Categories</xref> organizes
         parameters by functionality.</li>
-      <li><xref href="guc_category-list.xml#topic3">Configuration Parameters</xref> lists the
-        parameter descriptions in alphabetic order.</li>
+      <li><xref href="guc-list.xml#topic3">Configuration Parameters</xref> lists the parameter
+        descriptions in alphabetic order.</li>
     </ul>
   </body>
   <topic id="topic_vsn_22l_z4">
@@ -44,12 +43,13 @@
     <title>Setting Parameters</title>
     <body>
       <p>Many of the configuration parameters have limitations on who can change them and where or
-        when they can be set. For example, to change certain parameters, you must be a Greenplum Database superuser. Other parameters require a restart of the system for
-        the changes to take effect. A parameter that is classified as <i>session</i> can be set at
-        the system level (in the <codeph>postgresql.conf</codeph> file), at the database-level
-        (using <codeph>ALTER DATABASE</codeph>), at the role-level (using <codeph>ALTER
-          ROLE</codeph>), or at the session-level (using <codeph>SET</codeph>). System parameters
-        can only be set in the <codeph>postgresql.conf</codeph> file.</p>
+        when they can be set. For example, to change certain parameters, you must be a Greenplum
+        Database superuser. Other parameters require a restart of the system for the changes to take
+        effect. A parameter that is classified as <i>session</i> can be set at the system level (in
+        the <codeph>postgresql.conf</codeph> file), at the database-level (using <codeph>ALTER
+          DATABASE</codeph>), at the role-level (using <codeph>ALTER ROLE</codeph>), or at the
+        session-level (using <codeph>SET</codeph>). System parameters can only be set in the
+          <codeph>postgresql.conf</codeph> file.</p>
       <p>In Greenplum Database, the master and each segment instance has its own
           <codeph>postgresql.conf</codeph> file (located in their respective data directories). Some
         parameters are considered <i>local</i> parameters, meaning that each segment instance looks
@@ -74,12 +74,12 @@
             <row>
               <entry colname="col1">master or local</entry>
               <entry colname="col2">A <i>master</i> parameter only needs to be set in the
-                  <codeph>postgresql.conf</codeph> file of the Greenplum master instance. The value for this parameter is then either passed to (or
-                ignored by) the segments at run time.<p>A local parameter must be set in the
-                    <codeph>postgresql.conf</codeph> file of the master AND each segment instance.
-                  Each segment instance looks to its own configuration to get the value for the
-                  parameter. Local parameters always requires a system restart for changes to take
-                  effect.</p></entry>
+                  <codeph>postgresql.conf</codeph> file of the Greenplum master instance. The value
+                for this parameter is then either passed to (or ignored by) the segments at run
+                  time.<p>A local parameter must be set in the <codeph>postgresql.conf</codeph> file
+                  of the master AND each segment instance. Each segment instance looks to its own
+                  configuration to get the value for the parameter. Local parameters always requires
+                  a system restart for changes to take effect.</p></entry>
             </row>
             <row>
               <entry colname="col1">session or system</entry>
@@ -96,10 +96,10 @@
             <row>
               <entry colname="col1">restart or reload</entry>
               <entry colname="col2">When changing parameter values in the postgresql.conf file(s),
-                some require a <i>restart</i> of Greenplum Database for the change to
-                take effect. Other parameter values can be refreshed by just reloading the server
-                configuration file (using <codeph>gpstop -u</codeph>), and do not require stopping
-                the system.</entry>
+                some require a <i>restart</i> of Greenplum Database for the change to take effect.
+                Other parameter values can be refreshed by just reloading the server configuration
+                file (using <codeph>gpstop -u</codeph>), and do not require stopping the
+                system.</entry>
             </row>
             <row>
               <entry colname="col1">superuser</entry>
@@ -116,6 +116,4 @@
       </table>
     </body>
   </topic>
-
-
 </topic>

--- a/gpdb-doc/dita/ref_guide/function-summary.xml
+++ b/gpdb-doc/dita/ref_guide/function-summary.xml
@@ -562,7 +562,7 @@ SELECT foo();
                 by <i>expr</i>) and assigns a bucket number to each row.</entry>
             </row>
             <row>
-              <entry colname="col1"><codeph>percent_rank(</codeph>)</entry>
+              <entry colname="col1"><codeph>percent_rank()</codeph></entry>
               <entry colname="col2">
                 <codeph>double precision</codeph>
               </entry>
@@ -588,7 +588,7 @@ SELECT foo();
                 consecutive numbers in this case.</entry>
             </row>
             <row>
-              <entry colname="col1"><codeph>row_number(</codeph>)</entry>
+              <entry colname="col1"><codeph>row_number()</codeph></entry>
               <entry colname="col2">
                 <codeph>bigint</codeph>
               </entry>
@@ -764,7 +764,7 @@ FROM employees GROUP BY department_id;</codeblock>
             </row>
             <row>
               <entry colname="col1"><codeph>PERCENTILE_DISC (<i>expr</i>) WITHIN GROUP (ORDER BY
-                    <i>expr</i> [DESC/ASC]</codeph>)</entry>
+                    <i>expr</i> [DESC/ASC])</codeph></entry>
               <entry colname="col2">
                 <codeph>timestamp, timestampz, interval, float</codeph>
               </entry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -180,9 +180,9 @@ ALTER TABLE <varname>name</varname>
                                         it takes so long. It is better to recreate the table with
                                                   <codeph><xref href="./CREATE_TABLE_AS.xml#topic1"
                                                   type="topic" format="dita"/></codeph> and order it
-                                        by the index column(s).
-                                        <note><codeph>CLUSTER ON</codeph> is not supported on
-                                        append-optimized tables.</note></li>
+                                        by the index column(s). <note><codeph>CLUSTER ON</codeph> is
+                                                not supported on append-optimized
+                                        tables.</note></li>
                                 <li id="ay137152"><b>SET WITHOUT OIDS</b> — Removes the OID system
                                         column from the table. Note that there is no variant of
                                                 <codeph>ALTER TABLE</codeph> that allows OIDs to be
@@ -573,8 +573,8 @@ ALTER TABLE <varname>name</varname>
                                                   child partitions of the partitioned table.
                                                   Otherwise, queries against the partitioned table
                                                   with the exchanged default partition that are
-                                                  executed by GPORCA might
-                                                  return incorrect results.</note></pd>
+                                                  executed by GPORCA might return incorrect
+                                                  results.</note></pd>
                                         <pd><b>WITH TABLE</b>
                                                 <varname>table_name</varname> - The name of the
                                                 table you are swapping into the partition design.

--- a/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
@@ -24,8 +24,8 @@
       <note type="important">If you intend to execute queries on partitioned tables with the Pivotal
         Query Optimizer enabled, you must collect statistics on the root partition of the
         partitioned table with the <codeph>ANALYZE ROOTPARTITION</codeph> command. For information
-        about GPORCA, see "Querying Data" in the <cite>Greenplum Database
-          Administrator Guide</cite>.</note>
+        about GPORCA, see "Querying Data" in the <cite>Greenplum Database Administrator
+        Guide</cite>.</note>
       <note>You can also use the Greenplum Database utility <codeph>analyzedb</codeph> to update
         table statistics. The <codeph>analyzedb</codeph> utility can update statistics for multiple
         tables concurrently. The utility can also check table statistics and update statistics only
@@ -37,8 +37,9 @@
       <parml>
         <plentry>
           <pt>ROOTPARTITION [ALL]</pt>
-          <pd>Collect statistics only on the root partition of partitioned tables. When you specify
-              <codeph>ROOTPARTITION</codeph>, you must specify either <codeph>ALL</codeph> or the
+          <pd>Collect statistics only on the root partition of partitioned tables based on the data
+            in the partitioned table. Statistics are not collected on the leaf child partitions, the
+            data is only sampled. When you specify <codeph>ROOTPARTITION</codeph>, you must specify either <codeph>ALL</codeph> or the
             name of a partitioned table. </pd>
           <pd>If you specify <codeph>ALL</codeph> with <codeph>ROOTPARTITION</codeph>, Greenplum
             Database collects statistics for the root partition of all partitioned tables in the
@@ -51,8 +52,9 @@
           <pd>The <codeph>ROOTPARTITION</codeph> clause is not valid with <codeph>VACUUM
               ANALYZE</codeph>. The command <codeph>VACUUM ANALYZE ROOTPARTITION</codeph> returns an
             error. </pd>
-          <pd>The cost of refreshing the root level statistics is comparable to analyzing one leaf
-            partition. </pd>
+          <pd>The time to run <codeph>ANALYZE ROOTPARTITION</codeph> is similar to the time to
+            analyze a non-partitioned table with the same data since <codeph>ANALYZE
+              ROOTPARTITION</codeph> only samples the leaf child partition data. </pd>
           <pd>For the partitioned table <i>sales_curr_yr</i>, this example command collects
             statistics only on the root partition of the partitioned table. <codeph>ANALYZE
               ROOTPARTITION sales_curr_yr; </codeph></pd>
@@ -126,14 +128,14 @@
         table partition:</p>
       <ul id="ol_x5n_2ff_ss">
         <li>If <codeph>ANALYZE [ROOTPARTITION]</codeph> is run, external table partitions are not
-          analyzed and root table statistics do not include external table partition. </li>
+          sampled and root table statistics do not include external table partition. </li>
         <li>If <codeph>ANALYZE</codeph> is run on an external table partition, the partition is not
           analyzed.</li>
         <li>If the <codeph>VERBOSE</codeph> clause is specified, an informational message is
           displayed: <codeph>skipping external table</codeph>.</li>
       </ul>
       <p>The Greenplum Database server configuration parameter <codeph><xref
-            href="../config_params/guc_category-list.xml#optimizer_analyze_root_partition"
+            href="../config_params/guc-list.xml#optimizer_analyze_root_partition"
             >optimizer_analyze_root_partition</xref></codeph> affects when statistics are collected
         on the root partition of a partitioned table. If the parameter is enabled, statistics are
         also collected on the root partition when you run <codeph>ANALYZE</codeph> (without the
@@ -175,7 +177,7 @@
         removes the empty pages and allows an <codeph>ANALYZE</codeph> operation to collect accurate
         statistics. </p>
       <p>If there are no statistics for the table, the server configuration parameter <codeph><xref
-            href="../config_params/guc_category-list.xml#gp_enable_relsize_collection"/></codeph>
+            href="../config_params/guc-list.xml#gp_enable_relsize_collection"/></codeph>
         controls whether the legacy query optimizer uses a default statistics file or estimates the
         size of a table using the <codeph>pg_relation_size</codeph> function. By default, the legacy
         optimizer uses the default statistics file to estimate the number of rows if statistics are

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
@@ -14,7 +14,8 @@
         | ('gpfdists://<varname>filehost</varname>[:<varname>port</varname>]/<varname>file_pattern[#transform]</varname>'
             [, ...])
         | ('gphdfs://<varname>hdfs_host</varname>[:port]/<varname>path</varname>/<varname>file</varname>')
-        | ('s3://<varname>S3_endpoint</varname>/<varname>bucket_name</varname>/[<varname>S3_prefix</varname>]
+        | ('s3://<varname>S3_endpoint</varname>[:<varname>port</varname>]/<varname>bucket_name</varname>/[<varname>S3_prefix</varname>]
+             [region=<varname>S3-region</varname>]
             [config=<varname>config_file</varname>]')
       FORMAT 'TEXT' 
             [( [HEADER]
@@ -94,7 +95,8 @@ CREATE WRITABLE EXTERNAL TABLE <varname>table_name</varname>
 
 CREATE WRITABLE EXTERNAL TABLE <varname>table_name</varname>
     ( <varname>column_name</varname> <varname>data_type</varname> [, ...] | LIKE <varname>other_table </varname>)
-     LOCATION('s3://<varname>S3_endpoint</varname>/<varname>bucket_name</varname>/[<varname>S3_prefix</varname>]
+     LOCATION('s3://<varname>S3_endpoint</varname>[:<varname>port</varname>]/<varname>bucket_name</varname>/[<varname>S3_prefix</varname>]
+            [region=<varname>S3-region</varname>]
             [config=<varname>config_file</varname>]')
       FORMAT 'TEXT' 
                [( [DELIMITER [AS] '<varname>delimiter</varname>']
@@ -277,33 +279,71 @@ CREATE WRITABLE EXTERNAL WEB TABLE <varname>table_name</varname>
               <codeph>TEXT</codeph> and <codeph>CSV</codeph> formats are supported. The files can be
             in gzip compressed format. The <codeph>s3</codeph> protocol recognizes the gzip format
             and uncompress the files. Only the gzip compression format is supported. </pd>
-          <pd>Before you can create external tables with the <codeph>s3</codeph> protocol, you must
-            configure Greenplum Database. For information about configuring Greenplum Database, see
-              <xref href="#topic1/section10" format="dita"/>.</pd>
+          <pd>You can specify the <codeph>s3</codeph> protocol to access data on Amazon S3 or data
+            on an Amazon S3 compatible service. Before you can create external tables with the
+              <codeph>s3</codeph> protocol, you must configure Greenplum Database. For information
+            about configuring Greenplum Database, see <xref href="#topic1/section10" format="dita"
+            />.</pd>
+          <pd>For the <codeph>s3</codeph> protocol, the <codeph>LOCATION</codeph> clause specifies
+            the S3 endpoint and bucket name where data files are uploaded for the table. For
+            writable external tables you can specify an optional S3 file prefix to use when creating
+            new files for data inserted to the table.</pd>
+          <pd>If you specify an <varname>S3_prefix</varname> for read-only s3 tables, the
+              <codeph>s3</codeph> protocol selects those all those files that have the specified S3
+            file prefix.</pd>
           <pd>
-            <p>For writable S3 tables, the <codeph>s3</codeph> protocol URL specifies the endpoint
-              and bucket name where data files are uploaded for the table, as well as an optional S3
-              file prefix to use when creating new files for data inserted to the table. If you
-              specify an <varname>S3_prefix</varname> for read-only s3 tables, the
-                <codeph>s3</codeph> protocol selects those all those files that have the specified
-              S3 file prefix.</p>
             <note conref="../../admin_guide/load/topics/g-s3-protocol.xml#amazon-emr/s3-prefix-note"
             />
           </pd>
-          <pd>The <codeph>config</codeph> parameter specifies the location of the required
-              <codeph>s3</codeph> protocol configuration file that contains AWS connection
-            credentials and communication parameters. </pd>
+          <pd>The <codeph>config</codeph> parameter in the <codeph>LOCATION</codeph> clause
+            specifies the location of the required <codeph>s3</codeph> protocol configuration file
+            that contains Amazon Web Services (AWS) connection credentials and communication
+            parameters. For information about <codeph>s3</codeph> configuration file parameters, see
+              <xref href="../../admin_guide/load/topics/g-s3-protocol.xml#amazon-emr/s3_config_file"
+            />.</pd>
           <pd>This is an example read-only external table definition with the <codeph>s3</codeph>
             protocol.<codeblock>CREATE READABLE EXTERNAL TABLE S3TBL (date text, time text, amt int)
-   location('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/
+   LOCATION('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/
       config=/home/gpadmin/aws_s3/s3.conf')
    FORMAT 'csv';</codeblock></pd>
           <pd>The S3 bucket is at the S3 endpoint <codeph>s3-us-west-2.amazonaws.com</codeph> and
             the S3 bucket name is <codeph>s3test.pivotal.io</codeph>. The S3 prefix for the files in
             the bucket is <codeph>/dataset1/normal/</codeph>. The configuration file is in
               <codeph>/home/gpadmin/s3/s3.conf</codeph> on all Greenplum Database segments.</pd>
-          <pd>See <xref href="../../admin_guide/load/topics/g-s3-protocol.xml#amazon-emr"/> for more
-            information.</pd>
+          <pd>This example read-only external table specifies the same location and specifies Amazon
+            S3 region <codeph>us-west-2</codeph> with the <codeph>region</codeph>
+            parameter.<codeblock>CREATE READABLE EXTERNAL TABLE S3TBL (date text, time text, amt int)
+   LOCATION('s3://amazonaws.com/s3test.pivotal.io/dataset1/normal/
+      region=s3-us-west-2 config=/home/gpadmin/aws_s3/s3.conf')
+   FORMAT 'csv';</codeblock></pd>
+          <pd>The <varname>port</varname> is optional in the URL of the <codeph>LOCATION</codeph>
+            clause. If the <varname>port</varname> is not specified in the URL of the
+              <codeph>LOCATION</codeph> clause, the <codeph>s3</codeph> configuration file parameter
+              <codeph>encryption</codeph> affects the port used by the <codeph>s3</codeph> protocol
+            (port 80 for HTTP or port 443 for HTTPS). If the port is specified, that port is used
+            regardless of the encryption setting. For example, if port 80 is specified in the
+              <codeph>LOCATION</codeph> clause and <codeph>encryption=true</codeph> in the
+              <codeph>s3</codeph> configuration file, HTTPS requests are sent to port 80 port
+            instead of 443 and a warning is logged. </pd>
+          <pd>To specify an Amazon S3 compatible service in the <codeph>LOCATION</codeph> clause,
+            set the <codeph>s3</codeph> configuration file parameter <codeph>version</codeph> to
+              <codeph>2</codeph> and specify the <codeph>region</codeph> parameter in the
+              <codeph>LOCATION</codeph> clause. (If <codeph>version</codeph> to <codeph>2</codeph>,
+            the <codeph>region</codeph> parameter is required in the <codeph>LOCATION</codeph>
+            clause.) When you define the service in the <codeph>LOCATION</codeph> clause, you
+            specify the service endpoint in the URL and specify the service region in the
+              <codeph>region</codeph> parameter. This is an example <codeph>LOCATION</codeph> clause
+            that contains a <codeph>region</codeph> parameter and specifies an Amazon S3 compatible
+            service.
+            <codeblock>LOCATION ('s3://test.company.com/s3test.company/dataset1/normal/ <b>region=local-test</b>
+      config=/home/gpadmin/aws_s3/s3.conf')</codeblock></pd>
+          <pd>When the <codeph>version</codeph> parameter is <codeph>2</codeph>, you can also
+            specify an Amazon S3 endpoint. This example specifies an Amazon S3
+            endpoint.<codeblock>LOCATION ('s3://s3-us-west-2.amazonaws.com/s3test.pivotal.io/dataset1/normal/ <b>region=us-west-2</b>
+      config=/home/gpadmin/aws_s3/s3.conf')</codeblock></pd>
+          <pd>For information about the <codeph>s3</codeph> protocol, see <xref
+              href="../../admin_guide/load/topics/g-s3-protocol.xml#amazon-emr">s3://
+              Protocol</xref> in the <cite>Greenplum Database Administrator Guide</cite>.</pd>
         </plentry>
         <plentry>
           <pt>EXECUTE <varname>'command'</varname> [ON ...]</pt>
@@ -560,7 +600,6 @@ customer_id=123;</codeblock>
     </section>
     <section id="section8">
       <title>Notes</title>
-      <draft-comment author="msk">remove INTO clause information</draft-comment>
       <p>When you specify the <codeph>LOG ERRORS</codeph> clause, Greenplum Database captures errors
         that occur while reading the external table data. You can view and manage the captured error
         log data. </p>
@@ -797,7 +836,8 @@ customer_id=123;</codeblock>
         Amazon Simple Storage Service (Amazon S3) bucket. The protocol creates or downloads all
         files specified by the <codeph>LOCATION</codeph> clause. Each Greenplum Database segment
         instance downloads or uploads one file at a time using several threads. See <xref
-          href="../../admin_guide/load/topics/g-s3-protocol.xml#amazon-emr"/>. </p>
+          href="../../admin_guide/load/topics/g-s3-protocol.xml#amazon-emr"/> in the <cite>Greenplum
+          Database Administrator Guide</cite>. </p>
     </section>
     <section conref="../../admin_guide/load/topics/g-s3-protocol.xml#amazon-emr/s3_prereq"/>
     <section conref="../../admin_guide/load/topics/g-s3-protocol.xml#amazon-emr/section_tsq_n3t_3x"/>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
@@ -11,7 +11,7 @@
        | <b>-r</b> <varname>param_name</varname> [<b>--masteronly</b> | <b>-l</b>
        [<b>--skipvalidation</b>] [<b>--verbose</b>] [<b>--debug</b>]
 
-<b>gpconfig</b> <b>-s</b> <varname>param_name</varname> [<b>--verbose</b>] [<b>--debug</b>]
+<b>gpconfig</b> <b>-s</b> <varname>param_name</varname> [<b>--file</b>] [<b>--verbose</b>] [<b>--debug</b>]
 
 <b>gpconfig</b> <b>--help</b></codeblock>
     </section>
@@ -19,11 +19,11 @@
       <title>Description</title>
       <p>The <codeph>gpconfig</codeph> utility allows you to set, unset, or view configuration
         parameters from the <codeph>postgresql.conf</codeph> files of all instances (master,
-        segments, and mirrors) in your Greenplum Database system. When setting a
-        parameter, you can also specify a different value for the master if necessary. For example,
-        parameters such as <codeph>max_connections</codeph> require a different setting on the
-        master than what is used for the segments. If you want to set or unset a global or master
-        only parameter, use the <codeph>--masteronly</codeph> option.</p>
+        segments, and mirrors) in your Greenplum Database system. When setting a parameter, you can
+        also specify a different value for the master if necessary. For example, parameters such as
+          <codeph>max_connections</codeph> require a different setting on the master than what is
+        used for the segments. If you want to set or unset a global or master only parameter, use
+        the <codeph>--masteronly</codeph> option.</p>
       <p><codeph>gpconfig</codeph> can only be used to manage certain parameters. For example, you
         cannot use it to set parameters such as <codeph>port</codeph>, which is required to be
         distinct for every segment instance. Use the <codeph>-l</codeph> (list) option to see a
@@ -37,16 +37,15 @@
         add it back (set a new value), there will be two instances of the parameter; one that is
         commented out, and one that is enabled and inserted at the bottom of the
           <codeph>postgresql.conf</codeph> file.</p>
-      <p>After setting a parameter, you must restart your Greenplum Database system or
-        reload the <codeph>postgresql.conf</codeph> files in order for the change to take effect.
-        Whether you require a restart or a reload depends on the parameter. </p>
-      <p>For more information about the server configuration parameters, see the
-          <i>Greenplum Database Reference Guide</i>.</p>
+      <p>After setting a parameter, you must restart your Greenplum Database system or reload the
+          <codeph>postgresql.conf</codeph> files in order for the change to take effect. Whether you
+        require a restart or a reload depends on the parameter. </p>
+      <p>For more information about the server configuration parameters, see the <i>Greenplum
+          Database Reference Guide</i>.</p>
       <p>To show the currently set values for a parameter across the system, use the
           <codeph>-s</codeph> option.</p>
       <p><codeph>gpconfig</codeph> uses the following environment variables to connect to the
-          Greenplum Database master instance and obtain system configuration
-        information: </p>
+        Greenplum Database master instance and obtain system configuration information: </p>
       <ul>
         <li id="kq141888">
           <codeph>PGHOST</codeph>
@@ -103,15 +102,28 @@
         <plentry>
           <pt>-s | --show <varname>param_name</varname></pt>
           <pd>Shows the value for a configuration parameter used on all instances (master and
-            segments) in the Greenplum Database system. If there is a discrepancy in a
-            parameter value between segment instances, the <codeph>gpconfig</codeph> utility
-            displays an error message. Note that the <codeph>gpconfig</codeph> utility reads
-            parameter values directly from the database, and not the
-              <codeph>postgresql.conf</codeph> file. If you are using <codeph>gpconfig</codeph> to
-            set configuration parameters across all segments, then running <codeph>gpconfig
-              -s</codeph> to verify the changes, you might still see the previous (old) values. You
-            must reload the configuration files (<codeph>gpstop -u</codeph>) or restart the system
-              (<codeph>gpstop -r</codeph>) for changes to take effect.</pd>
+            segments) in the Greenplum Database system. If there is a difference in a parameter
+            value among the instances, the utility displays an error message. Running
+              <codeph>gpconfig</codeph> with the <codeph>-s</codeph> option reads parameter values
+            directly from the database, and not the <codeph>postgresql.conf</codeph> file. If you
+            are using <codeph>gpconfig</codeph> to set configuration parameters across all segments,
+            then running <codeph>gpconfig -s</codeph> to verify the changes, you might still see the
+            previous (old) values. You must reload the configuration files (<codeph>gpstop
+              -u</codeph>) or restart the system (<codeph>gpstop -r</codeph>) for changes to take
+            effect.</pd>
+        </plentry>
+        <plentry>
+          <pt>--file</pt>
+          <pd>For a configuration parameter, shows the value from the
+              <codeph>postgresql.conf</codeph> file on all instances (master and segments) in the
+            Greenplum Database system. If there is a difference in a parameter value among the
+            instances, the utility displays a message. Must be specified with the
+              <codeph>-s</codeph> option.</pd>
+          <pd>For example, the configuration parameter <codeph>statement_mem</codeph> is set to 64MB
+            for a user with the <codeph>ALTER ROLE</codeph> command, and the value in the
+              <codeph>postgresql.conf</codeph> file is 128MB. Running the command <codeph>gpconfig
+              -s statement_mem --file</codeph> displays 128MB. The command <codeph>gpconfig -s
+              statement_mem</codeph> run by the user displays 64MB. </pd>
         </plentry>
         <plentry>
           <pt>--skipvalidation</pt>
@@ -139,8 +151,8 @@
     </section>
     <section id="section5">
       <title>Examples</title>
-      <p>Set the <codeph>gp_snmp_community</codeph> parameter to
-          <codeph>testenv</codeph> in the master host file
+      <p>Set the <codeph>gp_snmp_community</codeph> parameter to <codeph>testenv</codeph> in the
+        master host file
         only:<codeblock>gpconfig -c gp_snmp_community -v testenv --masteronly</codeblock></p>
       <p>Set the <codeph>max_connections</codeph> setting to 100 on all segments and 10 on the
         master:</p>
@@ -150,8 +162,8 @@
         When you specify the values for the parameters, enclose the values with double quotes
           (<codeph>"</codeph>).<codeblock>$ gpconfig -c gp_email_from -v "'gpdb-server@example.com'"
 $ gpconfig -c gp_email_to -v "'gpdb-admin@example.com'"</codeblock></p>
-      <p>In the <codeph>postgresql.conf</codeph> file, the parameters are set
-        correctly, with single quotes around the
+      <p>In the <codeph>postgresql.conf</codeph> file, the parameters are set correctly, with single
+        quotes around the
         values:<codeblock>gp_email_from='gpdb-server@example.com'
 gp_email_to='gpdb-admin@example.com'</codeblock></p>
       <p>Comment out all instances of the <codeph>default_statistics_target</codeph> configuration

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpcrondump.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpcrondump.xml
@@ -91,6 +91,15 @@
           <codeph>" ` $ \</codeph> .</p><p>When the name is specified in an input file, the name
         must <i>not</i> be enclosed in double quotes. Special characters do not require escaping.
       </p></section>
+    <section>
+      <title>Backup Filenames</title>
+      <p>The utility creates backup files with this file name format.</p>
+      <p><codeblock><varname>prefix_</varname>gp_dump_<varname>content</varname>_<varname>dbid</varname>_<varname>timestamp</varname></codeblock>The
+          <codeph>content</codeph> and <codeph>dbid</codeph> are identifiers for the Greenplum
+        Database segment instances that are assigned by Greenplum Database. For information about
+        the identifiers, see the Greenplum Database system catalog table <i>gp_id</i> in the
+          <cite>Greenplum Database Reference Guide</cite>. </p>
+    </section>
     <section id="ddboost"><b>Using Data Domain Boost</b><p>The <codeph>gpcrondump</codeph> utility
         is used to schedule Data Domain Boost (DD Boost) backup operations. The utility is also used
         to set, change, or remove one-time credentials and storage unit ID for DD Boost. The
@@ -164,8 +173,8 @@
         </p><note>The UNIX mail utility must be running on Greenplum Database host and must be
         configured to allow the Greenplum superuser (<codeph>gpadmin</codeph>) to send
       email.</note></section>
-    <section><b>Limitations</b><p>Dell EMC DD Boost is integrated with Pivotal Greenplum Database and
-        requires a DD Boost license. Open source Greenplum Database cannot use the DD Boost
+    <section><b>Limitations</b><p>Dell EMC DD Boost is integrated with Pivotal Greenplum Database
+        and requires a DD Boost license. Open source Greenplum Database cannot use the DD Boost
         software, but can back up to a Dell EMC Data Domain system mounted as an NFS share on the
         Greenplum master and segment hosts.</p><p>NetBackup is not compatible with DD Boost. Both
         NetBackup and DD Boost cannot be used in a single back up operation.</p><p>For incremental
@@ -386,7 +395,7 @@
           <pd>Specify this option to back up database statistics. The data is written to an SQL file
             and can be restored manually or with <codeph>gpdbrestore</codeph> utility. </pd>
           <pd>The statistics are written in the master data directory to
-              <codeph>db_dumps/</codeph><varname>YYYYMMDD</varname><codeph>/<varname>prefix_string_</varname>gp_statistics_1_1_</codeph><varname>timestamp</varname>. </pd>
+              <codeph>db_dumps/</codeph><varname>YYYYMMDD</varname><codeph>/<varname>prefix_string_</varname>gp_statistics_-1_1_</codeph><varname>timestamp</varname>. </pd>
           <pd>If this option is specified with options that include or exclude tables or schemas,
             the utility backs up only the statistics for the tables that are backed up.</pd>
         </plentry>
@@ -427,7 +436,7 @@
           <pd>Back up database metadata information that is not associated with any particular
             schema or table such as roles and tablespaces. Global objects are dumped in the master
             data directory to
-                <codeph>db_dumps/</codeph><varname>YYYYMMDD</varname><codeph>/<varname>prefix_string_</varname>gp_global_1_1_</codeph><varname>timestamp</varname>. </pd>
+                <codeph>db_dumps/</codeph><varname>YYYYMMDD</varname><codeph>/<varname>prefix_string_</varname>gp_global_-1_1_</codeph><varname>timestamp</varname>. </pd>
           <pd>If <codeph>--ddboost</codeph> is specified, the backup is located on the default
             storage unit in the directory specified by <codeph>--ddboost-backupdir</codeph> when the
             Data Domain Boost credentials were set.</pd>
@@ -535,7 +544,8 @@ gp_dump_20130514093000_regular_files</codeblock>
             files listed in the <codeph>_regular_files</codeph> file must also be backed up after
             the completion of the backup job.</pd>
           <pd>To use named pipes for a backup, you need to create the named pipes on all the
-            Greenplum Database and make them writable before running <codeph>gpcrondump</codeph>. </pd>
+            Greenplum Database hosts and make them writable before running
+              <codeph>gpcrondump</codeph>. </pd>
           <pd>If <codeph>--ddboost</codeph> is specified, <codeph>-K <varname>timestamp</varname>
               [--list-backup-files]</codeph> is not supported.</pd>
         </plentry>
@@ -768,8 +778,7 @@ gp_dump_20130514093000_regular_files</codeblock>
           <pt>-z (no compression)</pt>
           <pd>Do not use compression. Default is to compress the dump files using
               <codeph>gzip</codeph>.</pd>
-          <pd>Use this option (<codeph>-z</codeph>) for NFS and Data Domain
-            Boost backups.</pd>
+          <pd>Use this option (<codeph>-z</codeph>) for NFS and Data Domain Boost backups.</pd>
         </plentry>
         <plentry>
           <pt>-? (help)</pt>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpdbrestore.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpdbrestore.xml
@@ -202,7 +202,7 @@
           <pt>-G [include | only] (restore global objects) </pt>
           <pd>Restores database metadata information that is not associated with a specific schema
             or table, such as roles and tablespaces, if the global object dump file
-                <codeph>db_dumps/<varname>date</varname>/<varname>prefix_string_</varname>gp_global_1_1_<varname>timestamp</varname></codeph>
+                <codeph>db_dumps/<varname>date</varname>/<varname>prefix_string_</varname>gp_global_-1_1_<varname>timestamp</varname></codeph>
             is found in the master data directory. The global object file is created with the
               <codeph>gpcrondump</codeph> option <codeph>-G</codeph>.<ul id="ul_xx1_44g_h5">
               <li>The keyword <codeph>include</codeph> restores global objects in addition to

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpdeletesystem.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpdeletesystem.xml
@@ -40,7 +40,11 @@
             <parml>
                 <plentry>
                     <pt>-d <varname>data_directory</varname></pt>
-                    <pd>Required. The master host data directory.</pd>
+                    <pd>Specifies the master host data directory. If this option is not specified,
+                        the setting for the environment variable
+                            <codeph>MASTER_DATA_DIRECTORY</codeph> is used. If
+                            <varname>data_directory</varname> cannot be determined, the utility
+                        returns an error. </pd>
                 </plentry>
                 <plentry>
                     <pt>-B <varname>parallel_processes</varname></pt>


### PR DESCRIPTION
Port these items from 4.3.12.0  to 5.0.0
- Clarify ANALYZE ROOTPARTITION command
- Add support for HDP 2.4, 2.5
- Add s3 protocol support for S3 compatible services
- New s3 protocol configuration file parameters
- Change in backup file names to use content ID
- CLUSTER ON clause not supported for append optimized tables
- gpdeletesystem uses MASTER_DATA_DIRECTORY
- Fix typos.

[ci skip]