### PR TITLE
Fix collocation checks in window query planning.

### DIFF
--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -453,3 +453,41 @@ from (select * from mpp23240 where f > 10) x;
 -- start_ignore
 drop table mpp23240;
 -- end_ignore
+-- Test for the bug reported at https://github.com/greenplum-db/gpdb/issues/2236
+create table test1 (x int, y int, z double precision);
+insert into test1 select a, b, a*10 + b from generate_series(1, 5) a, generate_series(1, 5) b;
+select sum(z) over (partition by x) as sumx, sum(z) over (partition by y) as sumy from test1;
+ sumx | sumy 
+------+------
+   65 |  155
+   65 |  160
+   65 |  165
+   65 |  170
+   65 |  175
+  115 |  155
+  115 |  160
+  115 |  165
+  115 |  170
+  115 |  175
+  165 |  155
+  165 |  160
+  165 |  165
+  165 |  170
+  165 |  175
+  215 |  155
+  215 |  160
+  215 |  165
+  215 |  170
+  215 |  175
+  265 |  155
+  265 |  160
+  265 |  165
+  265 |  170
+  265 |  175
+(25 rows)
+
+drop table test1;
+-- CLEANUP
+-- start_ignore
+drop schema bfv_olap cascade;
+-- end_ignore

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -451,5 +451,42 @@ from (select * from mpp23240 where f > 10) x;
 -- CLEANUP
 -- start_ignore
 drop table mpp23240;
-drop schema if exists bfv_olap;
+-- end_ignore
+-- Test for the bug reported at https://github.com/greenplum-db/gpdb/issues/2236
+create table test1 (x int, y int, z double precision);
+insert into test1 select a, b, a*10 + b from generate_series(1, 5) a, generate_series(1, 5) b;
+select sum(z) over (partition by x) as sumx, sum(z) over (partition by y) as sumy from test1;
+ sumx | sumy 
+------+------
+   65 |  155
+   65 |  160
+   65 |  165
+   65 |  170
+   65 |  175
+  115 |  155
+  115 |  160
+  115 |  165
+  115 |  170
+  115 |  175
+  165 |  155
+  165 |  160
+  165 |  165
+  165 |  170
+  165 |  175
+  215 |  155
+  215 |  160
+  215 |  165
+  215 |  170
+  215 |  175
+  265 |  155
+  265 |  160
+  265 |  165
+  265 |  170
+  265 |  175
+(25 rows)
+
+drop table test1;
+-- CLEANUP
+-- start_ignore
+drop schema bfv_olap cascade;
 -- end_ignore

--- a/src/test/regress/sql/bfv_olap.sql
+++ b/src/test/regress/sql/bfv_olap.sql
@@ -413,7 +413,19 @@ from (select * from mpp23240 where f > 10) x;
 -- CLEANUP
 -- start_ignore
 drop table mpp23240;
+-- end_ignore
 
-drop schema if exists bfv_olap;
+-- Test for the bug reported at https://github.com/greenplum-db/gpdb/issues/2236
+create table test1 (x int, y int, z double precision);
+insert into test1 select a, b, a*10 + b from generate_series(1, 5) a, generate_series(1, 5) b;
+
+select sum(z) over (partition by x) as sumx, sum(z) over (partition by y) as sumy from test1;
+
+drop table test1;
+
+
+-- CLEANUP
+-- start_ignore
+drop schema bfv_olap cascade;
 -- end_ignore
 


### PR DESCRIPTION
In assure_collocation_and_order, we check if the lower plan is already
distributed on the partitioning key, and insert a Motion node if not.
That check was broken. When a query with multiple windows is planned, we
create a chain of Group+Sort stages, to compute each aggregate. To do that,
we create a synthetic subquery for each stage, and each subquery will have
its own minimal range table and target list. The sort and distribution
path keys should use expressions that refer to the original plan and
PlannerInfo that we started with, but in assure_collocation_and_order(), we
were incorrectly building path keys based on the target lists in the
intermediate stages. Those are not comparable with path keys referring to
the original target list, and as a result.

Fixes github issue #2236.