### PR TITLE
Clean up HashAgg

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -751,7 +751,7 @@ agg_hash_initial_pass(AggState *aggstate)
 	MemTupleBinding *mt_bind = aggstate->hashslot->tts_mt_bind;
 
 	Assert(hashtable);
-	AssertImply(!streaming, hashtable->state == HASHAGG_BEFORE_FIRST_PASS);
+	AssertImply(!streaming, aggstate->hashaggstatus == HASHAGG_BEFORE_FIRST_PASS);
 	elog(HHA_MSG_LVL,
 		 "HashAgg: initial pass -- beginning to load hash table");
 
@@ -775,8 +775,6 @@ agg_hash_initial_pass(AggState *aggstate)
 	/*
 	 * Process outer-plan tuples, until we exhaust the outer plan.
 	 */
-	hashtable->pass = 0;
-
 	while(true)
 	{
 		HashKey hashkey;
@@ -1256,6 +1254,7 @@ spill_hash_table(AggState *aggstate)
 			}
 
 			hashtable->buckets[bucket_no] = NULL;
+			hashtable->bloom[bucket_no] = 0;
 		}
 	}
 

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1059,6 +1059,11 @@ ExecAgg(AggState *node)
 
 				case HASHAGG_END_OF_PASSES:
 					node->agg_done = true;
+					/* Append stats before destroying the htable for EXPLAIN ANALYZE */
+					if (node->ss.ps.instrument)
+					{
+						agg_hash_explain(node);
+					}
 					ExecEagerFreeAgg(node);
 					return NULL;
 

--- a/src/include/executor/execHHashagg.h
+++ b/src/include/executor/execHHashagg.h
@@ -214,6 +214,7 @@ extern bool agg_hash_next_pass(AggState *aggstate);
 extern bool agg_hash_continue_pass(AggState *aggstate);
 extern void destroy_agg_hash_table(AggState *aggstate);
 
+extern void agg_hash_explain(AggState *aggstate);
 extern HashAggEntry *agg_hash_iter(AggState *aggstate);
 
 extern bool 

--- a/src/include/executor/execHHashagg.h
+++ b/src/include/executor/execHHashagg.h
@@ -154,6 +154,9 @@ typedef struct HashAggTable
 	HashAggEntry  **buckets;
 	uint64 *bloom;
 
+	/* hashkey bitshift amount to determine bucket - used when spilling */
+	unsigned pshift;
+
 	/* Overflow batches */
 	SpillSet       *spill_set;
 	/* Representation of all workfile names, used by the workfile manager */

--- a/src/include/executor/execHHashagg.h
+++ b/src/include/executor/execHHashagg.h
@@ -40,12 +40,10 @@ typedef struct BatchFileInfo BatchFileInfo;
  */
 typedef struct HashAggEntry
 {
-	struct HashAggEntry	   *next; /* Next entry in chain. */
-	void *tuple_and_aggs; /* point to a chunk that contains both grouping keys
-						   * and aggregate values.
-						   */
-	HashKey	hashvalue;
-	bool is_primodial; /* indicate if this entry is there before spilling. */
+	struct HashAggEntry *next; /* Next entry in chain. */
+	void *tuple_and_aggs; /* grouping keys and aggregate values.*/
+	HashKey hashvalue;
+	bool is_primodial; /* indicates if this entry is there before spilling. */
 } HashAggEntry;
 
 /* A SpillFile controls access to a temporary file used to hold  
@@ -119,13 +117,13 @@ typedef struct SpillSet
 
 typedef struct HashAggTableSizes
 {
-    unsigned             nbuckets;   /* Calculated # of hash buckets. */
-    unsigned             nentries;   /* Calculated # of hash entries. */
-    unsigned             nbatches;   /* Calculated # of passes. */
-	double               hashentry_width; /* Estimated hash entry size */
-    unsigned             workmem_initial;    /* Estimated work_mem bytes at #entries=0 */
-    unsigned             workmem_per_entry;  /* Additional work_mem bytes per entry */
-    bool                 spill;      /* Do we expect to spill ? */
+	unsigned  nbuckets;   /* Calculated # of hash buckets. */
+	unsigned  nentries;   /* Calculated # of hash entries. */
+	unsigned  nbatches;   /* Calculated # of passes. */
+	double    hashentry_width; /* Estimated hash entry size */
+	unsigned  workmem_initial;    /* Estimated work_mem bytes at #entries=0 */
+	unsigned  workmem_per_entry;  /* Additional work_mem bytes per entry */
+	bool      spill;      /* Do we expect to spill ? */
 } HashAggTableSizes;
 
 /*
@@ -137,15 +135,6 @@ typedef struct GroupKeysAndAggs
 	struct MemTupleData *tuple; /* tuple that contains grouping keys */
 	AggStatePerGroup aggs; /* the location for the first aggregate values. */
 } GroupKeysAndAggs;
-
-typedef enum HashAggState
-{
-	HASHAGG_BEFORE_FIRST_PASS,
-	HASHAGG_IN_A_PASS,
-	HASHAGG_BETWEEN_PASSES,
-	HASHAGG_STREAMING,
-	HASHAGG_END_OF_PASSES
-} HashAggState;
 
 /* An Agg hash table with associated overflow batches and processing
  * state.  
@@ -177,9 +166,6 @@ typedef struct HashAggTable
 	SpillFile *curr_spill_file;
 	int curr_spill_level;
 
-	HashAggState		state;	/* state of processing */
-	unsigned			pass;	/* current pass (0 is initial) */
-
 	/*
 	 * The space to buffer the free hash entries and AggStatePerGroups. Using this,
 	 * we can reduce palloc/pfree calls.
@@ -202,7 +188,7 @@ typedef struct HashAggTable
 	double max_mem; /* Maximum available memory */
 	double mem_for_metadata; /* Current memory usage for metadata */
 	double mem_wanted; /* The desirable work_mem */
-	double mem_used; /* The maxinum amount of used memory. */
+	double mem_used; /* The maximum amount of used memory. */
 	
 	uint32 num_reloads; /* number of times reloading a batch file */
 	uint32 num_batches; /* number of batch files */
@@ -214,7 +200,8 @@ typedef struct HashAggTable
 	uint64 total_buckets; /* total number of buckets allocated */
 	bool is_spilling; /* indicate that spilling happened for this batch. */
 	struct TupleTableSlot *prev_slot; /* a slot that is read previously. */
-    CdbExplain_Agg      chainlength;
+
+	CdbExplain_Agg      chainlength;
 } HashAggTable;
 
 extern HashAggTable *create_agg_hash_table(AggState *aggstate);
@@ -232,6 +219,6 @@ calcHashAggTableSizes(double memquota,	/* Memory quota in bytes. */
 					   int numaggs,		/* Est # of aggregate functions */
 					   int keywidth,	/* Est per entry size of hash key. */
 					   int transpace,	/* Est per entry size of by-ref values. */
-                       bool force,      /* true => succeed even if work_mem too small */
-                       HashAggTableSizes   *out_hats);
+					   bool force,	/* true => succeed even if work_mem too small */
+					   HashAggTableSizes	*out_hats);
 #endif

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2354,6 +2354,15 @@ typedef struct AdvanceAggregatesCodegenInfo
 typedef struct AggStatePerAggData *AggStatePerAgg;
 typedef struct AggStatePerGroupData *AggStatePerGroup;
 
+typedef enum HashAggStatus
+{
+	HASHAGG_BEFORE_FIRST_PASS,
+	HASHAGG_IN_A_PASS,
+	HASHAGG_BETWEEN_PASSES,
+	HASHAGG_STREAMING,
+	HASHAGG_END_OF_PASSES
+} HashAggStatus;
+
 typedef struct AggState
 {
 	ScanState	ss;				/* its first field is NodeTag */
@@ -2380,6 +2389,7 @@ typedef struct AggState
 
 	/* MPP */
 	struct HashAggTable *hhashtable;
+	HashAggStatus hashaggstatus;
 	MemoryManagerContainer mem_manager;
 
 	/* ROLLUP */


### PR DESCRIPTION
Lots of minor changes. I'm cleaning things up as I implement a growing hash table.

1. Fix indentation & spelling mistakes wherever I saw them.
2. Remove some unused variables & dead code
3. Some calculations (which will be used in multiple places) are converted to macros : BLOOMVAL, BUCKET_IDX.
4. Chain statistics were shown only if we spilled - but it would be nice to know this even when the table was in memory.
5. Fix a small performance issue (because we didn't reset bloom filters while spilling).
6. Moved HashAggState to AggState from the hash table since it is referenced in nodeAgg.c and renamed that struct since it was very ambiguous.

For the 4th point, see the additional line in EXPLAIN ANALYZE that shows the chain length and number of buckets : 
```
shardikar=# explain analyze select i, count(*) from bar group by i;
                                                 QUERY PLAN
------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1.01..1.03 rows=1 width=12)
   Rows out:  1 rows at destination with 11 ms to end, start offset by 9.732 ms.
   ->  HashAggregate  (cost=1.01..1.03 rows=1 width=12)
         Group By: i
         Rows out:  1 rows (seg0) with 6.699 ms to first row, 7.830 ms to end, start offset by 12 ms.
         Executor memory:  8233K bytes avg, 8281K bytes max (seg0).
         (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
         ->  Seq Scan on bar  (cost=0.00..1.01 rows=1 width=4)
               Rows out:  1 rows (seg0) with 0.276 ms to first row, 0.280 ms to end, start offset by 16 ms.
 Slice statistics:
   (slice0)    Executor memory: 322K bytes.
   (slice1)    Executor memory: 8318K bytes avg x 3 workers, 8366K bytes max (seg0).
 Statement statistics:
   Memory used: 128000K bytes
 Optimizer status: legacy query optimizer
 Total runtime: 21.601 ms
(16 rows)
```