### PR TITLE
Raise warning for gp_resource_manager now

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -134,6 +134,13 @@ class Guc:
             except:
                 return "invalid value for max_connections"
 
+        elif self.name == "gp_resource_manager":
+            if newval == "group":
+                logger.warn(
+                        "Managing queries with resource groups is an experimental feature. A work-in-progress version is enabled.")
+            elif newval != "queue":
+                return "the value of gp_resource_manager must be 'group' or 'queue'"
+
         elif self.name == 'unix_socket_permissions':
             if newval[0] != '0':
                 logger.warn(


### PR DESCRIPTION
I know this is trivial, but ...

This is mainly for 5.0 release to inform incomplete feature and warning message is copied from tracker.