### PR TITLE
gpperfmon: support library location directives

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/Makefile
+++ b/gpAux/gpperfmon/src/gpmon/Makefile
@@ -44,13 +44,13 @@ SIGTEST_LIBS+= -lsigar
 all: gpsmon gpmmon
 
 gpsmon: $(GPSMON_OBJS)
-	$(CC) -o gpsmon $(COPT) $(GPSMON_OBJS) $(LDLIBS) $(GPSMON_LIBS)
+	$(CC) -o gpsmon $(CFLAGS) $(COPT) $(GPSMON_OBJS) $(LDLIBS) $(GPSMON_LIBS)
 
 gpmmon: $(GPMMON_OBJS)
-	$(CC) -o gpmmon $(COPT) $(GPMMON_OBJS) $(LDLIBS) $(GPMMON_LIBS)
+	$(CC) -o gpmmon $(CFLAGS) $(COPT) $(GPMMON_OBJS) $(LDLIBS) $(GPMMON_LIBS)
 
 sigartest: $(SIGTEST_OBJS)
-	$(CC) -o sigartest $(COPT) $(SIGTEST_OBJS) $(LDLIBS) $(GPSMON_LIBS)
+	$(CC) -o sigartest $(CFLAGS) $(COPT) $(SIGTEST_OBJS) $(LDLIBS) $(GPSMON_LIBS)
 
 %.o: %.c
 ifeq ($(enable_gpperfmon),no)


### PR DESCRIPTION
* If a user builds dependencies into an arbitrary directory, allow
  CFLAGS to propagate that information to the compiler and linker.

Signed-off-by: Marbin Tan <mtan@pivotal.io>