### PR TITLE
Make PR pipeline jobs public

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -33,6 +33,7 @@ resources:
 
 jobs:
   - name: compile_and_test_gpdb
+    public: true
     max_in_flight: 4
     plan:
     - aggregate:


### PR DESCRIPTION
Being an OSS project, this helps us being public about failing PR jobs and enables OSS developers to understand what's causing failures in their pipeline. 

[#137900495](https://www.pivotaltracker.com/n/projects/1321816)