### PR TITLE
Fix two NULL related warnings in resource queues/groups

### DIFF
--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -585,7 +585,7 @@ AlterResqueueCapabilityEntry(Oid queueid,
 												  resTypeInt,
 												  pResSetting,
 												  rel,
-												  InvalidOid);
+												  NULL /* InvalidOid */);
 		}
 
 	} /* end foreach elem */

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -329,7 +329,7 @@ Oid
 GetResGroupIdForRole(Oid roleid)
 {
 	HeapTuple	tuple;
-	ResourceOwner owner;
+	ResourceOwner owner = NULL;
 	Oid			groupId;
 	Relation	rel;
 	ScanKeyData	key;


### PR DESCRIPTION
Passing InvalidOid to as a HeapTuple argument cause a warning for NULL pointer constant, replace InvalidOid with NULL in call to AlterResqueueCapabilityEntry() to avoid. Also initialize the owner in GetResGroupIdForRole() since we otherwise read an uninitialized value in case the CurrentResourceOwner was set. The latter was identified by Coverity in the last scan.