### PR TITLE
Fix syntax error combined with NULL string and CRLF in COPY text mode

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -5791,8 +5791,9 @@ CopyReadAttributesText(CopyState cstate, bool * __restrict nulls,
 			/* check if this is a NULL value or data value (assumed NULL) */
 			if (attr_pre_len == cstate->null_print_len
 				&&
-				strncmp(cstate->line_buf.data + cstate->line_buf.len - attr_pre_len - 1, cstate->null_print, attr_pre_len)
-				== 0)
+				strncmp(cstate->line_buf.data + cstate->line_buf.len
+					- attr_pre_len - (cstate->eol_type == EOL_CRLF ? 2 : 1),
+					cstate->null_print, attr_pre_len) == 0)
 				nulls[m] = true;
 			else
 				nulls[m] = false;

--- a/src/test/regress/data/venue_pipe.txt
+++ b/src/test/regress/data/venue_pipe.txt
@@ -1,0 +1,10 @@
+250|Sahara Hotel|Las Vegas|NV|\N
+251|Paris Hotel|Las Vegas|NV|\N
+252|Hilton Hotel|Las Vegas|NV|\N
+253|Mirage Hotel|Las Vegas|NV|\N
+254|Caesars Palace|Las Vegas|NV|\N
+255|Venetian Hotel|Las Vegas|NV|\N
+256|Paris MGM Grand|Las Vegas|NV|\N
+257|Luxor Hotel|Las Vegas|NV|\N
+258|Tropicana Hotel|Las Vegas|NV|\N
+264|New York New York|Las Vegas|NV|\N

--- a/src/test/regress/input/copy.source
+++ b/src/test/regress/input/copy.source
@@ -119,3 +119,14 @@ insert into copytest4 values (1,4);
 copy (select * from copytest4) to stdout csv delimiter ',' force quote id, id1, id2;
 copy (select * from copytest4) to stdout csv delimiter ',' force quote id, id1;
 
+-- test null string with CRLF for text mode
+
+CREATE TEMP TABLE venue(
+    venueid smallint not null,
+    venuename varchar(100),
+    venuecity varchar(30),
+    venuestate char(2),
+    venueseats integer) DISTRIBUTED BY (venueid);
+
+COPY venue FROM '@abs_srcdir@/data/venue_pipe.txt' WITH DELIMITER AS '|';
+SELECT count(*) FROM venue;

--- a/src/test/regress/output/copy.source
+++ b/src/test/regress/output/copy.source
@@ -83,3 +83,17 @@ copy (select * from copytest4) to stdout csv delimiter ',' force quote id, id1;
 "1","2"
 "1","3"
 "1","4"
+-- test null string with CRLF for text mode
+CREATE TEMP TABLE venue(
+    venueid smallint not null,
+    venuename varchar(100),
+    venuecity varchar(30),
+    venuestate char(2),
+    venueseats integer) DISTRIBUTED BY (venueid);
+COPY venue FROM '@abs_srcdir@/data/venue_pipe.txt' WITH DELIMITER AS '|';
+SELECT count(*) FROM venue;
+ count
+-------
+    10
+(1 row)
+


### PR DESCRIPTION
In a copy statement, while processing NULL string at the last column, GPDB
assumed the length of EOL was 1, which is wrong when it's a DOS format file
ends line with '\r\n'.

For example:

```
/tmp/file.txt:
abc|\N\r\n
cde|123\r\n

test=# CREATE TABLE tbl (c1 text, c2 int);
CREATE TABLE
test=# COPY tbl FROM '/tmp/file.txt' WITH DELIMITER AS '|' NEWLINE AS 'CRLF';
ERROR:  invalid input syntax for integer: "N"
```

This commit fixes it.

Signed-off-by: Adam Lee <ali@pivotal.io>
Signed-off-by: Peifeng Qiu <pqiu@pivotal.io>