### PR TITLE
Remove Orca translator dead code

### DIFF
--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" resolve);
 	@echo "Resolve finished";
 
-	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.17.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget -O - https://github.com/greenplum-db/gporca/releases/download/v2.18.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 
 clean_tools: opt_write_test
 	@cd releng/make/dependencies; \

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -55,7 +55,6 @@ CContextDXLToPlStmt::CContextDXLToPlStmt
 	m_pintocl(NULL),
 	m_pdistrpolicy(NULL)
 {
-	m_phmuldxltrctxSharedScan = GPOS_NEW(m_pmp) HMUlDxltrctx(m_pmp);
 	m_phmulcteconsumerinfo = GPOS_NEW(m_pmp) HMUlCTEConsumerInfo(m_pmp);
 	m_pdrgpulNumSelectors = GPOS_NEW(m_pmp) DrgPul(m_pmp);
 }
@@ -70,7 +69,6 @@ CContextDXLToPlStmt::CContextDXLToPlStmt
 //---------------------------------------------------------------------------
 CContextDXLToPlStmt::~CContextDXLToPlStmt()
 {
-	m_phmuldxltrctxSharedScan->Release();
 	m_phmulcteconsumerinfo->Release();
 	m_pdrgpulNumSelectors->Release();
 }
@@ -361,49 +359,6 @@ CContextDXLToPlStmt::AddCtasInfo
 	
 	m_pintocl = pintocl;
 	m_pdistrpolicy = pdistrpolicy;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CContextDXLToPlStmt::PdxltrctxForSharedScan
-//
-//	@doc:
-//		Returns the context for the shared scan with the given spool id
-//
-//---------------------------------------------------------------------------
-const CDXLTranslateContext *
-CContextDXLToPlStmt::PdxltrctxForSharedScan
-	(
-	ULONG ulSpoolId
-	)
-{
-	const CDXLTranslateContext *pdxltrctx = m_phmuldxltrctxSharedScan->PtLookup(&ulSpoolId);
-	return pdxltrctx;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CContextDXLToPlStmt::AddSharedScanTranslationContext
-//
-//	@doc:
-//		Stores the context for the shared scan with the given spool id
-//
-//---------------------------------------------------------------------------
-void
-CContextDXLToPlStmt::AddSharedScanTranslationContext
-	(
-	ULONG ulSpoolId,
-	CDXLTranslateContext *pdxltrctx
-	)
-{
-	ULONG *pul = GPOS_NEW(m_pmp) ULONG(ulSpoolId);
-
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif
-	m_phmuldxltrctxSharedScan->FInsert(pul, pdxltrctx);
-
-	GPOS_ASSERT(fInserted);
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -156,7 +156,6 @@ CTranslatorDXLToPlStmt::InitTranslators()
 	{
 			{EdxlopPhysicalTableScan,				&gpopt::CTranslatorDXLToPlStmt::PtsFromDXLTblScan},
 			{EdxlopPhysicalExternalScan,			&gpopt::CTranslatorDXLToPlStmt::PtsFromDXLTblScan},
-			//{EdxlopPhysicalIndexOnlyScan,			&gpopt::CTranslatorDXLToPlStmt::PiosFromDXLIndexOnlyScan},
 			{EdxlopPhysicalIndexScan,				&gpopt::CTranslatorDXLToPlStmt::PisFromDXLIndexScan},
 			{EdxlopPhysicalHashJoin, 				&gpopt::CTranslatorDXLToPlStmt::PhjFromDXLHJ},
 			{EdxlopPhysicalNLJoin, 					&gpopt::CTranslatorDXLToPlStmt::PnljFromDXLNLJ},
@@ -174,7 +173,6 @@ CTranslatorDXLToPlStmt::InitTranslators()
 			{EdxlopPhysicalResult, 					&gpopt::CTranslatorDXLToPlStmt::PresultFromDXLResult},
 			{EdxlopPhysicalAppend, 					&gpopt::CTranslatorDXLToPlStmt::PappendFromDXLAppend},
 			{EdxlopPhysicalMaterialize, 			&gpopt::CTranslatorDXLToPlStmt::PmatFromDXLMaterialize},
-			{EdxlopPhysicalSharedScan, 				&gpopt::CTranslatorDXLToPlStmt::PshscanFromDXLSharedScan},
 			{EdxlopPhysicalSequence, 				&gpopt::CTranslatorDXLToPlStmt::PplanSequence},
 			{EdxlopPhysicalDynamicTableScan,		&gpopt::CTranslatorDXLToPlStmt::PplanDTS},
 			{EdxlopPhysicalDynamicIndexScan,		&gpopt::CTranslatorDXLToPlStmt::PplanDIS},
@@ -3693,103 +3691,6 @@ CTranslatorDXLToPlStmt::PmatFromDXLMaterialize
 	pdrgpdxltrctx->Release();
 
 	return (Plan *) pmat;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CTranslatorDXLToPlStmt::PshscanFromDXLSharedScan
-//
-//	@doc:
-//		Translate DXL materialize node into GPDB Material plan node
-//
-//---------------------------------------------------------------------------
-Plan *
-CTranslatorDXLToPlStmt::PshscanFromDXLSharedScan
-	(
-	const CDXLNode *pdxlnSharedScan,
-	CDXLTranslateContext *pdxltrctxOut,
-	Plan *pplanParent,
-	DrgPdxltrctx *pdrgpdxltrctxPrevSiblings
-	)
-{
-	// create sort plan node
-	ShareInputScan *pshscan = MakeNode(ShareInputScan);
-
-	CDXLPhysicalSharedScan *pdxlopShscan = CDXLPhysicalSharedScan::PdxlopConvert(pdxlnSharedScan->Pdxlop());
-
-	// set spooling info
-	const CDXLSpoolInfo *pspoolinfo = pdxlopShscan->Pspoolinfo();
-
-	pshscan->share_id = pspoolinfo->UlSpoolId();
-	pshscan->driver_slice = pspoolinfo->IExecutorSlice();
-	pshscan->share_type = ShtypeFromSpoolInfo(pspoolinfo);
-
-	GPOS_ASSERT(SHARE_NOTSHARED != pshscan->share_type);
-
-	Plan *pplan = &(pshscan->scan.plan);
-	pplan->plan_node_id = m_pctxdxltoplstmt->UlNextPlanId();
-	pplan->plan_parent_node_id = IPlanId(pplanParent);
-
-	// translate operator costs
-	TranslatePlanCosts
-		(
-		CDXLPhysicalProperties::PdxlpropConvert(pdxlnSharedScan->Pdxlprop())->Pdxlopcost(),
-		&(pplan->startup_cost),
-		&(pplan->total_cost),
-		&(pplan->plan_rows),
-		&(pplan->plan_width)
-		);
-
-	CDXLTranslateContext *pdxltrctxChild = NULL;
-
-	if (EdxlshscanIndexSentinel == pdxlnSharedScan->UlArity())
-	{
-		// translate shared scan child
-		CDXLNode *pdxlnChild = (*pdxlnSharedScan)[EdxlshscanIndexChild];
-		pdxltrctxChild = GPOS_NEW(m_pmp) CDXLTranslateContext(m_pmp, false, pdxltrctxOut->PhmColParam());
-
-		Plan *pplanChild = PplFromDXL(pdxlnChild, pdxltrctxChild, pplan, pdrgpdxltrctxPrevSiblings);
-
-		pplan->lefttree = pplanChild;
-		pplan->nMotionNodes = pplanChild->nMotionNodes;
-
-		// store translation context
-		m_pctxdxltoplstmt->AddSharedScanTranslationContext(pspoolinfo->UlSpoolId(), pdxltrctxChild);
-	}
-	else
-	{
-		// no direct child: we must have translated the actual spool for this shared scan already
-		// find the corresponding translation context
-		pdxltrctxChild = const_cast<CDXLTranslateContext*>(m_pctxdxltoplstmt->PdxltrctxForSharedScan(pspoolinfo->UlSpoolId()));
-	}
-
-	GPOS_ASSERT(NULL != pdxltrctxChild);
-
-	CDXLNode *pdxlnPrL = (*pdxlnSharedScan)[EdxlshscanIndexProjList];
-	CDXLNode *pdxlnFilter = (*pdxlnSharedScan)[EdxlshscanIndexFilter];
-
-	DrgPdxltrctx *pdrgpdxltrctx = GPOS_NEW(m_pmp) DrgPdxltrctx(m_pmp);
-	pdrgpdxltrctx->Append(pdxltrctxChild);
-
-	// translate proj list and filter
-	TranslateProjListAndFilter
-		(
-		pdxlnPrL,
-		pdxlnFilter,
-		NULL,			// translate context for the base table
-		pdrgpdxltrctx,
-		&pplan->targetlist,
-		&pplan->qual,
-		pdxltrctxOut,
-		pplan
-		);
-
-	SetParamIds(pplan);
-
-	// cleanup
-	pdrgpdxltrctx->Release();
-
-	return (Plan *) pshscan;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -58,42 +58,6 @@ using namespace gpmd;
 
 //---------------------------------------------------------------------------
 //	@function:
-//		ShtypeFromSpoolInfo
-//
-//	@doc:
-//		Helper function for extracting the GPDB share type from a DXL spool info object
-//
-//---------------------------------------------------------------------------
-ShareType
-ShtypeFromSpoolInfo(const CDXLSpoolInfo *pspoolinfo)
-{
-	ShareType shtype = SHARE_NOTSHARED;
-
-	GPOS_ASSERT(NULL != pspoolinfo);
-
-	if (EdxlspoolMaterialize == pspoolinfo->Edxlsptype())
-	{
-		shtype = SHARE_MATERIAL;
-		if (pspoolinfo->FMultiSlice())
-		{
-			shtype = SHARE_MATERIAL_XSLICE;
-		}
-	}
-	else if (EdxlspoolSort == pspoolinfo->Edxlsptype())
-	{
-		shtype = SHARE_SORT;
-		if (pspoolinfo->FMultiSlice())
-		{
-			shtype = SHARE_SORT_XSLICE;
-		}
-	}
-
-	return shtype;
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
 //		CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt
 //
 //	@doc:

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -96,9 +96,6 @@ namespace gpdxl
 
 			IMemoryPool *m_pmp;
 
-			// mappings for share scan nodes
-			HMUlDxltrctx *m_phmuldxltrctxSharedScan;
-
 			// counter for generating plan ids
 			CIdGenerator *m_pidgtorPlan;
 
@@ -147,10 +144,6 @@ namespace gpdxl
 
 			// dtor
 			~CContextDXLToPlStmt();
-
-			const CDXLTranslateContext *PdxltrctxForSharedScan(ULONG ulSpoolId);
-
-			void AddSharedScanTranslationContext(ULONG ulSpoolId, CDXLTranslateContext *pdxltrctx);
 
 			// retrieve the next plan id
 			ULONG UlNextPlanId();


### PR DESCRIPTION
When I was trying to understand how does Orca generate plan for CTE using
shared input scan, I found that the share input scan is generated during CTE
producer & consumer DXL node to PlannedStmt translation stage, instead of Expr
to DXL stage inside Orca. It turns out CDXLPhysicalSharedScan is not used
anywhere, so remove all the related dead code.