### PR TITLE
Define prototype for find_option

### DIFF
--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -650,6 +650,9 @@ extern int  gp_guc_list_show(struct StringInfoData    *buf,
                 /* This extension allows gcc to check the format string */
                 __attribute__((__format__(__printf__, 3, 0)));
 
+extern struct config_generic *find_option(const char *name,
+				bool create_placeholders, int elevel);
+
 #ifdef EXEC_BACKEND
 extern void write_nondefault_variables(GucContext context);
 extern void read_nondefault_variables(void);


### PR DESCRIPTION
Commit 7143309 exposed find_option to outside callers, with a
prototype declared in guc_gp.c. This cause compiler warning on
guc.c so expose it in guc.h as it is now an exported symbol.
This fixes:

guc.c:3231:1: warning: no previous prototype for function 'find_option'
			  [-Wmissing-prototypes]
find_option(const char *name, bool create_placeholders, int elevel)
^

I'm a bit on the fence on this one, but avoiding compiler warnings in the default CFLAGS for our main compilers seem worthwhile.