### PR TITLE
Only list complete logical indices for a partitioned table

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -3042,4 +3042,17 @@ gpdb::FMDCacheNeedsReset
 	return true;
 }
 
+bool
+gpdb::FPartialLogicalIndex
+		(
+			const LogicalIndexInfo *logicalIndexInfo
+		)
+{
+	// A logical index is complete when it's on all leaf partitions
+	// A partial logical index will have part constraints or default levels
+	// set
+	// c.f. BuildLogicalIndexInfo in cdbpartindex.c
+	return logicalIndexInfo->partCons || logicalIndexInfo->defaultLevels;
+}
+
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -343,7 +343,10 @@ CTranslatorRelcacheToDXL::PlIndexOidsPartTable
 	for (ULONG ul = 0; ul < ulIndexes; ul++)
 	{
 		LogicalIndexInfo *pidxinfo = (plgidx->logicalIndexInfo)[ul];
-		plOids = gpdb::PlAppendOid(plOids, pidxinfo->logicalIndexOid);
+		if (!gpdb::FPartialLogicalIndex(pidxinfo))
+		{
+			plOids = gpdb::PlAppendOid(plOids, pidxinfo->logicalIndexOid);
+		}
 	}
 	
 	gpdb::GPDBFree(plgidx);
@@ -1224,7 +1227,7 @@ CTranslatorRelcacheToDXL::PmdindexPartTable
 		}
 	}
 
-	BOOL fPartial = (NULL != pnodePartCnstr || NIL != plDefaultLevels);
+	BOOL fPartial = gpdb::FPartialLogicalIndex(pidxinfo);
 
 	if (NULL == pnodePartCnstr)
 	{

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -516,6 +516,10 @@ namespace gpdb {
 	// close the given relation
 	void CloseRelation(Relation rel);
 
+	// A logical index is partial if it's not present on all leaf partitions
+	// c.f. BuildLogicalIndexInfo in cdbpartindex.c
+	bool FPartialLogicalIndex(const LogicalIndexInfo* logicalIndexInfo);
+
 	// return the logical indexes for a partitioned table
 	LogicalIndexes *Plgidx(Oid oid);
 	


### PR DESCRIPTION
With cd2cfa7 (disabling heterogeneous index scans) , now we can make
stronger assumption about the usefulness of partial logical indices and return
only complete logical indices for a partitioned table.