### PR TITLE
Enable compile_gpdb.bash to be run multiple times

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -177,7 +177,7 @@ function _main() {
   # symlink and `cd`s to the actual directory. Currently the Makefile in the
   # addon directory assumes that it is located in a particular location under
   # the source tree and hence needs to be copied over.
-  cp -R gpaddon_src gpdb_src/gpAux/$ADDON_DIR
+  rsync -auv gpaddon_src/ gpdb_src/gpAux/$ADDON_DIR
   build_gpdb "${BLD_TARGET_OPTION[@]}"
   build_gppkg
   if [ "$TARGET_OS" != "win32" ] ; then


### PR DESCRIPTION
- Before this change, if you were iterating in a container and wanted to
  run the compilation again, you would have to remove gpaddon because
  its presence caused the `cp` to fail

Signed-off-by: Larry Hamel <lhamel@pivotal.io>