### PR TITLE
Fix dereference after null check in ProcArrayEndTransaction.

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3337,9 +3337,9 @@ CommitTransaction(void)
 	 * must be done _before_ releasing locks we hold and _after_
 	 * RecordTransactionCommit.
 	 */
-	ProcArrayEndTransaction(MyProc, latestXid,
-							true,
-							&needNotifyCommittedDtxTransaction);
+	needNotifyCommittedDtxTransaction = ProcArrayEndTransaction(MyProc,
+																latestXid,
+																true);
 	/*
 	 * Note that in GPDB, ProcArrayEndTransaction does *not* clear the PGPROC
 	 * entry, if it sets *needNotifyCommittedDtxTransaction!
@@ -3910,7 +3910,7 @@ AbortTransaction(void)
 	 * must be done _before_ releasing locks we hold and _after_
 	 * RecordTransactionAbort.
 	 */
-	ProcArrayEndTransaction(MyProc, latestXid, false, NULL);
+	ProcArrayEndTransaction(MyProc, latestXid, false);
 
 	/*
 	 * Post-abort cleanup.	See notes in CommitTransaction() concerning

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -25,8 +25,7 @@ extern Size ProcArrayShmemSize(void);
 extern void CreateSharedProcArray(void);
 extern void ProcArrayAdd(PGPROC *proc);
 extern void ProcArrayRemove(PGPROC *proc, TransactionId latestXid);
-extern void ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid, bool isCommit,
-						bool *needNotifyCommittedDtxTransaction);
+extern bool ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid, bool isCommit);
 extern void ProcArrayClearTransaction(PGPROC *proc, bool commit);
 extern void ClearTransactionFromPgProc_UnderLock(PGPROC *proc, bool commit);
 


### PR DESCRIPTION
Fixing a coverity issue reported for my recent commit.
Coverity reported: Either the check against null is unnecessary, or there may be
a null pointer dereference. In ProcArrayEndTransaction: Pointer is checked
against null but then dereferenced anyway.

While its not an issue and for commit case, pointer is never null, but simplify
the code and stop using pointer itself here.