### PR TITLE
gpperfmon: Add test coverage for queries_history

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -698,14 +698,16 @@ class Command:
             self.validate()
         pass
 
-
-
     def set_results(self,results):
         self.results=results
 
-
     def get_results(self):
         return self.results
+
+    def get_stdout(self, strip=True):
+        if self.results is None:
+            raise Exception("command not run yet")
+        return self.results.stdout if not strip else self.results.stdout.strip()
 
     def get_stdout_lines(self):
         return self.results.stdout.splitlines()
@@ -713,6 +715,15 @@ class Command:
     def get_stderr_lines(self):
         return self.results.stderr.splitlines()
 
+    def get_return_code(self):
+        if self.results is None:
+            raise Exception("command not run yet")
+        return self.results.rc
+
+    def get_stderr(self):
+        if self.results is None:
+            raise Exception("command not run yet")
+        return self.results.stderr
 
     def cancel(self):
         if self.exec_context and isinstance(self.exec_context, ExecutionContext):
@@ -727,7 +738,6 @@ class Command:
             return False
         else:
             return self.results.wasSuccessful()
-
 
     def validate(self,expected_rc=0):
         """Plain vanilla validation which expects a 0 return code."""

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_command.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_command.py
@@ -1,0 +1,49 @@
+from commands.base import Command, CommandResult
+from gp_unittest import *
+
+class CommandTest(GpTestCase):
+    def setUp(self):
+        self.subject = Command("my name", "my command string")
+
+    def test_get_stdout_before_running_raises(self):
+        with self.assertRaisesRegexp(Exception, "command not run yet"):
+            self.subject.get_stdout()
+
+    def test_get_stdout_after_running_returns_stdout(self):
+        self.subject.set_results(CommandResult(0, "my stdout", "", True, False))
+
+        self.assertEqual(self.subject.get_stdout(), "my stdout")
+
+    def test_get_stdout_after_running_returns_stripped_stdout(self):
+        self.subject.set_results(CommandResult(0, "  my stdout\n", "", True, False))
+
+        self.assertEqual(self.subject.get_stdout(), "my stdout")
+
+    def test_get_stdout_after_running_with_no_strip_returns_unstripped_stdout(self):
+        self.subject.set_results(CommandResult(0, "  my stdout\n", "", True, False))
+
+        self.assertEqual(self.subject.get_stdout(strip=False), "  my stdout\n")
+
+    def test_get_return_code_before_running_raises(self):
+        with self.assertRaisesRegexp(Exception, "command not run yet"):
+            self.subject.get_return_code()
+
+    def test_get_stdout_after_running_returns_rc(self):
+        self.subject.set_results(CommandResult(-23, "my stdout", "", True, False))
+
+        self.assertEqual(self.subject.get_return_code(), -23)
+
+    def test_get_stderr_before_running_raises(self):
+        with self.assertRaisesRegexp(Exception, "command not run yet"):
+            self.subject.get_stderr()
+
+    def test_get_stderr_after_running_returns_stderr(self):
+        self.subject.set_results(CommandResult(0, "", "my stderr", True, False))
+
+        self.assertEqual(self.subject.get_stderr(), "my stderr")
+
+    # @patch("gppylib.commands.base.Command.__init__", create=False)
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -27,6 +27,36 @@ Feature: gpperfmon
         Then wait until the process "gpmmon" is up
         And wait until the process "gpsmon" is up
 
+    @gpperfmon_query_history
+    Scenario: gpperfmon adds to query_history table
+        # important: to succeed on macOS, see steps in gpdb/gpAux/gpperfmon/README
+        Given the database "gpperfmon" does not exist
+        When the user runs command "rm -rf $MASTER_DATA_DIRECTORY/gpperfmon/data"
+        When the user runs "gpperfmon_install --port 15432 --enable --password foo"
+        Then gpperfmon_install should return a return code of 0
+        And verify that there is a "heap" table "queries_history" in "gpperfmon"
+        When the user runs command "echo 'qamode = 1' >> $MASTER_DATA_DIRECTORY/gpperfmon/conf/gpperfmon.conf"
+        When the user runs command "echo 'verbose = 1' >> $MASTER_DATA_DIRECTORY/gpperfmon/conf/gpperfmon.conf"
+        When the user runs command "echo 'min_query_time = 2' >> $MASTER_DATA_DIRECTORY/gpperfmon/conf/gpperfmon.conf"
+        # Quantum controls how frequently text files get their data put in external tables.
+        # Note that only certain values are possible: 10, 15, 20, 30, 60.
+        # In this test setup, it's within the second quantum that the files are processed
+        # perhaps because of some initialization.
+        # So for quantum = 10, an initial query-log-to-external-table phase will take up to 20 seconds
+        When the user runs command "echo 'quantum = 10' >> $MASTER_DATA_DIRECTORY/gpperfmon/conf/gpperfmon.conf"
+        # Harvest_interval controls how frequently the perfmon external tables are brought into the heap tables
+        When the user runs command "echo 'harvest_interval = 5' >> $MASTER_DATA_DIRECTORY/gpperfmon/conf/gpperfmon.conf"
+        When the user runs command "pkill postgres"
+        Then wait until the process "postgres" goes down
+        And the user runs "gpstart -a"
+        Then gpstart should return a return code of 0
+        And wait until the process "gpmmon" is up
+        And wait until the process "gpsmon" is up
+        When the user runs "psql -c 'select pg_sleep(3);' template1"
+        Then psql should return a return code of 0
+        Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history" is "true"
+
+
 #    todo this test may have never run. Is it valid? Worthy of fixing?
 #    Scenario: drop old partition
 #        When the user runs command "echo 'partition_age = 4' >> $MASTER_DATA_DIRECTORY/gpperfmon/conf/gpperfmon.conf"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1,4 +1,3 @@
-import commands
 import fnmatch
 import getpass
 import glob
@@ -26,6 +25,7 @@ from gppylib.operations.unix import ListRemoteFilesByPattern, CheckRemoteFile
 from test.behave_utils.gpfdist_utils.gpfdist_mgmt import Gpfdist
 from test.behave_utils.utils import *
 from test.behave_utils.PgHba import PgHba, Entry
+from gppylib.commands.base import Command
 
 timestamp_json = '/tmp/old_to_new_timestamps.json'
 labels_json = '/tmp/old_to_new_timestamp_labels.json'
@@ -87,8 +87,7 @@ def impl(context):
     for i in range (30):
         sleep(10)
         cmd.run()
-        results = cmd.get_results()
-        if results.rc == 0:
+        if cmd.get_return_code() == 0:
             return
     raise Exception("Database did not start up within 5 minutes`")
 
@@ -113,8 +112,7 @@ def impl(context):
     for i in range (30):
         sleep(10)
         cmd.run()
-        results = cmd.get_results()
-        if results.rc == 0:
+        if cmd.get_return_code() == 0:
             return
     raise Exception("Database did not start up within 5 minutes`")
 
@@ -1287,8 +1285,7 @@ def impl(context, dbname):
             for dump_file in master_dump_files:
                 cmd = Command('check for dump files', 'ls -1 %s | wc -l' % (dump_file))
                 cmd.run(validateAfter=True)
-                results = cmd.get_results()
-                if int(results.stdout.strip()) != 1:
+                if int(cmd.get_stdout()) != 1:
                     raise Exception('Dump file %s not found after gp_dump on host %s' % (dump_file, host))
         else:
             if hasattr(context, 'backup_dir'):
@@ -1302,8 +1299,7 @@ def impl(context, dbname):
             for dump_file in segment_dump_files:
                 cmd = Command('check for dump files', 'ls -1 %s | wc -l' % (dump_file), ctxt=REMOTE, remoteHost=host)
                 cmd.run(validateAfter=True)
-                results = cmd.get_results()
-                if int(results.stdout.strip()) != 1:
+                if int(cmd.get_stdout()) != 1:
                     raise Exception('Dump file %s not found after gp_dump on host %s' % (dump_file, host))
 
 @then('"{filetype}" file should not be created under "{dir}"')
@@ -2359,8 +2355,7 @@ def impl(context, filename_prefix):
                       ctxt=REMOTE,
                       remoteHost=host)
         cmd.run(validateAfter=True)
-        results = cmd.get_results()
-        if int(results.stdout.strip()) > 0:
+        if int(cmd.get_stdout()) > 0:
             raise Exception('Temp files with prefix %s are not cleaned up on host %s after gpcrondump' % (filename_prefix, host))
 
 @when('the user activates standby on the standbyhost')
@@ -2576,7 +2571,7 @@ def get_segment_dump_files(context, dir):
         segment_dump_dir =  dir.strip() if len(dir.strip()) != 0 else seg.getSegmentDataDirectory()
         cmd = Command('check dump files', 'ls %s/db_dumps/%s/*%s*' % (segment_dump_dir, context.backup_timestamp[0:8], context.backup_timestamp), ctxt=REMOTE, remoteHost=seg.getSegmentHostName())
         cmd.run(validateAfter=False) #because we expect ls to fail
-        results.append((seg, [os.path.basename(r) for r in cmd.get_results().stdout.strip().split()]))
+        results.append((seg, [os.path.basename(r) for r in cmd.get_stdout().split()]))
     return results
 
 @then('the named pipes are created for the timestamp "{timestamp_key}" under "{dir}"')
@@ -2590,14 +2585,12 @@ def impl(context, timestamp_key, dir):
             cmd_str = 'mkdir -p %s' % os.path.dirname(filename)
             cmd = Command('create named pipes directory', cmd_str, ctxt=REMOTE, remoteHost=host)
             cmd.run(validateAfter=True)
-            results = cmd.get_results()
-            if int(results.rc) != 0:
+            if int(cmd.get_return_code()) != 0:
                 raise Exception('Non zero return code during makedirs command')
 
             cmd = Command('create named pipes', 'mkfifo %s' % filename, ctxt=REMOTE, remoteHost=host)
             cmd.run(validateAfter=True)
-            results = cmd.get_results()
-            if int(results.rc) != 0:
+            if int(cmd.get_return_code()) != 0:
                 raise Exception('Non zero return code during mkfifo command')
 
 @then('the named pipes are validated against the timestamp "{timestamp_key}" under "{dir}"')
@@ -2610,10 +2603,9 @@ def impl(context, timestamp_key, dir):
             (host, filename) = [t.strip() for t in f.split(':')]
             cmd = Command('create named pipes', 'file %s' % filename, ctxt=REMOTE, remoteHost=host)
             cmd.run(validateAfter=True)
-            results = cmd.get_results()
-            if int(results.rc) != 0:
+            if int(cmd.get_return_code()) != 0:
                 raise Exception('Non zero return code during mkfifo command')
-            if not 'named pipe' in results.stdout:
+            if not 'named pipe' in cmd.get_stdout():
                 raise Exception('Expected %s to be a named pipe' % filename)
 
 @when('the named pipe script for the "{operation}" is run for the files under "{dump_directory}"')
@@ -2637,7 +2629,7 @@ def impl(context):
                       ctxt=REMOTE,
                       remoteHost=h)
         find_cmd.run()
-        results = find_cmd.get_results().stdout.strip().split('\n')
+        results = find_cmd.get_stdout().split('\n')
         for process in results:
             if not process.strip():
                 continue
@@ -2649,9 +2641,8 @@ def impl(context):
                           remoteHost=h)
             cmd.run(validateAfter=True)
 
-        find_cmd.run() # We expecte failure here
-
-        results = find_cmd.get_results().stdout.strip()
+        find_cmd.run()  # We expect failure here
+        results = find_cmd.get_stdout()
         if results:
             raise Exception('Unexpected pipe processes found "%s"' % results)
 
@@ -2781,7 +2772,7 @@ def impl(context, directory, prefix):
 
     cmd = Command('check dump files', 'ls %s/db_dumps/%s/*%s*' % (master_dump_dir, context.backup_timestamp[0:8], context.backup_timestamp))
     cmd.run(validateAfter=True)
-    results = cmd.get_results().stdout.strip().split('\n')
+    results = cmd.get_stdout().split('\n')
 
     if len(results) == 0:
         raise Exception('Failed to find dump files %s on the master under %s' % (results, master_dump_dir))
@@ -3216,20 +3207,24 @@ def impl(context, seg):
 
     filename = os.path.join(os.getcwd(), './test/behave/mgmt_utils/steps/data/pid_background_script.py')
 
-    cmd = Command(name="Remove background script on remote host", cmdStr='rm -f /tmp/pid_background_script.py', remoteHost=hostname, ctxt=REMOTE)
+    cmd = Command(name="Remove background script on remote host", cmdStr='rm -f /tmp/pid_background_script.py',
+                  remoteHost=hostname, ctxt=REMOTE)
     cmd.run(validateAfter=True)
 
     cmd = Command(name="Copy background script to remote host", cmdStr='scp %s %s:/tmp' % (filename, hostname))
     cmd.run(validateAfter=True)
 
-    cmd = Command(name="Run Bg process to save pid", cmdStr='sh -c "python /tmp/pid_background_script.py" &>/dev/null &', remoteHost=hostname, ctxt=REMOTE)
+    cmd = Command(name="Run Bg process to save pid",
+                  cmdStr='sh -c "python /tmp/pid_background_script.py" &>/dev/null &', remoteHost=hostname, ctxt=REMOTE)
     cmd.run(validateAfter=True)
 
-    cmd = Command(name="get bg pid", cmdStr="ps ux | grep pid_background_script.py | grep -v grep | awk '{print \$2}'", remoteHost=hostname, ctxt=REMOTE)
+    cmd = Command(name="get bg pid", cmdStr="ps ux | grep pid_background_script.py | grep -v grep | awk '{print \$2}'",
+                  remoteHost=hostname, ctxt=REMOTE)
     cmd.run(validateAfter=True)
-    context.bg_pid = cmd.get_results().stdout.strip()
+    context.bg_pid = cmd.get_stdout()
     if not context.bg_pid:
-        raise Exception("Unable to obtain the pid of the background script. Seg Host: %s, get_results: %s" % (hostname, cmd.get_results().stdout.strip()))
+        raise Exception("Unable to obtain the pid of the background script. Seg Host: %s, get_results: %s" %
+                        (hostname, cmd.get_stdout()))
 
 @when('the background pid is killed on "{seg}" segment')
 @then('the background pid is killed on "{seg}" segment')
@@ -3245,8 +3240,7 @@ def impl(context, seg):
 
     cmd = Command(name="get bg pid", cmdStr="ps ux | grep pid_background_script.py | grep -v grep | awk '{print \$2}'", remoteHost=hostname, ctxt=REMOTE)
     cmd.run(validateAfter=True)
-    pids = cmd.get_results().stdout.strip().splitlines()
-
+    pids = cmd.get_stdout().splitlines()
     for pid in pids:
         cmd = Command(name="killbg pid", cmdStr='kill -9 %s' % pid, remoteHost=hostname, ctxt=REMOTE)
         cmd.run(validateAfter=True)
@@ -3314,9 +3308,10 @@ def impl(context, seg):
         pid = fr.readline().strip()
 
     while True:
-        cmd = Command(name="get non-existing pid", cmdStr="ps ux | grep %s | grep -v grep | awk '{print \$2}'" % pid, remoteHost=hostname, ctxt=REMOTE)
+        cmd = Command(name="get non-existing pid", cmdStr="ps ux | grep %s | grep -v grep | awk '{print \$2}'" % pid,
+                      remoteHost=hostname, ctxt=REMOTE)
         cmd.run(validateAfter=True)
-        if cmd.get_results().stdout.strip():
+        if cmd.get_stdout():
             pid = pid + 1
         else:
             break
@@ -4113,11 +4108,13 @@ def impl(context, proc):
     start_time = current_time = datetime.now()
     while (current_time - start_time).seconds < 120:
         cmd.run()
-        if cmd.get_results().rc != 0: # 1 is a good outcome; 2 or 3 we should fail fast because they're errors
+        if cmd.get_return_code() > 1:
+            raise Exception("unexpected problem with gprep, return code: %s" % cmd.get_return_code())
+        if cmd.get_return_code() != 0:  # 1 means no match
             break
         time.sleep(2)
         current_time = datetime.now()
-    context.ret_code = cmd.get_results().rc
+    context.ret_code = cmd.get_return_code()
     context.error_message = ''
     if context.ret_code > 1:
         context.error_message = 'pgrep internal error'
@@ -4131,15 +4128,46 @@ def impl(context, proc):
     start_time = current_time = datetime.now()
     while (current_time - start_time).seconds < 120:
         cmd.run()
-        if cmd.get_results().rc != 1: # 0 is a good outcome; 2 or 3 we should fail fast because they're errors
+        if cmd.get_return_code() > 1:
+            raise Exception("unexpected problem with gprep, return code: %s" % cmd.get_return_code())
+        if cmd.get_return_code() != 1:  # 0 means match
             break
         time.sleep(2)
         current_time = datetime.now()
-    context.ret_code = cmd.get_results().rc
+    context.ret_code = cmd.get_return_code()
     context.error_message = ''
     if context.ret_code > 1:
         context.error_message = 'pgrep internal error'
     check_return_code(context, 0) # 0 means one or more processes were matched
+
+@when('wait until the results from boolean sql "{sql}" is "{boolean}"')
+@then('wait until the results from boolean sql "{sql}" is "{boolean}"')
+@given('wait until the results from boolean sql "{sql}" is "{boolean}"')
+def impl(context, sql, boolean):
+    cmd = Command(name='psql', cmdStr='psql --tuples-only -d gpperfmon -c "%s"' % sql)
+    start_time = current_time = datetime.now()
+    result = None
+    while (current_time - start_time).seconds < 120:
+        cmd.run()
+        if cmd.get_return_code() != 0:
+            break
+        result = cmd.get_stdout()
+        if _str2bool(result) == _str2bool(boolean):
+            break
+        time.sleep(2)
+        current_time = datetime.now()
+
+    if cmd.get_return_code() != 0:
+        context.ret_code = cmd.get_return_code()
+        context.error_message = 'psql internal error: %s' % cmd.get_stderr()
+        check_return_code(context, 0)
+    else:
+        if _str2bool(result) != _str2bool(boolean):
+            raise Exception("sql output '%s' is not same as '%s'" % (result, boolean))
+
+
+def _str2bool(string):
+    return string.lower().strip() in ['t', 'true', '1', 'yes', 'y']
 
 @when('run gppersistent_rebuild with the saved content id')
 @then('run gppersistent_rebuild with the saved content id')
@@ -4147,7 +4175,7 @@ def impl(context):
     cmdStr = "echo -e 'y\ny\n' | $GPHOME/sbin/gppersistentrebuild -c %s" % context.saved_segcid
     cmd=Command(name='Run gppersistentrebuild',cmdStr=cmdStr)
     cmd.run(validateAfter=True)
-    context.ret_code = cmd.get_results().rc
+    context.ret_code = cmd.get_return_code()
 
 @given('the information of a "{seg}" segment on any host is saved')
 @when('the information of a "{seg}" segment on any host is saved')

--- a/gpdb-doc/dita/utility_guide/admin_utilities/gpperfmon_install.xml
+++ b/gpdb-doc/dita/utility_guide/admin_utilities/gpperfmon_install.xml
@@ -151,6 +151,9 @@ host       all           gpmon  127.0.0.1/28   password</codeblock></p>
         <li>Restart the Greenplum Command Center with the Command Center <codeph>gpcmdr</codeph>
           utility. <codeblock> $ gpcmdr --restart</codeblock></li>
       </ol>
+	  <p>This gpperfmon monitoring system requires some initialization after startup,
+		  so expect monitoring information to appear after a few minutes have passed, and not 
+		  immediately after installation and startup of the gpperfmon system.</p>
     </section>
     <section id="section5">
       <title>Examples</title>


### PR DESCRIPTION
The parts of this test that rely on timing are relevant because are testing time-sensitive behavior of the sleeps, waits, and loops involved in running gpperfmon

We're all ears for better approaches for the next iteration :)

Signed-off-by: Marbin Tan <mtan@pivotal.io>