### PR TITLE
Rewrite syslogger unittest to not mock fopen()

### DIFF
--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -103,7 +103,7 @@ static char *alert_last_file_name = NULL;
 static bool alert_log_level_opened = false;
 static bool write_to_alert_log = false;
 
-/* An err msg may break into sever pipe chunks, so we need a buffer to assemble them.
+/* An err msg may break into several pipe chunks, so we need a buffer to assemble them.
  * We fix the number of buffers.  Generally a relative small number should suffice.
  * If we run out, we will flush partial message.  The assemble code will make sure we
  * may log partial msg, but we never garble msg.  We also make sure the output is valid

--- a/src/backend/postmaster/test/syslogger_test.c
+++ b/src/backend/postmaster/test/syslogger_test.c
@@ -5,31 +5,6 @@
 
 #include "../syslogger.c"
 
-int
-mkdir(const char *path, mode_t mode)
-{
-    check_expected(path);
-    check_expected(mode);
-    return (int)mock();
-}
-
-FILE*
-fopen(const char *restrict filename, const char *restrict mode)
-{
-    check_expected(filename);
-    check_expected(mode);
-    return (FILE*)mock();
-}
-
-int
-setvbuf(FILE *restrict stream, char *restrict buf, int type, size_t size)
-{
-    check_expected(buf);
-    check_expected(type);
-    check_expected(size);
-    return (int)mock();
-}
-
 time_t
 time(time_t *unused)
 {
@@ -55,26 +30,15 @@ test__open_alert_log_file__NonMaster(void **state)
 }
 
 void 
-test__open_alert_log_file__OpenAlertLog(void **state)
+test__logfile_getname(void **state)
 {
-    Gp_entry_postmaster = true;
-    Gp_role = GP_ROLE_DISPATCH;
-    gpperfmon_log_alert_level = GPPERFMON_LOG_ALERT_LEVEL_WARNING;
+    char *alert_file_name;
 
     alert_file_pattern = "alert_log";
-    expect_string(mkdir, path, gp_perf_mon_directory);
-    expect_value(mkdir, mode, 0700);
-    will_return(mkdir, 0);
     will_return(time, 12345);
-    expect_string(fopen, filename, "gpperfmon/logs/alert_log.12345");
-    expect_string(fopen, mode, "a");
-    will_return(fopen, (FILE*)0x0DA7ABA53);
-    expect_value(setvbuf, buf, NULL);
-    expect_value(setvbuf, type, LBF_MODE);
-    expect_value(setvbuf, size, 0);
-    will_return(setvbuf, 0);
-    open_alert_log_file();
-    assert_true(alert_log_level_opened);
+
+    alert_file_name = logfile_getname(time(NULL), NULL, "gpperfmon/logs", "alert_log");
+    assert_true(strcmp(alert_file_name, "gpperfmon/logs/alert_log.12345") == 0);
 }
 
 int
@@ -84,7 +48,7 @@ main(int argc, char* argv[]) {
     const UnitTest tests[] = {
     		unit_test(test__open_alert_log_file__NonGucOpen),
     		unit_test(test__open_alert_log_file__NonMaster),
-    		unit_test(test__open_alert_log_file__OpenAlertLog)
+    		unit_test(test__logfile_getname)
     };
 
 	MemoryContextInit();


### PR DESCRIPTION
Mocking `fopen()` caused an error in the pipeline due to an OpenSSL init function segfaulting on the mock. Rewrite the test to only test the interesting bit of `open_alert_log_file()` once the mocks are taken away.