### PR TITLE
Win32 clients and loaders packaging infrastructure

### DIFF
--- a/concourse/pipelines/pipeline.yml
+++ b/concourse/pipelines/pipeline.yml
@@ -41,6 +41,17 @@ resources:
     username: {{docker_username}}
     password: {{docker_password}}
 
+# TODO: Currently the windows clients and loaders are not packaging correctly.
+#       This resource will be used when the team responsible for the CLs is
+#       ready to fix the issues, and integrate the changes into the full CI for
+#       gpdb.
+# - name: centos-mingw
+#   type: docker-image
+#   source:
+#     repository: pivotaldata/centos-mingw
+#     username: {{docker_username}}
+#     password: {{docker_password}}
+
 - name: bin_gpdb_centos6
   type: s3
   source:
@@ -67,6 +78,28 @@ resources:
     region_name: {{aws-region}}
     secret_access_key: {{bucket-secret-access-key}}
     versioned_file: {{bin_gpdb_sles11_versioned_file}}
+
+# TODO: Currently the windows clients and loaders are not packaging correctly.
+#       This resource will be used when the team responsible for the CLs is
+#       ready to fix the issues, and integrate the changes into the full CI for
+#       gpdb.
+# - name: bin_gpdb_windows_clients
+#   type: s3
+#   source:
+#     access_key_id: {{bucket-access-key-id}}
+#     bucket: {{bucket-name}}
+#     region_name: {{aws-region}}
+#     secret_access_key: {{bucket-secret-access-key}}
+#     regexp: windows-cl/greenplum-clients-5.(.*)-WinXP-x86_32.msi
+#
+# - name: bin_gpdb_windows_loaders
+#   type: s3
+#   source:
+#     access_key_id: {{bucket-access-key-id}}
+#     bucket: {{bucket-name}}
+#     region_name: {{aws-region}}
+#     secret_access_key: {{bucket-secret-access-key}}
+#     regexp: windows-cl/greenplum-loaders-5.(.*)-WinXP-x86_32.msi
 
 - name: installer_rhel6_gpdb_rc
   type: s3
@@ -298,6 +331,35 @@ jobs:
   - put: bin_gpdb_sles11
     params:
       file: gpdb_artifacts/bin_gpdb.tar.gz
+
+# TODO: Currently the windows clients and loaders are not packaging correctly.
+#       This task will be used when the team responsible for the CLs is ready
+#       to fix the issues, and integrate the changes into the full CI for gpdb.
+# - name: compile_gpdb_windows_cl
+#   plan:
+#   - aggregate:
+#     - get: gpdb_src
+#       trigger: true
+#     - get: gpaddon_src
+#     - get: centos-mingw
+#   - task: compile_gpdb
+#     file: gpdb_src/concourse/tasks/compile_gpdb.yml
+#     image: centos-mingw
+#     params:
+#       TARGET_OS: win32
+#       TARGET_OS_VERSION:
+#       BLD_TARGETS: clients loaders
+#       IVYREPO_HOST: {{ivyrepo_host}}
+#       IVYREPO_REALM: {{ivyrepo_realm}}
+#       IVYREPO_USER: {{ivyrepo_user}}
+#       IVYREPO_PASSWD: {{ivyrepo_passwd}}
+#   - aggregate:
+#     - put: bin_gpdb_windows_clients
+#       params:
+#         file: gpdb_artifacts/greenplum-clients-*-WinXP-x86_32.msi
+#     - put: bin_gpdb_windows_loaders
+#       params:
+#         file: gpdb_artifacts/greenplum-loaders-*-WinXP-x86_32.msi
 
 # Stage 2a: Run regression tests against binaries (make installcheck-world and similar)
 

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -57,9 +57,12 @@ endif
 
 BLD_CXX_LIB_DIR=$($(BLD_ARCH)_CXX_LIB_DIR)
 
-# help Windows builds find the cross-compiler and a pre-built curl
 ifeq ($(BLD_ARCH),win32)
+  # help Windows builds find the cross-compiler and a pre-built curl
   include Makefile.windows
+
+  # Host used for Windows packaging (only accessible from the gpdb5 concourse pipeline)
+  WIX_PACKAGER=build@wix-packaging.gpdb5-pipeline-vpc.pivotal.io
 endif
 
 #---------------------------------------------------------------------
@@ -620,9 +623,10 @@ INSTLOC=$(GPDIR)
 endif
 
 VERSION:=$(shell [ -f ../VERSION ] && perl -pe 's, ,-,g' ../VERSION)
+VERSION_SHORT:=$(shell [ -f ../VERSION ] && perl -pe 's, .*,,g' ../VERSION)
 
 ifeq "$(findstring win,$(BLD_ARCH))" "win"
-BLD_PACKAGING_PID:=$(shell ssh build@harpy 'echo $$$$')
+BLD_PACKAGING_PID:=$(shell ssh $(WIX_PACKAGER) 'echo $$$$')
 endif
 
 clients :
@@ -661,14 +665,14 @@ else
 	    echo "ERROR: BLD_PACKAGING_PID must have a value for Windows packaging operations; check your Makefile"; \
 	    exit 1; \
 	fi
-	ssh build@harpy 'if [ -d $(BLD_PACKAGING_PID) ]; then rm -rf $(BLD_PACKAGING_PID); fi'
-	ssh build@harpy 'mkdir -p $(BLD_PACKAGING_PID)/packaging/src/windows'
-	scp -r client/install/src/windows/* build@harpy:$(BLD_PACKAGING_PID)/packaging/src/windows/
-	scp -r $(CLIENTINSTLOC) build@harpy:$(BLD_PACKAGING_PID)/packaging/
-	ssh build@harpy 'cd $(BLD_PACKAGING_PID)/packaging/src/windows/ && make PACKAGE=greenplum-$@ VERSION=$(VERSION) SRCDIR=../../$(notdir $(CLIENTINSTLOC))'
-	scp build@harpy:$(BLD_PACKAGING_PID)/packaging/greenplum-$@-$(VERSION)-WinXP-x86_32.msi .
-	chmod 755 greenplum-$@-$(VERSION)-WinXP-x86_32.msi
-	ssh build@harpy 'rm -rf $(BLD_PACKAGING_PID)'
+	ssh $(WIX_PACKAGER) 'if [ -d $(BLD_PACKAGING_PID) ]; then rm -rf $(BLD_PACKAGING_PID); fi'
+	ssh $(WIX_PACKAGER) 'mkdir -p $(BLD_PACKAGING_PID)/packaging/src/windows'
+	scp -r client/install/src/windows/* $(WIX_PACKAGER):$(BLD_PACKAGING_PID)/packaging/src/windows/
+	scp -r $(CLIENTINSTLOC) $(WIX_PACKAGER):$(BLD_PACKAGING_PID)/packaging/
+	ssh $(WIX_PACKAGER) 'cd $(BLD_PACKAGING_PID)/packaging/src/windows/ && make PACKAGE=greenplum-$@ VERSION=$(VERSION_SHORT) SRCDIR=../../$(notdir $(CLIENTINSTLOC))'
+	scp $(WIX_PACKAGER):$(BLD_PACKAGING_PID)/packaging/greenplum-$@-$(VERSION_SHORT)-WinXP-x86_32.msi .
+	chmod 755 greenplum-$@-$(VERSION_SHORT)-WinXP-x86_32.msi
+	ssh $(WIX_PACKAGER) 'rm -rf $(BLD_PACKAGING_PID)'
 endif
 endif
 
@@ -731,14 +735,14 @@ else
 	    echo "ERROR: BLD_PACKAGING_PID must have a value for Windows packaging operations; check your Makefile"; \
 	    exit 1; \
 	fi
-	ssh build@harpy 'if [ -d $(BLD_PACKAGING_PID) ]; then rm -rf $(BLD_PACKAGING_PID); fi'
-	ssh build@harpy 'mkdir -p $(BLD_PACKAGING_PID)/packaging/src/windows'
-	scp -r client/install/src/windows/* build@harpy:$(BLD_PACKAGING_PID)/packaging/src/windows/
-	scp -r $(LOADERSINSTLOC) build@harpy:$(BLD_PACKAGING_PID)/packaging/
-	ssh build@harpy 'cd $(BLD_PACKAGING_PID)/packaging/src/windows/ && make PACKAGE=greenplum-$@ VERSION=$(VERSION) SRCDIR=../../$(notdir $(LOADERSINSTLOC))'
-	scp build@harpy:$(BLD_PACKAGING_PID)/packaging/greenplum-$@-$(VERSION)-WinXP-x86_32.msi .
-	chmod 755 greenplum-$@-$(VERSION)-WinXP-x86_32.msi
-	ssh build@harpy 'rm -rf $(BLD_PACKAGING_PID)'
+	ssh $(WIX_PACKAGER) 'if [ -d $(BLD_PACKAGING_PID) ]; then rm -rf $(BLD_PACKAGING_PID); fi'
+	ssh $(WIX_PACKAGER) 'mkdir -p $(BLD_PACKAGING_PID)/packaging/src/windows'
+	scp -r client/install/src/windows/* $(WIX_PACKAGER):$(BLD_PACKAGING_PID)/packaging/src/windows/
+	scp -r $(LOADERSINSTLOC) $(WIX_PACKAGER):$(BLD_PACKAGING_PID)/packaging/
+	ssh $(WIX_PACKAGER) 'cd $(BLD_PACKAGING_PID)/packaging/src/windows/ && make PACKAGE=greenplum-$@ VERSION=$(VERSION_SHORT) SRCDIR=../../$(notdir $(LOADERSINSTLOC))'
+	scp $(WIX_PACKAGER):$(BLD_PACKAGING_PID)/packaging/greenplum-$@-$(VERSION_SHORT)-WinXP-x86_32.msi .
+	chmod 755 greenplum-$@-$(VERSION_SHORT)-WinXP-x86_32.msi
+	ssh $(WIX_PACKAGER) 'rm -rf $(BLD_PACKAGING_PID)'
 endif
 endif
 

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -625,7 +625,6 @@ ifeq "$(findstring win,$(BLD_ARCH))" "win"
 BLD_PACKAGING_PID:=$(shell ssh build@harpy 'echo $$$$')
 endif
 
-
 clients :
 	if [ ! -z "$(CLIENTINSTLOC)" ] && [ "$(CLIENTINSTLOC)" != "/" ]; then rm -rf $(CLIENTINSTLOC); fi
 ifeq "$(findstring clients,$(BLD_TARGETS))" ""
@@ -654,6 +653,23 @@ endif
 	cd client/install/src/unix/ && \
 	$(MAKE) TAR=$(TAR) PRODUCT=Clients PACKAGE=greenplum-clients README=GPClientToolsUnix VERSION=`perl -pe 's, ,-,g' ../../../../../VERSION` INSTALL_SRC=$(CLIENTINSTLOC) INSTALL_DIR=../../../..
 
+ifneq "$(findstring win,$(BLD_ARCH))" "win"
+	cd client/install/src/unix/ && \
+	  $(MAKE) TAR=$(TAR) PRODUCT=Clients PACKAGE=greenplum-clients README=GPClientToolsUnix VERSION=`perl -pe 's, ,-,g' ../../../../../VERSION` INSTALL_SRC=$(CLIENTINSTLOC) INSTALL_DIR=../../../..
+else
+	if [ "$(BLD_PACKAGING_PID)" = "" ]; then \
+	    echo "ERROR: BLD_PACKAGING_PID must have a value for Windows packaging operations; check your Makefile"; \
+	    exit 1; \
+	fi
+	ssh build@harpy 'if [ -d $(BLD_PACKAGING_PID) ]; then rm -rf $(BLD_PACKAGING_PID); fi'
+	ssh build@harpy 'mkdir -p $(BLD_PACKAGING_PID)/packaging/src/windows'
+	scp -r client/install/src/windows/* build@harpy:$(BLD_PACKAGING_PID)/packaging/src/windows/
+	scp -r $(CLIENTINSTLOC) build@harpy:$(BLD_PACKAGING_PID)/packaging/
+	ssh build@harpy 'cd $(BLD_PACKAGING_PID)/packaging/src/windows/ && make PACKAGE=greenplum-$@ VERSION=$(VERSION) SRCDIR=../../$(notdir $(CLIENTINSTLOC))'
+	scp build@harpy:$(BLD_PACKAGING_PID)/packaging/greenplum-$@-$(VERSION)-WinXP-x86_32.msi .
+	chmod 755 greenplum-$@-$(VERSION)-WinXP-x86_32.msi
+	ssh build@harpy 'rm -rf $(BLD_PACKAGING_PID)'
+endif
 endif
 
 loaders :
@@ -707,6 +723,23 @@ endif
 	cd client/install/src/unix/ && \
 	$(MAKE) TAR=$(TAR) PRODUCT=Loaders PACKAGE=greenplum-loaders README=GPLoadToolsUnix VERSION=`perl -pe 's, ,-,g' ../../../../../VERSION` INSTALL_SRC=$(LOADERSINSTLOC) INSTALL_DIR=../../../..
 
+ifneq "$(findstring win,$(BLD_ARCH))" "win"
+	cd client/install/src/unix/ && \
+	  $(MAKE) TAR=$(TAR) PRODUCT=Loaders PACKAGE=greenplum-loaders README=GPLoadToolsUnix VERSION=`perl -pe 's, ,-,g' ../../../../../VERSION` INSTALL_SRC=$(LOADERSINSTLOC) INSTALL_DIR=../../../..
+else
+	if [ "$(BLD_PACKAGING_PID)" = "" ]; then \
+	    echo "ERROR: BLD_PACKAGING_PID must have a value for Windows packaging operations; check your Makefile"; \
+	    exit 1; \
+	fi
+	ssh build@harpy 'if [ -d $(BLD_PACKAGING_PID) ]; then rm -rf $(BLD_PACKAGING_PID); fi'
+	ssh build@harpy 'mkdir -p $(BLD_PACKAGING_PID)/packaging/src/windows'
+	scp -r client/install/src/windows/* build@harpy:$(BLD_PACKAGING_PID)/packaging/src/windows/
+	scp -r $(LOADERSINSTLOC) build@harpy:$(BLD_PACKAGING_PID)/packaging/
+	ssh build@harpy 'cd $(BLD_PACKAGING_PID)/packaging/src/windows/ && make PACKAGE=greenplum-$@ VERSION=$(VERSION) SRCDIR=../../$(notdir $(LOADERSINSTLOC))'
+	scp build@harpy:$(BLD_PACKAGING_PID)/packaging/greenplum-$@-$(VERSION)-WinXP-x86_32.msi .
+	chmod 755 greenplum-$@-$(VERSION)-WinXP-x86_32.msi
+	ssh build@harpy 'rm -rf $(BLD_PACKAGING_PID)'
+endif
 endif
 
 #---------------------------------------------------------------------

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -93,13 +93,18 @@ sol10_sparc_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
 sol10_sparc_32_PYTHONHOME=/opt/python32-2.5.1
 suse10_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
 suse11_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
+ifneq "$($(BLD_ARCH)_PYTHONHOME)" ""
 export PYTHONHOME=$($(BLD_ARCH)_PYTHONHOME)
+endif
 
-PYTHON=$(PYTHONHOME)/bin/python
+export PYTHON=python
+ifneq "$(PYTHONHOME)" ""
+export PYTHON=$(PYTHONHOME)/bin/python
 aix5_ppc_32_PYTHON=$(PYTHONHOME)/bin/python2.7
 aix5_ppc_64_PYTHON=$(PYTHONHOME)/bin/python2.7_64
 ifneq "$($(BLD_ARCH)_PYTHON)" ""
 export PYTHON=$($(BLD_ARCH)_PYTHON)
+endif
 endif
 
 # if PYTHONHOME was specified above, use it for the build

--- a/gpAux/client/install/src/unix/Makefile
+++ b/gpAux/client/install/src/unix/Makefile
@@ -9,7 +9,7 @@ VERSION=3.1.1.1-build-2
 
 SHELL:=$(shell which bash)
 WORK_DIR:=$(shell pwd)
-INSTALLER_TEMPLATE=${WORK_DIR}/installer-header-template.txt
+INSTALLER_TEMPLATE=${BLD_TOP}/${ADDON_DIR}/gpAux/client/install/src/unix/installer-header-template.txt
 INSTALLER_HEADER=${WORK_DIR}/installer-header.txt
 PRODUCT=Clients
 PACKAGE=greenplum-clients

--- a/gpAux/client/install/src/windows/Makefile
+++ b/gpAux/client/install/src/windows/Makefile
@@ -13,10 +13,10 @@ MSI=../../${NAME}-WinXP-x86_32.msi
 SRCDIR=../../${PACKAGE}-devel
 DATESTAMP=$(shell datestamp.pl)
 
-#Wix related 
-CANDLE="C:/Program Files/WixEdit/wix-3.0.2211.0/candle.exe"
+#Wix related
+CANDLE="C:/Program Files (x86)/WiX Toolset v3.10/bin/candle.exe"
 CANDLE_OPTS=-nologo
-LIGHT="C:/Program Files/WixEdit/wix-3.0.2211.0/light.exe"
+LIGHT="C:/Program Files (x86)/WiX Toolset v3.10/bin/light.exe"
 LIGHT_OPTS=-nologo -sval
 WXS_TEMPLATE=${PACKAGE}.wxs
 WXS=${NAME}.wxs
@@ -46,7 +46,7 @@ msi:
 	@echo Creating ${MSI}
 	${LIGHT} ${LIGHT_OPTS} ${WIXOBJ} -out ${MSI} 
 
-sign: 
+sign:
 	@echo Signing ${MSI}
 	@echo "`date` -- WARNING: signing disabled while we acquire a new certificate"
 	#signtool sign /a /t ${TIMESTAMP_SERVER} ${MSI}


### PR DESCRIPTION
This doesn't work yet, but moves towards building win32 clients and loaders packages.

Remaining work that we are aware of:
- Fix paths to `greenplum_clients_path.bat` and documentation.
- msvc71.dll needs to be packaged (see `C:\gpdb_artifacts` on wix-packaging host).
- Add (uncomment) task to gpdb_master pipeline.