### PR TITLE
Update the docs to use the correct Wiki URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,4 +445,7 @@ just commit to the repository directly.
 For Greenplum Database documentation, please check online docs:
 http://gpdb.docs.pivotal.io
 
+For further information beyond the scope of this README, please see
+[our wiki](https://github.com/greenplum-db/gpdb/wiki)
+
 There is also a Vagrant-based quickstart guide for developers in `src/tools/vagrant/README.md`.

--- a/gpdb-doc/book/config.yml
+++ b/gpdb-doc/book/config.yml
@@ -16,7 +16,7 @@ template_variables:
   product_link: <div class="header-item"><a href="http://greenplum.org">Back to Greenplum Database</a></div>
   product_url: http://greenplum.org
   support_call_to_action: <a href="http://greenplum.org#contribute" target="_blank">Need Support?</a>
-  support_link: <a href="https://github.com/greenplum-db/greenplum-db.github.io/wiki">Wiki</a>
+  support_link: <a href="https://github.com/greenplum-db/gpdb/wiki">Wiki</a>
   support_url: http://greenplum.org
 
 broken_link_exclusions: iefix|arrowhead


### PR DESCRIPTION
We have moved over to using the Github wiki on the main repo and not the website repo.

@dyozie is this fine to push in or do I need to do anything more? (I'm a bit unfamiliar with the docs toolchain).