### PR TITLE
Removed stopping the hash inner subtree under a subplan node

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -148,10 +148,6 @@ ExecHashJoin(HashJoinState *node)
 				if (TupIsNull(node->hj_FirstOuterTupleSlot))
 				{
 					node->hj_OuterNotEmpty = false;
-
-					/* CDB: Tell inner subtree that its data will not be needed. */
-					ExecSquelchNode((PlanState *)hashNode);
-
 					return NULL;
 				}
 				else


### PR DESCRIPTION
First of all, I want to say that this PR is more about issue reporting rather than bug fixing. There must be some better solution than this one. My solution just serves as the starting point (actually, I am not quite sure it is correct).

Following are the reproduce steps for this issue.

Environment: Two segments without mirror, optimizer is set off (meaning we use the legacy planner).

Working SQLs (can run successfully):
```
-- prepare data
create table A(i integer, j integer) distributed by (i);
insert into A values(1,1);
insert into A values(19,5);
insert into A values(99,62);
insert into A values(1,1);
insert into A values(78,-1);
analyze A;
create table B(i integer, j integer) distributed by (i);
insert into B values(1,43);
insert into B values(88,1);
insert into B values(-1,62);
insert into B values(1,1);
insert into B values(32,5);
insert into B values(2,7);
analyze B;
create table C(i integer, j integer) distributed by (i);
insert into C values(1,889);
insert into C values(288,1);
insert into C values(-1,625);
insert into C values(32,65);
insert into C values(32,62);
insert into C values(3,-1);
insert into C values(99,7);
insert into C values(78,62);
insert into C values(2,7);
analyze C;
-- data query
select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and not exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
```
Failed SQLs (report error):
```
-- prepare data
create table A(i integer, j integer) distributed by (i);
insert into A values(19,5);
insert into A values(1,1);
insert into A values(99,62);
insert into A values(1,1);
insert into A values(78,-1);
analyze A;
create table B(i integer, j integer) distributed by (i);
insert into B values(1,43);
insert into B values(88,1);
insert into B values(-1,62);
insert into B values(1,1);
insert into B values(32,5);
insert into B values(2,7);
analyze B;
create table C(i integer, j integer) distributed by (i);
insert into C values(1,889);
insert into C values(288,1);
insert into C values(-1,625);
insert into C values(32,65);
insert into C values(32,62);
insert into C values(3,-1);
insert into C values(99,7);
insert into C values(78,62);
insert into C values(2,7);
analyze C;
-- data query
select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and not exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
```
The output of the failed SQLs is as follows:
```
postgres=# select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and not exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
ERROR:  more than one row returned by a subquery used as an expression  (seg0 slice3 192.168.11.200:40000 pid=10190)
```
The difference between these two SQL sets is that, I just changed the order of the tuple insert of Table A: (19,5) before (1,1).

Following is my root cause analysis:

Here is the execution plan generated by the legacy planner:
```
postgres=# EXPLAIN select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and not exists (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
                                                                       QUERY PLAN              
                                                          
-----------------------------------------------------------------------------------------------
----------------------------------------------------------
 Limit  (cost=31.58..31.80 rows=10 width=12)
   ->  Gather Motion 2:1  (slice5; segments: 2)  (cost=31.58..31.80 rows=10 width=12)
         Merge Key: a.i, public.b.i, public.c.j
         ->  Limit  (cost=31.58..31.60 rows=5 width=12)
               ->  Sort  (cost=31.58..31.71 rows=27 width=12)
                     Sort Key: a.i, public.b.i, public.c.j
                     ->  Nested Loop  (cost=4.35..30.41 rows=27 width=12)
                           ->  Nested Loop  (cost=2.10..26.00 rows=5 width=8)
                                 ->  Broadcast Motion 2:2  (slice3; segments: 2)  (cost=0.00..23.54 rows=1 width=8)
                                       ->  Seq Scan on a  (cost=0.00..23.51 rows=1 width=8)
                                             Filter: j = ((subplan))
                                             SubPlan 1
                                               ->  Hash Left Anti Semi Join  (cost=2.14..4.29 rows=2 width=4)
                                                     Hash Cond: public.c.i = public.b.i
                                                     ->  Result  (cost=2.11..2.13 rows=1 width=8)
                                                           Filter: public.c.j = $0
                                                           ->  Materialize  (cost=2.11..2.13 rows=1 width=8)
                                                                 ->  Broadcast Motion 2:2  (slice1; segments: 2)  (cost=0.00..2.11 rows=1 width=8)
                                                                       ->  Seq Scan on c  (cost=0.00..2.11 rows=1 width=8)
                                                     ->  Hash  (cost=2.08..2.08 rows=3 width=4)
                                                           ->  Result  (cost=2.08..2.13 rows=3 width=4)
                                                                 ->  Materialize  (cost=2.08..2.13 rows=3 width=4)
                                                                       ->  Broadcast Motion 2:2  (slice2; segments: 2)  (cost=0.00..2.08 rows=3 width=4)
                                                                             ->  Seq Scan on b  (cost=0.00..2.08 rows=3 width=4)
                                                                                   Filter: i IS NOT NULL AND i <> 10
                                 ->  Materialize  (cost=2.10..2.19 rows=5 width=4)
                                       ->  Seq Scan on c  (cost=0.00..2.09 rows=5 width=4)
                           ->  Materialize  (cost=2.25..2.37 rows=6 width=4)
                                 ->  Broadcast Motion 2:2  (slice4; segments: 2)  (cost=0.00..2.24 rows=6 width=4)
                                       ->  Seq Scan on b  (cost=0.00..2.06 rows=3 width=4)
 Optimizer status: legacy query optimizer
(31 rows)
```

In my opinion, the plan is correct, even maybe it is not the optimal one. The root cause of this issue is related to the SubPlan 1: it is a correlated subquery, and a hash left anti semi join. Following is the code 
snippet of the root cause:
```
src/backend/executor/nodeHashjoin.c: ExecHashJoin, line 137-159

			if ((node->js.jointype == JOIN_LEFT) ||
					(node->js.jointype == JOIN_LASJ) ||
					(node->js.jointype == JOIN_LASJ_NOTIN) ||
					(outerNode->plan->startup_cost < hashNode->ps.plan->total_cost &&
						!node->hj_OuterNotEmpty))
			{
				TupleTableSlot *slot;

				slot = ExecProcNode(outerNode);

				node->hj_FirstOuterTupleSlot = slot;
				if (TupIsNull(node->hj_FirstOuterTupleSlot))
				{
					node->hj_OuterNotEmpty = false;

					/* CDB: Tell inner subtree that its data will not be needed. */
					ExecSquelchNode((PlanState *)hashNode);

					return NULL;
				}
				else
					node->hj_OuterNotEmpty = true;
			}
```

Since this hash join node serves as a subplan, meaning it may be called multiple times. For the first time, it will check the outerNode first. If the output of the outerNode is empty (this is the case of the failed SQLs aforementioned), it would call the function: ExecSquelchNode((PlanState *)hashNode). This would stop the inner subtree. In the case aforementioned, this action would stop the motion node under the hashNode, which causes that, in following calls of the hash join node, the hash table is always empty (no data is received from the underlying motion node since the motion node has been stopped in the first call), which also makes the hash left anti semi join always being true.

The issue only occurs when the output of the outerNode is empty when calling scansubplan the first time. If the output is not empty, then inner hashNode is executed and the needed tuples are materialized. At that point, calling or not calling ExecSquelchNode((PlanState *)hashNode) doesn't matter. That's why changing the order of inserting tuples into Table A would given total different results. If the first tuple of Table A is (1,1), then the output of the outerNode is not empty on seg0 (we can just calculate this result by hand following the generated execution plan). Everything works fine. If the first tuple is (19,5), then the output of the outerNode is empty on seg0. The issue is hit.

According to the comments of the code, this issue seems related to MPP-13921. Because I have left Pivotal, I could not check the detail of the issue any more. Maybe some guy still with Pivotal can double check that.

My fix is that: we just don't call ExecSquelchNode in a such case. According to the code, this only occurs when hashtable is NULL, meaning this should be the first call. 




