### PR TITLE
Remap transient typmods on QD instead of on QEs.

### DIFF
--- a/src/backend/access/common/tupdesc.c
+++ b/src/backend/access/common/tupdesc.c
@@ -87,7 +87,6 @@ CreateTemplateTupleDesc(int natts, bool hasoid)
 	desc->constr = NULL;
 	desc->tdtypeid = RECORDOID;
 	desc->tdtypmod = -1;
-	desc->tdqdtypmod = -1;
 	desc->tdhasoid = hasoid;
 	desc->tdrefcount = -1;		/* assume not reference-counted */
 
@@ -121,7 +120,6 @@ CreateTupleDesc(int natts, bool hasoid, Form_pg_attribute *attrs)
 	desc->constr = NULL;
 	desc->tdtypeid = RECORDOID;
 	desc->tdtypmod = -1;
-	desc->tdqdtypmod = -1;
 	desc->tdhasoid = hasoid;
 	desc->tdrefcount = -1;		/* assume not reference-counted */
 
@@ -152,7 +150,6 @@ CreateTupleDescCopy(TupleDesc tupdesc)
 
 	desc->tdtypeid = tupdesc->tdtypeid;
 	desc->tdtypmod = tupdesc->tdtypmod;
-	desc->tdqdtypmod = tupdesc->tdqdtypmod;
 
 	return desc;
 }
@@ -211,7 +208,6 @@ CreateTupleDescCopyConstr(TupleDesc tupdesc)
 
 	desc->tdtypeid = tupdesc->tdtypeid;
 	desc->tdtypmod = tupdesc->tdtypmod;
-	desc->tdqdtypmod = tupdesc->tdqdtypmod;
 
 	return desc;
 }

--- a/src/backend/cdb/cdbdirectopen.c
+++ b/src/backend/cdb/cdbdirectopen.c
@@ -425,7 +425,6 @@ Relation DirectOpen_Open(
 		direct->descData.constr = &direct->constrData;
 		direct->descData.tdtypeid = pgClass->reltype;
 		direct->descData.tdtypmod = -1;
-		direct->descData.tdqdtypmod = -1;
 		direct->descData.tdhasoid = relHasOid;
 		direct->descData.tdrefcount = 1;
 

--- a/src/backend/cdb/motion/Makefile
+++ b/src/backend/cdb/motion/Makefile
@@ -13,6 +13,6 @@ include $(top_builddir)/src/Makefile.global
 override CPPFLAGS := -I$(top_srcdir)/src/backend/gp_libpq_fe $(CPPFLAGS)
 
 OBJS = cdbmotion.o tupchunklist.o tupser.o  \
-	ic_common.o ic_udpifc.o htupfifo.o
+	ic_common.o ic_udpifc.o htupfifo.o tupleremap.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -706,6 +706,8 @@ createChunkTransportState(ChunkTransportState *transportStates,
         conn->stillActive = false;
         conn->stopRequested = false;
         conn->cdbProc = NULL;
+        conn->sent_record_typmod = 0;
+        conn->remapper = NULL;
     }
 
 	return pEntry;

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3099,6 +3099,7 @@ SetupUDPIFCInterconnect_Internal(EState *estate)
 
 				conn->conn_info.seq = 1;
 				conn->stillActive = true;
+				conn->remapper = CreateTupleRemapper();
 
 				incoming_count++;
 
@@ -3487,6 +3488,10 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 					/* free up the packet queue */
 					pfree(conn->pkt_q);
 					conn->pkt_q = NULL;
+
+					/* free up the tuple remapper */
+					if (conn->remapper)
+						DestroyTupleRemapper(conn->remapper);
 				}
 				pfree(pEntry->conns);
 				pEntry->conns = NULL;

--- a/src/backend/cdb/motion/tupleremap.c
+++ b/src/backend/cdb/motion/tupleremap.c
@@ -1,0 +1,714 @@
+/*-------------------------------------------------------------------------
+ *
+ * tupleremap.c
+ *
+ * Derived from executor/tqueue.c in upstream PostgreSQL.
+ *
+ * Reused the remap logic on the motion receiver for record type remap,
+ * with some changes:
+ *
+ * - TupleQueueReader is renamed to TupleRemapper;
+ * - {Create,Destroy}TupleQueueReader() are renamed to
+ *   {Create,Destroy}TupleRemapper;
+ * - all TQ prefixes are renamed to TR;
+ * - typmodmap use array instead of hash table for faster lookup;
+ * - put range support in conditional compilation, only enabled if
+ *   TYPTYPE_RANGE is defined;
+ *
+ * Portions Copyright (c) 1996-2016, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  src/backend/cdb/motion/tupleremap.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "catalog/pg_type.h"
+#include "cdb/tupleremap.h"
+#include "funcapi.h"
+#include "lib/stringinfo.h"
+#include "miscadmin.h"
+#include "utils/array.h"
+#include "utils/lsyscache.h"
+#include "utils/memutils.h"
+#include "utils/syscache.h"
+#include "utils/typcache.h"
+
+
+/*
+ * When a tuple is received on the motion receiver, the typmod of RECORDOID
+ * represents the index of cache on the sender, which is meaningless on the
+ * receiver. So we build a typmod map of RECORDOID type on the motion receiver,
+ * and translate the typmod of tuple from remote to local.
+ *
+ * Motion receiver build a tree of TupleRemapInfo nodes to help them identify
+ * which (sub) fields of transmitted tuples are composite and may thus need
+ * remap processing.  We might need to look within arrays and ranges, not only
+ * composites, to find composite sub-fields.  A NULL TupleRemapInfo pointer
+ * indicates that it is known that the described field is not composite and
+ * has no composite substructure.
+ *
+ * Note that we currently have to look at each composite field at runtime,
+ * even if we believe it's of a named composite type (i.e., not RECORD).
+ * This is because we allow the actual value to be a compatible transient
+ * RECORD type.  That's grossly inefficient, and it would be good to get
+ * rid of the requirement, but it's not clear what would need to change.
+ *
+ * Also, we allow the top-level tuple structure, as well as the actual
+ * structure of composite subfields, to change from one tuple to the next
+ * at runtime.  This may well be entirely historical, but it's mostly free
+ * to support given the previous requirement; and other places in the system
+ * also permit this, so it's not entirely clear if we could drop it.
+ */
+
+typedef enum
+{
+	TUPLE_REMAP_ARRAY,			/* array */
+	TUPLE_REMAP_RANGE,			/* range */
+	TUPLE_REMAP_RECORD			/* composite type, named or transient */
+} TupleRemapClass;
+
+typedef struct TupleRemapInfo TupleRemapInfo;
+
+typedef struct ArrayRemapInfo
+{
+	int16		typlen;			/* array element type's storage properties */
+	bool		typbyval;
+	char		typalign;
+	TupleRemapInfo *element_remap;		/* array element type's remap info */
+} ArrayRemapInfo;
+
+typedef struct RangeRemapInfo
+{
+	TypeCacheEntry *typcache;	/* range type's typcache entry */
+	TupleRemapInfo *bound_remap;	/* range bound type's remap info */
+} RangeRemapInfo;
+
+typedef struct RecordRemapInfo
+{
+	/* Original (remote) type ID info last seen for this composite field */
+	Oid			rectypid;
+	int32		rectypmod;
+	/* Local RECORD typmod, or -1 if unset; not used on sender side */
+	int32		localtypmod;
+	/* If no fields of the record require remapping, these are NULL: */
+	TupleDesc	tupledesc;		/* copy of record's tupdesc */
+	TupleRemapInfo **field_remap;		/* each field's remap info */
+} RecordRemapInfo;
+
+struct TupleRemapInfo
+{
+	TupleRemapClass remapclass;
+	union
+	{
+		ArrayRemapInfo arr;
+		RangeRemapInfo rng;
+		RecordRemapInfo rec;
+	} u;
+};
+
+/*
+ * TupleRemapper object's private contents
+ *
+ * tupledesc is a pointer to data supplied by remapper's caller.
+ * The typmodmap and remap info are owned by the TupleRemapper and
+ * are kept in mycontext.
+ *
+ * "typedef struct TupleRemapper TupleRemapper" is in tupleremap.h
+ */
+struct TupleRemapper
+{
+	MemoryContext mycontext;	/* context containing TupleRemapper */
+	int32	   *typmodmap;		/* typmod map from remote to local */
+	int			typmodmapsize;	/* size of typmodmap */
+	TupleDesc	tupledesc;		/* current top-level tuple descriptor */
+	TupleRemapInfo **field_remapinfo;	/* current top-level remap info */
+	bool		remap_needed;	/* is remap needed */
+};
+
+static HeapTuple TRRemapTuple(TupleRemapper *remapper,
+			 TupleDesc tupledesc,
+			 TupleRemapInfo **field_remapinfo,
+			 HeapTuple tuple);
+static Datum TRRemap(TupleRemapper *remapper, TupleRemapInfo *remapinfo,
+		Datum value, bool *changed);
+static Datum TRRemapArray(TupleRemapper *remapper, ArrayRemapInfo *remapinfo,
+			 Datum value, bool *changed);
+#ifdef TYPTYPE_RANGE
+/* GPDB_92_MERGE_FIXME remove these ifdef when range type is supported */
+static Datum TRRemapRange(TupleRemapper *remapper, RangeRemapInfo *remapinfo,
+			 Datum value, bool *changed);
+#endif
+static Datum TRRemapRecord(TupleRemapper *remapper, RecordRemapInfo *remapinfo,
+			  Datum value, bool *changed);
+static TupleRemapInfo *BuildTupleRemapInfo(Oid typid, MemoryContext mycontext);
+static TupleRemapInfo *BuildArrayRemapInfo(Oid elemtypid,
+					MemoryContext mycontext);
+#ifdef TYPTYPE_RANGE
+static TupleRemapInfo *BuildRangeRemapInfo(Oid rngtypid,
+					MemoryContext mycontext);
+#endif
+static TupleRemapInfo **BuildFieldRemapInfo(TupleDesc tupledesc,
+					MemoryContext mycontext);
+
+
+/*
+ * Create a tuple remapper.
+ */
+TupleRemapper *
+CreateTupleRemapper(void)
+{
+	TupleRemapper *remapper = palloc0(sizeof(TupleRemapper));
+
+	remapper->mycontext = CurrentMemoryContext;
+	remapper->typmodmap = NULL;
+	remapper->typmodmapsize = 0;
+	remapper->tupledesc = NULL;
+	remapper->field_remapinfo = NULL;
+	remapper->remap_needed = false;
+
+	return remapper;
+}
+
+/*
+ * Destroy a tuple remapper.
+ */
+void
+DestroyTupleRemapper(TupleRemapper *remapper)
+{
+	if (remapper->typmodmap != NULL)
+		pfree(remapper->typmodmap);
+	/* Is it worth trying to free substructure of the remap tree? */
+	if (remapper->field_remapinfo != NULL)
+		pfree(remapper->field_remapinfo);
+	pfree(remapper);
+}
+
+/*
+ * Remap a tuple if needed
+ *
+ * Form a new tuple with all the remote typmods remapped to local typmods.
+ */
+HeapTuple
+TRCheckAndRemap(TupleRemapper *remapper, TupleDesc tupledesc, HeapTuple tuple)
+{
+	if (!remapper->remap_needed)
+		return tuple;
+
+	if (!remapper->field_remapinfo)
+	{
+		Assert(remapper->tupledesc == NULL);
+		remapper->tupledesc = tupledesc;
+		remapper->field_remapinfo = BuildFieldRemapInfo(tupledesc,
+														remapper->mycontext);
+	}
+
+	return TRRemapTuple(remapper, tupledesc, remapper->field_remapinfo, tuple);
+}
+
+/*
+ * Handle the record type cache from motion sender.
+ *
+ * Add the record types to local cache, and build a map from remote to local.
+ */
+void
+TRHandleTypeLists(TupleRemapper *remapper, List *typelist)
+{
+	int j;
+	ListCell *cell;
+	int mapsize = remapper->typmodmapsize + list_length(typelist);
+
+	if (remapper->typmodmap)
+		remapper->typmodmap = repalloc(remapper->typmodmap, mapsize * sizeof(int32));
+	else
+		remapper->typmodmap = palloc(mapsize * sizeof(int32));
+
+	for (j = 0; j < list_length(typelist); j++)
+		remapper->typmodmap[remapper->typmodmapsize + j] = -1;
+
+	remapper->typmodmapsize = mapsize;
+
+	foreach(cell, typelist)
+	{
+		int32 local_typmod;
+		TupleDescNode * descnode = (TupleDescNode *) lfirst(cell);
+		int32 remote_typmod = descnode->tuple->tdtypmod;
+
+		/* assign_record_type_typmod() will update tdtypmod to the local typmod */
+		assign_record_type_typmod(descnode->tuple);
+
+		local_typmod = descnode->tuple->tdtypmod;
+
+		Assert(remote_typmod >= 0);
+		Assert(local_typmod >= 0);
+		Assert(remote_typmod < remapper->typmodmapsize);
+
+		remapper->typmodmap[remote_typmod] = local_typmod;
+
+		if (!remapper->remap_needed && local_typmod != remote_typmod)
+			remapper->remap_needed = true;
+	}
+}
+
+/*
+ * Copy the given tuple, remapping any transient typmods contained in it.
+ */
+static HeapTuple
+TRRemapTuple(TupleRemapper *remapper,
+			 TupleDesc tupledesc,
+			 TupleRemapInfo **field_remapinfo,
+			 HeapTuple tuple)
+{
+	Datum	   *values;
+	bool	   *isnull;
+	bool		changed = false;
+	int			i;
+
+	/*
+	 * If no remapping is necessary, just copy the tuple into a single
+	 * palloc'd chunk, as caller will expect.
+	 */
+	if (field_remapinfo == NULL)
+		return tuple;
+
+	/* Deform tuple so we can remap record typmods for individual attrs. */
+	values = (Datum *) palloc(tupledesc->natts * sizeof(Datum));
+	isnull = (bool *) palloc(tupledesc->natts * sizeof(bool));
+
+	/* CDB */
+	if (is_heaptuple_memtuple(tuple))
+	{
+		MemTupleBinding *pbind = create_memtuple_binding(tupledesc);
+		memtuple_deform((MemTuple) tuple, pbind, values, isnull);
+	}
+	else
+	{
+		heap_deform_tuple(tuple, tupledesc, values, isnull);
+	}
+
+	/* Recursively process each interesting non-NULL attribute. */
+	for (i = 0; i < tupledesc->natts; i++)
+	{
+		if (isnull[i] || field_remapinfo[i] == NULL)
+			continue;
+		values[i] = TRRemap(remapper, field_remapinfo[i], values[i], &changed);
+	}
+
+	/* Reconstruct the modified tuple, if anything was modified. */
+	if (changed)
+		return heap_form_tuple(tupledesc, values, isnull);
+	else
+		return tuple;
+}
+
+/*
+ * Process the given datum and replace any transient record typmods
+ * contained in it.  Set *changed to TRUE if we actually changed the datum.
+ *
+ * remapinfo is previously-computed remapping info about the datum's type.
+ *
+ * This function just dispatches based on the remap class.
+ */
+static Datum
+TRRemap(TupleRemapper *remapper, TupleRemapInfo *remapinfo,
+		Datum value, bool *changed)
+{
+	/* This is recursive, so it could be driven to stack overflow. */
+	check_stack_depth();
+
+	switch (remapinfo->remapclass)
+	{
+		case TUPLE_REMAP_ARRAY:
+			return TRRemapArray(remapper, &remapinfo->u.arr, value, changed);
+
+		case TUPLE_REMAP_RANGE:
+#ifdef TYPTYPE_RANGE
+			return TRRemapRange(remapper, &remapinfo->u.rng, value, changed);
+#else
+			return value;
+#endif
+
+		case TUPLE_REMAP_RECORD:
+			return TRRemapRecord(remapper, &remapinfo->u.rec, value, changed);
+	}
+
+	elog(ERROR, "unrecognized remapper remap class: %d",
+		 (int) remapinfo->remapclass);
+	return (Datum) 0;
+}
+
+/*
+ * Process the given array datum and replace any transient record typmods
+ * contained in it.  Set *changed to TRUE if we actually changed the datum.
+ */
+static Datum
+TRRemapArray(TupleRemapper *remapper, ArrayRemapInfo *remapinfo,
+			 Datum value, bool *changed)
+{
+	ArrayType  *arr = DatumGetArrayTypeP(value);
+	Oid			typid = ARR_ELEMTYPE(arr);
+	bool		element_changed = false;
+	Datum	   *elem_values;
+	bool	   *elem_nulls;
+	int			num_elems;
+	int			i;
+
+	/* Deconstruct the array. */
+	deconstruct_array(arr, typid, remapinfo->typlen,
+					  remapinfo->typbyval, remapinfo->typalign,
+					  &elem_values, &elem_nulls, &num_elems);
+
+	/* Remap each element. */
+	for (i = 0; i < num_elems; i++)
+	{
+		if (!elem_nulls[i])
+			elem_values[i] = TRRemap(remapper,
+									 remapinfo->element_remap,
+									 elem_values[i],
+									 &element_changed);
+	}
+
+	if (element_changed)
+	{
+		/* Reconstruct and return the array.  */
+		*changed = true;
+		arr = construct_md_array(elem_values, elem_nulls,
+							   ARR_NDIM(arr), ARR_DIMS(arr), ARR_LBOUND(arr),
+								 typid, remapinfo->typlen,
+								 remapinfo->typbyval, remapinfo->typalign);
+		return PointerGetDatum(arr);
+	}
+
+	/* Else just return the value as-is. */
+	return value;
+}
+
+/*
+ * Process the given range datum and replace any transient record typmods
+ * contained in it.  Set *changed to TRUE if we actually changed the datum.
+ */
+#ifdef TYPTYPE_RANGE
+static Datum
+TRRemapRange(TupleRemapper *remapper, RangeRemapInfo *remapinfo,
+			 Datum value, bool *changed)
+{
+	RangeType  *range = DatumGetRangeType(value);
+	bool		bound_changed = false;
+	RangeBound	lower;
+	RangeBound	upper;
+	bool		empty;
+
+	/* Extract the lower and upper bounds. */
+	range_deserialize(remapinfo->typcache, range, &lower, &upper, &empty);
+
+	/* Nothing to do for an empty range. */
+	if (empty)
+		return value;
+
+	/* Remap each bound, if present. */
+	if (!upper.infinite)
+		upper.val = TRRemap(remapper, remapinfo->bound_remap,
+							upper.val, &bound_changed);
+	if (!lower.infinite)
+		lower.val = TRRemap(remapper, remapinfo->bound_remap,
+							lower.val, &bound_changed);
+
+	if (bound_changed)
+	{
+		/* Reserialize.  */
+		*changed = true;
+		range = range_serialize(remapinfo->typcache, &lower, &upper, empty);
+		return RangeTypeGetDatum(range);
+	}
+
+	/* Else just return the value as-is. */
+	return value;
+}
+#endif
+
+/*
+ * Process the given record datum and replace any transient record typmods
+ * contained in it.  Set *changed to TRUE if we actually changed the datum.
+ */
+static Datum
+TRRemapRecord(TupleRemapper *remapper, RecordRemapInfo *remapinfo,
+			  Datum value, bool *changed)
+{
+	HeapTupleHeader tup;
+	Oid			typid;
+	int32		typmod;
+	bool		changed_typmod;
+	TupleDesc	tupledesc;
+
+	/* Extract type OID and typmod from tuple. */
+	tup = DatumGetHeapTupleHeader(value);
+	typid = HeapTupleHeaderGetTypeId(tup);
+	typmod = HeapTupleHeaderGetTypMod(tup);
+
+	/*
+	 * If first time through, or if this isn't the same composite type as last
+	 * time, identify the required typmod mapping, and then look up the
+	 * necessary information for processing the fields.
+	 */
+	if (typid != remapinfo->rectypid || typmod != remapinfo->rectypmod)
+	{
+		/* Free any old data. */
+		if (remapinfo->tupledesc != NULL)
+			FreeTupleDesc(remapinfo->tupledesc);
+		/* Is it worth trying to free substructure of the remap tree? */
+		if (remapinfo->field_remap != NULL)
+			pfree(remapinfo->field_remap);
+
+		/* If transient record type, look up matching local typmod. */
+		if (typid == RECORDOID)
+		{
+			Assert(remapper->typmodmap != NULL);
+			Assert(typmod >= 0);
+			Assert(typmod < remapper->typmodmapsize);
+
+			remapinfo->localtypmod = remapper->typmodmap[typmod];
+			Assert(remapinfo->localtypmod >= 0);
+		}
+		else
+			remapinfo->localtypmod = -1;
+
+		/* Look up tuple descriptor in typcache. */
+		tupledesc = lookup_rowtype_tupdesc(typid, remapinfo->localtypmod);
+
+		/* Figure out whether fields need recursive processing. */
+		remapinfo->field_remap = BuildFieldRemapInfo(tupledesc,
+													 remapper->mycontext);
+		if (remapinfo->field_remap != NULL)
+		{
+			/*
+			 * We need to inspect the record contents, so save a copy of the
+			 * tupdesc.  (We could possibly just reference the typcache's
+			 * copy, but then it's problematic when to release the refcount.)
+			 */
+			MemoryContext oldcontext = MemoryContextSwitchTo(remapper->mycontext);
+
+			remapinfo->tupledesc = CreateTupleDescCopy(tupledesc);
+			MemoryContextSwitchTo(oldcontext);
+		}
+		else
+		{
+			/* No fields of the record require remapping. */
+			remapinfo->tupledesc = NULL;
+		}
+		remapinfo->rectypid = typid;
+		remapinfo->rectypmod = typmod;
+
+		/* Release reference count acquired by lookup_rowtype_tupdesc. */
+		DecrTupleDescRefCount(tupledesc);
+	}
+
+	/* If transient record, replace remote typmod with local typmod. */
+	if (typid == RECORDOID && typmod != remapinfo->localtypmod)
+	{
+		typmod = remapinfo->localtypmod;
+		changed_typmod = true;
+	}
+	else
+		changed_typmod = false;
+
+	/*
+	 * If we need to change the typmod, or if there are any potentially
+	 * remappable fields, replace the tuple.
+	 */
+	if (changed_typmod || remapinfo->field_remap != NULL)
+	{
+		HeapTupleData htup;
+		HeapTuple	atup;
+
+		/* For now, assume we always need to change the tuple in this case. */
+		*changed = true;
+
+		/* Copy tuple, possibly remapping contained fields. */
+		ItemPointerSetInvalid(&htup.t_self);
+		htup.t_len = HeapTupleHeaderGetDatumLength(tup);
+		htup.t_data = tup;
+		atup = TRRemapTuple(remapper,
+							remapinfo->tupledesc,
+							remapinfo->field_remap,
+							&htup);
+
+		/* Apply the correct labeling for a local Datum. */
+		HeapTupleHeaderSetTypeId(atup->t_data, typid);
+		HeapTupleHeaderSetTypMod(atup->t_data, typmod);
+		HeapTupleHeaderSetDatumLength(atup->t_data, htup.t_len);
+
+		/* And return the results. */
+		return PointerGetDatum(atup->t_data);
+	}
+
+	/* Else just return the value as-is. */
+	return value;
+}
+
+/*
+ * Build remap info for the specified data type, storing it in mycontext.
+ * Returns NULL if neither the type nor any subtype could require remapping.
+ */
+static TupleRemapInfo *
+BuildTupleRemapInfo(Oid typid, MemoryContext mycontext)
+{
+	HeapTuple	tup;
+	Form_pg_type typ;
+
+	/* This is recursive, so it could be driven to stack overflow. */
+	check_stack_depth();
+
+restart:
+	tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typid));
+	if (!HeapTupleIsValid(tup))
+		elog(ERROR, "cache lookup failed for type %u", typid);
+	typ = (Form_pg_type) GETSTRUCT(tup);
+
+	/* Look through domains to underlying base type. */
+	if (typ->typtype == TYPTYPE_DOMAIN)
+	{
+		typid = typ->typbasetype;
+		ReleaseSysCache(tup);
+		goto restart;
+	}
+
+	/* If it's a true array type, deal with it that way. */
+	if (OidIsValid(typ->typelem) && typ->typlen == -1)
+	{
+		typid = typ->typelem;
+		ReleaseSysCache(tup);
+		return BuildArrayRemapInfo(typid, mycontext);
+	}
+
+#ifdef TYPTYPE_RANGE
+	/* Similarly, deal with ranges appropriately. */
+	if (typ->typtype == TYPTYPE_RANGE)
+	{
+		ReleaseSysCache(tup);
+		return BuildRangeRemapInfo(typid, mycontext);
+	}
+#endif
+
+	/*
+	 * If it's a composite type (including RECORD), set up for remapping.  We
+	 * don't attempt to determine the status of subfields here, since we do
+	 * not have enough information yet; just mark everything invalid.
+	 */
+	if (typ->typtype == TYPTYPE_COMPOSITE || typid == RECORDOID)
+	{
+		TupleRemapInfo *remapinfo;
+
+		remapinfo = (TupleRemapInfo *)
+			MemoryContextAlloc(mycontext, sizeof(TupleRemapInfo));
+		remapinfo->remapclass = TUPLE_REMAP_RECORD;
+		remapinfo->u.rec.rectypid = InvalidOid;
+		remapinfo->u.rec.rectypmod = -1;
+		remapinfo->u.rec.localtypmod = -1;
+		remapinfo->u.rec.tupledesc = NULL;
+		remapinfo->u.rec.field_remap = NULL;
+		ReleaseSysCache(tup);
+		return remapinfo;
+	}
+
+	/* Nothing else can possibly need remapping attention. */
+	ReleaseSysCache(tup);
+	return NULL;
+}
+
+static TupleRemapInfo *
+BuildArrayRemapInfo(Oid elemtypid, MemoryContext mycontext)
+{
+	TupleRemapInfo *remapinfo;
+	TupleRemapInfo *element_remapinfo;
+
+	/* See if element type requires remapping. */
+	element_remapinfo = BuildTupleRemapInfo(elemtypid, mycontext);
+	/* If not, the array doesn't either. */
+	if (element_remapinfo == NULL)
+		return NULL;
+	/* OK, set up to remap the array. */
+	remapinfo = (TupleRemapInfo *)
+		MemoryContextAlloc(mycontext, sizeof(TupleRemapInfo));
+	remapinfo->remapclass = TUPLE_REMAP_ARRAY;
+	get_typlenbyvalalign(elemtypid,
+						 &remapinfo->u.arr.typlen,
+						 &remapinfo->u.arr.typbyval,
+						 &remapinfo->u.arr.typalign);
+	remapinfo->u.arr.element_remap = element_remapinfo;
+	return remapinfo;
+}
+
+#ifdef TYPTYPE_RANGE
+static TupleRemapInfo *
+BuildRangeRemapInfo(Oid rngtypid, MemoryContext mycontext)
+{
+	TupleRemapInfo *remapinfo;
+	TupleRemapInfo *bound_remapinfo;
+	TypeCacheEntry *typcache;
+
+	/*
+	 * Get range info from the typcache.  We assume this pointer will stay
+	 * valid for the duration of the query.
+	 */
+	typcache = lookup_type_cache(rngtypid, TYPECACHE_RANGE_INFO);
+	if (typcache->rngelemtype == NULL)
+		elog(ERROR, "type %u is not a range type", rngtypid);
+
+	/* See if range bound type requires remapping. */
+	bound_remapinfo = BuildTupleRemapInfo(typcache->rngelemtype->type_id,
+										  mycontext);
+	/* If not, the range doesn't either. */
+	if (bound_remapinfo == NULL)
+		return NULL;
+	/* OK, set up to remap the range. */
+	remapinfo = (TupleRemapInfo *)
+		MemoryContextAlloc(mycontext, sizeof(TupleRemapInfo));
+	remapinfo->remapclass = TUPLE_REMAP_RANGE;
+	remapinfo->u.rng.typcache = typcache;
+	remapinfo->u.rng.bound_remap = bound_remapinfo;
+	return remapinfo;
+}
+#endif
+
+/*
+ * Build remap info for fields of the type described by the given tupdesc.
+ * Returns an array of TupleRemapInfo pointers, or NULL if no field
+ * requires remapping.  Data is allocated in mycontext.
+ */
+static TupleRemapInfo **
+BuildFieldRemapInfo(TupleDesc tupledesc, MemoryContext mycontext)
+{
+	TupleRemapInfo **remapinfo;
+	bool		noop = true;
+	int			i;
+
+	/* Recursively determine the remapping status of each field. */
+	remapinfo = (TupleRemapInfo **)
+		MemoryContextAlloc(mycontext,
+						   tupledesc->natts * sizeof(TupleRemapInfo *));
+	for (i = 0; i < tupledesc->natts; i++)
+	{
+		Form_pg_attribute attr = tupledesc->attrs[i];
+
+		if (attr->attisdropped)
+		{
+			remapinfo[i] = NULL;
+			continue;
+		}
+		remapinfo[i] = BuildTupleRemapInfo(attr->atttypid, mycontext);
+		if (remapinfo[i] != NULL)
+			noop = false;
+	}
+
+	/* If no fields require remapping, report that by returning NULL. */
+	if (noop)
+	{
+		pfree(remapinfo);
+		remapinfo = NULL;
+	}
+
+	return remapinfo;
+}

--- a/src/backend/executor/execJunk.c
+++ b/src/backend/executor/execJunk.c
@@ -59,13 +59,19 @@
  * An optional resultSlot can be passed as well.
  */
 JunkFilter *
-ExecInitJunkFilter(List *targetList, TupleDesc cleanTupType, TupleTableSlot *slot)
+ExecInitJunkFilter(List *targetList, bool hasoid, TupleTableSlot *slot)
 {
 	JunkFilter *junkfilter;
+	TupleDesc	cleanTupType;
 	int			cleanLength;
 	AttrNumber *cleanMap;
 	ListCell   *t;
 	AttrNumber	cleanResno;
+
+	/*
+	 * Compute the tuple descriptor for the cleaned tuple.
+	 */
+	cleanTupType = ExecCleanTypeFromTL(targetList, hasoid);
 
 	/*
 	 * Use the given slot, or make a new slot if we weren't given one.

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -900,7 +900,7 @@ ExecEvalWholeRowVar(WholeRowVarExprState *wrvstate, ExprContext *econtext,
 				oldcontext = MemoryContextSwitchTo(econtext->ecxt_per_query_memory);
 				wrvstate->wrv_junkFilter =
 					ExecInitJunkFilter(subplan->plan->targetlist,
-									   ExecGetResultType(subplan),
+									   ExecGetResultType(subplan)->tdhasoid,
 									   NULL);
 				MemoryContextSwitchTo(oldcontext);
 			}

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -1197,10 +1197,7 @@ check_sql_fn_retval(Oid func_id, Oid rettype, List *queryTreeList,
 			 * what the caller expects will happen at runtime.
 			 */
 			if (junkFilter)
-			{
-				TupleDesc cleanTupType = ExecCleanTypeFromTL(tlist, false /* hasoid */);
-				*junkFilter = ExecInitJunkFilter(tlist, cleanTupType, NULL);
-			}
+				*junkFilter = ExecInitJunkFilter(tlist, false, NULL);
 			return true;
 		}
 		Assert(tupdesc);

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -168,9 +168,8 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 	 * Both input and output of the junk filter include dropped attributes, so
 	 * the junk filter doesn't need to do anything special there about them
 	 */
-	TupleDesc cleanTupType = CreateTupleDescCopy(dmlstate->ps.state->es_result_relation_info->ri_RelationDesc->rd_att); 
 	dmlstate->junkfilter = ExecInitJunkFilter(node->plan.targetlist,
-			cleanTupType,
+			false,
 			dmlstate->cleanedUpSlot);
 
 	if (estate->es_instrument)

--- a/src/backend/executor/nodeTableFunction.c
+++ b/src/backend/executor/nodeTableFunction.c
@@ -434,12 +434,9 @@ ExecInitTableFunction(TableFunctionScan *node, EState *estate, int eflags)
 	scanstate->inputscan->subdesc  = inputdesc;
 
 	/* Determine projection information for subplan */
-	TupleDesc cleanTupType = ExecCleanTypeFromTL(subplan->plan->targetlist, 
-						     false /* hasoid */);
-
 	scanstate->inputscan->junkfilter =
 		ExecInitJunkFilter(subplan->plan->targetlist, 
-						   cleanTupType,
+						   false,
 						   NULL  /* slot */);
 	BlessTupleDesc(scanstate->inputscan->junkfilter->jf_cleanTupType);
 

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1144,7 +1144,6 @@ _outTupleDescNode(StringInfo str, TupleDescNode *node)
 
 	WRITE_OID_FIELD(tuple->tdtypeid);
 	WRITE_INT_FIELD(tuple->tdtypmod);
-	WRITE_INT_FIELD(tuple->tdqdtypmod);
 	WRITE_BOOL_FIELD(tuple->tdhasoid);
 	WRITE_INT_FIELD(tuple->tdrefcount);
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -327,7 +327,6 @@ _outQueryDispatchDesc(StringInfo str, QueryDispatchDesc *node)
 {
 	WRITE_NODE_TYPE("QUERYDISPATCHDESC");
 
-	WRITE_NODE_FIELD(transientTypeRecords);
 	WRITE_STRING_FIELD(intoTableSpaceName);
 	WRITE_NODE_FIELD(oidAssignments);
 	WRITE_NODE_FIELD(sliceTable);
@@ -4293,7 +4292,6 @@ _outTupleDescNode(StringInfo str, TupleDescNode *node)
 
 	WRITE_OID_FIELD(tuple->tdtypeid);
 	WRITE_INT_FIELD(tuple->tdtypmod);
-	WRITE_INT_FIELD(tuple->tdqdtypmod);
 	WRITE_BOOL_FIELD(tuple->tdhasoid);
 	WRITE_INT_FIELD(tuple->tdrefcount);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1501,7 +1501,6 @@ _readQueryDispatchDesc(void)
 {
 	READ_LOCALS(QueryDispatchDesc);
 
-	READ_NODE_FIELD(transientTypeRecords);
 	READ_STRING_FIELD(intoTableSpaceName);
 	READ_NODE_FIELD(oidAssignments);
 	READ_NODE_FIELD(sliceTable);
@@ -2567,7 +2566,6 @@ _readTupleDescNode(void)
 
 	READ_OID_FIELD(tuple->tdtypeid);
 	READ_INT_FIELD(tuple->tdtypmod);
-	READ_INT_FIELD(tuple->tdqdtypmod);
 	READ_BOOL_FIELD(tuple->tdhasoid);
 	READ_INT_FIELD(tuple->tdrefcount);
 

--- a/src/backend/utils/fmgr/funcapi.c
+++ b/src/backend/utils/fmgr/funcapi.c
@@ -1163,7 +1163,6 @@ TypeGetTupleDesc(Oid typeoid, List *colaliases)
 			/* The tuple type is now an anonymous record type */
 			tupdesc->tdtypeid = RECORDOID;
 			tupdesc->tdtypmod = -1;
-			tupdesc->tdqdtypmod = -1;
 		}
 	}
 	else if (functypclass == TYPEFUNC_SCALAR)

--- a/src/include/access/tupdesc.h
+++ b/src/include/access/tupdesc.h
@@ -74,7 +74,6 @@ typedef struct tupleDesc
 	TupleConstr *constr;		/* constraints, or NULL if none */
 	Oid			tdtypeid;		/* composite type ID for tuple type */
 	int32		tdtypmod;		/* typmod for tuple type */
-	int32		tdqdtypmod;	/* typmod for tuple type on Master */
 	bool		tdhasoid;		/* tuple has oid attribute in its header */
 	int			tdrefcount;		/* reference count, or -1 if not counting */
 }	*TupleDesc;

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -18,6 +18,7 @@
 #include "cdb/tupser.h"
 #include "cdb/tupchunk.h"
 #include "cdb/tupchunklist.h"
+#include "cdb/tupleremap.h"
 
 struct CdbProcess;                          /* #include "nodes/execnodes.h" */
 struct Slice;                               /* #include "nodes/execnodes.h" */
@@ -270,6 +271,21 @@ struct MotionConn
 	/* Indicate whether an EOS is received and acked. */
 	bool eosAcked;
 
+	/*
+	 * used by the sender.
+	 *
+	 * the typmod of last sent record type in current connection,
+	 * if the connection is for broadcasting then we only check
+	 * and update this attribute on connection 0.
+	 */
+	int32		 sent_record_typmod;
+
+	/*
+	 * used by the receiver.
+	 *
+	 * all the remap information.
+	 */
+	TupleRemapper	*remapper;
 };
 
 /*

--- a/src/include/cdb/cdbmotion.h
+++ b/src/include/cdb/cdbmotion.h
@@ -71,6 +71,10 @@ extern void EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool
  * or error-cleanup). */
 extern void RemoveMotionLayer(MotionLayerState *ml_states, bool flushCommLayer  __attribute__((unused)) );
 
+extern void CheckAndSendRecordCache(MotionLayerState *mlStates,
+									ChunkTransportState *transportStates,
+									int16 motNodeID,
+									int16 targetRoute);
 
 /* non-blocking operation that may perform only part (or none) of the
  * send before returning.  The TupleSendContext is used to help keep track

--- a/src/include/cdb/tupleremap.h
+++ b/src/include/cdb/tupleremap.h
@@ -1,0 +1,26 @@
+/*-------------------------------------------------------------------------
+ *
+ * tupleremap.h
+ *
+ * Portions Copyright (c) 1996-2016, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/include/cdb/tupleremap.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef TUPLEREMAP_H
+#define TUPLEREMAP_H
+
+#include "tcop/dest.h"
+
+/* Opaque struct, only known inside tupleremap.c. */
+typedef struct TupleRemapper TupleRemapper;
+
+extern TupleRemapper *CreateTupleRemapper(void);
+extern void DestroyTupleRemapper(TupleRemapper *remapper);
+extern HeapTuple TRCheckAndRemap(TupleRemapper *remapper, TupleDesc tupledesc, HeapTuple tuple);
+extern void TRHandleTypeLists(TupleRemapper *remapper, List *typelist);
+
+#endif   /* TUPLEREMAP_H */

--- a/src/include/cdb/tupser.h
+++ b/src/include/cdb/tupser.h
@@ -13,6 +13,7 @@
 #include "cdb/tupchunklist.h"
 #include "lib/stringinfo.h"
 #include "utils/lsyscache.h"
+#include "cdb/tupleremap.h"
 
 
 /* Define this to pack the NULLs-mask into the minimum number of bytes
@@ -28,6 +29,8 @@
 #undef TUPSER_SCRATCH_SPACE
 #define VARLEN_SCRATCH_SIZE 500
 
+typedef struct ChunkSorterEntry ChunkSorterEntry;
+typedef struct MotionConn MotionConn;
 
 /*
  * The next two structures are for cached tuple serialization and
@@ -77,6 +80,9 @@ typedef struct SerTupInfo
 	/* Preallocated space for deformtuple and formtuple. */
 	Datum	   *values;
 	bool	   *nulls;
+
+	/* true if tupdesc contains record types */
+	bool		has_record_types;
 }	SerTupInfo;
 
 /*
@@ -93,6 +99,11 @@ extern void InitSerTupInfo(TupleDesc tupdesc, SerTupInfo *pSerInfo);
 /* Free up storage in a previously initialized SerTupInfo struct. */
 extern void CleanupSerTupInfo(SerTupInfo *pSerInfo);
 
+/* Convert RecordCache into chunks ready to send out, in one pass */
+extern void SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
+										   TupleChunkList tcList,
+										   MotionConn *conn);
+
 /* Convert a HeapTuple into chunks ready to send out, in one pass */
 extern void SerializeTupleIntoChunks(HeapTuple tuple, SerTupInfo *pSerInfo, TupleChunkList tcList);
 
@@ -105,6 +116,6 @@ extern HeapTuple DeserializeTuple(SerTupInfo * pSerInfo, StringInfo serialTup);
 /* Convert a sequence of chunks containing serialized tuple data into a
  * HeapTuple.
  */
-extern HeapTuple CvtChunksToHeapTup(TupleChunkList tclist, SerTupInfo * pSerInfo);
+extern HeapTuple CvtChunksToHeapTup(TupleChunkList tclist, SerTupInfo * pSerInfo, TupleRemapper *remapper);
 
 #endif   /* TUPSER_H */

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -165,12 +165,6 @@ typedef struct QueryDispatchDesc
 	NodeTag		type;
 
 	/*
-	 * List of TupleDescNodes, one for each transient record type currently
-	 * assigned.
-	 */
-	List	   *transientTypeRecords;
-
-	/*
 	 * For a SELECT INTO statement, this stores the tablespace to use for the
 	 * new table and related auxiliary tables.
 	 */

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -139,7 +139,7 @@ extern TupleHashEntry FindTupleHashEntry(TupleHashTable hashtable,
 /*
  * prototypes from functions in execJunk.c
  */
-extern JunkFilter *ExecInitJunkFilter(List *targetList, TupleDesc cleanTupType,
+extern JunkFilter *ExecInitJunkFilter(List *targetList, bool hasoid,
 				   TupleTableSlot *slot);
 extern JunkFilter *ExecInitJunkFilterConversion(List *targetList,
 							 TupleDesc cleanTupType,

--- a/src/include/utils/typcache.h
+++ b/src/include/utils/typcache.h
@@ -75,6 +75,8 @@ typedef struct TypeCacheEntry
 #define TYPECACHE_TUPDESC			0x0040
 #define TYPECACHE_BTREE_OPFAMILY	0x0080
 
+extern int32 NextRecordTypmod;
+
 extern TypeCacheEntry *lookup_type_cache(Oid type_id, int flags);
 
 extern TupleDesc lookup_rowtype_tupdesc(Oid type_id, int32 typmod);
@@ -86,6 +88,6 @@ extern TupleDesc lookup_rowtype_tupdesc_copy(Oid type_id, int32 typmod);
 
 extern void assign_record_type_typmod(TupleDesc tupDesc);
 
-extern void build_tuple_node_list(List **transientTypeList);
+extern List *build_tuple_node_list(int start);
 
 #endif   /* TYPCACHE_H */

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -540,14 +540,16 @@ group by f1,f2,fs;
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --
--- This test works in upstream PostgreSQL but triggers a problem in GPDB; in
--- Greenplum the typmods must be the same between all segments and the master
--- but PostgreSQL executor defers typmod assignment to ExecEvalWholeRowVar()
--- which is too late for Greenplum since the plan has already been dispatched.
--- This should be fixed but requires new infrastructure.
---
-select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
-ERROR:  record type has not been registered
+select q from (select max(f1) as max from int4_tbl group by f1 order by f1) q order by max;
+       q       
+---------------
+ (-2147483647)
+ (-123456)
+ (0)
+ (123456)
+ (2147483647)
+(5 rows)
+
 --
 -- Test case for sublinks pushed down into subselects via join alias expansion
 --

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -551,14 +551,16 @@ group by f1,f2,fs;
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --
--- This test works in upstream PostgreSQL but triggers a problem in GPDB; in
--- Greenplum the typmods must be the same between all segments and the master
--- but PostgreSQL executor defers typmod assignment to ExecEvalWholeRowVar()
--- which is too late for Greenplum since the plan has already been dispatched.
--- This should be fixed but requires new infrastructure.
---
-select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
-ERROR:  record type has not been registered
+select q from (select max(f1) as max from int4_tbl group by f1 order by f1) q order by max;
+       q       
+---------------
+ (-2147483647)
+ (-123456)
+ (0)
+ (123456)
+ (2147483647)
+(5 rows)
+
 --
 -- Test case for sublinks pushed down into subselects via join alias expansion
 --

--- a/src/test/regress/input/transient_types.source
+++ b/src/test/regress/input/transient_types.source
@@ -143,4 +143,38 @@ select foo();
 drop function foo();
 drop table t;
 
+-- This test case use UDF assign_new_record() to generate a new record type in cache
+-- for each tuple, these types should be sync to receiver. 
+-- test function
+create or replace function assign_new_record()
+returns SETOF record as '@abs_builddir@/regress@DLSUFFIX@',
+'assign_new_record' LANGUAGE C VOLATILE;
+
+-- transfer record types via motion incrementally
+select assign_new_record() from gp_dist_random('gp_id');
+
+-- cleanup
+drop function assign_new_record();
+
+-- Test cases for record type nested in array 
+drop table if exists t_array_record;
+create table t_array_record as select i as c1, i * 2 as c2 from generate_series(1,10) i;
+select c1, array[row(c1,array[row(2,3),row(c2,5,array[c1],'abc')])] from t_array_record order by c1;
+drop table t_array_record;
+
+-- Test the case that new record type is created during execution stage, which makes
+-- QE have more transient types than QD.
+drop table if exists t_record_qe;
+create table t_record_qe as select f1 from generate_series(1,10) f1;
+select q from (select max(f1) as max from t_record_qe group by f1 order by f1) q order by max;
+drop table t_record_qe;
+
+-- Customer reported case which used to segment fault.
+DROP TABLE IF EXISTS typemod_init ;
+CREATE TABLE typemod_init ( varchar_col character varying(7)); 
+INSERT INTO typemod_init VALUES ('A');
+SELECT C FROM ( SELECT B.varchar_col FROM ( SELECT A.varchar_col FROM typemod_init A) B GROUP BY B.varchar_col) C;
+DROP TABLE typemod_init ;
+
+
 drop schema transient_types;

--- a/src/test/regress/output/transient_types.source
+++ b/src/test/regress/output/transient_types.source
@@ -297,4 +297,107 @@ select foo();
 -- cleanup
 drop function foo();
 drop table t;
+-- This test case use UDF assign_new_record() to generate a new record type in cache
+-- for each tuple, these types should be sync to receiver. 
+-- test function
+create or replace function assign_new_record()
+returns SETOF record as '@abs_builddir@/regress@DLSUFFIX@',
+'assign_new_record' LANGUAGE C VOLATILE;
+-- transfer record types via motion incrementally
+select assign_new_record() from gp_dist_random('gp_id');
+ assign_new_record 
+-------------------
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+ (1)
+(30 rows)
+
+-- cleanup
+drop function assign_new_record();
+-- Test cases for record type nested in array 
+drop table if exists t_array_record;
+NOTICE:  table "t_array_record" does not exist, skipping
+create table t_array_record as select i as c1, i * 2 as c2 from generate_series(1,10) i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select c1, array[row(c1,array[row(2,3),row(c2,5,array[c1],'abc')])] from t_array_record order by c1;
+ c1 |                        array                         
+----+------------------------------------------------------
+  1 | {"(1,\"{\"\"(2,3)\"\",\"\"(2,5,{1},abc)\"\"}\")"}
+  2 | {"(2,\"{\"\"(2,3)\"\",\"\"(4,5,{2},abc)\"\"}\")"}
+  3 | {"(3,\"{\"\"(2,3)\"\",\"\"(6,5,{3},abc)\"\"}\")"}
+  4 | {"(4,\"{\"\"(2,3)\"\",\"\"(8,5,{4},abc)\"\"}\")"}
+  5 | {"(5,\"{\"\"(2,3)\"\",\"\"(10,5,{5},abc)\"\"}\")"}
+  6 | {"(6,\"{\"\"(2,3)\"\",\"\"(12,5,{6},abc)\"\"}\")"}
+  7 | {"(7,\"{\"\"(2,3)\"\",\"\"(14,5,{7},abc)\"\"}\")"}
+  8 | {"(8,\"{\"\"(2,3)\"\",\"\"(16,5,{8},abc)\"\"}\")"}
+  9 | {"(9,\"{\"\"(2,3)\"\",\"\"(18,5,{9},abc)\"\"}\")"}
+ 10 | {"(10,\"{\"\"(2,3)\"\",\"\"(20,5,{10},abc)\"\"}\")"}
+(10 rows)
+
+drop table t_array_record;
+-- Test the case that new record type is created during execution stage, which makes
+-- QE have more transient types than QD.
+drop table if exists t_record_qe;
+NOTICE:  table "t_record_qe" does not exist, skipping
+create table t_record_qe as select f1 from generate_series(1,10) f1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select q from (select max(f1) as max from t_record_qe group by f1 order by f1) q order by max;
+  q   
+------
+ (1)
+ (2)
+ (3)
+ (4)
+ (5)
+ (6)
+ (7)
+ (8)
+ (9)
+ (10)
+(10 rows)
+
+drop table t_record_qe;
+-- Customer reported case which used to segment fault.
+DROP TABLE IF EXISTS typemod_init ;
+NOTICE:  table "typemod_init" does not exist, skipping
+CREATE TABLE typemod_init ( varchar_col character varying(7)); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'varchar_col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO typemod_init VALUES ('A');
+SELECT C FROM ( SELECT B.varchar_col FROM ( SELECT A.varchar_col FROM typemod_init A) B GROUP BY B.varchar_col) C;
+  c  
+-----
+ (A)
+(1 row)
+
+DROP TABLE typemod_init ;
 drop schema transient_types;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -324,14 +324,8 @@ group by f1,f2,fs;
 -- Check that whole-row Vars reading the result of a subselect don't include
 -- any junk columns therein
 --
--- This test works in upstream PostgreSQL but triggers a problem in GPDB; in
--- Greenplum the typmods must be the same between all segments and the master
--- but PostgreSQL executor defers typmod assignment to ExecEvalWholeRowVar()
--- which is too late for Greenplum since the plan has already been dispatched.
--- This should be fixed but requires new infrastructure.
---
 
-select q from (select max(f1) from int4_tbl group by f1 order by f1) q;
+select q from (select max(f1) as max from int4_tbl group by f1 order by f1) q order by max;
 
 --
 -- Test case for sublinks pushed down into subselects via join alias expansion


### PR DESCRIPTION
QD used to send a transient types table to QEs, then QE would remap the
tuples with this table before sending them to QD. However in complex
queries QD can't discover all the transient types so tuples can't be
correctly remapped on QEs. One example is like below:

    SELECT q FROM (SELECT MAX(f1) FROM int4_tbl
                   GROUP BY f1 ORDER BY f1) q;
    ERROR:  record type has not been registered

To fix this issue we changed the underlying logic: instead of sending
the possibly incomplete transient types table from QD to QEs, we now
send the tables from QEs to QD and do the remap on QD. QD maintains a
remap table for each motion so tuples from different QEs can be
remapped accordingly.

One side effect for this approach is a performance down is introduced
on QD as the remap requires recursively checks on each record type
tuples. However optimization is made to make this side effect minimum
on non-record types.

Old logic that building transient types table on QD and sending them to
QEs are removed. There are also minor fixes for record types to be
correctly handled.

Signed-off-by: Ning Yu <nyu@pivotal.io>