### PR TITLE
Add assert that number of sort columns is 1 always for range in window functions.

### DIFF
--- a/src/backend/executor/nodeWindow.c
+++ b/src/backend/executor/nodeWindow.c
@@ -1744,6 +1744,8 @@ hasTuplesInFrame(WindowStatePerLevel level_state,
 
 			has_entry = getCurrentValue(level_state->lead_reader, level_state, entry);
 			Assert(has_entry);
+			Assert(level_state->numSortCols <= 1);
+
 			is_less = cmp_deformed_tuple(entry->keys, entry->nulls,
 										 &trail_edge_value,
 										 &trail_edge_value_isnull,
@@ -3687,6 +3689,8 @@ forwardEdgeForRange(WindowStatePerLevel level_state,
 		if (!has_entry)
 			break;
 
+		Assert(level_state->numSortCols <= 1);
+
 		is_less = cmp_deformed_tuple(entry->keys, entry->nulls,
 									 &new_edge_value,
 									 &new_edge_value_isnull,
@@ -4080,6 +4084,7 @@ checkLastRowForEdge(WindowStatePerLevel level_state,
 						level_state->numSortCols, level_state->sortColIdx,
 						entry->keys, entry->nulls,
 						wstate);
+	Assert(level_state->numSortCols <= 1);
 
 	is_less = cmp_deformed_tuple(entry->keys, entry->nulls,
 								 &new_edge_value, &new_edge_value_isnull,
@@ -4186,6 +4191,8 @@ advanceEdgeForRange(WindowStatePerLevel level_state,
 
 			if (!has_entry)
 				break;
+
+			Assert(level_state->numSortCols <= 1);
 
 			is_less = cmp_deformed_tuple(entry->keys, entry->nulls,
 										 &new_edge_value,


### PR DESCRIPTION
Coverity complains that the function `cmp_deformed_tuple` access the datum from
expression eval as an array. But we don't have that use case due to the
following error. For e.g., the parser will complain that it can't have more than 1 columns for
sorting when we use range in window function as shown below. 

```
select depname, empno, salary, LAST_VALUE(salary)
error.
over (partition by depname order by empno, salary range
between 5000 preceding and 3900 preceding) as
highest_salary from empsalary;
ERROR:  only one ORDER BY column may be specified when RANGE is used in
a window specification
```
@hardikar @foyzur @hsyuan  Please take a look.