### PR TITLE
Fix intermittently failing test ao_locks by looking for specific locks

### DIFF
--- a/src/test/regress/expected/ao_locks.out
+++ b/src/test/regress/expected/ao_locks.out
@@ -1,8 +1,5 @@
 -- @Description The locks held after different operations
-DROP TABLE IF EXISTS ao;
-CREATE TABLE ao (a INT, b INT) WITH (appendonly=true);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE ao (a INT, b INT) WITH (appendonly=true) distributed by (a);
 INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100) AS i;
 create or replace view locktest_master as
 select coalesce(
@@ -57,70 +54,61 @@ SELECT coalesce(
 -- Actual test begins
 BEGIN;
 INSERT INTO ao VALUES (200, 200);
-SELECT * FROM locktest_master;
-          coalesce          |        mode         |         locktype         |  node  
-----------------------------+---------------------+--------------------------+--------
- ao                         | AccessExclusiveLock | append-only segment file | master
- ao                         | RowExclusiveLock    | relation                 | master
- pg_class                   | AccessShareLock     | relation                 | master
- pg_class_oid_index         | AccessShareLock     | relation                 | master
- pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
- pg_locks                   | AccessShareLock     | relation                 | master
-(6 rows)
+SELECT * FROM locktest_master where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+ coalesce |        mode         |         locktype         |  node  
+----------+---------------------+--------------------------+--------
+ ao       | AccessExclusiveLock | append-only segment file | master
+ ao       | RowExclusiveLock    | relation                 | master
+(2 rows)
 
-SELECT * FROM locktest_segments;
- coalesce |        mode         |         locktype         |    node    
-----------+---------------------+--------------------------+------------
- ao       | RowExclusiveLock    | relation                 | 1 segment
+SELECT * FROM locktest_segments where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+ coalesce |        mode         |         locktype         |   node    
+----------+---------------------+--------------------------+-----------
  ao       | AccessExclusiveLock | append-only segment file | 1 segment
- pg_class | AccessShareLock     | relation                 | n segments
-(3 rows)
+ ao       | RowExclusiveLock    | relation                 | 1 segment
+(2 rows)
 
 COMMIT;
 BEGIN;
 DELETE FROM ao WHERE a = 1;
-SELECT * FROM locktest_master;
-          coalesce          |        mode         |         locktype         |  node  
-----------------------------+---------------------+--------------------------+--------
- ao                         | AccessExclusiveLock | append-only segment file | master
- ao                         | ExclusiveLock       | relation                 | master
- pg_class                   | AccessShareLock     | relation                 | master
- pg_class_oid_index         | AccessShareLock     | relation                 | master
- pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
- pg_locks                   | AccessShareLock     | relation                 | master
-(6 rows)
+SELECT * FROM locktest_master where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+ coalesce |        mode         |         locktype         |  node  
+----------+---------------------+--------------------------+--------
+ ao       | AccessExclusiveLock | append-only segment file | master
+ ao       | ExclusiveLock       | relation                 | master
+(2 rows)
 
-SELECT * FROM locktest_segments;
-    coalesce     |       mode       | locktype |    node    
------------------+------------------+----------+------------
- pg_class        | AccessShareLock  | relation | n segments
+SELECT * FROM locktest_segments where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+    coalesce     |       mode       | locktype |   node    
+-----------------+------------------+----------+-----------
+ aovisimap table | RowExclusiveLock | relation | 1 segment
  ao              | RowExclusiveLock | relation | 1 segment
  aovisimap index | RowExclusiveLock | relation | 1 segment
- aovisimap table | RowExclusiveLock | relation | 1 segment
-(4 rows)
+(3 rows)
 
 COMMIT;
 BEGIN;
 UPDATE ao SET b = -1 WHERE a = 2;
-SELECT * FROM locktest_master;
-          coalesce          |        mode         |         locktype         |  node  
-----------------------------+---------------------+--------------------------+--------
- ao                         | AccessExclusiveLock | append-only segment file | master
- ao                         | ExclusiveLock       | relation                 | master
- pg_class                   | AccessShareLock     | relation                 | master
- pg_class_oid_index         | AccessShareLock     | relation                 | master
- pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
- pg_locks                   | AccessShareLock     | relation                 | master
-(6 rows)
+SELECT * FROM locktest_master where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+ coalesce |        mode         |         locktype         |  node  
+----------+---------------------+--------------------------+--------
+ ao       | AccessExclusiveLock | append-only segment file | master
+ ao       | ExclusiveLock       | relation                 | master
+(2 rows)
 
-SELECT * FROM locktest_segments;
-    coalesce     |        mode         |         locktype         |    node    
------------------+---------------------+--------------------------+------------
+SELECT * FROM locktest_segments where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+    coalesce     |        mode         |         locktype         |   node    
+-----------------+---------------------+--------------------------+-----------
  ao              | AccessExclusiveLock | append-only segment file | 1 segment
+ aovisimap table | RowExclusiveLock    | relation                 | 1 segment
  ao              | RowExclusiveLock    | relation                 | 1 segment
  aovisimap index | RowExclusiveLock    | relation                 | 1 segment
- aovisimap table | RowExclusiveLock    | relation                 | 1 segment
- pg_class        | AccessShareLock     | relation                 | n segments
-(5 rows)
+(4 rows)
 
 COMMIT;

--- a/src/test/regress/expected/ao_locks_optimizer.out
+++ b/src/test/regress/expected/ao_locks_optimizer.out
@@ -1,8 +1,5 @@
 -- @Description The locks held after different operations
-DROP TABLE IF EXISTS ao;
-CREATE TABLE ao (a INT, b INT) WITH (appendonly=true);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE ao (a INT, b INT) WITH (appendonly=true) distributed by (a);
 INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100) AS i;
 create or replace view locktest_master as
 select coalesce(
@@ -57,74 +54,65 @@ SELECT coalesce(
 -- Actual test begins
 BEGIN;
 INSERT INTO ao VALUES (200, 200);
-SELECT * FROM locktest_master;
-          coalesce          |        mode         |         locktype         |  node  
-----------------------------+---------------------+--------------------------+--------
- ao                         | AccessExclusiveLock | append-only segment file | master
- ao                         | RowExclusiveLock    | relation                 | master
- pg_class                   | AccessShareLock     | relation                 | master
- pg_class_oid_index         | AccessShareLock     | relation                 | master
- pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
- pg_locks                   | AccessShareLock     | relation                 | master
-(6 rows)
+SELECT * FROM locktest_master where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+ coalesce |        mode         |         locktype         |  node  
+----------+---------------------+--------------------------+--------
+ ao       | AccessExclusiveLock | append-only segment file | master
+ ao       | RowExclusiveLock    | relation                 | master
+(2 rows)
 
-SELECT * FROM locktest_segments;
- coalesce |        mode         |         locktype         |    node    
-----------+---------------------+--------------------------+------------
+SELECT * FROM locktest_segments where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+ coalesce |        mode         |         locktype         |   node    
+----------+---------------------+--------------------------+-----------
  ao       | AccessExclusiveLock | append-only segment file | 1 segment
- pg_class | AccessShareLock     | relation                 | n segments
  ao       | RowExclusiveLock    | relation                 | 1 segment
-(3 rows)
+(2 rows)
 
 COMMIT;
 BEGIN;
 DELETE FROM ao WHERE a = 1;
-SELECT * FROM locktest_master;
-          coalesce          |        mode         |         locktype         |  node  
-----------------------------+---------------------+--------------------------+--------
- ao                         | AccessExclusiveLock | append-only segment file | master
- ao                         | AccessShareLock     | relation                 | master
- ao                         | ExclusiveLock       | relation                 | master
- pg_class                   | AccessShareLock     | relation                 | master
- pg_class_oid_index         | AccessShareLock     | relation                 | master
- pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
- pg_locks                   | AccessShareLock     | relation                 | master
-(7 rows)
+SELECT * FROM locktest_master where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+ coalesce |        mode         |         locktype         |  node  
+----------+---------------------+--------------------------+--------
+ ao       | AccessExclusiveLock | append-only segment file | master
+ ao       | AccessShareLock     | relation                 | master
+ ao       | ExclusiveLock       | relation                 | master
+(3 rows)
 
-SELECT * FROM locktest_segments;
+SELECT * FROM locktest_segments where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
     coalesce     |       mode       | locktype |    node    
 -----------------+------------------+----------+------------
+ aovisimap table | RowExclusiveLock | relation | 1 segment
  ao              | AccessShareLock  | relation | n segments
  ao              | RowExclusiveLock | relation | n segments
  aovisimap index | RowExclusiveLock | relation | 1 segment
- aovisimap table | RowExclusiveLock | relation | 1 segment
- pg_class        | AccessShareLock  | relation | n segments
-(5 rows)
+(4 rows)
 
 COMMIT;
 BEGIN;
 UPDATE ao SET b = -1 WHERE a = 2;
-SELECT * FROM locktest_master;
-          coalesce          |        mode         |         locktype         |  node  
-----------------------------+---------------------+--------------------------+--------
- ao                         | AccessExclusiveLock | append-only segment file | master
- ao                         | AccessShareLock     | relation                 | master
- ao                         | ExclusiveLock       | relation                 | master
- pg_class                   | AccessShareLock     | relation                 | master
- pg_class_oid_index         | AccessShareLock     | relation                 | master
- pg_class_relname_nsp_index | AccessShareLock     | relation                 | master
- pg_locks                   | AccessShareLock     | relation                 | master
-(7 rows)
+SELECT * FROM locktest_master where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+ coalesce |        mode         |         locktype         |  node  
+----------+---------------------+--------------------------+--------
+ ao       | AccessExclusiveLock | append-only segment file | master
+ ao       | AccessShareLock     | relation                 | master
+ ao       | ExclusiveLock       | relation                 | master
+(3 rows)
 
-SELECT * FROM locktest_segments;
+SELECT * FROM locktest_segments where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
     coalesce     |        mode         |         locktype         |    node    
 -----------------+---------------------+--------------------------+------------
- ao              | AccessExclusiveLock | append-only segment file | 1 segment
- pg_class        | AccessShareLock     | relation                 | n segments
- ao              | AccessShareLock     | relation                 | n segments
- aovisimap index | RowExclusiveLock    | relation                 | 1 segment
  aovisimap table | RowExclusiveLock    | relation                 | 1 segment
+ ao              | AccessExclusiveLock | append-only segment file | 1 segment
+ ao              | AccessShareLock     | relation                 | n segments
  ao              | RowExclusiveLock    | relation                 | n segments
-(6 rows)
+ aovisimap index | RowExclusiveLock    | relation                 | 1 segment
+(5 rows)
 
 COMMIT;

--- a/src/test/regress/sql/ao_locks.sql
+++ b/src/test/regress/sql/ao_locks.sql
@@ -1,7 +1,5 @@
 -- @Description The locks held after different operations
-DROP TABLE IF EXISTS ao;
-
-CREATE TABLE ao (a INT, b INT) WITH (appendonly=true);
+CREATE TABLE ao (a INT, b INT) WITH (appendonly=true) distributed by (a);
 INSERT INTO ao SELECT i as a, i as b FROM generate_series(1, 100) AS i;
 
 create or replace view locktest_master as
@@ -60,18 +58,24 @@ SELECT coalesce(
 -- Actual test begins
 BEGIN;
 INSERT INTO ao VALUES (200, 200);
-SELECT * FROM locktest_master;
-SELECT * FROM locktest_segments;
+SELECT * FROM locktest_master where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+SELECT * FROM locktest_segments where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
 COMMIT;
 
 BEGIN;
 DELETE FROM ao WHERE a = 1;
-SELECT * FROM locktest_master;
-SELECT * FROM locktest_segments;
+SELECT * FROM locktest_master where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+SELECT * FROM locktest_segments where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
 COMMIT;
 
 BEGIN;
 UPDATE ao SET b = -1 WHERE a = 2;
-SELECT * FROM locktest_master;
-SELECT * FROM locktest_segments;
+SELECT * FROM locktest_master where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
+SELECT * FROM locktest_segments where coalesce = 'ao' or
+ coalesce like 'aovisimap%' or coalesce like 'aoseg%';
 COMMIT;


### PR DESCRIPTION
The test was querying all locks when it really needed to validate only locks
relevant to appendonly tables.