### PR TITLE
Initialize hashaggstatus correctly

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1011,6 +1011,7 @@ ExecAgg(AggState *node)
 			bool		tupremain;
 
 			node->hhashtable = create_agg_hash_table(node);
+			node->hashaggstatus = HASHAGG_BEFORE_FIRST_PASS;
 			tupremain = agg_hash_initial_pass(node);
 
 			if (streaming)


### PR DESCRIPTION
Fixes assert failure introduced by 8baaa67. Before we got lucky as it
was in a structures that was zero'd to the correct enum value.

```
============== running regression test queries        ==============
test uao_dml/uao_dml_select_row ... ok
```