### PR TITLE
Fix gpfdist Makefile rules

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -92,7 +92,6 @@ install: generate_greenplum_path_file
 
 	$(MAKE) -C sbin $@ prefix=$(DESTDIR)$(prefix)
 
-	#cp -p extensions/gpfdist/gpfdist$(EXE_EXT) $(DESTDIR)$(prefix)/bin/
 	cp $(top_builddir)/src/test/regress/*.pl $(DESTDIR)$(prefix)/bin
 	cp $(top_builddir)/src/test/regress/*.pm $(DESTDIR)$(prefix)/bin
 	if [ ! -d ${DESTDIR}${prefix}/docs ] ; then mkdir ${DESTDIR}${prefix}/docs ; fi

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -31,7 +31,7 @@ endif
 
 LDLIBS += $(LIBS) $(GPFDIST_LIBS) $(apr_link_ld_libs)
 
-all: gpfdist$(EXE_EXT)
+all: gpfdist$(X)
 
 fstream.c: $(top_builddir)/src/backend/utils/misc/fstream/fstream.c
 	ln -s $< $@
@@ -39,18 +39,18 @@ fstream.c: $(top_builddir)/src/backend/utils/misc/fstream/fstream.c
 gfile.c: $(top_builddir)/src/backend/utils/misc/fstream/gfile.c
 	ln -s $< $@
 
-gpfdist$(EXE_EXT): $(OBJS)
+gpfdist$(X): $(OBJS)
 	$(CC) $(LDFLAGS) $(CFLAGS) $(OBJS) $(LDLIBS) -o $@
 
 install: all
-	$(INSTALL) gpfdist$(EXE_EXT) $(DESTDIR)$(prefix)/bin
+	$(INSTALL) gpfdist$(X) $(DESTDIR)$(prefix)/bin
 
 installcheck:
 	$(MAKE) -C regress installcheck
 
 .PHONY: clean distclean
 clean:
-	rm -f $(OBJS) gpfdist$(EXE_EXT)
+	rm -f $(OBJS) gpfdist$(X)
 
 distclean: clean
 	rm -f fstream.c gfile.c GNUmakefile config.log config.status


### PR DESCRIPTION
The extension ror executable binaries is defined in X, replace the
old (and now defunct) references to EXE_EXT. Also remove a commented
out dead gpfdist rule in gpAux from before the move to core.