### PR TITLE
Relocating memory usage dump from ExecutorEnd to MemoryAccounting_Reset

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1111,10 +1111,6 @@ ExecutorEnd(QueryDesc *queryDesc)
 	}
 	END_MEMORY_ACCOUNT();
 
-	if (gp_dump_memory_usage)
-	{
-		MemoryAccounting_SaveToFile(currentSliceId);
-	}
 	ReportOOMConsumption();
 }
 

--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -202,6 +202,11 @@ MemoryAccounting_Reset()
 	 */
 	if (MemoryAccounting_IsInitialized())
 	{
+		if (gp_dump_memory_usage)
+		{
+			MemoryAccounting_SaveToFile(currentSliceId);
+		}
+
 		/* No one should create child context under MemoryAccountMemoryContext */
 		Assert(MemoryAccountMemoryContext->firstchild == NULL);
 


### PR DESCRIPTION
This is necessary as we no longer call ExecutorEnd upon abort since 8d251945d0. This was breaking TINC OOMTestCase.test_05_dumpusage. This ensures that we dump memory usage (if configured) once per command before resetting memory accounting.