### PR TITLE
Enforce resource group concurrency constraint

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -56,6 +56,7 @@
 #include "utils/memutils.h"
 #include "utils/relcache.h"
 #include "utils/resscheduler.h"
+#include "utils/resgroup.h"
 #include "utils/sharedsnapshot.h"
 #include "access/distributedlog.h"
 #include "access/clog.h"
@@ -388,6 +389,13 @@ IsAbortInProgress(void)
 	return (s->state == TRANS_ABORT);
 }
 
+bool
+IsTransactionPreparing(void)
+{
+	TransactionState s = CurrentTransactionState;
+
+	return (s->state == TRANS_PREPARE);
+}
 /*
  *	IsAbortedTransactionBlockState
  *
@@ -2901,6 +2909,10 @@ StartTransaction(void)
 		elog(WARNING, "StartTransaction while in %s state",
 			 TransStateAsString(s->state));
 
+	/* Acquire a resource group slot at the beginning of a transaction */
+	if (Gp_role == GP_ROLE_DISPATCH && IsResGroupEnabled() && IsNormalProcessingMode())
+		ResGroupSlotAcquire();
+
 	/*
 	 * set the current transaction state information appropriately during
 	 * start processing
@@ -3475,6 +3487,10 @@ CommitTransaction(void)
 	RESUME_INTERRUPTS();
 
 	freeGangsForPortal(NULL);
+
+	/* Release resource group slot at the end of a transaction */
+	if (Gp_role == GP_ROLE_DISPATCH && IsResGroupEnabled() && IsNormalProcessingMode())
+		ResGroupSlotRelease();
 }
 
 
@@ -4027,6 +4043,9 @@ CleanupTransaction(void)
 
 	finishDistributedTransactionContext("CleanupTransaction", true);
 
+	/* Release resource group slot at the end of a transaction */
+	if (Gp_role == GP_ROLE_DISPATCH && IsResGroupEnabled() && IsNormalProcessingMode())
+		ResGroupSlotRelease();
 }
 
 /*

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3218,7 +3218,7 @@ CommitTransaction(void)
 	AtEOXact_SharedSnapshot();
 
 	/* Perform any Resource Scheduler commit procesing. */
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
+	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 		AtCommit_ResScheduler();
 
 	/* Perform any AO table commit processing */
@@ -3844,7 +3844,7 @@ AbortTransaction(void)
 	AtEOXact_SharedSnapshot();
 
 	/* Perform any Resource Scheduler abort procesing. */
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
+	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 		AtAbort_ResScheduler();
 		
 	/* Perform any AO table abort processing */

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -26,6 +26,7 @@
 #include "libpq/libpq-be.h"
 #include "utils/memutils.h"
 #include "utils/resource_manager.h"
+#include "utils/resgroup.h"
 #include "storage/bfz.h"
 #include "storage/proc.h"
 #include "cdb/memquota.h"
@@ -1234,6 +1235,25 @@ gpvars_show_gp_resource_manager_policy(void)
 			return "unknown";
 	}
 }
+
+/*
+ * gpvars_assign_max_resource_groups
+ */
+bool
+gpvars_assign_max_resource_groups(int newval, bool doit, GucSource source __attribute__((unused)))
+{
+	if (newval > MaxConnections)
+		elog(ERROR, "Invalid input for max_resource_groups. Must be no larger than max_connections(%d).", MaxConnections);
+
+	if (doit)
+	{
+		MaxResourceGroups = newval;
+	}
+
+	return true;
+}
+
+
 /*
  * gpvars_assign_gp_resqueue_memory_policy
  * gpvars_show_gp_resqueue_memory_policy

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -66,6 +66,8 @@ bool		Debug_print_prelim_plan;	/* Shall we log argument of
 
 bool		Debug_print_slice_table;	/* Shall we log the slice table? */
 
+bool		Debug_resource_group;	/* Shall we log the resource group? */
+
 bool		gp_backup_directIO = false; /* disable\enable direct I/O dump */
 
 int			gp_backup_directIO_read_chunk_mb = 20;		/* size of readChunk

--- a/src/backend/commands/Makefile
+++ b/src/backend/commands/Makefile
@@ -23,6 +23,6 @@ OBJS = aggregatecmds.o alter.o analyze.o async.o cluster.o comment.o  \
 	variable.o view.o
 
 OBJS += analyzefuncs.o extprotocolcmds.o exttablecmds.o filespace.o queue.o
-OBJS += resgroup.o
+OBJS += resgroupcmds.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -947,7 +947,7 @@ CreateQueue(CreateQueueStmt *stmt)
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		if (ResourceScheduler)
+		if (IsResQueueEnabled())
 		{
 			LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
 
@@ -973,7 +973,7 @@ CreateQueue(CreateQueueStmt *stmt)
 		{
 				ereport(WARNING,
 						(errmsg("resource scheduling is disabled"),
-						 errhint("To enable set resource_scheduler=on")));
+						 errhint("To enable set resource_scheduler=on and gp_resource_manager=queue")));
 		}
 	}
 
@@ -1358,7 +1358,7 @@ AlterQueue(AlterQueueStmt *stmt)
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		if (ResourceScheduler)
+		if (IsResQueueEnabled())
 		{
 			LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
 
@@ -1391,7 +1391,7 @@ AlterQueue(AlterQueueStmt *stmt)
 		{
 			ereport(WARNING,
 					(errmsg("resource scheduling is disabled"),
-					 errhint("To enable set resource_scheduler=on")));
+					 errhint("To enable set resource_scheduler=on and gp_resource_manager=queue")));
 		}
 	}
 
@@ -1512,7 +1512,7 @@ DropQueue(DropQueueStmt *stmt)
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		if (ResourceScheduler)
+		if (IsResQueueEnabled())
 		{
 			LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
 
@@ -1529,7 +1529,7 @@ DropQueue(DropQueueStmt *stmt)
 		{
 			ereport(WARNING,
 					(errmsg("resource scheduling is disabled"),
-					 errhint("To enable set resource_scheduler=on")));
+					 errhint("To enable set resource_scheduler=on and gp_resource_manager=queue")));
 		}
 	}
 

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -23,7 +23,7 @@
 #include "cdb/cdbvars.h"
 #include "commands/comment.h"
 #include "commands/defrem.h"
-#include "commands/resgroup.h"
+#include "commands/resgroupcmds.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"

--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -26,6 +26,7 @@
 #include "catalog/pg_resgroup.h"
 #include "catalog/pg_resqueue.h"
 #include "commands/comment.h"
+#include "commands/resgroup.h"
 #include "commands/user.h"
 #include "libpq/auth.h"
 #include "libpq/password_hash.h"

--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -26,7 +26,7 @@
 #include "catalog/pg_resgroup.h"
 #include "catalog/pg_resqueue.h"
 #include "commands/comment.h"
-#include "commands/resgroup.h"
+#include "commands/resgroupcmds.h"
 #include "commands/user.h"
 #include "libpq/auth.h"
 #include "libpq/password_hash.h"

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2052,7 +2052,7 @@ static void
 _SPI_assign_query_mem(QueryDesc * queryDesc)
 {
 	if (Gp_role == GP_ROLE_DISPATCH &&
-			ResourceScheduler &&
+			IsResQueueEnabled() &&
 			!superuser() &&
 			ActivePortal &&
 			(gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE))
@@ -2098,9 +2098,7 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, long tcount)
 			 * If the Active portal already hold a lock on the queue, we cannot
 			 * acquire it again.
 			 */
-			if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler &&
-					!superuser()
-			   )
+			if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled() && !superuser())
 			{
 				/*
 				 * This is SELECT, so we should have planTree anyway.

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -55,6 +55,7 @@
 #include "storage/sinvaladt.h"
 #include "storage/spin.h"
 #include "utils/resscheduler.h"
+#include "utils/resgroup.h"
 #include "utils/faultinjector.h"
 #include "utils/sharedsnapshot.h"
 #include "utils/simex.h"
@@ -144,6 +145,9 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 			size = add_size(size, ResSchedulerShmemSize());
 			size = add_size(size, ResPortalIncrementShmemSize());
 		}
+		else if (IsResGroupEnabled())
+			size = add_size(size, ResGroupShmemSize());
+
 		size = add_size(size, ProcGlobalShmemSize());
 		size = add_size(size, XLOGShmemSize());
 		size = add_size(size, DistributedLog_ShmemSize());
@@ -326,7 +330,8 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		InitResScheduler();
 		InitResPortalIncrementHash();
 	}
-
+	else if (IsResGroupEnabled() && !IsUnderPostmaster)
+		ResGroupControlInit();
 
 	if (!IsUnderPostmaster)
 	{

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -137,14 +137,12 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		size = add_size(size, LockShmemSize());
 		size = add_size(size, workfile_mgr_shmem_size());
 		if (Gp_role == GP_ROLE_DISPATCH)
-		{
 			size = add_size(size, AppendOnlyWriterShmemSize());
-			
-			if(ResourceScheduler)
-			{
-				size = add_size(size, ResSchedulerShmemSize());
-				size = add_size(size, ResPortalIncrementShmemSize());				
-			}
+
+		if (IsResQueueEnabled() && Gp_role == GP_ROLE_DISPATCH)
+		{
+			size = add_size(size, ResSchedulerShmemSize());
+			size = add_size(size, ResPortalIncrementShmemSize());
 		}
 		size = add_size(size, ProcGlobalShmemSize());
 		size = add_size(size, XLOGShmemSize());
@@ -323,7 +321,7 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	/*
 	 * Set up resource schedular
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
+	if (IsResQueueEnabled() && Gp_role == GP_ROLE_DISPATCH)
 	{
 		InitResScheduler();
 		InitResPortalIncrementHash();

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -312,7 +312,7 @@ InitLocks(void)
 	max_table_size = NLOCKENTS();
 	
 		/* Allow for extra entries if resource locking is enabled. */
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
+	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 	{
 		add_size(max_table_size, NRESLOCKENTS() );
 		//add_size(max_plock_table_size, NRESPROCLOCKENTS() );
@@ -2311,14 +2311,14 @@ LockShmemSize(void)
 	/* lock hash table */
 	max_table_size = NLOCKENTS();
 
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
+	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 	{
 		add_size(max_table_size, NRESLOCKENTS() );
 	}
 
 	size = add_size(size, hash_estimate_size(max_table_size, sizeof(LOCK)));
 	
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
+	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 	{
 		add_size(max_table_size, NRESPROCLOCKENTS() );
 	}

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -372,6 +372,7 @@ InitProcess(void)
 	MyProc->lwWaitLink = NULL;
 	MyProc->waitLock = NULL;
 	MyProc->waitProcLock = NULL;
+	MyProc->resWaiting = false;
 	for (i = 0; i < NUM_LOCK_PARTITIONS; i++)
 		SHMQueueInit(&(MyProc->myProcLocks[i]));
 

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -618,7 +618,7 @@ LockWaitCancel(void)
 		return;
 
 	/* Don't try to cancel resource locks.*/
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler &&
+	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled() &&
 		LOCALLOCK_LOCKMETHOD(*lockAwaited) == RESOURCE_LOCKMETHOD)
 		return;
 
@@ -738,7 +738,7 @@ ProcKill(int code, Datum arg)
 	 * Cleanup for any resource locks on portals - from holdable cursors or
 	 * unclean process abort (assertion failures).
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
+	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 		AtExitCleanup_ResPortals();
 
 	/*
@@ -1437,7 +1437,7 @@ CheckDeadLock(void)
 		 * handler.
 		 */
 		Assert(MyProc->waitLock != NULL);
-		if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler && 
+		if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled() &&
 			LOCK_LOCKMETHOD(*(MyProc->waitLock)) == RESOURCE_LOCKMETHOD)
 		{
 			ResRemoveFromWaitQueue(MyProc, 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4624,6 +4624,8 @@ PostgresMain(int argc, char *argv[],
 	 */
 	if (IsResQueueEnabled() && Gp_role == GP_ROLE_DISPATCH && !am_walsender)
 		InitResQueues();
+	else if (IsResGroupEnabled() && (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) && !am_walsender)
+		InitResGroups();
 
 	/*
 	 * Now all GUC states are fully set up.  Report them to client if

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4620,9 +4620,9 @@ PostgresMain(int argc, char *argv[],
 	SetProcessingMode(NormalProcessing);
 
 	/*
-	 * Initialize resource queue hash structure.
+	 * Initialize resource scheduler hash structure.
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler && !am_walsender)
+	if (IsResQueueEnabled() && Gp_role == GP_ROLE_DISPATCH && !am_walsender)
 		InitResQueues();
 
 	/*

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -250,7 +250,7 @@ ProcessQuery(Portal portal,
 	 * we are superuser.
 	 */
 	if (Gp_role == GP_ROLE_DISPATCH && 
-		ResourceScheduler && 
+		IsResQueueEnabled() &&
 		(!ResourceSelectOnly || portal->sourceTag == T_SelectStmt) && 
 		stmt->canSetTag
 		&& !superuser())
@@ -677,7 +677,7 @@ PortalStart(Portal portal, ParamListInfo params, Snapshot snapshot,
 				 * Skip this if we are superuser!
 				 */
 				if (Gp_role == GP_ROLE_DISPATCH
-						&& ResourceScheduler
+						&& IsResQueueEnabled()
 						&& !superuser() )
 				{
 					/* 

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -42,7 +42,7 @@
 #include "commands/prepare.h"
 #include "commands/queue.h"
 #include "commands/proclang.h"
-#include "commands/resgroup.h"
+#include "commands/resgroupcmds.h"
 #include "commands/schemacmds.h"
 #include "commands/sequence.h"
 #include "commands/tablecmds.h"

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -558,7 +558,7 @@ InitializeSessionUserId(const char *rolename)
 	 * queue. Do this even in standalone backend mode, just in case someone
 	 * gives the superuser a resource queue.
 	 */
-	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) && ResourceScheduler)
+	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) && IsResQueueEnabled())
 	{
 		SetResQueueId();
 	}
@@ -621,7 +621,7 @@ SetSessionAuthorization(Oid userid, bool is_superuser)
 	SetSessionUserId(userid, is_superuser);
 
 	/* If resource scheduling enabled, set the cached queue for the new role.*/
-	if ((Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_DISPATCH) && ResourceScheduler)
+	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) && IsResQueueEnabled())
 	{
 		SetResQueueId();
 	}
@@ -684,7 +684,7 @@ SetCurrentRoleId(Oid roleid, bool is_superuser)
 	SetOuterUserId(roleid);
 
 	/* If resource scheduling enabled, set the cached queue for the new role.*/
-	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) && ResourceScheduler)
+	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) && IsResQueueEnabled())
 	{
 		SetResQueueId();
 	}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -38,6 +38,7 @@
 #include "utils/guc_tables.h"
 #include "utils/inval.h"
 #include "utils/resscheduler.h"
+#include "utils/resgroup.h"
 #include "utils/vmem_tracker.h"
 
 #ifdef USE_CONNECTEMC
@@ -3628,6 +3629,15 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&MaxResourceQueues,
 		9, 0, INT_MAX, NULL, NULL
+	},
+
+	{
+		{"max_resource_groups", PGC_POSTMASTER, RESOURCES_MGM,
+			gettext_noop("Maximum number of resource groups."),
+			NULL
+		},
+		&MaxResourceGroups,
+		9, 0, INT_MAX, gpvars_assign_max_resource_groups, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -165,6 +165,7 @@ int			Debug_appendonly_bad_header_print_level = ERROR;
 bool		Debug_appendonly_print_datumstream = false;
 bool		Debug_appendonly_print_visimap = false;
 bool		Debug_appendonly_print_compaction = false;
+bool		Debug_resource_group = false;
 bool		gp_crash_recovery_abort_suppress_fatal = false;
 bool		gp_persistent_statechange_suppress_error = false;
 bool		Debug_bitmap_print_insert = false;
@@ -1305,7 +1306,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"resource_scheduler", PGC_POSTMASTER, RESOURCES_MGM,
 			gettext_noop("Enable resource scheduling."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&ResourceScheduler,
 		true, NULL, NULL
@@ -2135,6 +2136,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Debug_filerep_memory_log_flush,
+		false, NULL, NULL
+	},
+
+	{
+		{"debug_resource_group", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Prints resource groups debug logs."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Debug_resource_group,
 		false, NULL, NULL
 	},
 

--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -243,7 +243,7 @@ CreatePortal(const char *name, bool allowDup, bool dupSilent)
 	portal->creation_time = GetCurrentStatementStartTimestamp();
 
 	/* set portal id and queue id if have enabled resource scheduling */
-	if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
+	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 	{
 		portal->portalId = ResCreatePortalId(name);
 		portal->queueId = GetResQueueId();

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -11,54 +11,46 @@
  */
 #include "postgres.h"
 
-#include "funcapi.h"
-#include "pgstat.h"
 #include "access/genam.h"
-#include "access/heapam.h"
-#include "catalog/indexing.h"
+#include "catalog/pg_authid.h"
 #include "catalog/pg_resgroup.h"
-#include "catalog/pg_type.h"
+#include "cdb/cdbvars.h"
+#include "cdb/memquota.h"
+#include "commands/resgroup.h"
+#include "funcapi.h"
+#include "miscadmin.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "storage/lmgr.h"
+#include "storage/lock.h"
+#include "storage/pg_shmem.h"
+#include "storage/proc.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
+#include "utils/memutils.h"
 #include "utils/resgroup.h"
+#include "utils/resowner.h"
 
-/*
- * GetResGroupIdForName -- Return the Oid for a resource group name
- *
- * Notes:
- *	Used by the various admin commands to convert a user supplied group name
- *	to Oid.
- */
-Oid
-GetResGroupIdForName(char *name, LOCKMODE lockmode)
-{
-	Relation	rel;
-	ScanKeyData scankey;
-	SysScanDesc scan;
-	HeapTuple	tuple;
-	Oid			rsgid;
+/* GUC */
+int		MaxResourceGroups;
 
-	rel = heap_open(ResGroupRelationId, lockmode);
+/* global variables */
+Oid			CurrentResGroupId = InvalidOid;
 
-	/* SELECT oid FROM pg_resgroup WHERE rsgname = :1 */
-	ScanKeyInit(&scankey,
-				Anum_pg_resgroup_rsgname,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				CStringGetDatum(name));
-	scan = systable_beginscan(rel, ResGroupRsgnameIndexId, true,
-							  SnapshotNow, 1, &scankey);
+/* static variables */
+static ResGroupControl *pResGroupControl;
 
-	tuple = systable_getnext(scan);
-	if (HeapTupleIsValid(tuple))
-		rsgid = HeapTupleGetOid(tuple);
-	else
-		rsgid = InvalidOid;
+static bool localResWaiting = false;
 
-	systable_endscan(scan);
-	heap_close(rel, lockmode);
+/* static functions */
 
-	return rsgid;
-}
+static ResGroup ResGroupHashNew(Oid groupId);
+static ResGroup ResGroupHashFind(Oid groupId);
+static bool ResGroupHashRemove(Oid groupId);
+static void ResGroupWait(ResGroup group);
+static bool ResGroupCreate(Oid groupId);
+static void AtProcExit_ResGroup(int code, Datum arg);
+static void ResGroupWaitCancel(void);
 
 Datum
 pg_resgroup_get_status_kv(PG_FUNCTION_ARGS)
@@ -145,3 +137,516 @@ pg_resgroup_get_status_kv(PG_FUNCTION_ARGS)
 	}
 }
 
+/*
+ * Estimate size the resource group structures will need in
+ * shared memory.
+ */
+Size
+ResGroupShmemSize(void)
+{
+	Size		size = 0;
+
+	/* The hash of groups. */
+	size = hash_estimate_size(MaxResourceGroups, sizeof(ResGroupData));
+
+	/* The control structure. */
+	size = add_size(size, sizeof(ResGroupControl));
+
+	/* Add a safety margin */
+	size = add_size(size, size / 10);
+
+	return size;
+}
+
+/*
+ * Initialize the global ResGroupControl struct of resource groups.
+ */
+void
+ResGroupControlInit(void)
+{
+    bool        found;
+    HASHCTL     info;
+    int         hash_flags;
+
+    pResGroupControl = ShmemInitStruct("global resource group control",
+                                       sizeof(*pResGroupControl), &found);
+    if (found)
+        return;
+    if (pResGroupControl == NULL)
+        goto error_out;
+
+    /* Set key and entry sizes of hash table */
+    MemSet(&info, 0, sizeof(info));
+    info.keysize = sizeof(Oid);
+    info.entrysize = sizeof(ResGroupData);
+    info.hash = tag_hash;
+
+    hash_flags = (HASH_ELEM | HASH_FUNCTION);
+
+    LOG_RESGROUP_DEBUG(LOG, "Creating hash table for %d resource groups", MaxResourceGroups);
+
+    pResGroupControl->htbl = ShmemInitHash("Resource Group Hash Table",
+                                           MaxResourceGroups,
+                                           MaxResourceGroups,
+                                           &info, hash_flags);
+
+    if (!pResGroupControl->htbl)
+        goto error_out;
+
+    /*
+     * No need to acquire LWLock here, since this is expected to be called by
+     * postmaster only
+     */
+    pResGroupControl->loaded = false;
+    return;
+
+error_out:
+	ereport(FATAL,
+			(errcode(ERRCODE_OUT_OF_MEMORY),
+			 errmsg("not enough shared memory for resource group control")));
+}
+
+/*
+ * Allocate a resource group entry from a hash table
+ */
+void
+AllocResGroupEntry(Oid groupId)
+{
+	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+
+	bool groupOK = ResGroupCreate(groupId);
+	if (!groupOK)
+	{
+		LWLockRelease(ResGroupLock);
+
+		ereport(PANIC,
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				errmsg("not enough shared memory for resource groups")));
+	}
+
+	LWLockRelease(ResGroupLock);
+}
+
+/*
+ * Remove a resource group entry from the hash table
+ */
+void
+FreeResGroupEntry(Oid groupId)
+{
+	ResGroup group;
+
+	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+
+	group = ResGroupHashFind(groupId);
+	if (group == NULL)
+	{
+		LWLockRelease(ResGroupLock);
+		
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+			 	 errmsg("Cannot find resource group with Oid %d in shared memory", groupId)));
+	}
+
+	if (group->nRunning > 0)
+	{
+		LWLockRelease(ResGroupLock);
+
+		ereport(ERROR,
+				(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+				 errmsg("Cannot drop resource group with Oid %d", groupId),
+				 errhint("There are running transactions in this group."
+						 "Please terminate the queries first, or try dropping the group later.")));
+	}
+
+#ifdef USE_ASSERT_CHECKING
+	bool groupOK = 
+#endif
+		ResGroupHashRemove(groupId);
+	Assert(groupOK);
+
+	LWLockRelease(ResGroupLock);
+}
+
+/*
+ * Load the resource groups in shared memory. Note this
+ * can only be done after enough setup has been done. This uses
+ * heap_open etc which in turn requires shared memory to be set up.
+ */
+void
+InitResGroups(void)
+{
+	HeapTuple	tuple;
+	SysScanDesc	sscan;
+	int			numGroups;
+
+	on_shmem_exit(AtProcExit_ResGroup, 0);
+	if (pResGroupControl->loaded)
+		return;
+	/*
+	 * Need a resource owner to keep the heapam code happy.
+	 */
+	Assert(CurrentResourceOwner == NULL);
+	ResourceOwner owner = ResourceOwnerCreate(NULL, "InitResGroups");
+	CurrentResourceOwner = owner;
+
+	/*
+	 * The resgroup shared mem initialization must be serialized. Only the first session
+	 * should do the init.
+	 * Serialization is done by LW_EXCLUSIVE ResGroupLock. However, we must obtain all DB
+	 * locks before obtaining LWlock to prevent deadlock.
+	 */
+	Relation relResGroup = heap_open(ResGroupRelationId, AccessShareLock);
+	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+
+	if (pResGroupControl->loaded)
+		goto exit;
+
+	numGroups = 0;
+	sscan = systable_beginscan(relResGroup, InvalidOid, false, SnapshotNow, 0, NULL);
+	while (HeapTupleIsValid(tuple = systable_getnext(sscan)))
+	{
+		bool groupOK = ResGroupCreate(HeapTupleGetOid(tuple));
+
+		if (!groupOK)
+			ereport(PANIC,
+					(errcode(ERRCODE_OUT_OF_MEMORY),
+			 		errmsg("not enough shared memory for resource groups")));
+
+		numGroups ++;
+		Assert(numGroups <= MaxResourceGroups);
+	}
+	systable_endscan(sscan);
+
+	pResGroupControl->loaded = true;
+	LOG_RESGROUP_DEBUG(LOG, "initialized %d resource groups", numGroups);
+
+exit:
+	LWLockRelease(ResGroupLock);
+	heap_close(relResGroup, AccessShareLock);
+	CurrentResourceOwner = NULL;
+	ResourceOwnerDelete(owner);
+}
+
+/*
+ * ResGroupCreate -- initialize the elements for a resource group.
+ *
+ * Notes:
+ *	It is expected that the appropriate lightweight lock is held before
+ *	calling this - unless we are the startup process.
+ */
+static bool
+ResGroupCreate(Oid groupId)
+{
+	ResGroup		group;
+
+	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
+	Assert(OidIsValid(groupId));
+
+	group = ResGroupHashNew(groupId);
+	if (group == NULL)
+		return false;
+
+	group->groupId = groupId;
+	group->nRunning = 0;
+	ProcQueueInit(&group->waitProcs);
+
+	return true;
+}
+
+/*
+ * Acquire a resource group slot 
+ *
+ * Call this function at the start of the transaction.
+ */
+void
+ResGroupSlotAcquire(void)
+{
+	ResGroup	group;
+	Oid			groupId;
+	int			concurrencyLimit;
+
+	groupId = GetResGroupIdForRole(GetUserId());
+	if (groupId == InvalidOid)
+		groupId = superuser() ? ADMINRESGROUP_OID : DEFAULTRESGROUP_OID;
+
+	CurrentResGroupId = groupId;
+
+	if (groupId == ADMINRESGROUP_OID)
+		return;
+
+	concurrencyLimit = GetConcurrencyForGroup(groupId);
+
+	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+
+	group = ResGroupHashFind(groupId);
+
+	if (group == NULL)
+	{
+		LWLockRelease(ResGroupLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+			 	 errmsg("Cannot find resource group %d in shared memory", groupId)));
+	}
+
+	if (group->nRunning < concurrencyLimit) 
+	{
+		group->nRunning ++;
+		LWLockRelease(ResGroupLock);
+		return;
+	}
+
+	ResGroupWait(group);
+
+	/*
+	 * The waking process has granted us the slot.
+	 */
+}
+
+/*
+ * Release the resource group slot
+ *
+ * Call this function at the end of the transaction.
+ */
+void
+ResGroupSlotRelease(void)
+{
+	ResGroup	group;
+	PROC_QUEUE	*waitQueue;
+	PGPROC		*waitProc;
+
+	Assert(CurrentResGroupId != InvalidOid);
+	if (CurrentResGroupId == ADMINRESGROUP_OID)
+		return;
+
+	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+
+	group = ResGroupHashFind(CurrentResGroupId);
+	if (group == NULL)
+	{
+		LWLockRelease(ResGroupLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+			 	 errmsg("Cannot find resource group %d in shared memory", CurrentResGroupId)));
+	}
+
+	waitQueue = &(group->waitProcs);
+	
+	if (waitQueue->size == 0)
+	{
+		Assert(waitQueue->links.next == MAKE_OFFSET(&waitQueue->links) &&
+			   waitQueue->links.prev == MAKE_OFFSET(&waitQueue->links));
+		Assert(group->nRunning > 0);
+
+		group->nRunning--;
+		LWLockRelease(ResGroupLock);
+		return;
+	}
+
+	/* wake up one process in the wait queue */
+	waitProc = (PGPROC *) MAKE_PTR(waitQueue->links.next);
+	SHMQueueDelete(&(waitProc->links));
+	waitQueue->size --;
+
+	LWLockRelease(ResGroupLock);
+
+	waitProc->resWaiting = false;
+	SetLatch(&waitProc->procLatch);
+
+	CurrentResGroupId = InvalidOid;
+}
+
+static void
+ResGroupWait(ResGroup group)
+{
+	PGPROC *proc = MyProc, *headProc;
+	PROC_QUEUE *waitQueue;
+
+	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
+
+	proc->resWaiting = true;
+
+	waitQueue = &(group->waitProcs);
+
+	headProc = (PGPROC *) &(waitQueue->links);
+	SHMQueueInsertBefore(&(headProc->links), &(proc->links));
+	waitQueue->size++;
+
+	LWLockRelease(ResGroupLock);
+
+	/* similar to lockAwaited in ProcSleep for interrupt cleanup */
+	localResWaiting = true;
+
+	/*
+	 * Make sure we have released all locks before going to sleep, to eliminate
+	 * deadlock situations
+	 */
+	PG_TRY();
+	{
+		for (;;)
+		{
+			ResetLatch(&proc->procLatch);
+
+			CHECK_FOR_INTERRUPTS();
+
+			if (!proc->resWaiting)
+				break;
+			WaitLatch(&proc->procLatch, WL_LATCH_SET | WL_POSTMASTER_DEATH, -1);
+		}
+	}
+	PG_CATCH();
+	{
+		ResGroupWaitCancel();
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	localResWaiting = false;
+}
+
+/*
+ * ResGroupHashNew -- return a new (empty) group object to initialize.
+ *
+ * Notes
+ *	The resource group lightweight lock (ResGroupLock) *must* be held for
+ *	this operation.
+ */
+static ResGroup
+ResGroupHashNew(Oid groupId)
+{
+	bool		found;
+	ResGroup	group = NULL;
+
+	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
+
+	group = (ResGroup)
+		hash_search(pResGroupControl->htbl, (void *) &groupId, HASH_ENTER_NULL, &found);
+
+	/* caller should test that the group does not exist already */
+	Assert(!found);
+
+	return group;
+}
+
+/*
+ * ResGroupHashFind -- return the group for a given oid.
+ *
+ * Notes
+ *	The resource group lightweight lock (ResGroupLock) *must* be held for
+ *	this operation.
+ */
+static ResGroup
+ResGroupHashFind(Oid groupId)
+{
+	bool		found;
+	ResGroup	group = NULL;
+
+	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
+
+	group = (ResGroup)
+		hash_search(pResGroupControl->htbl, (void *) &groupId, HASH_FIND, &found);
+
+	return group;
+}
+
+
+/*
+ * ResGroupHashRemove -- remove the group for a given oid.
+ *
+ * Notes
+ *	The resource group lightweight lock (ResGroupLock) *must* be held for
+ *	this operation.
+ */
+static bool
+ResGroupHashRemove(Oid groupId)
+{
+	bool		found;
+	void	   *group;
+
+	Assert(LWLockHeldExclusiveByMe(ResGroupLock));
+
+	group = hash_search(pResGroupControl->htbl, (void *) &groupId, HASH_REMOVE, &found);
+	if (!group || !found)
+		return false;
+
+	return true;
+}
+
+static void
+AtProcExit_ResGroup(int code, Datum arg)
+{
+	ResGroupWaitCancel();
+}
+
+static void
+ResGroupWaitCancel(void)
+{
+	ResGroup group;
+	PROC_QUEUE	*waitQueue;
+	PGPROC		*waitProc;
+	bool		granted = false;
+
+	if (CurrentResGroupId == InvalidOid)
+		return;
+
+	if (!localResWaiting)
+		return;
+
+	/* we are sure to be interrupted in the for loop of ResGroupWait now */
+	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+	group = ResGroupHashFind(CurrentResGroupId);
+
+	/*
+	 * We either have been granted the lock, or is still on the waiting list, so
+	 * this group should not have been dropped
+	 */
+	Assert(group != NULL);
+
+	/*
+	 * Check if we are on the waiting list to decide whether we have been granted
+	 * the lock, not resWaiting.
+	 */
+	if (MyProc->links.next == INVALID_OFFSET)
+	{
+		Assert(MyProc->links.prev == INVALID_OFFSET);
+		granted = true;
+	}
+
+	waitQueue = &(group->waitProcs);
+	if (granted)
+	{
+		if (waitQueue->size == 0)
+		{
+			Assert(waitQueue->links.next == MAKE_OFFSET(&waitQueue->links) &&
+				   waitQueue->links.prev == MAKE_OFFSET(&waitQueue->links));
+			Assert(group->nRunning > 0);
+
+			group->nRunning--;
+
+			LWLockRelease(ResGroupLock);
+			localResWaiting = false;
+			return;
+		}
+
+		/* wake up one process in the wait queue */
+		waitProc = (PGPROC *) MAKE_PTR(waitQueue->links.next);
+		SHMQueueDelete(&(waitProc->links));
+		waitQueue->size --;
+
+		LWLockRelease(ResGroupLock);
+
+		waitProc->resWaiting = false;
+		SetLatch(&waitProc->procLatch);
+
+		localResWaiting = false;
+		return;
+	}
+
+	Assert(waitQueue->size > 0);
+	Assert(MyProc->resWaiting);
+
+	SHMQueueDelete(&(MyProc->links));
+	waitQueue->size --;
+
+	LWLockRelease(ResGroupLock);
+	localResWaiting = false;
+}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -16,7 +16,7 @@
 #include "catalog/pg_resgroup.h"
 #include "cdb/cdbvars.h"
 #include "cdb/memquota.h"
-#include "commands/resgroup.h"
+#include "commands/resgroupcmds.h"
 #include "funcapi.h"
 #include "miscadmin.h"
 #include "storage/ipc.h"

--- a/src/backend/utils/resowner/resowner.c
+++ b/src/backend/utils/resowner/resowner.c
@@ -268,7 +268,7 @@ ResourceOwnerReleaseInternal(ResourceOwner owner,
 			{
 				ProcReleaseLocks(isCommit);
 				
-				if (Gp_role == GP_ROLE_DISPATCH && ResourceScheduler)
+				if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
  					ResLockWaitCancel();
 			}
 		}

--- a/src/backend/utils/resowner/resowner.c
+++ b/src/backend/utils/resowner/resowner.c
@@ -205,7 +205,7 @@ ResourceOwnerReleaseInternal(ResourceOwner owner,
 {
 	ResourceOwner child;
 	ResourceOwner save;
-	ResourceReleaseCallbackItem *item;
+	ResourceReleaseCallbackItem *item, *next;
 
 	/* Recurse to handle descendants */
 	for (child = owner->firstchild; child != NULL; child = child->nextchild)
@@ -339,8 +339,11 @@ ResourceOwnerReleaseInternal(ResourceOwner owner,
 	}
 
 	/* Let add-on modules get a chance too */
-	for (item = ResourceRelease_callbacks; item; item = item->next)
+	for (item = ResourceRelease_callbacks; item; item = next)
+	{
+		next = item->next;
 		(*item->callback) (phase, isCommit, isTopLevel, item->arg);
+	}
 
 	CurrentResourceOwner = save;
 }

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -1070,7 +1070,7 @@ ResHandleUtilityStmt(Portal portal, Node *stmt)
 	}
 
 	if (Gp_role == GP_ROLE_DISPATCH
-		&& ResourceScheduler
+		&& IsResQueueEnabled()
 		&& (!ResourceSelectOnly)
 		&& !superuser())
 	{

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -195,6 +195,7 @@ extern void SetSharedTransactionId(void);
 extern void SetSharedTransactionId_reader(TransactionId xid, CommandId cid);
 extern bool IsTransactionState(void);
 extern bool IsAbortInProgress(void);
+extern bool IsTransactionPreparing(void);
 extern bool IsAbortedTransactionBlockState(void);
 extern void GetAllTransactionXids(
 	DistributedTransactionId	*distribXid,

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -232,6 +232,8 @@ extern bool Debug_print_prelim_plan;
  */
 extern bool Debug_print_slice_table;
 
+extern bool Debug_resource_group;
+
 /*
  * gp_backup_directIO
  *

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -1026,6 +1026,8 @@ extern const char *gpvars_assign_gp_resource_manager_policy(const char *newval, 
 
 extern const char *gpvars_show_gp_resource_manager_policy(void);
 
+extern bool gpvars_assign_max_resource_groups(int newval, bool doit, GucSource source __attribute__((unused)));
+
 extern const char *gpvars_assign_gp_resqueue_memory_policy(const char *newval, bool doit, GucSource source __attribute__((unused)) );
 
 extern const char *gpvars_show_gp_resqueue_memory_policy(void);

--- a/src/include/commands/resgroup.h
+++ b/src/include/commands/resgroup.h
@@ -18,4 +18,9 @@
 extern void CreateResourceGroup(CreateResourceGroupStmt *stmt);
 extern void DropResourceGroup(DropResourceGroupStmt *stmt);
 
+/* catalog access function */
+extern Oid GetResGroupIdForName(char *name, LOCKMODE lockmode);
+extern int GetConcurrencyForGroup(int groupId);
+extern Oid GetResGroupIdForRole(Oid roleid);
+
 #endif   /* RESGROUP_H */

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -1,17 +1,17 @@
 /*-------------------------------------------------------------------------
  *
- * resgroup.h
+ * resgroupcmds.h
  *	  Commands for manipulating resource group.
  *
  * Copyright (c) 2006-2017, Greenplum inc.
  *
  * IDENTIFICATION
- * 		src/include/commands/resgroup.h
+ * 		src/include/commands/resgroupcmds.h
  *
  *-------------------------------------------------------------------------
  */
-#ifndef RESGROUP_H
-#define RESGROUP_H
+#ifndef RESGROUPCMDS_H
+#define RESGROUPCMDS_H
 
 #include "nodes/parsenodes.h"
 
@@ -23,4 +23,4 @@ extern Oid GetResGroupIdForName(char *name, LOCKMODE lockmode);
 extern int GetConcurrencyForGroup(int groupId);
 extern Oid GetResGroupIdForRole(Oid roleid);
 
-#endif   /* RESGROUP_H */
+#endif   /* RESGROUPCMDS_H */

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -89,6 +89,7 @@ typedef enum LWLockId
 	ChangeTrackingCompactLock,
 	MirroredLock,
 	ResQueueLock,
+	ResGroupLock,
 	FileRepAppendOnlyCommitCountLock,
 	SyncRepLock,
 	ErrorLogLock,

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -129,6 +129,8 @@ struct PGPROC
 	LOCKMASK	heldLocks;		/* bitmask for lock types already held on this
 								 * lock object by this backend */
 
+	bool		resWaiting;		/* true if waiting for an Resource Group lock */
+
 	/*
 	 * Info to allow us to wait for synchronous replication, if needed.
 	 * waitLSN is InvalidXLogRecPtr if not waiting; set only by user backend.

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -241,6 +241,7 @@ extern bool Debug_filerep_print;
 extern bool Debug_filerep_gcov;
 extern bool Debug_filerep_config_print;
 extern bool Debug_filerep_memory_log_flush;
+extern bool Debug_resource_group;
 extern bool filerep_mirrorvalidation_during_resync;
 extern bool log_filerep_to_syslogger;
 extern bool gp_crash_recovery_suppress_ao_eof;

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -14,16 +14,50 @@
 /*
  * GUC variables.
  */
+extern int MaxResourceGroups;
 
+extern Oid	CurrentGroupId;
 
 /*
  * Data structures
  */
+/* Resource Groups */
+typedef struct ResGroupData
+{
+	Oid			groupId;		/* Id for this group */
+	int 		nRunning;		/* number of running trans */
+	PROC_QUEUE	waitProcs;
+} ResGroupData;
+typedef ResGroupData *ResGroup;
 
+/*
+ * The hash table for resource groups in shared memory should only be populated
+ * once, so we add a flag here to implement this requirement.
+ */
+typedef struct ResGroupControl
+{
+	HTAB			*htbl;
+	bool			loaded;
+} ResGroupControl;
 
 /*
  * Functions in resgroup.c
  */
-extern Oid GetResGroupIdForName(char *name, LOCKMODE lockmode);
+/* Shared memory and semaphores */
+extern Size ResGroupShmemSize(void);
+extern void ResGroupControlInit(void);
+
+/* Load resource group information from catalog */
+extern void	InitResGroups(void);
+
+extern void AllocResGroupEntry(Oid groupId);
+extern void FreeResGroupEntry(Oid groupId);
+
+/* Acquire and release resource group slot */
+extern void ResGroupSlotAcquire(void);
+extern void ResGroupSlotRelease(void);
+
+#define LOG_RESGROUP_DEBUG(...) \
+	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);
 
 #endif   /* RES_GROUP_H */

--- a/src/include/utils/resource_manager.h
+++ b/src/include/utils/resource_manager.h
@@ -26,4 +26,10 @@ typedef enum
 extern bool	ResourceScheduler;
 extern ResourceManagerPolicy Gp_resource_manager_policy;
 
+#define IsResQueueEnabled() \
+	(bool)(ResourceScheduler && Gp_resource_manager_policy == RESOURCE_MANAGER_POLICY_QUEUE)
+#define IsResGroupEnabled() \
+	(bool)(ResourceScheduler && Gp_resource_manager_policy == RESOURCE_MANAGER_POLICY_GROUP)
+
+
 #endif   /* RESOURCEMANAGER_H */

--- a/src/test/regress/expected/resource_group.out
+++ b/src/test/regress/expected/resource_group.out
@@ -30,7 +30,8 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 (1 row)
 
 ALTER ROLE rg_test_role RESOURCE GROUP none;
-NOTICE:  resource group required -- using default resource group "default_group"
+WARNING:  resource group is disabled
+HINT:  To enable set resource_scheduler=on and gp_resource_manager=group
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
  rolresgroup 
 -------------
@@ -46,6 +47,8 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 (1 row)
 
 ALTER ROLE rg_test_role RESOURCE GROUP default_group;
+WARNING:  resource group is disabled
+HINT:  To enable set resource_scheduler=on and gp_resource_manager=group
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
  rolresgroup 
 -------------
@@ -53,7 +56,8 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 (1 row)
 
 ALTER ROLE rg_test_role RESOURCE GROUP none;
-NOTICE:  resource group required -- using default resource group "admin_group"
+WARNING:  resource group is disabled
+HINT:  To enable set resource_scheduler=on and gp_resource_manager=group
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
  rolresgroup 
 -------------
@@ -91,6 +95,8 @@ ERROR:  must specify both memory_limit and cpu_rate_limit
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.5, memory_redzone_limit=.7);
 ERROR:  must specify both memory_limit and cpu_rate_limit
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.5, memory_limit=.6, memory_redzone_limit=.7);
+WARNING:  resource group is disabled
+HINT:  To enable set resource_scheduler=on and gp_resource_manager=group
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_redzone_limit FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
    groupname   | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_redzone_limit 
 ---------------+-------------+----------------------+----------------+--------------+-----------------------+----------------------


### PR DESCRIPTION
`gpconfig -c gp_resource_manager -v group` && `gpstop -ra` to test this functionality of resource group.

A simple running example:
```
CREATE RESOURCE GROUP rg1 WITH (CPU_RATE_LIMIT=0.1, MEMORY_LIMIT=0.1, concurrency=2);
CREATE ROLE r1 RESOURCE GROUP rg1;
set role r1;
-- verify concurrent transactions are limited
```