### PR TITLE
Fix error message, if EXCHANGE PARTITION with multiple constraints fails

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -1189,18 +1189,18 @@ cdb_exchange_part_constraints(Relation table,
 static char *
 constraint_names(List *cons)
 {
-	HeapTuple tuple;
-	Form_pg_constraint con;
-	ListCell *lc;
+	ListCell   *lc;
 	StringInfoData str;
+	char	   *p;
 
 	initStringInfo(&str);
 
-	char *p = "";
+	p = "";
 	foreach (lc, cons)
 	{
-		tuple = linitial(cons);
-		con = (Form_pg_constraint) GETSTRUCT(tuple);
+		HeapTuple tuple = lfirst(lc);
+		Form_pg_constraint con = (Form_pg_constraint) GETSTRUCT(tuple);
+
 		appendStringInfo(&str, "%s\"%s\"", p, NameStr(con->conname));
 		p = ", ";
 	}

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -334,69 +334,44 @@ drop table foo_p, bar_p, baz_p;
 -- partitioning rule". 
 create table foo_p (i int, j int) distributed by (i)
 partition by range(j)
-(start(1) end(10) every(1));
+(start(1) end(5) every(1));
 NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
 NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
 NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
 NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p(i int, j int check (j > 1000)) distributed by (i);
-alter table foo_p exchange partition for(rank(2)) with table bar_p;
-ERROR:  invalid constraint(s) found on "bar_p": "bar_p_j_check"
+create table bar_a(i int, j int check (j > 1000)) distributed by (i);
+alter table foo_p exchange partition for(rank(2)) with table bar_a;
+ERROR:  invalid constraint(s) found on "bar_a": "bar_a_j_check"
 HINT:  drop the invalid constraints and retry
-drop table foo_p, bar_p;
 -- Should fail: A constraint on bar_p isn't shared by all the parts.
 -- Allowing this would make an inconsistent partitioned table. 
 -- Prior versions allowed this, so parts could have differing constraints
 -- as long as they avoided the partition columns.
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p(i int check (i > 1000), j int) distributed by (i);
-alter table foo_p exchange partition for(rank(2)) with table bar_p;
-ERROR:  invalid constraint(s) found on "bar_p": "bar_p_i_check"
+create table bar_b(i int check (i > 1000), j int) distributed by (i);
+alter table foo_p exchange partition for(rank(2)) with table bar_b;
+ERROR:  invalid constraint(s) found on "bar_b": "bar_b_i_check"
 HINT:  drop the invalid constraints and retry
-drop table foo_p, bar_p;
+-- like above, but with two contraints, just to check that the error
+-- message can print that correctly.
+create table bar_c(i int check (i > 1000), j int check (j > 1000)) distributed by (i);
+alter table foo_p exchange partition for(rank(2)) with table bar_c;
+ERROR:  invalid constraint(s) found on "bar_c": "bar_c_i_check", "bar_c_j_check"
+HINT:  drop the invalid constraints and retry
 -- Shouldn't fail: check constraint matches partition rule.
 -- Note this test is slightly different from prior versions to get
 -- in line with constraint consistency requirement.
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p(i int, j int check (j >= 2 and j < 3 ))
+create table bar_d(i int, j int check (j >= 2 and j < 3 ))
 distributed by (i);
-insert into bar_p values(100000, 2);
-alter table foo_p exchange partition for(rank(2)) with table bar_p;
-insert into bar_p values(200000, 2);
-select * from bar_p;
+insert into bar_d values(100000, 2);
+alter table foo_p exchange partition for(rank(2)) with table bar_d;
+insert into bar_d values(200000, 2);
+select * from bar_d;
    i    | j 
 --------+---
  200000 | 2
 (1 row)
 
-drop table foo_p, bar_p;
+drop table foo_p, bar_a, bar_b, bar_c, bar_d;
 -- permissions
 create role part_role;
 NOTICE:  resource queue required -- using default resource queue "pg_default"

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -334,69 +334,44 @@ drop table foo_p, bar_p, baz_p;
 -- partitioning rule". 
 create table foo_p (i int, j int) distributed by (i)
 partition by range(j)
-(start(1) end(10) every(1));
+(start(1) end(5) every(1));
 NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
 NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
 NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
 NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p(i int, j int check (j > 1000)) distributed by (i);
-alter table foo_p exchange partition for(rank(2)) with table bar_p;
-ERROR:  invalid constraint(s) found on "bar_p": "bar_p_j_check"
+create table bar_a(i int, j int check (j > 1000)) distributed by (i);
+alter table foo_p exchange partition for(rank(2)) with table bar_a;
+ERROR:  invalid constraint(s) found on "bar_a": "bar_a_j_check"
 HINT:  drop the invalid constraints and retry
-drop table foo_p, bar_p;
 -- Should fail: A constraint on bar_p isn't shared by all the parts.
 -- Allowing this would make an inconsistent partitioned table. 
 -- Prior versions allowed this, so parts could have differing constraints
 -- as long as they avoided the partition columns.
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p(i int check (i > 1000), j int) distributed by (i);
-alter table foo_p exchange partition for(rank(2)) with table bar_p;
-ERROR:  invalid constraint(s) found on "bar_p": "bar_p_i_check"
+create table bar_b(i int check (i > 1000), j int) distributed by (i);
+alter table foo_p exchange partition for(rank(2)) with table bar_b;
+ERROR:  invalid constraint(s) found on "bar_b": "bar_b_i_check"
 HINT:  drop the invalid constraints and retry
-drop table foo_p, bar_p;
+-- like above, but with two contraints, just to check that the error
+-- message can print that correctly.
+create table bar_c(i int check (i > 1000), j int check (j > 1000)) distributed by (i);
+alter table foo_p exchange partition for(rank(2)) with table bar_c;
+ERROR:  invalid constraint(s) found on "bar_c": "bar_c_i_check", "bar_c_j_check"
+HINT:  drop the invalid constraints and retry
 -- Shouldn't fail: check constraint matches partition rule.
 -- Note this test is slightly different from prior versions to get
 -- in line with constraint consistency requirement.
-create table foo_p (i int, j int) distributed by (i)
-partition by range(j)
-(start(1) end(10) every(1));
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_1" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_2" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_3" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_4" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_5" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_6" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_7" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_8" for table "foo_p"
-NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
-create table bar_p(i int, j int check (j >= 2 and j < 3 ))
+create table bar_d(i int, j int check (j >= 2 and j < 3 ))
 distributed by (i);
-insert into bar_p values(100000, 2);
-alter table foo_p exchange partition for(rank(2)) with table bar_p;
-insert into bar_p values(200000, 2);
-select * from bar_p;
+insert into bar_d values(100000, 2);
+alter table foo_p exchange partition for(rank(2)) with table bar_d;
+insert into bar_d values(200000, 2);
+select * from bar_d;
    i    | j 
 --------+---
  200000 | 2
 (1 row)
 
-drop table foo_p, bar_p;
+drop table foo_p, bar_a, bar_b, bar_c, bar_d;
 -- permissions
 create role part_role;
 NOTICE:  resource queue required -- using default resource queue "pg_default"


### PR DESCRIPTION
The loop to print each constraint's name was broken: it printed the name of
the first constraint multiple times. A test case, as matter of principle.

In the passing, change the set of tests around this error to all use the
same partitioned table, rather than drop and recreate it for each command.
And reduce the number of partitions from 10 to 5. Shaves some milliseconds
from the time to run the test.