### PR TITLE
Remove -m from gpstart on gpstop test.

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpstop/test_gpstop.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/walrepl/gpstop/test_gpstop.py
@@ -60,7 +60,7 @@ class GpstopTestCase(MPPTestCase):
 
    def test_gpstop_master_only(self):
        self.assertTrue(self.gputil.gpstop_and_verify(option = '-m'))
-       self.gputil.run('gpstart -a -m')
+       self.gputil.run('gpstart -a')
 
    def test_gpstop_fast(self):
        #run transactions, and stop fast, check if transaction aborted, and the cluster was stopped


### PR DESCRIPTION
Previously, -a -m from gpstart still resulted into a prompt due to a
bug.
This actually made it such that the changed line did not run
properly -- probably hung on the prompt, since we don't validate if
gpstart actually runs properly.
6edeefec0f8a3f9c88691d7a41712e161bfe5ad4 fixed the gpstart prompt issue and
caused this issue (actually running with master only) to finally show
up, which made the later tests to fail for unabling queries to the
database.. Ensure that we start fresh by doing
a gpstart -a instead of just doing master only.