### PR TITLE
Add a basic file based progress report to pg_upgrade

### DIFF
--- a/contrib/pg_upgrade/aotable.c
+++ b/contrib/pg_upgrade/aotable.c
@@ -118,7 +118,14 @@ restore_aosegment_tables(migratorContext *ctx)
 	int			dbnum;
 
 	prep_status(ctx, "Restoring append-only auxiliary tables in new cluster");
+
+	/*
+	 * Rebuilding gp_relation_node can potentially take some time in a large
+	 * cluster so swap out the current progress file before starting so that
+	 * the user can see what's going on.
+	 */
 	report_progress(ctx, CLUSTER_NEW, FIXUP, "Rebuilding AO auxiliary tables");
+	close_progress(ctx);
 
 	for (dbnum = 0; dbnum < ctx->old.dbarr.ndbs; dbnum++)
 	{

--- a/contrib/pg_upgrade/aotable.c
+++ b/contrib/pg_upgrade/aotable.c
@@ -118,6 +118,7 @@ restore_aosegment_tables(migratorContext *ctx)
 	int			dbnum;
 
 	prep_status(ctx, "Restoring append-only auxiliary tables in new cluster");
+	report_progress(ctx, CLUSTER_NEW, FIXUP, "Rebuilding AO auxiliary tables");
 
 	for (dbnum = 0; dbnum < ctx->old.dbarr.ndbs; dbnum++)
 	{
@@ -153,6 +154,7 @@ restore_persistent_tables(migratorContext *ctx)
 	PGconn	   *conn = connectToServer(ctx, "template1", CLUSTER_NEW);
 
 	prep_status(ctx, "Rebuild gp_relation_node in new cluster");
+	report_progress(ctx, CLUSTER_NEW, FIXUP, "Rebuild gp_relation_node");
 
 	PQclear(executeQueryOrDie(ctx, conn, "checkpoint"));
 	PQclear(executeQueryOrDie(ctx, conn, "select gp_persistent_reset_all()"));

--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -95,6 +95,7 @@ check_old_cluster(migratorContext *ctx, bool live_check,
 	 * Check for various failure cases
 	 */
 
+	report_progress(ctx, CLUSTER_OLD, CHECK, "Failure checks");
 	check_proper_datallowconn(ctx, CLUSTER_OLD);
 	check_for_reg_data_type_usage(ctx, CLUSTER_OLD);
 	check_for_isn_and_int8_passing_mismatch(ctx, CLUSTER_OLD);
@@ -151,6 +152,7 @@ check_old_cluster(migratorContext *ctx, bool live_check,
 	 */
 	if (!ctx->check)
 	{
+		report_progress(ctx, CLUSTER_OLD, SCHEMA_DUMP, "Creating catalog dump");
 		generate_old_dump(ctx);
 		split_old_dump(ctx);
 	}

--- a/contrib/pg_upgrade/file.c
+++ b/contrib/pg_upgrade/file.c
@@ -38,6 +38,8 @@ const char *
 copyAndUpdateFile(migratorContext *ctx, pageCnvCtx *pageConverter,
 				  const char *src, const char *dst, bool force)
 {
+	report_progress(ctx, NONE, FILE_COPY, "Copy \"%s\" to \"%s\"", src, dst);
+
 	if (pageConverter == NULL)
 	{
 		if (pg_copy_file(src, dst, force) == -1)

--- a/contrib/pg_upgrade/info.c
+++ b/contrib/pg_upgrade/info.c
@@ -156,6 +156,8 @@ map_rel_by_id(migratorContext *ctx, Oid oldid, Oid newid,
 		snprintf(map->new_file, sizeof(map->new_file), "%s%s/%u", new_tablespace,
 				 ctx->new.tablespace_suffix, new_db->db_oid);
 	}
+
+	report_progress(ctx, NONE, FILE_MAP, "Map \"%s\" to \"%s\"", map->old_file, map->new_file);
 }
 
 

--- a/contrib/pg_upgrade/option.c
+++ b/contrib/pg_upgrade/option.c
@@ -47,6 +47,7 @@ parseCommandLine(migratorContext *ctx, int argc, char *argv[])
 		{"link", no_argument, NULL, 'k'},
 		{"logfile", required_argument, NULL, 'l'},
 		{"verbose", no_argument, NULL, 'v'},
+		{"progress", no_argument, NULL, 'X'},
 		{NULL, 0, NULL, 0}
 	};
 	int			option;			/* Command line option */
@@ -161,6 +162,11 @@ parseCommandLine(migratorContext *ctx, int argc, char *argv[])
 				ctx->verbose = true;
 				break;
 
+			case 'X':
+				pg_log(ctx, PG_REPORT, "Running in progress report mode\n");
+				ctx->progress = true;
+				break;
+
 			default:
 				pg_log(ctx, PG_FATAL,
 					   "Try \"%s --help\" for more information.\n",
@@ -227,6 +233,7 @@ Options:\n\
  -P, --new-port=new_portnum       new cluster port number (default %d)\n\
  -u, --user=username              clusters superuser (default \"%s\")\n\
  -v, --verbose                    enable verbose output\n\
+ -X, --progress                   enable progress reporting\n\
  -V, --version                    display version information, then exit\n\
  -h, --help                       show this help, then exit\n\
 \n\

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -55,6 +55,7 @@ main(int argc, char **argv)
 
 	setup(&ctx, argv[0], live_check);
 
+	report_progress(&ctx, NONE, CHECK, "Checking cluster compatability");
 	check_cluster_versions(&ctx);
 	check_cluster_compatibility(&ctx, live_check);
 
@@ -111,6 +112,9 @@ main(int argc, char **argv)
 
 	pg_log(&ctx, PG_REPORT, "\nUpgrade complete\n");
 	pg_log(&ctx, PG_REPORT, "----------------\n");
+
+	report_progress(&ctx, NONE, DONE, "Upgrade complete");
+	close_progress(&ctx);
 
 	output_completion_banner(&ctx, deletion_script_file_name);
 

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -69,7 +69,7 @@
 #define DEVTTY	"/dev/tty"
 #endif
 
-#define CLUSTERNAME(cluster)	((cluster) == CLUSTER_OLD ? "old" : "new")
+#define CLUSTERNAME(cluster)	((cluster) == NONE ? "none" : ((cluster) == CLUSTER_OLD ? "old" : "new"))
 
 #define atooid(x)  ((Oid) strtoul((x), NULL, 10))
 
@@ -270,6 +270,20 @@ typedef enum
 
 typedef long pgpid_t;
 
+/*
+ * Enumeration for operations in the progress report
+ */
+typedef enum
+{
+	CHECK,
+	SCHEMA_DUMP,
+	SCHEMA_RESTORE,
+	FILE_MAP,
+	FILE_COPY,
+	FIXUP,
+	ABORT,
+	DONE
+} progress_type;
 
 /*
  * cluster
@@ -318,6 +332,7 @@ typedef struct
 	bool		check;			/* TRUE -> ask user for permission to make
 								 * changes */
 	bool		verbose;		/* TRUE -> be verbose in messages */
+	bool		progress;		/* TRUE -> file based progress queue */
 	bool		debug;			/* TRUE -> log more information */
 	transferMode transfer_mode; /* copy files or link them? */
 } migratorContext;
@@ -489,6 +504,8 @@ void	   *pg_malloc(migratorContext *ctx, int size);
 void		pg_free(void *ptr);
 const char *getErrorText(int errNum);
 unsigned int str2uint(const char *str);
+void 		report_progress(migratorContext *ctx, Cluster cluster, progress_type op, char *fmt,...);
+void		close_progress(migratorContext *ctx);
 
 
 /* version.c */

--- a/contrib/pg_upgrade/util.c
+++ b/contrib/pg_upgrade/util.c
@@ -10,7 +10,16 @@
 #include "pg_upgrade.h"
 
 #include <signal.h>
+#include <time.h>
 
+static FILE			   *progress_file = NULL;
+static int				progress_id = 0;
+static int				progress_counter = 0;
+static unsigned long	progress_prev = 0;
+
+/* Number of operations per progress report file */
+#define OP_PER_PROGRESS	25
+#define TS_PER_PROGRESS (5 * 1000000)
 
 /*
  * report_status()
@@ -185,6 +194,8 @@ get_user_info(migratorContext *ctx, char **user_name)
 void
 exit_nicely(migratorContext *ctx, bool need_cleanup)
 {
+	close_progress(ctx);
+
 	stop_postmaster(ctx, true, true);
 
 	pg_free(ctx->logfile);
@@ -270,4 +281,112 @@ unsigned int
 str2uint(const char *str)
 {
 	return strtoul(str, NULL, 10);
+}
+
+static char *
+opname(progress_type op)
+{
+	char *ret = "unknown";
+
+	switch(op)
+	{
+		case CHECK:
+			ret = "check";
+			break;
+		case SCHEMA_DUMP:
+			ret = "dump";
+			break;
+		case SCHEMA_RESTORE:
+			ret = "restore";
+			break;
+		case FILE_MAP:
+			ret = "map";
+			break;
+		case FILE_COPY:
+			ret = "copy";
+			break;
+		case FIXUP:
+			ret = "fixup";
+			break;
+		case ABORT:
+			ret = "error";
+			break;
+		case DONE:
+			ret = "done";
+			break;
+		default:
+			break;
+	}
+
+	return ret;
+}
+
+static unsigned long
+epoch_ms(void)
+{
+	struct timeval	tv;
+
+	gettimeofday(&tv, NULL);
+
+	return (tv.tv_sec) * 1000000 + tv.tv_usec;
+}
+
+void
+report_progress(migratorContext *ctx, Cluster cluster, progress_type op, char *fmt,...)
+{
+	va_list			args;
+	char			message[MAX_STRING];
+	char			filename[MAXPGPATH];
+	unsigned long	ts;
+
+	if (!ctx->progress)
+		return;
+
+	ts = epoch_ms();
+
+	va_start(args, fmt);
+	vsnprintf(message, sizeof(message), fmt, args);
+	va_end(args);
+
+	if (!progress_file)
+	{
+		snprintf(filename, sizeof(filename), "%s/%d.inprogress",
+				 ctx->cwd, ++progress_id);
+		if ((progress_file = fopen(filename, "w")) == NULL)
+			pg_log(ctx, PG_FATAL, "Could not create progress file:  %s\n",
+				   filename);
+	}
+
+	fprintf(progress_file, "%lu;%s;%s;%s;\n",
+			epoch_ms(), CLUSTERNAME(cluster), opname(op), message);
+	progress_counter++;
+
+	/*
+	 * Swap the progress report to a new file if we have exceeded the max
+	 * number of operations per file as well as the minumum time per report. We
+	 * want to avoid too frequent reports while still providing timely feedback
+	 * to the user.
+	 */
+	if ((progress_counter > OP_PER_PROGRESS) && (ts > progress_prev + TS_PER_PROGRESS))
+		close_progress(ctx);
+}
+
+void
+close_progress(migratorContext *ctx)
+{
+	char	old[MAXPGPATH];
+	char	new[MAXPGPATH];
+
+	if (!ctx->progress || !progress_file)
+		return;
+
+	snprintf(old, sizeof(old), "%s/%d.inprogress", ctx->cwd, progress_id);
+	snprintf(new, sizeof(new), "%s/%d.done", ctx->cwd, progress_id);
+
+	fclose(progress_file);
+	progress_file = NULL;
+
+	rename(old, new);
+	progress_counter = 0;
+	progress_prev = epoch_ms();
 }

--- a/contrib/pg_upgrade/util.c
+++ b/contrib/pg_upgrade/util.c
@@ -322,7 +322,7 @@ opname(progress_type op)
 }
 
 static unsigned long
-epoch_ms(void)
+epoch_us(void)
 {
 	struct timeval	tv;
 
@@ -342,7 +342,7 @@ report_progress(migratorContext *ctx, Cluster cluster, progress_type op, char *f
 	if (!ctx->progress)
 		return;
 
-	ts = epoch_ms();
+	ts = epoch_us();
 
 	va_start(args, fmt);
 	vsnprintf(message, sizeof(message), fmt, args);
@@ -358,7 +358,7 @@ report_progress(migratorContext *ctx, Cluster cluster, progress_type op, char *f
 	}
 
 	fprintf(progress_file, "%lu;%s;%s;%s;\n",
-			epoch_ms(), CLUSTERNAME(cluster), opname(op), message);
+			epoch_us(), CLUSTERNAME(cluster), opname(op), message);
 	progress_counter++;
 
 	/*
@@ -388,5 +388,5 @@ close_progress(migratorContext *ctx)
 
 	rename(old, new);
 	progress_counter = 0;
-	progress_prev = epoch_ms();
+	progress_prev = epoch_us();
 }


### PR DESCRIPTION
In order for higher-level wrappers around pg_upgrade to know what pg_upgrade does, this adds a trivial file based queue which reports information on the operations performed. When started with `-X`, or `--progress`, pg_upgrade will write progress as a set of operations to a logfile. At intervals of either X number of operations, or Y number of seconds, the file will be released and a new created such that the released file can be consumed by a wrapper program. The files will be named `<sequence>.inprogress` until released when they are renamed to `<sequence>.done`. The sequence is gapless. Once the file is renamed to `<sequence>.done`, pg_upgrade will never touch it again and it can at that point be removed.

The interval in this PR is defined by grabbing into thin air and I expect that to be altered at some point, but let's get started with this to see what we need.

The format of the progress file is a simple semicolon delimited line-based protocol:
```
<timestamp>;<cluster>;<operation>;<message>;
```
`timestamp` is the number of microseconds since epoch; `cluster` defines either "new", "old" or "none" (for operations touching either both or no cluster); `operation` defines what actually did happen and `message` contains the user defined message per report. The timestamp is monotonically increasing for each operation such that reading files in order is less important, operations can still be individually sorted.

This commit includes a small set of progress report operations, while not likely to be the final set it's enough to  get us started and show how more can be added. Once we start using this we can decide where to take this without prematurely optimizing it.

Discussion: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/CVgK36oU5Oo