### PR TITLE
Fix SQL escaping bug in internal query.

### DIFF
--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -125,3 +125,7 @@ SELECT * FROM altable ORDER BY 1;
  0 | 1
 (1 row)
 
+-- Verify that changing the datatype of a funnily-named column works.
+-- (There used to be a quoting bug in the internal query this issues.)
+create table "foo'bar" (id int4, t text);
+alter table "foo'bar" alter column t type integer using length(t);

--- a/src/test/regress/expected/alter_table_gp_optimizer.out
+++ b/src/test/regress/expected/alter_table_gp_optimizer.out
@@ -127,3 +127,7 @@ SELECT * FROM altable ORDER BY 1;
  0 | 1
 (1 row)
 
+-- Verify that changing the datatype of a funnily-named column works.
+-- (There used to be a quoting bug in the internal query this issues.)
+create table "foo'bar" (id int4, t text);
+alter table "foo'bar" alter column t type integer using length(t);

--- a/src/test/regress/sql/alter_table_gp.sql
+++ b/src/test/regress/sql/alter_table_gp.sql
@@ -82,3 +82,9 @@ UPDATE altable SET c = -10;
 SELECT * FROM altable ORDER BY 1;
 UPDATE altable SET c = 1;
 SELECT * FROM altable ORDER BY 1;
+
+
+-- Verify that changing the datatype of a funnily-named column works.
+-- (There used to be a quoting bug in the internal query this issues.)
+create table "foo'bar" (id int4, t text);
+alter table "foo'bar" alter column t type integer using length(t);


### PR DESCRIPTION
The old comment was unsure if toast tables and indexes have their Oids
in sync across the cluster. They do, so let's rely on that, which is
simpler.
