### PR TITLE
Fix Printable Filters in Explain for Orca

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2012 EMC Corp.
+//	Copyright (C) 2017 Pivotal Software, Inc.
 //
 //	@filename:
 //		gpdbwrappers.cpp
@@ -3026,4 +3026,23 @@ gpdb::FMDCacheNeedsReset
 	return true;
 }
 
+// Create a PrintableFilterCol for expression aliases in printable predicate
+PrintableFilterCol*
+gpdb::PMakePrintableFilter
+	(
+		char *str,
+		Oid oid
+	)
+{
+	GP_WRAP_START;
+	{
+		PrintableFilterCol *partSelectKey = makeNode(PrintableFilterCol);
+		partSelectKey->columnname = str;
+		partSelectKey->type = oid;
+		return partSelectKey;
+	}
+	GP_WRAP_END;
+
+	return NULL;
+}
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -1833,8 +1833,25 @@ CTranslatorDXLToScalar::PexprFromDXLNodeScId
 	Expr *pexprResult = NULL;
 	if (NULL == pmapcidvarplstmt || NULL == pmapcidvarplstmt->PpdxltrctxOut()->Pmecolidparamid(pdxlop->Pdxlcr()->UlID()))
 	{
-		// not an outer ref -> create var node
-		pexprResult = (Expr *) pmapcidvar->PvarFromDXLNodeScId(pdxlop);
+
+		if(!pmapcidvarplstmt->FuseInnerOuter())
+		{
+			const ULONG ulColId = pdxlop->Pdxlcr()->UlID();
+			CWStringConst *aliasName = pmapcidvarplstmt->PhmColIdAliasPrintableFilter()->PtLookup(&ulColId);
+			if (aliasName)
+			{
+				char *alias = CTranslatorUtils::SzFromWsz(aliasName->Wsz());
+				IMDId *pmdid = (m_pmda->Pmdtype(pdxlop->PmdidType()))->Pmdid();
+				Oid aliasOid = CMDIdGPDB::PmdidConvert(pmdid)->OidObjectId();
+				if(alias)
+					pexprResult = (Expr *) gpdb::PMakePrintableFilter(alias, aliasOid);
+			}
+		}
+		if (pexprResult == NULL)
+		{
+			// not an outer ref -> create var node
+			pexprResult = (Expr *) pmapcidvar->PvarFromDXLNodeScId(pdxlop);
+		}
 	}
 	else
 	{

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2019,6 +2019,16 @@ _copyFlow(Flow *from)
 	return newnode;
 }
 
+static  PrintableFilterCol *
+_copyPrintableFilterCol(PrintableFilterCol *from)
+{
+	PrintableFilterCol *newnode = makeNode(PrintableFilterCol);
+
+	COPY_STRING_FIELD(columnname);
+	COPY_SCALAR_FIELD(type);
+	return newnode;
+}
+
 
 /* ****************************************************************
  *						relation.h copy functions
@@ -4723,6 +4733,9 @@ copyObject(void *from)
 			break;
 		case T_Flow:
 			retval = _copyFlow(from);
+			break;
+		case T_PrintableFilterCol:
+			retval = _copyPrintableFilterCol(from);
 			break;
 
 			/*

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4227,6 +4227,15 @@ _outAlterTSDictionaryStmt(StringInfo str, AlterTSDictionaryStmt *node)
 	WRITE_NODE_FIELD(options);
 }
 
+static void
+_outPrintableFilterCol(StringInfo str, PrintableFilterCol *node)
+{
+	WRITE_NODE_TYPE("PRINTABLEFILTERCOLUMN");
+
+	WRITE_STRING_FIELD(columnname);
+	WRITE_OID_FIELD(type);
+}
+
 #ifndef COMPILING_BINARY_FUNCS
 static void
 _outTupleDescNode(StringInfo str, TupleDescNode *node)
@@ -5130,6 +5139,9 @@ _outNode(StringInfo str, void *obj)
 				_outAlterTSDictionaryStmt(str, obj);
 				break;
 
+			case T_PrintableFilterCol:
+				_outPrintableFilterCol(str, obj);
+				break;
 			default:
 
 				/*

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -2889,6 +2889,9 @@ exprType(Node *expr)
 		case T_PartBoundOpenExpr:
 			type = BOOLOID;
 			break;
+		case T_PrintableFilterCol:
+			type = ((PrintableFilterCol *) expr)->type;
+			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(expr));
 			type = InvalidOid;	/* keep compiler quiet */

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -3760,6 +3760,7 @@ isSimpleNode(Node *node, Node *parentNode, int prettyFlags)
 		case T_CoerceToDomainValue:
 		case T_SetToDefault:
 		case T_CurrentOfExpr:
+		case T_PrintableFilterCol:
 			/* single words: always simple */
 			return true;
 
@@ -4928,6 +4929,12 @@ get_rule_expr(Node *node, deparse_context *context,
 					get_rule_expr((Node *) lfirst(l), context, showimplicit);
 					sep = ", ";
 				}
+			}
+			break;
+
+		case T_PrintableFilterCol:
+			{
+				appendStringInfoString(buf, ((PrintableFilterCol *) node)->columnname);
 			}
 			break;
 

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -624,6 +624,8 @@ namespace gpdb {
 	// table has been changed?)
 	bool FMDCacheNeedsReset(void);
 
+	PrintableFilterCol *PMakePrintableFilter(char *str, Oid oid);
+
 } //namespace gpdb
 
 #define ForEach(cell, l)	\

--- a/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
+++ b/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2011 Greenplum, Inc.
+//	Copyright (C) 2017 Pivotal Software, Inc.
 //
 //	@filename:
 //		CMappingColIdVarPlStmt.h
@@ -23,6 +23,7 @@
 
 #include "gpopt/translate/CMappingColIdVar.h"
 #include "gpopt/translate/CDXLTranslateContext.h"
+#include "gpopt/translate/CTranslatorUtils.h"
 
 //fwd decl
 struct Var;
@@ -30,7 +31,6 @@ struct Plan;
 
 namespace gpdxl
 {
-
 	// fwd decl
 	class CDXLTranslateContextBaseTable;
 	class CContextDXLToPlStmt;
@@ -61,6 +61,20 @@ namespace gpdxl
 			// with a param node
 			CContextDXLToPlStmt *m_pctxdxltoplstmt;
 
+			BOOL m_fUseInnerOuter;
+
+			// map of UlColId to RTE index for printable filters
+			HMUlUl *m_phmColIdRteIdxPrintableFilter;
+
+			// map UlColdId to Attno for printable filters
+			HMUlUl *m_phmColIdAttnoPrintableFilter;
+
+			// map UlColdId to Column Alias for printable filters
+			typedef CHashMap<ULONG, CWStringConst, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>,
+				CleanupDelete<ULONG>, CleanupDelete<CWStringConst> > HMUlStr;
+
+			HMUlStr *m_phmColIdAliasPrintableFilter;
+
 		public:
 
 			CMappingColIdVarPlStmt
@@ -71,6 +85,20 @@ namespace gpdxl
 				CDXLTranslateContext *pdxltrctxOut,
 				CContextDXLToPlStmt *pctxdxltoplstmt,
 				Plan *pplan
+				);
+
+			CMappingColIdVarPlStmt
+				(
+				IMemoryPool *pmp,
+				const CDXLTranslateContextBaseTable *pdxltrctxbt,
+				DrgPdxltrctx *pdrgpdxltrctx,
+				CDXLTranslateContext *pdxltrctxOut,
+				CContextDXLToPlStmt *pctxdxltoplstmt,
+				Plan *pplan,
+				bool fUseInnerOuter,
+				HMUlUl *phmColIdRteIdxPrintableFilter,
+				HMUlUl *phmColIdAttnoPrintableFilter,
+				HMUlStr *phmColIdAliasPrintableFilter
 				);
 
 			// translate DXL ScalarIdent node into GPDB Var node
@@ -88,6 +116,14 @@ namespace gpdxl
 
 			// return the context of the DXL->PlStmt translation
 			CContextDXLToPlStmt *Pctxdxltoplstmt();
+
+			BOOL FuseInnerOuter();
+
+			HMUlUl *PhmColIdRteIdxPrintableFilter();
+
+			HMUlUl *PhmColIdAttnoPrintableFilter();
+
+			HMUlStr *PhmColIdAliasPrintableFilter();
 	};
 }
 

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2010 Greenplum, Inc.
+//	Copyright (C) 2017 Pivotal Software, Inc.
 //
 //	@filename:
 //		CTranslatorDXLToPlStmt.h
@@ -140,6 +140,18 @@ namespace gpdxl
 			
 			CTranslatorDXLToScalar *m_pdxlsctranslator;
 
+			// map of UlColId to RTE index for printable filters
+			HMUlUl *m_phmColIdRteIdxPrintableFilter;
+
+			// map UlColdId to Attno for printable filters
+			HMUlUl *m_phmColIdAttnoPrintableFilter;
+
+			// map UlColdId to Column Alias for printable filters
+			typedef CHashMap<ULONG, CWStringConst, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>,
+					CleanupDelete<ULONG>, CleanupDelete<CWStringConst> > HMUlStr;
+
+			HMUlStr *m_phmColIdAliasPrintableFilter;
+
 			// command type
 			CmdType m_cmdtype;
 			
@@ -270,6 +282,15 @@ namespace gpdxl
 			// translate the join types from its DXL representation to the GPDB one
 			static JoinType JtFromEdxljt(EdxlJoinType edxljt);
 
+			// get hash map
+			HMUlUl *PhmColIdRteIdxPrintableFilter();
+
+			// get hash map
+			HMUlUl *PhmColIdAttnoPrintableFilter();
+
+			// get hash map
+			HMUlStr *PhmColIdAliasPrintableFilter();
+
 		private:
 
 			// initialize index of operator translators
@@ -283,6 +304,9 @@ namespace gpdxl
 
 			// Set InitPlanVariable in PlannedStmt
 			void SetInitPlanVariables(PlannedStmt *);
+
+			// insert mappings for printable filters for partition selectors
+			void InsertMappingsForPrintableFilter(const CDXLTableDescr *pdxltabdesc);
 
 			// Returns the id of the plan;
 			INT IPlanId(Plan* pplparent);

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -221,6 +221,7 @@ typedef enum NodeTag
 	T_PartBoundInclusionExpr,
 	T_PartBoundOpenExpr,
 	T_TableOidInfo,
+	T_PrintableFilterCol,
 
 	/*
 	 * TAGS FOR EXPRESSION STATE NODES (execnodes.h)

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -151,6 +151,16 @@ typedef struct Var
 } Var;
 
 /*
+ * Printable Filter Column Aliases
+ */
+typedef struct PrintableFilterCol
+{
+	Expr		xpr;
+	char		*columnname;
+	Oid			type;
+} PrintableFilterCol;
+
+/*
  * Const
  */
 typedef struct Const

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -135,3 +135,24 @@ WHERE et like '%Hash Cond:%';
    Hash Cond: "*VALUES*".column1 = "*VALUES*".column1
 (1 row)
 
+--
+-- Test Printable Filter
+--
+create table partition_table(a int, pk int) distributed by (a) partition by range(pk) (start (1) end (4) every (2));
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_1" for table "partition_table"
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_2" for table "partition_table"
+create table another_partition_table(x int, another_pk int) distributed by (x) partition by range(another_pk) (start (1) end (4) every (2));
+NOTICE:  CREATE TABLE will create partition "another_partition_table_1_prt_1" for table "another_partition_table"
+NOTICE:  CREATE TABLE will create partition "another_partition_table_1_prt_2" for table "another_partition_table"
+create table bar (c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT * from
+  get_explain_output($$
+select * from partition_table join bar on a = c and d = pk join another_partition_table on x = a and d = another_pk;
+  $$) as et
+  WHERE et like '%Filter: partition_table.pk = another_partition_table.another_pk%';
+ et
+----
+(0 rows)
+

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -145,3 +145,25 @@ WHERE et like '%Hash Cond:%';
    Hash Cond: column1 = column1
 (1 row)
 
+--
+-- Test Printable Filter
+--
+create table partition_table(a int, pk int) distributed by (a) partition by range(pk) (start (1) end (4) every (2));
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_1" for table "partition_table"
+NOTICE:  CREATE TABLE will create partition "partition_table_1_prt_2" for table "partition_table"
+create table another_partition_table(x int, another_pk int) distributed by (x) partition by range(another_pk) (start (1) end (4) every (2));
+NOTICE:  CREATE TABLE will create partition "another_partition_table_1_prt_1" for table "another_partition_table"
+NOTICE:  CREATE TABLE will create partition "another_partition_table_1_prt_2" for table "another_partition_table"
+create table bar (c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT * from
+  get_explain_output($$
+select * from partition_table join bar on a = c and d = pk join another_partition_table on x = a and d = another_pk;
+  $$) as et
+  WHERE et like '%Filter: partition_table.pk = another_partition_table.another_pk%';
+                                         et
+-------------------------------------------------------------------------------------
+                     Filter: partition_table.pk = another_partition_table.another_pk
+(1 row)
+

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -105,3 +105,16 @@ SELECT * from
 get_explain_output($$
 	select * from (values (1)) as f(a) join (values(2)) b(b) on a = b$$) as et
 WHERE et like '%Hash Cond:%';
+
+--
+-- Test Printable Filter
+--
+create table partition_table(a int, pk int) distributed by (a) partition by range(pk) (start (1) end (4) every (2));
+create table another_partition_table(x int, another_pk int) distributed by (x) partition by range(another_pk) (start (1) end (4) every (2));
+create table bar (c int, d int);
+
+SELECT * from
+  get_explain_output($$
+select * from partition_table join bar on a = c and d = pk join another_partition_table on x = a and d = another_pk;
+  $$) as et
+  WHERE et like '%Filter: partition_table.pk = another_partition_table.another_pk%';


### PR DESCRIPTION
For printable filters, the INNER/OUTER references in varno are not
relevant. We need true varnos for them.  

We  added two new hashmaps in CTranslatorDXLToPlStmt which contain following mappings:
	ColId -> RTE index   and
	ColId -> Attno

Varnos and varattnos will be set by performing lookup on these hashmaps instead of performing a lookup on left/right child context.

Please refer https://github.com/greenplum-db/gpdb/pull/2003 for detailed discussion about this.

Signed-off-by: Omer Arap <oarap@pivotal.io>