### PR TITLE
Enable debug in open source CI builds

### DIFF
--- a/concourse/scripts/compile_gpdb_open_source.bash
+++ b/concourse/scripts/compile_gpdb_open_source.bash
@@ -47,7 +47,7 @@ function build_gpdb() {
   pushd gpdb_src
     source /opt/gcc_env.sh
     CC=$(which gcc) CXX=$(which g++) ./configure --enable-mapreduce --with-perl --with-libxml \
-    	--with-python --disable-gpfdist --prefix=${GREENPLUM_INSTALL_DIR} \
+	--enable-debug --with-python --disable-gpfdist --prefix=${GREENPLUM_INSTALL_DIR} \
 	--enable-codegen --with-codegen-prefix=/opt/llvm-3.7.1
     # Use -j4 to speed up the build. (Doesn't seem worth trying to guess a better
     # value based on number of CPUs or anything like that. Going above -j4 wouldn't

--- a/concourse/scripts/compile_gpdb_open_source.bash
+++ b/concourse/scripts/compile_gpdb_open_source.bash
@@ -60,7 +60,7 @@ function build_gpdb() {
 
 function unittest_check_gpdb() {
   pushd gpdb_src/src/backend
-    make -s unittest-check
+    make unittest-check
   popd
 }
 


### PR DESCRIPTION
Since the pipeline job in question isn't building production artifacts for shipping, enable debug to get symbol decorated corefiles to aid debugging.