### PR TITLE
gpconfig: Add flag --file-compare

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -15,6 +15,10 @@ try:
     from gppylib.db import dbconn
     from gppylib.userinput import *
     from pygresql.pg import DatabaseError
+    from gpconfig_modules.segment_guc import SegmentGuc
+    from gpconfig_modules.database_segment_guc import DatabaseSegmentGuc
+    from gpconfig_modules.file_segment_guc import FileSegmentGuc
+    from gpconfig_modules.guc_collection import GucCollection
 except ImportError, e:
     sys.exit('Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -22,7 +26,6 @@ EXECNAME = os.path.split(__file__)[-1]
 
 prohibitedGucs = set(["port", "listen_addresses"])
 sameValueGucs = set(["gp_default_storage_options"])
-longShow = set(["port"])
 logger = get_default_logger()
 setup_tool_logging(EXECNAME, getLocalHostname(), getUserName())
 
@@ -44,6 +47,8 @@ def parseargs():
     parser.add_option('-P', '--primaryvalue', type='string')
     parser.add_option('-M', '--mirrorvalue', type='string')
     parser.add_option('-f', '--file', action='store_true')
+    parser.add_option('--file-compare', dest='file_compare', action='store_true')
+
     (options, args) = parser.parse_args()
 
     options.entry = None
@@ -55,7 +60,6 @@ def parseargs():
 def validate_four_verbs(options):
     if options.change:
         options.entry = options.change
-
     elif options.remove:
         options.entry = options.remove
         options.remove = True
@@ -70,6 +74,8 @@ def validate_mutual_options(options):
 
     if options.file and not options.show:
         log_and_raise("'--file' option must accompany '--show' option")
+    if options.file and options.file_compare and options.show:
+        log_and_raise("'--file' option and '--file-compare' option cannot be used together")
     if options.file and "MASTER_DATA_DIRECTORY" not in os.environ:
         log_and_raise("--file option requires that MASTER_DATA_DIRECTORY be set")
     if options.remove and (options.value or options.primaryvalue or options.mirrorvalue or options.mastervalue):
@@ -88,19 +94,9 @@ def validate_mutual_options(options):
         options.mastervalue = options.value
 
 
-class JetPackQuery:
+class ToolkitQuery:
     def __init__(self, name):
         self.query = "select * from gp_toolkit.gp_param_setting('%s')" % name
-
-
-class JetPackGuc:
-    def __init__(self, row):
-        self.context = row[0]
-        self.name = row[1]
-        self.value = row[2]
-
-    def print_info(self):
-        print "[context: %s] [name: %s] [value: %s]" % (self.context, self.name, self.value)
 
 
 class GucQuery:
@@ -166,10 +162,10 @@ class Guc:
             self.name, self.unit, self.context, self.vartype, self.min_val, self.max_val)
 
 
-def confirm_user():
+def confirm_user_wants_to_continue():
     if not ask_yesno('', "Are you sure you want to ignore unreachable hosts?", 'N'):
         logger.info("User Aborted. Exiting...")
-        sys.exit(0)
+        raise Exception("User Aborted. Exiting.")
 
 
 def print_verbosely(options, normalized_hostname, hostname, directory):
@@ -195,15 +191,16 @@ def do_list(skipvalidation):
         logger.error('Failed to connect to database, this script can only be run when the database is up.')
 
 
-def do_show_from_psql(gucname, longform):
+def get_gucs_from_database(gucname):
     try:
         dburl = dbconn.DbURL()
         conn = dbconn.connect(dburl, False)
-        query = JetPackQuery(gucname).query
-        rows = dbconn.execSQL(conn, query)
-        gucs = [JetPackGuc(r) for r in rows]
-        _print_gucs(gucname, gucs, longform)
+        query = ToolkitQuery(gucname).query
+        cursor = dbconn.execSQL(conn, query)
+        # we assume that all roles are primary due to the query.
+        gucs = [DatabaseSegmentGuc(row) for row in cursor]
         conn.close()
+        return gucs
 
     except DatabaseError as ex:
 
@@ -215,40 +212,26 @@ def do_show_from_psql(gucname, longform):
             logger.error('Failed to retrieve GUC information: ' + ex.__str__())
 
 
-def _print_gucs(gucname, gucs, longform):
-    mastervalue = None
-    value = None
-    valid = True
-    if longform:
+def _print_gucs(gucname, gucs, options):
+    collection = GucCollection()
+    collection.update_list(gucs)
+
+    if _show_all_segment_values_always(options):
         print "GUC                 : %s" % gucname
-        for guc in gucs:
+        for guc in collection.values():
             print "Context: %5s Value: %s" % (guc.context, guc.value)
     else:
-        for guc in gucs:
-
-            if guc.context == -1:
-                mastervalue = guc.value
-
-            elif not value:
-                value = guc.value
-
-            elif value == guc.value:
-                pass
-
-            else:
-                valid = False
-                break
-
-        if valid:
+        if collection.are_segments_consistent():
             print "Values on all segments are consistent"
             print "GUC          : %s" % gucname
-            print "Master  value: %s" % mastervalue
-            print "Segment value: %s" % value
-
+            print collection.report()
         else:
             print "WARNING: GUCS ARE OUT OF SYNC: "
-            for guc in gucs:
-                guc.print_info()
+            print collection.report()
+
+
+def _show_all_segment_values_always(options):
+    return options.show == "port"
 
 
 def do_add_config_script(pool, hostname, segs, value, options):
@@ -293,7 +276,7 @@ def do_change(options):
     if len(failed_pings):
         for i in failed_pings:
             logger.warning('unreachable host: ' + i.hostname)
-        confirm_user()
+        confirm_user_wants_to_continue()
 
     failure = False
     try:
@@ -400,21 +383,10 @@ def log_and_raise(err_str):
     raise Exception(err_str)
 
 
-def do_show_from_file(gucname, long_format):
-    dburl = dbconn.DbURL()
-    gparray = GpArray.initFromCatalog(dburl, utility=True)
-
-    pool = WorkerPool()
-    host_cache = GpHostCache(gparray, pool, withMasters=True)
-    failed_pings = host_cache.ping_hosts(pool)
-
-    if len(failed_pings):
-        for i in failed_pings:
-            logger.warning('unreachable host: ' + i.hostname)
-        confirm_user()
-
+def get_gucs_from_files(gucname):
+    hosts, pool = _get_hosts()
     commands = []
-    for h in host_cache.get_hosts():
+    for h in hosts:
         for seg in h.dbs:
             command = GpReadConfig("readConfig", h, seg, gucname)
             commands.append(command)
@@ -425,14 +397,46 @@ def do_show_from_file(gucname, long_format):
     gucs = []
     for cmd in pool.getCompletedItems():
         value = cmd.get_guc_value()
-        if not value:
-            value = "not set in postgresql.conf"
-        gucs.append(JetPackGuc([cmd.get_seg_content_id(), gucname, value]))
-    _print_gucs(gucname, gucs, long_format)
+        gucs.append(
+            FileSegmentGuc([cmd.get_seg_content_id(), gucname, value, cmd.get_seg_dbid()]))
 
     pool.check_results()
     pool.haltWork()
     pool.joinWorkers()
+    return gucs
+
+
+def _get_hosts():
+    dburl = dbconn.DbURL()
+    gparray = GpArray.initFromCatalog(dburl, utility=True)
+    pool = WorkerPool()
+    host_cache = GpHostCache(gparray, pool, withMasters=True)
+    failed_pings = host_cache.ping_hosts(pool)
+    if len(failed_pings):
+        for i in failed_pings:
+            logger.warning('unreachable host: ' + i.hostname)
+        confirm_user_wants_to_continue()  # todo test me
+    hosts = host_cache.get_hosts()
+    return hosts, pool
+
+
+def do_show(options):
+    if options.skipvalidation:
+        log_and_raise('--skipvalidation can not be combined with --show')
+        return
+
+    gucname = options.show
+    gucs = []
+
+    if options.file:
+        gucs.extend(get_gucs_from_files(gucname))
+    elif options.file_compare:
+        gucs.extend(get_gucs_from_database(gucname))
+        gucs.extend(get_gucs_from_files(gucname))
+    else:
+        gucs.extend(get_gucs_from_database(gucname))
+
+    _print_gucs(gucname, gucs, options)
 
 
 def do_main():
@@ -441,15 +445,7 @@ def do_main():
         do_list(options.skipvalidation)
 
     elif options.show:
-        # TODO looks like the following line is supposed to be ... options.value in longShow
-        # therefore, this long format has NEVER been used and can be removed.
-        long_format = options.show in longShow
-        if options.skipvalidation:
-            log_and_raise('--skipvalidation can not be combined with --show')
-        elif options.file:
-            do_show_from_file(options.show, long_format)
-        else:
-            do_show_from_psql(options.show, long_format)
+        do_show(options)
 
     elif options.remove or options.change:
         do_change(options)

--- a/gpMgmt/bin/gpconfig_modules/compare_segment_guc.py
+++ b/gpMgmt/bin/gpconfig_modules/compare_segment_guc.py
@@ -1,0 +1,138 @@
+from gpconfig_modules.database_segment_guc import DatabaseSegmentGuc
+from gpconfig_modules.file_segment_guc import FileSegmentGuc
+from gpconfig_modules.segment_guc import SegmentGuc
+
+
+class MultiValueGuc(SegmentGuc):
+    """
+    encapsulate various GUC locations within a given segment.
+    A segment can include 2 databases: the primary and a mirror.
+    The database value is singular, since we strongly expect the values to be the same, given mirroring.
+    However, the file values of primary and mirror can be different. 
+    So we model this MultiValueGuc object to accept 2 file values, and one database value.
+    """
+    def __init__(self, guc1, guc2):
+        """
+        accept 2 gucs in any order. gucs can be any combination of:
+
+        * database guc
+        * file guc
+            - primary
+            - mirror
+        * existing comparison guc, with or without mirror
+        """
+        self.primary_file_seg_guc = None
+        self.mirror_file_seg_guc = None
+        self.db_seg_guc = None
+
+        if not guc1 or not guc2:
+            raise Exception("comparison requires two gucs")
+
+        SegmentGuc.__init__(self, [guc1.context, guc1.name])
+        if guc1.context != guc2.context:
+            raise Exception("Not the same context")
+
+        if isinstance(guc1, MultiValueGuc):
+            # copy constructor
+            self.db_seg_guc = guc1.db_seg_guc
+            self.primary_file_seg_guc = guc1.primary_file_seg_guc
+            self.mirror_file_seg_guc = guc1.mirror_file_seg_guc
+
+        if isinstance(guc2, MultiValueGuc):
+            # copy constructor
+            self.db_seg_guc = guc2.db_seg_guc
+            self.primary_file_seg_guc = guc2.primary_file_seg_guc
+            self.mirror_file_seg_guc = guc2.mirror_file_seg
+
+        if isinstance(guc1, FileSegmentGuc):
+            if self.primary_file_seg_guc:
+                if self.primary_file_seg_guc.dbid == guc1.dbid:
+                    self.primary_file_seg_guc = guc1
+                else:
+                    self.mirror_file_seg_guc = guc1
+            else:
+                self.primary_file_seg_guc = guc1
+
+        if isinstance(guc2, FileSegmentGuc):
+            if self.primary_file_seg_guc:
+                if self.primary_file_seg_guc.dbid == guc2.dbid:
+                    self.primary_file_seg_guc = guc2
+                else:
+                    self.mirror_file_seg_guc = guc2
+            else:
+                self.primary_file_seg_guc = guc2
+
+        if isinstance(guc1, DatabaseSegmentGuc):
+            self.db_seg_guc = guc1
+
+        if isinstance(guc2, DatabaseSegmentGuc):
+            self.db_seg_guc = guc2
+
+    def report_success_format(self):
+        file_val = self.primary_file_seg_guc.get_value()
+        if self.db_seg_guc:
+            result = "%s value: %s | file: %s" % (self.get_label(), self.db_seg_guc.value, self._use_dash_when_none(file_val))
+        else:
+            result = "%s value: %s" % (self.get_label(), file_val)
+        return result
+
+    def report_fail_format(self):
+        sort_seg_guc_objs = [obj for obj in [self.primary_file_seg_guc, self.mirror_file_seg_guc] if obj]
+        sort_seg_guc_objs.sort(key=lambda x: x.dbid)
+
+        if self.db_seg_guc:
+            report = [self._report_fail_format_with_database_and_file_gucs(seg_guc_obj) for seg_guc_obj in sort_seg_guc_objs]
+        else:
+            report = [seg_guc_obj.report_fail_format()[0] for seg_guc_obj in sort_seg_guc_objs]
+        return report
+
+    def _report_fail_format_with_database_and_file_gucs(self, segment_guc_obj):
+        return "[context: %s] [dbid: %s] [name: %s] [value: %s | file: %s]" % (
+            self.db_seg_guc.context,
+            segment_guc_obj.dbid,
+            self.db_seg_guc.name,
+            self.db_seg_guc.value,
+            self._use_dash_when_none(segment_guc_obj.value))
+
+    def _use_dash_when_none(self, value):
+      return value if value is not None else "-"
+
+
+    def is_internally_consistent(self):
+        if not self.db_seg_guc:
+            return self.compare_primary_and_mirror_files()
+        else:
+            if self.primary_file_seg_guc is None:
+                return True
+            if self.primary_file_seg_guc.get_value() is None:
+                return True
+            result = True
+            if self.mirror_file_seg_guc and self.db_seg_guc:
+                result = self.mirror_file_seg_guc.value == self.db_seg_guc.value
+            if not result:
+                return result
+            return self.db_seg_guc.value == self.primary_file_seg_guc.value and result
+
+    def get_value(self):
+        file_value = ""
+        if self.primary_file_seg_guc:
+            file_value = str(self.primary_file_seg_guc.get_value())
+        db_value = ""
+        if self.db_seg_guc:
+            db_value = str(self.db_seg_guc.get_value())
+
+        return db_value + "||" + file_value
+
+    def set_mirror_file_segment(self, mirror_file_seg):
+        self.mirror_file_seg_guc = mirror_file_seg
+
+    def get_primary_dbid(self):
+        return self.primary_file_seg_guc.dbid
+
+    def set_primary_file_segment(self, guc):
+        self.primary_file_seg_guc = guc
+
+    def compare_primary_and_mirror_files(self):
+        if self.primary_file_seg_guc and self.mirror_file_seg_guc:
+            return self.primary_file_seg_guc.get_value() == self.mirror_file_seg_guc.get_value()
+        return True

--- a/gpMgmt/bin/gpconfig_modules/database_segment_guc.py
+++ b/gpMgmt/bin/gpconfig_modules/database_segment_guc.py
@@ -1,0 +1,24 @@
+from gpconfig_modules.segment_guc import SegmentGuc
+
+
+class DatabaseSegmentGuc(SegmentGuc):
+
+    def __init__(self, row):
+        SegmentGuc.__init__(self, row)
+
+        if len(row) < 3:
+            raise Exception("must provide ['context', 'guc name', 'value']")
+
+        self.value = row[2]
+
+    def report_success_format(self):
+        return "%s value: %s" % (self.get_label(), self.get_value())
+
+    def report_fail_format(self):
+        return ["[context: %s] [name: %s] [value: %s]" % (self.context, self.name, self.get_value())]
+
+    def is_internally_consistent(self):
+        return True
+
+    def get_value(self):
+        return self.value

--- a/gpMgmt/bin/gpconfig_modules/file_segment_guc.py
+++ b/gpMgmt/bin/gpconfig_modules/file_segment_guc.py
@@ -1,0 +1,29 @@
+from gpconfig_modules.segment_guc import SegmentGuc
+
+
+class FileSegmentGuc(SegmentGuc):
+
+    def __init__(self, row):
+        SegmentGuc.__init__(self, row)
+
+        if len(row) < 4:
+            raise Exception("must provide ['context', 'guc name', 'value', 'dbid']")
+
+        self.value = row[2]
+        self.dbid = str(row[3])
+
+    def report_success_format(self):
+        return "%s value: %s" % (self.get_label(), self._use_dash_when_none(self.get_value()))
+
+    def report_fail_format(self):
+        return ["[context: %s] [dbid: %s] [name: %s] [value: %s]" % (self.context, self.dbid, self.name, self._use_dash_when_none(self.get_value()))]
+
+    def is_internally_consistent(self):
+        return True
+
+    def get_value(self):
+        return self.value
+
+    def _use_dash_when_none(self, value):
+        return value if value is not None else "-"
+

--- a/gpMgmt/bin/gpconfig_modules/guc_collection.py
+++ b/gpMgmt/bin/gpconfig_modules/guc_collection.py
@@ -1,0 +1,73 @@
+from gpconfig_modules.compare_segment_guc import MultiValueGuc
+from gpconfig_modules.database_segment_guc import DatabaseSegmentGuc
+
+
+class GucCollection:
+    """
+    provide an enhanced dict of gucs, with responsibilities to assemble sets of info per segment.
+
+    """
+    MASTER_KEY = '-1'
+
+    def __init__(self):
+        self.gucs = {}
+
+    def update_list(self, guc_list):
+        for guc in guc_list:
+            self.update(guc)
+
+    def update(self, guc):
+        existing = self.gucs.get(guc.context)
+        if existing:
+            if isinstance(existing, DatabaseSegmentGuc) and type(guc) == type(existing):
+                pass  # discard mirror
+            else:
+                self.gucs[guc.context] = MultiValueGuc(existing, guc)
+        else:
+            self.gucs[guc.context] = guc
+
+    def are_segments_consistent(self):
+        self.validate()
+
+        if not self._check_consistency_within_single_segment():
+            return False
+
+        if not self._check_consistency_across_segments():
+            return False
+
+        return True
+
+    def _check_consistency_across_segments(self):
+        segments_only = [v for k, v in self.gucs.iteritems() if self.MASTER_KEY != k]
+        segment_values = [guc.get_value() for guc in segments_only]
+        if len(set(segment_values)) > 1:
+            return False
+        return True
+
+    def _check_consistency_within_single_segment(self):
+        for guc in self.gucs.values():
+            if not guc.is_internally_consistent():
+                return False
+        return True
+
+    def validate(self):
+        if len(self.gucs) < 2 or self.MASTER_KEY not in self.gucs:
+            raise Exception("Collections must have at least a master and segment value")
+
+    def values(self):
+        return sorted(self.gucs.values(), key=lambda x: x.context)
+
+    def report(self):
+        self.validate()
+
+        if self.are_segments_consistent():
+            last_seg_key = sorted(self.gucs.keys(), reverse=True)[0]
+            report = [self.gucs[self.MASTER_KEY].report_success_format(),
+                      self.gucs[last_seg_key].report_success_format()]
+            return "\n".join(report)
+        else:
+            sorted_gucs = sorted(self.gucs.values(), key=lambda x: x.context)
+            report = []
+            for guc in sorted_gucs:
+                report.extend(guc.report_fail_format())
+        return "\n".join(report)

--- a/gpMgmt/bin/gpconfig_modules/segment_guc.py
+++ b/gpMgmt/bin/gpconfig_modules/segment_guc.py
@@ -1,0 +1,31 @@
+import abc
+
+
+class SegmentGuc():
+    __metaclass__ = abc.ABCMeta
+
+    MASTER_CONTEXT = '-1'
+
+    def __init__(self, row):
+        self.context = str(row[0])
+        self.name = row[1]
+
+    def get_label(self):
+        label = "Segment" if self.context != self.MASTER_CONTEXT else "Master "
+        return label
+
+    @abc.abstractmethod
+    def report_success_format(self):
+        raise NotImplementedError('users must define __str__ to use this base class')
+
+    @abc.abstractmethod
+    def report_fail_format(self):
+        raise NotImplementedError('users must define __str__ to use this base class')
+
+    @abc.abstractmethod
+    def is_internally_consistent(self):
+        raise NotImplementedError('users must define __str__ to use this base class')
+
+    @abc.abstractmethod
+    def get_value(self):
+        raise NotImplementedError('users must define __str__ to use this base class')

--- a/gpMgmt/bin/gpload_test/gpload/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload/TEST.py
@@ -173,9 +173,9 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
 
     LMYD = os.path.abspath(os.path.dirname(__file__))
     if not os.access( f1, os.R_OK ):
-        raise GPTestError( 'Error: cannot find file %s' % f1 )
+        raise Exception( 'Error: cannot find file %s' % f1 )
     if not os.access( f2, os.R_OK ):
-        raise GPTestError( 'Error: cannot find file %s' % f2 )
+        raise Exception( 'Error: cannot find file %s' % f2 )
     dfile = diffFile( f1, outputPath = outputPath )
     # Gets the suitePath name to add init_file
     suitePath = f1[0:f1.rindex( "/" )]
@@ -242,7 +242,7 @@ def initialize():
         user = os.environ.get('USER')
 
     if not get_port():
-        raise GPTestError('Could not get port')
+        raise Exception('Could not get port')
 
     os.environ['PGPORT'] = get_port()
     os.environ['PGHOST'] = get_hostname()
@@ -345,9 +345,9 @@ def get_port():
                 if match1:
                     return match1.group()
         f.close()
-        raise GPTestError('Could not get port from '+file)
+        raise Exception('Could not get port from '+file)
     else:
-        raise GPTestError(file+' does not exist.  Cannot get port.')
+        raise Exception(file+' does not exist.  Cannot get port.')
 
 class GPLoad_Env_TestCase(unittest.TestCase):
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -56,7 +56,7 @@ def getPortMasterOnly(host = 'localhost',master_value = None,
 
     (ok,out) = run(cmd)
     if not ok:
-        raise GPTestError("Unable to connect to segment server %s as user %s" % (host, user))
+        raise Exception("Unable to connect to segment server %s as user %s" % (host, user))
 
     for line in out:
         out = line.split('\n')
@@ -66,7 +66,7 @@ def getPortMasterOnly(host = 'localhost',master_value = None,
 
     if master_value == None:
         error_msg = "".join(out)
-        raise GPTestError(error_msg)
+        raise Exception(error_msg)
 
     return str(master_value)
 
@@ -283,9 +283,9 @@ def isFileEqual( f1, f2, optionalFlags = "", outputPath = "", myinitfile = ""):
 
     LMYD = os.path.abspath(os.path.dirname(__file__))
     if not os.access( f1, os.R_OK ):
-        raise GPTestError( 'Error: cannot find file %s' % f1 )
+        raise Exception( 'Error: cannot find file %s' % f1 )
     if not os.access( f2, os.R_OK ):
-        raise GPTestError( 'Error: cannot find file %s' % f2 )
+        raise Exception( 'Error: cannot find file %s' % f2 )
     dfile = diffFile( f1, outputPath = outputPath )
     # Gets the suitePath name to add init_file
     suitePath = f1[0:f1.rindex( "/" )]

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1732,6 +1732,7 @@ class GpReadConfig(Command):
         self.seg_db_id = seg.getSegmentDbId()
         self.seg_content_id = seg.getSegmentContentId()
         self.guc_name = guc_name
+        self.role = seg.getSegmentRole()
         cat_path = findCmdInPath('cat')
 
         cmdStr = "%s %s/postgresql.conf" % (cat_path, seg.getSegmentDataDirectory())
@@ -1755,6 +1756,12 @@ class GpReadConfig(Command):
 
     def get_seg_content_id(self):
         return self.seg_content_id
+
+    def get_seg_role(self):
+        return self.role
+
+    def get_seg_dbid(self):
+        return self.seg_db_id
 
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_compare_segment_guc.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_compare_segment_guc.py
@@ -1,0 +1,106 @@
+from mock import *
+from gp_unittest import *
+from gpconfig_modules.compare_segment_guc import MultiValueGuc
+from gpconfig_modules.database_segment_guc import DatabaseSegmentGuc
+from gpconfig_modules.file_segment_guc import FileSegmentGuc
+
+
+class CompareSegmentGucTest(GpTestCase):
+    def setUp(self):
+        row = ['contentid', 'guc_name', 'file_value', "dbid"]
+        self.file_seg_guc = FileSegmentGuc(row)
+        row = ['contentid', 'guc_name', 'sql_value']
+        self.db_seg_guc = DatabaseSegmentGuc(row)
+
+        self.subject = MultiValueGuc(self.file_seg_guc, self.db_seg_guc)
+
+    def test_init_when_comparison_guc_supplied(self):
+        row = ['contentid', 'guc_name', 'file_value', "diff_dbid"]
+        file_seg_guc = FileSegmentGuc(row)
+        old = self.subject
+
+        self.subject = MultiValueGuc(self.subject, file_seg_guc)
+
+        self.assertEquals(self.subject.db_seg_guc, old.db_seg_guc)
+        self.assertEquals(self.subject.primary_file_seg_guc, old.primary_file_seg_guc)
+        self.assertEquals(self.subject.mirror_file_seg_guc, file_seg_guc)
+
+    def test_init_with_wrong_content_id_raises(self):
+        row = ['contentid', 'guc_name', 'file_value', "dbid"]
+        file_seg_guc = FileSegmentGuc(row)
+        row = ['different', 'guc_name', 'sql_value']
+        db_seg_guc = DatabaseSegmentGuc(row)
+
+        with self.assertRaisesRegexp(Exception, "Not the same context"):
+            MultiValueGuc(file_seg_guc, db_seg_guc)
+
+    def test_init_handles_both_orders(self):
+        self.assertEquals(self.file_seg_guc, self.subject.primary_file_seg_guc)
+        self.assertEquals(self.db_seg_guc, self.subject.db_seg_guc)
+        self.assertTrue(isinstance(self.subject.primary_file_seg_guc, FileSegmentGuc))
+        self.assertTrue(isinstance(self.subject.db_seg_guc, DatabaseSegmentGuc))
+
+        self.subject = MultiValueGuc(self.db_seg_guc, self.file_seg_guc)
+
+        self.assertEquals(self.file_seg_guc, self.subject.primary_file_seg_guc)
+        self.assertEquals(self.db_seg_guc, self.subject.db_seg_guc)
+        self.assertTrue(isinstance(self.subject.primary_file_seg_guc, FileSegmentGuc))
+        self.assertTrue(isinstance(self.subject.db_seg_guc, DatabaseSegmentGuc))
+
+    def test_init_when_none_raises(self):
+        with self.assertRaisesRegexp(Exception, "comparison requires two gucs"):
+            self.subject = MultiValueGuc(self.db_seg_guc, None)
+
+        with self.assertRaisesRegexp(Exception, "comparison requires two gucs"):
+            self.subject = MultiValueGuc(None, self.db_seg_guc)
+
+    def test_report_fail_format_for_database_and_file_gucs(self):
+        self.assertEquals(self.subject.report_fail_format(),
+                          ["[context: contentid] [dbid: dbid] [name: guc_name] [value: sql_value | file: file_value]"])
+
+    def test_report_fail_format_file_segment_guc_only(self):
+        self.subject.db_seg_guc = None
+        row = ['contentid', 'guc_name', 'primary_value', "dbid1"]
+        self.subject.set_primary_file_segment(FileSegmentGuc(row))
+        row = ['contentid', 'guc_name', 'mirror_value', "dbid2"]
+        self.subject.set_mirror_file_segment(FileSegmentGuc(row))
+        self.assertEquals(self.subject.report_fail_format(),
+                          ["[context: contentid] [dbid: dbid1] [name: guc_name] [value: primary_value]",
+                          "[context: contentid] [dbid: dbid2] [name: guc_name] [value: mirror_value]"])
+
+    def test_when_segment_report_success_format(self):
+        self.assertEquals(self.subject.report_success_format(),
+                          "Segment value: sql_value | file: file_value")
+
+    def test_when_values_match_report_success_format_file_compare(self):
+        self.subject.db_seg_guc.value = 'value'
+        self.subject.primary_file_seg_guc.value = 'value'
+        self.assertEquals(self.subject.report_success_format(), "Segment value: value | file: value")
+
+    def test_is_internally_consistent_fails(self):
+        self.assertEquals(self.subject.is_internally_consistent(), False)
+
+    def test_is_internally_consistent_when_file_value_is_none_succeeds(self):
+        self.file_seg_guc.value = None
+        self.assertEquals(self.subject.is_internally_consistent(), True)
+
+    def test_is_internally_consistent_when_primary_is_same_succeeds(self):
+        self.subject.primary_file_seg_guc.value = "sql_value"
+        self.assertEquals(self.subject.is_internally_consistent(), True)
+
+    def test_is_internally_consistent_when_mirror_is_different_fails(self):
+        self.subject.primary_file_seg_guc.value = "sql_value"
+        row = ['contentid', 'guc_name', 'diffvalue', "dbid1"]
+        self.subject.set_mirror_file_segment(FileSegmentGuc(row))
+        self.assertEquals(self.subject.is_internally_consistent(), False)
+
+    def test_set_file_segment_succeeds(self):
+        row = ['contentid', 'guc_name', 'file_value', "diff_dbid"]
+        file_seg_guc = FileSegmentGuc(row)
+
+        self.subject.set_mirror_file_segment(file_seg_guc)
+
+        self.assertEquals(self.subject.mirror_file_seg_guc, file_seg_guc)
+
+    def test_get_value_returns_unique(self):
+        self.assertEquals(self.subject.get_value(), "sql_value||file_value")

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_database_segment_guc.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_database_segment_guc.py
@@ -1,0 +1,28 @@
+from mock import *
+from gp_unittest import *
+from gpconfig_modules.database_segment_guc import DatabaseSegmentGuc
+from gpconfig_modules.segment_guc import SegmentGuc
+
+
+class DatabaseSegmentGucTest(GpTestCase):
+    def setUp(self):
+        row = ['contentid', 'guc_name', 'sql_value']
+        self.subject = DatabaseSegmentGuc(row)
+
+    def test_when_segment_report_success_format_database(self):
+        self.subject.context = '0'
+        self.assertEquals(self.subject.report_success_format(), "Segment value: sql_value")
+
+    def test_when_master_report_success_format_database(self):
+        self.subject.context = '-1'
+        self.assertEquals(self.subject.report_success_format(), "Master  value: sql_value")
+
+    def test_report_fail_format_database(self):
+        self.assertEquals(self.subject.report_fail_format(),
+                          ["[context: contentid] [name: guc_name] [value: sql_value]"])
+
+    def test_init_with_insufficient_database_values_raises(self):
+        row = ['contentid', 'guc_name']
+        with self.assertRaisesRegexp(Exception, "must provide \['context', 'guc name', 'value'\]"):
+            DatabaseSegmentGuc(row)
+

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_file_segment_guc.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_file_segment_guc.py
@@ -1,0 +1,39 @@
+from mock import *
+from gp_unittest import *
+from gpconfig_modules.file_segment_guc import FileSegmentGuc
+from gpconfig_modules.segment_guc import SegmentGuc
+
+
+class FileSegmentGucTest(GpTestCase):
+    def setUp(self):
+        row = ['contentid', 'guc_name', 'value_from_file', 'dbid']
+        self.subject = FileSegmentGuc(row)
+
+    def test_when_segment_report_success_format_file(self):
+        self.subject.context = '0'
+        self.assertEquals(self.subject.report_success_format(), "Segment value: value_from_file")
+
+    def test_when_master_report_success_format_file(self):
+        self.subject.context = '-1'
+        self.assertEquals(self.subject.report_success_format(), "Master  value: value_from_file")
+
+    def test_report_fail_format_file(self):
+        self.assertEquals(self.subject.report_fail_format(),
+                          ["[context: contentid] [dbid: dbid] [name: guc_name] [value: value_from_file]"])
+
+    def test_init_with_insufficient_file_values_raises(self):
+        row = ['contentid', 'guc_name', 'value_from_file']
+        with self.assertRaisesRegexp(Exception, "must provide \['context', 'guc name', 'value', 'dbid'\]"):
+            FileSegmentGuc(row)
+
+    def test_when_master_when_integer_dbid_report_success_format_file(self):
+        row = [-1, 'guc_name', 'value', 0]
+        self.subject = FileSegmentGuc(row)
+
+        self.assertEquals(self.subject.report_success_format(), "Master  value: value")
+        self.assertEqual(self.subject.dbid, '0')
+
+    def test_when_value_none_report_success_uses_hyphen(self):
+        self.subject.value = None
+
+        self.assertEquals(self.subject.report_success_format(), "Segment value: -")

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpconfig.py
@@ -14,12 +14,11 @@ from mock import *
 from gp_unittest import *
 from gphostcache import GpHost
 
-
 db_singleton_side_effect_list = []
 
 
 def singleton_side_effect(unused1, unused2):
-    # function that replaces dbconn.execSQLForSingleton(conn, sql), conditionally raising exception
+    # this function replaces dbconn.execSQLForSingleton(conn, sql), conditionally raising exception
     if db_singleton_side_effect_list[0] == "DatabaseError":
         raise DatabaseError("mock exception")
     return db_singleton_side_effect_list[0]
@@ -43,11 +42,10 @@ class GpConfig(GpTestCase):
 
         self.conn = Mock()
         self.cursor = FakeCursor()
-        # self.conn.execSql.return_value = self.rows
 
         self.os_env = dict(USER="my_user")
         self.os_env["MASTER_DATA_DIRECTORY"] = self.temp_dir
-        self.gparray = self.createGpArrayWith2Primary2Mirrors()
+        self.gparray = self._create_gparray_with_2_primary_2_mirrors()
         self.host_cache = Mock()
 
         self.host = GpHost('localhost')
@@ -63,10 +61,10 @@ class GpConfig(GpTestCase):
 
         self.master_read_config = Mock()
         self.master_read_config.get_guc_value.return_value = "foo"
-        self.master_read_config.get_seg_id.return_value = -1
+        self.master_read_config.get_seg_content_id.return_value = -1
         self.segment_read_config = Mock()
         self.segment_read_config.get_guc_value.return_value = "foo"
-        self.segment_read_config.get_seg_id.return_value = 0
+        self.segment_read_config.get_seg_content_id.return_value = 0
 
         self.pool = Mock()
         self.pool.getCompletedItems.return_value = [self.master_read_config, self.segment_read_config]
@@ -81,25 +79,47 @@ class GpConfig(GpTestCase):
             patch('gpconfig.GpReadConfig', return_value=self.master_read_config),
             patch('gpconfig.WorkerPool', return_value=self.pool)
         ])
-        sys.argv = ["gpconfig"] # reset to relatively empty args list
+        sys.argv = ["gpconfig"]  # reset to relatively empty args list
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
         super(GpConfig, self).tearDown()
         del db_singleton_side_effect_list[:]
 
-    def createGpArrayWith2Primary2Mirrors(self):
-        master = GpDB.initFromString(
-            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
-        primary0 = GpDB.initFromString(
-            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
-        primary1 = GpDB.initFromString(
-            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
-        mirror0 = GpDB.initFromString(
-            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
-        mirror1 = GpDB.initFromString(
-            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
-        return GpArray([master, primary0, primary1, mirror0, mirror1])
+    def test_when_no_options_prints_and_raises(self):
+        with self.assertRaisesRegexp(Exception, "No action specified.  See the --help info."):
+            self.subject.do_main()
+        self.subject.logger.error.assert_called_once_with("No action specified.  See the --help info.")
+
+    def test_option_list_parses(self):
+        sys.argv = ["gpconfig", "--list"]
+        options = self.subject.parseargs()
+
+        self.assertEquals(options.list, True)
+
+    def test_option_value_must_accompany_option_change_raise(self):
+        sys.argv = ["gpconfig", "--change", "statement_mem"]
+        with self.assertRaisesRegexp(Exception, "change requested but value not specified"):
+            self.subject.parseargs()
+        self.subject.logger.error.assert_called_once_with("change requested but value not specified")
+
+    def test_option_show_without_master_data_dir_will_succeed(self):
+        sys.argv = ["gpconfig", "--show", "statement_mem"]
+        del self.os_env["MASTER_DATA_DIRECTORY"]
+        self.subject.parseargs()
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_option_show_with_port_will_succeed(self, mock_stdout):
+        sys.argv = ["gpconfig", "--show", "port"]
+        # select * from gp_toolkit.gp_param_setting('port');                                                                                                                     ;
+        # paramsegment | paramname | paramvalue
+        # --------------+-----------+------------
+        self.cursor.set_result_for_testing([['-1', 'port', '1234'], ['0', 'port', '3456']])
+
+        self.subject.do_main()
+
+        self.assertIn("GUC                 : port\nContext:    -1 Value: 1234\nContext:     0 Value: 3456\n",
+                      mock_stdout.getvalue())
 
     def test_option_f_parses(self):
         sys.argv = ["gpconfig", "--file", "--show", "statement_mem"]
@@ -108,28 +128,17 @@ class GpConfig(GpTestCase):
         self.assertEquals(options.show, "statement_mem")
         self.assertEquals(options.file, True)
 
-    def test_option_list_parses(self):
-        sys.argv = ["gpconfig", "--list"]
-        options = self.subject.parseargs()
-
-        self.assertEquals(options.list, True)
-
-    def test_when_no_options_prints_and_throws(self):
-        with self.assertRaisesRegexp(Exception, "No action specified.  See the --help info."):
-            self.subject.do_main()
-        self.subject.logger.error.assert_called_once_with("No action specified.  See the --help info.")
-
-    def test_option_value_must_accompany_option_change(self):
-        sys.argv = ["gpconfig", "--change", "statement_mem"]
-        with self.assertRaisesRegexp(Exception, "change requested but value not specified"):
-            self.subject.parseargs()
-        self.subject.logger.error.assert_called_once_with("change requested but value not specified")
-
     def test_option_file_with_option_change_will_raise(self):
         sys.argv = ["gpconfig", "--file", "--change", "statement_mem"]
         with self.assertRaisesRegexp(Exception, "'--file' option must accompany '--show' option"):
             self.subject.parseargs()
         self.subject.logger.error.assert_called_once_with("'--file' option must accompany '--show' option")
+
+    def test_option_file_compare_with_file_will_raise(self):
+        sys.argv = ["gpconfig", "--file", "--show", "statement_mem", "--file-compare", ]
+        with self.assertRaisesRegexp(Exception, "'--file' option and '--file-compare' option cannot be used together"):
+            self.subject.parseargs()
+        self.subject.logger.error.assert_called_once_with("'--file' option and '--file-compare' option cannot be used together")
 
     def test_option_file_with_option_list_will_raise(self):
         sys.argv = ["gpconfig", "--file", "--list", "statement_mem"]
@@ -137,17 +146,12 @@ class GpConfig(GpTestCase):
             self.subject.parseargs()
         self.subject.logger.error.assert_called_once_with("'--file' option must accompany '--show' option")
 
-    def test_option_file_without_MASTER_DATA_DIR_will_raise(self):
+    def test_option_file_without_master_data_dir_will_raise(self):
         sys.argv = ["gpconfig", "--file", "--show", "statement_mem"]
         del self.os_env["MASTER_DATA_DIRECTORY"]
         with self.assertRaisesRegexp(Exception, "--file option requires that MASTER_DATA_DIRECTORY be set"):
             self.subject.parseargs()
         self.subject.logger.error.assert_called_once_with("--file option requires that MASTER_DATA_DIRECTORY be set")
-
-    def test_option_show_without_MASTER_DATA_DIR_will_not_raise(self):
-        sys.argv = ["gpconfig", "--show", "statement_mem"]
-        del self.os_env["MASTER_DATA_DIRECTORY"]
-        self.subject.parseargs()
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_option_f_will_report_presence_of_setting(self, mock_stdout):
@@ -161,18 +165,18 @@ class GpConfig(GpTestCase):
         self.pool.haltWork.assert_called_once_with()
         self.pool.joinWorkers.assert_called_once_with()
         self.assertEqual(self.subject.logger.error.call_count, 0)
-        self.assertIn("foo", mock_stdout.getvalue())
+        self.assertIn("Master  value: foo\nSegment value: foo", mock_stdout.getvalue())
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_option_f_will_report_absence_of_setting(self, mock_stdout):
         sys.argv = ["gpconfig", "--show", "my_property_name", "--file"]
-        self.master_read_config.get_guc_value.return_value = None
-        self.segment_read_config.get_guc_value.return_value = None
+        self.master_read_config.get_guc_value.return_value = "-"
+        self.segment_read_config.get_guc_value.return_value = "seg_value"
 
         self.subject.do_main()
 
         self.assertEqual(self.subject.logger.error.call_count, 0)
-        self.assertIn("not set in postgresql.conf", mock_stdout.getvalue())
+        self.assertIn("Master  value: -\nSegment value: seg_value", mock_stdout.getvalue())
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_option_f_will_report_difference_segments_out_of_sync(self, mock_stdout):
@@ -181,7 +185,7 @@ class GpConfig(GpTestCase):
         self.segment_read_config.get_guc_value.return_value = 'bar'
         another_segment_read_config = Mock()
         another_segment_read_config.get_guc_value.return_value = "baz"
-        another_segment_read_config.get_seg_id.return_value = 1
+        another_segment_read_config.get_seg_content_id.return_value = 1
         self.pool.getCompletedItems.return_value.append(another_segment_read_config)
         self.host_cache.get_hosts.return_value.extend([self.host, self.host])
 
@@ -191,7 +195,7 @@ class GpConfig(GpTestCase):
         self.assertEqual(self.subject.logger.error.call_count, 0)
         self.assertIn("WARNING: GUCS ARE OUT OF SYNC", mock_stdout.getvalue())
         self.assertIn("bar", mock_stdout.getvalue())
-        self.assertIn("baz", mock_stdout.getvalue())
+        self.assertIn("[name: my_property_name] [value: baz]", mock_stdout.getvalue())
 
     def test_option_change_value_master_separate_succeed(self):
         db_singleton_side_effect_list.append("some happy result")
@@ -199,20 +203,20 @@ class GpConfig(GpTestCase):
         sys.argv = ["gpconfig", "-c", entry, "-v", "100", "-m", "20"]
         # 'SELECT name, setting, unit, short_desc, context, vartype, min_val, max_val FROM pg_settings'
         self.cursor.set_result_for_testing([['my_property_name', 'setting', 'unit', 'short_desc',
-                         'context', 'vartype', 'min_val', 'max_val']])
+                                             'context', 'vartype', 'min_val', 'max_val']])
 
         self.subject.do_main()
 
         self.subject.logger.info.assert_called_with("completed successfully")
         self.assertEqual(self.pool.addCommand.call_count, 2)
-        segmentCommand = self.pool.addCommand.call_args_list[0][0][0]
-        self.assertTrue("my_property_name" in segmentCommand.cmdStr)
+        segment_command = self.pool.addCommand.call_args_list[0][0][0]
+        self.assertTrue("my_property_name" in segment_command.cmdStr)
         value = base64.urlsafe_b64encode(pickle.dumps("100"))
-        self.assertTrue(value in segmentCommand.cmdStr)
-        masterCommand = self.pool.addCommand.call_args_list[1][0][0]
-        self.assertTrue(("my_property_name") in masterCommand.cmdStr)
+        self.assertTrue(value in segment_command.cmdStr)
+        master_command = self.pool.addCommand.call_args_list[1][0][0]
+        self.assertTrue("my_property_name" in master_command.cmdStr)
         value = base64.urlsafe_b64encode(pickle.dumps("20"))
-        self.assertTrue(value in masterCommand.cmdStr)
+        self.assertTrue(value in master_command.cmdStr)
 
     def test_option_change_value_masteronly_succeed(self):
         db_singleton_side_effect_list.append("some happy result")
@@ -220,16 +224,16 @@ class GpConfig(GpTestCase):
         sys.argv = ["gpconfig", "-c", entry, "-v", "100", "--masteronly"]
         # 'SELECT name, setting, unit, short_desc, context, vartype, min_val, max_val FROM pg_settings'
         self.cursor.set_result_for_testing([['my_property_name', 'setting', 'unit', 'short_desc',
-                         'context', 'vartype', 'min_val', 'max_val']])
+                                             'context', 'vartype', 'min_val', 'max_val']])
 
         self.subject.do_main()
 
         self.subject.logger.info.assert_called_with("completed successfully")
         self.assertEqual(self.pool.addCommand.call_count, 1)
-        masterCommand = self.pool.addCommand.call_args_list[0][0][0]
-        self.assertTrue(("my_property_name") in masterCommand.cmdStr)
+        master_command = self.pool.addCommand.call_args_list[0][0][0]
+        self.assertTrue(("my_property_name") in master_command.cmdStr)
         value = base64.urlsafe_b64encode(pickle.dumps("100"))
-        self.assertTrue(value in masterCommand.cmdStr)
+        self.assertTrue(value in master_command.cmdStr)
 
     def test_option_change_value_master_separate_fail_not_valid_guc(self):
         db_singleton_side_effect_list.append("DatabaseError")
@@ -246,12 +250,12 @@ class GpConfig(GpTestCase):
 
         self.subject.logger.info.assert_called_with("completed successfully")
         self.assertEqual(self.pool.addCommand.call_count, 2)
-        segmentCommand = self.pool.addCommand.call_args_list[0][0][0]
-        self.assertTrue("my_hidden_guc_name" in segmentCommand.cmdStr)
-        masterCommand = self.pool.addCommand.call_args_list[1][0][0]
-        self.assertTrue(("my_hidden_guc_name") in masterCommand.cmdStr)
+        segment_command = self.pool.addCommand.call_args_list[0][0][0]
+        self.assertTrue("my_hidden_guc_name" in segment_command.cmdStr)
+        master_command = self.pool.addCommand.call_args_list[1][0][0]
+        self.assertTrue("my_hidden_guc_name" in master_command.cmdStr)
         value = base64.urlsafe_b64encode(pickle.dumps("100"))
-        self.assertTrue(value in masterCommand.cmdStr)
+        self.assertTrue(value in master_command.cmdStr)
 
     def test_option_change_value_hidden_guc_without_skipvalidation(self):
         db_singleton_side_effect_list.append("my happy result")
@@ -264,6 +268,101 @@ class GpConfig(GpTestCase):
         self.subject.logger.fatal.assert_called_once_with("GUC Validation Failed: my_hidden_guc_name cannot be "
                                                           "changed under normal conditions. "
                                                           "Please refer to gpconfig documentation.")
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_option_file_compare_returns_same_value(self, mock_stdout):
+        sys.argv = ["gpconfig", "-s", "my_property_name", "--file-compare"]
+        self.master_read_config.get_guc_value.return_value = 'foo'
+        self.master_read_config.get_seg_content_id.return_value = -1
+
+        self.segment_read_config.get_guc_value.return_value = 'foo'
+        self.segment_read_config.get_seg_content_id.return_value = 0
+
+        another_segment_read_config = Mock()
+        another_segment_read_config.get_guc_value.return_value = "foo"
+        another_segment_read_config.get_seg_content_id.return_value = 1
+        self.pool.getCompletedItems.return_value.append(another_segment_read_config)
+
+        self.cursor.set_result_for_testing([[-1, 'my_property_name', 'foo'],
+                                            [0, 'my_property_name', 'foo'],
+                                            [1, 'my_property_name', 'foo']])
+
+        self.subject.do_main()
+
+        self.assertIn("Master  value: foo | file: foo", mock_stdout.getvalue())
+        self.assertIn("Segment value: foo | file: foo", mock_stdout.getvalue())
+        self.assertIn("Values on all segments are consistent", mock_stdout.getvalue())
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_option_file_compare_returns_different_value(self, mock_stdout):
+        sys.argv = ["gpconfig", "-s", "my_property_name", "--file-compare"]
+        self.master_read_config.get_guc_value.return_value = 'foo'
+        self.master_read_config.get_seg_content_id.return_value = -1
+        self.master_read_config.get_seg_dbid.return_value = 0
+
+        self.segment_read_config.get_guc_value.return_value = 'foo'
+        self.segment_read_config.get_seg_content_id.return_value = 0
+        self.segment_read_config.get_seg_dbid.return_value = 1
+
+        another_segment_read_config = Mock()
+        another_segment_read_config.get_guc_value.return_value = "bar"
+        another_segment_read_config.get_seg_content_id.return_value = 1
+        another_segment_read_config.get_seg_dbid.return_value = 2
+        self.pool.getCompletedItems.return_value.append(another_segment_read_config)
+
+        self.cursor.set_result_for_testing([[-1, 'my_property_name', 'foo'],
+                                            [0, 'my_property_name', 'foo'],
+                                            [1, 'my_property_name', 'foo']])
+
+        self.subject.do_main()
+
+        self.assertIn("WARNING: GUCS ARE OUT OF SYNC: ", mock_stdout.getvalue())
+        self.assertIn("[context: -1] [dbid: 0] [name: my_property_name] [value: foo | file: foo]",
+                      mock_stdout.getvalue())
+        self.assertIn("[context: 0] [dbid: 1] [name: my_property_name] [value: foo | file: foo]",
+                      mock_stdout.getvalue())
+        self.assertIn("[context: 1] [dbid: 2] [name: my_property_name] [value: foo | file: bar]",
+                      mock_stdout.getvalue())
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_option_file_compare_with_standby_master_with_different_file_value_will_report_failure(self, mock_stdout):
+        sys.argv = ["gpconfig", "-s", "my_property_name", "--file-compare"]
+        self.cursor.set_result_for_testing([[-1, 'my_property_name', 'foo']])
+        self.master_read_config.get_guc_value.return_value = 'foo'
+        self.master_read_config.get_seg_content_id.return_value = -1
+        self.master_read_config.get_seg_dbid.return_value = 0
+        # standby mirror with bad file value
+        self.segment_read_config.get_guc_value.return_value = 'foo'
+        self.segment_read_config.get_seg_content_id.return_value = 0
+        self.segment_read_config.get_seg_dbid.return_value = 1
+
+        standby_segment_read_config = Mock()
+        standby_segment_read_config.get_guc_value.return_value = "bar"
+        standby_segment_read_config.get_seg_content_id.return_value = -1
+        standby_segment_read_config.get_seg_dbid.return_value = 2
+        self.pool.getCompletedItems.return_value.append(standby_segment_read_config)
+
+        self.subject.do_main()
+
+        self.assertIn("WARNING: GUCS ARE OUT OF SYNC: ", mock_stdout.getvalue())
+        self.assertIn("[context: -1] [dbid: 0] [name: my_property_name] [value: foo | file: foo]",
+                      mock_stdout.getvalue())
+        self.assertIn("[context: -1] [dbid: 2] [name: my_property_name] [value: foo | file: bar]",
+                      mock_stdout.getvalue())
+
+    @staticmethod
+    def _create_gparray_with_2_primary_2_mirrors():
+        master = GpDB.initFromString(
+            "1|-1|p|p|s|u|mdw|mdw|5432|None|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
+        primary0 = GpDB.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|40000|41000|/data/primary0||/data/primary0/base/10899,/data/primary0/base/1,/data/primary0/base/10898,/data/primary0/base/25780,/data/primary0/base/34782")
+        primary1 = GpDB.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|40001|41001|/data/primary1||/data/primary1/base/10899,/data/primary1/base/1,/data/primary1/base/10898,/data/primary1/base/25780,/data/primary1/base/34782")
+        mirror0 = GpDB.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|50000|51000|/data/mirror0||/data/mirror0/base/10899,/data/mirror0/base/1,/data/mirror0/base/10898,/data/mirror0/base/25780,/data/mirror0/base/34782")
+        mirror1 = GpDB.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|50001|51001|/data/mirror1||/data/mirror1/base/10899,/data/mirror1/base/1,/data/mirror1/base/10898,/data/mirror1/base/25780,/data/mirror1/base/34782")
+        return GpArray([master, primary0, primary1, mirror0, mirror1])
 
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_guccollection.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_guccollection.py
@@ -1,0 +1,253 @@
+from mock import *
+from gp_unittest import *
+from gpconfig_modules.database_segment_guc import DatabaseSegmentGuc
+from gpconfig_modules.file_segment_guc import FileSegmentGuc
+from gpconfig_modules.guc_collection import GucCollection
+
+
+class GucCollectionTest(GpTestCase):
+    def setUp(self):
+        self.subject = GucCollection()
+        row = ['-1', 'guc_name', 'master_value']
+        self.db_seg_guc_1 = DatabaseSegmentGuc(row)
+        self.subject.update(self.db_seg_guc_1)
+        row = ['0', 'guc_name', 'value']
+        self.db_seg_guc_2 = DatabaseSegmentGuc(row)
+        self.subject.update(self.db_seg_guc_2)
+
+    def test_when_non_matching_file_value_yields_failure_format(self):
+        row = ['-1', 'guc_name', 'master_file_value', 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'file_value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("[context: -1] [dbid: dbid1] [name: guc_name] [value: master_value | file: master_file_value]"
+                      "\n[context: 0] [dbid: dbid2] [name: guc_name] [value: value | file: file_value]",
+                      self.subject.report())
+
+    def test_when_the_master_is_different_from_segment_yet_all_segments_same_yields_success_format(self):
+        row = ['0', 'guc_name', 'value', 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', 'master_value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("Master  value: master_value | file: master_value", self.subject.report())
+        self.assertIn("Segment value: value | file: value", self.subject.report())
+
+    def test_less_than_two_segments_raises(self):
+        del self.subject.gucs['0']
+
+        with self.assertRaisesRegexp(Exception,
+                                     "Collections must have at least a master and segment value"):
+            self.subject.report()
+
+    def test_when_invalid_gucs_with_no_master_raises(self):
+        del self.subject.gucs['-1']
+        with self.assertRaisesRegexp(Exception,
+                                     "Collections must have at least a master and segment value"):
+            self.subject.validate()
+
+    def test_when_three_segments_match_success_format(self):
+        row = ['-1', 'guc_name', 'master_value', 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['1', 'guc_name', 'value']
+        self.subject.update(DatabaseSegmentGuc(row))
+        row = ['1', 'guc_name', 'value', 'dbid3']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("Master  value: master_value | file: master_value", self.subject.report())
+        self.assertIn("Segment value: value | file: value", self.subject.report())
+
+    def test_file_format_succeeds(self):
+        row = ['-1', 'guc_name', 'master_value', 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("Master  value: master_value", self.subject.report())
+        self.assertIn("Segment value: value", self.subject.report())
+
+    def test_database_format_succeeds(self):
+        self.assertIn("Master  value: master_value", self.subject.report())
+        self.assertIn("Segment value: value", self.subject.report())
+
+    def test_update_adds_to_empty(self):
+        self.assertEqual(len(self.subject.gucs), 2)
+
+    def test_update_when_same_database_segment_guc_type_overrides_existing(self):
+        row = ['-1', 'guc_name', 'new_value', 'dbid']
+        self.subject.update(DatabaseSegmentGuc(row))
+        self.assertEqual(len(self.subject.gucs), 2)
+
+    def test_update_after_having_full_comparison_for_a_given_contentid_succeeds(self):
+        row = ['0', 'guc_name', 'value', 'dbid']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', 'master_value', 'dbid']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', 'master_value', 'dbid']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("Master  value: master_value | file: master_value", self.subject.report())
+        self.assertIn("Segment value: value | file: value", self.subject.report())
+
+    def test_when_file_value_empty_file_compare_succeeds(self):
+        row = ['0', 'guc_name', None, 'dbid']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', None, 'dbid']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("Master  value: master_value | file: -", self.subject.report())
+        self.assertIn("Segment value: value | file: -", self.subject.report())
+
+    def test_when_multiple_dbids_per_contentid_reports_failure(self):
+        row = ['-1', 'guc_name', 'master_value', '1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', 'master_value', '2']
+        self.subject.update(FileSegmentGuc(row))
+
+        row = ['0', 'guc_name', 'value', '3']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', '4']
+        self.subject.update(FileSegmentGuc(row))
+
+        row = ['1', 'guc_name', 'value']
+        self.subject.update(DatabaseSegmentGuc(row))
+        row = ['1', 'guc_name', 'different', '5']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['1', 'guc_name', 'different', '6']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn(""
+                      "[context: -1] [dbid: 1] [name: guc_name] [value: master_value | file: master_value]"
+                      "\n[context: -1] [dbid: 2] [name: guc_name] [value: master_value | file: master_value]",
+                      # "\n[context: 0] [dbid: dbid] [name: guc_name] [value: value | file: file_value]",
+                      self.subject.report())
+
+    def test_update_when_file_segment_has_same_dbid_overwrites_and_succeeds(self):
+        row = ['-1', 'guc_name', 'master_value', 'dbid']
+        self.subject.update(FileSegmentGuc(row))
+        primary_file_seg = FileSegmentGuc(row)
+        self.subject.update(primary_file_seg)
+
+        self.assertEquals(self.subject.gucs["-1"].primary_file_seg_guc, primary_file_seg)
+        self.assertEquals(self.subject.gucs["-1"].mirror_file_seg_guc, None)
+
+    def test_update_when_file_segments_first_succeeds(self):
+        row = ['-1', 'guc_name', 'master_value', 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+        primary_file_seg = FileSegmentGuc(row)
+        self.subject.update(primary_file_seg)
+        row = ['-1', 'guc_name', 'master_value']
+        self.subject.update(DatabaseSegmentGuc(row))
+        row = ['0', 'guc_name', 'value']
+        self.subject.update(DatabaseSegmentGuc(row))
+
+        self.assertIn("Master  value: master_value | file: master_value", self.subject.report())
+        self.assertIn("Segment value: value | file: value", self.subject.report())
+
+    def test_update_when_only_database_segments_succeeds(self):
+        row = ['-1', 'guc_name', 'master_value']
+        self.subject.update(DatabaseSegmentGuc(row))
+        row = ['0', 'guc_name', 'value']
+        self.subject.update(DatabaseSegmentGuc(row))
+
+        self.assertIn("Master  value: master_value", self.subject.report())
+        self.assertIn("Segment value: value", self.subject.report())
+
+    def test_update_when_only_file_segments_overwriting_succeeds(self):
+        self.subject = GucCollection()
+        row = ['-1', 'guc_name', 'master_value', 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', 'master_value', 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("Master  value: master_value", self.subject.report())
+        self.assertIn("Segment value: value", self.subject.report())
+
+    def test_update_when_only_file_segments_primary_and_mirror_succeeds(self):
+        self.subject = GucCollection()
+        row = ['-1', 'guc_name', 'master_value', 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', 'master_value', 'dbid3']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid4']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("Master  value: master_value", self.subject.report())
+        self.assertIn("Segment value: value", self.subject.report())
+
+    def test_update_when_only_file_segments_primary_and_mirror_fails(self):
+        self.subject = GucCollection()
+        row = ['-1', 'guc_name', None, 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', 'master_value', 'dbid3']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid4']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertIn("[context: -1] [dbid: dbid1] [name: guc_name] [value: -]\n", self.subject.report())
+        self.assertIn("[context: -1] [dbid: dbid3] [name: guc_name] [value: master_value]\n", self.subject.report())
+        self.assertIn("[context: 0] [dbid: dbid2] [name: guc_name] [value: value]\n", self.subject.report())
+        self.assertIn("[context: 0] [dbid: dbid4] [name: guc_name] [value: value]", self.subject.report())
+
+    def test_for_sorting_based_on_context_and_dbid_with_file_option_succeeds(self):
+        self.subject = GucCollection()
+        row = ['-1', 'guc_name', None, 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', 'master_value', 'dbid3']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['1', 'guc_name', 'value', 'dbid6']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid4']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['1', 'guc_name', 'value', 'dbid5']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertEquals("[context: -1] [dbid: dbid1] [name: guc_name] [value: -]\n"
+                          "[context: -1] [dbid: dbid3] [name: guc_name] [value: master_value]\n"
+                          "[context: 0] [dbid: dbid2] [name: guc_name] [value: value]\n"
+                          "[context: 0] [dbid: dbid4] [name: guc_name] [value: value]\n"
+                          "[context: 1] [dbid: dbid5] [name: guc_name] [value: value]\n"
+                          "[context: 1] [dbid: dbid6] [name: guc_name] [value: value]", self.subject.report())
+
+    def test_for_sorting_based_on_context_and_dbid_with_file_compare_option_succeeds(self):
+        self.subject = GucCollection()
+        row = ['-1', 'guc_name', 'master_value', 'dbid1']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid2']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['-1', 'guc_name', 'master_value']
+        self.subject.update(DatabaseSegmentGuc(row))
+        row = ['0', 'guc_name', 'value']
+        self.subject.update(DatabaseSegmentGuc(row))
+        row = ['1', 'guc_name', 'value', 'dbid5']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['1', 'guc_name', 'wrong_value', 'dbid4']
+        self.subject.update(FileSegmentGuc(row))
+        row = ['1', 'guc_name', 'value']
+        self.subject.update(DatabaseSegmentGuc(row))
+        row = ['0', 'guc_name', 'value', 'dbid3']
+        self.subject.update(FileSegmentGuc(row))
+
+        self.assertEquals("[context: -1] [dbid: dbid1] [name: guc_name] [value: master_value | file: master_value]\n"
+                          "[context: 0] [dbid: dbid2] [name: guc_name] [value: value | file: value]\n"
+                          "[context: 0] [dbid: dbid3] [name: guc_name] [value: value | file: value]\n"
+                          "[context: 1] [dbid: dbid4] [name: guc_name] [value: value | file: wrong_value]\n"
+                          "[context: 1] [dbid: dbid5] [name: guc_name] [value: value | file: value]", self.subject.report())
+
+    def test_values_succeeds(self):
+        self.assertEquals([self.db_seg_guc_1, self.db_seg_guc_2], self.subject.values())

--- a/gpMgmt/doc/gpconfig_help
+++ b/gpMgmt/doc/gpconfig_help
@@ -135,6 +135,17 @@ postgresql.conf file is 128MB. Running the command
 gpconfig -s statement_mem --file displays 128MB. The command
 gpconfig -s statement_mem run by the user displays 64MB.
 
+--file-compare
+
+Like the --file option, the --file-compare option will read the
+postgresql.conf files on all instances (master and segments). It
+then compares these file values with the corresponding database values,
+where the database values represent current running settings, and
+the file values represent what will be used upon the next restart
+of Greenplum. In the case where all segments have consistent values,
+the report from --file-compare will summarize results. In the case
+where any inconsistencies are found, --file-compare will detail the
+values from all segments.
 
 --skipvalidation
 

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpconfig.xml
@@ -11,7 +11,7 @@
        | <b>-r</b> <varname>param_name</varname> [<b>--masteronly</b> | <b>-l</b>
        [<b>--skipvalidation</b>] [<b>--verbose</b>] [<b>--debug</b>]
 
-<b>gpconfig</b> <b>-s</b> <varname>param_name</varname> [<b>--file</b>] [<b>--verbose</b>] [<b>--debug</b>]
+<b>gpconfig</b> <b>-s</b> <varname>param_name</varname> [<b>--file</b> | <b>--file-compare</b>] [<b>--verbose</b>] [<b>--debug</b>]
 
 <b>gpconfig</b> <b>--help</b></codeblock>
     </section>
@@ -124,6 +124,17 @@
               <codeph>postgresql.conf</codeph> file is 128MB. Running the command <codeph>gpconfig
               -s statement_mem --file</codeph> displays 128MB. The command <codeph>gpconfig -s
               statement_mem</codeph> run by the user displays 64MB. </pd>
+          <pd>Not valid with the <codeph>--file-compare</codeph> option.</pd>
+        </plentry>
+        <plentry>
+          <pt>--file-compare</pt>
+          <pd>For a configuration parameter, compares the current Greenplum Database value with the
+            value in the <codeph>postgresql.conf</codeph> files on hosts (master and segments). The
+            values in the <codeph>postgresql.conf files</codeph> represent the value when Greenplum
+            Database is restarted. </pd>
+          <pd>If the values are not the same, the utility displays the values from all hosts. If all
+            hosts have the same value, the utility displays a summary report.</pd>
+          <pd>Not valid with the <codeph>--file</codeph> option.</pd>
         </plentry>
         <plentry>
           <pt>--skipvalidation</pt>

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/full/__init__.py
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/utilities/backup_restore/full/__init__.py
@@ -1186,7 +1186,6 @@ class BackupTestCase(TINCTestCase):
         #Get the database info
         DBINFO[DBNAME] = self.get_db_info(DBNAME)
 
-        #raise GPTestError(msg)
         return GPDmpKey, msg
 
     def do_incr_bkup_test(self, name, DBNAME, bu_options):
@@ -1242,7 +1241,6 @@ class BackupTestCase(TINCTestCase):
         #Get the database info
         DBINFO[DBNAME] = self.get_db_info(DBNAME)
 
-        #raise GPTestError(msg)
         return GPDmpKey, msg
 
 class CancelReplicateThreader(threading.Thread):

--- a/src/test/tinc/tincrepo/mpp/lib/gpdbSegmentConfig.py
+++ b/src/test/tinc/tincrepo/mpp/lib/gpdbSegmentConfig.py
@@ -77,7 +77,6 @@ class GpdbSegmentConfig:
         out = self.psql.run_sql_command(sql_cmd='%s' % (cmd), out_file='-', flags='-t -q')
 
         #if not ok:
-        #    raise GPTestError( 'Errors when try to retrieve information of standby mastser.' )
 
         if out and out[0].strip() == 'True':
             return True


### PR DESCRIPTION
The file postgresql.conf contains GUC settings which are applied upon GPDB restart.
--file-compare contrasts the current GPDB settings (stored in the database)
to settings in the file which would be applied upon restart.

For almost all GUCs, all segments should have the same value; the --file-compare flag
either summarizes success, when consistent, or, in the case of
unexpected differences, outputs detailed information about a given GUC
on all segments.