### PR TITLE
Restore errors on filter error

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprestore_filter.py
@@ -59,12 +59,22 @@ class GpRestoreFilterTestCase(unittest.TestCase):
         with self.assertRaisesRegexp(Exception, "Failed to extract schema name"):
             schema = extract_schema(line)
 
-    def test_extract_table00(self):
-        line = 'COPY ao_table (column1, column2, column3) FROM stdin;'
+    def test_extract_table_with_no_columns(self):
+        line = 'COPY nocolumn  FROM stdin;'
         table = extract_table(line)
-        self.assertEqual(table, 'ao_table')
+        self.assertEquals(table, 'nocolumn')
 
-    def test_extract_table01(self):
+    def test_extract_table_with_one_column(self):
+        line = 'COPY onecolumn (a) FROM stdin;'
+        table = extract_table(line)
+        self.assertEquals(table, 'onecolumn')
+
+    def test_extract_table_with_two_columns(self):
+        line = 'COPY twocolumns (a,b) FROM stdin;'
+        table = extract_table(line)
+        self.assertEquals(table, 'twocolumns')
+
+    def test_extract_table_fails(self):
         line = 'COPYao_table(column1column2column3)FROMstdin;'
         with self.assertRaisesRegexp(Exception, "Failed to extract table name"):
             table = extract_table(line)

--- a/gpMgmt/bin/gprestore_filter.py
+++ b/gpMgmt/bin/gprestore_filter.py
@@ -320,11 +320,18 @@ def extract_table(line):
     Removing the enclosing double quote only, don't do strip('"') in case table name has double quote
     """
     temp = line[len_copy_expr:]
+
     idx = temp.rfind(" (")
-    if idx == -1:
+    if idx != -1:
+        table = temp[:idx]
+        return checkAndRemoveEnclosingDoubleQuote(table)
+
+    idx = temp.rfind("  FROM")
+    if idx != -1:
+        table = temp[:idx]
+        return checkAndRemoveEnclosingDoubleQuote(table)
+    else:
         raise Exception('Failed to extract table name from line %s' % line)
-    table = temp[:idx]
-    return checkAndRemoveEnclosingDoubleQuote(table)
 
 def check_dropped_table(line, dump_tables, schema_level_restore_list, drop_table_expr):
     """

--- a/src/bin/pg_dump/cdb/cdb_restore_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_restore_agent.c
@@ -1316,6 +1316,8 @@ formPsqlCommandLine(PQExpBuffer buf, const char *argv0, bool post_data, int role
 		exit(1);
 	}
 
+	appendPQExpBuffer(buf, "set -o pipefail && ");
+
 	if (netbackupServiceHost)
 	{
 		if (find_other_exec(argv0, "gp_bsa_restore_agent", NULL, gpNBURestorePg) < 0)


### PR DESCRIPTION
1. Before, when the gprestore_filter failed, the gprestore would report success

2. gprestore will now work when restoring nocolumn tables through a filter