### PR TITLE
Retry ping test

### DIFF
--- a/gpMgmt/bin/gpmfr.py
+++ b/gpMgmt/bin/gpmfr.py
@@ -1192,12 +1192,15 @@ class GpMfr(Operation):
 
     def checkDDReachable(self, ddSystem):
         """
-        Raise exception if ping test fails else continue.
+        Try to reach DD three times, raise exception if ping test fails.
         """
-        loss = ddSystem.pingTest()
+        for i in range(3):
+            loss = ddSystem.pingTest()
+            if loss == 0:
+                return
+            time.sleep(2)
         # Non zero packet loss
-        if loss > 0:
-            raise Exception("%s Data Domain not reachable." % ddSystem)
+        raise Exception("%s Data Domain not reachable." % ddSystem)
 
     def execute(self):
         if self.options.remote:


### PR DESCRIPTION
Connecting to the virtual data domains is somewhat unreliable. Tests would previously fail if they were unable to ping successfully on the first try.