### PR TITLE
Adding last seen idle time in SessionState

### DIFF
--- a/src/backend/utils/mmgr/idle_tracker.c
+++ b/src/backend/utils/mmgr/idle_tracker.c
@@ -161,6 +161,7 @@ IdleTracker_DeactivateProcess()
 		/* No atomic update necessary as the update is protected by spin lock */
 		MySessionState->activeProcessCount -= 1;
 		Assert(0 <= MySessionState->activeProcessCount);
+		MySessionState->last_idle_time = GetCurrentTimestamp();
 		isProcessActive = false;
 
 		/* Save the point where we reduced the activeProcessCount */

--- a/src/backend/utils/mmgr/idle_tracker.c
+++ b/src/backend/utils/mmgr/idle_tracker.c
@@ -161,7 +161,7 @@ IdleTracker_DeactivateProcess()
 		/* No atomic update necessary as the update is protected by spin lock */
 		MySessionState->activeProcessCount -= 1;
 		Assert(0 <= MySessionState->activeProcessCount);
-		MySessionState->last_idle_time = GetCurrentTimestamp();
+		MySessionState->idle_start = GetCurrentTimestamp();
 		isProcessActive = false;
 
 		/* Save the point where we reduced the activeProcessCount */

--- a/src/backend/utils/mmgr/test/idle_tracker_test.c
+++ b/src/backend/utils/mmgr/test/idle_tracker_test.c
@@ -128,6 +128,8 @@ CheckForDeactivationWithoutCleanup(void (*testFunc)(void))
 	 * possible
 	 */
 	will_be_called(RunawayCleaner_StartCleanup);
+	TimestampTz lastTime = GetCurrentTimestamp();
+	MySessionState->last_idle_time = 0;
 
 #ifdef USE_ASSERT_CHECKING
 	will_return(RunawayCleaner_IsCleanupInProgress, true);
@@ -155,6 +157,7 @@ CheckForDeactivationWithoutCleanup(void (*testFunc)(void))
 	assert_true(deactivationVersion == *CurrentVersion);
 	assert_true(isProcessActive == false);
 	assert_true(MySessionState->activeProcessCount == 0);
+	assert_true(lastTime > 0 && MySessionState->last_idle_time >= lastTime);
 }
 
 /*
@@ -199,7 +202,8 @@ CheckForDeactivationWithProperCleanup(void (*testFunc)(void))
 	 * site
 	 */
 	will_be_called_with_sideeffect(RunawayCleaner_StartCleanup, &_ExceptionalCondition, NULL);
-
+	TimestampTz lastTime = GetCurrentTimestamp();
+	MySessionState->last_idle_time = 0;
 	PG_TRY();
 	{
 		testFunc();
@@ -215,6 +219,7 @@ CheckForDeactivationWithProperCleanup(void (*testFunc)(void))
 	assert_true(deactivationVersion == *CurrentVersion);
 	assert_true(isProcessActive == false);
 	assert_true(MySessionState->activeProcessCount == 0);
+	assert_true(lastTime > 0 && MySessionState->last_idle_time >= lastTime);
 }
 
 /*
@@ -255,6 +260,7 @@ PreventDuplicateDeactivationDuringProcExit(void (*testFunc)(void))
 	proc_exit_inprogress = true;
 	/* Interrupts should be held off during proc_exit_inprogress*/
 	InterruptHoldoffCount = 1;
+	MySessionState->last_idle_time = 0;
 	/* Now the deactivation should succeed as we have held off interrupts */
 	testFunc();
 	InterruptHoldoffCount = 0;
@@ -264,6 +270,8 @@ PreventDuplicateDeactivationDuringProcExit(void (*testFunc)(void))
 	assert_true(isProcessActive == false);
 	/* We haven't reduced the activeProcessCount */
 	assert_true(MySessionState->activeProcessCount == 1);
+	/* last_idle_time shouldn't change as we were already idle */
+	assert_true(MySessionState->last_idle_time == 0);
 
 #ifdef USE_ASSERT_CHECKING
 	/*

--- a/src/backend/utils/session_state.c
+++ b/src/backend/utils/session_state.c
@@ -102,6 +102,7 @@ SessionState_Acquire(int sessionId)
 		acquired->sessionVmem = 0;
 		acquired->cleanupCountdown = CLEANUP_COUNTDOWN_BEFORE_RUNAWAY;
 		acquired->activeProcessCount = 0;
+		acquired->last_idle_time = 0;
 
 #ifdef USE_ASSERT_CHECKING
 		acquired->isModifiedSessionId = false;
@@ -174,6 +175,7 @@ SessionState_Release(SessionState *acquired)
 		acquired->commandCountRunaway = 0;
 		acquired->cleanupCountdown = CLEANUP_COUNTDOWN_BEFORE_RUNAWAY;
 		acquired->activeProcessCount = 0;
+		acquired->last_idle_time = 0;
 
 #ifdef USE_ASSERT_CHECKING
 		acquired->isModifiedSessionId = false;

--- a/src/backend/utils/session_state.c
+++ b/src/backend/utils/session_state.c
@@ -102,7 +102,7 @@ SessionState_Acquire(int sessionId)
 		acquired->sessionVmem = 0;
 		acquired->cleanupCountdown = CLEANUP_COUNTDOWN_BEFORE_RUNAWAY;
 		acquired->activeProcessCount = 0;
-		acquired->last_idle_time = 0;
+		acquired->idle_start = 0;
 
 #ifdef USE_ASSERT_CHECKING
 		acquired->isModifiedSessionId = false;
@@ -175,7 +175,7 @@ SessionState_Release(SessionState *acquired)
 		acquired->commandCountRunaway = 0;
 		acquired->cleanupCountdown = CLEANUP_COUNTDOWN_BEFORE_RUNAWAY;
 		acquired->activeProcessCount = 0;
-		acquired->last_idle_time = 0;
+		acquired->idle_start = 0;
 
 #ifdef USE_ASSERT_CHECKING
 		acquired->isModifiedSessionId = false;

--- a/src/backend/utils/test/session_state_test.c
+++ b/src/backend/utils/test/session_state_test.c
@@ -316,7 +316,7 @@ test__SessionState_ShmemInit__InitializesWhenPostmaster(void **state)
 			assert_true(cur->runawayStatus == RunawayStatus_NotRunaway);
 			assert_true(cur->pinCount == 0);
 			assert_true(cur->activeProcessCount == 0);
-			assert_true(cur->last_idle_time == 0);
+			assert_true(cur->idle_start == 0);
 			assert_true(cur->sessionVmem == 0);
 			assert_true(cur->spinLock == 0);
 
@@ -365,7 +365,7 @@ test__SessionState_Init__AcquiresAndInitializes(void **state)
 	SessionState *theEntry = AllSessionStateEntries->freeList;
 
 	theEntry->activeProcessCount = 1234;
-	theEntry->last_idle_time = 1234;
+	theEntry->idle_start = 1234;
 	theEntry->cleanupCountdown = 1234;
 	theEntry->runawayStatus = RunawayStatus_PrimaryRunawaySession;
 	theEntry->pinCount = 1234;
@@ -384,7 +384,7 @@ test__SessionState_Init__AcquiresAndInitializes(void **state)
 	assert_true(first == theEntry);
 
 	assert_true(theEntry->activeProcessCount == 0);
-	assert_true(theEntry->last_idle_time == 0);
+	assert_true(theEntry->idle_start == 0);
 	assert_true(theEntry->cleanupCountdown == CLEANUP_COUNTDOWN_BEFORE_RUNAWAY);
 	assert_true(theEntry->runawayStatus == RunawayStatus_NotRunaway);
 	assert_true(theEntry->pinCount == 1);

--- a/src/backend/utils/test/session_state_test.c
+++ b/src/backend/utils/test/session_state_test.c
@@ -316,6 +316,7 @@ test__SessionState_ShmemInit__InitializesWhenPostmaster(void **state)
 			assert_true(cur->runawayStatus == RunawayStatus_NotRunaway);
 			assert_true(cur->pinCount == 0);
 			assert_true(cur->activeProcessCount == 0);
+			assert_true(cur->last_idle_time == 0);
 			assert_true(cur->sessionVmem == 0);
 			assert_true(cur->spinLock == 0);
 
@@ -364,6 +365,7 @@ test__SessionState_Init__AcquiresAndInitializes(void **state)
 	SessionState *theEntry = AllSessionStateEntries->freeList;
 
 	theEntry->activeProcessCount = 1234;
+	theEntry->last_idle_time = 1234;
 	theEntry->cleanupCountdown = 1234;
 	theEntry->runawayStatus = RunawayStatus_PrimaryRunawaySession;
 	theEntry->pinCount = 1234;
@@ -382,6 +384,7 @@ test__SessionState_Init__AcquiresAndInitializes(void **state)
 	assert_true(first == theEntry);
 
 	assert_true(theEntry->activeProcessCount == 0);
+	assert_true(theEntry->last_idle_time == 0);
 	assert_true(theEntry->cleanupCountdown == CLEANUP_COUNTDOWN_BEFORE_RUNAWAY);
 	assert_true(theEntry->runawayStatus == RunawayStatus_NotRunaway);
 	assert_true(theEntry->pinCount == 1);

--- a/src/bin/gp_session_state/gp_session_state.sql.in
+++ b/src/bin/gp_session_state/gp_session_state.sql.in
@@ -24,6 +24,7 @@ BEGIN;
 --        int - number of QEs that already freed their memory,
 --        int - amount of vmem allocated at the time it was flagged as runaway
 --        int - command count running at the time it was flagged as runaway
+--        TimeStampTz - last time a QE of this session became idle
 --
 -- @doc:
 --        UDF to retrieve memory usage entries for sessions
@@ -58,7 +59,8 @@ WITH all_entries AS (
             active_qe_count int, 
             dirty_qe_count int,
             runaway_vmem_mb int, 
-            runaway_command_cnt int
+            runaway_command_cnt int,
+            last_idle_time timestamp with time zone
           )
     UNION ALL
     SELECT C.*
@@ -71,7 +73,8 @@ WITH all_entries AS (
             active_qe_count int, 
             dirty_qe_count int,
             runaway_vmem_mb int, 
-            runaway_command_cnt int      
+            runaway_command_cnt int,
+            last_idle_time timestamp with time zone
           ))
 SELECT S.datname, 
        M.sessionid as sess_id, 
@@ -84,7 +87,8 @@ SELECT S.datname,
        M.active_qe_count,
        M.dirty_qe_count,
        M.runaway_vmem_mb, 
-       M.runaway_command_cnt
+       M.runaway_command_cnt,
+       last_idle_time
 FROM all_entries M LEFT OUTER JOIN 
 pg_stat_activity as S
 ON M.sessionid = S.sess_id;

--- a/src/bin/gp_session_state/gp_session_state.sql.in
+++ b/src/bin/gp_session_state/gp_session_state.sql.in
@@ -60,7 +60,7 @@ WITH all_entries AS (
             dirty_qe_count int,
             runaway_vmem_mb int, 
             runaway_command_cnt int,
-            last_idle_time timestamp with time zone
+            idle_start timestamp with time zone
           )
     UNION ALL
     SELECT C.*
@@ -74,7 +74,7 @@ WITH all_entries AS (
             dirty_qe_count int,
             runaway_vmem_mb int, 
             runaway_command_cnt int,
-            last_idle_time timestamp with time zone
+            idle_start timestamp with time zone
           ))
 SELECT S.datname, 
        M.sessionid as sess_id, 
@@ -88,7 +88,7 @@ SELECT S.datname,
        M.dirty_qe_count,
        M.runaway_vmem_mb, 
        M.runaway_command_cnt,
-       last_idle_time
+       idle_start
 FROM all_entries M LEFT OUTER JOIN 
 pg_stat_activity as S
 ON M.sessionid = S.sess_id;

--- a/src/bin/gp_session_state/gp_session_state_memory_stats.c
+++ b/src/bin/gp_session_state/gp_session_state_memory_stats.c
@@ -21,7 +21,7 @@
 #include "miscadmin.h"
 
 /* The number of columns as defined in gp_session_state_memory_stats view */
-#define NUM_SESSION_STATE_MEMORY_ELEM 9
+#define NUM_SESSION_STATE_MEMORY_ELEM 10
 
 Datum gp_session_state_memory_entries(PG_FUNCTION_ARGS);
 
@@ -76,7 +76,10 @@ gp_session_state_memory_entries(PG_FUNCTION_ARGS)
 		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "runaway_command_cnt",
 				INT4OID, -1 /* typmod */, 0 /* attdim */);
 
-		Assert(NUM_SESSION_STATE_MEMORY_ELEM == 9);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 10, "last_idle_time",
+				TIMESTAMPTZOID, -1 /* typmod */, 0 /* attdim */);
+
+		Assert(NUM_SESSION_STATE_MEMORY_ELEM == 10);
 
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 
@@ -117,6 +120,7 @@ gp_session_state_memory_entries(PG_FUNCTION_ARGS)
 			values[6] = Int32GetDatum(sessionState.cleanupCountdown);
 			values[7] = Int32GetDatum(sessionState.sessionVmemRunaway);
 			values[8] = Int32GetDatum(sessionState.commandCountRunaway);
+			values[9] = TimestampTzGetDatum(sessionState.last_idle_time);
 
 			HeapTuple tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 			Datum result = HeapTupleGetDatum(tuple);

--- a/src/bin/gp_session_state/gp_session_state_memory_stats.c
+++ b/src/bin/gp_session_state/gp_session_state_memory_stats.c
@@ -76,7 +76,7 @@ gp_session_state_memory_entries(PG_FUNCTION_ARGS)
 		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "runaway_command_cnt",
 				INT4OID, -1 /* typmod */, 0 /* attdim */);
 
-		TupleDescInitEntry(tupdesc, (AttrNumber) 10, "last_idle_time",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 10, "idle_start",
 				TIMESTAMPTZOID, -1 /* typmod */, 0 /* attdim */);
 
 		Assert(NUM_SESSION_STATE_MEMORY_ELEM == 10);
@@ -120,7 +120,7 @@ gp_session_state_memory_entries(PG_FUNCTION_ARGS)
 			values[6] = Int32GetDatum(sessionState.cleanupCountdown);
 			values[7] = Int32GetDatum(sessionState.sessionVmemRunaway);
 			values[8] = Int32GetDatum(sessionState.commandCountRunaway);
-			values[9] = TimestampTzGetDatum(sessionState.last_idle_time);
+			values[9] = TimestampTzGetDatum(sessionState.idle_start);
 
 			HeapTuple tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 			Datum result = HeapTupleGetDatum(tuple);

--- a/src/include/utils/session_state.h
+++ b/src/include/utils/session_state.h
@@ -57,6 +57,9 @@ typedef struct SessionState
 	/* How many QEs are not blocked in ReadCommand */
 	int activeProcessCount;
 
+	/* The last seen time that a QE from this session became idle */
+	TimestampTz last_idle_time;
+
 	/*
 	 * At the time of a runaway event, we set this to the activeQECount and
 	 * as each QE cleans up, it decrements this counter. Once the counter

--- a/src/include/utils/session_state.h
+++ b/src/include/utils/session_state.h
@@ -58,7 +58,7 @@ typedef struct SessionState
 	int activeProcessCount;
 
 	/* The last seen time that a QE from this session became idle */
-	TimestampTz last_idle_time;
+	TimestampTz idle_start;
 
 	/*
 	 * At the time of a runaway event, we set this to the activeQECount and


### PR DESCRIPTION
This PR addresses external tools such as WLM requirement to determine the idle time for each session. We add a per-session last seen idle time across all QEs on each segment. Each QE updates this value in its own SessionState whenever it becomes idle. To determine how long a session has been idle we can run a query like this:

```
frahman=# select sess_id, now() - last_idle_time as idle_duration from session_state.session_level_memory_consumption where active_qe_count = 0 and segid = -1;
 sess_id |  idle_duration
---------+-----------------
      16 | 00:01:45.882067
(1 row)
```

While the value is mostly useful on the master, the operation itself is not very expensive and so we record it on all the segments. Note: WLM currently issues cancellation on the segment directly (in utility mode). Therefore, exposing segment level idle timeout might offer additional flexibility to define WLM rules. This can also be coupled with "idle in transaction" vs. true idle using pg_stat_activity (or we can expose the idle in transaction status in the future, if necessary).