### PR TITLE
Use the right API in vacuum TINC test to wait until master and segmen…

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/test_faults.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/vacuum/scenario/test_faults.py
@@ -59,18 +59,10 @@ class scenario_fault(MPPTestCase):
 
     def check_connection(self):
         '''
-        Wait till the system is up, as master may take some time
+        Wait till the system is up, as master/segments may take some time
         to come back after FI crash.
         '''
-        up = False
-        for i in range(60):
-            res = PSQL.run_sql_command('select 1', flags='-A -t')
-            if res.strip() == '1':
-                up = True
-                break
-            time.sleep(1)
-
-        self.assertTrue(up, 'database has not come up')
+        PSQL.wait_for_database_up()
 
 class vacuumFaultsTest(MPPTestCase, ScenarioTestCase):
     '''


### PR DESCRIPTION
…ts are up

Otherwise the test would prematurely determine that all segments are up after
PANIC and move on.  This is causing intermittent failure in CI.