### PR TITLE
Modify gpcheckcat issue report to show content id instead of segname+1

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3767,12 +3767,8 @@ def getCatalog():
 # -------------------------------------------------------------------------------
 def getReportConfiguration():
     cfg = {}
-    for dbid, each in GV.cfg.iteritems():
-        if each['content'] == -1:
-            segname = 'master'
-        else:
-            segname = 'seg' + str(each['content'] + 1)
-        cfg[each['content']] = {'segname': segname,
+    for _, each in GV.cfg.iteritems():
+        cfg[each['content']] = {'segname': "content " + str(each['content']),
                                 'hostname': each['hostname'],
                                 'port': each['port']}
     return cfg

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -321,6 +321,9 @@ class GpCheckCatTestCase(GpTestCase):
         self.assertEquals(aTable.getPrimaryKey.call_count, 1)
         self.subject.setError.assert_called_once_with(self.subject.ERROR_REMOVE)
 
+    def test_getReportConfiguration_uses_contentid(self):
+        report_cfg = self.subject.getReportConfiguration()
+        self.assertEqual("content -1", report_cfg[-1]['segname'])
 
     ####################### PRIVATE METHODS #######################
 

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -75,6 +75,7 @@ Feature: gpcheckcat tests
         And gpcheckcat should print Table miss_attr_db1.public.ao_table.-1 to stdout
         And gpcheckcat should print Table miss_attr_db1.public.ao_part_table.-1 to stdout
         And gpcheckcat should print Table miss_attr_db1.public.ao_part_table_1_prt_p1_2_prt_1.-1 to stdout
+        And gpcheckcat should print on content -1 to stdout
         Examples:
           | attrname   | tablename     |
           | attrelid   | pg_attribute  |


### PR DESCRIPTION
Formerly, the output had a label like "seg18"
```
        Missing rewrite metadata of {'ev_class': 140750, 'rulename': 'notify_me'} on seg18 (office-5-231.pa.pivotal.io)
```

Now the output label is just the content ID, identified as "content N":
```
        Missing rewrite metadata of {'ev_class': 140750, 'rulename': 'notify_me'} on content 17 (office-5-231.pa.pivotal.io)
```