### PR TITLE
Analyze large datums

### DIFF
--- a/src/test/regress/expected/alter_distpol_dropped.out
+++ b/src/test/regress/expected/alter_distpol_dropped.out
@@ -35,8 +35,8 @@ do
 
 				cat <<EOF
 create type break_${typesuffix};
-create function breakin_${typesuffix} (cstring) returns break_${typesuffix} as 'textin' language internal;
-create function breakout_${typesuffix} (break_${typesuffix}) returns cstring as 'textout' language internal;
+create function breakin_${typesuffix} (cstring) returns break_${typesuffix} as 'textin' language internal strict;
+create function breakout_${typesuffix} (break_${typesuffix}) returns cstring as 'textout' language internal strict;
 
 create type break_${typesuffix} (input = breakin_${typesuffix}, output = breakout_${typesuffix}, internallength = $l, passedbyvalue = $p, alignment = $a);
 create table alter_distpol_g_${typesuffix} (i int, j break_${typesuffix}, k text) with (appendonly = $s) distributed by (i);
@@ -86,833 +86,833 @@ BEGIN;
 CREATE SCHEMA adp_dropped;
 set search_path='adp_dropped';
 create type break_int2_variable_false_true;
-create function breakin_int2_variable_false_true (cstring) returns break_int2_variable_false_true as 'textin' language internal;
+create function breakin_int2_variable_false_true (cstring) returns break_int2_variable_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_variable_false_true is only a shell
-create function breakout_int2_variable_false_true (break_int2_variable_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_variable_false_true (break_int2_variable_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_variable_false_true is only a shell
 create type break_int2_variable_false_true (input = breakin_int2_variable_false_true, output = breakout_int2_variable_false_true, internallength = variable, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_variable_false_true (i int, j break_int2_variable_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_variable_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_variable_false_false;
-create function breakin_int2_variable_false_false (cstring) returns break_int2_variable_false_false as 'textin' language internal;
+create function breakin_int2_variable_false_false (cstring) returns break_int2_variable_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_variable_false_false is only a shell
-create function breakout_int2_variable_false_false (break_int2_variable_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_variable_false_false (break_int2_variable_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_variable_false_false is only a shell
 create type break_int2_variable_false_false (input = breakin_int2_variable_false_false, output = breakout_int2_variable_false_false, internallength = variable, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_variable_false_false (i int, j break_int2_variable_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_variable_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_1_true_true;
-create function breakin_int2_1_true_true (cstring) returns break_int2_1_true_true as 'textin' language internal;
+create function breakin_int2_1_true_true (cstring) returns break_int2_1_true_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_1_true_true is only a shell
-create function breakout_int2_1_true_true (break_int2_1_true_true) returns cstring as 'textout' language internal;
+create function breakout_int2_1_true_true (break_int2_1_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_1_true_true is only a shell
 create type break_int2_1_true_true (input = breakin_int2_1_true_true, output = breakout_int2_1_true_true, internallength = 1, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_1_true_true (i int, j break_int2_1_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_1_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_1_true_false;
-create function breakin_int2_1_true_false (cstring) returns break_int2_1_true_false as 'textin' language internal;
+create function breakin_int2_1_true_false (cstring) returns break_int2_1_true_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_1_true_false is only a shell
-create function breakout_int2_1_true_false (break_int2_1_true_false) returns cstring as 'textout' language internal;
+create function breakout_int2_1_true_false (break_int2_1_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_1_true_false is only a shell
 create type break_int2_1_true_false (input = breakin_int2_1_true_false, output = breakout_int2_1_true_false, internallength = 1, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_1_true_false (i int, j break_int2_1_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_1_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_1_false_true;
-create function breakin_int2_1_false_true (cstring) returns break_int2_1_false_true as 'textin' language internal;
+create function breakin_int2_1_false_true (cstring) returns break_int2_1_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_1_false_true is only a shell
-create function breakout_int2_1_false_true (break_int2_1_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_1_false_true (break_int2_1_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_1_false_true is only a shell
 create type break_int2_1_false_true (input = breakin_int2_1_false_true, output = breakout_int2_1_false_true, internallength = 1, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_1_false_true (i int, j break_int2_1_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_1_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_1_false_false;
-create function breakin_int2_1_false_false (cstring) returns break_int2_1_false_false as 'textin' language internal;
+create function breakin_int2_1_false_false (cstring) returns break_int2_1_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_1_false_false is only a shell
-create function breakout_int2_1_false_false (break_int2_1_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_1_false_false (break_int2_1_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_1_false_false is only a shell
 create type break_int2_1_false_false (input = breakin_int2_1_false_false, output = breakout_int2_1_false_false, internallength = 1, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_1_false_false (i int, j break_int2_1_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_1_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_3_true_true;
-create function breakin_int2_3_true_true (cstring) returns break_int2_3_true_true as 'textin' language internal;
+create function breakin_int2_3_true_true (cstring) returns break_int2_3_true_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_3_true_true is only a shell
-create function breakout_int2_3_true_true (break_int2_3_true_true) returns cstring as 'textout' language internal;
+create function breakout_int2_3_true_true (break_int2_3_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_3_true_true is only a shell
 create type break_int2_3_true_true (input = breakin_int2_3_true_true, output = breakout_int2_3_true_true, internallength = 3, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_3_true_true (i int, j break_int2_3_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_3_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_3_true_false;
-create function breakin_int2_3_true_false (cstring) returns break_int2_3_true_false as 'textin' language internal;
+create function breakin_int2_3_true_false (cstring) returns break_int2_3_true_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_3_true_false is only a shell
-create function breakout_int2_3_true_false (break_int2_3_true_false) returns cstring as 'textout' language internal;
+create function breakout_int2_3_true_false (break_int2_3_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_3_true_false is only a shell
 create type break_int2_3_true_false (input = breakin_int2_3_true_false, output = breakout_int2_3_true_false, internallength = 3, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_3_true_false (i int, j break_int2_3_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_3_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_3_false_true;
-create function breakin_int2_3_false_true (cstring) returns break_int2_3_false_true as 'textin' language internal;
+create function breakin_int2_3_false_true (cstring) returns break_int2_3_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_3_false_true is only a shell
-create function breakout_int2_3_false_true (break_int2_3_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_3_false_true (break_int2_3_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_3_false_true is only a shell
 create type break_int2_3_false_true (input = breakin_int2_3_false_true, output = breakout_int2_3_false_true, internallength = 3, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_3_false_true (i int, j break_int2_3_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_3_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_3_false_false;
-create function breakin_int2_3_false_false (cstring) returns break_int2_3_false_false as 'textin' language internal;
+create function breakin_int2_3_false_false (cstring) returns break_int2_3_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_3_false_false is only a shell
-create function breakout_int2_3_false_false (break_int2_3_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_3_false_false (break_int2_3_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_3_false_false is only a shell
 create type break_int2_3_false_false (input = breakin_int2_3_false_false, output = breakout_int2_3_false_false, internallength = 3, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_3_false_false (i int, j break_int2_3_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_3_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_4_true_true;
-create function breakin_int2_4_true_true (cstring) returns break_int2_4_true_true as 'textin' language internal;
+create function breakin_int2_4_true_true (cstring) returns break_int2_4_true_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_4_true_true is only a shell
-create function breakout_int2_4_true_true (break_int2_4_true_true) returns cstring as 'textout' language internal;
+create function breakout_int2_4_true_true (break_int2_4_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_4_true_true is only a shell
 create type break_int2_4_true_true (input = breakin_int2_4_true_true, output = breakout_int2_4_true_true, internallength = 4, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_4_true_true (i int, j break_int2_4_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_4_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_4_true_false;
-create function breakin_int2_4_true_false (cstring) returns break_int2_4_true_false as 'textin' language internal;
+create function breakin_int2_4_true_false (cstring) returns break_int2_4_true_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_4_true_false is only a shell
-create function breakout_int2_4_true_false (break_int2_4_true_false) returns cstring as 'textout' language internal;
+create function breakout_int2_4_true_false (break_int2_4_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_4_true_false is only a shell
 create type break_int2_4_true_false (input = breakin_int2_4_true_false, output = breakout_int2_4_true_false, internallength = 4, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_4_true_false (i int, j break_int2_4_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_4_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_4_false_true;
-create function breakin_int2_4_false_true (cstring) returns break_int2_4_false_true as 'textin' language internal;
+create function breakin_int2_4_false_true (cstring) returns break_int2_4_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_4_false_true is only a shell
-create function breakout_int2_4_false_true (break_int2_4_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_4_false_true (break_int2_4_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_4_false_true is only a shell
 create type break_int2_4_false_true (input = breakin_int2_4_false_true, output = breakout_int2_4_false_true, internallength = 4, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_4_false_true (i int, j break_int2_4_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_4_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_4_false_false;
-create function breakin_int2_4_false_false (cstring) returns break_int2_4_false_false as 'textin' language internal;
+create function breakin_int2_4_false_false (cstring) returns break_int2_4_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_4_false_false is only a shell
-create function breakout_int2_4_false_false (break_int2_4_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_4_false_false (break_int2_4_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_4_false_false is only a shell
 create type break_int2_4_false_false (input = breakin_int2_4_false_false, output = breakout_int2_4_false_false, internallength = 4, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_4_false_false (i int, j break_int2_4_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_4_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_11_false_true;
-create function breakin_int2_11_false_true (cstring) returns break_int2_11_false_true as 'textin' language internal;
+create function breakin_int2_11_false_true (cstring) returns break_int2_11_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_11_false_true is only a shell
-create function breakout_int2_11_false_true (break_int2_11_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_11_false_true (break_int2_11_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_11_false_true is only a shell
 create type break_int2_11_false_true (input = breakin_int2_11_false_true, output = breakout_int2_11_false_true, internallength = 11, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_11_false_true (i int, j break_int2_11_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_11_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_11_false_false;
-create function breakin_int2_11_false_false (cstring) returns break_int2_11_false_false as 'textin' language internal;
+create function breakin_int2_11_false_false (cstring) returns break_int2_11_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_11_false_false is only a shell
-create function breakout_int2_11_false_false (break_int2_11_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_11_false_false (break_int2_11_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_11_false_false is only a shell
 create type break_int2_11_false_false (input = breakin_int2_11_false_false, output = breakout_int2_11_false_false, internallength = 11, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_11_false_false (i int, j break_int2_11_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_11_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_17_false_true;
-create function breakin_int2_17_false_true (cstring) returns break_int2_17_false_true as 'textin' language internal;
+create function breakin_int2_17_false_true (cstring) returns break_int2_17_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_17_false_true is only a shell
-create function breakout_int2_17_false_true (break_int2_17_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_17_false_true (break_int2_17_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_17_false_true is only a shell
 create type break_int2_17_false_true (input = breakin_int2_17_false_true, output = breakout_int2_17_false_true, internallength = 17, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_17_false_true (i int, j break_int2_17_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_17_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_17_false_false;
-create function breakin_int2_17_false_false (cstring) returns break_int2_17_false_false as 'textin' language internal;
+create function breakin_int2_17_false_false (cstring) returns break_int2_17_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_17_false_false is only a shell
-create function breakout_int2_17_false_false (break_int2_17_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_17_false_false (break_int2_17_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_17_false_false is only a shell
 create type break_int2_17_false_false (input = breakin_int2_17_false_false, output = breakout_int2_17_false_false, internallength = 17, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_17_false_false (i int, j break_int2_17_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_17_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_19_false_true;
-create function breakin_int2_19_false_true (cstring) returns break_int2_19_false_true as 'textin' language internal;
+create function breakin_int2_19_false_true (cstring) returns break_int2_19_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_19_false_true is only a shell
-create function breakout_int2_19_false_true (break_int2_19_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_19_false_true (break_int2_19_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_19_false_true is only a shell
 create type break_int2_19_false_true (input = breakin_int2_19_false_true, output = breakout_int2_19_false_true, internallength = 19, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_19_false_true (i int, j break_int2_19_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_19_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_19_false_false;
-create function breakin_int2_19_false_false (cstring) returns break_int2_19_false_false as 'textin' language internal;
+create function breakin_int2_19_false_false (cstring) returns break_int2_19_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_19_false_false is only a shell
-create function breakout_int2_19_false_false (break_int2_19_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_19_false_false (break_int2_19_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_19_false_false is only a shell
 create type break_int2_19_false_false (input = breakin_int2_19_false_false, output = breakout_int2_19_false_false, internallength = 19, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_19_false_false (i int, j break_int2_19_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_19_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_23_false_true;
-create function breakin_int2_23_false_true (cstring) returns break_int2_23_false_true as 'textin' language internal;
+create function breakin_int2_23_false_true (cstring) returns break_int2_23_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_23_false_true is only a shell
-create function breakout_int2_23_false_true (break_int2_23_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_23_false_true (break_int2_23_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_23_false_true is only a shell
 create type break_int2_23_false_true (input = breakin_int2_23_false_true, output = breakout_int2_23_false_true, internallength = 23, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_23_false_true (i int, j break_int2_23_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_23_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_23_false_false;
-create function breakin_int2_23_false_false (cstring) returns break_int2_23_false_false as 'textin' language internal;
+create function breakin_int2_23_false_false (cstring) returns break_int2_23_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_23_false_false is only a shell
-create function breakout_int2_23_false_false (break_int2_23_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_23_false_false (break_int2_23_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_23_false_false is only a shell
 create type break_int2_23_false_false (input = breakin_int2_23_false_false, output = breakout_int2_23_false_false, internallength = 23, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_23_false_false (i int, j break_int2_23_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_23_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_32_false_true;
-create function breakin_int2_32_false_true (cstring) returns break_int2_32_false_true as 'textin' language internal;
+create function breakin_int2_32_false_true (cstring) returns break_int2_32_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_32_false_true is only a shell
-create function breakout_int2_32_false_true (break_int2_32_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_32_false_true (break_int2_32_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_32_false_true is only a shell
 create type break_int2_32_false_true (input = breakin_int2_32_false_true, output = breakout_int2_32_false_true, internallength = 32, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_32_false_true (i int, j break_int2_32_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_32_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_32_false_false;
-create function breakin_int2_32_false_false (cstring) returns break_int2_32_false_false as 'textin' language internal;
+create function breakin_int2_32_false_false (cstring) returns break_int2_32_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_32_false_false is only a shell
-create function breakout_int2_32_false_false (break_int2_32_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_32_false_false (break_int2_32_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_32_false_false is only a shell
 create type break_int2_32_false_false (input = breakin_int2_32_false_false, output = breakout_int2_32_false_false, internallength = 32, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_32_false_false (i int, j break_int2_32_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_32_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_196_false_true;
-create function breakin_int2_196_false_true (cstring) returns break_int2_196_false_true as 'textin' language internal;
+create function breakin_int2_196_false_true (cstring) returns break_int2_196_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int2_196_false_true is only a shell
-create function breakout_int2_196_false_true (break_int2_196_false_true) returns cstring as 'textout' language internal;
+create function breakout_int2_196_false_true (break_int2_196_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_196_false_true is only a shell
 create type break_int2_196_false_true (input = breakin_int2_196_false_true, output = breakout_int2_196_false_true, internallength = 196, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_196_false_true (i int, j break_int2_196_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_196_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_196_false_false;
-create function breakin_int2_196_false_false (cstring) returns break_int2_196_false_false as 'textin' language internal;
+create function breakin_int2_196_false_false (cstring) returns break_int2_196_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int2_196_false_false is only a shell
-create function breakout_int2_196_false_false (break_int2_196_false_false) returns cstring as 'textout' language internal;
+create function breakout_int2_196_false_false (break_int2_196_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int2_196_false_false is only a shell
 create type break_int2_196_false_false (input = breakin_int2_196_false_false, output = breakout_int2_196_false_false, internallength = 196, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_196_false_false (i int, j break_int2_196_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_196_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_variable_false_true;
-create function breakin_int4_variable_false_true (cstring) returns break_int4_variable_false_true as 'textin' language internal;
+create function breakin_int4_variable_false_true (cstring) returns break_int4_variable_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_variable_false_true is only a shell
-create function breakout_int4_variable_false_true (break_int4_variable_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_variable_false_true (break_int4_variable_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_variable_false_true is only a shell
 create type break_int4_variable_false_true (input = breakin_int4_variable_false_true, output = breakout_int4_variable_false_true, internallength = variable, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_variable_false_true (i int, j break_int4_variable_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_variable_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_variable_false_false;
-create function breakin_int4_variable_false_false (cstring) returns break_int4_variable_false_false as 'textin' language internal;
+create function breakin_int4_variable_false_false (cstring) returns break_int4_variable_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_variable_false_false is only a shell
-create function breakout_int4_variable_false_false (break_int4_variable_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_variable_false_false (break_int4_variable_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_variable_false_false is only a shell
 create type break_int4_variable_false_false (input = breakin_int4_variable_false_false, output = breakout_int4_variable_false_false, internallength = variable, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_variable_false_false (i int, j break_int4_variable_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_variable_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_1_true_true;
-create function breakin_int4_1_true_true (cstring) returns break_int4_1_true_true as 'textin' language internal;
+create function breakin_int4_1_true_true (cstring) returns break_int4_1_true_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_1_true_true is only a shell
-create function breakout_int4_1_true_true (break_int4_1_true_true) returns cstring as 'textout' language internal;
+create function breakout_int4_1_true_true (break_int4_1_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_1_true_true is only a shell
 create type break_int4_1_true_true (input = breakin_int4_1_true_true, output = breakout_int4_1_true_true, internallength = 1, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_1_true_true (i int, j break_int4_1_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_1_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_1_true_false;
-create function breakin_int4_1_true_false (cstring) returns break_int4_1_true_false as 'textin' language internal;
+create function breakin_int4_1_true_false (cstring) returns break_int4_1_true_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_1_true_false is only a shell
-create function breakout_int4_1_true_false (break_int4_1_true_false) returns cstring as 'textout' language internal;
+create function breakout_int4_1_true_false (break_int4_1_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_1_true_false is only a shell
 create type break_int4_1_true_false (input = breakin_int4_1_true_false, output = breakout_int4_1_true_false, internallength = 1, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_1_true_false (i int, j break_int4_1_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_1_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_1_false_true;
-create function breakin_int4_1_false_true (cstring) returns break_int4_1_false_true as 'textin' language internal;
+create function breakin_int4_1_false_true (cstring) returns break_int4_1_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_1_false_true is only a shell
-create function breakout_int4_1_false_true (break_int4_1_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_1_false_true (break_int4_1_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_1_false_true is only a shell
 create type break_int4_1_false_true (input = breakin_int4_1_false_true, output = breakout_int4_1_false_true, internallength = 1, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_1_false_true (i int, j break_int4_1_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_1_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_1_false_false;
-create function breakin_int4_1_false_false (cstring) returns break_int4_1_false_false as 'textin' language internal;
+create function breakin_int4_1_false_false (cstring) returns break_int4_1_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_1_false_false is only a shell
-create function breakout_int4_1_false_false (break_int4_1_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_1_false_false (break_int4_1_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_1_false_false is only a shell
 create type break_int4_1_false_false (input = breakin_int4_1_false_false, output = breakout_int4_1_false_false, internallength = 1, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_1_false_false (i int, j break_int4_1_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_1_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_3_true_true;
-create function breakin_int4_3_true_true (cstring) returns break_int4_3_true_true as 'textin' language internal;
+create function breakin_int4_3_true_true (cstring) returns break_int4_3_true_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_3_true_true is only a shell
-create function breakout_int4_3_true_true (break_int4_3_true_true) returns cstring as 'textout' language internal;
+create function breakout_int4_3_true_true (break_int4_3_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_3_true_true is only a shell
 create type break_int4_3_true_true (input = breakin_int4_3_true_true, output = breakout_int4_3_true_true, internallength = 3, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_3_true_true (i int, j break_int4_3_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_3_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_3_true_false;
-create function breakin_int4_3_true_false (cstring) returns break_int4_3_true_false as 'textin' language internal;
+create function breakin_int4_3_true_false (cstring) returns break_int4_3_true_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_3_true_false is only a shell
-create function breakout_int4_3_true_false (break_int4_3_true_false) returns cstring as 'textout' language internal;
+create function breakout_int4_3_true_false (break_int4_3_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_3_true_false is only a shell
 create type break_int4_3_true_false (input = breakin_int4_3_true_false, output = breakout_int4_3_true_false, internallength = 3, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_3_true_false (i int, j break_int4_3_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_3_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_3_false_true;
-create function breakin_int4_3_false_true (cstring) returns break_int4_3_false_true as 'textin' language internal;
+create function breakin_int4_3_false_true (cstring) returns break_int4_3_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_3_false_true is only a shell
-create function breakout_int4_3_false_true (break_int4_3_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_3_false_true (break_int4_3_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_3_false_true is only a shell
 create type break_int4_3_false_true (input = breakin_int4_3_false_true, output = breakout_int4_3_false_true, internallength = 3, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_3_false_true (i int, j break_int4_3_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_3_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_3_false_false;
-create function breakin_int4_3_false_false (cstring) returns break_int4_3_false_false as 'textin' language internal;
+create function breakin_int4_3_false_false (cstring) returns break_int4_3_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_3_false_false is only a shell
-create function breakout_int4_3_false_false (break_int4_3_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_3_false_false (break_int4_3_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_3_false_false is only a shell
 create type break_int4_3_false_false (input = breakin_int4_3_false_false, output = breakout_int4_3_false_false, internallength = 3, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_3_false_false (i int, j break_int4_3_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_3_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_4_true_true;
-create function breakin_int4_4_true_true (cstring) returns break_int4_4_true_true as 'textin' language internal;
+create function breakin_int4_4_true_true (cstring) returns break_int4_4_true_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_4_true_true is only a shell
-create function breakout_int4_4_true_true (break_int4_4_true_true) returns cstring as 'textout' language internal;
+create function breakout_int4_4_true_true (break_int4_4_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_4_true_true is only a shell
 create type break_int4_4_true_true (input = breakin_int4_4_true_true, output = breakout_int4_4_true_true, internallength = 4, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_4_true_true (i int, j break_int4_4_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_4_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_4_true_false;
-create function breakin_int4_4_true_false (cstring) returns break_int4_4_true_false as 'textin' language internal;
+create function breakin_int4_4_true_false (cstring) returns break_int4_4_true_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_4_true_false is only a shell
-create function breakout_int4_4_true_false (break_int4_4_true_false) returns cstring as 'textout' language internal;
+create function breakout_int4_4_true_false (break_int4_4_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_4_true_false is only a shell
 create type break_int4_4_true_false (input = breakin_int4_4_true_false, output = breakout_int4_4_true_false, internallength = 4, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_4_true_false (i int, j break_int4_4_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_4_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_4_false_true;
-create function breakin_int4_4_false_true (cstring) returns break_int4_4_false_true as 'textin' language internal;
+create function breakin_int4_4_false_true (cstring) returns break_int4_4_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_4_false_true is only a shell
-create function breakout_int4_4_false_true (break_int4_4_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_4_false_true (break_int4_4_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_4_false_true is only a shell
 create type break_int4_4_false_true (input = breakin_int4_4_false_true, output = breakout_int4_4_false_true, internallength = 4, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_4_false_true (i int, j break_int4_4_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_4_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_4_false_false;
-create function breakin_int4_4_false_false (cstring) returns break_int4_4_false_false as 'textin' language internal;
+create function breakin_int4_4_false_false (cstring) returns break_int4_4_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_4_false_false is only a shell
-create function breakout_int4_4_false_false (break_int4_4_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_4_false_false (break_int4_4_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_4_false_false is only a shell
 create type break_int4_4_false_false (input = breakin_int4_4_false_false, output = breakout_int4_4_false_false, internallength = 4, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_4_false_false (i int, j break_int4_4_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_4_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_11_false_true;
-create function breakin_int4_11_false_true (cstring) returns break_int4_11_false_true as 'textin' language internal;
+create function breakin_int4_11_false_true (cstring) returns break_int4_11_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_11_false_true is only a shell
-create function breakout_int4_11_false_true (break_int4_11_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_11_false_true (break_int4_11_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_11_false_true is only a shell
 create type break_int4_11_false_true (input = breakin_int4_11_false_true, output = breakout_int4_11_false_true, internallength = 11, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_11_false_true (i int, j break_int4_11_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_11_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_11_false_false;
-create function breakin_int4_11_false_false (cstring) returns break_int4_11_false_false as 'textin' language internal;
+create function breakin_int4_11_false_false (cstring) returns break_int4_11_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_11_false_false is only a shell
-create function breakout_int4_11_false_false (break_int4_11_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_11_false_false (break_int4_11_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_11_false_false is only a shell
 create type break_int4_11_false_false (input = breakin_int4_11_false_false, output = breakout_int4_11_false_false, internallength = 11, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_11_false_false (i int, j break_int4_11_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_11_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_17_false_true;
-create function breakin_int4_17_false_true (cstring) returns break_int4_17_false_true as 'textin' language internal;
+create function breakin_int4_17_false_true (cstring) returns break_int4_17_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_17_false_true is only a shell
-create function breakout_int4_17_false_true (break_int4_17_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_17_false_true (break_int4_17_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_17_false_true is only a shell
 create type break_int4_17_false_true (input = breakin_int4_17_false_true, output = breakout_int4_17_false_true, internallength = 17, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_17_false_true (i int, j break_int4_17_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_17_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_17_false_false;
-create function breakin_int4_17_false_false (cstring) returns break_int4_17_false_false as 'textin' language internal;
+create function breakin_int4_17_false_false (cstring) returns break_int4_17_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_17_false_false is only a shell
-create function breakout_int4_17_false_false (break_int4_17_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_17_false_false (break_int4_17_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_17_false_false is only a shell
 create type break_int4_17_false_false (input = breakin_int4_17_false_false, output = breakout_int4_17_false_false, internallength = 17, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_17_false_false (i int, j break_int4_17_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_17_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_19_false_true;
-create function breakin_int4_19_false_true (cstring) returns break_int4_19_false_true as 'textin' language internal;
+create function breakin_int4_19_false_true (cstring) returns break_int4_19_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_19_false_true is only a shell
-create function breakout_int4_19_false_true (break_int4_19_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_19_false_true (break_int4_19_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_19_false_true is only a shell
 create type break_int4_19_false_true (input = breakin_int4_19_false_true, output = breakout_int4_19_false_true, internallength = 19, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_19_false_true (i int, j break_int4_19_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_19_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_19_false_false;
-create function breakin_int4_19_false_false (cstring) returns break_int4_19_false_false as 'textin' language internal;
+create function breakin_int4_19_false_false (cstring) returns break_int4_19_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_19_false_false is only a shell
-create function breakout_int4_19_false_false (break_int4_19_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_19_false_false (break_int4_19_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_19_false_false is only a shell
 create type break_int4_19_false_false (input = breakin_int4_19_false_false, output = breakout_int4_19_false_false, internallength = 19, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_19_false_false (i int, j break_int4_19_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_19_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_23_false_true;
-create function breakin_int4_23_false_true (cstring) returns break_int4_23_false_true as 'textin' language internal;
+create function breakin_int4_23_false_true (cstring) returns break_int4_23_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_23_false_true is only a shell
-create function breakout_int4_23_false_true (break_int4_23_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_23_false_true (break_int4_23_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_23_false_true is only a shell
 create type break_int4_23_false_true (input = breakin_int4_23_false_true, output = breakout_int4_23_false_true, internallength = 23, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_23_false_true (i int, j break_int4_23_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_23_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_23_false_false;
-create function breakin_int4_23_false_false (cstring) returns break_int4_23_false_false as 'textin' language internal;
+create function breakin_int4_23_false_false (cstring) returns break_int4_23_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_23_false_false is only a shell
-create function breakout_int4_23_false_false (break_int4_23_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_23_false_false (break_int4_23_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_23_false_false is only a shell
 create type break_int4_23_false_false (input = breakin_int4_23_false_false, output = breakout_int4_23_false_false, internallength = 23, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_23_false_false (i int, j break_int4_23_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_23_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_32_false_true;
-create function breakin_int4_32_false_true (cstring) returns break_int4_32_false_true as 'textin' language internal;
+create function breakin_int4_32_false_true (cstring) returns break_int4_32_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_32_false_true is only a shell
-create function breakout_int4_32_false_true (break_int4_32_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_32_false_true (break_int4_32_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_32_false_true is only a shell
 create type break_int4_32_false_true (input = breakin_int4_32_false_true, output = breakout_int4_32_false_true, internallength = 32, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_32_false_true (i int, j break_int4_32_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_32_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_32_false_false;
-create function breakin_int4_32_false_false (cstring) returns break_int4_32_false_false as 'textin' language internal;
+create function breakin_int4_32_false_false (cstring) returns break_int4_32_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_32_false_false is only a shell
-create function breakout_int4_32_false_false (break_int4_32_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_32_false_false (break_int4_32_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_32_false_false is only a shell
 create type break_int4_32_false_false (input = breakin_int4_32_false_false, output = breakout_int4_32_false_false, internallength = 32, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_32_false_false (i int, j break_int4_32_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_32_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_196_false_true;
-create function breakin_int4_196_false_true (cstring) returns break_int4_196_false_true as 'textin' language internal;
+create function breakin_int4_196_false_true (cstring) returns break_int4_196_false_true as 'textin' language internal strict;
 NOTICE:  return type break_int4_196_false_true is only a shell
-create function breakout_int4_196_false_true (break_int4_196_false_true) returns cstring as 'textout' language internal;
+create function breakout_int4_196_false_true (break_int4_196_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_196_false_true is only a shell
 create type break_int4_196_false_true (input = breakin_int4_196_false_true, output = breakout_int4_196_false_true, internallength = 196, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_196_false_true (i int, j break_int4_196_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_196_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_196_false_false;
-create function breakin_int4_196_false_false (cstring) returns break_int4_196_false_false as 'textin' language internal;
+create function breakin_int4_196_false_false (cstring) returns break_int4_196_false_false as 'textin' language internal strict;
 NOTICE:  return type break_int4_196_false_false is only a shell
-create function breakout_int4_196_false_false (break_int4_196_false_false) returns cstring as 'textout' language internal;
+create function breakout_int4_196_false_false (break_int4_196_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_int4_196_false_false is only a shell
 create type break_int4_196_false_false (input = breakin_int4_196_false_false, output = breakout_int4_196_false_false, internallength = 196, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_196_false_false (i int, j break_int4_196_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_196_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_variable_false_true;
-create function breakin_char_variable_false_true (cstring) returns break_char_variable_false_true as 'textin' language internal;
+create function breakin_char_variable_false_true (cstring) returns break_char_variable_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_variable_false_true is only a shell
-create function breakout_char_variable_false_true (break_char_variable_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_variable_false_true (break_char_variable_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_variable_false_true is only a shell
 create type break_char_variable_false_true (input = breakin_char_variable_false_true, output = breakout_char_variable_false_true, internallength = variable, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_variable_false_true (i int, j break_char_variable_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_variable_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_variable_false_false;
-create function breakin_char_variable_false_false (cstring) returns break_char_variable_false_false as 'textin' language internal;
+create function breakin_char_variable_false_false (cstring) returns break_char_variable_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_variable_false_false is only a shell
-create function breakout_char_variable_false_false (break_char_variable_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_variable_false_false (break_char_variable_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_variable_false_false is only a shell
 create type break_char_variable_false_false (input = breakin_char_variable_false_false, output = breakout_char_variable_false_false, internallength = variable, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_variable_false_false (i int, j break_char_variable_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_variable_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_1_true_true;
-create function breakin_char_1_true_true (cstring) returns break_char_1_true_true as 'textin' language internal;
+create function breakin_char_1_true_true (cstring) returns break_char_1_true_true as 'textin' language internal strict;
 NOTICE:  return type break_char_1_true_true is only a shell
-create function breakout_char_1_true_true (break_char_1_true_true) returns cstring as 'textout' language internal;
+create function breakout_char_1_true_true (break_char_1_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_1_true_true is only a shell
 create type break_char_1_true_true (input = breakin_char_1_true_true, output = breakout_char_1_true_true, internallength = 1, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_1_true_true (i int, j break_char_1_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_1_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_1_true_false;
-create function breakin_char_1_true_false (cstring) returns break_char_1_true_false as 'textin' language internal;
+create function breakin_char_1_true_false (cstring) returns break_char_1_true_false as 'textin' language internal strict;
 NOTICE:  return type break_char_1_true_false is only a shell
-create function breakout_char_1_true_false (break_char_1_true_false) returns cstring as 'textout' language internal;
+create function breakout_char_1_true_false (break_char_1_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_1_true_false is only a shell
 create type break_char_1_true_false (input = breakin_char_1_true_false, output = breakout_char_1_true_false, internallength = 1, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_1_true_false (i int, j break_char_1_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_1_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_1_false_true;
-create function breakin_char_1_false_true (cstring) returns break_char_1_false_true as 'textin' language internal;
+create function breakin_char_1_false_true (cstring) returns break_char_1_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_1_false_true is only a shell
-create function breakout_char_1_false_true (break_char_1_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_1_false_true (break_char_1_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_1_false_true is only a shell
 create type break_char_1_false_true (input = breakin_char_1_false_true, output = breakout_char_1_false_true, internallength = 1, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_1_false_true (i int, j break_char_1_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_1_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_1_false_false;
-create function breakin_char_1_false_false (cstring) returns break_char_1_false_false as 'textin' language internal;
+create function breakin_char_1_false_false (cstring) returns break_char_1_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_1_false_false is only a shell
-create function breakout_char_1_false_false (break_char_1_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_1_false_false (break_char_1_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_1_false_false is only a shell
 create type break_char_1_false_false (input = breakin_char_1_false_false, output = breakout_char_1_false_false, internallength = 1, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_1_false_false (i int, j break_char_1_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_1_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_3_true_true;
-create function breakin_char_3_true_true (cstring) returns break_char_3_true_true as 'textin' language internal;
+create function breakin_char_3_true_true (cstring) returns break_char_3_true_true as 'textin' language internal strict;
 NOTICE:  return type break_char_3_true_true is only a shell
-create function breakout_char_3_true_true (break_char_3_true_true) returns cstring as 'textout' language internal;
+create function breakout_char_3_true_true (break_char_3_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_3_true_true is only a shell
 create type break_char_3_true_true (input = breakin_char_3_true_true, output = breakout_char_3_true_true, internallength = 3, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_3_true_true (i int, j break_char_3_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_3_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_3_true_false;
-create function breakin_char_3_true_false (cstring) returns break_char_3_true_false as 'textin' language internal;
+create function breakin_char_3_true_false (cstring) returns break_char_3_true_false as 'textin' language internal strict;
 NOTICE:  return type break_char_3_true_false is only a shell
-create function breakout_char_3_true_false (break_char_3_true_false) returns cstring as 'textout' language internal;
+create function breakout_char_3_true_false (break_char_3_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_3_true_false is only a shell
 create type break_char_3_true_false (input = breakin_char_3_true_false, output = breakout_char_3_true_false, internallength = 3, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_3_true_false (i int, j break_char_3_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_3_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_3_false_true;
-create function breakin_char_3_false_true (cstring) returns break_char_3_false_true as 'textin' language internal;
+create function breakin_char_3_false_true (cstring) returns break_char_3_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_3_false_true is only a shell
-create function breakout_char_3_false_true (break_char_3_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_3_false_true (break_char_3_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_3_false_true is only a shell
 create type break_char_3_false_true (input = breakin_char_3_false_true, output = breakout_char_3_false_true, internallength = 3, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_3_false_true (i int, j break_char_3_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_3_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_3_false_false;
-create function breakin_char_3_false_false (cstring) returns break_char_3_false_false as 'textin' language internal;
+create function breakin_char_3_false_false (cstring) returns break_char_3_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_3_false_false is only a shell
-create function breakout_char_3_false_false (break_char_3_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_3_false_false (break_char_3_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_3_false_false is only a shell
 create type break_char_3_false_false (input = breakin_char_3_false_false, output = breakout_char_3_false_false, internallength = 3, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_3_false_false (i int, j break_char_3_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_3_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_4_true_true;
-create function breakin_char_4_true_true (cstring) returns break_char_4_true_true as 'textin' language internal;
+create function breakin_char_4_true_true (cstring) returns break_char_4_true_true as 'textin' language internal strict;
 NOTICE:  return type break_char_4_true_true is only a shell
-create function breakout_char_4_true_true (break_char_4_true_true) returns cstring as 'textout' language internal;
+create function breakout_char_4_true_true (break_char_4_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_4_true_true is only a shell
 create type break_char_4_true_true (input = breakin_char_4_true_true, output = breakout_char_4_true_true, internallength = 4, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_4_true_true (i int, j break_char_4_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_4_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_4_true_false;
-create function breakin_char_4_true_false (cstring) returns break_char_4_true_false as 'textin' language internal;
+create function breakin_char_4_true_false (cstring) returns break_char_4_true_false as 'textin' language internal strict;
 NOTICE:  return type break_char_4_true_false is only a shell
-create function breakout_char_4_true_false (break_char_4_true_false) returns cstring as 'textout' language internal;
+create function breakout_char_4_true_false (break_char_4_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_4_true_false is only a shell
 create type break_char_4_true_false (input = breakin_char_4_true_false, output = breakout_char_4_true_false, internallength = 4, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_4_true_false (i int, j break_char_4_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_4_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_4_false_true;
-create function breakin_char_4_false_true (cstring) returns break_char_4_false_true as 'textin' language internal;
+create function breakin_char_4_false_true (cstring) returns break_char_4_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_4_false_true is only a shell
-create function breakout_char_4_false_true (break_char_4_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_4_false_true (break_char_4_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_4_false_true is only a shell
 create type break_char_4_false_true (input = breakin_char_4_false_true, output = breakout_char_4_false_true, internallength = 4, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_4_false_true (i int, j break_char_4_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_4_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_4_false_false;
-create function breakin_char_4_false_false (cstring) returns break_char_4_false_false as 'textin' language internal;
+create function breakin_char_4_false_false (cstring) returns break_char_4_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_4_false_false is only a shell
-create function breakout_char_4_false_false (break_char_4_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_4_false_false (break_char_4_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_4_false_false is only a shell
 create type break_char_4_false_false (input = breakin_char_4_false_false, output = breakout_char_4_false_false, internallength = 4, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_4_false_false (i int, j break_char_4_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_4_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_11_false_true;
-create function breakin_char_11_false_true (cstring) returns break_char_11_false_true as 'textin' language internal;
+create function breakin_char_11_false_true (cstring) returns break_char_11_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_11_false_true is only a shell
-create function breakout_char_11_false_true (break_char_11_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_11_false_true (break_char_11_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_11_false_true is only a shell
 create type break_char_11_false_true (input = breakin_char_11_false_true, output = breakout_char_11_false_true, internallength = 11, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_11_false_true (i int, j break_char_11_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_11_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_11_false_false;
-create function breakin_char_11_false_false (cstring) returns break_char_11_false_false as 'textin' language internal;
+create function breakin_char_11_false_false (cstring) returns break_char_11_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_11_false_false is only a shell
-create function breakout_char_11_false_false (break_char_11_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_11_false_false (break_char_11_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_11_false_false is only a shell
 create type break_char_11_false_false (input = breakin_char_11_false_false, output = breakout_char_11_false_false, internallength = 11, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_11_false_false (i int, j break_char_11_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_11_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_17_false_true;
-create function breakin_char_17_false_true (cstring) returns break_char_17_false_true as 'textin' language internal;
+create function breakin_char_17_false_true (cstring) returns break_char_17_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_17_false_true is only a shell
-create function breakout_char_17_false_true (break_char_17_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_17_false_true (break_char_17_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_17_false_true is only a shell
 create type break_char_17_false_true (input = breakin_char_17_false_true, output = breakout_char_17_false_true, internallength = 17, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_17_false_true (i int, j break_char_17_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_17_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_17_false_false;
-create function breakin_char_17_false_false (cstring) returns break_char_17_false_false as 'textin' language internal;
+create function breakin_char_17_false_false (cstring) returns break_char_17_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_17_false_false is only a shell
-create function breakout_char_17_false_false (break_char_17_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_17_false_false (break_char_17_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_17_false_false is only a shell
 create type break_char_17_false_false (input = breakin_char_17_false_false, output = breakout_char_17_false_false, internallength = 17, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_17_false_false (i int, j break_char_17_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_17_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_19_false_true;
-create function breakin_char_19_false_true (cstring) returns break_char_19_false_true as 'textin' language internal;
+create function breakin_char_19_false_true (cstring) returns break_char_19_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_19_false_true is only a shell
-create function breakout_char_19_false_true (break_char_19_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_19_false_true (break_char_19_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_19_false_true is only a shell
 create type break_char_19_false_true (input = breakin_char_19_false_true, output = breakout_char_19_false_true, internallength = 19, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_19_false_true (i int, j break_char_19_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_19_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_19_false_false;
-create function breakin_char_19_false_false (cstring) returns break_char_19_false_false as 'textin' language internal;
+create function breakin_char_19_false_false (cstring) returns break_char_19_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_19_false_false is only a shell
-create function breakout_char_19_false_false (break_char_19_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_19_false_false (break_char_19_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_19_false_false is only a shell
 create type break_char_19_false_false (input = breakin_char_19_false_false, output = breakout_char_19_false_false, internallength = 19, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_19_false_false (i int, j break_char_19_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_19_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_23_false_true;
-create function breakin_char_23_false_true (cstring) returns break_char_23_false_true as 'textin' language internal;
+create function breakin_char_23_false_true (cstring) returns break_char_23_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_23_false_true is only a shell
-create function breakout_char_23_false_true (break_char_23_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_23_false_true (break_char_23_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_23_false_true is only a shell
 create type break_char_23_false_true (input = breakin_char_23_false_true, output = breakout_char_23_false_true, internallength = 23, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_23_false_true (i int, j break_char_23_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_23_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_23_false_false;
-create function breakin_char_23_false_false (cstring) returns break_char_23_false_false as 'textin' language internal;
+create function breakin_char_23_false_false (cstring) returns break_char_23_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_23_false_false is only a shell
-create function breakout_char_23_false_false (break_char_23_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_23_false_false (break_char_23_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_23_false_false is only a shell
 create type break_char_23_false_false (input = breakin_char_23_false_false, output = breakout_char_23_false_false, internallength = 23, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_23_false_false (i int, j break_char_23_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_23_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_32_false_true;
-create function breakin_char_32_false_true (cstring) returns break_char_32_false_true as 'textin' language internal;
+create function breakin_char_32_false_true (cstring) returns break_char_32_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_32_false_true is only a shell
-create function breakout_char_32_false_true (break_char_32_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_32_false_true (break_char_32_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_32_false_true is only a shell
 create type break_char_32_false_true (input = breakin_char_32_false_true, output = breakout_char_32_false_true, internallength = 32, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_32_false_true (i int, j break_char_32_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_32_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_32_false_false;
-create function breakin_char_32_false_false (cstring) returns break_char_32_false_false as 'textin' language internal;
+create function breakin_char_32_false_false (cstring) returns break_char_32_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_32_false_false is only a shell
-create function breakout_char_32_false_false (break_char_32_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_32_false_false (break_char_32_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_32_false_false is only a shell
 create type break_char_32_false_false (input = breakin_char_32_false_false, output = breakout_char_32_false_false, internallength = 32, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_32_false_false (i int, j break_char_32_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_32_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_196_false_true;
-create function breakin_char_196_false_true (cstring) returns break_char_196_false_true as 'textin' language internal;
+create function breakin_char_196_false_true (cstring) returns break_char_196_false_true as 'textin' language internal strict;
 NOTICE:  return type break_char_196_false_true is only a shell
-create function breakout_char_196_false_true (break_char_196_false_true) returns cstring as 'textout' language internal;
+create function breakout_char_196_false_true (break_char_196_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_196_false_true is only a shell
 create type break_char_196_false_true (input = breakin_char_196_false_true, output = breakout_char_196_false_true, internallength = 196, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_196_false_true (i int, j break_char_196_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_196_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_196_false_false;
-create function breakin_char_196_false_false (cstring) returns break_char_196_false_false as 'textin' language internal;
+create function breakin_char_196_false_false (cstring) returns break_char_196_false_false as 'textin' language internal strict;
 NOTICE:  return type break_char_196_false_false is only a shell
-create function breakout_char_196_false_false (break_char_196_false_false) returns cstring as 'textout' language internal;
+create function breakout_char_196_false_false (break_char_196_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_char_196_false_false is only a shell
 create type break_char_196_false_false (input = breakin_char_196_false_false, output = breakout_char_196_false_false, internallength = 196, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_196_false_false (i int, j break_char_196_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_196_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_variable_false_true;
-create function breakin_double_variable_false_true (cstring) returns break_double_variable_false_true as 'textin' language internal;
+create function breakin_double_variable_false_true (cstring) returns break_double_variable_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_variable_false_true is only a shell
-create function breakout_double_variable_false_true (break_double_variable_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_variable_false_true (break_double_variable_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_variable_false_true is only a shell
 create type break_double_variable_false_true (input = breakin_double_variable_false_true, output = breakout_double_variable_false_true, internallength = variable, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_variable_false_true (i int, j break_double_variable_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_variable_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_variable_false_false;
-create function breakin_double_variable_false_false (cstring) returns break_double_variable_false_false as 'textin' language internal;
+create function breakin_double_variable_false_false (cstring) returns break_double_variable_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_variable_false_false is only a shell
-create function breakout_double_variable_false_false (break_double_variable_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_variable_false_false (break_double_variable_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_variable_false_false is only a shell
 create type break_double_variable_false_false (input = breakin_double_variable_false_false, output = breakout_double_variable_false_false, internallength = variable, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_variable_false_false (i int, j break_double_variable_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_variable_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_1_true_true;
-create function breakin_double_1_true_true (cstring) returns break_double_1_true_true as 'textin' language internal;
+create function breakin_double_1_true_true (cstring) returns break_double_1_true_true as 'textin' language internal strict;
 NOTICE:  return type break_double_1_true_true is only a shell
-create function breakout_double_1_true_true (break_double_1_true_true) returns cstring as 'textout' language internal;
+create function breakout_double_1_true_true (break_double_1_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_1_true_true is only a shell
 create type break_double_1_true_true (input = breakin_double_1_true_true, output = breakout_double_1_true_true, internallength = 1, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_1_true_true (i int, j break_double_1_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_1_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_1_true_false;
-create function breakin_double_1_true_false (cstring) returns break_double_1_true_false as 'textin' language internal;
+create function breakin_double_1_true_false (cstring) returns break_double_1_true_false as 'textin' language internal strict;
 NOTICE:  return type break_double_1_true_false is only a shell
-create function breakout_double_1_true_false (break_double_1_true_false) returns cstring as 'textout' language internal;
+create function breakout_double_1_true_false (break_double_1_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_1_true_false is only a shell
 create type break_double_1_true_false (input = breakin_double_1_true_false, output = breakout_double_1_true_false, internallength = 1, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_1_true_false (i int, j break_double_1_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_1_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_1_false_true;
-create function breakin_double_1_false_true (cstring) returns break_double_1_false_true as 'textin' language internal;
+create function breakin_double_1_false_true (cstring) returns break_double_1_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_1_false_true is only a shell
-create function breakout_double_1_false_true (break_double_1_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_1_false_true (break_double_1_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_1_false_true is only a shell
 create type break_double_1_false_true (input = breakin_double_1_false_true, output = breakout_double_1_false_true, internallength = 1, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_1_false_true (i int, j break_double_1_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_1_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_1_false_false;
-create function breakin_double_1_false_false (cstring) returns break_double_1_false_false as 'textin' language internal;
+create function breakin_double_1_false_false (cstring) returns break_double_1_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_1_false_false is only a shell
-create function breakout_double_1_false_false (break_double_1_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_1_false_false (break_double_1_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_1_false_false is only a shell
 create type break_double_1_false_false (input = breakin_double_1_false_false, output = breakout_double_1_false_false, internallength = 1, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_1_false_false (i int, j break_double_1_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_1_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_3_true_true;
-create function breakin_double_3_true_true (cstring) returns break_double_3_true_true as 'textin' language internal;
+create function breakin_double_3_true_true (cstring) returns break_double_3_true_true as 'textin' language internal strict;
 NOTICE:  return type break_double_3_true_true is only a shell
-create function breakout_double_3_true_true (break_double_3_true_true) returns cstring as 'textout' language internal;
+create function breakout_double_3_true_true (break_double_3_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_3_true_true is only a shell
 create type break_double_3_true_true (input = breakin_double_3_true_true, output = breakout_double_3_true_true, internallength = 3, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_3_true_true (i int, j break_double_3_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_3_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_3_true_false;
-create function breakin_double_3_true_false (cstring) returns break_double_3_true_false as 'textin' language internal;
+create function breakin_double_3_true_false (cstring) returns break_double_3_true_false as 'textin' language internal strict;
 NOTICE:  return type break_double_3_true_false is only a shell
-create function breakout_double_3_true_false (break_double_3_true_false) returns cstring as 'textout' language internal;
+create function breakout_double_3_true_false (break_double_3_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_3_true_false is only a shell
 create type break_double_3_true_false (input = breakin_double_3_true_false, output = breakout_double_3_true_false, internallength = 3, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_3_true_false (i int, j break_double_3_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_3_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_3_false_true;
-create function breakin_double_3_false_true (cstring) returns break_double_3_false_true as 'textin' language internal;
+create function breakin_double_3_false_true (cstring) returns break_double_3_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_3_false_true is only a shell
-create function breakout_double_3_false_true (break_double_3_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_3_false_true (break_double_3_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_3_false_true is only a shell
 create type break_double_3_false_true (input = breakin_double_3_false_true, output = breakout_double_3_false_true, internallength = 3, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_3_false_true (i int, j break_double_3_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_3_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_3_false_false;
-create function breakin_double_3_false_false (cstring) returns break_double_3_false_false as 'textin' language internal;
+create function breakin_double_3_false_false (cstring) returns break_double_3_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_3_false_false is only a shell
-create function breakout_double_3_false_false (break_double_3_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_3_false_false (break_double_3_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_3_false_false is only a shell
 create type break_double_3_false_false (input = breakin_double_3_false_false, output = breakout_double_3_false_false, internallength = 3, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_3_false_false (i int, j break_double_3_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_3_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_4_true_true;
-create function breakin_double_4_true_true (cstring) returns break_double_4_true_true as 'textin' language internal;
+create function breakin_double_4_true_true (cstring) returns break_double_4_true_true as 'textin' language internal strict;
 NOTICE:  return type break_double_4_true_true is only a shell
-create function breakout_double_4_true_true (break_double_4_true_true) returns cstring as 'textout' language internal;
+create function breakout_double_4_true_true (break_double_4_true_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_4_true_true is only a shell
 create type break_double_4_true_true (input = breakin_double_4_true_true, output = breakout_double_4_true_true, internallength = 4, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_4_true_true (i int, j break_double_4_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_4_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_4_true_false;
-create function breakin_double_4_true_false (cstring) returns break_double_4_true_false as 'textin' language internal;
+create function breakin_double_4_true_false (cstring) returns break_double_4_true_false as 'textin' language internal strict;
 NOTICE:  return type break_double_4_true_false is only a shell
-create function breakout_double_4_true_false (break_double_4_true_false) returns cstring as 'textout' language internal;
+create function breakout_double_4_true_false (break_double_4_true_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_4_true_false is only a shell
 create type break_double_4_true_false (input = breakin_double_4_true_false, output = breakout_double_4_true_false, internallength = 4, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_4_true_false (i int, j break_double_4_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_4_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_4_false_true;
-create function breakin_double_4_false_true (cstring) returns break_double_4_false_true as 'textin' language internal;
+create function breakin_double_4_false_true (cstring) returns break_double_4_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_4_false_true is only a shell
-create function breakout_double_4_false_true (break_double_4_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_4_false_true (break_double_4_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_4_false_true is only a shell
 create type break_double_4_false_true (input = breakin_double_4_false_true, output = breakout_double_4_false_true, internallength = 4, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_4_false_true (i int, j break_double_4_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_4_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_4_false_false;
-create function breakin_double_4_false_false (cstring) returns break_double_4_false_false as 'textin' language internal;
+create function breakin_double_4_false_false (cstring) returns break_double_4_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_4_false_false is only a shell
-create function breakout_double_4_false_false (break_double_4_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_4_false_false (break_double_4_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_4_false_false is only a shell
 create type break_double_4_false_false (input = breakin_double_4_false_false, output = breakout_double_4_false_false, internallength = 4, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_4_false_false (i int, j break_double_4_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_4_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_11_false_true;
-create function breakin_double_11_false_true (cstring) returns break_double_11_false_true as 'textin' language internal;
+create function breakin_double_11_false_true (cstring) returns break_double_11_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_11_false_true is only a shell
-create function breakout_double_11_false_true (break_double_11_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_11_false_true (break_double_11_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_11_false_true is only a shell
 create type break_double_11_false_true (input = breakin_double_11_false_true, output = breakout_double_11_false_true, internallength = 11, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_11_false_true (i int, j break_double_11_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_11_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_11_false_false;
-create function breakin_double_11_false_false (cstring) returns break_double_11_false_false as 'textin' language internal;
+create function breakin_double_11_false_false (cstring) returns break_double_11_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_11_false_false is only a shell
-create function breakout_double_11_false_false (break_double_11_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_11_false_false (break_double_11_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_11_false_false is only a shell
 create type break_double_11_false_false (input = breakin_double_11_false_false, output = breakout_double_11_false_false, internallength = 11, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_11_false_false (i int, j break_double_11_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_11_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_17_false_true;
-create function breakin_double_17_false_true (cstring) returns break_double_17_false_true as 'textin' language internal;
+create function breakin_double_17_false_true (cstring) returns break_double_17_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_17_false_true is only a shell
-create function breakout_double_17_false_true (break_double_17_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_17_false_true (break_double_17_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_17_false_true is only a shell
 create type break_double_17_false_true (input = breakin_double_17_false_true, output = breakout_double_17_false_true, internallength = 17, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_17_false_true (i int, j break_double_17_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_17_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_17_false_false;
-create function breakin_double_17_false_false (cstring) returns break_double_17_false_false as 'textin' language internal;
+create function breakin_double_17_false_false (cstring) returns break_double_17_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_17_false_false is only a shell
-create function breakout_double_17_false_false (break_double_17_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_17_false_false (break_double_17_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_17_false_false is only a shell
 create type break_double_17_false_false (input = breakin_double_17_false_false, output = breakout_double_17_false_false, internallength = 17, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_17_false_false (i int, j break_double_17_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_17_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_19_false_true;
-create function breakin_double_19_false_true (cstring) returns break_double_19_false_true as 'textin' language internal;
+create function breakin_double_19_false_true (cstring) returns break_double_19_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_19_false_true is only a shell
-create function breakout_double_19_false_true (break_double_19_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_19_false_true (break_double_19_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_19_false_true is only a shell
 create type break_double_19_false_true (input = breakin_double_19_false_true, output = breakout_double_19_false_true, internallength = 19, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_19_false_true (i int, j break_double_19_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_19_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_19_false_false;
-create function breakin_double_19_false_false (cstring) returns break_double_19_false_false as 'textin' language internal;
+create function breakin_double_19_false_false (cstring) returns break_double_19_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_19_false_false is only a shell
-create function breakout_double_19_false_false (break_double_19_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_19_false_false (break_double_19_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_19_false_false is only a shell
 create type break_double_19_false_false (input = breakin_double_19_false_false, output = breakout_double_19_false_false, internallength = 19, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_19_false_false (i int, j break_double_19_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_19_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_23_false_true;
-create function breakin_double_23_false_true (cstring) returns break_double_23_false_true as 'textin' language internal;
+create function breakin_double_23_false_true (cstring) returns break_double_23_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_23_false_true is only a shell
-create function breakout_double_23_false_true (break_double_23_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_23_false_true (break_double_23_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_23_false_true is only a shell
 create type break_double_23_false_true (input = breakin_double_23_false_true, output = breakout_double_23_false_true, internallength = 23, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_23_false_true (i int, j break_double_23_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_23_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_23_false_false;
-create function breakin_double_23_false_false (cstring) returns break_double_23_false_false as 'textin' language internal;
+create function breakin_double_23_false_false (cstring) returns break_double_23_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_23_false_false is only a shell
-create function breakout_double_23_false_false (break_double_23_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_23_false_false (break_double_23_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_23_false_false is only a shell
 create type break_double_23_false_false (input = breakin_double_23_false_false, output = breakout_double_23_false_false, internallength = 23, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_23_false_false (i int, j break_double_23_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_23_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_32_false_true;
-create function breakin_double_32_false_true (cstring) returns break_double_32_false_true as 'textin' language internal;
+create function breakin_double_32_false_true (cstring) returns break_double_32_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_32_false_true is only a shell
-create function breakout_double_32_false_true (break_double_32_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_32_false_true (break_double_32_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_32_false_true is only a shell
 create type break_double_32_false_true (input = breakin_double_32_false_true, output = breakout_double_32_false_true, internallength = 32, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_32_false_true (i int, j break_double_32_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_32_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_32_false_false;
-create function breakin_double_32_false_false (cstring) returns break_double_32_false_false as 'textin' language internal;
+create function breakin_double_32_false_false (cstring) returns break_double_32_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_32_false_false is only a shell
-create function breakout_double_32_false_false (break_double_32_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_32_false_false (break_double_32_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_32_false_false is only a shell
 create type break_double_32_false_false (input = breakin_double_32_false_false, output = breakout_double_32_false_false, internallength = 32, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_32_false_false (i int, j break_double_32_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_32_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_196_false_true;
-create function breakin_double_196_false_true (cstring) returns break_double_196_false_true as 'textin' language internal;
+create function breakin_double_196_false_true (cstring) returns break_double_196_false_true as 'textin' language internal strict;
 NOTICE:  return type break_double_196_false_true is only a shell
-create function breakout_double_196_false_true (break_double_196_false_true) returns cstring as 'textout' language internal;
+create function breakout_double_196_false_true (break_double_196_false_true) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_196_false_true is only a shell
 create type break_double_196_false_true (input = breakin_double_196_false_true, output = breakout_double_196_false_true, internallength = 196, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_196_false_true (i int, j break_double_196_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_196_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_196_false_false;
-create function breakin_double_196_false_false (cstring) returns break_double_196_false_false as 'textin' language internal;
+create function breakin_double_196_false_false (cstring) returns break_double_196_false_false as 'textin' language internal strict;
 NOTICE:  return type break_double_196_false_false is only a shell
-create function breakout_double_196_false_false (break_double_196_false_false) returns cstring as 'textout' language internal;
+create function breakout_double_196_false_false (break_double_196_false_false) returns cstring as 'textout' language internal strict;
 NOTICE:  argument type break_double_196_false_false is only a shell
 create type break_double_196_false_false (input = breakin_double_196_false_false, output = breakout_double_196_false_false, internallength = 196, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_196_false_false (i int, j break_double_196_false_false, k text) with (appendonly = false) distributed by (i);

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -791,6 +791,38 @@ select * from pg_stats where tablename like 'p3_sales%' order by tablename, attn
  public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
+---
+--- Test statistics collection on very large datums. In the current implementation,
+--- they are left out of the sample, to avoid running out of memory for the main relation
+--- statistics. In case of indexes on the relation, large datums are masked as NULLs in the sample
+--- and are evaluated as NULL in index stats collection.
+--- Expression / partial indexes are not commonly used, and its rare to have them on wide columns, so the
+--- effect of considering them as NULL is minimal.
+---
+CREATE TABLE foo_stats (a text, b bytea, c varchar, d int) DISTRIBUTED RANDOMLY;
+CREATE INDEX expression_idx_foo_stats ON foo_stats (upper(a));
+INSERT INTO foo_stats values ('aaa', 'bbbbb', 'cccc', 2);
+INSERT INTO foo_stats values ('aaa', 'bbbbb', 'cccc', 2);
+--- Insert large datum values
+INSERT INTO foo_stats values (repeat('a', 3000), 'bbbbb2', 'cccc2', 3);
+INSERT INTO foo_stats values (repeat('a', 3000), 'bbbbb2', 'cccc2', 3);
+ANALYZE foo_stats;
+SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='foo_stats' ORDER BY attname;
+ schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds
+------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------
+ public     | foo_stats | a       |         0 |         4 |      -0.25 | {aaa}            | {1}               |
+ public     | foo_stats | b       |         0 |         6 |       -0.5 | {bbbbb,bbbbb2}   | {0.5,0.5}         |
+ public     | foo_stats | c       |         0 |         5 |       -0.5 | {cccc,cccc2}     | {0.5,0.5}         |
+ public     | foo_stats | d       |         0 |         4 |       -0.5 | {2,3}            | {0.5,0.5}         |
+(4 rows)
+
+SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='expression_idx_foo_stats' ORDER BY attname; 
+  schemaname |        tablename         |     attname     | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds
+ ------------+--------------------------+-----------------+-----------+-----------+------------+------------------+-------------------+------------------
+  public     | expression_idx_foo_stats | pg_expression_1 |       0.5 |         7 |      -0.25 | {AAA}            | {0.5}             |
+ (1 row)
+
+DROP TABLE IF EXISTS foo_stats;
 -- start_ignore
 DROP TABLE IF EXISTS p3_sales;
 -- end_ignore

--- a/src/test/regress/sql/alter_distpol_dropped.sql
+++ b/src/test/regress/sql/alter_distpol_dropped.sql
@@ -35,8 +35,8 @@ do
 
 				cat <<EOF
 create type break_${typesuffix};
-create function breakin_${typesuffix} (cstring) returns break_${typesuffix} as 'textin' language internal;
-create function breakout_${typesuffix} (break_${typesuffix}) returns cstring as 'textout' language internal;
+create function breakin_${typesuffix} (cstring) returns break_${typesuffix} as 'textin' language internal strict;
+create function breakout_${typesuffix} (break_${typesuffix}) returns cstring as 'textout' language internal strict;
 
 create type break_${typesuffix} (input = breakin_${typesuffix}, output = breakout_${typesuffix}, internallength = $l, passedbyvalue = $p, alignment = $a);
 create table alter_distpol_g_${typesuffix} (i int, j break_${typesuffix}, k text) with (appendonly = $s) distributed by (i);
@@ -87,729 +87,729 @@ BEGIN;
 CREATE SCHEMA adp_dropped;
 set search_path='adp_dropped';
 create type break_int2_variable_false_true;
-create function breakin_int2_variable_false_true (cstring) returns break_int2_variable_false_true as 'textin' language internal;
-create function breakout_int2_variable_false_true (break_int2_variable_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_variable_false_true (cstring) returns break_int2_variable_false_true as 'textin' language internal strict;
+create function breakout_int2_variable_false_true (break_int2_variable_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_variable_false_true (input = breakin_int2_variable_false_true, output = breakout_int2_variable_false_true, internallength = variable, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_variable_false_true (i int, j break_int2_variable_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_variable_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_variable_false_false;
-create function breakin_int2_variable_false_false (cstring) returns break_int2_variable_false_false as 'textin' language internal;
-create function breakout_int2_variable_false_false (break_int2_variable_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_variable_false_false (cstring) returns break_int2_variable_false_false as 'textin' language internal strict;
+create function breakout_int2_variable_false_false (break_int2_variable_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_variable_false_false (input = breakin_int2_variable_false_false, output = breakout_int2_variable_false_false, internallength = variable, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_variable_false_false (i int, j break_int2_variable_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_variable_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_1_true_true;
-create function breakin_int2_1_true_true (cstring) returns break_int2_1_true_true as 'textin' language internal;
-create function breakout_int2_1_true_true (break_int2_1_true_true) returns cstring as 'textout' language internal;
+create function breakin_int2_1_true_true (cstring) returns break_int2_1_true_true as 'textin' language internal strict;
+create function breakout_int2_1_true_true (break_int2_1_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_1_true_true (input = breakin_int2_1_true_true, output = breakout_int2_1_true_true, internallength = 1, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_1_true_true (i int, j break_int2_1_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_1_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_1_true_false;
-create function breakin_int2_1_true_false (cstring) returns break_int2_1_true_false as 'textin' language internal;
-create function breakout_int2_1_true_false (break_int2_1_true_false) returns cstring as 'textout' language internal;
+create function breakin_int2_1_true_false (cstring) returns break_int2_1_true_false as 'textin' language internal strict;
+create function breakout_int2_1_true_false (break_int2_1_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_1_true_false (input = breakin_int2_1_true_false, output = breakout_int2_1_true_false, internallength = 1, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_1_true_false (i int, j break_int2_1_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_1_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_1_false_true;
-create function breakin_int2_1_false_true (cstring) returns break_int2_1_false_true as 'textin' language internal;
-create function breakout_int2_1_false_true (break_int2_1_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_1_false_true (cstring) returns break_int2_1_false_true as 'textin' language internal strict;
+create function breakout_int2_1_false_true (break_int2_1_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_1_false_true (input = breakin_int2_1_false_true, output = breakout_int2_1_false_true, internallength = 1, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_1_false_true (i int, j break_int2_1_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_1_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_1_false_false;
-create function breakin_int2_1_false_false (cstring) returns break_int2_1_false_false as 'textin' language internal;
-create function breakout_int2_1_false_false (break_int2_1_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_1_false_false (cstring) returns break_int2_1_false_false as 'textin' language internal strict;
+create function breakout_int2_1_false_false (break_int2_1_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_1_false_false (input = breakin_int2_1_false_false, output = breakout_int2_1_false_false, internallength = 1, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_1_false_false (i int, j break_int2_1_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_1_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_3_true_true;
-create function breakin_int2_3_true_true (cstring) returns break_int2_3_true_true as 'textin' language internal;
-create function breakout_int2_3_true_true (break_int2_3_true_true) returns cstring as 'textout' language internal;
+create function breakin_int2_3_true_true (cstring) returns break_int2_3_true_true as 'textin' language internal strict;
+create function breakout_int2_3_true_true (break_int2_3_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_3_true_true (input = breakin_int2_3_true_true, output = breakout_int2_3_true_true, internallength = 3, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_3_true_true (i int, j break_int2_3_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_3_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_3_true_false;
-create function breakin_int2_3_true_false (cstring) returns break_int2_3_true_false as 'textin' language internal;
-create function breakout_int2_3_true_false (break_int2_3_true_false) returns cstring as 'textout' language internal;
+create function breakin_int2_3_true_false (cstring) returns break_int2_3_true_false as 'textin' language internal strict;
+create function breakout_int2_3_true_false (break_int2_3_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_3_true_false (input = breakin_int2_3_true_false, output = breakout_int2_3_true_false, internallength = 3, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_3_true_false (i int, j break_int2_3_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_3_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_3_false_true;
-create function breakin_int2_3_false_true (cstring) returns break_int2_3_false_true as 'textin' language internal;
-create function breakout_int2_3_false_true (break_int2_3_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_3_false_true (cstring) returns break_int2_3_false_true as 'textin' language internal strict;
+create function breakout_int2_3_false_true (break_int2_3_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_3_false_true (input = breakin_int2_3_false_true, output = breakout_int2_3_false_true, internallength = 3, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_3_false_true (i int, j break_int2_3_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_3_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_3_false_false;
-create function breakin_int2_3_false_false (cstring) returns break_int2_3_false_false as 'textin' language internal;
-create function breakout_int2_3_false_false (break_int2_3_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_3_false_false (cstring) returns break_int2_3_false_false as 'textin' language internal strict;
+create function breakout_int2_3_false_false (break_int2_3_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_3_false_false (input = breakin_int2_3_false_false, output = breakout_int2_3_false_false, internallength = 3, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_3_false_false (i int, j break_int2_3_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_3_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_4_true_true;
-create function breakin_int2_4_true_true (cstring) returns break_int2_4_true_true as 'textin' language internal;
-create function breakout_int2_4_true_true (break_int2_4_true_true) returns cstring as 'textout' language internal;
+create function breakin_int2_4_true_true (cstring) returns break_int2_4_true_true as 'textin' language internal strict;
+create function breakout_int2_4_true_true (break_int2_4_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_4_true_true (input = breakin_int2_4_true_true, output = breakout_int2_4_true_true, internallength = 4, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_4_true_true (i int, j break_int2_4_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_4_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_4_true_false;
-create function breakin_int2_4_true_false (cstring) returns break_int2_4_true_false as 'textin' language internal;
-create function breakout_int2_4_true_false (break_int2_4_true_false) returns cstring as 'textout' language internal;
+create function breakin_int2_4_true_false (cstring) returns break_int2_4_true_false as 'textin' language internal strict;
+create function breakout_int2_4_true_false (break_int2_4_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_4_true_false (input = breakin_int2_4_true_false, output = breakout_int2_4_true_false, internallength = 4, passedbyvalue = true, alignment = int2);
 create table alter_distpol_g_int2_4_true_false (i int, j break_int2_4_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_4_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_4_false_true;
-create function breakin_int2_4_false_true (cstring) returns break_int2_4_false_true as 'textin' language internal;
-create function breakout_int2_4_false_true (break_int2_4_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_4_false_true (cstring) returns break_int2_4_false_true as 'textin' language internal strict;
+create function breakout_int2_4_false_true (break_int2_4_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_4_false_true (input = breakin_int2_4_false_true, output = breakout_int2_4_false_true, internallength = 4, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_4_false_true (i int, j break_int2_4_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_4_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_4_false_false;
-create function breakin_int2_4_false_false (cstring) returns break_int2_4_false_false as 'textin' language internal;
-create function breakout_int2_4_false_false (break_int2_4_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_4_false_false (cstring) returns break_int2_4_false_false as 'textin' language internal strict;
+create function breakout_int2_4_false_false (break_int2_4_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_4_false_false (input = breakin_int2_4_false_false, output = breakout_int2_4_false_false, internallength = 4, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_4_false_false (i int, j break_int2_4_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_4_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_11_false_true;
-create function breakin_int2_11_false_true (cstring) returns break_int2_11_false_true as 'textin' language internal;
-create function breakout_int2_11_false_true (break_int2_11_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_11_false_true (cstring) returns break_int2_11_false_true as 'textin' language internal strict;
+create function breakout_int2_11_false_true (break_int2_11_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_11_false_true (input = breakin_int2_11_false_true, output = breakout_int2_11_false_true, internallength = 11, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_11_false_true (i int, j break_int2_11_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_11_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_11_false_false;
-create function breakin_int2_11_false_false (cstring) returns break_int2_11_false_false as 'textin' language internal;
-create function breakout_int2_11_false_false (break_int2_11_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_11_false_false (cstring) returns break_int2_11_false_false as 'textin' language internal strict;
+create function breakout_int2_11_false_false (break_int2_11_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_11_false_false (input = breakin_int2_11_false_false, output = breakout_int2_11_false_false, internallength = 11, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_11_false_false (i int, j break_int2_11_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_11_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_17_false_true;
-create function breakin_int2_17_false_true (cstring) returns break_int2_17_false_true as 'textin' language internal;
-create function breakout_int2_17_false_true (break_int2_17_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_17_false_true (cstring) returns break_int2_17_false_true as 'textin' language internal strict;
+create function breakout_int2_17_false_true (break_int2_17_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_17_false_true (input = breakin_int2_17_false_true, output = breakout_int2_17_false_true, internallength = 17, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_17_false_true (i int, j break_int2_17_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_17_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_17_false_false;
-create function breakin_int2_17_false_false (cstring) returns break_int2_17_false_false as 'textin' language internal;
-create function breakout_int2_17_false_false (break_int2_17_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_17_false_false (cstring) returns break_int2_17_false_false as 'textin' language internal strict;
+create function breakout_int2_17_false_false (break_int2_17_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_17_false_false (input = breakin_int2_17_false_false, output = breakout_int2_17_false_false, internallength = 17, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_17_false_false (i int, j break_int2_17_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_17_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_19_false_true;
-create function breakin_int2_19_false_true (cstring) returns break_int2_19_false_true as 'textin' language internal;
-create function breakout_int2_19_false_true (break_int2_19_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_19_false_true (cstring) returns break_int2_19_false_true as 'textin' language internal strict;
+create function breakout_int2_19_false_true (break_int2_19_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_19_false_true (input = breakin_int2_19_false_true, output = breakout_int2_19_false_true, internallength = 19, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_19_false_true (i int, j break_int2_19_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_19_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_19_false_false;
-create function breakin_int2_19_false_false (cstring) returns break_int2_19_false_false as 'textin' language internal;
-create function breakout_int2_19_false_false (break_int2_19_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_19_false_false (cstring) returns break_int2_19_false_false as 'textin' language internal strict;
+create function breakout_int2_19_false_false (break_int2_19_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_19_false_false (input = breakin_int2_19_false_false, output = breakout_int2_19_false_false, internallength = 19, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_19_false_false (i int, j break_int2_19_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_19_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_23_false_true;
-create function breakin_int2_23_false_true (cstring) returns break_int2_23_false_true as 'textin' language internal;
-create function breakout_int2_23_false_true (break_int2_23_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_23_false_true (cstring) returns break_int2_23_false_true as 'textin' language internal strict;
+create function breakout_int2_23_false_true (break_int2_23_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_23_false_true (input = breakin_int2_23_false_true, output = breakout_int2_23_false_true, internallength = 23, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_23_false_true (i int, j break_int2_23_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_23_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_23_false_false;
-create function breakin_int2_23_false_false (cstring) returns break_int2_23_false_false as 'textin' language internal;
-create function breakout_int2_23_false_false (break_int2_23_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_23_false_false (cstring) returns break_int2_23_false_false as 'textin' language internal strict;
+create function breakout_int2_23_false_false (break_int2_23_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_23_false_false (input = breakin_int2_23_false_false, output = breakout_int2_23_false_false, internallength = 23, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_23_false_false (i int, j break_int2_23_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_23_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_32_false_true;
-create function breakin_int2_32_false_true (cstring) returns break_int2_32_false_true as 'textin' language internal;
-create function breakout_int2_32_false_true (break_int2_32_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_32_false_true (cstring) returns break_int2_32_false_true as 'textin' language internal strict;
+create function breakout_int2_32_false_true (break_int2_32_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_32_false_true (input = breakin_int2_32_false_true, output = breakout_int2_32_false_true, internallength = 32, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_32_false_true (i int, j break_int2_32_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_32_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_32_false_false;
-create function breakin_int2_32_false_false (cstring) returns break_int2_32_false_false as 'textin' language internal;
-create function breakout_int2_32_false_false (break_int2_32_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_32_false_false (cstring) returns break_int2_32_false_false as 'textin' language internal strict;
+create function breakout_int2_32_false_false (break_int2_32_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_32_false_false (input = breakin_int2_32_false_false, output = breakout_int2_32_false_false, internallength = 32, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_32_false_false (i int, j break_int2_32_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_32_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_196_false_true;
-create function breakin_int2_196_false_true (cstring) returns break_int2_196_false_true as 'textin' language internal;
-create function breakout_int2_196_false_true (break_int2_196_false_true) returns cstring as 'textout' language internal;
+create function breakin_int2_196_false_true (cstring) returns break_int2_196_false_true as 'textin' language internal strict;
+create function breakout_int2_196_false_true (break_int2_196_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int2_196_false_true (input = breakin_int2_196_false_true, output = breakout_int2_196_false_true, internallength = 196, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_196_false_true (i int, j break_int2_196_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int2_196_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int2_196_false_false;
-create function breakin_int2_196_false_false (cstring) returns break_int2_196_false_false as 'textin' language internal;
-create function breakout_int2_196_false_false (break_int2_196_false_false) returns cstring as 'textout' language internal;
+create function breakin_int2_196_false_false (cstring) returns break_int2_196_false_false as 'textin' language internal strict;
+create function breakout_int2_196_false_false (break_int2_196_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int2_196_false_false (input = breakin_int2_196_false_false, output = breakout_int2_196_false_false, internallength = 196, passedbyvalue = false, alignment = int2);
 create table alter_distpol_g_int2_196_false_false (i int, j break_int2_196_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int2_196_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_variable_false_true;
-create function breakin_int4_variable_false_true (cstring) returns break_int4_variable_false_true as 'textin' language internal;
-create function breakout_int4_variable_false_true (break_int4_variable_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_variable_false_true (cstring) returns break_int4_variable_false_true as 'textin' language internal strict;
+create function breakout_int4_variable_false_true (break_int4_variable_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_variable_false_true (input = breakin_int4_variable_false_true, output = breakout_int4_variable_false_true, internallength = variable, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_variable_false_true (i int, j break_int4_variable_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_variable_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_variable_false_false;
-create function breakin_int4_variable_false_false (cstring) returns break_int4_variable_false_false as 'textin' language internal;
-create function breakout_int4_variable_false_false (break_int4_variable_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_variable_false_false (cstring) returns break_int4_variable_false_false as 'textin' language internal strict;
+create function breakout_int4_variable_false_false (break_int4_variable_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_variable_false_false (input = breakin_int4_variable_false_false, output = breakout_int4_variable_false_false, internallength = variable, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_variable_false_false (i int, j break_int4_variable_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_variable_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_1_true_true;
-create function breakin_int4_1_true_true (cstring) returns break_int4_1_true_true as 'textin' language internal;
-create function breakout_int4_1_true_true (break_int4_1_true_true) returns cstring as 'textout' language internal;
+create function breakin_int4_1_true_true (cstring) returns break_int4_1_true_true as 'textin' language internal strict;
+create function breakout_int4_1_true_true (break_int4_1_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_1_true_true (input = breakin_int4_1_true_true, output = breakout_int4_1_true_true, internallength = 1, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_1_true_true (i int, j break_int4_1_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_1_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_1_true_false;
-create function breakin_int4_1_true_false (cstring) returns break_int4_1_true_false as 'textin' language internal;
-create function breakout_int4_1_true_false (break_int4_1_true_false) returns cstring as 'textout' language internal;
+create function breakin_int4_1_true_false (cstring) returns break_int4_1_true_false as 'textin' language internal strict;
+create function breakout_int4_1_true_false (break_int4_1_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_1_true_false (input = breakin_int4_1_true_false, output = breakout_int4_1_true_false, internallength = 1, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_1_true_false (i int, j break_int4_1_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_1_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_1_false_true;
-create function breakin_int4_1_false_true (cstring) returns break_int4_1_false_true as 'textin' language internal;
-create function breakout_int4_1_false_true (break_int4_1_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_1_false_true (cstring) returns break_int4_1_false_true as 'textin' language internal strict;
+create function breakout_int4_1_false_true (break_int4_1_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_1_false_true (input = breakin_int4_1_false_true, output = breakout_int4_1_false_true, internallength = 1, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_1_false_true (i int, j break_int4_1_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_1_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_1_false_false;
-create function breakin_int4_1_false_false (cstring) returns break_int4_1_false_false as 'textin' language internal;
-create function breakout_int4_1_false_false (break_int4_1_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_1_false_false (cstring) returns break_int4_1_false_false as 'textin' language internal strict;
+create function breakout_int4_1_false_false (break_int4_1_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_1_false_false (input = breakin_int4_1_false_false, output = breakout_int4_1_false_false, internallength = 1, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_1_false_false (i int, j break_int4_1_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_1_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_3_true_true;
-create function breakin_int4_3_true_true (cstring) returns break_int4_3_true_true as 'textin' language internal;
-create function breakout_int4_3_true_true (break_int4_3_true_true) returns cstring as 'textout' language internal;
+create function breakin_int4_3_true_true (cstring) returns break_int4_3_true_true as 'textin' language internal strict;
+create function breakout_int4_3_true_true (break_int4_3_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_3_true_true (input = breakin_int4_3_true_true, output = breakout_int4_3_true_true, internallength = 3, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_3_true_true (i int, j break_int4_3_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_3_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_3_true_false;
-create function breakin_int4_3_true_false (cstring) returns break_int4_3_true_false as 'textin' language internal;
-create function breakout_int4_3_true_false (break_int4_3_true_false) returns cstring as 'textout' language internal;
+create function breakin_int4_3_true_false (cstring) returns break_int4_3_true_false as 'textin' language internal strict;
+create function breakout_int4_3_true_false (break_int4_3_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_3_true_false (input = breakin_int4_3_true_false, output = breakout_int4_3_true_false, internallength = 3, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_3_true_false (i int, j break_int4_3_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_3_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_3_false_true;
-create function breakin_int4_3_false_true (cstring) returns break_int4_3_false_true as 'textin' language internal;
-create function breakout_int4_3_false_true (break_int4_3_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_3_false_true (cstring) returns break_int4_3_false_true as 'textin' language internal strict;
+create function breakout_int4_3_false_true (break_int4_3_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_3_false_true (input = breakin_int4_3_false_true, output = breakout_int4_3_false_true, internallength = 3, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_3_false_true (i int, j break_int4_3_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_3_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_3_false_false;
-create function breakin_int4_3_false_false (cstring) returns break_int4_3_false_false as 'textin' language internal;
-create function breakout_int4_3_false_false (break_int4_3_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_3_false_false (cstring) returns break_int4_3_false_false as 'textin' language internal strict;
+create function breakout_int4_3_false_false (break_int4_3_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_3_false_false (input = breakin_int4_3_false_false, output = breakout_int4_3_false_false, internallength = 3, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_3_false_false (i int, j break_int4_3_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_3_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_4_true_true;
-create function breakin_int4_4_true_true (cstring) returns break_int4_4_true_true as 'textin' language internal;
-create function breakout_int4_4_true_true (break_int4_4_true_true) returns cstring as 'textout' language internal;
+create function breakin_int4_4_true_true (cstring) returns break_int4_4_true_true as 'textin' language internal strict;
+create function breakout_int4_4_true_true (break_int4_4_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_4_true_true (input = breakin_int4_4_true_true, output = breakout_int4_4_true_true, internallength = 4, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_4_true_true (i int, j break_int4_4_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_4_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_4_true_false;
-create function breakin_int4_4_true_false (cstring) returns break_int4_4_true_false as 'textin' language internal;
-create function breakout_int4_4_true_false (break_int4_4_true_false) returns cstring as 'textout' language internal;
+create function breakin_int4_4_true_false (cstring) returns break_int4_4_true_false as 'textin' language internal strict;
+create function breakout_int4_4_true_false (break_int4_4_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_4_true_false (input = breakin_int4_4_true_false, output = breakout_int4_4_true_false, internallength = 4, passedbyvalue = true, alignment = int4);
 create table alter_distpol_g_int4_4_true_false (i int, j break_int4_4_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_4_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_4_false_true;
-create function breakin_int4_4_false_true (cstring) returns break_int4_4_false_true as 'textin' language internal;
-create function breakout_int4_4_false_true (break_int4_4_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_4_false_true (cstring) returns break_int4_4_false_true as 'textin' language internal strict;
+create function breakout_int4_4_false_true (break_int4_4_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_4_false_true (input = breakin_int4_4_false_true, output = breakout_int4_4_false_true, internallength = 4, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_4_false_true (i int, j break_int4_4_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_4_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_4_false_false;
-create function breakin_int4_4_false_false (cstring) returns break_int4_4_false_false as 'textin' language internal;
-create function breakout_int4_4_false_false (break_int4_4_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_4_false_false (cstring) returns break_int4_4_false_false as 'textin' language internal strict;
+create function breakout_int4_4_false_false (break_int4_4_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_4_false_false (input = breakin_int4_4_false_false, output = breakout_int4_4_false_false, internallength = 4, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_4_false_false (i int, j break_int4_4_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_4_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_11_false_true;
-create function breakin_int4_11_false_true (cstring) returns break_int4_11_false_true as 'textin' language internal;
-create function breakout_int4_11_false_true (break_int4_11_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_11_false_true (cstring) returns break_int4_11_false_true as 'textin' language internal strict;
+create function breakout_int4_11_false_true (break_int4_11_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_11_false_true (input = breakin_int4_11_false_true, output = breakout_int4_11_false_true, internallength = 11, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_11_false_true (i int, j break_int4_11_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_11_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_11_false_false;
-create function breakin_int4_11_false_false (cstring) returns break_int4_11_false_false as 'textin' language internal;
-create function breakout_int4_11_false_false (break_int4_11_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_11_false_false (cstring) returns break_int4_11_false_false as 'textin' language internal strict;
+create function breakout_int4_11_false_false (break_int4_11_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_11_false_false (input = breakin_int4_11_false_false, output = breakout_int4_11_false_false, internallength = 11, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_11_false_false (i int, j break_int4_11_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_11_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_17_false_true;
-create function breakin_int4_17_false_true (cstring) returns break_int4_17_false_true as 'textin' language internal;
-create function breakout_int4_17_false_true (break_int4_17_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_17_false_true (cstring) returns break_int4_17_false_true as 'textin' language internal strict;
+create function breakout_int4_17_false_true (break_int4_17_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_17_false_true (input = breakin_int4_17_false_true, output = breakout_int4_17_false_true, internallength = 17, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_17_false_true (i int, j break_int4_17_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_17_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_17_false_false;
-create function breakin_int4_17_false_false (cstring) returns break_int4_17_false_false as 'textin' language internal;
-create function breakout_int4_17_false_false (break_int4_17_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_17_false_false (cstring) returns break_int4_17_false_false as 'textin' language internal strict;
+create function breakout_int4_17_false_false (break_int4_17_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_17_false_false (input = breakin_int4_17_false_false, output = breakout_int4_17_false_false, internallength = 17, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_17_false_false (i int, j break_int4_17_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_17_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_19_false_true;
-create function breakin_int4_19_false_true (cstring) returns break_int4_19_false_true as 'textin' language internal;
-create function breakout_int4_19_false_true (break_int4_19_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_19_false_true (cstring) returns break_int4_19_false_true as 'textin' language internal strict;
+create function breakout_int4_19_false_true (break_int4_19_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_19_false_true (input = breakin_int4_19_false_true, output = breakout_int4_19_false_true, internallength = 19, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_19_false_true (i int, j break_int4_19_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_19_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_19_false_false;
-create function breakin_int4_19_false_false (cstring) returns break_int4_19_false_false as 'textin' language internal;
-create function breakout_int4_19_false_false (break_int4_19_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_19_false_false (cstring) returns break_int4_19_false_false as 'textin' language internal strict;
+create function breakout_int4_19_false_false (break_int4_19_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_19_false_false (input = breakin_int4_19_false_false, output = breakout_int4_19_false_false, internallength = 19, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_19_false_false (i int, j break_int4_19_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_19_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_23_false_true;
-create function breakin_int4_23_false_true (cstring) returns break_int4_23_false_true as 'textin' language internal;
-create function breakout_int4_23_false_true (break_int4_23_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_23_false_true (cstring) returns break_int4_23_false_true as 'textin' language internal strict;
+create function breakout_int4_23_false_true (break_int4_23_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_23_false_true (input = breakin_int4_23_false_true, output = breakout_int4_23_false_true, internallength = 23, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_23_false_true (i int, j break_int4_23_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_23_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_23_false_false;
-create function breakin_int4_23_false_false (cstring) returns break_int4_23_false_false as 'textin' language internal;
-create function breakout_int4_23_false_false (break_int4_23_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_23_false_false (cstring) returns break_int4_23_false_false as 'textin' language internal strict;
+create function breakout_int4_23_false_false (break_int4_23_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_23_false_false (input = breakin_int4_23_false_false, output = breakout_int4_23_false_false, internallength = 23, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_23_false_false (i int, j break_int4_23_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_23_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_32_false_true;
-create function breakin_int4_32_false_true (cstring) returns break_int4_32_false_true as 'textin' language internal;
-create function breakout_int4_32_false_true (break_int4_32_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_32_false_true (cstring) returns break_int4_32_false_true as 'textin' language internal strict;
+create function breakout_int4_32_false_true (break_int4_32_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_32_false_true (input = breakin_int4_32_false_true, output = breakout_int4_32_false_true, internallength = 32, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_32_false_true (i int, j break_int4_32_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_32_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_32_false_false;
-create function breakin_int4_32_false_false (cstring) returns break_int4_32_false_false as 'textin' language internal;
-create function breakout_int4_32_false_false (break_int4_32_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_32_false_false (cstring) returns break_int4_32_false_false as 'textin' language internal strict;
+create function breakout_int4_32_false_false (break_int4_32_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_32_false_false (input = breakin_int4_32_false_false, output = breakout_int4_32_false_false, internallength = 32, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_32_false_false (i int, j break_int4_32_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_32_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_196_false_true;
-create function breakin_int4_196_false_true (cstring) returns break_int4_196_false_true as 'textin' language internal;
-create function breakout_int4_196_false_true (break_int4_196_false_true) returns cstring as 'textout' language internal;
+create function breakin_int4_196_false_true (cstring) returns break_int4_196_false_true as 'textin' language internal strict;
+create function breakout_int4_196_false_true (break_int4_196_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_int4_196_false_true (input = breakin_int4_196_false_true, output = breakout_int4_196_false_true, internallength = 196, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_196_false_true (i int, j break_int4_196_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_int4_196_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_int4_196_false_false;
-create function breakin_int4_196_false_false (cstring) returns break_int4_196_false_false as 'textin' language internal;
-create function breakout_int4_196_false_false (break_int4_196_false_false) returns cstring as 'textout' language internal;
+create function breakin_int4_196_false_false (cstring) returns break_int4_196_false_false as 'textin' language internal strict;
+create function breakout_int4_196_false_false (break_int4_196_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_int4_196_false_false (input = breakin_int4_196_false_false, output = breakout_int4_196_false_false, internallength = 196, passedbyvalue = false, alignment = int4);
 create table alter_distpol_g_int4_196_false_false (i int, j break_int4_196_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_int4_196_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_variable_false_true;
-create function breakin_char_variable_false_true (cstring) returns break_char_variable_false_true as 'textin' language internal;
-create function breakout_char_variable_false_true (break_char_variable_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_variable_false_true (cstring) returns break_char_variable_false_true as 'textin' language internal strict;
+create function breakout_char_variable_false_true (break_char_variable_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_variable_false_true (input = breakin_char_variable_false_true, output = breakout_char_variable_false_true, internallength = variable, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_variable_false_true (i int, j break_char_variable_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_variable_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_variable_false_false;
-create function breakin_char_variable_false_false (cstring) returns break_char_variable_false_false as 'textin' language internal;
-create function breakout_char_variable_false_false (break_char_variable_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_variable_false_false (cstring) returns break_char_variable_false_false as 'textin' language internal strict;
+create function breakout_char_variable_false_false (break_char_variable_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_variable_false_false (input = breakin_char_variable_false_false, output = breakout_char_variable_false_false, internallength = variable, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_variable_false_false (i int, j break_char_variable_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_variable_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_1_true_true;
-create function breakin_char_1_true_true (cstring) returns break_char_1_true_true as 'textin' language internal;
-create function breakout_char_1_true_true (break_char_1_true_true) returns cstring as 'textout' language internal;
+create function breakin_char_1_true_true (cstring) returns break_char_1_true_true as 'textin' language internal strict;
+create function breakout_char_1_true_true (break_char_1_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_1_true_true (input = breakin_char_1_true_true, output = breakout_char_1_true_true, internallength = 1, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_1_true_true (i int, j break_char_1_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_1_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_1_true_false;
-create function breakin_char_1_true_false (cstring) returns break_char_1_true_false as 'textin' language internal;
-create function breakout_char_1_true_false (break_char_1_true_false) returns cstring as 'textout' language internal;
+create function breakin_char_1_true_false (cstring) returns break_char_1_true_false as 'textin' language internal strict;
+create function breakout_char_1_true_false (break_char_1_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_1_true_false (input = breakin_char_1_true_false, output = breakout_char_1_true_false, internallength = 1, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_1_true_false (i int, j break_char_1_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_1_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_1_false_true;
-create function breakin_char_1_false_true (cstring) returns break_char_1_false_true as 'textin' language internal;
-create function breakout_char_1_false_true (break_char_1_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_1_false_true (cstring) returns break_char_1_false_true as 'textin' language internal strict;
+create function breakout_char_1_false_true (break_char_1_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_1_false_true (input = breakin_char_1_false_true, output = breakout_char_1_false_true, internallength = 1, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_1_false_true (i int, j break_char_1_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_1_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_1_false_false;
-create function breakin_char_1_false_false (cstring) returns break_char_1_false_false as 'textin' language internal;
-create function breakout_char_1_false_false (break_char_1_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_1_false_false (cstring) returns break_char_1_false_false as 'textin' language internal strict;
+create function breakout_char_1_false_false (break_char_1_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_1_false_false (input = breakin_char_1_false_false, output = breakout_char_1_false_false, internallength = 1, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_1_false_false (i int, j break_char_1_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_1_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_3_true_true;
-create function breakin_char_3_true_true (cstring) returns break_char_3_true_true as 'textin' language internal;
-create function breakout_char_3_true_true (break_char_3_true_true) returns cstring as 'textout' language internal;
+create function breakin_char_3_true_true (cstring) returns break_char_3_true_true as 'textin' language internal strict;
+create function breakout_char_3_true_true (break_char_3_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_3_true_true (input = breakin_char_3_true_true, output = breakout_char_3_true_true, internallength = 3, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_3_true_true (i int, j break_char_3_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_3_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_3_true_false;
-create function breakin_char_3_true_false (cstring) returns break_char_3_true_false as 'textin' language internal;
-create function breakout_char_3_true_false (break_char_3_true_false) returns cstring as 'textout' language internal;
+create function breakin_char_3_true_false (cstring) returns break_char_3_true_false as 'textin' language internal strict;
+create function breakout_char_3_true_false (break_char_3_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_3_true_false (input = breakin_char_3_true_false, output = breakout_char_3_true_false, internallength = 3, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_3_true_false (i int, j break_char_3_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_3_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_3_false_true;
-create function breakin_char_3_false_true (cstring) returns break_char_3_false_true as 'textin' language internal;
-create function breakout_char_3_false_true (break_char_3_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_3_false_true (cstring) returns break_char_3_false_true as 'textin' language internal strict;
+create function breakout_char_3_false_true (break_char_3_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_3_false_true (input = breakin_char_3_false_true, output = breakout_char_3_false_true, internallength = 3, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_3_false_true (i int, j break_char_3_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_3_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_3_false_false;
-create function breakin_char_3_false_false (cstring) returns break_char_3_false_false as 'textin' language internal;
-create function breakout_char_3_false_false (break_char_3_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_3_false_false (cstring) returns break_char_3_false_false as 'textin' language internal strict;
+create function breakout_char_3_false_false (break_char_3_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_3_false_false (input = breakin_char_3_false_false, output = breakout_char_3_false_false, internallength = 3, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_3_false_false (i int, j break_char_3_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_3_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_4_true_true;
-create function breakin_char_4_true_true (cstring) returns break_char_4_true_true as 'textin' language internal;
-create function breakout_char_4_true_true (break_char_4_true_true) returns cstring as 'textout' language internal;
+create function breakin_char_4_true_true (cstring) returns break_char_4_true_true as 'textin' language internal strict;
+create function breakout_char_4_true_true (break_char_4_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_4_true_true (input = breakin_char_4_true_true, output = breakout_char_4_true_true, internallength = 4, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_4_true_true (i int, j break_char_4_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_4_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_4_true_false;
-create function breakin_char_4_true_false (cstring) returns break_char_4_true_false as 'textin' language internal;
-create function breakout_char_4_true_false (break_char_4_true_false) returns cstring as 'textout' language internal;
+create function breakin_char_4_true_false (cstring) returns break_char_4_true_false as 'textin' language internal strict;
+create function breakout_char_4_true_false (break_char_4_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_4_true_false (input = breakin_char_4_true_false, output = breakout_char_4_true_false, internallength = 4, passedbyvalue = true, alignment = char);
 create table alter_distpol_g_char_4_true_false (i int, j break_char_4_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_4_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_4_false_true;
-create function breakin_char_4_false_true (cstring) returns break_char_4_false_true as 'textin' language internal;
-create function breakout_char_4_false_true (break_char_4_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_4_false_true (cstring) returns break_char_4_false_true as 'textin' language internal strict;
+create function breakout_char_4_false_true (break_char_4_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_4_false_true (input = breakin_char_4_false_true, output = breakout_char_4_false_true, internallength = 4, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_4_false_true (i int, j break_char_4_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_4_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_4_false_false;
-create function breakin_char_4_false_false (cstring) returns break_char_4_false_false as 'textin' language internal;
-create function breakout_char_4_false_false (break_char_4_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_4_false_false (cstring) returns break_char_4_false_false as 'textin' language internal strict;
+create function breakout_char_4_false_false (break_char_4_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_4_false_false (input = breakin_char_4_false_false, output = breakout_char_4_false_false, internallength = 4, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_4_false_false (i int, j break_char_4_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_4_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_11_false_true;
-create function breakin_char_11_false_true (cstring) returns break_char_11_false_true as 'textin' language internal;
-create function breakout_char_11_false_true (break_char_11_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_11_false_true (cstring) returns break_char_11_false_true as 'textin' language internal strict;
+create function breakout_char_11_false_true (break_char_11_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_11_false_true (input = breakin_char_11_false_true, output = breakout_char_11_false_true, internallength = 11, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_11_false_true (i int, j break_char_11_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_11_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_11_false_false;
-create function breakin_char_11_false_false (cstring) returns break_char_11_false_false as 'textin' language internal;
-create function breakout_char_11_false_false (break_char_11_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_11_false_false (cstring) returns break_char_11_false_false as 'textin' language internal strict;
+create function breakout_char_11_false_false (break_char_11_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_11_false_false (input = breakin_char_11_false_false, output = breakout_char_11_false_false, internallength = 11, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_11_false_false (i int, j break_char_11_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_11_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_17_false_true;
-create function breakin_char_17_false_true (cstring) returns break_char_17_false_true as 'textin' language internal;
-create function breakout_char_17_false_true (break_char_17_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_17_false_true (cstring) returns break_char_17_false_true as 'textin' language internal strict;
+create function breakout_char_17_false_true (break_char_17_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_17_false_true (input = breakin_char_17_false_true, output = breakout_char_17_false_true, internallength = 17, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_17_false_true (i int, j break_char_17_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_17_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_17_false_false;
-create function breakin_char_17_false_false (cstring) returns break_char_17_false_false as 'textin' language internal;
-create function breakout_char_17_false_false (break_char_17_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_17_false_false (cstring) returns break_char_17_false_false as 'textin' language internal strict;
+create function breakout_char_17_false_false (break_char_17_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_17_false_false (input = breakin_char_17_false_false, output = breakout_char_17_false_false, internallength = 17, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_17_false_false (i int, j break_char_17_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_17_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_19_false_true;
-create function breakin_char_19_false_true (cstring) returns break_char_19_false_true as 'textin' language internal;
-create function breakout_char_19_false_true (break_char_19_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_19_false_true (cstring) returns break_char_19_false_true as 'textin' language internal strict;
+create function breakout_char_19_false_true (break_char_19_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_19_false_true (input = breakin_char_19_false_true, output = breakout_char_19_false_true, internallength = 19, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_19_false_true (i int, j break_char_19_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_19_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_19_false_false;
-create function breakin_char_19_false_false (cstring) returns break_char_19_false_false as 'textin' language internal;
-create function breakout_char_19_false_false (break_char_19_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_19_false_false (cstring) returns break_char_19_false_false as 'textin' language internal strict;
+create function breakout_char_19_false_false (break_char_19_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_19_false_false (input = breakin_char_19_false_false, output = breakout_char_19_false_false, internallength = 19, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_19_false_false (i int, j break_char_19_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_19_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_23_false_true;
-create function breakin_char_23_false_true (cstring) returns break_char_23_false_true as 'textin' language internal;
-create function breakout_char_23_false_true (break_char_23_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_23_false_true (cstring) returns break_char_23_false_true as 'textin' language internal strict;
+create function breakout_char_23_false_true (break_char_23_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_23_false_true (input = breakin_char_23_false_true, output = breakout_char_23_false_true, internallength = 23, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_23_false_true (i int, j break_char_23_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_23_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_23_false_false;
-create function breakin_char_23_false_false (cstring) returns break_char_23_false_false as 'textin' language internal;
-create function breakout_char_23_false_false (break_char_23_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_23_false_false (cstring) returns break_char_23_false_false as 'textin' language internal strict;
+create function breakout_char_23_false_false (break_char_23_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_23_false_false (input = breakin_char_23_false_false, output = breakout_char_23_false_false, internallength = 23, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_23_false_false (i int, j break_char_23_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_23_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_32_false_true;
-create function breakin_char_32_false_true (cstring) returns break_char_32_false_true as 'textin' language internal;
-create function breakout_char_32_false_true (break_char_32_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_32_false_true (cstring) returns break_char_32_false_true as 'textin' language internal strict;
+create function breakout_char_32_false_true (break_char_32_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_32_false_true (input = breakin_char_32_false_true, output = breakout_char_32_false_true, internallength = 32, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_32_false_true (i int, j break_char_32_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_32_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_32_false_false;
-create function breakin_char_32_false_false (cstring) returns break_char_32_false_false as 'textin' language internal;
-create function breakout_char_32_false_false (break_char_32_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_32_false_false (cstring) returns break_char_32_false_false as 'textin' language internal strict;
+create function breakout_char_32_false_false (break_char_32_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_32_false_false (input = breakin_char_32_false_false, output = breakout_char_32_false_false, internallength = 32, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_32_false_false (i int, j break_char_32_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_32_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_196_false_true;
-create function breakin_char_196_false_true (cstring) returns break_char_196_false_true as 'textin' language internal;
-create function breakout_char_196_false_true (break_char_196_false_true) returns cstring as 'textout' language internal;
+create function breakin_char_196_false_true (cstring) returns break_char_196_false_true as 'textin' language internal strict;
+create function breakout_char_196_false_true (break_char_196_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_char_196_false_true (input = breakin_char_196_false_true, output = breakout_char_196_false_true, internallength = 196, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_196_false_true (i int, j break_char_196_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_char_196_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_char_196_false_false;
-create function breakin_char_196_false_false (cstring) returns break_char_196_false_false as 'textin' language internal;
-create function breakout_char_196_false_false (break_char_196_false_false) returns cstring as 'textout' language internal;
+create function breakin_char_196_false_false (cstring) returns break_char_196_false_false as 'textin' language internal strict;
+create function breakout_char_196_false_false (break_char_196_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_char_196_false_false (input = breakin_char_196_false_false, output = breakout_char_196_false_false, internallength = 196, passedbyvalue = false, alignment = char);
 create table alter_distpol_g_char_196_false_false (i int, j break_char_196_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_char_196_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_variable_false_true;
-create function breakin_double_variable_false_true (cstring) returns break_double_variable_false_true as 'textin' language internal;
-create function breakout_double_variable_false_true (break_double_variable_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_variable_false_true (cstring) returns break_double_variable_false_true as 'textin' language internal strict;
+create function breakout_double_variable_false_true (break_double_variable_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_variable_false_true (input = breakin_double_variable_false_true, output = breakout_double_variable_false_true, internallength = variable, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_variable_false_true (i int, j break_double_variable_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_variable_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_variable_false_false;
-create function breakin_double_variable_false_false (cstring) returns break_double_variable_false_false as 'textin' language internal;
-create function breakout_double_variable_false_false (break_double_variable_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_variable_false_false (cstring) returns break_double_variable_false_false as 'textin' language internal strict;
+create function breakout_double_variable_false_false (break_double_variable_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_variable_false_false (input = breakin_double_variable_false_false, output = breakout_double_variable_false_false, internallength = variable, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_variable_false_false (i int, j break_double_variable_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_variable_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_1_true_true;
-create function breakin_double_1_true_true (cstring) returns break_double_1_true_true as 'textin' language internal;
-create function breakout_double_1_true_true (break_double_1_true_true) returns cstring as 'textout' language internal;
+create function breakin_double_1_true_true (cstring) returns break_double_1_true_true as 'textin' language internal strict;
+create function breakout_double_1_true_true (break_double_1_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_1_true_true (input = breakin_double_1_true_true, output = breakout_double_1_true_true, internallength = 1, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_1_true_true (i int, j break_double_1_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_1_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_1_true_false;
-create function breakin_double_1_true_false (cstring) returns break_double_1_true_false as 'textin' language internal;
-create function breakout_double_1_true_false (break_double_1_true_false) returns cstring as 'textout' language internal;
+create function breakin_double_1_true_false (cstring) returns break_double_1_true_false as 'textin' language internal strict;
+create function breakout_double_1_true_false (break_double_1_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_1_true_false (input = breakin_double_1_true_false, output = breakout_double_1_true_false, internallength = 1, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_1_true_false (i int, j break_double_1_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_1_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_1_false_true;
-create function breakin_double_1_false_true (cstring) returns break_double_1_false_true as 'textin' language internal;
-create function breakout_double_1_false_true (break_double_1_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_1_false_true (cstring) returns break_double_1_false_true as 'textin' language internal strict;
+create function breakout_double_1_false_true (break_double_1_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_1_false_true (input = breakin_double_1_false_true, output = breakout_double_1_false_true, internallength = 1, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_1_false_true (i int, j break_double_1_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_1_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_1_false_false;
-create function breakin_double_1_false_false (cstring) returns break_double_1_false_false as 'textin' language internal;
-create function breakout_double_1_false_false (break_double_1_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_1_false_false (cstring) returns break_double_1_false_false as 'textin' language internal strict;
+create function breakout_double_1_false_false (break_double_1_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_1_false_false (input = breakin_double_1_false_false, output = breakout_double_1_false_false, internallength = 1, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_1_false_false (i int, j break_double_1_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_1_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_3_true_true;
-create function breakin_double_3_true_true (cstring) returns break_double_3_true_true as 'textin' language internal;
-create function breakout_double_3_true_true (break_double_3_true_true) returns cstring as 'textout' language internal;
+create function breakin_double_3_true_true (cstring) returns break_double_3_true_true as 'textin' language internal strict;
+create function breakout_double_3_true_true (break_double_3_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_3_true_true (input = breakin_double_3_true_true, output = breakout_double_3_true_true, internallength = 3, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_3_true_true (i int, j break_double_3_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_3_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_3_true_false;
-create function breakin_double_3_true_false (cstring) returns break_double_3_true_false as 'textin' language internal;
-create function breakout_double_3_true_false (break_double_3_true_false) returns cstring as 'textout' language internal;
+create function breakin_double_3_true_false (cstring) returns break_double_3_true_false as 'textin' language internal strict;
+create function breakout_double_3_true_false (break_double_3_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_3_true_false (input = breakin_double_3_true_false, output = breakout_double_3_true_false, internallength = 3, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_3_true_false (i int, j break_double_3_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_3_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_3_false_true;
-create function breakin_double_3_false_true (cstring) returns break_double_3_false_true as 'textin' language internal;
-create function breakout_double_3_false_true (break_double_3_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_3_false_true (cstring) returns break_double_3_false_true as 'textin' language internal strict;
+create function breakout_double_3_false_true (break_double_3_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_3_false_true (input = breakin_double_3_false_true, output = breakout_double_3_false_true, internallength = 3, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_3_false_true (i int, j break_double_3_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_3_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_3_false_false;
-create function breakin_double_3_false_false (cstring) returns break_double_3_false_false as 'textin' language internal;
-create function breakout_double_3_false_false (break_double_3_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_3_false_false (cstring) returns break_double_3_false_false as 'textin' language internal strict;
+create function breakout_double_3_false_false (break_double_3_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_3_false_false (input = breakin_double_3_false_false, output = breakout_double_3_false_false, internallength = 3, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_3_false_false (i int, j break_double_3_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_3_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_4_true_true;
-create function breakin_double_4_true_true (cstring) returns break_double_4_true_true as 'textin' language internal;
-create function breakout_double_4_true_true (break_double_4_true_true) returns cstring as 'textout' language internal;
+create function breakin_double_4_true_true (cstring) returns break_double_4_true_true as 'textin' language internal strict;
+create function breakout_double_4_true_true (break_double_4_true_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_4_true_true (input = breakin_double_4_true_true, output = breakout_double_4_true_true, internallength = 4, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_4_true_true (i int, j break_double_4_true_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_4_true_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_4_true_false;
-create function breakin_double_4_true_false (cstring) returns break_double_4_true_false as 'textin' language internal;
-create function breakout_double_4_true_false (break_double_4_true_false) returns cstring as 'textout' language internal;
+create function breakin_double_4_true_false (cstring) returns break_double_4_true_false as 'textin' language internal strict;
+create function breakout_double_4_true_false (break_double_4_true_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_4_true_false (input = breakin_double_4_true_false, output = breakout_double_4_true_false, internallength = 4, passedbyvalue = true, alignment = double);
 create table alter_distpol_g_double_4_true_false (i int, j break_double_4_true_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_4_true_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_4_false_true;
-create function breakin_double_4_false_true (cstring) returns break_double_4_false_true as 'textin' language internal;
-create function breakout_double_4_false_true (break_double_4_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_4_false_true (cstring) returns break_double_4_false_true as 'textin' language internal strict;
+create function breakout_double_4_false_true (break_double_4_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_4_false_true (input = breakin_double_4_false_true, output = breakout_double_4_false_true, internallength = 4, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_4_false_true (i int, j break_double_4_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_4_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_4_false_false;
-create function breakin_double_4_false_false (cstring) returns break_double_4_false_false as 'textin' language internal;
-create function breakout_double_4_false_false (break_double_4_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_4_false_false (cstring) returns break_double_4_false_false as 'textin' language internal strict;
+create function breakout_double_4_false_false (break_double_4_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_4_false_false (input = breakin_double_4_false_false, output = breakout_double_4_false_false, internallength = 4, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_4_false_false (i int, j break_double_4_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_4_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_11_false_true;
-create function breakin_double_11_false_true (cstring) returns break_double_11_false_true as 'textin' language internal;
-create function breakout_double_11_false_true (break_double_11_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_11_false_true (cstring) returns break_double_11_false_true as 'textin' language internal strict;
+create function breakout_double_11_false_true (break_double_11_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_11_false_true (input = breakin_double_11_false_true, output = breakout_double_11_false_true, internallength = 11, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_11_false_true (i int, j break_double_11_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_11_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_11_false_false;
-create function breakin_double_11_false_false (cstring) returns break_double_11_false_false as 'textin' language internal;
-create function breakout_double_11_false_false (break_double_11_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_11_false_false (cstring) returns break_double_11_false_false as 'textin' language internal strict;
+create function breakout_double_11_false_false (break_double_11_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_11_false_false (input = breakin_double_11_false_false, output = breakout_double_11_false_false, internallength = 11, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_11_false_false (i int, j break_double_11_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_11_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_17_false_true;
-create function breakin_double_17_false_true (cstring) returns break_double_17_false_true as 'textin' language internal;
-create function breakout_double_17_false_true (break_double_17_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_17_false_true (cstring) returns break_double_17_false_true as 'textin' language internal strict;
+create function breakout_double_17_false_true (break_double_17_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_17_false_true (input = breakin_double_17_false_true, output = breakout_double_17_false_true, internallength = 17, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_17_false_true (i int, j break_double_17_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_17_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_17_false_false;
-create function breakin_double_17_false_false (cstring) returns break_double_17_false_false as 'textin' language internal;
-create function breakout_double_17_false_false (break_double_17_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_17_false_false (cstring) returns break_double_17_false_false as 'textin' language internal strict;
+create function breakout_double_17_false_false (break_double_17_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_17_false_false (input = breakin_double_17_false_false, output = breakout_double_17_false_false, internallength = 17, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_17_false_false (i int, j break_double_17_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_17_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_19_false_true;
-create function breakin_double_19_false_true (cstring) returns break_double_19_false_true as 'textin' language internal;
-create function breakout_double_19_false_true (break_double_19_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_19_false_true (cstring) returns break_double_19_false_true as 'textin' language internal strict;
+create function breakout_double_19_false_true (break_double_19_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_19_false_true (input = breakin_double_19_false_true, output = breakout_double_19_false_true, internallength = 19, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_19_false_true (i int, j break_double_19_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_19_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_19_false_false;
-create function breakin_double_19_false_false (cstring) returns break_double_19_false_false as 'textin' language internal;
-create function breakout_double_19_false_false (break_double_19_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_19_false_false (cstring) returns break_double_19_false_false as 'textin' language internal strict;
+create function breakout_double_19_false_false (break_double_19_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_19_false_false (input = breakin_double_19_false_false, output = breakout_double_19_false_false, internallength = 19, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_19_false_false (i int, j break_double_19_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_19_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_23_false_true;
-create function breakin_double_23_false_true (cstring) returns break_double_23_false_true as 'textin' language internal;
-create function breakout_double_23_false_true (break_double_23_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_23_false_true (cstring) returns break_double_23_false_true as 'textin' language internal strict;
+create function breakout_double_23_false_true (break_double_23_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_23_false_true (input = breakin_double_23_false_true, output = breakout_double_23_false_true, internallength = 23, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_23_false_true (i int, j break_double_23_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_23_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_23_false_false;
-create function breakin_double_23_false_false (cstring) returns break_double_23_false_false as 'textin' language internal;
-create function breakout_double_23_false_false (break_double_23_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_23_false_false (cstring) returns break_double_23_false_false as 'textin' language internal strict;
+create function breakout_double_23_false_false (break_double_23_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_23_false_false (input = breakin_double_23_false_false, output = breakout_double_23_false_false, internallength = 23, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_23_false_false (i int, j break_double_23_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_23_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_32_false_true;
-create function breakin_double_32_false_true (cstring) returns break_double_32_false_true as 'textin' language internal;
-create function breakout_double_32_false_true (break_double_32_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_32_false_true (cstring) returns break_double_32_false_true as 'textin' language internal strict;
+create function breakout_double_32_false_true (break_double_32_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_32_false_true (input = breakin_double_32_false_true, output = breakout_double_32_false_true, internallength = 32, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_32_false_true (i int, j break_double_32_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_32_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_32_false_false;
-create function breakin_double_32_false_false (cstring) returns break_double_32_false_false as 'textin' language internal;
-create function breakout_double_32_false_false (break_double_32_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_32_false_false (cstring) returns break_double_32_false_false as 'textin' language internal strict;
+create function breakout_double_32_false_false (break_double_32_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_32_false_false (input = breakin_double_32_false_false, output = breakout_double_32_false_false, internallength = 32, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_32_false_false (i int, j break_double_32_false_false, k text) with (appendonly = false) distributed by (i);
 insert into alter_distpol_g_double_32_false_false (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_196_false_true;
-create function breakin_double_196_false_true (cstring) returns break_double_196_false_true as 'textin' language internal;
-create function breakout_double_196_false_true (break_double_196_false_true) returns cstring as 'textout' language internal;
+create function breakin_double_196_false_true (cstring) returns break_double_196_false_true as 'textin' language internal strict;
+create function breakout_double_196_false_true (break_double_196_false_true) returns cstring as 'textout' language internal strict;
 
 create type break_double_196_false_true (input = breakin_double_196_false_true, output = breakout_double_196_false_true, internallength = 196, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_196_false_true (i int, j break_double_196_false_true, k text) with (appendonly = true) distributed by (i);
 insert into alter_distpol_g_double_196_false_true (i, k) select i, i from generate_series(1, 10) i;
 create type break_double_196_false_false;
-create function breakin_double_196_false_false (cstring) returns break_double_196_false_false as 'textin' language internal;
-create function breakout_double_196_false_false (break_double_196_false_false) returns cstring as 'textout' language internal;
+create function breakin_double_196_false_false (cstring) returns break_double_196_false_false as 'textin' language internal strict;
+create function breakout_double_196_false_false (break_double_196_false_false) returns cstring as 'textout' language internal strict;
 
 create type break_double_196_false_false (input = breakin_double_196_false_false, output = breakout_double_196_false_false, internallength = 196, passedbyvalue = false, alignment = double);
 create table alter_distpol_g_double_196_false_false (i int, j break_double_196_false_false, k text) with (appendonly = false) distributed by (i);


### PR DESCRIPTION
    Mask columns exceeding threshold in analyze sample

    Analyze collects a sample from the table, in case the
    sample contains columns with huge length, the columns may
    result memory usage to go high cancelling the query.

    This commit masks the lengthy columns to avoid high
    memory usage while collecting sample. Column values exceeding
    WIDTH_THRESHOLD will be ignored from the samples.

    Approach to address this issue :

     Numeric types or Fixed length user defined types:
      Always include the column in the sample.

    Variable length types:
      Check the toasted/compressed size and mask the column value if size
      exceeds column_threshhold (compressed)