### PR TITLE
Print diff output when behave backup and transfer tests fail

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/backup.feature
+++ b/gpMgmt/test/behave/mgmt_utils/backup.feature
@@ -2129,7 +2129,7 @@ Feature: Validate command line arguments
         When the user runs "gpdbrestore -a -t 30160101010101 -u /tmp"
         Then gpdbrestore should return a return code of 0
         And the user runs "psql -f test/behave/mgmt_utils/steps/data/check_metadata.sql bkdb > /tmp/check_metadata.out"
-        And verify that the contents of the files "/tmp/check_metadata.out" and "test/behave/mgmt_utils/steps/data/check_metadata.ans" are identical
+        And verify that the contents of the files "/tmp/check_metadata.ans" and "test/behave/mgmt_utils/steps/data/check_metadata.out" are identical
         And the directory "/tmp/db_dumps" is removed or does not exist
         And the directory "/tmp/check_metadata.out" is removed or does not exist
 
@@ -3126,7 +3126,7 @@ Feature: Validate command line arguments
         And the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.ans"
         And the user runs gpdbrestore with the stored timestamp
         And the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.out"
-        And verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
+        And verify that the contents of the files "/tmp/special_table_data.ans" and "/tmp/special_table_data.out" are identical
 
         # -s option
         When the user runs command "gpcrondump -a -x " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " -s " S\`~@#\$%^&*()-+[{]}|\\;: \\'\"/?><1 ""
@@ -3135,7 +3135,7 @@ Feature: Validate command line arguments
         And the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.ans"
         And the user runs gpdbrestore with the stored timestamp
         And the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.out"
-        And verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
+        And verify that the contents of the files "/tmp/special_table_data.ans" and "/tmp/special_table_data.out" are identical
 
         # --exclude-schema-file option
         When the user runs command "gpcrondump -a -x " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " --exclude-schema-file test/behave/mgmt_utils/steps/data/special_chars/schema-file.txt"
@@ -3252,7 +3252,7 @@ Feature: Validate command line arguments
         When the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.ans"
         And the user runs gpdbrestore with the stored timestamp
         And the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.out"
-        Then verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
+        Then verify that the contents of the files "/tmp/special_table_data.ans" and "/tmp/special_table_data.out" are identical
 
         # cleanup
         And the user runs "psql -f test/behave/mgmt_utils/steps/data/special_chars/drop_special_database.sql template1"
@@ -3272,7 +3272,7 @@ Feature: Validate command line arguments
         When the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.ans"
         When the user runs gpdbrestore with the stored timestamp and options "--redirect " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;2 "" without -e option
         And the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;2 " > /tmp/special_table_data.out"
-        Then verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
+        Then verify that the contents of the files "/tmp/special_table_data.ans" and "/tmp/special_table_data.out" are identical
 
         # cleanup
         And the directory "/tmp/special_table_data.out" is removed or does not exist
@@ -3298,13 +3298,13 @@ Feature: Validate command line arguments
         When the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.ans"
         When the user runs gpdbrestore with the stored timestamp and options "-S " S\`~@#\$%^&*()-+[{]}|\\;: \\'\"/?><1 ""
         And the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.out"
-        Then verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
+        Then verify that the contents of the files "/tmp/special_table_data.ans" and "/tmp/special_table_data.out" are identical
 
         # -S with truncate option
         When the user runs "gpdbrestore -S " S\`~@#\$%^&*()-+[{]}|\\;: \\'\"/?><1 " -a --truncate" with the stored timestamp
         Then gpdbrestore should return a return code of 0
         And the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_table_data.out"
-        Then verify that the contents of the files "/tmp/special_table_data.out" and "/tmp/special_table_data.ans" are identical
+        Then verify that the contents of the files "/tmp/special_table_data.ans" and "/tmp/special_table_data.out" are identical
 
         # cleanup
         And the directory "/tmp/special_table_data.out" is removed or does not exist
@@ -3328,7 +3328,7 @@ Feature: Validate command line arguments
         And the user runs "psql -f test/behave/mgmt_utils/steps/data/special_chars/truncate_special_ao_table.sql template1"
         And the user runs gpdbrestore with the stored timestamp and options "--noplan" without -e option
         And the user runs command "psql -f test/behave/mgmt_utils/steps/data/special_chars/select_from_special_ao_table.sql " DB\`~@#\$%^&*()_-+[{]}|\\;: \\'/?><;1 " > /tmp/special_ao_table_data.out"
-        Then verify that the contents of the files "/tmp/special_ao_table_data.out" and "/tmp/special_ao_table_data.ans" are identical
+        Then verify that the contents of the files "/tmp/special_ao_table_data.ans" and "/tmp/special_ao_table_data.out" are identical
 
         # cleanup
         And the directory "/tmp/special_ao_table_data.out" is removed or does not exist

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -8,6 +8,7 @@ import stat
 import time
 import glob
 import shutil
+import difflib
 
 import yaml
 
@@ -295,9 +296,13 @@ def get_table_data_to_file(filename, tablename, dbname):
         print "Exception: %s" % str(e)
     conn.close()
 
-def diff_backup_restore_data(context, backup_file, restore_file):
-    if not filecmp.cmp(backup_file, restore_file):
-        raise Exception('%s and %s do not match' % (backup_file, restore_file))
+def diff_files(expected_file, result_file):
+    with open (expected_file,'r') as expected_f:
+        with open(result_file, 'r') as result_f:
+            diff_contents = difflib.unified_diff(expected_f.readlines(), result_f.readlines())
+    diff_contents = ''.join(diff_contents)
+    if diff_contents:
+        raise Exception('Expected file %s does not match result file %s. Diff Contents: %s\r' % (expected_file, result_file, diff_contents))
 
 def validate_restore_data(context, new_table, dbname, backedup_table=None, backedup_dbname=None):
     if new_table == "public.gpcrondump_history":
@@ -322,7 +327,7 @@ def validate_restore_data(context, new_table, dbname, backedup_table=None, backe
     restore_filename = dbname + '_' + new_table.strip()
     restore_path = os.path.join(current_dir, './test/data', restore_filename + "_restore")
 
-    diff_backup_restore_data(context, backup_path, restore_path)
+    diff_files(backup_path, restore_path)
 
 def validate_restore_data_in_file(context, tablename, dbname, file_name, backedup_table=None):
     filename = file_name + "_restore"
@@ -333,7 +338,7 @@ def validate_restore_data_in_file(context, tablename, dbname, file_name, backedu
     else:
         backup_file = os.path.join(current_dir, './test/data', file_name + "_backup")
     restore_file = os.path.join(current_dir, './test/data', file_name + "_restore")
-    diff_backup_restore_data(context, backup_file, restore_file)
+    diff_files(backup_file, restore_file)
 
 def validate_db_data(context, dbname, expected_table_count, backedup_dbname=None):
     tbls = get_table_names(dbname)
@@ -854,7 +859,7 @@ def validate_distribution_policy(context, dbname):
     current_dir = os.getcwd()
     backup_file = os.path.join(current_dir, './test/data', dbname.strip() + "_dist_policy_backup")
     restore_file = os.path.join(current_dir, './test/data', dbname.strip() + "_dist_policy_restore")
-    diff_backup_restore_data(context, backup_file, restore_file)
+    diff_files(backup_file, restore_file)
 
 def check_row_count(tablename, dbname, nrows):
     NUM_ROWS_QUERY = 'select count(*) from %s' % tablename

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/incremental/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/incremental/__init__.py
@@ -608,9 +608,15 @@ class BackupTestCase(TINCTestCase):
             dump_dirty_list = self.sort_file_contents(os.path.join(dump_dir, 'db_dumps', '%s' % self.backup_timestamp[0:8] ,'%sgp_dump_%s_dirty_list' % (prefix, self.backup_timestamp)))
             tinctest.logger.info("output dump_dirty_list_file: %s" % (os.path.join(dump_dir, 'db_dumps', '%s' % self.backup_timestamp[0:8] ,'%sgp_dump_%s_dirty_list' % (prefix, self.backup_timestamp))))
         if dirty_list != dump_dirty_list :
+            ans_set = set(dirty_list)
+            out_set = set(dump_dirty_list)
+            if ans_set > out_set:
+                msg = "The following tables are present in the answer file but not the output: " + ','.join(ans_set - out_set)
+            else:
+                msg = "The following tables are present in the output but not the answer file: " + ','.join(out_set - ans_set)
             tinctest.logger.info("dirty_list:\n%s" % dirty_list)
             tinctest.logger.info("dump_dirty_list:\n%s" % dump_dirty_list)
-            raise Exception("Incremental backup validation failed with diff")
+            raise Exception("Incremental backup validation failed with diff: %s" % msg)
         else:
             tinctest.logger.info("The tablelist for the incremental backup is validated")
 


### PR DESCRIPTION
Instead of simply printing which files are different, print the contents
of the diff files.