### PR TITLE
Subselect 8.4-9.0 Merge: Cherry-pick upstream commit eaf1b5d3 "SS_finalize_plan" 

### DIFF
--- a/src/backend/optimizer/plan/planagg.c
+++ b/src/backend/optimizer/plan/planagg.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/optimizer/plan/planagg.c,v 1.36.2.2 2008/07/10 01:17:36 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/optimizer/plan/planagg.c,v 1.41 2008/07/10 02:14:03 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -488,7 +488,6 @@ make_agg_subplan(PlannerInfo *root, MinMaxAggInfo *info)
 	 */
 	memcpy(&subroot, root, sizeof(PlannerInfo));
 	subroot.parse = subparse = (Query *) copyObject(root->parse);
-	subroot.init_plans = NIL;
 	subparse->commandType = CMD_SELECT;
 	subparse->resultRelation = 0;
 	subparse->returningList = NIL;
@@ -570,11 +569,9 @@ make_agg_subplan(PlannerInfo *root, MinMaxAggInfo *info)
 											 -1);
 
 	/*
-	 * Make sure the InitPlan gets into the outer list.  It has to appear
-	 * after any other InitPlans it might depend on, too (see comments in
-	 * ExecReScan).
+	 * Put the updated list of InitPlans back into the outer PlannerInfo.
 	 */
-	root->init_plans = list_concat(root->init_plans, subroot.init_plans);
+	root->init_plans = subroot.init_plans;
 }
 
 /*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -9,7 +9,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/optimizer/plan/planner.c,v 1.226.2.4 2008/04/17 21:22:23 tgl Exp $
+ *	  $PostgreSQL: pgsql/src/backend/optimizer/plan/planner.c,v 1.234 2008/07/10 02:14:03 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -956,7 +956,7 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	if (list_length(glob->subplans) != num_old_subplans ||
 		root->query_level > 1)
 	{
-		Assert(root->parse == parse); /* GPDP isn't always careful about this. */
+		Assert(root->parse == parse); /* GPDB isn't always careful about this. */
 		SS_finalize_plan(root, plan, true);
 	}
 

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -6,7 +6,7 @@
  * Portions Copyright (c) 1996-2008, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $PostgreSQL: pgsql/src/include/optimizer/subselect.h,v 1.30 2008/01/01 19:45:58 momjian Exp $
+ * $PostgreSQL: pgsql/src/include/optimizer/subselect.h,v 1.31 2008/07/10 02:14:03 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */


### PR DESCRIPTION
Tighten up SS_finalize_plan's computation of valid_params to exclude Params of
the current query level that aren't in fact output parameters of the current
initPlans.  (This means, for example, output parameters of regular subplans.)
To make this work correctly for output parameters coming from sibling
initplans requires rejiggering the API of SS_finalize_plan just a bit:
we need the siblings to be visible to it, rather than hidden as
SS_make_initplan_from_plan had been doing.  This is really part of my response
to bug #4290, but I concluded this part probably shouldn't be back-patched,
since all that it's doing is to make a debugging cross-check tighter.

(cherry picked from commit eaf1b5d348981fefc8deb03e1e7234f698f26818)