### PR TITLE
Fix how the bitmap are freed 

### DIFF
--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -258,7 +258,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
 	{
 		if(node->bitmap && IsA(node->bitmap, StreamBitmap))
 			stream_add_node((StreamBitmap *)node->bitmap,
-						tbm_create_stream_node_ref(hbm), BMS_AND);
+						tbm_create_stream_node(hbm), BMS_AND);
 		else
 			node->bitmap = (Node *)hbm;
 	}

--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -178,17 +178,6 @@ MultiExecBitmapAnd(BitmapAndState *node)
 			else
 			{
 				tbm_intersect(hbm, (HashBitmap *)subresult);
-
-				/* For optimizer BitmapIndexScan would free all bitmaps */
-				if (PLANGEN_PLANNER == node->ps.state->es_plannedstmt->planGen)
-				{
-					tbm_free((HashBitmap *)subresult);
-
-					/* Since we release the space for subresult, we want to
-					 * reset the bitmaps in subnode tree to NULL.
-					 */
-					tbm_reset_bitmaps(subnode);
-				}
 			}
 
 			/* If tbm is empty, short circuit, per logic outlined above */
@@ -232,24 +221,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
 
 	if (empty)
 	{
-		/* Free node->bitmap */
-		if (node->bitmap)
-		{
-			if (PLANGEN_PLANNER == node->ps.state->es_plannedstmt->planGen)
-			{
-				tbm_bitmap_free(node->bitmap);
-
-				/* Since we release the space for subresult, we want to
-				 * reset the bitmaps in subnode tree to NULL.
-				 */
-				tbm_reset_bitmaps(&(node->ps));
-			}
-			else
-			{
-				node->bitmap = NULL;
-			}
-		}
-
+		node->bitmap = NULL;
 		return (Node*) NULL;
 	}
 
@@ -307,10 +279,7 @@ ExecReScanBitmapAnd(BitmapAndState *node, ExprContext *exprCtxt)
 	 * we voluntarily set our bitmap to NULL to ensure that we don't have an out
 	 * of scope pointer
 	 */
-	if (PLANGEN_OPTIMIZER == node->ps.state->es_plannedstmt->planGen)
-	{
-		node->bitmap = NULL;
-	}
+	node->bitmap = NULL;
 
 	int			i;
 
@@ -330,59 +299,6 @@ ExecReScanBitmapAnd(BitmapAndState *node, ExprContext *exprCtxt)
 		 * any outer tuple that might be used in index quals.
 		 */
 		ExecReScan(subnode, exprCtxt);
-	}
-}
-
-/*
- * tbm_reset_bitmaps -- reset the bitmap fields for the given plan
- * state and all its subplan states to NULL.
- */
-void
-tbm_reset_bitmaps(PlanState *pstate)
-{
-	if (pstate == NULL)
-		return;
-
-	/*
-	 * Optimizer generated plans have better memory management where
-	 * the bitmap index scan takes responsibility to free the bitmaps
-	 */
-	Assert(PLANGEN_PLANNER == pstate->state->es_plannedstmt->planGen);
-
-	Assert (IsA(pstate, BitmapIndexScanState) ||
-			IsA(pstate, BitmapAndState) ||
-			IsA(pstate, BitmapOrState));
-
-	if (IsA(pstate, BitmapIndexScanState))
-	{
-		((BitmapIndexScanState *)pstate)->bitmap = NULL;
-	}
-	
-
-	else if (IsA(pstate, BitmapAndState))
-	{
-		PlanState **bitmapplans;
-		int i;
-
-		bitmapplans = ((BitmapAndState *)pstate)->bitmapplans;
-		for (i=0; i<((BitmapAndState *)pstate)->nplans; i++)
-		{
-			tbm_reset_bitmaps(bitmapplans[i]);
-		}
-		((BitmapAndState *)pstate)->bitmap = NULL;
-	}
-	
-
-	else {
-		PlanState **bitmapplans;
-		int i;
-
-		bitmapplans = ((BitmapOrState *)pstate)->bitmapplans;
-		for (i=0; i<((BitmapOrState *)pstate)->nplans; i++)
-		{
-			tbm_reset_bitmaps(bitmapplans[i]);
-		}
-		((BitmapOrState *)pstate)->bitmap = NULL;		
 	}
 }
 

--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -198,16 +198,7 @@ MultiExecBitmapAnd(BitmapAndState *node)
 				if (node->bitmap != subresult)
    				{
 	   				StreamBitmap *s = (StreamBitmap *)subresult;
-		   			stream_add_node((StreamBitmap *)node->bitmap,
-									s->streamNode, BMS_AND);
-		   			/* node->bitmap should be the only owner of the newly created AND StreamNode */
-		   			s->streamNode = NULL;
-
-					/*
-					 * Don't free subresult here, as we are still using the StreamNode inside it.
-					 * For Planner, this would introduce memory leak. For optimizer, however,
-					 * BitmapIndexScan would free the bitmap at the end of the scan of the part
-					 */
+	   				stream_move_node((StreamBitmap *)node->bitmap, s, BMS_AND);
 			   	}
 			}
    			else

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -209,7 +209,7 @@ MultiExecBitmapOr(BitmapOrState *node)
 	{
 		if(node->bitmap && IsA(node->bitmap, StreamBitmap))
 			stream_add_node((StreamBitmap *)node->bitmap, 
-						tbm_create_stream_node_ref(hbm), BMS_OR);
+						tbm_create_stream_node(hbm), BMS_OR);
 		else
 			node->bitmap = (Node *)hbm;
 	}

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -170,17 +170,7 @@ MultiExecBitmapOr(BitmapOrState *node)
 				if(node->bitmap != subresult)
 				{
 					StreamBitmap *s = (StreamBitmap *)subresult;
-					stream_add_node((StreamBitmap *)node->bitmap, 
-									s->streamNode, BMS_OR);
-					/* node->bitmap should be the only owner of the newly created OR StreamNode */
-					s->streamNode = NULL;
-
-					/*
-					 * Don't free subresult here, as we are still using the StreamNode inside it.
-					 * For Planner, this would introduce memory leak. For optimizer, however,
-					 * BitmapIndexScan would free the bitmap at the end of the scan of the part
-					 */
-				}
+					stream_move_node((StreamBitmap *)node->bitmap, s, BMS_OR);				}
 			}
 			else
 				node->bitmap = subresult;

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -95,7 +95,7 @@ struct HashBitmap
 /* A struct to hide away HashBitmap state for a streaming bitmap */
 typedef struct HashStreamOpaque
 {
-	HashBitmap *tbm;
+	HashBitmap *tbm;  /* HashStreamOpaque will not take the ownership of freeing HashBitmap */
 	PagetableEntry *entry;
 }	HashStreamOpaque;
 
@@ -1247,20 +1247,11 @@ static void
 tbm_stream_free(StreamNode *self)
 {
 	HashStreamOpaque *op = (HashStreamOpaque *) self->opaque;
-	HashBitmap *tbm = op->tbm;
-
-	/* CDB: Report statistics for EXPLAIN ANALYZE */
-	if (tbm->instrument)
-	{
-		tbm_upd_instrument(tbm);
-		tbm_set_instrument(tbm, NULL);
-	}
-
 	/*
-	 * A reference to the plan is kept in the BitmapIndexScanState
-	 * so this is a no-op for now.
+	 * op->tbm is actually a reference to node->bitmap from BitmapIndexScanState
+	 * BitmapIndexScanState would have freed the op->tbm already so we shouldn't
+	 * access now.
 	 */
-	tbm_free(tbm);
 	pfree(op);
 	pfree(self);
 }

--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -1134,6 +1134,23 @@ make_opstream(StreamType kind, StreamNode *n1, StreamNode *n2)
 }
 
 /*
+ * stream_move_node - move a streamnode from StreamBitMap (source)'s streamnode
+ * to given StreamBitMap(destination). Also transfer the ownership of source streamnode by
+ * resetting to NULL.
+ */
+void
+stream_move_node(StreamBitmap *destination, StreamBitmap *source, StreamType kind)
+{
+	Assert(NULL != destination);
+	Assert(NULL != source);
+	stream_add_node(destination,
+			source->streamNode, kind);
+	/* destination owns the streamNode and hence resetting it to NULL for source->streamNode. */
+	source->streamNode = NULL;
+}
+
+
+/*
  * stream_add_node() - add a new node to a bitmap stream
  * node is a base node -- i.e., an index/external
  * kind is one of BMS_INDEX, BMS_OR or BMS_AND

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -502,9 +502,6 @@ extern int64 tuple_grouping(TupleTableSlot *outerslot, int numGroupCols,
 extern uint64 get_grouping_groupid(TupleTableSlot *slot,
 								   int grping_idx);
 
-/* prototypes defined in nodeBitmapAnd.c */
-extern void tbm_reset_bitmaps(PlanState *pstate);
-
 extern ResultRelInfo *slot_get_partition(TupleTableSlot *slot, EState *estate);
 extern ResultRelInfo *values_get_partition(Datum *values, bool *nulls,
 										   TupleDesc desc, EState *estate);

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -169,7 +169,6 @@ extern bool tbm_iterate(Node *tbm, TBMIterateResult *output);
 
 extern void stream_add_node(StreamBitmap *strm, StreamNode *node, StreamType kind);
 extern StreamNode *tbm_create_stream_node(HashBitmap *tbm);
-extern StreamNode *tbm_create_stream_node_ref(HashBitmap *tbm);
 extern bool bitmap_stream_iterate(StreamNode *n, PagetableEntry *e);
 
 /* These functions accept either a HashBitmap or a StreamBitmap... */

--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -167,6 +167,7 @@ extern bool tbm_is_empty(const HashBitmap *tbm);
 extern void tbm_begin_iterate(HashBitmap *tbm);
 extern bool tbm_iterate(Node *tbm, TBMIterateResult *output);
 
+extern void stream_move_node(StreamBitmap *strm, StreamBitmap *other, StreamType kind);
 extern void stream_add_node(StreamBitmap *strm, StreamNode *node, StreamType kind);
 extern StreamNode *tbm_create_stream_node(HashBitmap *tbm);
 extern bool bitmap_stream_iterate(StreamNode *n, PagetableEntry *e);

--- a/src/test/regress/expected/bitmapscan_ao.out
+++ b/src/test/regress/expected/bitmapscan_ao.out
@@ -235,6 +235,23 @@ select count(1) from bmcrash where btree_col1 = 'abcdefg999' OR btree_col2 = '20
     23
 (1 row)
 
+set enable_bitmapscan=on; 
+set enable_hashjoin=off; 
+set enable_indexscan=on; 
+set enable_nestloop=on; 
+set enable_seqscan=off;
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND bitmap_col = '999' OR bitmap_col = '888' OR btree_col2 = '2015-01-01';
+ count 
+-------
+    33
+(1 row)
+
+select count(1) from bmcrash b1, bmcrash b2 where b1.bitmap_col = b2.bitmap_col or b1.bitmap_col = '999' and b1.btree_col1 = 'abcdefg999';
+ count  
+--------
+ 199900
+(1 row)
+
 -- start_ignore
 drop schema bm_ao cascade;
 NOTICE:  drop cascades to append only table bmcrash

--- a/src/test/regress/sql/bitmapscan_ao.sql
+++ b/src/test/regress/sql/bitmapscan_ao.sql
@@ -181,6 +181,15 @@ select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND btree_col2 = '2
 select count(1) from bmcrash where btree_col1 = 'abcdefg999' OR btree_col2 = '2015-01-01' AND bitmap_col = '999';
 select count(1) from bmcrash where btree_col1 = 'abcdefg999' OR btree_col2 = '2015-01-01' OR bitmap_col = '999';
 
+set enable_bitmapscan=on; 
+set enable_hashjoin=off; 
+set enable_indexscan=on; 
+set enable_nestloop=on; 
+set enable_seqscan=off;
+
+select count(1) from bmcrash where btree_col1 = 'abcdefg999' AND bitmap_col = '999' OR bitmap_col = '888' OR btree_col2 = '2015-01-01';
+select count(1) from bmcrash b1, bmcrash b2 where b1.bitmap_col = b2.bitmap_col or b1.bitmap_col = '999' and b1.btree_col1 = 'abcdefg999';
+
 -- start_ignore
 drop schema bm_ao cascade;
 -- end_ignore


### PR DESCRIPTION
There are four commits. Below is the brief of those and please see the individual commits for details.

Commit 1: Revert(except test) the fix b5d7b30 (PR #1089) that didn't solve the full problem of freeing bitmap.
Commit 2: Fix HashStreamOpaque from bad access / double free'ing HashBitMap.
Commit 3: Address PR #2193 comments on how we handle the free for the bitmap in planner plan.
Commit 4: New API to add streambitmap to another streambitmap. 

@foyzur @hsyuan @hardikar Please take a look when you have a chance. 