### PR TITLE
Remove unite_ccle_gpdb5 from main pipeline

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -1095,26 +1095,6 @@ jobs:
       <<: *pulse_properties
       PULSE_PROJECT_NAME: "mpp-interconnect"
 
-- name: unite_ccle_gpdb5
-  plan:
-  - get: nightly-trigger
-    trigger: true
-  - aggregate: *post_packaging_gets_trigger_false
-  - task: trigger_pulse
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/trigger_pulse.yml
-    input_mapping: *input_mappings
-    params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-5-CCLE"
-  - task: monitor_pulse
-    attempts: 2
-    tags: ["gpdb5-pulse-worker"]
-    file: gpdb_src/ci/pulse/api/monitor_pulse.yml
-    params:
-      <<: *pulse_properties
-      PULSE_PROJECT_NAME: "GPDB-5-CCLE"
-
 - name: QP_runaway-query
   plan:
   - aggregate:


### PR DESCRIPTION
All test cases it used to run are covered by ICW now.