### PR TITLE
gpcloud: fix exception message and symlink issues

### DIFF
--- a/gpAux/extensions/Makefile
+++ b/gpAux/extensions/Makefile
@@ -46,7 +46,6 @@ mkgphdfs:
 mkgpcloud:
 	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gpcloud USE_PGXS=1 install
 	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) -C gpcloud/bin/gpcheckcloud USE_PGXS=1 install
-	ln -sf gpcloud.so $(pkglibdir)/gps3ext.so
 
 # Only include include these files when running enterprise build
 ENTERPRISE_TARGETS="mkgphdfs mkorafce mkplr"

--- a/gpAux/extensions/gpcloud/Makefile
+++ b/gpAux/extensions/gpcloud/Makefile
@@ -23,6 +23,11 @@ include $(PGXS)
 gpcheckcloud:
 	@$(MAKE) -C bin/gpcheckcloud
 
+install: install-symlink
+
+install-symlink:
+	ln -sf gpcloud.so $(pkglibdir)/gps3ext.so
+
 test: format
 	@$(MAKE) -C test test
 

--- a/gpAux/extensions/gpcloud/include/s3exception.h
+++ b/gpAux/extensions/gpcloud/include/s3exception.h
@@ -103,19 +103,20 @@ class S3PartialResponseError : public S3Exception {
 // User press control + C or transaction is aborted.
 class S3QueryAbort : public S3Exception {
    public:
-    S3QueryAbort() {
+    S3QueryAbort() : message("Query is aborted") {
     }
-    S3QueryAbort(const string& msg) {
+    S3QueryAbort(const string& msg) : message(msg) {
     }
     virtual ~S3QueryAbort() {
     }
     virtual string getMessage() {
-        return "Query is aborted";
+        return message;
     }
 
     virtual string getType() {
         return "S3QueryAbort";
     }
+    string message;
 };
 
 // Used for AWS S3 errors (e.g. 403, 404)


### PR DESCRIPTION
This PR fixes two issues:

1, symlink were created in gpAux/extensions/Makefile, better to move it into gpcloud
2, S3QueryAbort's message was not initialized via constructor, detailed message was missed.