### PR TITLE
Remove calling of DXL Utils dummy function

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -129,7 +129,7 @@ CTranslatorUtils::Pdxltabdesc
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Query over external partitions"));
 	}
 
-	CMDIdGPDB *pmdid = CDXLUtils::Pmdid(pmp, oidRel);
+	CMDIdGPDB *pmdid = GPOS_NEW(pmp) CMDIdGPDB(oidRel);
 
 	const IMDRelation *pmdrel = pmda->Pmdrel(pmdid);
 	


### PR DESCRIPTION
We seem to be calling the DXL Utils function only for table mdid and not any other OID. This is inconsistent and causes duplicate entries for the same table inside MD Cache (only difference is the minor version). Associated GPORCA is https://github.com/greenplum-db/gporca/pull/163