### PR TITLE
GPDB DOCS Port 4.3.x updates to 5.0

### DIFF
--- a/gpdb-doc/dita/ref_guide/sql_commands/COPY.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/COPY.xml
@@ -120,6 +120,7 @@ COPY {table [(<varname>column</varname> [, ...])] | (<varname>query</varname>)} 
             specify the <codeph>DELIMITER</codeph>, <codeph>NULL</codeph>, or <codeph>CSV</codeph>
             options in binary mode. See <xref href="#topic1/section10" format="dita">Binary
               Format</xref>.</pd>
+          <pd>When copying in binary format, a row of data can be up to 1GB. </pd>
         </plentry>
         <plentry>
           <pt>OIDS</pt>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
@@ -9,37 +9,37 @@
       <title>Synopsis</title>
       <codeblock id="sql_command_synopsis">CREATE [READABLE] EXTERNAL TABLE <varname>table_name</varname>     
     ( <varname>column_name</varname> <varname>data_type</varname> [, ...] | LIKE <varname>other_table </varname>)
-      LOCATION ('file://<varname>seghost</varname>[:<varname>port</varname>]/<varname>path</varname>/<varname>file</varname>' [, ...])
-        | ('gpfdist://<varname>filehost</varname>[:<varname>port</varname>]/<varname>file_pattern[#transform]</varname>' [, ...]
-        | ('gpfdists://<varname>filehost</varname>[:<varname>port</varname>]/<varname>file_pattern[#transform]</varname>'
-            [, ...])
-        | ('gphdfs://<varname>hdfs_host</varname>[:port]/<varname>path</varname>/<varname>file</varname>')
-        | ('s3://<varname>S3_endpoint</varname>[:<varname>port</varname>]/<varname>bucket_name</varname>/[<varname>S3_prefix</varname>]
+     LOCATION ('file://<varname>seghost</varname>[:<varname>port</varname>]/<varname>path</varname>/<varname>file</varname>' [, ...])
+       | ('gpfdist://<varname>filehost</varname>[:<varname>port</varname>]/<varname>file_pattern</varname>[#transform=<varname>trans_name</varname>]'
+           [, ...]
+       | ('gpfdists://<varname>filehost</varname>[:<varname>port</varname>]/<varname>file_pattern</varname>[#transform=<varname>trans_name</varname>]'
+           [, ...])
+       | ('gphdfs://<varname>hdfs_host</varname>[:port]/<varname>path</varname>/<varname>file</varname>')
+       | ('s3://<varname>S3_endpoint</varname>[:<varname>port</varname>]/<varname>bucket_name</varname>/[<varname>S3_prefix</varname>]
              [region=<varname>S3-region</varname>]
             [config=<varname>config_file</varname>]')
-      FORMAT 'TEXT' 
-            [( [HEADER]
-               [DELIMITER [AS] '<varname>delimiter</varname>' | 'OFF']
-               [NULL [AS] '<varname>null string</varname>']
-               [ESCAPE [AS] '<varname>escape</varname>' | 'OFF']
-               [NEWLINE [ AS ] 'LF' | 'CR' | 'CRLF']
-               [FILL MISSING FIELDS] )]
-           | 'CSV'
-            [( [HEADER]
-               [QUOTE [AS] '<varname>quote</varname>'] 
-               [DELIMITER [AS] '<varname>delimiter</varname>']
-               [NULL [AS] '<varname>null string</varname>']
-               [FORCE NOT NULL <varname>column</varname> [, ...]]
-               [ESCAPE [AS] '<varname>escape</varname>']
-               [NEWLINE [ AS ] 'LF' | 'CR' | 'CRLF']
-               [FILL MISSING FIELDS] )]
-           | 'AVRO' 
-           | 'PARQUET'
-
-           | 'CUSTOM' (Formatter=<varname>&lt;formatter specifications&gt;</varname>)
-     [ ENCODING '<varname>encoding</varname>' ]
-     [ [LOG ERRORS] SEGMENT REJECT LIMIT <varname>count</varname>
-       [ROWS | PERCENT] ]
+     FORMAT 'TEXT' 
+           [( [HEADER]
+              [DELIMITER [AS] '<varname>delimiter</varname>' | 'OFF']
+              [NULL [AS] '<varname>null string</varname>']
+              [ESCAPE [AS] '<varname>escape</varname>' | 'OFF']
+              [NEWLINE [ AS ] 'LF' | 'CR' | 'CRLF']
+              [FILL MISSING FIELDS] )]
+          | 'CSV'
+           [( [HEADER]
+              [QUOTE [AS] '<varname>quote</varname>'] 
+              [DELIMITER [AS] '<varname>delimiter</varname>']
+              [NULL [AS] '<varname>null string</varname>']
+              [FORCE NOT NULL <varname>column</varname> [, ...]]
+              [ESCAPE [AS] '<varname>escape</varname>']
+              [NEWLINE [ AS ] 'LF' | 'CR' | 'CRLF']
+              [FILL MISSING FIELDS] )]
+          | 'AVRO' 
+          | 'PARQUET'
+          | 'CUSTOM' (Formatter=<varname>&lt;formatter_specifications&gt;</varname>)
+    [ ENCODING '<varname>encoding</varname>' ]
+      [ [LOG ERRORS] SEGMENT REJECT LIMIT <varname>count</varname>
+      [ROWS | PERCENT] ]
 
 CREATE [READABLE] EXTERNAL WEB TABLE <varname>table_name</varname>     
    ( <varname>column_name</varname> <varname>data_type</varname> [, ...] | LIKE <varname>other_table </varname>)
@@ -72,8 +72,9 @@ CREATE [READABLE] EXTERNAL WEB TABLE <varname>table_name</varname>     
 
 CREATE WRITABLE EXTERNAL TABLE <varname>table_name</varname>
     ( <varname>column_name</varname> <varname>data_type</varname> [, ...] | LIKE <varname>other_table </varname>)
-     LOCATION('gpfdist://<varname>outputhost</varname>[:<varname>port</varname>]/<varname>filename[#transform]</varname>'
-      | ('gpfdists://<varname>outputhost</varname>[:<varname>port</varname>]/<varname>file_pattern[#transform]</varname>'
+     LOCATION('gpfdist://<varname>outputhost</varname>[:<varname>port</varname>]/<varname>filename</varname>[#transform=<varname>trans_name</varname>]'
+          [, ...])
+      | ('gpfdists://<varname>outputhost</varname>[:<varname>port</varname>]/<varname>file_pattern</varname>[#transform=<varname>trans_name</varname>]'
           [, ...])
       | ('gphdfs://<varname>hdfs_host</varname>[:port]/<varname>path</varname>')
       FORMAT 'TEXT' 
@@ -269,6 +270,13 @@ CREATE WRITABLE EXTERNAL WEB TABLE <varname>table_name</varname>
           <pd>With two <codeph>gpfdist</codeph> locations listed as in the above example, half of
             the segments would send their output data to the <codeph>data1.out</codeph> file and the
             other half to the <codeph>data2.out</codeph> file.</pd>
+          <pd>With the option <codeph>#transform=<varname>trans_name</varname></codeph>, you can
+            specify a transform to apply when loading or extracting data. The
+              <varname>trans_name</varname> is the name of the transform in the YAML configuration
+            file you specify with the you run the <codeph>gpfdist</codeph> utility. For information
+            about specifying a transform, see <xref
+              href="../../utility_guide/admin_utilities/gpfdist.xml#topic1"
+              ><codeph>gpfdist</codeph></xref> in the <cite>Greenplum Utility Guide</cite>. </pd>
           <pd>If you specify <codeph>gphdfs</codeph> protocol to read or write a file to a Hadoop
             file system (HDFS), you can read or write an Avro or Parquet format file by specifying
             the <codeph>FORMAT</codeph> clause with either <codeph>AVRO</codeph> or

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpfdist.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpfdist.xml
@@ -2,13 +2,15 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic1">
-    <title id="ku137116">gpfdist</title>
-    <body>
-        <p>Serves data files to or writes data files out from Greenplum Database segments.</p>
-        <section id="section2">
-            <title>Synopsis</title>
-            <codeblock><b>gpfdist</b> [<b>-d</b> <varname>directory</varname>] [<b>-p</b> <varname>http_port</varname>] [<b>-l</b> <varname>log_file</varname>] [<b>-t</b> <varname>timeout</varname>] 
-   [<b>-S</b>] [<b>-w</b> <varname>time</varname>] [<b>-v</b> | <b>-V</b>] [<b>-s</b>] [<b>-m</b> <varname>max_length</varname>] [<b>--ssl</b> <varname>certificate_path</varname>]
+  <title id="ku137116">gpfdist</title>
+  <body>
+    <p>Serves data files to or writes data files out from Greenplum Database segments.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock><b>gpfdist</b> [<b>-d</b> <varname>directory</varname>] [<b>-p</b> <varname>http_port</varname>] [<b>-l</b> <varname>log_file</varname>] [<b>-t</b> <varname>timeout</varname>] 
+   [<b>-S</b>] [<b>-w</b> <varname>time</varname>] [<b>-v</b> | <b>-V</b>] [<b>-s</b>] [<b>-m</b> <varname>max_length</varname>]
+   [<b>--ssl</b> <varname>certificate_path</varname> [<b>--sslclean</b> <varname>wait_time</varname>] ]
+   [<b>-c</b> <varname>config.yml</varname>]
 
 <b>gpfdist -?</b> | <b>--help</b> 
 
@@ -121,9 +123,9 @@
           <pd>Adds SSL encryption to data transferred with <codeph>gpfdist</codeph>. After executing
               <codeph>gpfdist</codeph> with the <codeph>--ssl
               <varname>certificate_path</varname></codeph> option, the only way to load data from
-            this file server is with the <codeph>gpfdist://</codeph> protocol. <ph
-              >For information on the <codeph>gpfdist://</codeph> protocol, see "Loading and
-              Unloading Data" in the <i>Greenplum Database Administrator Guide</i>.</ph></pd>
+            this file server is with the <codeph>gpfdist://</codeph> protocol. <ph>For information
+              on the <codeph>gpfdist://</codeph> protocol, see "Loading and Unloading Data" in the
+                <i>Greenplum Database Administrator Guide</i>.</ph></pd>
           <pd>The location specified in <varname>certificate_path</varname> must contain the
             following files:<ul id="ul_dyp_eqt_mo">
               <li id="ku140282">The server certificate file, <codeph>server.crt</codeph></li>
@@ -131,6 +133,31 @@
               <li id="ku140284">The trusted certificate authorities, <codeph>root.crt</codeph></li>
             </ul><p>The root directory (<codeph>/</codeph>) cannot be specified as
                 <varname>certificate_path</varname>.</p></pd>
+        </plentry>
+        <plentry>
+          <pt>--sslclean <varname>wait_time</varname></pt>
+          <pd>When the utility is run with the <codeph>--ssl</codeph> option, sets the number of
+            seconds that the utility delays before closing an SSL session and cleaning up the SSL
+            resources after it completes writing data to or from a Greenplum Database segment. The
+            default value is 0, no delay. The maximum value is 500 seconds. If the delay is
+            increased, the transfer speed decreases.</pd>
+          <pd>In some cases, this error might occur when copying large amounts of data:
+              <codeph>gpfdist server closed connection</codeph>. To avoid the error, you can add a
+            delay, for example <codeph>--sslclean 5</codeph>. </pd>
+        </plentry>
+        <plentry>
+          <pt>-c <varname>config.yaml</varname></pt>
+          <pd>Specifies rules that <codeph>gpfdist</codeph> uses to select a transform to apply when
+            loading or extracting data. The <codeph>gpfdist</codeph> configuration file is a YAML
+            1.1 document. </pd>
+          <pd>For information about the file format, see <xref
+              href="../../admin_guide/load/topics/g-configuration-file-format.xml#topic83"
+              >Configuration File Format</xref> in the <cite>Greenplum Database Administrator
+              Guide</cite>. For information about configuring data transformation with
+              <codeph>gpfdist</codeph>, see <xref
+              href="../../admin_guide/load/topics/g-transforming-xml-data.xml#topic75">Transforming
+              XML Data</xref> in the <cite>Greenplum Database Administrator Guide</cite>.</pd>
+          <pd>This option is not available on Windows platforms.</pd>
         </plentry>
         <plentry>
           <pt>-v (verbose)</pt>
@@ -157,8 +184,8 @@
         as a service: </p>
       <ol>
         <li id="ku139499">Update your Greenplum Database Loader package to the latest version. This
-          package is available from <xref href="https://network.pivotal.io"
-            scope="external" format="html">Pivotal Network</xref>. </li>
+          package is available from <xref href="https://network.pivotal.io" scope="external"
+            format="html">Pivotal Network</xref>. </li>
         <li id="ku139444">Register <codeph>gpfdist</codeph> as a Windows service:<ol>
             <li id="ku139445">Open a Windows command window</li>
             <li id="ku139446">Run the following
@@ -200,8 +227,8 @@
     <section id="section7">
       <title>See Also</title>
       <p><codeph><xref href="./gpload.xml#topic1" type="topic" format="dita"/></codeph>,
-          <codeph>CREATE EXTERNAL TABLE</codeph><ph> in the <i>Greenplum Database
-            Reference Guide</i></ph></p>
+          <codeph>CREATE EXTERNAL TABLE</codeph><ph> in the <i>Greenplum Database Reference
+            Guide</i></ph></p>
     </section>
   </body>
 </topic>

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpload.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpload.xml
@@ -26,8 +26,9 @@
                     installation, so if you have Greenplum Database installed on the machine where
                         <codeph>gpload</codeph> is running, you do not need a separate Python
                         installation.<note>Greenplum Database Loaders for Windows supports only
-                        Python 2.5 (available from <xref href="https://www.python.org" scope="external"
-                            format="html">https://www.python.org</xref>).</note></li>
+                        Python 2.5 (available from <xref href="https://www.python.org"
+                            scope="external" format="html"
+                    >https://www.python.org</xref>).</note></li>
                 <li id="ke147925">The <codeph><xref href="gpfdist.xml#topic1" type="topic"
                             format="dita"/></codeph> parallel file distribution program installed
                     and in your <codeph>$PATH</codeph>. This program is located in
@@ -426,15 +427,16 @@
                                         </plentry>
                                         <plentry>
                                             <pt id="cftransform">TRANSFORM</pt>
-                                            <pd>Optional. Specifies the name of the input XML
+                                            <pd>Optional. Specifies the name of the input
                                                 transformation passed to <codeph>gpload</codeph>.
-                                                For more information about XML transformations, see
+                                                For information about XML transformations, see
                                                 "Loading and Unloading Data" in the <cite>Greenplum
                                                   Database Administrator Guide</cite>.</pd>
                                         </plentry>
                                         <plentry>
                                             <pt id="cftransformconfig">TRANSFORM_CONFIG</pt>
-                                            <pd>Optional. Specifies the location of the XML
+                                            <pd>Required when <codeph>TRANSFORM</codeph> is
+                                                specified. Specifies the location of the
                                                 transformation configuration file that is specified
                                                 in the <codeph>TRANSFORM</codeph> parameter,
                                                 above.</pd>
@@ -539,8 +541,9 @@
                                                 number, or <codeph>'DEFAULT'</codeph> to use the
                                                 default client encoding. If not specified, the
                                                 default client encoding is used. For information
-                                                about supported character sets, see the <i>Greenplum
-                                                  Database Reference Guide</i>.</pd>
+                                                about supported character sets, see the
+                                                  <cite>Greenplum Database Reference
+                                                Guide</cite>.</pd>
                                         </plentry>
                                         <plentry>
                                             <pt id="cferrorlimit">ERROR_LIMIT</pt>
@@ -843,8 +846,8 @@ GPLOAD:
         <section id="section11">
             <title>See Also</title>
             <p><codeph><xref href="gpfdist.xml#topic1" type="topic" format="dita"/></codeph>,
-                    <codeph>CREATE EXTERNAL TABLE</codeph> in the <i>Greenplum Database Reference
-                    Guide</i></p>
+                    <codeph>CREATE EXTERNAL TABLE</codeph> in the <cite>Greenplum Database Reference
+                    Guide</cite></p>
         </section>
     </body>
 </topic>


### PR DESCRIPTION
Doc updates
- gpfdist -c option (gpfdist, and CREATE EXNTERNAL TABLE)
- gpfdist --sslclean option
- COPY binary mode limitation -max row size is 1GB.

[ci skip]