### PR TITLE
Fix database test in gpstart

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -750,8 +750,9 @@ class GpStart:
 
         logger.info("Command pg_ctl reports Master %s instance active" % self.gparray.master.hostname)
 
+        msg = None
         try:
-            masterconn = dbconn.connect(testurl)
+            masterconn = dbconn.connect(self.dburl)
             masterconn.close()
 
         except Exception, e:


### PR DESCRIPTION
Commit f41552e92f500632f1ada0fc9214e9687e7fb4b6 removed the upgrade code from gpstart, but took some of the code to test connections with it. Reinstate the url test but with `self.dburl` instead since it's the only remaining value to test here.

@Chibin does this look good to you?