### PR TITLE
Optimize HashAgg for sparse HHashTable iteration

### DIFF
--- a/src/backend/executor/test/execHHashagg_test.c
+++ b/src/backend/executor/test/execHHashagg_test.c
@@ -169,10 +169,12 @@ test__destroy_agg_hash_table__check_for_leaks(void **state)
 	ht->group_buf = mpool_create(ht->entry_cxt,
 			"GroupsAndAggs Context");
 
+#define NUM_BUCKETS_PER_SEGMENT (1 << 10)
 #define NUM_SPILL_FILES 3
-#define NUM_BUCKETS 1024
+#define NUM_SEGMENTS (2)
+#define NUM_BUCKETS (NUM_BUCKETS_PER_SEGMENT * NUM_SEGMENTS)
 
-	ht->buckets = MemoryContextAllocZero(testContext, sizeof(HashAggEntry) * NUM_BUCKETS);
+	ht->dir = MemoryContextAllocZero(testContext, sizeof(HashAggSegment) * NUM_SEGMENTS);
 	ht->bloom = MemoryContextAllocZero(testContext, NUM_BUCKETS / (sizeof(uint64) * 8 /* bits */));
 
 	SpillSet *spill_set = createSpillSet(NUM_SPILL_FILES, 0 /* parent_hash_bit */);


### PR DESCRIPTION
If statement_mem is large, HHashtable creates a large number of buckets
even if the number of groups is small. Iterating the hash table in such
cases is unnecessarily slow. Also allocating this large array and
zeroing it very expensive. This commit physically splits the buckets
array into "segments" that be allocated lazily. This provides a
significant performance boost (up to 2x with warm cache).  Note that the
static number of buckets helps with the spilling functionality of
HHashTable.
Also fixed indentations and added more comments.

Improvements in this commit :
-  It reduces the number & amount of allocation, but allocating segments on demand instead of all up front.
-  Less allocation -> less memory zeroing as well.
-  It improves the iteration time during agg_hash_table_stat_upd called during EXPLAIN ANALYSE by skipping segments with empty buckets
-  It improves the iteration time at the end by skipping segments with empty buckets.


This is most evident with the following script:
```
create table foo (i int, j int);
set max_statement_mem='17GB';
set statement_mem = '8GB';
explain analyze select i, sum(j) from foo group by i;
```

Experimental results on my Mac:
BEFORE
```
shardikar=# explain analyze select i, sum(j) from foo group by i;
                                       QUERY PLAN
-----------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1391.50..1404.00 rows=1000 width=12)
   Rows out:  0 rows at destination with 419 ms to end, start offset by 0.322 ms.
   ->  HashAggregate  (cost=1391.50..1404.00 rows=334 width=12)
         Group By: i
         Rows out:  0 rows (seg0) with 419 ms to end, start offset by 0.602 ms.
         Executor memory:  524305K bytes avg, 524305K bytes max (seg0).
         ->  Seq Scan on foo  (cost=0.00..961.00 rows=28700 width=8)
               Rows out:  0 rows (seg0) with 0.030 ms to end, start offset by 254 ms.
 Slice statistics:
   (slice0)    Executor memory: 322K bytes.
   (slice1)    Executor memory: 524390K bytes avg x 3 workers, 524390K bytes max (seg0).
 Statement statistics:
   Memory used: 8388608K bytes
 Optimizer status: legacy query optimizer
 Total runtime: 419.731 ms
(15 rows)
```

AFTER
```
shardikar=# explain analyze select i, sum(j) from foo group by i;
                                       QUERY PLAN
-----------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1391.50..1404.00 rows=1000 width=12)
   Rows out:  0 rows at destination with 141 ms to end, start offset by 0.410 ms.
   ->  HashAggregate  (cost=1391.50..1404.00 rows=334 width=12)
         Group By: i
         Rows out:  0 rows (seg0) with 141 ms to end, start offset by 0.675 ms.
         Executor memory:  262225K bytes avg, 262225K bytes max (seg0).
         ->  Seq Scan on foo  (cost=0.00..961.00 rows=28700 width=8)
               Rows out:  0 rows (seg0) with 0.019 ms to end, start offset by 115 ms.
 Slice statistics:
   (slice0)    Executor memory: 322K bytes.
   (slice1)    Executor memory: 262310K bytes avg x 3 workers, 262310K bytes max (seg0).
 Statement statistics:
   Memory used: 8388608K bytes
 Optimizer status: legacy query optimizer
 Total runtime: 141.713 ms
(15 rows)
```

@foyzur @hsyuan @karthijrk Please take a look.