### PR TITLE
Make sure gptransfer with md5 validation exits at end of program.

### DIFF
--- a/gpMgmt/bin/gptransfer
+++ b/gpMgmt/bin/gptransfer
@@ -2617,7 +2617,11 @@ class GpTransfer(object):
         self._pool.addCommand(cmd)
 
         self._pool.join()
-        self._pool.check_results()
+        try:
+            self._pool.check_results()
+        except ExecutionError, e:
+            logger.fatal("Unable to create work directory: %s" % e)
+            os._exit(2)
 
         # if transferring entire system, dumpall and execute on destination
         if self._options.full:
@@ -2815,6 +2819,7 @@ class GpTransfer(object):
                 logger.warn('manually cleaned up.')
 
         logger.info("Finished.")
+        os._exit(0)
 
     def _dry_run(self):
         """


### PR DESCRIPTION
Gptransfer will hang at the end of the program if there are existing
threads when the --validate=md5 argument is passed.

Authors: Chris Hajas and Jamie McAtamney