### PR TITLE
Include pg_upgrade in the default set for contrib/

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -19,7 +19,8 @@ WANTED_DIRS = \
 		dict_xsyn \
 		intarray \
 		pageinspect \
-		test_parser
+		test_parser \
+		pg_upgrade
 
 ifeq ($(with_openssl),yes)
 WANTED_DIRS += sslinfo


### PR DESCRIPTION
Since we're already building pg_upgrade as part of the toplevel
GNUmakefile, add to the contrib Makefile as well to allow make
-C contrib/ <target> to include pg_upgrade.