### PR TITLE
Fix HashStreamOpaque from bad access / double free'ing HashBitMap

### DIFF
--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -258,7 +258,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
 	{
 		if(node->bitmap && IsA(node->bitmap, StreamBitmap))
 			stream_add_node((StreamBitmap *)node->bitmap,
-						tbm_create_stream_node_ref(hbm), BMS_AND);
+						tbm_create_stream_node(hbm), BMS_AND);
 		else
 			node->bitmap = (Node *)hbm;
 	}

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -209,7 +209,7 @@ MultiExecBitmapOr(BitmapOrState *node)
 	{
 		if(node->bitmap && IsA(node->bitmap, StreamBitmap))
 			stream_add_node((StreamBitmap *)node->bitmap, 
-						tbm_create_stream_node_ref(hbm), BMS_OR);
+						tbm_create_stream_node(hbm), BMS_OR);
 		else
 			node->bitmap = (Node *)hbm;
 	}

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -95,7 +95,7 @@ struct HashBitmap
 /* A struct to hide away HashBitmap state for a streaming bitmap */
 typedef struct HashStreamOpaque
 {
-	HashBitmap *tbm;
+	HashBitmap *tbm;  /* HashStreamOpaque will not take the ownership of freeing HashBitmap */
 	PagetableEntry *entry;
 }	HashStreamOpaque;
 
@@ -1247,20 +1247,11 @@ static void
 tbm_stream_free(StreamNode *self)
 {
 	HashStreamOpaque *op = (HashStreamOpaque *) self->opaque;
-	HashBitmap *tbm = op->tbm;
-
-	/* CDB: Report statistics for EXPLAIN ANALYZE */
-	if (tbm->instrument)
-	{
-		tbm_upd_instrument(tbm);
-		tbm_set_instrument(tbm, NULL);
-	}
-
 	/*
-	 * A reference to the plan is kept in the BitmapIndexScanState
-	 * so this is a no-op for now.
+	 * op->tbm is actually a reference to node->bitmap from BitmapIndexScanState
+	 * BitmapIndexScanState would have freed the op->tbm already so we shouldn't
+	 * access now.
 	 */
-	tbm_free(tbm);
 	pfree(op);
 	pfree(self);
 }

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -169,7 +169,6 @@ extern bool tbm_iterate(Node *tbm, TBMIterateResult *output);
 
 extern void stream_add_node(StreamBitmap *strm, StreamNode *node, StreamType kind);
 extern StreamNode *tbm_create_stream_node(HashBitmap *tbm);
-extern StreamNode *tbm_create_stream_node_ref(HashBitmap *tbm);
 extern bool bitmap_stream_iterate(StreamNode *n, PagetableEntry *e);
 
 /* These functions accept either a HashBitmap or a StreamBitmap... */


### PR DESCRIPTION
There are two commits, the first commit revert(except test) the fix b5d7b30 (PR #1089) that didn't solve the full problem. The second commit is the fix that this PR propose. Please see the individual commit for more details. 

This should fix the occasional crash that we observed in our CI from bitmapscan_ao test.

@hardikar @foyzur @hsyuan Please take a look when you get a chance.