### PR TITLE
Fully enable lazy XID allocation in GPDB.

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -82,6 +82,8 @@ DistributedLog_SetCommitted(
 	DistributedTransactionId 			distribXid,
 	bool								isRedo)
 {
+	Assert(TransactionIdIsValid(localXid));
+
 	MIRRORED_LOCK_DECLARE;
 
 	int			page = TransactionIdToPage(localXid);

--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -154,14 +154,22 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 		if (distribXid == inProgressEntryArray[i].distribXid)
 		{
 			/*
-			 * Save the relationship to the local xid so we may avoid
-			 * checking the distributed committed log in a subsequent check.
+			 * Save the relationship to the local xid so we may avoid checking
+			 * the distributed committed log in a subsequent check.
 			 */
 			if (inProgressEntryArray[i].localXid == InvalidTransactionId)
 				inProgressEntryArray[i].localXid = localXid;
-			
 			return DISTRIBUTEDSNAPSHOT_COMMITTED_INPROGRESS;
 		}
+
+		/*
+		 * Leverage the fact that inProgressEntryArray is sorted in ascending
+		 * order based on distribXid while creating the snapshot in
+		 * createDtxSnapshot. So, can fail fast once known are lower than
+		 * rest of them.
+		 */
+		if (distribXid < inProgressEntryArray[i].distribXid)
+			break;
 	}
 
 	/*

--- a/src/backend/cdb/cdblocaldistribxact.c
+++ b/src/backend/cdb/cdblocaldistribxact.c
@@ -73,55 +73,37 @@ void
 LocalDistribXact_StartOnMaster(
 	DistributedTransactionTimeStamp	newDistribTimeStamp,
 	DistributedTransactionId 		newDistribXid,
-	TransactionId					*newLocalXid,
 	LocalDistribXactData			*masterLocalDistribXactRef)
 {
 	LocalDistribXactData *ele = masterLocalDistribXactRef;
-	TransactionId	localXid;
 
 	Assert(newDistribTimeStamp != 0);
 	Assert(newDistribXid != InvalidDistributedTransactionId);
-	Assert(newLocalXid != NULL);
 	Assert(masterLocalDistribXactRef != NULL);
-
-	localXid = GetNewTransactionId(false, false);
-								// NOT subtrans, DO NOT Set PROC struct xid;
 
 	ele->distribTimeStamp = newDistribTimeStamp;
 	ele->distribXid = newDistribXid;
 	ele->state = LOCALDISTRIBXACT_STATE_ACTIVE;
-
-	MyProc->xid = localXid;
-	*newLocalXid = localXid;
 }
 
 void
 LocalDistribXact_StartOnSegment(
 	DistributedTransactionTimeStamp	newDistribTimeStamp,
-	DistributedTransactionId 		newDistribXid,
-	TransactionId					*newLocalXid)
+	DistributedTransactionId 		newDistribXid)
 {
 	LocalDistribXactData *ele = &MyProc->localDistribXactData;
-	TransactionId	localXid;
 
 	MIRRORED_LOCK_DECLARE;
 
 	Assert(newDistribTimeStamp != 0);
 	Assert(newDistribXid != InvalidDistributedTransactionId);
-	Assert(newLocalXid != NULL);
 
 	MIRRORED_LOCK;
 	LWLockAcquire(ProcArrayLock, LW_EXCLUSIVE);
 
-	localXid = GetNewTransactionId(false, false);
-								// NOT subtrans, DO NOT Set PROC struct xid;
-
 	ele->distribTimeStamp = newDistribTimeStamp;
 	ele->distribXid = newDistribXid;
 	ele->state = LOCALDISTRIBXACT_STATE_ACTIVE;
-
-	MyProc->xid = localXid;
-	*newLocalXid = localXid;
 
 	LWLockRelease(ProcArrayLock);
 	MIRRORED_UNLOCK;

--- a/src/backend/cdb/cdbpersistentdatabase.c
+++ b/src/backend/cdb/cdbpersistentdatabase.c
@@ -462,6 +462,7 @@ void PersistentDatabase_MarkCreatePending(
 	SharedOidSearchAddResult addResult;
 
 	PersistentFileSysObjName fsObjName;
+	TransactionId topXid;
 
 	if (Persistent_BeforePersistenceWork())
 	{	
@@ -484,6 +485,8 @@ void PersistentDatabase_MarkCreatePending(
 									&fsObjName,
 									dbDirNode->tablespace,
 									dbDirNode->database);
+
+	topXid = GetTopTransactionId();
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
@@ -526,7 +529,7 @@ void PersistentDatabase_MarkCreatePending(
 							/* createMirrorDataLossTrackingSessionNum */ 0,
 							mirrorExistenceState,
 							/* reserved */ 0,
-							/* parentXid */ GetTopTransactionId(),
+							/* parentXid */ topXid,
 							flushToXLog);
 
 	*persistentTid = databaseDirEntry->persistentTid;

--- a/src/backend/cdb/cdbpersistentfilespace.c
+++ b/src/backend/cdb/cdbpersistentfilespace.c
@@ -623,6 +623,7 @@ void PersistentFilespace_MarkCreatePending(
 	PersistentFileSysObjName fsObjName;
 
 	FilespaceDirEntry filespaceDirEntry;
+	TransactionId topXid;
 
 	if (Persistent_BeforePersistenceWork())
 	{
@@ -637,6 +638,8 @@ void PersistentFilespace_MarkCreatePending(
 	PersistentFilespace_VerifyInitScan();
 
 	PersistentFileSysObjName_SetFilespaceDir(&fsObjName,filespaceOid);
+
+	topXid = GetTopTransactionId();
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
@@ -662,7 +665,7 @@ void PersistentFilespace_MarkCreatePending(
 							/* createMirrorDataLossTrackingSessionNum */ 0,
 							mirrorExistenceState,
 							/* reserved */ 0,
-							/* parentXid */ GetTopTransactionId(),
+							/* parentXid */ topXid,
 							flushToXLog);
 
 	*persistentTid = filespaceDirEntry->persistentTid;

--- a/src/backend/cdb/cdbpersistentrelation.c
+++ b/src/backend/cdb/cdbpersistentrelation.c
@@ -248,6 +248,7 @@ void PersistentRelation_AddCreatePending(
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK_DECLARE;
 
 	PersistentFileSysObjName fsObjName;
+	TransactionId topXid;
 
 	XLogRecPtr mirrorBufpoolResyncCkptLoc;
 
@@ -280,6 +281,8 @@ void PersistentRelation_AddCreatePending(
 										relFileNode,
 										segmentFileNum);
 
+	topXid = GetTopTransactionId();
+
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
 	/* Create a values array which will be used to create a 'gp_persistent_relation_node' tuple */
@@ -303,7 +306,7 @@ void PersistentRelation_AddCreatePending(
 										/* mirrorAppendOnlyLossEof */ 0,
 										/* mirrorAppendOnlyNewEof */ 0,
 										relBufpoolKind,
-										GetTopTransactionId(),
+										topXid,
 										/* persistentSerialNum */ 0);	// This will be set by PersistentFileSysObj_AddTuple.
 
 	/* Add a new tuple to 'gp_persistent_relation_node' table for the new relation/segment file

--- a/src/backend/cdb/cdbpersistenttablespace.c
+++ b/src/backend/cdb/cdbpersistenttablespace.c
@@ -632,6 +632,7 @@ void PersistentTablespace_MarkCreatePending(
 	PersistentFileSysObjName fsObjName;
 
 	TablespaceDirEntry tablespaceDirEntry;
+	TransactionId topXid;
 
 	if (Persistent_BeforePersistenceWork())
 	{	
@@ -646,6 +647,8 @@ void PersistentTablespace_MarkCreatePending(
 	PersistentTablespace_VerifyInitScan();
 
 	PersistentFileSysObjName_SetTablespaceDir(&fsObjName,tablespaceOid);
+
+	topXid = GetTopTransactionId();
 
 	WRITE_PERSISTENT_STATE_ORDERED_LOCK;
 
@@ -662,7 +665,7 @@ void PersistentTablespace_MarkCreatePending(
 							/* createMirrorDataLossTrackingSessionNum */ 0,
 							mirrorExistenceState,
 							/* reserved */ 0,
-							/* parentXid */ GetTopTransactionId(),
+							/* parentXid */ topXid,
 							flushToXLog);
 
 	*persistentTid = tablespaceDirEntry->persistentTid;

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -998,7 +998,7 @@ FillInDistributedSnapshot(Snapshot snapshot)
 				{
 					dslm->inProgressEntryArray[i].distribXid = ds->inProgressXidArray[i];
 
-					/* UNDONE: Lookup in distributed cache. */
+					/* Lookup in distributed cache. */
 					dslm->inProgressEntryArray[i].localXid = InvalidTransactionId;
 				}
 			}

--- a/src/backend/utils/adt/xid.c
+++ b/src/backend/utils/adt/xid.c
@@ -147,13 +147,18 @@ btxidcmp(PG_FUNCTION_ARGS)
 
 
 /*
- *		xid_age			- compute age of an XID (relative to current xact)
+ * xid_age - compute age of an XID (relative to latest transaction id
+ * allocated in system)
+ *
+ * ReadNewTransactionId() is used here instead of GetTopTransactionId(), as
+ * this function may be called on QE Reader and with laxy XID try to allocate
+ * XID as QE Reader which is not allowed.
  */
 Datum
 xid_age(PG_FUNCTION_ARGS)
 {
 	TransactionId xid = PG_GETARG_TRANSACTIONID(0);
-	TransactionId now = GetTopTransactionId();
+	TransactionId now = ReadNewTransactionId();
 
 	/* Permanent XIDs are always infinitely old */
 	if (!TransactionIdIsNormal(xid))

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -16,6 +16,12 @@
 /*
  * Combine global and local information captured while scanning the
  * distributed transactions so they can be sorted as a unit.
+ *
+ * For sub-transaction same distribXid can be associated with multiple
+ * localXid, but currently we cache only one localXid for distribXid, for
+ * others we will consult the distributed_log. Opportunity exist though to
+ * improve performance by caching every localXid corresponding to distribXid,
+ * in inProgressEntryArray.
  */
 typedef struct DistributedSnapshotMapEntry
 {

--- a/src/include/cdb/cdblocaldistribxact.h
+++ b/src/include/cdb/cdblocaldistribxact.h
@@ -15,13 +15,9 @@ typedef enum
 {
 	LOCALDISTRIBXACT_STATE_NONE = 0,
 	LOCALDISTRIBXACT_STATE_ACTIVE,
-	LOCALDISTRIBXACT_STATE_COMMITDELIVERY,
 	LOCALDISTRIBXACT_STATE_COMMITTED,
-	LOCALDISTRIBXACT_STATE_ABORTDELIVERY,
 	LOCALDISTRIBXACT_STATE_ABORTED,
-	LOCALDISTRIBXACT_STATE_PREPARED,
-	LOCALDISTRIBXACT_STATE_COMMITPREPARED,
-	LOCALDISTRIBXACT_STATE_ABORTPREPARED
+	LOCALDISTRIBXACT_STATE_PREPARED
 } LocalDistribXactState;
 
 /*
@@ -42,15 +38,6 @@ typedef struct LocalDistribXactData
 	DistributedTransactionId 		distribXid;
 
 } LocalDistribXactData;
-
-extern void LocalDistribXact_StartOnMaster(
-	DistributedTransactionTimeStamp	newDistribTimeStamp,
-	DistributedTransactionId 		newDistribXid,
-	LocalDistribXactData			*masterLocalDistribXactRef);
-
-extern void LocalDistribXact_StartOnSegment(
-	DistributedTransactionTimeStamp	newDistribTimeStamp,
-	DistributedTransactionId 		newDistribXid);
 
 extern void LocalDistribXact_ChangeState(PGPROC *proc,
 	LocalDistribXactState		newState);

--- a/src/include/cdb/cdblocaldistribxact.h
+++ b/src/include/cdb/cdblocaldistribxact.h
@@ -46,13 +46,11 @@ typedef struct LocalDistribXactData
 extern void LocalDistribXact_StartOnMaster(
 	DistributedTransactionTimeStamp	newDistribTimeStamp,
 	DistributedTransactionId 		newDistribXid,
-	TransactionId					*newLocalXid,
 	LocalDistribXactData			*masterLocalDistribXactRef);
 
 extern void LocalDistribXact_StartOnSegment(
 	DistributedTransactionTimeStamp	newDistribTimeStamp,
-	DistributedTransactionId 		newDistribXid,
-	TransactionId					*newLocalXid);
+	DistributedTransactionId 		newDistribXid);
 
 extern void LocalDistribXact_ChangeState(PGPROC *proc,
 	LocalDistribXactState		newState);

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -214,8 +214,6 @@ typedef struct TMGXACT
 
 	int							sessionId;
 	
-	LocalDistribXactData		localDistribXactData;
-	
 	bool						explicitBeginRemembered;
 
 	DistributedTransactionId	xminDistributedSnapshot;

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -214,8 +214,6 @@ typedef struct TMGXACT
 
 	int							sessionId;
 	
-	TransactionId				localXid;
-
 	LocalDistribXactData		localDistribXactData;
 	
 	bool						explicitBeginRemembered;
@@ -296,8 +294,7 @@ extern void dtxCrackOpenGid(const char	*gid,
 extern DistributedTransactionId getDistributedTransactionId(void);
 extern bool getDistributedTransactionIdentifier(char *id);
 
-extern void createDtx(DistributedTransactionId	*distribXid,
-					  TransactionId				*localXid);
+extern void createDtx(DistributedTransactionId	*distribXid);
 extern bool createDtxSnapshot(DistributedSnapshotWithLocalMapping *distribSnapshotWithLocalMapping);
 extern void	prepareDtxTransaction(void);
 extern bool isPreparedDtxTransaction(void);

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -95,10 +95,12 @@ struct PGPROC
 								 * xid >= xmin ! */
 
 	/*
-	 * Distributed transaction information. This is only accessed by the backend
-	 * itself, so this doesn't need to be protected by any lock. In fact, it
-	 * could be just a global variable in backend-private memory, but it seems
-	 * useful to have this information available for debugging purposes.
+	 * Distributed transaction information. This is only maintained on QE's
+	 * and accessed by the backend itself, so this doesn't need to be
+	 * protected by any lock. On QD currentGXact provides this info, hence
+	 * redundant info is not maintained here for QD. In fact, it could be just
+	 * a global variable in backend-private memory, but it seems useful to
+	 * have this information available for debugging purposes.
 	 */
 	LocalDistribXactData localDistribXactData;
 

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -26,7 +26,6 @@ extern void CreateSharedProcArray(void);
 extern void ProcArrayAdd(PGPROC *proc);
 extern void ProcArrayRemove(PGPROC *proc, TransactionId latestXid);
 extern void ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid, bool isCommit,
-						bool *needStateChangeFromDistributed,
 						bool *needNotifyCommittedDtxTransaction);
 extern void ProcArrayClearTransaction(PGPROC *proc, bool commit);
 extern void ClearTransactionFromPgProc_UnderLock(PGPROC *proc, bool commit);

--- a/src/test/tinc/Makefile
+++ b/src/test/tinc/Makefile
@@ -66,8 +66,7 @@ non_discover_targets: aoco_compression filerep_end_to_end fts
 
 storage_vacuum_xidlimits:
 	$(TESTER) $(DISCOVER) \
-	-s tincrepo/mpp/gpdb/tests/storage/vacuum \
-	-q "class=XidlimitsTests"
+	-s tincrepo/mpp/gpdb/tests/storage/vacuum/xidlimits
 
 aocoalter_catalog_loaders:
 	$(TESTER) $(DISCOVER) -t tincrepo/mpp/gpdb/tests \

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/pg_twophase/__init__.py
@@ -238,10 +238,13 @@ class PgtwoPhaseClass(MPPTestCase):
             self.invoke_fault('checkpoint', 'skip', role='primary', port= self.port, occurence='0')
         self.inject_fault(fault_type)
 
+        # Can't do it after filerep_resync resume as gets stuck due to
+        # filerep_transition_to_sync_before_checkpoint suspend above for
+        # MirroedLock
+        PSQL.wait_for_database_up()
+
         if cluster_state == 'resync':
             self.filereputil.inject_fault(f='filerep_resync', y='resume', r='primary')
-
-        PSQL.wait_for_database_up()
 
     def run_crash_and_recover(self, crash_type, fault_type, test_dir, cluster_state='sync', checkpoint='noskip'):
         '''

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/transaction_management/mpp23395/test_mpp23395.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/transaction_management/mpp23395/test_mpp23395.py
@@ -79,6 +79,8 @@ class mpp23395(MPPTestCase):
 	if "PANIC" in results.stderr and not should_panic:
             raise Exception("Fault %s type %s (on segid: %d) caused a PANIC. dtx two phase retry failed" % (fault, fault_type, segid))
 
+        PSQL.wait_for_database_up()
+
     def test_mpp23395(self):
         """
         

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/xidlimits/sanity_warn.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/xidlimits/sanity_warn.ans
@@ -9,8 +9,6 @@ psql:/path/sql_file:1: WARNING:  database "kumara64" must be vacuumed within 149
 HINT:  To avoid a database shutdown, execute a full-database VACUUM in "kumara64".
 INSERT 0 1
 SELECT * FROM foo;
-psql:/path/sql_file:1: WARNING:  database "kumara64" must be vacuumed within 1499999997 transactions
-HINT:  To avoid a database shutdown, execute a full-database VACUUM in "kumara64".
  x 
 ---
  1

--- a/src/test/tinc/tincrepo/mpp/lib/PSQL.py
+++ b/src/test/tinc/tincrepo/mpp/lib/PSQL.py
@@ -557,11 +557,11 @@ class PSQL(Command):
         down = True
         results = {'rc':0, 'stdout':'', 'stderr':''}
         for i in range(60):
+            time.sleep(1)
             res = PSQL.run_sql_command('select count(*) from gp_dist_random(\'gp_id\');', results=results)
             if results['rc'] == 0:
                 down = False
                 break
-            time.sleep(1)
 
         if down:
             raise PSQLException('database has not come up')


### PR DESCRIPTION
**Major chunk of work**

As part of 8.3 merge, upstream commit 295e639
"Implement lazy XID allocation" was merged. But transactionIds were still
allocated in StartTransaction as code changes required to make it work for GPDB
with distrbuted transaction was pending, thereby feature remained as
disabled. Some progress was made by commit
a54d84a "Avoid assigning an XID to
DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT queries." Now this commit addresses the
pending work needed for handling deferred xid allocation correctly with
distributed transactions and fully enables the feature.

Important highlights of change:

1] Modify xlog write and xlog replay record for DISTRIBUTED_COMMIT. Even if
transacion is read-only for master and no xid is allocated to it, it can still
be distributed transaction and hence needs to persist itself in such a case. So,
write xlog record even if no local xid is assigned but transaction is
prepared. Similarly during xlog replay of the XLOG_XACT_DISTRIBUTED_COMMIT type,
perform distributed commit recovery ignoring local commit. Which also means for
this case don't commit to distrbuted log, as its only used to perform reverse
map of localxid to distributed xid.

2] Remove localXID from gxact, as its no more needed to be maintained and used.

3] Refactor code for QE Reader StartTransaction. There used to be wait-loop with
sleep checking to see if SharedLocalSnapshotSlot has distributed XID same as
that of READER to assign reader some xid as that of writer, for SET type
commands till READER actually performs GetSnapShotData(). Since now a) writer is
not going to have valid xid till it performs some write, writers transactionId
turns out InvalidTransaction always here and b) read operations like SET doesn't
need xid, any more hence need for this wait is gone.

4] Thow error if using distributed transaction without distributed xid. Earlier
AssignTransactionId() was called for this case in StartTransaction() but such
scenario doesn't exist hence convert it to ERROR.

5] QD earlier during snapshot creation in createDtxSnapshot() was able to assign
localXid in inProgressEntryArray corresponding to distribXid, as localXid was
known by that time. That's no more the case and localXid mostly will get
assigned after snapshot is taken. Hence now even for QD similar to QE's snapshot
creation time localXid is not populated but later found in
DistributedSnapshotWithLocalMapping_CommittedTest(). There is chance to optimize
and try to match earlier behavior somewhat by populating gxact in
AssignTransactionId() once locakXid is known but currently seems not so much
worth it as QE's anyways have to perform the lookups.

**Other supporting commits:**

- Cleanup LocalDistribXactData related code.
- Optimize distributed xact commit check.
- Use ReadNewTransactionId() for xid_age() and txid_current().
- And some test modifications shaken up due to modifications or exhibiting flakiness

**Note**

Passes all the regressions tests.
ICW run before the change bumped Xid to 48527 (master) and 20527 (segments), 
now with lazy xid fully on only gets to Xid 18173 (master) and (19677) segments.
