### PR TITLE
Transform the pg_lock_status() ids in tinc cases.

### DIFF
--- a/src/test/tinc/tincrepo/functions/builtin/__init__.py
+++ b/src/test/tinc/tincrepo/functions/builtin/__init__.py
@@ -45,6 +45,7 @@ class BuiltinFunctionTestCase(SQLTestCase):
             PSQL.run_sql_file(guc_sql_file, dbname = self.db_name, out_file = out_file)
 
             pattern = 's/transactionid,,,,,,[[:digit:]]\+,,,,[[:digit:]]\+\/[[:digit:]]\+,[[:digit:]]\+,ExclusiveLock,t,[[:digit:]]\+,/transactionid,,,,,,TRANSACTIONID,,,,VIRTUAL\/XID,PID,ExclusiveLock,t,SESSIONID,/;s/virtualxid,,,,,[[:digit:]]\+\/[[:digit:]]\+,,,,,[[:digit:]]\+\/[[:digit:]]\+,[[:digit:]]\+,ExclusiveLock,t,[[:digit:]]\+,/virtualxid,,,,,VIRTUAL\/XID,,,,,VIRTUAL\/XID,PID,ExclusiveLock,t,SESSIONID,/'
+            pattern += ';s@relation,\([[:digit:]]\+\),\([[:digit:]]\+\),,,,,,,,[[:digit:]]\+/[[:digit:]]\+,[[:digit:]]\+,AccessShareLock,t,[[:digit:]]\+,t,\([[:digit:]]\+\)@relation,\\1,\\2,,,,,,,,VIRTUAL/XID,PID,AccessShareLock,t,SESSIONID,t,\\3@'
             sedcmd = "sed -i '' -e '%(pattern)s' %(answer_file)s" % {"answer_file": new_ans_file, "pattern": pattern}
             sedcmd2 = "sed -i '' -e '%(pattern)s' %(answer_file)s" % {"answer_file" :out_file, "pattern": pattern}
             sedcmd3 = "sed -i '' -e 's/pg_aoseg_[[:digit:]]\+/pg_aoseg_XXXXX/' " +new_ans_file


### PR DESCRIPTION
The ids in "(relation,*)" lines are not transformed, this would cause
failures if executed on segments, like below:

    SELECT pg_lock_status() FROM foo
                                 pg_lock_status
     ----------------------------------------------------------------------
    - (relation,151955,151957,,,,,,,,2/4,29461,AccessShareLock,t,1117,t,0)
    - (relation,151955,151957,,,,,,,,2/4,29461,AccessShareLock,t,1117,t,0)
    - (relation,151955,151957,,,,,,,,2/4,29462,AccessShareLock,t,1117,t,1)
    - (relation,151955,151957,,,,,,,,2/4,29462,AccessShareLock,t,1117,t,1)
    + (relation,151955,151957,,,,,,,,2/4,29453,AccessShareLock,t,1116,t,0)
    + (relation,151955,151957,,,,,,,,2/4,29453,AccessShareLock,t,1116,t,0)
    + (relation,151955,151957,,,,,,,,2/4,29454,AccessShareLock,t,1116,t,1)
    + (relation,151955,151957,,,,,,,,2/4,29454,AccessShareLock,t,1116,t,1)
      (virtualxid,,,,,VIRTUAL/XID,,,,,VIRTUAL/XID,PID,ExclusiveLock,t,SESSIONID,t,0)
      (virtualxid,,,,,VIRTUAL/XID,,,,,VIRTUAL/XID,PID,ExclusiveLock,t,SESSIONID,t,0)
      (virtualxid,,,,,VIRTUAL/XID,,,,,VIRTUAL/XID,PID,ExclusiveLock,t,SESSIONID,t,1)
      (virtualxid,,,,,VIRTUAL/XID,,,,,VIRTUAL/XID,PID,ExclusiveLock,t,SESSIONID,t,1)
     (8 rows)

So we should transform them like the "(virtualxid,*)" lines.

Signed-off-by: Ning Yu <nyu@pivotal.io>