### PR TITLE
ci: extend how long concourse waits for Pulse to start a requested job

### DIFF
--- a/ci/pulse/api/lib/pulse_options.rb
+++ b/ci/pulse/api/lib/pulse_options.rb
@@ -4,7 +4,7 @@ class PulseOptions
   DEFAULT_TIMEOUT_IN_HOURS = 10
   DEFAULT_POLLING_TIME_IN_SECONDS = 60
   DEFAULT_TOKEN_REFRESH_TIME_IN_SECONDS = 1200
-  DEFAULT_BUILD_REQUEST_TIME_IN_SECONDS = 60 * 20
+  DEFAULT_BUILD_REQUEST_TIME_IN_SECONDS = 60 * 30
   CONCOURSE_URL = "https://gpdb.ci.pivotalci.info/"
 
   attr_reader :url, :project_name, :username, :password, :input_dir, :output_dir, :build_artifact_url,


### PR DESCRIPTION
We have seen instances where 5+ pulse projects try to get triggered at
once. This density comes about when lots of commits come through the
concourse pipeline all at the same time, and only applies to pulse jobs
that trigger on every commit.

Requested by @chrishajas 
Signed-off-by: Marbin Tan <mtan@pivotal.io>