### PR TITLE
Concurrency statistic information of resource group

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -1,17 +1,18 @@
 /*-------------------------------------------------------------------------
  *
- * resgroup.c
+ * resgroupcmds.c
  *	  Commands for manipulating resource group.
  *
  * Copyright (c) 2006-2017, Greenplum inc.
  *
  * IDENTIFICATION
- *    src/backend/commands/resgroup.c
+ *    src/backend/commands/resgroupcmds.c
  *
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
 
+#include "funcapi.h"
 #include "access/genam.h"
 #include "access/heapam.h"
 #include "access/xact.h"
@@ -391,6 +392,115 @@ GetResGroupIdForRole(Oid roleid)
 	}
 
 	return groupId;
+}
+
+/*
+ * Get status of resource groups
+ */
+Datum
+pg_resgroup_get_status_kv(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *funcctx;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		MemoryContext oldcontext;
+		TupleDesc	tupdesc;
+		int			nattr = 3;
+
+		funcctx = SRF_FIRSTCALL_INIT();
+
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		tupdesc = CreateTemplateTupleDesc(nattr, false);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "rsgid", OIDOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "prop", TEXTOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "value", TEXTOID, -1, 0);
+
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		if (PG_ARGISNULL(0))
+		{
+			funcctx->max_calls = 0;
+		}
+		else
+		{
+			Relation pg_resgroup_rel;
+			SysScanDesc sscan;
+			HeapTuple tuple;
+
+			funcctx->user_fctx = palloc0(sizeof(Datum) * MaxResourceGroups);
+
+			pg_resgroup_rel = heap_open(ResGroupRelationId, AccessShareLock);
+
+			sscan = systable_beginscan(pg_resgroup_rel, InvalidOid, false,
+									   SnapshotNow, 0, NULL);
+			while (HeapTupleIsValid(tuple = systable_getnext(sscan)))
+			{
+				Assert(funcctx->max_calls < MaxResourceGroups);
+				((Datum *) funcctx->user_fctx)[funcctx->max_calls++] = ObjectIdGetDatum(HeapTupleGetOid(tuple));
+			}
+			systable_endscan(sscan);
+
+			heap_close(pg_resgroup_rel, AccessShareLock);
+		}
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	/* stuff done on every call of the function */
+	funcctx = SRF_PERCALL_SETUP();
+
+	if (funcctx->call_cntr < funcctx->max_calls)
+	{
+		/* for each row */
+		char *		prop = text_to_cstring(PG_GETARG_TEXT_P(0));
+		Datum		values[3];
+		bool		nulls[3];
+		HeapTuple	tuple;
+		Oid			groupId;
+		int			statVal;
+		char		statValStr[10];
+
+		MemSet(values, 0, sizeof(values));
+		MemSet(nulls, 0, sizeof(nulls));
+
+		values[0] = ((Datum *) funcctx->user_fctx)[funcctx->call_cntr];
+		values[1] = CStringGetTextDatum(prop);
+
+		groupId = DatumGetObjectId(values[0]);
+
+		/* Fill with dummy values */
+		if (!strcmp(prop, "num_running"))
+			statVal = ResGroupGetStat(groupId, RES_GROUP_STAT_NRUNNING);
+		else if (!strcmp(prop, "num_queueing"))
+			statVal = ResGroupGetStat(groupId, RES_GROUP_STAT_NQUEUEING);
+		else if (!strcmp(prop, "cpu_usage"))
+			statVal = 0;
+		else if (!strcmp(prop, "memory_usage"))
+			statVal = 0;
+		else if (!strcmp(prop, "total_queue_duration"))
+			statVal = ResGroupGetStat(groupId, RES_GROUP_STAT_TOTAL_QUEUE_TIME);
+		else if (!strcmp(prop, "num_queued"))
+			statVal = ResGroupGetStat(groupId, RES_GROUP_STAT_TOTAL_QUEUED);
+		else if (!strcmp(prop, "num_executed"))
+			statVal = ResGroupGetStat(groupId, RES_GROUP_STAT_TOTAL_EXECUTED);
+		else
+			/* unknown property name */
+			nulls[2] = true;
+
+		snprintf(statValStr, sizeof(statValStr), "%d", statVal);
+		values[2] = CStringGetTextDatum(statValStr);
+
+		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+
+		SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+	}
+	else
+	{
+		/* nothing left */
+		SRF_RETURN_DONE(funcctx);
+	}
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -17,8 +17,8 @@
 #include "cdb/cdbvars.h"
 #include "cdb/memquota.h"
 #include "commands/resgroupcmds.h"
-#include "funcapi.h"
 #include "miscadmin.h"
+#include "pgstat.h"
 #include "storage/ipc.h"
 #include "storage/latch.h"
 #include "storage/lmgr.h"
@@ -30,6 +30,7 @@
 #include "utils/memutils.h"
 #include "utils/resgroup.h"
 #include "utils/resowner.h"
+#include "utils/resource_manager.h"
 
 /* GUC */
 int		MaxResourceGroups;
@@ -52,90 +53,6 @@ static bool ResGroupCreate(Oid groupId);
 static void AtProcExit_ResGroup(int code, Datum arg);
 static void ResGroupWaitCancel(void);
 
-Datum
-pg_resgroup_get_status_kv(PG_FUNCTION_ARGS)
-{
-	FuncCallContext *funcctx;
-
-	if (SRF_IS_FIRSTCALL())
-	{
-		MemoryContext oldcontext;
-		TupleDesc	tupdesc;
-		int			nattr = 3;
-
-		funcctx = SRF_FIRSTCALL_INIT();
-
-		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
-
-		tupdesc = CreateTemplateTupleDesc(nattr, false);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "rsgid", OIDOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "prop", TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "value", TEXTOID, -1, 0);
-
-		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
-
-		if (PG_ARGISNULL(0))
-		{
-			funcctx->max_calls = 0;
-		}
-		else
-		{
-			/* dummy output */
-			funcctx->max_calls = 2;
-			funcctx->user_fctx = palloc0(sizeof(Datum) * funcctx->max_calls);
-			((Datum *) funcctx->user_fctx)[0] = ObjectIdGetDatum(6437);
-			((Datum *) funcctx->user_fctx)[1] = ObjectIdGetDatum(6438);
-		}
-
-		MemoryContextSwitchTo(oldcontext);
-	}
-
-	/* stuff done on every call of the function */
-	funcctx = SRF_PERCALL_SETUP();
-
-	if (funcctx->call_cntr < funcctx->max_calls)
-	{
-		/* for each row */
-		char *		prop = text_to_cstring(PG_GETARG_TEXT_P(0));
-		Datum		values[3];
-		bool		nulls[3];
-		HeapTuple	tuple;
-
-		MemSet(values, 0, sizeof(values));
-		MemSet(nulls, 0, sizeof(nulls));
-
-		values[0] = ((Datum *) funcctx->user_fctx)[funcctx->call_cntr];
-		values[1] = CStringGetTextDatum(prop);
-
-		/* Fill with dummy values */
-		if (!strcmp(prop, "num_running"))
-			values[2] = CStringGetTextDatum("1");
-		else if (!strcmp(prop, "num_queueing"))
-			values[2] = CStringGetTextDatum("0");
-		else if (!strcmp(prop, "cpu_usage"))
-			values[2] = CStringGetTextDatum("0.0");
-		else if (!strcmp(prop, "memory_usage"))
-			values[2] = CStringGetTextDatum("0.0");
-		else if (!strcmp(prop, "total_queue_duration"))
-			values[2] = CStringGetTextDatum("00:00:00");
-		else if (!strcmp(prop, "num_queued"))
-			values[2] = CStringGetTextDatum("0");
-		else if (!strcmp(prop, "num_executed"))
-			values[2] = CStringGetTextDatum("0");
-		else
-			/* unknown property name */
-			nulls[2] = true;
-
-		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
-
-		SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
-	}
-	else
-	{
-		/* nothing left */
-		SRF_RETURN_DONE(funcctx);
-	}
-}
 
 /*
  * Estimate size the resource group structures will need in
@@ -312,7 +229,7 @@ InitResGroups(void)
 					(errcode(ERRCODE_OUT_OF_MEMORY),
 			 		errmsg("not enough shared memory for resource groups")));
 
-		numGroups ++;
+		numGroups++;
 		Assert(numGroups <= MaxResourceGroups);
 	}
 	systable_endscan(sscan);
@@ -325,6 +242,58 @@ exit:
 	heap_close(relResGroup, AccessShareLock);
 	CurrentResourceOwner = NULL;
 	ResourceOwnerDelete(owner);
+}
+
+/*
+ *  Retrieve statistic information of type from resource group
+ */
+int
+ResGroupGetStat(Oid groupId, ResGroupStatType type)
+{
+	ResGroup group;
+	int ret;
+
+	if (!IsResGroupEnabled())
+		return 0;
+
+	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+
+	group = ResGroupHashFind(groupId);
+	if (group == NULL)
+	{
+		LWLockRelease(ResGroupLock);
+
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("Cannot find resource group with Oid %d in shared memory", groupId)));
+	}
+
+	switch (type)
+	{
+		case RES_GROUP_STAT_NRUNNING:
+			ret = group->nRunning;
+			break;
+		case RES_GROUP_STAT_NQUEUEING:
+			ret = group->waitProcs.size;
+			break;
+		case RES_GROUP_STAT_TOTAL_EXECUTED:
+			ret = group->totalExecuted;
+			break;
+		case RES_GROUP_STAT_TOTAL_QUEUED:
+			ret = group->totalQueued;
+			break;
+		case RES_GROUP_STAT_TOTAL_QUEUE_TIME:
+			ret = group->totalQueuedTime;
+			break;
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("Invalid stat type %d", type)));
+	}
+
+	LWLockRelease(ResGroupLock);
+
+	return ret;
 }
 
 /*
@@ -349,6 +318,9 @@ ResGroupCreate(Oid groupId)
 	group->groupId = groupId;
 	group->nRunning = 0;
 	ProcQueueInit(&group->waitProcs);
+	group->totalExecuted = 0;
+	group->totalQueued = 0;
+	group->totalQueuedTime = 0;
 
 	return true;
 }
@@ -364,15 +336,14 @@ ResGroupSlotAcquire(void)
 	ResGroup	group;
 	Oid			groupId;
 	int			concurrencyLimit;
+	long		secs;
+	int			usecs;
 
 	groupId = GetResGroupIdForRole(GetUserId());
 	if (groupId == InvalidOid)
 		groupId = superuser() ? ADMINRESGROUP_OID : DEFAULTRESGROUP_OID;
 
 	CurrentResGroupId = groupId;
-
-	if (groupId == ADMINRESGROUP_OID)
-		return;
 
 	concurrencyLimit = GetConcurrencyForGroup(groupId);
 
@@ -388,18 +359,30 @@ ResGroupSlotAcquire(void)
 			 	 errmsg("Cannot find resource group %d in shared memory", groupId)));
 	}
 
-	if (group->nRunning < concurrencyLimit) 
+	if (concurrencyLimit == RESGROUP_CONCURRENCY_UNLIMITED || group->nRunning < concurrencyLimit)
 	{
-		group->nRunning ++;
+		group->nRunning++;
+		group->totalExecuted++;
 		LWLockRelease(ResGroupLock);
 		return;
 	}
+
+	/* Update the timestamp in PgBackendStatus before waiting on the slot */
+	pgstat_report_resgroup_queue_timestamp(GetCurrentTimestamp());
 
 	ResGroupWait(group);
 
 	/*
 	 * The waking process has granted us the slot.
+	 * Update the statistic information of the resource group.
 	 */
+	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
+	group->totalExecuted++;
+	TimestampDifference(pgstat_fetch_resgroup_queue_timestamp(),
+						GetCurrentTimestamp(),
+						&secs, &usecs);
+	group->totalQueuedTime += secs;
+	LWLockRelease(ResGroupLock);
 }
 
 /*
@@ -415,8 +398,6 @@ ResGroupSlotRelease(void)
 	PGPROC		*waitProc;
 
 	Assert(CurrentResGroupId != InvalidOid);
-	if (CurrentResGroupId == ADMINRESGROUP_OID)
-		return;
 
 	LWLockAcquire(ResGroupLock, LW_EXCLUSIVE);
 
@@ -431,6 +412,7 @@ ResGroupSlotRelease(void)
 
 	waitQueue = &(group->waitProcs);
 	
+	/* If the concurrency is RESGROUP_CONCURRENCY_UNLIMITED, the wait queue should also be empty */
 	if (waitQueue->size == 0)
 	{
 		Assert(waitQueue->links.next == MAKE_OFFSET(&waitQueue->links) &&
@@ -445,7 +427,7 @@ ResGroupSlotRelease(void)
 	/* wake up one process in the wait queue */
 	waitProc = (PGPROC *) MAKE_PTR(waitQueue->links.next);
 	SHMQueueDelete(&(waitProc->links));
-	waitQueue->size --;
+	waitQueue->size--;
 
 	LWLockRelease(ResGroupLock);
 
@@ -470,6 +452,8 @@ ResGroupWait(ResGroup group)
 	headProc = (PGPROC *) &(waitQueue->links);
 	SHMQueueInsertBefore(&(headProc->links), &(proc->links));
 	waitQueue->size++;
+
+	group->totalQueued++;
 
 	LWLockRelease(ResGroupLock);
 
@@ -583,6 +567,8 @@ ResGroupWaitCancel(void)
 	ResGroup group;
 	PROC_QUEUE	*waitQueue;
 	PGPROC		*waitProc;
+	long		secs;
+	int			usecs;
 	bool		granted = false;
 
 	if (CurrentResGroupId == InvalidOid)
@@ -611,9 +597,16 @@ ResGroupWaitCancel(void)
 		granted = true;
 	}
 
+	TimestampDifference(pgstat_fetch_resgroup_queue_timestamp(),
+						GetCurrentTimestamp(),
+						&secs, &usecs);
+	group->totalQueuedTime += secs;
+
 	waitQueue = &(group->waitProcs);
 	if (granted)
 	{
+		group->totalExecuted++;
+
 		if (waitQueue->size == 0)
 		{
 			Assert(waitQueue->links.next == MAKE_OFFSET(&waitQueue->links) &&

--- a/src/include/catalog/pg_resgroup.h
+++ b/src/include/catalog/pg_resgroup.h
@@ -70,6 +70,8 @@ DATA(insert OID = 6438 ( admin_group, 0 ));
 #define RESGROUP_LIMIT_TYPE_MEMORY		3
 #define RESGROUP_LIMIT_TYPE_MEMORY_REDZONE	4
 
+#define RESGROUP_CONCURRENCY_UNLIMITED (-1)
+
 CATALOG(pg_resgroupcapability,6439) BKI_SHARED_RELATION
 {
 	Oid		resgroupid;	/* OID of the group with this capability  */

--- a/src/include/commands/resgroupcmds.h
+++ b/src/include/commands/resgroupcmds.h
@@ -20,6 +20,7 @@ extern void DropResourceGroup(DropResourceGroupStmt *stmt);
 
 /* catalog access function */
 extern Oid GetResGroupIdForName(char *name, LOCKMODE lockmode);
+extern char *GetResGroupNameForId(Oid oid, LOCKMODE lockmode);
 extern int GetConcurrencyForGroup(int groupId);
 extern Oid GetResGroupIdForRole(Oid roleid);
 

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -621,6 +621,8 @@ typedef struct PgBackendStatus
 	TimestampTz st_proc_start_timestamp;
 	TimestampTz st_xact_start_timestamp;
 	TimestampTz st_activity_start_timestamp;
+	/* the start time of queueing on resource group */
+	TimestampTz	st_resgroup_queue_start_timestamp;
 
 	/* Database OID, owning user's OID, connection client address */
 	Oid			st_databaseid;
@@ -723,6 +725,9 @@ extern void pgstat_report_waiting(char reason);
 extern void pgstat_report_appname(const char *appname);
 extern void pgstat_report_xact_timestamp(TimestampTz tstamp);
 extern const char *pgstat_get_backend_current_activity(int pid, bool checkUser);
+
+extern void pgstat_report_resgroup_queue_timestamp(TimestampTz tstamp);
+extern TimestampTz pgstat_fetch_resgroup_queue_timestamp(void);
 
 extern void pgstat_initstats(Relation rel);
 

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -590,6 +590,7 @@ typedef struct PgStat_GlobalStats
 /* Definitions of waiting reason */
 #define PGBE_WAITING_LOCK			'l'
 #define PGBE_WAITING_REPLICATION	'r'
+#define PGBE_WAITING_RESGROUP		'g'
 #define PGBE_WAITING_NONE			'\0'
 
 /* ----------
@@ -639,6 +640,7 @@ typedef struct PgBackendStatus
 	/* current command string; MUST be null-terminated */
 	char		*st_activity;
 
+	Oid			st_rsgid;
 } PgBackendStatus;
 
 /*
@@ -726,7 +728,7 @@ extern void pgstat_report_appname(const char *appname);
 extern void pgstat_report_xact_timestamp(TimestampTz tstamp);
 extern const char *pgstat_get_backend_current_activity(int pid, bool checkUser);
 
-extern void pgstat_report_resgroup_queue_timestamp(TimestampTz tstamp);
+extern void pgstat_report_resgroup_wait(TimestampTz tstamp, Oid groupid);
 extern TimestampTz pgstat_fetch_resgroup_queue_timestamp(void);
 
 extern void pgstat_initstats(Relation rel);

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -129,8 +129,6 @@ struct PGPROC
 	LOCKMASK	heldLocks;		/* bitmask for lock types already held on this
 								 * lock object by this backend */
 
-	bool		resWaiting;		/* true if waiting for an Resource Group lock */
-
 	/*
 	 * Info to allow us to wait for synchronous replication, if needed.
 	 * waitLSN is InvalidXLogRecPtr if not waiting; set only by user backend.
@@ -166,6 +164,11 @@ struct PGPROC
 	bool serializableIsoLevel; /* true if proc has serializable isolation level set */
 
 	bool inDropTransaction; /* true if proc is in vacuum drop transaction */
+
+	/*
+	 * Information for resource group
+	 */
+	bool		resWaiting;		/* true if waiting for an Resource Group lock */
 };
 
 /* NOTE: "typedef struct PGPROC PGPROC" appears in storage/lock.h. */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -27,6 +27,9 @@ typedef struct ResGroupData
 	Oid			groupId;		/* Id for this group */
 	int 		nRunning;		/* number of running trans */
 	PROC_QUEUE	waitProcs;
+	int			totalExecuted;	/* total number of executed trans */
+	int			totalQueued;	/* total number of queued trans	*/
+	int			totalQueuedTime;/* total queue time */
 } ResGroupData;
 typedef ResGroupData *ResGroup;
 
@@ -39,6 +42,16 @@ typedef struct ResGroupControl
 	HTAB			*htbl;
 	bool			loaded;
 } ResGroupControl;
+
+/* Type of statistic infomation */
+typedef enum
+{
+	RES_GROUP_STAT_NRUNNING = 0,
+	RES_GROUP_STAT_NQUEUEING,
+	RES_GROUP_STAT_TOTAL_EXECUTED,
+	RES_GROUP_STAT_TOTAL_QUEUED,
+	RES_GROUP_STAT_TOTAL_QUEUE_TIME,
+} ResGroupStatType;
 
 /*
  * Functions in resgroup.c
@@ -56,6 +69,9 @@ extern void FreeResGroupEntry(Oid groupId);
 /* Acquire and release resource group slot */
 extern void ResGroupSlotAcquire(void);
 extern void ResGroupSlotRelease(void);
+
+/* Retrieve statistic information of type from resource group */
+extern int ResGroupGetStat(Oid groupId, ResGroupStatType type);
 
 #define LOG_RESGROUP_DEBUG(...) \
 	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -64,7 +64,7 @@ extern void ResGroupControlInit(void);
 extern void	InitResGroups(void);
 
 extern void AllocResGroupEntry(Oid groupId);
-extern void FreeResGroupEntry(Oid groupId);
+extern void FreeResGroupEntry(Oid groupId, char *name);
 
 /* Acquire and release resource group slot */
 extern void ResGroupSlotAcquire(void);

--- a/src/test/isolation2/expected/resource_group.out
+++ b/src/test/isolation2/expected/resource_group.out
@@ -38,6 +38,11 @@ rsgname            |num_running|num_queueing|num_queued|num_executed
 -------------------+-----------+------------+----------+------------
 rg_concurrency_test|2          |1           |1         |2           
 (1 row)
+1:SELECT waiting_reason, rsgqueueduration > '0'::interval as time from pg_stat_activity where current_query = 'BEGIN;' and rsgname = 'rg_concurrency_test';
+waiting_reason|time
+--------------+----
+resgroup      |t   
+(1 row)
 2:END;
 END
 3:END;

--- a/src/test/isolation2/expected/resource_group.out
+++ b/src/test/isolation2/expected/resource_group.out
@@ -1,0 +1,63 @@
+-- create a resource group when gp_resource_manager is queue
+0:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=.02, memory_limit=.02);
+CREATE
+0:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+rsgname            |num_running|num_queueing|num_queued|num_executed
+-------------------+-----------+------------+----------+------------
+rg_concurrency_test|0          |0           |0         |0           
+(1 row)
+
+-- enable resource group and restart cluster.
+-- start_ignore
+! gpconfig -c gp_resource_manager -v group;
+! gpstop -rai;
+-- end_ignore
+
+-- no query has been assigned to the this group
+1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+rsgname            |num_running|num_queueing|num_queued|num_executed
+-------------------+-----------+------------+----------+------------
+rg_concurrency_test|0          |0           |0         |0           
+(1 row)
+1:CREATE role role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+2:SET role role_concurrency_test;
+SET
+2:BEGIN;
+BEGIN
+3:SET role role_concurrency_test;
+SET
+3:BEGIN;
+BEGIN
+4:SET role role_concurrency_test;
+SET
+4&:BEGIN;  <waiting ...>
+-- new transaction will be blocked when the concurrency limit of the resource group is reached.
+1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+rsgname            |num_running|num_queueing|num_queued|num_executed
+-------------------+-----------+------------+----------+------------
+rg_concurrency_test|2          |1           |1         |2           
+(1 row)
+2:END;
+END
+3:END;
+END
+4<:  <... completed>
+BEGIN
+4:END;
+END
+1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+rsgname            |num_running|num_queueing|num_queued|num_executed
+-------------------+-----------+------------+----------+------------
+rg_concurrency_test|0          |0           |1         |3           
+(1 row)
+1:DROP role role_concurrency_test;
+DROP
+1:DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
+-- reset the GUC and restart cluster.
+-- start_ignore
+! gpconfig -r gp_resource_manager;
+! gpstop -rai;
+-- end_ignore

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,5 +1,6 @@
 test: commit_transaction_block_checkpoint
 test: pg_views_concurrent_drop
+test: resource_group
 
 test: setup
 # Tests on Append-Optimized tables (row-oriented).

--- a/src/test/isolation2/sql/resource_group.sql
+++ b/src/test/isolation2/sql/resource_group.sql
@@ -1,0 +1,34 @@
+-- create a resource group when gp_resource_manager is queue
+0:CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=2, cpu_rate_limit=.02, memory_limit=.02);
+0:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+
+-- enable resource group and restart cluster.
+-- start_ignore
+! gpconfig -c gp_resource_manager -v group;
+! gpstop -rai;
+-- end_ignore
+
+-- no query has been assigned to the this group
+1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+1:CREATE role role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+2:SET role role_concurrency_test;
+2:BEGIN;
+3:SET role role_concurrency_test;
+3:BEGIN;
+4:SET role role_concurrency_test;
+4&:BEGIN;
+-- new transaction will be blocked when the concurrency limit of the resource group is reached.
+1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+2:END;
+3:END;
+4<:
+4:END;
+1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+1:DROP role role_concurrency_test;
+1:DROP RESOURCE GROUP rg_concurrency_test;
+
+-- reset the GUC and restart cluster.
+-- start_ignore
+! gpconfig -r gp_resource_manager;
+! gpstop -rai;
+-- end_ignore

--- a/src/test/isolation2/sql/resource_group.sql
+++ b/src/test/isolation2/sql/resource_group.sql
@@ -19,6 +19,7 @@
 4&:BEGIN;
 -- new transaction will be blocked when the concurrency limit of the resource group is reached.
 1:SELECT r.rsgname, num_running, num_queueing, num_queued, num_executed FROM gp_toolkit.gp_resgroup_status s, pg_resgroup r WHERE s.groupid=r.oid AND r.rsgname='rg_concurrency_test';
+1:SELECT waiting_reason, rsgqueueduration > '0'::interval as time from pg_stat_activity where current_query = 'BEGIN;' and rsgname = 'rg_concurrency_test';
 2:END;
 3:END;
 4<:

--- a/src/test/regress/expected/resource_group.out
+++ b/src/test/regress/expected/resource_group.out
@@ -6,7 +6,7 @@ DROP ROLE IF EXISTS rg_test_role;
 NOTICE:  role "rg_test_role" does not exist, skipping
 --end_ignore
 CREATE ROLE rg_test_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
+NOTICE:  resource group required -- using default resource group "default_group"
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
  rolresgroup 
 -------------
@@ -30,8 +30,7 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 (1 row)
 
 ALTER ROLE rg_test_role RESOURCE GROUP none;
-WARNING:  resource group is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=group
+NOTICE:  resource group required -- using default resource group "default_group"
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
  rolresgroup 
 -------------
@@ -40,6 +39,7 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 
 DROP ROLE rg_test_role;
 CREATE ROLE rg_test_role SUPERUSER;
+NOTICE:  resource group required -- using admin resource group "admin_group"
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
  rolresgroup 
 -------------
@@ -47,8 +47,6 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 (1 row)
 
 ALTER ROLE rg_test_role RESOURCE GROUP default_group;
-WARNING:  resource group is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=group
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
  rolresgroup 
 -------------
@@ -56,8 +54,7 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 (1 row)
 
 ALTER ROLE rg_test_role RESOURCE GROUP none;
-WARNING:  resource group is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=group
+NOTICE:  resource group required -- using default resource group "admin_group"
 SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
  rolresgroup 
 -------------
@@ -66,11 +63,9 @@ SELECT rolresgroup FROM pg_authid WHERE rolname = 'rg_test_role';
 
 DROP ROLE rg_test_role;
 CREATE ROLE rg_test_role RESOURCE GROUP non_exist_group;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  resource group "non_exist_group" does not exist
 -- nonsuper user should not be assigned to admin group
 CREATE ROLE rg_test_role RESOURCE GROUP admin_group;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  only superuser can be assigned to admin resgroup
 -- ----------------------------------------------------------------------
 -- Test: create/drop a resource group
@@ -95,8 +90,6 @@ ERROR:  must specify both memory_limit and cpu_rate_limit
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.5, memory_redzone_limit=.7);
 ERROR:  must specify both memory_limit and cpu_rate_limit
 CREATE RESOURCE GROUP rg_test_group WITH (concurrency=1, cpu_rate_limit=.5, memory_limit=.6, memory_redzone_limit=.7);
-WARNING:  resource group is disabled
-HINT:  To enable set resource_scheduler=on and gp_resource_manager=group
 SELECT groupname,concurrency,proposed_concurrency,cpu_rate_limit,memory_limit,proposed_memory_limit,memory_redzone_limit FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
    groupname   | concurrency | proposed_concurrency | cpu_rate_limit | memory_limit | proposed_memory_limit | memory_redzone_limit 
 ---------------+-------------+----------------------+----------------+--------------+-----------------------+----------------------

--- a/src/test/regress/expected/resource_group_cleanup.out
+++ b/src/test/regress/expected/resource_group_cleanup.out
@@ -1,0 +1,7 @@
+--
+-- Clean up for resource_group.sql tests
+--
+-- start_ignore
+\! gpconfig -r gp_resource_manager
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore

--- a/src/test/regress/expected/resource_group_setup.out
+++ b/src/test/regress/expected/resource_group_setup.out
@@ -1,0 +1,8 @@
+--
+-- Setup for resource_group.sql tests
+--
+-- We are setting gp_resource_manager to be 'group' to enable resource group.
+-- start_ignore
+\! gpconfig -c gp_resource_manager -v group
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -79,7 +79,10 @@ test: resource_queue
 test: resource_queue_function
 test: wrkloadadmin
 
+# set gp_resource_manager and restart cluster to enable resource group
+test: resource_group_setup
 test: resource_group
+test: resource_group_cleanup
 
 # gp_toolkit performs a vacuum and checks that it truncated the relation. That
 # might not happen if other backends are holding transactions open, preventing

--- a/src/test/regress/sql/resource_group_cleanup.sql
+++ b/src/test/regress/sql/resource_group_cleanup.sql
@@ -1,0 +1,8 @@
+--
+-- Clean up for resource_group.sql tests
+--
+
+-- start_ignore
+\! gpconfig -r gp_resource_manager
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore

--- a/src/test/regress/sql/resource_group_setup.sql
+++ b/src/test/regress/sql/resource_group_setup.sql
@@ -1,0 +1,10 @@
+--
+-- Setup for resource_group.sql tests
+--
+
+-- We are setting gp_resource_manager to be 'group' to enable resource group.
+
+-- start_ignore
+\! gpconfig -c gp_resource_manager -v group
+\! PGDATESTYLE="" gpstop -rai
+-- end_ignore


### PR DESCRIPTION
Support num_running, num_queueing, num_queued, num_executed and
total_queue_duration in gp_toolkit.gp_resgroup_status.

Signed-off-by: Richard Guo <riguo@pivotal.io>